### PR TITLE
feat(proxy): add a live registry of active requests

### DIFF
--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -3,7 +3,7 @@
 import re
 import traceback
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Any, Final, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Final, Optional
 
 from pydantic import BaseModel
 
@@ -60,6 +60,8 @@ _BASE64_INLINE_PATTERN: Final = re.compile(
 
 class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callback#callback-class
     # Class variables or attributes
+    register_as_litellm_callback: ClassVar[bool] = True
+
     def __init__(
         self,
         turn_off_message_logging: bool = False,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -73,6 +73,7 @@ from litellm.proxy.litellm_pre_call_utils import (
     reject_url_valued_destination,
 )
 from litellm.types.utils import (
+    CallTypesLiteral,
     ModelResponse,
     ModelResponseStream,
     StandardLoggingPayloadErrorInformation,
@@ -1008,6 +1009,10 @@ async def _await_llm_call_cancelling_on_disconnect(
         monitor.cancel()
 
 
+WEBSOCKET_ROUTE_TYPES: Final = frozenset(("_arealtime", "_aresponses_websocket"))
+"""These routes build a synthetic http Request, so InFlightRequestsMiddleware never sees them close."""
+
+
 class ProxyBaseLLMRequestProcessing:
     def __init__(self, data: dict):
         self.data = data
@@ -1168,6 +1173,35 @@ class ProxyBaseLLMRequestProcessing:
             custom_headers.update(callback_headers)
 
         return custom_headers
+
+    async def _register_active_request(
+        self,
+        request: Request,
+        user_api_key_dict: UserAPIKeyAuth,
+        proxy_logging_obj: ProxyLogging,
+        route_type: CallTypesLiteral,
+    ) -> None:
+        from litellm.proxy.hooks.active_request_registry import ActiveRequestRegistry
+
+        if route_type in WEBSOCKET_ROUTE_TYPES:
+            return
+
+        hook: Final = proxy_logging_obj.get_proxy_hook("active_request_registry")
+        if not isinstance(hook, ActiveRequestRegistry):
+            return
+
+        request.state.active_request_registry = hook
+        started_at: Final = getattr(request.state, "active_request_started_at", time.time())
+        request.state.active_request_started_at = started_at
+        registry_id: Final = await hook.register(
+            user_api_key_dict=user_api_key_dict,
+            data=self.data,
+            call_type=route_type,
+            registry_id=getattr(request.state, "active_request_registry_id", None),
+            started_at=started_at,
+        )
+        if registry_id is not None:
+            request.state.active_request_registry_id = registry_id
 
     async def common_processing_pre_call_logic(
         self,
@@ -1379,6 +1413,12 @@ class ProxyBaseLLMRequestProcessing:
                     self.data["model"] = alias_target
 
         self.data["litellm_call_id"] = request.headers.get("x-litellm-call-id", str(uuid.uuid4()))
+        await self._register_active_request(
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+            proxy_logging_obj=proxy_logging_obj,
+            route_type=route_type,
+        )
         DDSpanTagger.tag_call_id(self.data.get("litellm_call_id"))
         DDSpanTagger.tag_request(
             user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1080,10 +1080,6 @@ async def _await_llm_call_cancelling_on_disconnect(
         monitor.cancel()
 
 
-WEBSOCKET_ROUTE_TYPES: Final = frozenset(("_arealtime", "_aresponses_websocket"))
-"""These routes build a synthetic http Request, so InFlightRequestsMiddleware never sees them close."""
-
-
 class ProxyBaseLLMRequestProcessing:
     def __init__(self, data: dict):
         self.data = data
@@ -1270,27 +1266,15 @@ class ProxyBaseLLMRequestProcessing:
         proxy_logging_obj: ProxyLogging,
         route_type: CallTypesLiteral,
     ) -> None:
-        from litellm.proxy.hooks.active_request_registry import ActiveRequestRegistry
+        from litellm.proxy.hooks.active_request_registry import register_http_request
 
-        if route_type in WEBSOCKET_ROUTE_TYPES:
-            return
-
-        hook: Final = proxy_logging_obj.get_proxy_hook("active_request_registry")
-        if not isinstance(hook, ActiveRequestRegistry):
-            return
-
-        request.state.active_request_registry = hook
-        started_at: Final = getattr(request.state, "active_request_started_at", time.time())
-        request.state.active_request_started_at = started_at
-        registry_id: Final = await hook.register(
+        await register_http_request(
+            request=request,
             user_api_key_dict=user_api_key_dict,
+            proxy_logging_obj=proxy_logging_obj,
             data=self.data,
             call_type=route_type,
-            registry_id=getattr(request.state, "active_request_registry_id", None),
-            started_at=started_at,
         )
-        if registry_id is not None:
-            request.state.active_request_registry_id = registry_id
 
     async def common_processing_pre_call_logic(
         self,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -74,6 +74,7 @@ from litellm.proxy.litellm_pre_call_utils import (
     reject_url_valued_destination,
 )
 from litellm.types.utils import (
+    CallTypesLiteral,
     ModelResponse,
     ModelResponseStream,
     StandardLoggingPayloadErrorInformation,
@@ -1079,6 +1080,10 @@ async def _await_llm_call_cancelling_on_disconnect(
         monitor.cancel()
 
 
+WEBSOCKET_ROUTE_TYPES: Final = frozenset(("_arealtime", "_aresponses_websocket"))
+"""These routes build a synthetic http Request, so InFlightRequestsMiddleware never sees them close."""
+
+
 class ProxyBaseLLMRequestProcessing:
     def __init__(self, data: dict):
         self.data = data
@@ -1257,6 +1262,35 @@ class ProxyBaseLLMRequestProcessing:
             custom_headers.update(callback_headers)
 
         return custom_headers
+
+    async def _register_active_request(
+        self,
+        request: Request,
+        user_api_key_dict: UserAPIKeyAuth,
+        proxy_logging_obj: ProxyLogging,
+        route_type: CallTypesLiteral,
+    ) -> None:
+        from litellm.proxy.hooks.active_request_registry import ActiveRequestRegistry
+
+        if route_type in WEBSOCKET_ROUTE_TYPES:
+            return
+
+        hook: Final = proxy_logging_obj.get_proxy_hook("active_request_registry")
+        if not isinstance(hook, ActiveRequestRegistry):
+            return
+
+        request.state.active_request_registry = hook
+        started_at: Final = getattr(request.state, "active_request_started_at", time.time())
+        request.state.active_request_started_at = started_at
+        registry_id: Final = await hook.register(
+            user_api_key_dict=user_api_key_dict,
+            data=self.data,
+            call_type=route_type,
+            registry_id=getattr(request.state, "active_request_registry_id", None),
+            started_at=started_at,
+        )
+        if registry_id is not None:
+            request.state.active_request_registry_id = registry_id
 
     async def common_processing_pre_call_logic(
         self,
@@ -1468,6 +1502,12 @@ class ProxyBaseLLMRequestProcessing:
                     self.data["model"] = alias_target
 
         self.data["litellm_call_id"] = request.headers.get("x-litellm-call-id", str(uuid.uuid4()))
+        await self._register_active_request(
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+            proxy_logging_obj=proxy_logging_obj,
+            route_type=route_type,
+        )
         DDSpanTagger.tag_call_id(self.data.get("litellm_call_id"))
         DDSpanTagger.tag_request(
             user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/hooks/__init__.py
+++ b/litellm/proxy/hooks/__init__.py
@@ -2,6 +2,7 @@ import os
 from typing import Final, Literal
 
 from . import *
+from .active_request_registry import ActiveRequestRegistry
 from .cache_control_check import _PROXY_CacheControlCheck
 from .litellm_skills import SkillsInjectionHook
 from .max_budget_limiter import _PROXY_MaxBudgetLimiter
@@ -17,6 +18,7 @@ from .sensitive_data_routing import _PROXY_SensitiveDataRoutingHandler
 # transitively through `enterprise.enterprise_hooks` can resolve `PROXY_HOOKS`
 # and `get_proxy_hook` from this partially-initialized module without circling.
 PROXY_HOOKS: Final = {
+    "active_request_registry": ActiveRequestRegistry,
     "max_budget_limiter": _PROXY_MaxBudgetLimiter,
     "parallel_request_limiter": _PROXY_MaxParallelRequestsHandler_v3,
     "cache_control_check": _PROXY_CacheControlCheck,

--- a/litellm/proxy/hooks/active_request_registry.py
+++ b/litellm/proxy/hooks/active_request_registry.py
@@ -1,9 +1,9 @@
 """Redis-backed registry of authenticated proxy requests that are still running."""
 
 import asyncio
-import hashlib
 import json
 import os
+import re
 import secrets
 import time
 from collections.abc import Iterable, Mapping, Sequence
@@ -13,7 +13,7 @@ from typing_extensions import ReadOnly
 
 from litellm._logging import verbose_proxy_logger
 from litellm.integrations.custom_logger import CustomLogger
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import UserAPIKeyAuth, hash_token
 from litellm.types.utils import CallTypesLiteral
 
 if TYPE_CHECKING:
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
 
     from litellm.caching.redis_cache import RedisCache
     from litellm.proxy.utils import InternalUsageCache, ProxyLogging
+
+
+HASHED_KEY_PATTERN: Final = re.compile(r"(?:hashed-jwt-)?[0-9a-f]{64}")
 
 
 class ActiveRequestRecord(TypedDict):
@@ -42,7 +45,7 @@ class ActiveRequestRecord(TypedDict):
     team_id: ReadOnly[str | None]
     team_alias: ReadOnly[str | None]
     key_alias: ReadOnly[str | None]
-    key_fingerprint: ReadOnly[str | None]
+    key_hash: ReadOnly[str | None]
     pod: ReadOnly[str | None]
 
 
@@ -221,23 +224,18 @@ class ActiveRequestRegistry(CustomLogger):
         return next((value for value in candidates if value is not None), None)
 
     @staticmethod
-    def _fingerprint_salt() -> str:
-        """Salt the fingerprint with the master key, which every replica shares."""
-        from litellm.proxy.proxy_server import master_key
+    def _key_hash(api_key: str | None) -> str | None:
+        """The key hash the rest of the UI shows, so a row can be traced back to its key.
 
-        return master_key or ""
-
-    @classmethod
-    def _key_fingerprint(cls, api_key: str | None) -> str | None:
-        """Correlate requests from one key without exposing the credential itself.
-
-        Virtual keys reach here already hashed, but custom auth can return the raw
-        credential, so this hashes unconditionally rather than slicing a prefix. The
-        salt keeps a short fingerprint from being verifiable offline against a guess.
+        `UserAPIKeyAuth` has already hashed virtual keys and JWTs by the time a record is
+        built and those pass through unchanged, which is what makes the value match the
+        Key Hash column in Logs and on the key pages. Custom auth can hand back a raw
+        credential, so anything that is neither of those two hashed forms is hashed here
+        rather than published.
         """
         if not api_key:
             return None
-        return hashlib.sha256(f"{cls._fingerprint_salt()}:{api_key}".encode()).hexdigest()[:12]
+        return api_key if HASHED_KEY_PATTERN.fullmatch(api_key) else hash_token(api_key)
 
     @classmethod
     def build_record(
@@ -270,7 +268,7 @@ class ActiveRequestRegistry(CustomLogger):
             team_id=cls._safe_string(auth.team_id),
             team_alias=cls._safe_string(auth.team_alias),
             key_alias=cls._safe_string(auth.key_alias),
-            key_fingerprint=cls._key_fingerprint(auth.api_key),
+            key_hash=cls._key_hash(auth.api_key),
             pod=cls._safe_string(os.getenv("HOSTNAME"), max_length=253),
         )
 
@@ -310,10 +308,11 @@ class ActiveRequestRegistry(CustomLogger):
                 await pipe.execute()
             self._filtered_cache.clear()
             self._track_locally(resolved_id)
-            return resolved_id
         except Exception:  # noqa: BLE001  # observability must never fail a model request
             verbose_proxy_logger.exception("Failed to register active request")
             return None
+        else:
+            return resolved_id
 
     async def remove(self, registry_id: str | None) -> None:
         if not registry_id:

--- a/litellm/proxy/hooks/active_request_registry.py
+++ b/litellm/proxy/hooks/active_request_registry.py
@@ -1,0 +1,419 @@
+"""Redis-backed registry of authenticated proxy requests that are still running."""
+
+import asyncio
+import hashlib
+import json
+import os
+import secrets
+import time
+from collections.abc import Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, ClassVar, Final, TypedDict
+
+from litellm._logging import verbose_proxy_logger
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.types.utils import CallTypesLiteral
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis, RedisCluster
+
+    from litellm.caching.redis_cache import RedisCache
+    from litellm.proxy.utils import InternalUsageCache
+
+
+class ActiveRequestRecord(TypedDict):
+    registry_id: str
+    request_id: str
+    started_at: float
+    model: str | None
+    call_type: str | None
+    streaming: bool
+    route: str | None
+    user_id: str | None
+    user_email: str | None
+    end_user_id: str | None
+    organization_id: str | None
+    organization_alias: str | None
+    project_id: str | None
+    project_alias: str | None
+    team_id: str | None
+    team_alias: str | None
+    key_alias: str | None
+    key_fingerprint: str | None
+    pod: str | None
+
+
+class ActiveRequestsPage(TypedDict):
+    available: bool
+    reason: str | None
+    items: tuple[ActiveRequestRecord, ...]
+    total: int
+    page: int
+    page_size: int
+    truncated: bool
+
+
+class ActiveRequestFilters(TypedDict):
+    model: str | None
+    user_id: str | None
+    end_user_id: str | None
+    organization_id: str | None
+    project_id: str | None
+
+
+MIN_TTL_SECONDS: Final = 300
+TTL_SETTING: Final = "active_request_ttl_seconds"
+INCLUDE_USER_EMAIL_SETTING: Final = "active_request_include_user_email"
+CANCEL_KEY_PREFIX: Final = "litellm:active_requests:cancel:"
+CANCEL_TTL_SECONDS: Final = 60
+CANCEL_POLL_SECONDS: Final = 1.0
+
+
+def _decode_member(value: bytes | str) -> str:
+    return value.decode() if isinstance(value, bytes) else str(value)
+
+
+def _decode_record(raw_item: bytes | str | None) -> ActiveRequestRecord | None:
+    if raw_item is None:
+        return None
+    try:
+        decoded: Final = raw_item.decode() if isinstance(raw_item, bytes) else raw_item
+        parsed: Final = json.loads(decoded)
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return ActiveRequestRecord(**parsed)  # pyright: ignore[reportArgumentType]  # json payload written by this class
+
+
+def _matches(record: ActiveRequestRecord, filters: ActiveRequestFilters) -> bool:
+    return all(expected is None or str(record.get(field) or "") == expected for field, expected in filters.items())
+
+
+class ActiveRequestRegistry(CustomLogger):
+    """Track live requests across proxy replicas without retaining request content."""
+
+    register_as_litellm_callback: ClassVar[bool] = False
+    INDEX_KEY: ClassVar[str] = "litellm:active_requests:index"
+    ITEM_KEY_PREFIX: ClassVar[str] = "litellm:active_requests:item:"
+    DEFAULT_TTL_SECONDS: ClassVar[int] = 1800
+    MAX_TTL_SECONDS: ClassVar[int] = 86400
+    MAX_FIELD_LENGTH: ClassVar[int] = 512
+    DEFAULT_MAX_SCAN_MEMBERS: ClassVar[int] = 5000
+
+    def __init__(self, internal_usage_cache: "InternalUsageCache", max_scan_members: int | None = None) -> None:
+        super().__init__()
+        self.internal_usage_cache: Final = internal_usage_cache
+        self.max_scan_members: Final = (
+            max_scan_members if max_scan_members is not None else self.DEFAULT_MAX_SCAN_MEMBERS
+        )
+        self._local_tasks: dict[str, asyncio.Task[object]] = {}  # mutable-ok: per-process handles for cancellation
+        self._cancel_watcher: asyncio.Task[None] | None = None  # rebind-ok: started lazily on first registration
+
+    @staticmethod
+    def _general_settings() -> Mapping[str, object]:
+        from litellm.proxy.proxy_server import general_settings
+
+        return general_settings
+
+    @property
+    def ttl_seconds(self) -> int:
+        """Read at call time, since general_settings is loaded after the hooks are built."""
+        raw: Final = self._general_settings().get(TTL_SETTING)
+        if raw is None:
+            return self.DEFAULT_TTL_SECONDS
+        try:
+            configured: Final = int(str(raw))
+        except ValueError:
+            verbose_proxy_logger.warning("Invalid general_settings.%s; using %s", TTL_SETTING, self.DEFAULT_TTL_SECONDS)
+            return self.DEFAULT_TTL_SECONDS
+        return min(max(configured, MIN_TTL_SECONDS), self.MAX_TTL_SECONDS)
+
+    def _redis_cache(self) -> "RedisCache | None":
+        return self.internal_usage_cache.dual_cache.redis_cache
+
+    @classmethod
+    def _include_user_email(cls) -> bool:
+        return cls._general_settings().get(INCLUDE_USER_EMAIL_SETTING) is True
+
+    @classmethod
+    def _safe_string(cls, value: object, max_length: int | None = None) -> str | None:
+        if value is None or isinstance(value, (dict, list, tuple, set)):
+            return None
+        normalized: Final = str(value).strip()
+        if not normalized:
+            return None
+        return normalized[: max_length or cls.MAX_FIELD_LENGTH]
+
+    @classmethod
+    def _mapping_value(cls, source: object, names: Sequence[str]) -> str | None:
+        if not isinstance(source, dict):
+            return None
+        candidates: Final = (cls._safe_string(source.get(name)) for name in names)
+        return next((value for value in candidates if value is not None), None)
+
+    @staticmethod
+    def _metadata_sources(auth: UserAPIKeyAuth) -> tuple[object, ...]:
+        return (auth.metadata, auth.project_metadata, auth.organization_metadata, auth.team_metadata)
+
+    @classmethod
+    def _metadata_value(cls, auth: UserAPIKeyAuth, names: Sequence[str]) -> str | None:
+        candidates: Final = (cls._mapping_value(source, names) for source in cls._metadata_sources(auth))
+        return next((value for value in candidates if value is not None), None)
+
+    @staticmethod
+    def _key_fingerprint(api_key: str | None) -> str | None:
+        """Correlate requests from one key without exposing the credential itself.
+
+        Virtual keys reach here already hashed, but custom auth can return the raw
+        credential, so this hashes unconditionally rather than slicing a prefix.
+        """
+        if not api_key:
+            return None
+        return hashlib.sha256(api_key.encode()).hexdigest()[:12]
+
+    @classmethod
+    def build_record(
+        cls,
+        data: Mapping[str, object],
+        auth: UserAPIKeyAuth,
+        call_type: CallTypesLiteral,
+        started_at: float | None = None,
+        registry_id: str = "",
+    ) -> ActiveRequestRecord:
+        return ActiveRequestRecord(
+            registry_id=registry_id,
+            request_id=cls._safe_string(data.get("litellm_call_id")) or "",
+            started_at=started_at if started_at is not None else time.time(),
+            model=cls._safe_string(data.get("model")),
+            call_type=cls._safe_string(call_type),
+            streaming=bool(data.get("stream", False)),
+            route=cls._safe_string(auth.request_route),
+            user_id=cls._safe_string(auth.user_id),
+            user_email=cls._safe_string(auth.user_email) if cls._include_user_email() else None,
+            end_user_id=cls._safe_string(auth.end_user_id)
+            or cls._metadata_value(auth, ("user_api_key_end_user_id", "end_user_id")),
+            organization_id=cls._safe_string(auth.org_id),
+            organization_alias=cls._mapping_value(
+                auth.organization_metadata, ("organization_alias", "organization_name")
+            ),
+            project_id=cls._safe_string(auth.project_id),
+            project_alias=cls._mapping_value(auth.project_metadata, ("project_alias", "project_name")),
+            team_id=cls._safe_string(auth.team_id),
+            team_alias=cls._safe_string(auth.team_alias),
+            key_alias=cls._safe_string(auth.key_alias),
+            key_fingerprint=cls._key_fingerprint(auth.api_key),
+            pod=cls._safe_string(os.getenv("HOSTNAME"), max_length=253),
+        )
+
+    def _index_key(self, redis_cache: "RedisCache") -> str:
+        return redis_cache.check_and_fix_namespace(self.INDEX_KEY)
+
+    def _item_key(self, redis_cache: "RedisCache", registry_id: str) -> str:
+        return redis_cache.check_and_fix_namespace(f"{self.ITEM_KEY_PREFIX}{registry_id}")
+
+    async def register(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        data: Mapping[str, object],
+        call_type: CallTypesLiteral,
+        registry_id: str | None = None,
+        started_at: float | None = None,
+    ) -> str | None:
+        redis_cache: Final = self._redis_cache()
+        if not data.get("litellm_call_id") or redis_cache is None:
+            return None
+
+        resolved_id: Final = registry_id if registry_id is not None else secrets.token_hex(16)
+        try:
+            client: Final = redis_cache.init_async_client()
+            record: Final = self.build_record(
+                data, user_api_key_dict, call_type, started_at=started_at, registry_id=resolved_id
+            )
+            async with client.pipeline(transaction=False) as pipe:
+                pipe.set(self._item_key(redis_cache, resolved_id), json.dumps(record), ex=self.ttl_seconds)
+                pipe.zadd(
+                    self._index_key(redis_cache),
+                    {resolved_id: record["started_at"]},  # mutable-ok: redis-py zadd takes a mapping
+                )
+                pipe.expire(self._index_key(redis_cache), self.ttl_seconds * 2)
+                await pipe.execute()
+        except Exception:  # noqa: BLE001  # observability must never fail a model request
+            verbose_proxy_logger.exception("Failed to register active request")
+            return None
+        self._track_locally(resolved_id)
+        return resolved_id
+
+    async def remove(self, registry_id: str | None) -> None:
+        redis_cache: Final = self._redis_cache()
+        if not registry_id or redis_cache is None:
+            return
+        try:
+            client: Final = redis_cache.init_async_client()
+            async with client.pipeline(transaction=False) as pipe:
+                pipe.delete(self._item_key(redis_cache, registry_id))
+                pipe.zrem(self._index_key(redis_cache), registry_id)
+                await pipe.execute()
+        except Exception:  # noqa: BLE001  # cleanup must never alter the HTTP response
+            verbose_proxy_logger.exception("Failed to remove active request")
+        self._local_tasks.pop(registry_id, None)
+
+    async def _read_members(
+        self,
+        client: "Redis | RedisCluster",
+        index_key: str,
+        start: int,
+        page_size: int,
+        has_filters: bool,
+    ) -> tuple[tuple[str, ...], bool]:
+        if not has_filters:
+            members: Final = await client.zrevrange(index_key, start, start + page_size - 1)
+            return tuple(_decode_member(member) for member in members), False
+
+        scanned: Final = await client.zrevrange(index_key, 0, self.max_scan_members - 1)
+        truncated: Final = len(scanned) >= self.max_scan_members
+        if truncated:
+            verbose_proxy_logger.warning(
+                "Active request index exceeds %s members; filtered results are truncated",
+                self.max_scan_members,
+            )
+        return tuple(_decode_member(member) for member in scanned), truncated
+
+    @staticmethod
+    async def _drop_stale(client: "Redis | RedisCluster", index_key: str, stale: Iterable[str]) -> None:
+        stale_members: Final = tuple(stale)
+        if stale_members:
+            await client.zrem(index_key, *stale_members)
+
+    def _track_locally(self, registry_id: str) -> None:
+        """Only the worker serving a request can cancel it, so it keeps the handle."""
+        task: Final = asyncio.current_task()
+        if task is not None:
+            self._local_tasks[registry_id] = task
+        self._ensure_cancel_watcher()
+
+    def _ensure_cancel_watcher(self) -> None:
+        if self._cancel_watcher is not None and not self._cancel_watcher.done():
+            return
+        if self._redis_cache() is None:
+            return
+        self._cancel_watcher = asyncio.create_task(self._watch_for_cancellations())
+
+    def _cancel_key(self, redis_cache: "RedisCache", registry_id: str) -> str:
+        return redis_cache.check_and_fix_namespace(f"{CANCEL_KEY_PREFIX}{registry_id}")
+
+    async def _watch_for_cancellations(self) -> None:
+        """Poll for cancellations of the requests this worker is serving.
+
+        Polling rather than pub/sub on purpose: REDIS_SOCKET_TIMEOUT defaults to
+        100ms, which kills a blocking subscription immediately.
+        """
+        while True:
+            await asyncio.sleep(CANCEL_POLL_SECONDS)
+            if not self._local_tasks:
+                return
+            try:
+                await self._cancel_flagged_requests()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001  # a failed poll must not take the worker down
+                verbose_proxy_logger.exception("Active request cancel watcher failed a poll")
+
+    async def _cancel_flagged_requests(self) -> None:
+        redis_cache: Final = self._redis_cache()
+        if redis_cache is None:
+            return
+        owned: Final = tuple(self._local_tasks)
+        client: Final = redis_cache.init_async_client()
+        flags: Final = await client.mget(tuple(self._cancel_key(redis_cache, rid) for rid in owned))
+        flagged: Final = tuple(rid for rid, flag in zip(owned, flags) if flag is not None)
+        for registry_id in flagged:
+            self._cancel_owned_task(registry_id)
+        if flagged:
+            await client.delete(*(self._cancel_key(redis_cache, rid) for rid in flagged))
+
+    def _cancel_owned_task(self, registry_id: str) -> None:
+        task: Final = self._local_tasks.get(registry_id)
+        if task is None or task.done():
+            return
+        verbose_proxy_logger.info("Cancelling active request %s on admin request", registry_id)
+        task.cancel()
+
+    async def request_cancel(self, registry_id: str) -> bool:
+        """Flag a request for cancellation by whichever worker is serving it.
+
+        A True here means the flag was written, not that the upstream call has
+        already unwound; the worker that owns the task does the cancelling.
+        """
+        redis_cache: Final = self._redis_cache()
+        if redis_cache is None:
+            return False
+        try:
+            client: Final = redis_cache.init_async_client()
+            known: Final = await client.zscore(self._index_key(redis_cache), registry_id)
+            if known is None:
+                return False
+            await client.set(self._cancel_key(redis_cache, registry_id), "1", ex=CANCEL_TTL_SECONDS)
+        except Exception:  # noqa: BLE001  # a failed cancel must not surface as a 500
+            verbose_proxy_logger.exception("Failed to flag an active request for cancellation")
+            return False
+        self._cancel_owned_task(registry_id)
+        return True
+
+    async def list_requests(
+        self,
+        *,
+        model: str | None = None,
+        user_id: str | None = None,
+        end_user_id: str | None = None,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> ActiveRequestsPage:
+        redis_cache: Final = self._redis_cache()
+        if redis_cache is None:
+            return ActiveRequestsPage(
+                available=False,
+                reason="Redis is not configured; cross-replica active requests are unavailable.",
+                items=(),
+                total=0,
+                page=page,
+                page_size=page_size,
+                truncated=False,
+            )
+
+        filters: Final = ActiveRequestFilters(
+            model=model,
+            user_id=user_id,
+            end_user_id=end_user_id,
+            organization_id=organization_id,
+            project_id=project_id,
+        )
+        has_filters: Final = any(value is not None for value in filters.values())
+        start: Final = (page - 1) * page_size
+
+        client: Final = redis_cache.init_async_client()
+        index_key: Final = self._index_key(redis_cache)
+        await client.zremrangebyscore(index_key, "-inf", time.time() - self.ttl_seconds)
+
+        indexed_total: Final = 0 if has_filters else await client.zcard(index_key)
+        members, truncated = await self._read_members(client, index_key, start, page_size, has_filters)
+        item_keys: Final = tuple(self._item_key(redis_cache, member) for member in members)
+        raw_items: Final = await client.mget(item_keys) if item_keys else ()
+
+        decoded: Final = tuple(zip(members, (_decode_record(raw_item) for raw_item in raw_items)))
+        await self._drop_stale(client, index_key, (member for member, record in decoded if record is None))
+
+        matching: Final = tuple(record for _, record in decoded if record is not None and _matches(record, filters))
+        stale_count: Final = sum(1 for _, record in decoded if record is None)
+
+        return ActiveRequestsPage(
+            available=True,
+            reason=None,
+            items=matching[start : start + page_size] if has_filters else matching,
+            total=len(matching) if has_filters else max(0, indexed_total - stale_count),
+            page=page,
+            page_size=page_size,
+            truncated=truncated,
+        )

--- a/litellm/proxy/hooks/active_request_registry.py
+++ b/litellm/proxy/hooks/active_request_registry.py
@@ -7,7 +7,9 @@ import os
 import secrets
 import time
 from collections.abc import Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, ClassVar, Final, TypedDict
+from typing import TYPE_CHECKING, ClassVar, Final, TypeAlias, TypedDict
+
+from typing_extensions import ReadOnly
 
 from litellm._logging import verbose_proxy_logger
 from litellm.integrations.custom_logger import CustomLogger
@@ -15,58 +17,81 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.utils import CallTypesLiteral
 
 if TYPE_CHECKING:
+    from fastapi import Request
     from redis.asyncio import Redis, RedisCluster
 
     from litellm.caching.redis_cache import RedisCache
-    from litellm.proxy.utils import InternalUsageCache
+    from litellm.proxy.utils import InternalUsageCache, ProxyLogging
 
 
 class ActiveRequestRecord(TypedDict):
-    registry_id: str
-    request_id: str
-    started_at: float
-    model: str | None
-    call_type: str | None
-    streaming: bool
-    route: str | None
-    user_id: str | None
-    user_email: str | None
-    end_user_id: str | None
-    organization_id: str | None
-    organization_alias: str | None
-    project_id: str | None
-    project_alias: str | None
-    team_id: str | None
-    team_alias: str | None
-    key_alias: str | None
-    key_fingerprint: str | None
-    pod: str | None
+    registry_id: ReadOnly[str]
+    request_id: ReadOnly[str]
+    started_at: ReadOnly[float]
+    model: ReadOnly[str | None]
+    call_type: ReadOnly[str | None]
+    streaming: ReadOnly[bool]
+    route: ReadOnly[str | None]
+    user_id: ReadOnly[str | None]
+    user_email: ReadOnly[str | None]
+    end_user_id: ReadOnly[str | None]
+    organization_id: ReadOnly[str | None]
+    organization_alias: ReadOnly[str | None]
+    project_id: ReadOnly[str | None]
+    project_alias: ReadOnly[str | None]
+    team_id: ReadOnly[str | None]
+    team_alias: ReadOnly[str | None]
+    key_alias: ReadOnly[str | None]
+    key_fingerprint: ReadOnly[str | None]
+    pod: ReadOnly[str | None]
+
+
+class ActiveRequestCall(TypedDict):
+    """The request fields a caller outside common_request_processing has to supply."""
+
+    litellm_call_id: ReadOnly[str]
+    model: ReadOnly[str]
+    stream: ReadOnly[bool]
 
 
 class ActiveRequestsPage(TypedDict):
-    available: bool
-    reason: str | None
-    items: tuple[ActiveRequestRecord, ...]
-    total: int
-    page: int
-    page_size: int
-    truncated: bool
+    available: ReadOnly[bool]
+    reason: ReadOnly[str | None]
+    items: ReadOnly[tuple[ActiveRequestRecord, ...]]
+    total: ReadOnly[int]
+    page: ReadOnly[int]
+    page_size: ReadOnly[int]
+    truncated: ReadOnly[bool]
 
 
 class ActiveRequestFilters(TypedDict):
-    model: str | None
-    user_id: str | None
-    end_user_id: str | None
-    organization_id: str | None
-    project_id: str | None
+    model: ReadOnly[str | None]
+    user_id: ReadOnly[str | None]
+    end_user_id: ReadOnly[str | None]
+    organization_id: ReadOnly[str | None]
+    project_id: ReadOnly[str | None]
+
+
+FilterCacheKey: TypeAlias = tuple[
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    int,
+    int,
+]
 
 
 MIN_TTL_SECONDS: Final = 300
 TTL_SETTING: Final = "active_request_ttl_seconds"
 INCLUDE_USER_EMAIL_SETTING: Final = "active_request_include_user_email"
-CANCEL_KEY_PREFIX: Final = "litellm:active_requests:cancel:"
+CANCEL_KEY_PREFIX: Final = "litellm:{active_requests}:cancel:"
 CANCEL_TTL_SECONDS: Final = 60
 CANCEL_POLL_SECONDS: Final = 1.0
+FILTER_CACHE_TTL_SECONDS: Final = 1.0
+FILTER_CACHE_MAX_ENTRIES: Final = 128
+WEBSOCKET_ROUTE_TYPES: Final = frozenset(("_arealtime", "_aresponses_websocket"))
 
 
 def _decode_member(value: bytes | str) -> str:
@@ -90,16 +115,49 @@ def _matches(record: ActiveRequestRecord, filters: ActiveRequestFilters) -> bool
     return all(expected is None or str(record.get(field) or "") == expected for field, expected in filters.items())
 
 
+async def register_http_request(
+    request: "Request",
+    user_api_key_dict: UserAPIKeyAuth,
+    proxy_logging_obj: "ProxyLogging",
+    data: Mapping[str, object],
+    call_type: CallTypesLiteral,
+) -> None:
+    if call_type in WEBSOCKET_ROUTE_TYPES:
+        return
+
+    hook: Final = proxy_logging_obj.get_proxy_hook("active_request_registry")
+    if not isinstance(hook, ActiveRequestRegistry):
+        return
+
+    # request.state is how the response lifecycle gets the record: the middleware
+    # reads these back out of scope["state"] to deregister the request.
+    request.state.active_request_registry = hook  # rebind-ok: handover to the middleware
+    started_at: Final = getattr(request.state, "active_request_started_at", time.time())
+    request.state.active_request_started_at = started_at  # rebind-ok: handover to the middleware
+    registry_id: Final = await hook.register(
+        user_api_key_dict=user_api_key_dict,
+        data=data,
+        call_type=call_type,
+        registry_id=getattr(request.state, "active_request_registry_id", None),
+        started_at=started_at,
+    )
+    if registry_id is not None:
+        request.state.active_request_registry_id = registry_id  # rebind-ok: handover to the middleware
+
+
 class ActiveRequestRegistry(CustomLogger):
     """Track live requests across proxy replicas without retaining request content."""
 
     register_as_litellm_callback: ClassVar[bool] = False
-    INDEX_KEY: ClassVar[str] = "litellm:active_requests:index"
-    ITEM_KEY_PREFIX: ClassVar[str] = "litellm:active_requests:item:"
+    # The {} is a Redis Cluster hash tag, not a format placeholder: index, items and
+    # cancel flags have to share a slot for MGET and multi-key DEL to be routable.
+    INDEX_KEY: ClassVar[str] = "litellm:{active_requests}:index"
+    ITEM_KEY_PREFIX: ClassVar[str] = "litellm:{active_requests}:item:"
     DEFAULT_TTL_SECONDS: ClassVar[int] = 1800
     MAX_TTL_SECONDS: ClassVar[int] = 86400
     MAX_FIELD_LENGTH: ClassVar[int] = 512
     DEFAULT_MAX_SCAN_MEMBERS: ClassVar[int] = 5000
+    MAX_PAGE_REFILLS: ClassVar[int] = 2
 
     def __init__(self, internal_usage_cache: "InternalUsageCache", max_scan_members: int | None = None) -> None:
         super().__init__()
@@ -109,6 +167,7 @@ class ActiveRequestRegistry(CustomLogger):
         )
         self._local_tasks: dict[str, asyncio.Task[object]] = {}  # mutable-ok: per-process handles for cancellation
         self._cancel_watcher: asyncio.Task[None] | None = None  # rebind-ok: started lazily on first registration
+        self._filtered_cache: dict[FilterCacheKey, tuple[float, ActiveRequestsPage]] = {}  # mutable-ok: bounded cache
 
     @staticmethod
     def _general_settings() -> Mapping[str, object]:
@@ -162,15 +221,23 @@ class ActiveRequestRegistry(CustomLogger):
         return next((value for value in candidates if value is not None), None)
 
     @staticmethod
-    def _key_fingerprint(api_key: str | None) -> str | None:
+    def _fingerprint_salt() -> str:
+        """Salt the fingerprint with the master key, which every replica shares."""
+        from litellm.proxy.proxy_server import master_key
+
+        return master_key or ""
+
+    @classmethod
+    def _key_fingerprint(cls, api_key: str | None) -> str | None:
         """Correlate requests from one key without exposing the credential itself.
 
         Virtual keys reach here already hashed, but custom auth can return the raw
-        credential, so this hashes unconditionally rather than slicing a prefix.
+        credential, so this hashes unconditionally rather than slicing a prefix. The
+        salt keeps a short fingerprint from being verifiable offline against a guess.
         """
         if not api_key:
             return None
-        return hashlib.sha256(api_key.encode()).hexdigest()[:12]
+        return hashlib.sha256(f"{cls._fingerprint_salt()}:{api_key}".encode()).hexdigest()[:12]
 
     @classmethod
     def build_record(
@@ -181,6 +248,7 @@ class ActiveRequestRegistry(CustomLogger):
         started_at: float | None = None,
         registry_id: str = "",
     ) -> ActiveRequestRecord:
+        user_id: Final = cls._safe_string(auth.user_id)
         return ActiveRequestRecord(
             registry_id=registry_id,
             request_id=cls._safe_string(data.get("litellm_call_id")) or "",
@@ -189,7 +257,7 @@ class ActiveRequestRegistry(CustomLogger):
             call_type=cls._safe_string(call_type),
             streaming=bool(data.get("stream", False)),
             route=cls._safe_string(auth.request_route),
-            user_id=cls._safe_string(auth.user_id),
+            user_id=user_id,
             user_email=cls._safe_string(auth.user_email) if cls._include_user_email() else None,
             end_user_id=cls._safe_string(auth.end_user_id)
             or cls._metadata_value(auth, ("user_api_key_end_user_id", "end_user_id")),
@@ -220,12 +288,14 @@ class ActiveRequestRegistry(CustomLogger):
         registry_id: str | None = None,
         started_at: float | None = None,
     ) -> str | None:
-        redis_cache: Final = self._redis_cache()
-        if not data.get("litellm_call_id") or redis_cache is None:
+        if not data.get("litellm_call_id"):
             return None
 
         resolved_id: Final = registry_id if registry_id is not None else secrets.token_hex(16)
         try:
+            redis_cache: Final = self._redis_cache()
+            if redis_cache is None:
+                return None
             client: Final = redis_cache.init_async_client()
             record: Final = self.build_record(
                 data, user_api_key_dict, call_type, started_at=started_at, registry_id=resolved_id
@@ -238,46 +308,46 @@ class ActiveRequestRegistry(CustomLogger):
                 )
                 pipe.expire(self._index_key(redis_cache), self.ttl_seconds * 2)
                 await pipe.execute()
+            self._filtered_cache.clear()
+            self._track_locally(resolved_id)
+            return resolved_id
         except Exception:  # noqa: BLE001  # observability must never fail a model request
             verbose_proxy_logger.exception("Failed to register active request")
             return None
-        self._track_locally(resolved_id)
-        return resolved_id
 
     async def remove(self, registry_id: str | None) -> None:
-        redis_cache: Final = self._redis_cache()
-        if not registry_id or redis_cache is None:
+        if not registry_id:
             return
         try:
-            client: Final = redis_cache.init_async_client()
-            async with client.pipeline(transaction=False) as pipe:
-                pipe.delete(self._item_key(redis_cache, registry_id))
-                pipe.zrem(self._index_key(redis_cache), registry_id)
-                await pipe.execute()
+            redis_cache: Final = self._redis_cache()
+            if redis_cache is not None:
+                client: Final = redis_cache.init_async_client()
+                async with client.pipeline(transaction=False) as pipe:
+                    pipe.delete(self._item_key(redis_cache, registry_id))
+                    pipe.zrem(self._index_key(redis_cache), registry_id)
+                    await pipe.execute()
         except Exception:  # noqa: BLE001  # cleanup must never alter the HTTP response
             verbose_proxy_logger.exception("Failed to remove active request")
-        self._local_tasks.pop(registry_id, None)
+        finally:
+            # Outside the try: a handle left behind keeps the cancel watcher polling
+            # for the rest of the pod's life.
+            self._local_tasks.pop(registry_id, None)
+            self._filtered_cache.clear()
 
-    async def _read_members(
+    async def _read_records(
         self,
         client: "Redis | RedisCluster",
+        redis_cache: "RedisCache",
         index_key: str,
-        start: int,
-        page_size: int,
-        has_filters: bool,
-    ) -> tuple[tuple[str, ...], bool]:
-        if not has_filters:
-            members: Final = await client.zrevrange(index_key, start, start + page_size - 1)
-            return tuple(_decode_member(member) for member in members), False
-
-        scanned: Final = await client.zrevrange(index_key, 0, self.max_scan_members - 1)
-        truncated: Final = len(scanned) >= self.max_scan_members
-        if truncated:
-            verbose_proxy_logger.warning(
-                "Active request index exceeds %s members; filtered results are truncated",
-                self.max_scan_members,
-            )
-        return tuple(_decode_member(member) for member in scanned), truncated
+        members: Sequence[str],
+    ) -> tuple[ActiveRequestRecord, ...]:
+        """Read the records for these index members, dropping the ones that expired."""
+        if not members:
+            return ()
+        raw_items: Final = await client.mget(tuple(self._item_key(redis_cache, member) for member in members))
+        decoded: Final = tuple(zip(members, (_decode_record(raw_item) for raw_item in raw_items)))
+        await self._drop_stale(client, index_key, (member for member, record in decoded if record is None))
+        return tuple(record for _, record in decoded if record is not None)
 
     @staticmethod
     async def _drop_stale(client: "Redis | RedisCluster", index_key: str, stale: Iterable[str]) -> None:
@@ -314,8 +384,6 @@ class ActiveRequestRegistry(CustomLogger):
                 return
             try:
                 await self._cancel_flagged_requests()
-            except asyncio.CancelledError:
-                raise
             except Exception:  # noqa: BLE001  # a failed poll must not take the worker down
                 verbose_proxy_logger.exception("Active request cancel watcher failed a poll")
 
@@ -345,10 +413,10 @@ class ActiveRequestRegistry(CustomLogger):
         A True here means the flag was written, not that the upstream call has
         already unwound; the worker that owns the task does the cancelling.
         """
-        redis_cache: Final = self._redis_cache()
-        if redis_cache is None:
-            return False
         try:
+            redis_cache: Final = self._redis_cache()
+            if redis_cache is None:
+                return False
             client: Final = redis_cache.init_async_client()
             known: Final = await client.zscore(self._index_key(redis_cache), registry_id)
             if known is None:
@@ -390,30 +458,103 @@ class ActiveRequestRegistry(CustomLogger):
             organization_id=organization_id,
             project_id=project_id,
         )
-        has_filters: Final = any(value is not None for value in filters.values())
-        start: Final = (page - 1) * page_size
-
         client: Final = redis_cache.init_async_client()
         index_key: Final = self._index_key(redis_cache)
         await client.zremrangebyscore(index_key, "-inf", time.time() - self.ttl_seconds)
 
-        indexed_total: Final = 0 if has_filters else await client.zcard(index_key)
-        members, truncated = await self._read_members(client, index_key, start, page_size, has_filters)
-        item_keys: Final = tuple(self._item_key(redis_cache, member) for member in members)
-        raw_items: Final = await client.mget(item_keys) if item_keys else ()
+        if any(value is not None for value in filters.values()):
+            return await self._list_filtered(client, redis_cache, index_key, filters, page, page_size)
+        return await self._list_page(client, redis_cache, index_key, page, page_size)
 
-        decoded: Final = tuple(zip(members, (_decode_record(raw_item) for raw_item in raw_items)))
-        await self._drop_stale(client, index_key, (member for member, record in decoded if record is None))
+    async def _list_filtered(
+        self,
+        client: "Redis | RedisCluster",
+        redis_cache: "RedisCache",
+        index_key: str,
+        filters: ActiveRequestFilters,
+        page: int,
+        page_size: int,
+    ) -> ActiveRequestsPage:
+        """Filtering happens here rather than in Redis, so the scan is capped."""
+        cache_key: Final = (
+            filters["model"],
+            filters["user_id"],
+            filters["end_user_id"],
+            filters["organization_id"],
+            filters["project_id"],
+            page,
+            page_size,
+        )
+        cached: Final = self._filtered_cache.get(cache_key)
+        now: Final = time.monotonic()
+        if cached is not None and now - cached[0] < FILTER_CACHE_TTL_SECONDS:
+            return cached[1]
 
-        matching: Final = tuple(record for _, record in decoded if record is not None and _matches(record, filters))
-        stale_count: Final = sum(1 for _, record in decoded if record is None)
-
-        return ActiveRequestsPage(
+        scanned: Final = await client.zrevrange(index_key, 0, self.max_scan_members - 1)
+        truncated: Final = len(scanned) >= self.max_scan_members
+        if truncated:
+            verbose_proxy_logger.warning(
+                "Active request index exceeds %s members; filtered results are truncated",
+                self.max_scan_members,
+            )
+        records: Final = await self._read_records(
+            client, redis_cache, index_key, tuple(_decode_member(member) for member in scanned)
+        )
+        matching: Final = tuple(record for record in records if _matches(record, filters))
+        start: Final = (page - 1) * page_size
+        result: Final = ActiveRequestsPage(
             available=True,
             reason=None,
-            items=matching[start : start + page_size] if has_filters else matching,
-            total=len(matching) if has_filters else max(0, indexed_total - stale_count),
+            items=matching[start : start + page_size],
+            total=len(matching),
             page=page,
             page_size=page_size,
             truncated=truncated,
+        )
+        if len(self._filtered_cache) >= FILTER_CACHE_MAX_ENTRIES:
+            self._filtered_cache.clear()
+        self._filtered_cache[cache_key] = (now, result)
+        return result
+
+    async def _list_page(
+        self,
+        client: "Redis | RedisCluster",
+        redis_cache: "RedisCache",
+        index_key: str,
+        page: int,
+        page_size: int,
+    ) -> ActiveRequestsPage:
+        items: Final = await self._read_live_slice(
+            client, redis_cache, index_key, (page - 1) * page_size, page_size, self.MAX_PAGE_REFILLS
+        )
+        return ActiveRequestsPage(
+            available=True,
+            reason=None,
+            items=items,
+            # Counted after the stale members are gone, so the total cannot claim
+            # requests that the page could not show.
+            total=await client.zcard(index_key),
+            page=page,
+            page_size=page_size,
+            truncated=False,
+        )
+
+    async def _read_live_slice(
+        self,
+        client: "Redis | RedisCluster",
+        redis_cache: "RedisCache",
+        index_key: str,
+        start: int,
+        page_size: int,
+        refills_left: int,
+    ) -> tuple[ActiveRequestRecord, ...]:
+        raw_members: Final = await client.zrevrange(index_key, start, start + page_size - 1)
+        members: Final = tuple(_decode_member(member) for member in raw_members)
+        records: Final = await self._read_records(client, redis_cache, index_key, members)
+        if len(records) == len(members) or len(records) >= page_size or refills_left == 0:
+            return records
+        # _read_records dropped the stale members, so the next unread one moved up
+        # into the position right behind the ones that survived.
+        return records + await self._read_live_slice(
+            client, redis_cache, index_key, start + len(records), page_size - len(records), refills_left - 1
         )

--- a/litellm/proxy/management_endpoints/active_request_endpoints.py
+++ b/litellm/proxy/management_endpoints/active_request_endpoints.py
@@ -42,7 +42,7 @@ class ActiveRequestRecord(BaseModel):
     team_id: str | None = None
     team_alias: str | None = None
     key_alias: str | None = None
-    key_fingerprint: str | None = None
+    key_hash: str | None = None
     pod: str | None = None
 
 

--- a/litellm/proxy/management_endpoints/active_request_endpoints.py
+++ b/litellm/proxy/management_endpoints/active_request_endpoints.py
@@ -1,0 +1,137 @@
+"""Admin API for inspecting requests currently running on the proxy."""
+
+from datetime import datetime, timezone
+from typing import Final
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from pydantic import BaseModel
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.hooks.active_request_registry import ActiveRequestRegistry
+
+router: Final = APIRouter()
+
+USER_API_KEY_AUTH: Final = Depends(user_api_key_auth)
+ADMIN_ROLES: Final = frozenset((LitellmUserRoles.PROXY_ADMIN, LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY))
+
+
+def _get_active_request_registry() -> ActiveRequestRegistry | None:
+    from litellm.proxy.proxy_server import proxy_logging_obj
+
+    hook: Final = proxy_logging_obj.get_proxy_hook("active_request_registry")
+    return hook if isinstance(hook, ActiveRequestRegistry) else None
+
+
+class ActiveRequestRecord(BaseModel):
+    registry_id: str
+    request_id: str
+    started_at: float
+    model: str | None = None
+    call_type: str | None = None
+    streaming: bool = False
+    route: str | None = None
+    user_id: str | None = None
+    user_email: str | None = None
+    end_user_id: str | None = None
+    organization_id: str | None = None
+    organization_alias: str | None = None
+    project_id: str | None = None
+    project_alias: str | None = None
+    team_id: str | None = None
+    team_alias: str | None = None
+    key_alias: str | None = None
+    key_fingerprint: str | None = None
+    pod: str | None = None
+
+
+class ActiveRequestsResponse(BaseModel):
+    available: bool
+    reason: str | None = None
+    items: tuple[ActiveRequestRecord, ...]
+    total: int
+    page: int
+    page_size: int
+    truncated: bool = False
+    generated_at: datetime
+
+
+@router.get(
+    "/global/active_requests",
+    response_model=ActiveRequestsResponse,
+    tags=["Active Requests"],  # mutable-ok: FastAPI types tags as a list
+    dependencies=[USER_API_KEY_AUTH],  # mutable-ok: FastAPI types dependencies as a list
+)
+async def get_active_requests(
+    response: Response,
+    model: str | None = None,
+    user_id: str | None = None,
+    end_user_id: str | None = None,
+    organization_id: str | None = None,
+    project_id: str | None = None,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=50, ge=1, le=100),
+    user_api_key_dict: UserAPIKeyAuth = USER_API_KEY_AUTH,
+) -> ActiveRequestsResponse:
+    response.headers["Cache-Control"] = "no-store, max-age=0"  # rebind-ok: FastAPI injects the Response
+    response.headers["Pragma"] = "no-cache"  # rebind-ok: FastAPI injects the Response
+    if user_api_key_dict.user_role not in ADMIN_ROLES:
+        raise HTTPException(
+            status_code=403,
+            detail="Only proxy administrators can view global active requests",
+        )
+
+    registry: Final = _get_active_request_registry()
+    if registry is None:
+        raise HTTPException(status_code=503, detail="Active request registry is unavailable")
+
+    try:
+        result: Final = await registry.list_requests(
+            model=model,
+            user_id=user_id,
+            end_user_id=end_user_id,
+            organization_id=organization_id,
+            project_id=project_id,
+            page=page,
+            page_size=page_size,
+        )
+    except Exception as exc:
+        verbose_proxy_logger.exception("Failed to list active requests")
+        raise HTTPException(status_code=503, detail="Unable to read the active request registry") from exc
+
+    return ActiveRequestsResponse(
+        **result,
+        generated_at=datetime.now(timezone.utc),
+    )
+
+
+class CancelActiveRequestResponse(BaseModel):
+    cancelled: bool
+    detail: str
+
+
+@router.post(
+    "/global/active_requests/{registry_id}/cancel",
+    response_model=CancelActiveRequestResponse,
+    tags=["Active Requests"],  # mutable-ok: FastAPI types tags as a list
+    dependencies=[USER_API_KEY_AUTH],  # mutable-ok: FastAPI types dependencies as a list
+)
+async def cancel_active_request(
+    registry_id: str,
+    user_api_key_dict: UserAPIKeyAuth = USER_API_KEY_AUTH,
+) -> CancelActiveRequestResponse:
+    if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+        raise HTTPException(status_code=403, detail="Only proxy administrators can cancel active requests")
+
+    registry: Final = _get_active_request_registry()
+    if registry is None:
+        raise HTTPException(status_code=503, detail="Active request registry is unavailable")
+
+    cancelled: Final = await registry.request_cancel(registry_id)
+    if not cancelled:
+        raise HTTPException(status_code=404, detail="That request is no longer running")
+    return CancelActiveRequestResponse(
+        cancelled=True,
+        detail="Cancellation sent to the worker serving the request",
+    )

--- a/litellm/proxy/middleware/in_flight_requests_middleware.py
+++ b/litellm/proxy/middleware/in_flight_requests_middleware.py
@@ -6,9 +6,13 @@ Prometheus gauge `litellm_in_flight_requests`.
 """
 
 import os
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Any, Final
 
 from starlette.types import ASGIApp, Receive, Scope, Send
+
+EMPTY_STATE: Final[Mapping[str, object]] = MappingProxyType({})  # mutable-ok: MappingProxyType needs a dict to wrap
 
 
 class InFlightRequestsMiddleware:
@@ -45,6 +49,10 @@ class InFlightRequestsMiddleware:
         try:
             await self.app(scope, receive, send)
         finally:
+            state: Final = scope.get("state", EMPTY_STATE)
+            registry: Final = state.get("active_request_registry")
+            if registry is not None:
+                await registry.remove(state.get("active_request_registry_id"))
             InFlightRequestsMiddleware._in_flight -= 1
             if gauge is not None:
                 gauge.dec()

--- a/litellm/proxy/middleware/in_flight_requests_middleware.py
+++ b/litellm/proxy/middleware/in_flight_requests_middleware.py
@@ -12,6 +12,8 @@ from typing import Any, Final
 
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from litellm._logging import verbose_proxy_logger
+
 EMPTY_STATE: Final[Mapping[str, object]] = MappingProxyType({})  # mutable-ok: MappingProxyType needs a dict to wrap
 
 
@@ -51,11 +53,15 @@ class InFlightRequestsMiddleware:
         finally:
             state: Final = scope.get("state", EMPTY_STATE)
             registry: Final = state.get("active_request_registry")
-            if registry is not None:
-                await registry.remove(state.get("active_request_registry_id"))
-            InFlightRequestsMiddleware._in_flight -= 1
-            if gauge is not None:
-                gauge.dec()
+            try:
+                if registry is not None:
+                    await registry.remove(state.get("active_request_registry_id"))
+            except BaseException:  # noqa: BLE001  # not Exception: CancelledError must still hit the finally below
+                verbose_proxy_logger.exception("Failed to deregister an active request")
+            finally:
+                InFlightRequestsMiddleware._in_flight -= 1
+                if gauge is not None:
+                    gauge.dec()
 
     @staticmethod
     def get_count() -> int:

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -9,6 +9,7 @@ Use litellm with Anthropic SDK, Vertex AI SDK, Cohere SDK, etc.
 import json
 import os
 import re
+import uuid
 from types import MappingProxyType
 from typing import Annotated, Any, Final, cast
 
@@ -99,6 +100,36 @@ def is_passthrough_request_streaming(request_body: object) -> bool:
     if not isinstance(request_body, dict):
         return False
     return bool(request_body.get("stream", False))
+
+
+async def _register_router_passthrough(
+    request: Request,
+    user_api_key_dict: UserAPIKeyAuth,
+    model: str | None,
+    stream: bool,
+) -> str:
+    """Register the router branch, which returns without ever reaching pass_through_request.
+
+    Returns the call id it registered under, so the caller can hand the same one to the
+    router and keep the active request row and the log entry on a single id.
+    """
+    from litellm.proxy.hooks.active_request_registry import ActiveRequestCall, register_http_request
+    from litellm.proxy.proxy_server import proxy_logging_obj
+
+    litellm_call_id: Final[str] = request.headers.get("x-litellm-call-id") or str(uuid.uuid4())
+    call_data: Final[ActiveRequestCall] = {
+        "litellm_call_id": litellm_call_id,
+        "model": model or "unknown",
+        "stream": stream,
+    }
+    await register_http_request(
+        request=request,
+        user_api_key_dict=user_api_key_dict,
+        proxy_logging_obj=proxy_logging_obj,
+        data=call_data,
+        call_type="allm_passthrough_route",
+    )
+    return litellm_call_id
 
 
 async def llm_passthrough_factory_proxy_route(
@@ -325,6 +356,12 @@ async def vllm_proxy_route(
     is_router_model: Final = is_passthrough_request_using_router_model(request_body, llm_router)
     is_streaming_request: Final = is_passthrough_request_streaming(request_body)
     if is_router_model and llm_router:
+        litellm_call_id: Final = await _register_router_passthrough(
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+            model=request_body.get("model"),
+            stream=bool(is_streaming_request),
+        )
         result: Final = cast(
             httpx.Response,
             await llm_router.allm_passthrough_route(
@@ -341,6 +378,7 @@ async def vllm_proxy_route(
                 params=None,
                 headers=None,
                 cookies=None,
+                litellm_call_id=litellm_call_id,
             ),
         )
 
@@ -1441,6 +1479,12 @@ async def azure_proxy_route(
             if is_router_model:
                 request_body = await get_request_body(request)
                 is_streaming_request = is_passthrough_request_streaming(request_body)
+                azure_litellm_call_id = await _register_router_passthrough(
+                    request=request,
+                    user_api_key_dict=user_api_key_dict,
+                    model=part,
+                    stream=bool(is_streaming_request),
+                )
                 result = await llm_router.allm_passthrough_route(
                     model=part,
                     method=request.method,
@@ -1455,6 +1499,7 @@ async def azure_proxy_route(
                     params=None,
                     headers=None,
                     cookies=None,
+                    litellm_call_id=azure_litellm_call_id,
                 )
 
                 if is_streaming_request:

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -66,6 +66,7 @@ from litellm.proxy.common_utils.http_parsing_utils import (
     _read_request_body,
     _safe_get_request_headers,
 )
+from litellm.proxy.hooks.active_request_registry import ActiveRequestCall, register_http_request
 from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 from litellm.proxy.utils import normalize_route_for_root_path
 from litellm.repositories.team_repository import TeamRepository
@@ -892,6 +893,18 @@ async def pass_through_request(
         # Surface the requested model (when the body carries one) so logging/spans
         # read e.g. ``chat gpt-4o`` instead of ``chat unknown``.
         passthrough_model: Final = (_parsed_body.get("model") if isinstance(_parsed_body, dict) else None) or "unknown"
+        active_request_call: Final[ActiveRequestCall] = {
+            "litellm_call_id": litellm_call_id,
+            "model": passthrough_model,
+            "stream": bool(stream),
+        }
+        await register_http_request(
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+            proxy_logging_obj=proxy_logging_obj,
+            data=active_request_call,
+            call_type="pass_through_endpoint",
+        )
         start_time: Final = datetime.now()
         logging_obj = Logging(
             model=passthrough_model,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -408,6 +408,9 @@ from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
 from litellm.proxy.logging_endpoints.callback_logs_endpoints import (
     rust_control_plane_router,
 )
+from litellm.proxy.management_endpoints.active_request_endpoints import (
+    router as active_request_router,
+)
 from litellm.proxy.management_endpoints.auto_router_endpoints import (
     router as auto_router_management_router,
 )
@@ -17223,6 +17226,7 @@ app.include_router(rust_control_plane_router)
 app.include_router(ui_crud_endpoints_router)
 app.include_router(user_banner_endpoints_router)
 app.include_router(team_callback_router)
+app.include_router(active_request_router)
 app.include_router(budget_management_router)
 app.include_router(model_management_router)
 app.include_router(model_access_group_management_router)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -384,6 +384,9 @@ from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
 from litellm.proxy.logging_endpoints.callback_logs_endpoints import (
     rust_control_plane_router,
 )
+from litellm.proxy.management_endpoints.active_request_endpoints import (
+    router as active_request_router,
+)
 from litellm.proxy.management_endpoints.auto_router_endpoints import (
     router as auto_router_management_router,
 )
@@ -16514,6 +16517,7 @@ app.include_router(rust_control_plane_router)
 app.include_router(ui_crud_endpoints_router)
 app.include_router(user_banner_endpoints_router)
 app.include_router(team_callback_router)
+app.include_router(active_request_router)
 app.include_router(budget_management_router)
 app.include_router(model_management_router)
 app.include_router(model_access_group_management_router)

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -612,7 +612,8 @@ class ProxyLogging:
             if "prisma_client" in expected_args:
                 passed_in_args["prisma_client"] = prisma_client
             proxy_hook_obj = cast(CustomLogger, proxy_hook(**passed_in_args))
-            litellm.logging_callback_manager.add_litellm_callback(proxy_hook_obj)
+            if getattr(proxy_hook_obj, "register_as_litellm_callback", True):
+                litellm.logging_callback_manager.add_litellm_callback(proxy_hook_obj)
 
             self.proxy_hook_mapping[hook] = proxy_hook_obj
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -549,7 +549,8 @@ class ProxyLogging:
             if "prisma_client" in expected_args:
                 passed_in_args["prisma_client"] = prisma_client
             proxy_hook_obj = cast(CustomLogger, proxy_hook(**passed_in_args))
-            litellm.logging_callback_manager.add_litellm_callback(proxy_hook_obj)
+            if getattr(proxy_hook_obj, "register_as_litellm_callback", True):
+                litellm.logging_callback_manager.add_litellm_callback(proxy_hook_obj)
 
             self.proxy_hook_mapping[hook] = proxy_hook_obj
 

--- a/tests/e2e/ui/fixtures/migratedPages.ts
+++ b/tests/e2e/ui/fixtures/migratedPages.ts
@@ -18,6 +18,7 @@ export const MIGRATED_E2E_PAGES: Record<string, string> = {
   projects: "projects",
   "access-groups": "access-groups",
   budgets: "budgets",
+  "active-requests": "active-requests",
   workflows: "workflows",
   "guardrails-monitor": "guardrails-monitor",
   "mcp-servers": "mcp-servers",
@@ -47,4 +48,6 @@ export const MIGRATED_E2E_PAGES: Record<string, string> = {
   organizations: "organizations",
 };
 
-export const MIGRATED_E2E_SEGMENTS: string[] = [...new Set(Object.values(MIGRATED_E2E_PAGES))];
+export const MIGRATED_E2E_SEGMENTS: string[] = [
+  ...new Set(Object.values(MIGRATED_E2E_PAGES)),
+];

--- a/tests/e2e/ui/fixtures/mock_llm_server/server.py
+++ b/tests/e2e/ui/fixtures/mock_llm_server/server.py
@@ -5,7 +5,9 @@ Responds to OpenAI-format endpoints with canned responses.
 
 import os
 import time
+import asyncio
 import json
+import re
 import uuid
 
 import uvicorn
@@ -40,12 +42,33 @@ async def list_models():
     }
 
 
+HOLD_MARKER = re.compile(r"e2e-hold-(\d+)s")
+
+
+def _hold_seconds(body: dict) -> float:
+    """Let a test keep a request in flight by putting `e2e-hold-<n>s` in the prompt.
+
+    The active-requests page only shows requests that have not finished, so a
+    browser test needs a completion that is still running while it asserts.
+    """
+    messages = body.get("messages") or []
+    for message in reversed(messages):
+        content = message.get("content")
+        match = HOLD_MARKER.search(content) if isinstance(content, str) else None
+        if match:
+            return min(float(match.group(1)), 60.0)
+    return 0.0
+
+
 @app.post("/v1/chat/completions")
 @app.post("/chat/completions")
 async def chat_completions(request: Request):
     body = await request.json()
     model = body.get("model", "mock-model")
     stream = body.get("stream", False)
+    hold_seconds = _hold_seconds(body)
+    if hold_seconds:
+        await asyncio.sleep(hold_seconds)
 
     response_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
     created = int(time.time())

--- a/tests/e2e/ui/fixtures/mock_llm_server/server.py
+++ b/tests/e2e/ui/fixtures/mock_llm_server/server.py
@@ -4,7 +4,9 @@ Responds to OpenAI-format endpoints with canned responses.
 """
 
 import time
+import asyncio
 import json
+import re
 import uuid
 
 import uvicorn
@@ -39,12 +41,33 @@ async def list_models():
     }
 
 
+HOLD_MARKER = re.compile(r"e2e-hold-(\d+)s")
+
+
+def _hold_seconds(body: dict) -> float:
+    """Let a test keep a request in flight by putting `e2e-hold-<n>s` in the prompt.
+
+    The active-requests page only shows requests that have not finished, so a
+    browser test needs a completion that is still running while it asserts.
+    """
+    messages = body.get("messages") or []
+    for message in reversed(messages):
+        content = message.get("content")
+        match = HOLD_MARKER.search(content) if isinstance(content, str) else None
+        if match:
+            return min(float(match.group(1)), 60.0)
+    return 0.0
+
+
 @app.post("/v1/chat/completions")
 @app.post("/chat/completions")
 async def chat_completions(request: Request):
     body = await request.json()
     model = body.get("model", "mock-model")
     stream = body.get("stream", False)
+    hold_seconds = _hold_seconds(body)
+    if hold_seconds:
+        await asyncio.sleep(hold_seconds)
 
     response_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
     created = int(time.time())

--- a/tests/e2e/ui/tests/proxy-admin/activeRequests.spec.ts
+++ b/tests/e2e/ui/tests/proxy-admin/activeRequests.spec.ts
@@ -1,0 +1,198 @@
+import test, { expect } from "@playwright/test";
+import type {
+  APIRequestContext,
+  Page as PlaywrightPage,
+} from "@playwright/test";
+import {
+  ADMIN_STORAGE_PATH,
+  INTERNAL_VIEWER_STORAGE_PATH,
+} from "../../constants";
+import { users } from "../../fixtures/users";
+import { Role } from "../../fixtures/roles";
+
+const MASTER_KEY = users[Role.ProxyAdmin].password;
+const HOLD_SECONDS = 25;
+
+/** Fires a completion the mock upstream holds open, so the request is still running while we assert. */
+function startHeldCompletion(
+  request: APIRequestContext,
+  endUser: string,
+): Promise<unknown> {
+  return request.post("/v1/chat/completions", {
+    headers: { Authorization: `Bearer ${MASTER_KEY}` },
+    data: {
+      model: "fake-openai-gpt-4",
+      user: endUser,
+      messages: [
+        {
+          role: "user",
+          content: `e2e-hold-${HOLD_SECONDS}s active requests page`,
+        },
+      ],
+    },
+    timeout: (HOLD_SECONDS + 30) * 1000,
+  });
+}
+
+async function openPage(page: PlaywrightPage): Promise<void> {
+  await page.goto("/ui/active-requests/");
+  await expect(
+    page.getByRole("heading", { name: "Active Requests" }),
+  ).toBeVisible();
+}
+
+test.describe("proxy admin active requests", () => {
+  test.use({ storageState: ADMIN_STORAGE_PATH });
+
+  test("should show a running request with its caller, then drop it once it finishes", async ({
+    page,
+    request,
+  }) => {
+    const endUser = `e2e-active-${Date.now()}`;
+    const inFlight = startHeldCompletion(request, endUser);
+
+    await openPage(page);
+    await expect(page.getByText(endUser)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("fake-openai-gpt-4").first()).toBeVisible();
+
+    await inFlight;
+
+    await expect(page.getByText(endUser)).toBeHidden({ timeout: 20_000 });
+  });
+
+  test("should narrow the page to one caller when filtering by end user", async ({
+    page,
+    request,
+  }) => {
+    const mine = `e2e-mine-${Date.now()}`;
+    const other = `e2e-other-${Date.now()}`;
+    const inFlight = Promise.all([
+      startHeldCompletion(request, mine),
+      startHeldCompletion(request, other),
+    ]);
+
+    await openPage(page);
+    await expect(page.getByText(mine)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(other)).toBeVisible();
+
+    await page.getByPlaceholder("End User ID").fill(mine);
+
+    await expect(page.getByText(other)).toBeHidden({ timeout: 15_000 });
+    await expect(page.getByText(mine)).toBeVisible();
+
+    await inFlight;
+  });
+
+  test("should regroup the chart by end user without leaving the page", async ({
+    page,
+    request,
+  }) => {
+    const endUser = `e2e-group-${Date.now()}`;
+    const inFlight = startHeldCompletion(request, endUser);
+
+    await openPage(page);
+    await expect(page.getByText("Running requests by model")).toBeVisible();
+
+    await page.getByRole("tab", { name: "End User", exact: true }).click();
+
+    await expect(page.getByText("Running requests by end user")).toBeVisible();
+    await expect(page).toHaveURL(/\/ui\/active-requests\/?($|\?)/);
+
+    await inFlight;
+  });
+
+  test("should open a request's details and cancel it", async ({
+    page,
+    request,
+  }) => {
+    const endUser = `e2e-cancel-${Date.now()}`;
+    const inFlight = startHeldCompletion(request, endUser);
+
+    await openPage(page);
+    await page.getByText(endUser).click();
+
+    const panel = page.getByRole("dialog");
+    await expect(panel.getByText("Request ID")).toBeVisible();
+    await expect(
+      panel.getByRole("link", { name: "Open in Logs" }),
+    ).toBeVisible();
+
+    await panel.getByRole("button", { name: "Cancel request" }).click();
+
+    await expect(page.getByText(endUser)).toBeHidden({ timeout: 20_000 });
+    await inFlight.catch(() => undefined);
+  });
+
+  test("should pause the poll so the table stops moving", async ({
+    page,
+    request,
+  }) => {
+    const endUser = `e2e-pause-${Date.now()}`;
+    const inFlight = startHeldCompletion(request, endUser);
+
+    await openPage(page);
+    const updated = page.getByText(/^Updated /);
+    await expect(updated).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole("switch").click();
+    const frozen = await updated.textContent();
+    await page.waitForTimeout(12_000);
+
+    expect(await updated.textContent()).toBe(frozen);
+    await inFlight;
+  });
+
+  test("should keep the filter in the url so the view can be shared", async ({
+    page,
+    request,
+  }) => {
+    const endUser = `e2e-url-${Date.now()}`;
+    const inFlight = startHeldCompletion(request, endUser);
+
+    await openPage(page);
+    await expect(page.getByText(endUser)).toBeVisible({ timeout: 15_000 });
+
+    await page.getByPlaceholder("End User ID").fill(endUser);
+
+    await expect(page).toHaveURL(new RegExp(`end_user_id=${endUser}`), {
+      timeout: 10_000,
+    });
+    await inFlight;
+  });
+
+  test("should keep polling and stay interactive while a request runs", async ({
+    page,
+    request,
+  }) => {
+    const endUser = `e2e-poll-${Date.now()}`;
+    const inFlight = startHeldCompletion(request, endUser);
+
+    await openPage(page);
+    const updated = page.getByText(/^Updated /);
+    await expect(updated).toBeVisible({ timeout: 15_000 });
+    const firstStamp = await updated.textContent();
+
+    await expect
+      .poll(async () => updated.textContent(), { timeout: 20_000 })
+      .not.toBe(firstStamp);
+
+    await page.getByRole("tab", { name: "Pod", exact: true }).click();
+    await expect(page.getByText("Running requests by pod")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await inFlight;
+  });
+});
+
+test.describe("internal viewer active requests", () => {
+  test.use({ storageState: INTERNAL_VIEWER_STORAGE_PATH });
+
+  test("should not offer the page to a non-admin", async ({ page }) => {
+    await page.goto("/ui");
+
+    await expect(
+      page.getByRole("link", { name: "Active Requests" }),
+    ).toHaveCount(0);
+  });
+});

--- a/tests/e2e/ui/tests/proxy-admin/activeRequests.spec.ts
+++ b/tests/e2e/ui/tests/proxy-admin/activeRequests.spec.ts
@@ -134,7 +134,7 @@ test.describe("proxy admin active requests", () => {
     const updated = page.getByText(/^Updated /);
     await expect(updated).toBeVisible({ timeout: 15_000 });
 
-    await page.getByRole("switch").click();
+    await page.getByRole("switch", { name: "Auto refresh" }).click();
     const frozen = await updated.textContent();
     await page.waitForTimeout(12_000);
 

--- a/tests/test_litellm/proxy/hooks/test_active_request_registry.py
+++ b/tests/test_litellm/proxy/hooks/test_active_request_registry.py
@@ -122,9 +122,6 @@ def set_general_settings(monkeypatch, **settings):
 
 def test_should_build_identity_record_without_request_content(monkeypatch):
     monkeypatch.setenv("HOSTNAME", "proxy-1")
-    import litellm.proxy.proxy_server as proxy_server
-
-    monkeypatch.setattr(proxy_server, "master_key", "master-key", raising=False)
     auth = UserAPIKeyAuth(
         api_key="sk-test-key-value",
         user_id="user-1",
@@ -151,7 +148,7 @@ def test_should_build_identity_record_without_request_content(monkeypatch):
     assert record["organization_id"] == "org-1"
     assert record["organization_alias"] == "Example Org"
     assert record["project_alias"] == "Chat Project"
-    assert record["key_fingerprint"] == hashlib.sha256(f"master-key:{auth.api_key}".encode()).hexdigest()[:12]
+    assert record["key_hash"] == hashlib.sha256(b"sk-test-key-value").hexdigest()
     assert record["pod"] == "proxy-1"
     assert "messages" not in record
 
@@ -564,14 +561,45 @@ def test_should_drop_fields_that_are_blank_after_trimming():
     assert record["model"] is None
 
 
-def test_should_omit_the_key_fingerprint_when_there_is_no_key():
+def test_should_omit_the_key_hash_when_there_is_no_key():
     record = ActiveRequestRegistry.build_record(
         {"litellm_call_id": "call-1"},
         UserAPIKeyAuth(api_key=None),
         "acompletion",
     )
 
-    assert record["key_fingerprint"] is None
+    assert record["key_hash"] is None
+
+
+@pytest.mark.parametrize(
+    "already_hashed",
+    (
+        hashlib.sha256(b"sk-virtual-key").hexdigest(),
+        f"hashed-jwt-{hashlib.sha256(b'jwt').hexdigest()}",
+    ),
+)
+def test_should_keep_the_key_hash_the_proxy_already_computed(already_hashed):
+    """The value has to match what Logs shows, so a hashed key passes through untouched."""
+    record = ActiveRequestRegistry.build_record(
+        {"litellm_call_id": "call-1"},
+        UserAPIKeyAuth(api_key=already_hashed),
+        "acompletion",
+    )
+
+    assert record["key_hash"] == already_hashed
+
+
+def test_should_never_publish_a_credential_that_custom_auth_returned_raw():
+    raw = "custom-auth-plaintext-credential"
+
+    record = ActiveRequestRegistry.build_record(
+        {"litellm_call_id": "call-1"},
+        UserAPIKeyAuth(api_key=raw),
+        "acompletion",
+    )
+
+    assert record["key_hash"] == hashlib.sha256(raw.encode()).hexdigest()
+    assert raw not in str(record)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/hooks/test_active_request_registry.py
+++ b/tests/test_litellm/proxy/hooks/test_active_request_registry.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import fakeredis.aioredis
 import pytest
+from redis.crc import key_slot
 
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.hooks.active_request_registry import ActiveRequestRegistry
@@ -22,7 +23,7 @@ class FakePipeline:
         return False
 
     def set(self, key, value, ex=None):
-        self.operations.append(("set", key, value))
+        self.operations.append(("set", key, value, ex))
 
     def zadd(self, key, values):
         self.operations.append(("zadd", key, values))
@@ -40,6 +41,7 @@ class FakePipeline:
         for operation in self.operations:
             if operation[0] == "set":
                 self.client.values[operation[1]] = operation[2]
+                self.client.expirations[operation[1]] = operation[3]
             elif operation[0] == "zadd":
                 self.client.sorted_sets.setdefault(operation[1], {}).update(operation[2])
             elif operation[0] == "delete":
@@ -53,6 +55,8 @@ class FakeRedisClient:
     def __init__(self):
         self.values = {}
         self.sorted_sets = {}
+        self.expirations = {}
+        self.zrevrange_calls = 0
 
     def pipeline(self, transaction=False):
         return FakePipeline(self)
@@ -63,6 +67,7 @@ class FakeRedisClient:
             values.pop(member)
 
     async def zrevrange(self, key, start, end):
+        self.zrevrange_calls += 1
         values = self.sorted_sets.setdefault(key, {})
         ordered = [member for member, _ in sorted(values.items(), key=lambda pair: pair[1], reverse=True)]
         return ordered[start : None if end == -1 else end + 1]
@@ -71,6 +76,9 @@ class FakeRedisClient:
         return len(self.sorted_sets.setdefault(key, {}))
 
     async def mget(self, keys):
+        slots = {key_slot(key.encode()) for key in keys}
+        if len(slots) > 1:
+            raise RuntimeError("CROSSSLOT Keys in request don't hash to the same slot")
         return [self.values.get(key) for key in keys]
 
     async def zrem(self, key, *members):
@@ -114,6 +122,9 @@ def set_general_settings(monkeypatch, **settings):
 
 def test_should_build_identity_record_without_request_content(monkeypatch):
     monkeypatch.setenv("HOSTNAME", "proxy-1")
+    import litellm.proxy.proxy_server as proxy_server
+
+    monkeypatch.setattr(proxy_server, "master_key", "master-key", raising=False)
     auth = UserAPIKeyAuth(
         api_key="sk-test-key-value",
         user_id="user-1",
@@ -140,7 +151,7 @@ def test_should_build_identity_record_without_request_content(monkeypatch):
     assert record["organization_id"] == "org-1"
     assert record["organization_alias"] == "Example Org"
     assert record["project_alias"] == "Chat Project"
-    assert record["key_fingerprint"] == hashlib.sha256(auth.api_key.encode()).hexdigest()[:12]
+    assert record["key_fingerprint"] == hashlib.sha256(f"master-key:{auth.api_key}".encode()).hexdigest()[:12]
     assert record["pod"] == "proxy-1"
     assert "messages" not in record
 
@@ -276,17 +287,25 @@ def test_should_bound_excessive_ttl_configuration(monkeypatch):
     assert registry.ttl_seconds == registry.MAX_TTL_SECONDS
 
 
-def test_should_not_leave_unformatted_placeholders_in_redis_keys():
-    assert "{" not in ActiveRequestRegistry.INDEX_KEY
-    assert "{" not in ActiveRequestRegistry.ITEM_KEY_PREFIX
+def test_all_multi_key_operations_share_a_redis_cluster_slot():
+    registry, redis_cache = make_registry()
+    keys = (
+        registry._index_key(redis_cache),
+        registry._item_key(redis_cache, "first"),
+        registry._item_key(redis_cache, "second"),
+        registry._cancel_key(redis_cache, "first"),
+    )
+
+    assert len({key_slot(key.encode()) for key in keys}) == 1
 
 
-def test_default_ttl_should_expire_ghost_entries_within_an_hour(monkeypatch):
-    set_general_settings(monkeypatch)
+def test_default_ttl_should_expire_ghost_entries_within_half_an_hour(monkeypatch):
     """A pod killed mid-request leaves entries behind until the TTL expires."""
+    set_general_settings(monkeypatch)
+
     registry, _ = make_registry()
 
-    assert registry.ttl_seconds <= 3600
+    assert registry.ttl_seconds == 1800
 
 
 @pytest.mark.asyncio
@@ -379,6 +398,48 @@ async def test_should_not_raise_when_redis_writes_fail():
 
 
 @pytest.mark.asyncio
+async def test_should_not_raise_when_resolving_redis_fails():
+    class ExplodingDualCache:
+        @property
+        def redis_cache(self):
+            raise ConnectionError("redis unavailable")
+
+    registry = ActiveRequestRegistry(SimpleNamespace(dual_cache=ExplodingDualCache()))
+    auth = UserAPIKeyAuth(api_key="sk-test-key")
+
+    assert await registry.register(auth, {"litellm_call_id": "call-1"}, "acompletion") is None
+    await registry.remove("registry-id")
+
+
+@pytest.mark.asyncio
+async def test_registration_sets_the_only_ghost_cleanup_ttl():
+    registry, redis_cache = make_registry()
+
+    registry_id = await registry.register(
+        UserAPIKeyAuth(api_key="sk-test-key"),
+        {"litellm_call_id": "call-1"},
+        "acompletion",
+    )
+
+    assert redis_cache.client.expirations[registry._item_key(redis_cache, registry_id)] == registry.ttl_seconds
+
+
+@pytest.mark.asyncio
+async def test_remove_drops_the_local_task_even_when_cleanup_is_cancelled(monkeypatch):
+    registry, _ = make_registry()
+    registry._local_tasks["registry-id"] = asyncio.current_task()
+
+    async def cancel_cleanup(_pipeline):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(FakePipeline, "execute", cancel_cleanup)
+
+    with pytest.raises(asyncio.CancelledError):
+        await registry.remove("registry-id")
+    assert "registry-id" not in registry._local_tasks
+
+
+@pytest.mark.asyncio
 async def test_should_drop_index_members_whose_record_expired():
     registry, redis_cache = make_registry()
     auth = UserAPIKeyAuth(api_key="sk-test-key", user_id="user-1")
@@ -394,6 +455,44 @@ async def test_should_drop_index_members_whose_record_expired():
     assert [item["request_id"] for item in result["items"]] == ["call-0"]
     assert result["total"] == 1
     assert list(redis_cache.client.sorted_sets[f"test:{registry.INDEX_KEY}"]) == [kept]
+
+
+@pytest.mark.asyncio
+async def test_should_refill_a_page_after_dropping_stale_members():
+    registry, redis_cache = make_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key")
+    started_at = time.time()
+    ids = [
+        await registry.register(
+            auth,
+            {"litellm_call_id": f"call-{index}"},
+            "acompletion",
+            started_at=started_at + index,
+        )
+        for index in range(3)
+    ]
+    redis_cache.client.values.pop(registry._item_key(redis_cache, ids[2]))
+
+    result = await registry.list_requests(page_size=2)
+
+    assert [item["request_id"] for item in result["items"]] == ["call-1", "call-0"]
+    assert result["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_filtered_queries_are_cached_for_one_second():
+    registry, redis_cache = make_registry()
+    await registry.register(
+        UserAPIKeyAuth(api_key="sk-test-key"),
+        {"litellm_call_id": "call-1", "model": "model-a"},
+        "acompletion",
+    )
+
+    await registry.list_requests(model="model-a")
+    calls_after_first_query = redis_cache.client.zrevrange_calls
+    await registry.list_requests(model="model-a")
+
+    assert redis_cache.client.zrevrange_calls == calls_after_first_query
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/hooks/test_active_request_registry.py
+++ b/tests/test_litellm/proxy/hooks/test_active_request_registry.py
@@ -1,0 +1,666 @@
+import asyncio
+import hashlib
+import time
+from types import SimpleNamespace
+
+import fakeredis.aioredis
+import pytest
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.hooks.active_request_registry import ActiveRequestRegistry
+
+
+class FakePipeline:
+    def __init__(self, client):
+        self.client = client
+        self.operations = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    def set(self, key, value, ex=None):
+        self.operations.append(("set", key, value))
+
+    def zadd(self, key, values):
+        self.operations.append(("zadd", key, values))
+
+    def expire(self, key, ttl):
+        self.operations.append(("expire", key, ttl))
+
+    def delete(self, key):
+        self.operations.append(("delete", key))
+
+    def zrem(self, key, value):
+        self.operations.append(("zrem", key, value))
+
+    async def execute(self):
+        for operation in self.operations:
+            if operation[0] == "set":
+                self.client.values[operation[1]] = operation[2]
+            elif operation[0] == "zadd":
+                self.client.sorted_sets.setdefault(operation[1], {}).update(operation[2])
+            elif operation[0] == "delete":
+                self.client.values.pop(operation[1], None)
+            elif operation[0] == "zrem":
+                self.client.sorted_sets.setdefault(operation[1], {}).pop(operation[2], None)
+        return []
+
+
+class FakeRedisClient:
+    def __init__(self):
+        self.values = {}
+        self.sorted_sets = {}
+
+    def pipeline(self, transaction=False):
+        return FakePipeline(self)
+
+    async def zremrangebyscore(self, key, minimum, maximum):
+        values = self.sorted_sets.setdefault(key, {})
+        for member in [member for member, score in values.items() if score <= maximum]:
+            values.pop(member)
+
+    async def zrevrange(self, key, start, end):
+        values = self.sorted_sets.setdefault(key, {})
+        ordered = [member for member, _ in sorted(values.items(), key=lambda pair: pair[1], reverse=True)]
+        return ordered[start : None if end == -1 else end + 1]
+
+    async def zcard(self, key):
+        return len(self.sorted_sets.setdefault(key, {}))
+
+    async def mget(self, keys):
+        return [self.values.get(key) for key in keys]
+
+    async def zrem(self, key, *members):
+        for member in members:
+            self.sorted_sets.setdefault(key, {}).pop(member, None)
+
+
+class FakeRedisCache:
+    def __init__(self):
+        self.client = FakeRedisClient()
+
+    def init_async_client(self):
+        return self.client
+
+    def check_and_fix_namespace(self, key):
+        return f"test:{key}"
+
+
+def make_registry(max_scan_members=None):
+    redis_cache = FakeRedisCache()
+    usage_cache = SimpleNamespace(dual_cache=SimpleNamespace(redis_cache=redis_cache))
+    return ActiveRequestRegistry(usage_cache, max_scan_members=max_scan_members), redis_cache
+
+
+def make_fakeredis_registry(max_scan_members=None):
+    redis_cache = SimpleNamespace(
+        init_async_client=lambda: redis_cache.client,
+        check_and_fix_namespace=lambda key: f"integration:{key}",
+        client=fakeredis.aioredis.FakeRedis(),
+    )
+    usage_cache = SimpleNamespace(dual_cache=SimpleNamespace(redis_cache=redis_cache))
+    return ActiveRequestRegistry(usage_cache, max_scan_members=max_scan_members)
+
+
+def set_general_settings(monkeypatch, **settings):
+    """The registry reads its knobs from general_settings at call time."""
+    import litellm.proxy.proxy_server as proxy_server
+
+    monkeypatch.setattr(proxy_server, "general_settings", settings, raising=False)
+
+
+def test_should_build_identity_record_without_request_content(monkeypatch):
+    monkeypatch.setenv("HOSTNAME", "proxy-1")
+    auth = UserAPIKeyAuth(
+        api_key="sk-test-key-value",
+        user_id="user-1",
+        user_email="user@example.test",
+        key_alias="production",
+        team_id="team-1",
+        team_alias="AI Team",
+        org_id="org-1",
+        project_id="project-1",
+        end_user_id="end-user-1",
+        metadata={"organization_alias": "spoofed"},
+        organization_metadata={"organization_alias": "Example Org"},
+        project_metadata={"project_alias": "Chat Project"},
+    )
+
+    record = ActiveRequestRegistry.build_record(
+        {"litellm_call_id": "call-1", "model": "gpt-test", "messages": ["secret"]},
+        auth,
+        "acompletion",
+        started_at=100.0,
+    )
+
+    assert record["end_user_id"] == "end-user-1"
+    assert record["organization_id"] == "org-1"
+    assert record["organization_alias"] == "Example Org"
+    assert record["project_alias"] == "Chat Project"
+    assert record["key_fingerprint"] == hashlib.sha256(auth.api_key.encode()).hexdigest()[:12]
+    assert record["pod"] == "proxy-1"
+    assert "messages" not in record
+
+
+@pytest.mark.asyncio
+async def test_should_register_list_filter_and_remove_requests():
+    registry, _ = make_registry()
+    auth = UserAPIKeyAuth(
+        api_key="sk-test-key",
+        user_id="user-1",
+        end_user_id="end-user-1",
+        org_id="org-1",
+        project_id="project-1",
+    )
+    data = {"litellm_call_id": "same-call-id", "model": "model-a", "stream": True}
+
+    first_id = await registry.register(auth, data, "acompletion")
+    second_id = await registry.register(auth, data, "acompletion")
+
+    assert first_id is not None
+    assert second_id is not None
+    assert first_id != second_id
+    result = await registry.list_requests(end_user_id="end-user-1")
+    assert result["available"] is True
+    assert result["total"] == 2
+    assert all(item["streaming"] for item in result["items"])
+
+    await registry.remove(first_id)
+    remaining = await registry.list_requests()
+    assert remaining["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_should_update_one_record_when_pre_call_runs_again():
+    registry, redis_cache = make_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key", user_id="user-1")
+    started_at = time.time()
+
+    registry_id = await registry.register(
+        auth,
+        {"litellm_call_id": "client-call-id", "model": "model-a"},
+        "acompletion",
+        started_at=started_at,
+    )
+    updated_registry_id = await registry.register(
+        auth,
+        {"litellm_call_id": "client-call-id", "model": "fallback-model"},
+        "acompletion",
+        registry_id=registry_id,
+        started_at=started_at,
+    )
+
+    assert registry_id == updated_registry_id
+    assert registry_id is not None
+    assert "client-call-id" not in registry_id
+    assert len(redis_cache.client.sorted_sets["test:" + registry.INDEX_KEY]) == 1
+    result = await registry.list_requests()
+    assert result["total"] == 1
+    assert result["items"][0]["model"] == "fallback-model"
+    assert result["items"][0]["started_at"] == started_at
+
+
+@pytest.mark.asyncio
+async def test_should_bound_untrusted_record_fields():
+    registry, _ = make_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key", metadata={"organization_alias": {"large": "value"}})
+    long_value = "x" * 2000
+
+    await registry.register(
+        auth,
+        {"litellm_call_id": long_value, "model": long_value},
+        "acompletion",
+    )
+
+    result = await registry.list_requests()
+    assert len(result["items"][0]["request_id"]) == registry.MAX_FIELD_LENGTH
+    assert len(result["items"][0]["model"]) == registry.MAX_FIELD_LENGTH
+    assert result["items"][0]["organization_alias"] is None
+
+
+@pytest.mark.asyncio
+async def test_should_use_real_redis_pipeline_semantics_with_pagination():
+    registry = make_fakeredis_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key", user_id="user-1")
+    started_at = time.time()
+
+    registry_ids = await asyncio.gather(
+        *[
+            registry.register(
+                auth,
+                {"litellm_call_id": f"call-{index}", "model": "model-a"},
+                "acompletion",
+                started_at=started_at + index / 1000,
+            )
+            for index in range(25)
+        ]
+    )
+
+    first_page = await registry.list_requests(page=1, page_size=10)
+    third_page = await registry.list_requests(page=3, page_size=10)
+    assert first_page["total"] == 25
+    assert len(first_page["items"]) == 10
+    assert len(third_page["items"]) == 5
+
+    await asyncio.gather(*(registry.remove(registry_id) for registry_id in registry_ids))
+    assert (await registry.list_requests())["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_should_report_unavailable_without_redis():
+    usage_cache = SimpleNamespace(dual_cache=SimpleNamespace(redis_cache=None))
+    registry = ActiveRequestRegistry(usage_cache)
+
+    result = await registry.list_requests()
+
+    assert result["available"] is False
+    assert result["items"] == ()
+
+
+def test_should_fall_back_to_safe_ttl_for_invalid_configuration(monkeypatch):
+    set_general_settings(monkeypatch, active_request_ttl_seconds="invalid")
+
+    registry, _ = make_registry()
+
+    assert registry.ttl_seconds == registry.DEFAULT_TTL_SECONDS
+
+
+def test_should_bound_excessive_ttl_configuration(monkeypatch):
+    set_general_settings(monkeypatch, active_request_ttl_seconds=999999999)
+
+    registry, _ = make_registry()
+
+    assert registry.ttl_seconds == registry.MAX_TTL_SECONDS
+
+
+def test_should_not_leave_unformatted_placeholders_in_redis_keys():
+    assert "{" not in ActiveRequestRegistry.INDEX_KEY
+    assert "{" not in ActiveRequestRegistry.ITEM_KEY_PREFIX
+
+
+def test_default_ttl_should_expire_ghost_entries_within_an_hour(monkeypatch):
+    set_general_settings(monkeypatch)
+    """A pod killed mid-request leaves entries behind until the TTL expires."""
+    registry, _ = make_registry()
+
+    assert registry.ttl_seconds <= 3600
+
+
+@pytest.mark.asyncio
+async def test_should_cap_the_index_scan_when_filters_are_applied():
+    registry = make_fakeredis_registry(max_scan_members=2)
+    auth = UserAPIKeyAuth(api_key="sk-test-key", user_id="user-1")
+    started_at = time.time()
+
+    for index in range(5):
+        await registry.register(
+            auth,
+            {"litellm_call_id": f"call-{index}", "model": "model-a"},
+            "acompletion",
+            started_at=started_at + index / 1000,
+        )
+
+    result = await registry.list_requests(model="model-a", page_size=10)
+
+    assert result["truncated"] is True
+    assert len(result["items"]) == 2
+    assert result["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_should_not_report_truncation_below_the_scan_cap():
+    registry = make_fakeredis_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key", user_id="user-1")
+
+    await registry.register(auth, {"litellm_call_id": "call-0", "model": "model-a"}, "acompletion")
+
+    assert (await registry.list_requests(model="model-a"))["truncated"] is False
+    assert (await registry.list_requests())["truncated"] is False
+
+
+def test_should_omit_user_email_by_default(monkeypatch):
+    set_general_settings(monkeypatch)
+
+    record = ActiveRequestRegistry.build_record(
+        {"litellm_call_id": "call-1"},
+        UserAPIKeyAuth(api_key="sk-test-key", user_email="user@example.test"),
+        "acompletion",
+    )
+
+    assert record["user_email"] is None
+
+
+def test_should_include_user_email_when_explicitly_enabled(monkeypatch):
+    set_general_settings(monkeypatch, active_request_include_user_email=True)
+
+    record = ActiveRequestRegistry.build_record(
+        {"litellm_call_id": "call-1"},
+        UserAPIKeyAuth(api_key="sk-test-key", user_email="user@example.test"),
+        "acompletion",
+    )
+
+    assert record["user_email"] == "user@example.test"
+
+
+@pytest.mark.asyncio
+async def test_should_skip_registration_without_redis_or_call_id():
+    usage_cache = SimpleNamespace(dual_cache=SimpleNamespace(redis_cache=None))
+    without_redis = ActiveRequestRegistry(usage_cache)
+    with_redis, _ = make_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key")
+
+    assert await without_redis.register(auth, {"litellm_call_id": "c"}, "acompletion") is None
+    assert await with_redis.register(auth, {}, "acompletion") is None
+    await without_redis.remove("registry-id")
+    await with_redis.remove(None)
+
+
+@pytest.mark.asyncio
+async def test_should_not_raise_when_redis_writes_fail():
+    registry, redis_cache = make_registry()
+
+    def explode():
+        raise ConnectionError("redis down")
+
+    redis_cache.init_async_client = explode
+
+    assert (
+        await registry.register(
+            UserAPIKeyAuth(api_key="sk-test-key"),
+            {"litellm_call_id": "call-1"},
+            "acompletion",
+        )
+        is None
+    )
+    await registry.remove("registry-id")
+
+
+@pytest.mark.asyncio
+async def test_should_drop_index_members_whose_record_expired():
+    registry, redis_cache = make_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key", user_id="user-1")
+
+    started_at = time.time()
+    kept = await registry.register(auth, {"litellm_call_id": "call-0"}, "acompletion", started_at=started_at)
+    expired = await registry.register(auth, {"litellm_call_id": "call-1"}, "acompletion", started_at=started_at + 1)
+    # Simulate the item key hitting its TTL while the index member survives.
+    redis_cache.client.values.pop(f"test:{registry.ITEM_KEY_PREFIX}{expired}")
+
+    result = await registry.list_requests()
+
+    assert [item["request_id"] for item in result["items"]] == ["call-0"]
+    assert result["total"] == 1
+    assert list(redis_cache.client.sorted_sets[f"test:{registry.INDEX_KEY}"]) == [kept]
+
+
+@pytest.mark.asyncio
+async def test_should_match_filters_exactly_not_by_substring():
+    registry = make_fakeredis_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key", user_id="user-1")
+
+    await registry.register(auth, {"litellm_call_id": "call-0", "model": "gpt-4o-mini"}, "acompletion")
+
+    assert (await registry.list_requests(model="gpt-4o-mini"))["total"] == 1
+    assert (await registry.list_requests(model="gpt-4o"))["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_should_return_an_empty_page_past_the_end_without_losing_the_total():
+    registry = make_fakeredis_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key", user_id="user-1")
+    started_at = time.time()
+
+    for index in range(3):
+        await registry.register(
+            auth,
+            {"litellm_call_id": f"call-{index}", "model": "model-a"},
+            "acompletion",
+            started_at=started_at + index / 1000,
+        )
+
+    unfiltered = await registry.list_requests(page=9, page_size=10)
+    filtered = await registry.list_requests(model="model-a", page=9, page_size=10)
+
+    assert unfiltered["items"] == () and unfiltered["total"] == 3
+    assert filtered["items"] == () and filtered["total"] == 3
+
+
+@pytest.mark.asyncio
+async def test_should_treat_an_unreadable_record_as_stale():
+    registry, redis_cache = make_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key")
+    started_at = time.time()
+
+    registry_id = await registry.register(auth, {"litellm_call_id": "call-0"}, "acompletion", started_at=started_at)
+    redis_cache.client.values[f"test:{registry.ITEM_KEY_PREFIX}{registry_id}"] = "{not json"
+
+    result = await registry.list_requests()
+
+    assert result["items"] == ()
+    assert result["total"] == 0
+    assert redis_cache.client.sorted_sets[f"test:{registry.INDEX_KEY}"] == {}
+
+
+@pytest.mark.asyncio
+async def test_should_treat_a_non_object_record_as_stale():
+    registry, redis_cache = make_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key")
+
+    registry_id = await registry.register(auth, {"litellm_call_id": "call-0"}, "acompletion", started_at=time.time())
+    redis_cache.client.values[f"test:{registry.ITEM_KEY_PREFIX}{registry_id}"] = "[1, 2, 3]"
+
+    assert (await registry.list_requests())["items"] == ()
+
+
+def test_should_drop_fields_that_are_blank_after_trimming():
+    record = ActiveRequestRegistry.build_record(
+        {"litellm_call_id": "call-1", "model": "   "},
+        UserAPIKeyAuth(api_key="sk-test-key"),
+        "acompletion",
+    )
+
+    assert record["model"] is None
+
+
+def test_should_omit_the_key_fingerprint_when_there_is_no_key():
+    record = ActiveRequestRegistry.build_record(
+        {"litellm_call_id": "call-1"},
+        UserAPIKeyAuth(api_key=None),
+        "acompletion",
+    )
+
+    assert record["key_fingerprint"] is None
+
+
+@pytest.mark.asyncio
+async def test_should_not_publish_a_cancellation_for_an_unknown_request():
+    registry = make_fakeredis_registry()
+
+    assert await registry.request_cancel("does-not-exist") is False
+
+
+@pytest.mark.asyncio
+async def test_should_flag_a_running_request_for_cancellation():
+    registry = make_fakeredis_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key")
+    started = asyncio.Event()
+    ids: list[str] = []
+
+    async def served_request():
+        ids.append(await registry.register(auth, {"litellm_call_id": "call-0"}, "acompletion"))
+        started.set()
+        await asyncio.sleep(30)
+
+    task = asyncio.create_task(served_request())
+    await started.wait()
+
+    assert await registry.request_cancel(ids[0]) is True
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_should_report_no_cancellation_without_redis():
+    usage_cache = SimpleNamespace(dual_cache=SimpleNamespace(redis_cache=None))
+    registry = ActiveRequestRegistry(usage_cache)
+
+    assert await registry.request_cancel("anything") is False
+
+
+@pytest.mark.asyncio
+async def test_should_cancel_the_task_this_worker_is_serving():
+    registry = make_fakeredis_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key")
+    started = asyncio.Event()
+    registry_ids: list[str] = []
+
+    async def served_request():
+        registry_id = await registry.register(auth, {"litellm_call_id": "call-0"}, "acompletion")
+        registry_ids.append(registry_id)
+        started.set()
+        await asyncio.sleep(30)
+
+    task = asyncio.create_task(served_request())
+    await started.wait()
+    await asyncio.sleep(0.2)
+
+    await registry.request_cancel(registry_ids[0])
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=5)
+
+
+def test_should_ignore_a_cancellation_for_a_request_this_worker_does_not_own():
+    registry, _ = make_registry()
+
+    registry._cancel_owned_task("not-a-known-request")
+
+
+def test_should_leave_a_finished_task_alone():
+    registry, _ = make_registry()
+
+    async def already_done():
+        return None
+
+    loop = asyncio.new_event_loop()
+    try:
+        task = loop.create_task(already_done())
+        loop.run_until_complete(task)
+        registry._local_tasks["done-id"] = task
+        registry._cancel_owned_task("done-id")
+    finally:
+        loop.close()
+
+    assert task.cancelled() is False
+
+
+@pytest.mark.asyncio
+async def test_should_not_raise_when_publishing_a_cancellation_fails():
+    registry, redis_cache = make_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key")
+    registry_id = await registry.register(auth, {"litellm_call_id": "call-0"}, "acompletion")
+
+    def explode():
+        raise ConnectionError("redis down")
+
+    redis_cache.init_async_client = explode
+
+    assert await registry.request_cancel(registry_id) is False
+
+
+@pytest.mark.asyncio
+async def test_should_start_the_cancel_watcher_once_per_worker():
+    registry = make_fakeredis_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key")
+
+    await registry.register(auth, {"litellm_call_id": "call-0"}, "acompletion")
+    first = registry._cancel_watcher
+    await registry.register(auth, {"litellm_call_id": "call-1"}, "acompletion")
+
+    assert first is not None
+    assert registry._cancel_watcher is first
+
+
+def test_should_not_start_a_cancel_watcher_without_redis():
+    usage_cache = SimpleNamespace(dual_cache=SimpleNamespace(redis_cache=None))
+    registry = ActiveRequestRegistry(usage_cache)
+
+    registry._ensure_cancel_watcher()
+
+    assert registry._cancel_watcher is None
+
+
+@pytest.mark.asyncio
+async def test_should_cancel_a_request_another_replica_flagged():
+    """The flag is written by whichever replica served the admin call; the owner acts on it."""
+    registry = make_fakeredis_registry()
+    auth = UserAPIKeyAuth(api_key="sk-test-key")
+    started = asyncio.Event()
+    ids: list[str] = []
+
+    async def served_request():
+        ids.append(await registry.register(auth, {"litellm_call_id": "call-0"}, "acompletion"))
+        started.set()
+        await asyncio.sleep(30)
+
+    task = asyncio.create_task(served_request())
+    await started.wait()
+
+    redis_cache = registry._redis_cache()
+    await redis_cache.init_async_client().set(registry._cancel_key(redis_cache, ids[0]), "1")
+
+    await registry._cancel_flagged_requests()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=5)
+    assert await redis_cache.init_async_client().get(registry._cancel_key(redis_cache, ids[0])) is None
+
+
+@pytest.mark.asyncio
+async def test_should_ignore_a_poll_without_redis():
+    usage_cache = SimpleNamespace(dual_cache=SimpleNamespace(redis_cache=None))
+
+    await ActiveRequestRegistry(usage_cache)._cancel_flagged_requests()
+
+
+@pytest.mark.asyncio
+async def test_should_stop_watching_once_the_worker_has_no_requests_left():
+    registry = make_fakeredis_registry()
+
+    await asyncio.wait_for(registry._watch_for_cancellations(), timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_should_keep_watching_after_a_failed_poll():
+    registry = make_fakeredis_registry()
+    registry._local_tasks["phantom"] = asyncio.current_task()
+    calls: list[int] = []
+
+    async def explode():
+        calls.append(1)
+        if len(calls) > 1:
+            registry._local_tasks.clear()
+        raise ConnectionError("redis down")
+
+    registry._cancel_flagged_requests = explode
+
+    await asyncio.wait_for(registry._watch_for_cancellations(), timeout=5)
+
+    assert calls == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_should_let_a_shutdown_cancel_the_watcher():
+    registry = make_fakeredis_registry()
+    registry._local_tasks["phantom"] = asyncio.current_task()
+
+    watcher = asyncio.create_task(registry._watch_for_cancellations())
+    await asyncio.sleep(0)
+    watcher.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await watcher

--- a/tests/test_litellm/proxy/management_endpoints/test_active_request_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_active_request_endpoints.py
@@ -1,0 +1,224 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException, Response
+
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.hooks.active_request_registry import ActiveRequestRegistry
+from litellm.proxy.management_endpoints import active_request_endpoints
+
+
+class FakeRegistry:
+    def __init__(self):
+        self.kwargs = None
+
+    async def list_requests(self, **kwargs):
+        self.kwargs = kwargs
+        return {
+            "available": True,
+            "reason": None,
+            "items": [
+                {
+                    "registry_id": "reg-1", "request_id": "request-1",
+                    "started_at": 100.0,
+                    "model": "model-a",
+                    "end_user_id": "end-user-1",
+                }
+            ],
+            "total": 1,
+            "page": kwargs["page"],
+            "page_size": kwargs["page_size"],
+        }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "role",
+    [LitellmUserRoles.PROXY_ADMIN, LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY],
+)
+async def test_admin_roles_can_list_active_requests_without_caching(monkeypatch, role):
+    registry = FakeRegistry()
+    monkeypatch.setattr(
+        active_request_endpoints,
+        "_get_active_request_registry",
+        lambda: registry,
+    )
+    response = Response()
+
+    result = await active_request_endpoints.get_active_requests(
+        response=response,
+        model="model-a",
+        end_user_id="end-user-1",
+        page=2,
+        page_size=25,
+        user_api_key_dict=UserAPIKeyAuth(user_role=role),
+    )
+
+    assert result.total == 1
+    assert result.items[0].end_user_id == "end-user-1"
+    assert isinstance(result.generated_at, datetime)
+    assert response.headers["Cache-Control"] == "no-store, max-age=0"
+    assert response.headers["Pragma"] == "no-cache"
+    assert registry.kwargs == {
+        "model": "model-a",
+        "user_id": None,
+        "end_user_id": "end-user-1",
+        "organization_id": None,
+        "project_id": None,
+        "page": 2,
+        "page_size": 25,
+    }
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_list_active_requests(monkeypatch):
+    get_registry = SimpleNamespace(called=False)
+
+    def unexpected_registry_lookup():
+        get_registry.called = True
+
+    monkeypatch.setattr(
+        active_request_endpoints,
+        "_get_active_request_registry",
+        unexpected_registry_lookup,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await active_request_endpoints.get_active_requests(
+            response=Response(),
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert get_registry.called is False
+
+
+@pytest.mark.asyncio
+async def test_missing_registry_returns_service_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        active_request_endpoints,
+        "_get_active_request_registry",
+        lambda: None,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await active_request_endpoints.get_active_requests(
+            response=Response(),
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_registry_failure_is_reported_as_service_unavailable(monkeypatch):
+    class ExplodingRegistry:
+        async def list_requests(self, **_):
+            raise ConnectionError("redis down")
+
+    monkeypatch.setattr(active_request_endpoints, "_get_active_request_registry", lambda: ExplodingRegistry())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await active_request_endpoints.get_active_requests(
+            response=Response(),
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert "active request registry" in exc_info.value.detail
+
+
+def test_registry_lookup_ignores_an_unrelated_hook(monkeypatch):
+    import litellm.proxy.proxy_server as proxy_server
+
+    monkeypatch.setattr(
+        proxy_server,
+        "proxy_logging_obj",
+        SimpleNamespace(get_proxy_hook=lambda _: object()),
+        raising=False,
+    )
+
+    assert active_request_endpoints._get_active_request_registry() is None
+
+
+def test_registry_lookup_returns_the_registered_hook(monkeypatch):
+    import litellm.proxy.proxy_server as proxy_server
+
+    registry = ActiveRequestRegistry(SimpleNamespace(dual_cache=SimpleNamespace(redis_cache=None)))
+    monkeypatch.setattr(
+        proxy_server,
+        "proxy_logging_obj",
+        SimpleNamespace(get_proxy_hook=lambda _: registry),
+        raising=False,
+    )
+
+    assert active_request_endpoints._get_active_request_registry() is registry
+
+
+@pytest.mark.asyncio
+async def test_only_proxy_admin_may_cancel_a_request(monkeypatch):
+    cancelled = []
+
+    class Registry:
+        async def request_cancel(self, registry_id):
+            cancelled.append(registry_id)
+            return True
+
+    monkeypatch.setattr(active_request_endpoints, "_get_active_request_registry", lambda: Registry())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await active_request_endpoints.cancel_active_request(
+            registry_id="abc",
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert cancelled == []
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_running_request_reports_the_signal_was_sent(monkeypatch):
+    class Registry:
+        async def request_cancel(self, registry_id):
+            assert registry_id == "abc"
+            return True
+
+    monkeypatch.setattr(active_request_endpoints, "_get_active_request_registry", lambda: Registry())
+
+    result = await active_request_endpoints.cancel_active_request(
+        registry_id="abc",
+        user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+    )
+
+    assert result.cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_finished_request_is_not_found(monkeypatch):
+    class Registry:
+        async def request_cancel(self, registry_id):
+            return False
+
+    monkeypatch.setattr(active_request_endpoints, "_get_active_request_registry", lambda: Registry())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await active_request_endpoints.cancel_active_request(
+            registry_id="gone",
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cancelling_without_a_registry_is_service_unavailable(monkeypatch):
+    monkeypatch.setattr(active_request_endpoints, "_get_active_request_registry", lambda: None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await active_request_endpoints.cancel_active_request(
+            registry_id="abc",
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+    assert exc_info.value.status_code == 503

--- a/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
@@ -121,6 +121,68 @@ def test_removes_the_active_request_even_when_the_handler_raises():
     assert get_in_flight_requests() == 0
 
 
+def test_counter_decrements_when_active_request_cleanup_raises():
+    class Registry:
+        async def remove(self, registry_id):
+            raise ConnectionError("redis down")
+
+    async def handler(request: Request) -> Response:
+        request.state.active_request_registry = Registry()
+        request.state.active_request_registry_id = "registry-id"
+        return JSONResponse({})
+
+    response = TestClient(_make_app(handler)).get("/")
+
+    assert response.status_code == 200
+    assert get_in_flight_requests() == 0
+
+
+def test_counter_decrements_when_active_request_cleanup_is_cancelled():
+    """The cleanup runs while the request task may already be cancelled, so the
+    decrement has to survive a BaseException, not only an Exception."""
+
+    class Registry:
+        async def remove(self, registry_id):
+            raise asyncio.CancelledError
+
+    async def handler(request: Request) -> Response:
+        request.state.active_request_registry = Registry()
+        request.state.active_request_registry_id = "registry-id"
+        return JSONResponse({})
+
+    response = TestClient(_make_app(handler)).get("/")
+
+    assert response.status_code == 200
+    assert get_in_flight_requests() == 0
+
+
+def test_counter_decrements_when_the_cleanup_logger_raises(monkeypatch):
+    """The decrement sits behind its own finally because the logging call above it
+    can fail too, and this counter gates graceful shutdown."""
+
+    class Registry:
+        async def remove(self, registry_id):
+            raise ConnectionError("redis down")
+
+    def explode(*args, **kwargs):
+        raise RuntimeError("logging handler down")
+
+    monkeypatch.setattr(
+        "litellm.proxy.middleware.in_flight_requests_middleware.verbose_proxy_logger.exception",
+        explode,
+    )
+
+    async def handler(request: Request) -> Response:
+        request.state.active_request_registry = Registry()
+        request.state.active_request_registry_id = "registry-id"
+        return JSONResponse({})
+
+    with pytest.raises(RuntimeError):
+        TestClient(_make_app(handler)).get("/")
+
+    assert get_in_flight_requests() == 0
+
+
 def test_counts_a_request_that_registered_nothing():
     async def handler(request: Request) -> Response:
         return JSONResponse({})

--- a/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
@@ -84,6 +84,52 @@ def test_counter_decrements_after_error():
     assert get_in_flight_requests() == 0
 
 
+def test_removes_the_active_request_registered_during_the_call():
+    removed = []
+
+    class Registry:
+        async def remove(self, registry_id):
+            removed.append(registry_id)
+
+    async def handler(request: Request) -> Response:
+        request.state.active_request_registry = Registry()
+        request.state.active_request_registry_id = "registry-id"
+        return JSONResponse({})
+
+    TestClient(_make_app(handler)).get("/")
+
+    assert removed == ["registry-id"]
+    assert get_in_flight_requests() == 0
+
+
+def test_removes_the_active_request_even_when_the_handler_raises():
+    removed = []
+
+    class Registry:
+        async def remove(self, registry_id):
+            removed.append(registry_id)
+
+    async def handler(request: Request) -> Response:
+        request.state.active_request_registry = Registry()
+        request.state.active_request_registry_id = "registry-id"
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        TestClient(_make_app(handler)).get("/")
+
+    assert removed == ["registry-id"]
+    assert get_in_flight_requests() == 0
+
+
+def test_counts_a_request_that_registered_nothing():
+    async def handler(request: Request) -> Response:
+        return JSONResponse({})
+
+    TestClient(_make_app(handler)).get("/")
+
+    assert get_in_flight_requests() == 0
+
+
 def test_non_http_scopes_not_counted():
     """Lifespan / websocket scopes must not touch the counter."""
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -1130,7 +1130,10 @@ async def test_pass_through_request_uses_resolved_timeout():
     with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
         with patch(
             "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client"
-        ) as mock_get_client:
+        ) as mock_get_client, patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.register_http_request",
+            new_callable=AsyncMock,
+        ) as register_active:
             mock_proxy_logging.pre_call_hook = AsyncMock(
                 side_effect=lambda **kwargs: kwargs["data"]
             )
@@ -1161,6 +1164,9 @@ async def test_pass_through_request_uses_resolved_timeout():
 
             mock_get_client.assert_called_once()
             assert mock_get_client.call_args[1]["params"]["timeout"] == 1500
+            register_active.assert_awaited_once()
+            assert register_active.await_args.kwargs["request"] is mock_request
+            assert register_active.await_args.kwargs["call_type"] == "pass_through_endpoint"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_active_request_registration.py
+++ b/tests/test_litellm/proxy/test_active_request_registration.py
@@ -1,12 +1,20 @@
-from collections.abc import Mapping
+import json
+from collections.abc import Mapping, Sequence
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from fastapi import Request
 
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.hooks.active_request_registry import ActiveRequestRegistry
+from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+    azure_proxy_route,
+    vllm_proxy_route,
+)
+from litellm.router import Router
 from litellm.types.utils import CallTypesLiteral
 
 
@@ -26,7 +34,9 @@ class RecordingRegistry(ActiveRequestRegistry):
         registry_id: str | None = None,
         started_at: float | None = None,
     ) -> str | None:
-        self.calls.append({"registry_id": registry_id, "started_at": started_at, "call_type": call_type})
+        self.calls.append(
+            {"registry_id": registry_id, "started_at": started_at, "call_type": call_type, "data": dict(data)}
+        )
         return self.returned_id
 
 
@@ -36,6 +46,39 @@ def make_request() -> Request:
 
 def make_proxy_logging(hook: object) -> SimpleNamespace:
     return SimpleNamespace(get_proxy_hook=lambda _: hook)
+
+
+def make_body_request(path: str, body: dict[str, object], extra_headers: Sequence[tuple[bytes, bytes]] = ()) -> Request:
+    """A Request the route handlers can actually read a body off, so the router branch is real."""
+    payload = json.dumps(body).encode()
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": payload, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": path,
+            "headers": [(b"content-type", b"application/json"), *extra_headers],
+            "query_string": b"",
+            "state": {},
+        },
+        receive,
+    )
+
+
+def make_router(model_name: str) -> Router:
+    router = Router(
+        model_list=[
+            {
+                "model_name": model_name,
+                "litellm_params": {"model": "hosted_vllm/upstream", "api_base": "http://127.0.0.1:9", "api_key": "k"},
+            }
+        ]
+    )
+    router.allm_passthrough_route = AsyncMock(return_value=httpx.Response(200, json={"ok": True}))
+    return router
 
 
 @pytest.mark.asyncio
@@ -94,3 +137,89 @@ async def test_websocket_routes_are_not_registered(route_type):
 
     assert registry.calls == []
     assert not hasattr(request.state, "active_request_registry")
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.asyncio
+async def test_vllm_router_model_passthrough_is_registered(stream):
+    """The router branch returns before pass_through_request, so it has to register itself."""
+    registry = RecordingRegistry(returned_id="registry-vllm")
+    router = make_router("router-model")
+    request = make_body_request("/vllm/chat/completions", {"model": "router-model", "stream": stream})
+
+    with (
+        patch("litellm.proxy.proxy_server.llm_router", router),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", make_proxy_logging(registry)),
+    ):
+        await vllm_proxy_route(
+            endpoint="/chat/completions",
+            request=request,
+            fastapi_response=SimpleNamespace(headers={}),
+            user_api_key_dict=UserAPIKeyAuth(api_key="key-1"),
+        )
+
+    router.allm_passthrough_route.assert_awaited_once()
+    assert request.state.active_request_registry_id == "registry-vllm"
+    assert len(registry.calls) == 1
+    assert registry.calls[0]["call_type"] == "allm_passthrough_route"
+    assert registry.calls[0]["data"]["model"] == "router-model"
+    assert registry.calls[0]["data"]["stream"] is stream
+    # One id for the overview row and the log entry, so the row can be looked up.
+    assert (
+        router.allm_passthrough_route.await_args.kwargs["litellm_call_id"]
+        == registry.calls[0]["data"]["litellm_call_id"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_azure_router_model_passthrough_is_registered():
+    registry = RecordingRegistry(returned_id="registry-azure")
+    router = make_router("router-model")
+    endpoint = "openai/deployments/router-model/chat/completions"
+    request = make_body_request(f"/azure/{endpoint}", {"messages": []})
+
+    with (
+        patch("litellm.proxy.proxy_server.llm_router", router),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", make_proxy_logging(registry)),
+    ):
+        await azure_proxy_route(
+            endpoint=endpoint,
+            request=request,
+            fastapi_response=SimpleNamespace(headers={}),
+            user_api_key_dict=UserAPIKeyAuth(api_key="key-1"),
+        )
+
+    router.allm_passthrough_route.assert_awaited_once()
+    assert request.state.active_request_registry_id == "registry-azure"
+    assert len(registry.calls) == 1
+    assert registry.calls[0]["call_type"] == "allm_passthrough_route"
+    # Azure carries the model in the url, not in the body.
+    assert registry.calls[0]["data"]["model"] == "router-model"
+    assert (
+        router.allm_passthrough_route.await_args.kwargs["litellm_call_id"]
+        == registry.calls[0]["data"]["litellm_call_id"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_router_passthrough_keeps_the_client_supplied_call_id():
+    registry = RecordingRegistry(returned_id="registry-vllm")
+    router = make_router("router-model")
+    request = make_body_request(
+        "/vllm/chat/completions",
+        {"model": "router-model"},
+        extra_headers=((b"x-litellm-call-id", b"caller-supplied-id"),),
+    )
+
+    with (
+        patch("litellm.proxy.proxy_server.llm_router", router),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", make_proxy_logging(registry)),
+    ):
+        await vllm_proxy_route(
+            endpoint="/chat/completions",
+            request=request,
+            fastapi_response=SimpleNamespace(headers={}),
+            user_api_key_dict=UserAPIKeyAuth(api_key="key-1"),
+        )
+
+    assert registry.calls[0]["data"]["litellm_call_id"] == "caller-supplied-id"

--- a/tests/test_litellm/proxy/test_active_request_registration.py
+++ b/tests/test_litellm/proxy/test_active_request_registration.py
@@ -1,0 +1,96 @@
+from collections.abc import Mapping
+from types import SimpleNamespace
+
+import pytest
+from fastapi import Request
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+from litellm.proxy.hooks.active_request_registry import ActiveRequestRegistry
+from litellm.types.utils import CallTypesLiteral
+
+
+class RecordingRegistry(ActiveRequestRegistry):
+    """Real registry with Redis replaced by a recorder, so the call contract is exercised."""
+
+    def __init__(self, returned_id: str | None) -> None:
+        super().__init__(SimpleNamespace(dual_cache=SimpleNamespace(redis_cache=None)))
+        self.returned_id = returned_id
+        self.calls: list[dict[str, object]] = []
+
+    async def register(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        data: Mapping[str, object],
+        call_type: CallTypesLiteral,
+        registry_id: str | None = None,
+        started_at: float | None = None,
+    ) -> str | None:
+        self.calls.append({"registry_id": registry_id, "started_at": started_at, "call_type": call_type})
+        return self.returned_id
+
+
+def make_request() -> Request:
+    return Request({"type": "http", "method": "POST", "path": "/v1/chat/completions", "headers": []})
+
+
+def make_proxy_logging(hook: object) -> SimpleNamespace:
+    return SimpleNamespace(get_proxy_hook=lambda _: hook)
+
+
+@pytest.mark.asyncio
+async def test_repeated_pre_call_registration_reuses_registry_identity_and_start_time():
+    processor = ProxyBaseLLMRequestProcessing(data={"litellm_call_id": "call-1", "model": "model-a"})
+    registry = RecordingRegistry(returned_id="registry-1")
+    proxy_logging = make_proxy_logging(registry)
+    request = make_request()
+    auth = UserAPIKeyAuth(api_key="key-1")
+
+    await processor._register_active_request(request, auth, proxy_logging, "acompletion")
+    first_started_at = request.state.active_request_started_at
+    await processor._register_active_request(request, auth, proxy_logging, "acompletion")
+
+    assert len(registry.calls) == 2
+    assert registry.calls[0]["registry_id"] is None
+    assert registry.calls[1]["registry_id"] == "registry-1"
+    assert registry.calls[1]["started_at"] == first_started_at
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_keeps_registry_identity_for_cleanup():
+    processor = ProxyBaseLLMRequestProcessing(data={"litellm_call_id": "call-1"})
+    proxy_logging = make_proxy_logging(RecordingRegistry(returned_id=None))
+    request = make_request()
+    request.state.active_request_registry_id = "registry-1"
+
+    await processor._register_active_request(request, UserAPIKeyAuth(api_key="key-1"), proxy_logging, "acompletion")
+
+    assert request.state.active_request_registry_id == "registry-1"
+
+
+@pytest.mark.asyncio
+async def test_unrelated_hook_is_ignored_without_affecting_requests():
+    processor = ProxyBaseLLMRequestProcessing(data={"litellm_call_id": "call-1"})
+    proxy_logging = make_proxy_logging(SimpleNamespace(register=lambda **_: None))
+    request = make_request()
+
+    await processor._register_active_request(request, UserAPIKeyAuth(api_key="key-1"), proxy_logging, "acompletion")
+
+    assert not hasattr(request.state, "active_request_registry_id")
+    assert not hasattr(request.state, "active_request_registry")
+
+
+@pytest.mark.parametrize("route_type", ["_arealtime", "_aresponses_websocket"])
+@pytest.mark.asyncio
+async def test_websocket_routes_are_not_registered(route_type):
+    """Those routes hand in a synthetic http Request, so the middleware never sees them close."""
+    processor = ProxyBaseLLMRequestProcessing(data={"litellm_call_id": "call-1"})
+    registry = RecordingRegistry(returned_id="registry-1")
+    request = make_request()
+
+    await processor._register_active_request(
+        request, UserAPIKeyAuth(api_key="key-1"), make_proxy_logging(registry), route_type
+    )
+
+    assert registry.calls == []
+    assert not hasattr(request.state, "active_request_registry")

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -2,6 +2,7 @@ import datetime as real_datetime
 import os
 import smtplib
 import sys
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -12,9 +13,7 @@ from litellm.proxy._types import ProxyErrorTypes
 from litellm.proxy.utils import ProxyLogging
 from litellm.types.guardrails import GuardrailEventHooks
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
 
 from unittest.mock import MagicMock, patch
@@ -87,9 +86,7 @@ async def test_proxy_only_error_log_marks_no_upstream_llm_call():
     captured = {}
 
     def fake_pre_call(self, *args, **kwargs):
-        captured["flag"] = self.model_call_details.get(
-            LITELLM_LOGGING_NO_UPSTREAM_LLM_CALL
-        )
+        captured["flag"] = self.model_call_details.get(LITELLM_LOGGING_NO_UPSTREAM_LLM_CALL)
 
     from litellm.litellm_core_utils.litellm_logging import Logging
 
@@ -107,9 +104,7 @@ async def test_proxy_only_error_log_marks_no_upstream_llm_call():
                 "model": "gpt-4o",
                 "messages": [{"role": "user", "content": "hi"}],
             },
-            user_api_key_dict=UserAPIKeyAuth(
-                api_key="sk-bad", request_route="/v1/chat/completions"
-            ),
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-bad", request_route="/v1/chat/completions"),
             route="/v1/chat/completions",
             original_exception=Exception("bad key"),
         )
@@ -153,13 +148,9 @@ async def test_proxy_only_error_log_keeps_litellm_metadata_in_litellm_params():
             request_data={
                 "model": "gpt-4o",
                 "input": "blocked prompt",
-                "litellm_metadata": {
-                    "standard_logging_guardrail_information": guardrail_info
-                },
+                "litellm_metadata": {"standard_logging_guardrail_information": guardrail_info},
             },
-            user_api_key_dict=UserAPIKeyAuth(
-                api_key="sk-1234", request_route="/v1/responses"
-            ),
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-1234", request_route="/v1/responses"),
             route="/v1/responses",
             original_exception=HTTPException(status_code=400, detail="blocked"),
         )
@@ -168,12 +159,7 @@ async def test_proxy_only_error_log_keeps_litellm_metadata_in_litellm_params():
         Logging.pre_call = orig_pre_call
         Logging.async_failure_handler = orig_async_failure
 
-    assert (
-        captured["litellm_params"]["litellm_metadata"][
-            "standard_logging_guardrail_information"
-        ]
-        == guardrail_info
-    )
+    assert captured["litellm_params"]["litellm_metadata"]["standard_logging_guardrail_information"] == guardrail_info
     assert "litellm_metadata" not in captured["optional_params"]
 
 
@@ -211,9 +197,7 @@ def test_get_model_group_info_order():
 
 def test_join_paths_no_duplication():
     """Test that join_paths doesn't duplicate route when base_path already ends with it"""
-    result = join_paths(
-        base_path="http://0.0.0.0:4000/my-custom-path/", route="/my-custom-path"
-    )
+    result = join_paths(base_path="http://0.0.0.0:4000/my-custom-path/", route="/my-custom-path")
     assert result == "http://0.0.0.0:4000/my-custom-path"
 
 
@@ -498,9 +482,7 @@ def test_create_model_info_response_includes_max_tokens_from_lookup():
         model_id="some-model",
         provider="openai",
         llm_router=None,
-        get_model_info=lambda _model: _fake_model_info(
-            max_input_tokens=128000, max_output_tokens=16384
-        ),
+        get_model_info=lambda _model: _fake_model_info(max_input_tokens=128000, max_output_tokens=16384),
     )
 
     assert response["id"] == "some-model"
@@ -517,9 +499,7 @@ def test_create_model_info_response_does_not_call_router_group_info():
         model_id="some-model",
         provider="openai",
         llm_router=router,
-        get_model_info=lambda _model: _fake_model_info(
-            max_input_tokens=128000, max_output_tokens=16384
-        ),
+        get_model_info=lambda _model: _fake_model_info(max_input_tokens=128000, max_output_tokens=16384),
     )
 
     router.get_model_group_info.assert_not_called()
@@ -550,9 +530,7 @@ def test_create_model_info_response_deployment_limits_override_cost_map():
         model_id="gpt-4o",
         provider="openai",
         llm_router=router,
-        get_model_info=lambda _model: _fake_model_info(
-            max_input_tokens=128000, max_output_tokens=16384
-        ),
+        get_model_info=lambda _model: _fake_model_info(max_input_tokens=128000, max_output_tokens=16384),
     )
 
     assert response["max_input_tokens"] == 200000
@@ -590,9 +568,7 @@ def test_create_model_info_response_survives_malformed_cost_map_limits(bad_value
         model_id="some-model",
         provider="openai",
         llm_router=None,
-        get_model_info=lambda _model: _fake_model_info(
-            max_input_tokens=bad_value, max_output_tokens=bad_value
-        ),
+        get_model_info=lambda _model: _fake_model_info(max_input_tokens=bad_value, max_output_tokens=bad_value),
     )
 
     assert response["id"] == "some-model"
@@ -605,9 +581,7 @@ def test_create_model_info_response_keeps_valid_cost_map_limit_beside_malformed_
         model_id="some-model",
         provider="openai",
         llm_router=None,
-        get_model_info=lambda _model: _fake_model_info(
-            max_input_tokens="128,000", max_output_tokens=16384
-        ),
+        get_model_info=lambda _model: _fake_model_info(max_input_tokens="128,000", max_output_tokens=16384),
     )
 
     assert "max_input_tokens" not in response
@@ -650,9 +624,7 @@ def test_create_model_info_response_emits_integer_token_counts():
         model_id="some-model",
         provider="openai",
         llm_router=None,
-        get_model_info=lambda _model: _fake_model_info(
-            max_input_tokens=128000, max_output_tokens=16384
-        ),
+        get_model_info=lambda _model: _fake_model_info(max_input_tokens=128000, max_output_tokens=16384),
     )
 
     assert isinstance(response["max_input_tokens"], int)
@@ -701,9 +673,7 @@ def test_create_model_info_response_no_router_keeps_base_fields():
 
 
 def test_create_model_info_response_reads_real_cost_map():
-    response = create_model_info_response(
-        model_id="gpt-4o", provider="openai", llm_router=None
-    )
+    response = create_model_info_response(model_id="gpt-4o", provider="openai", llm_router=None)
 
     assert isinstance(response["max_input_tokens"], int)
     assert response["max_input_tokens"] > 0
@@ -787,10 +757,7 @@ class TestPostCallFailureHookLLMExceptionAlerting:
 
     @pytest.mark.asyncio
     async def test_http_exception_does_not_alert(self):
-        assert (
-            await self._alerted(HTTPException(status_code=400, detail="blocked"))
-            is False
-        )
+        assert await self._alerted(HTTPException(status_code=400, detail="blocked")) is False
 
     @pytest.mark.asyncio
     async def test_genuine_llm_api_error_still_alerts(self):
@@ -823,9 +790,7 @@ class TestPostCallFailureHookProxyExceptionLogging:
             await proxy_logging_obj.post_call_failure_hook(
                 request_data={},
                 original_exception=exc,
-                user_api_key_dict=UserAPIKeyAuth(
-                    api_key="sk-test", request_route=request_route
-                ),
+                user_api_key_dict=UserAPIKeyAuth(api_key="sk-test", request_route=request_route),
             )
         return handle_mock.await_count > 0
 
@@ -842,20 +807,12 @@ class TestPostCallFailureHookProxyExceptionLogging:
 
     @pytest.mark.asyncio
     async def test_proxy_exception_on_llm_route_is_logged(self):
-        assert (
-            await self._logged(self._block(), request_route="/v1/chat/completions")
-            is True
-        )
+        assert await self._logged(self._block(), request_route="/v1/chat/completions") is True
 
     @pytest.mark.asyncio
     async def test_generic_exception_on_llm_route_is_not_logged(self):
         # A raw provider/unknown exception is logged by the LLM call path, not here.
-        assert (
-            await self._logged(
-                Exception("upstream 503"), request_route="/v1/chat/completions"
-            )
-            is False
-        )
+        assert await self._logged(Exception("upstream 503"), request_route="/v1/chat/completions") is False
 
 
 class TestShouldUseSmtpSsl:
@@ -889,9 +846,7 @@ class TestCreateSmtpConnection:
             patch("smtplib.SMTP_SSL") as mock_smtp_ssl,
             patch("smtplib.SMTP") as mock_smtp,
         ):
-            result = _create_smtp_connection(
-                smtp_host="mail.example.com", smtp_port=465
-            )
+            result = _create_smtp_connection(smtp_host="mail.example.com", smtp_port=465)
 
         mock_smtp.assert_not_called()
         assert result is mock_smtp_ssl.return_value
@@ -911,9 +866,7 @@ class TestCreateSmtpConnection:
             patch("smtplib.SMTP_SSL") as mock_smtp_ssl,
             patch("smtplib.SMTP") as mock_smtp,
         ):
-            result = _create_smtp_connection(
-                smtp_host="mail.example.com", smtp_port=587
-            )
+            result = _create_smtp_connection(smtp_host="mail.example.com", smtp_port=587)
 
         mock_smtp_ssl.assert_not_called()
         assert result is mock_smtp.return_value
@@ -934,9 +887,7 @@ class TestSendEmailStartTls:
         monkeypatch.delenv("SMTP_USE_SSL", raising=False)
 
         mock_server = MagicMock(spec=smtplib.SMTP)
-        with patch(
-            "litellm.proxy.utils._create_smtp_connection"
-        ) as mock_create_connection:
+        with patch("litellm.proxy.utils._create_smtp_connection") as mock_create_connection:
             mock_create_connection.return_value.__enter__.return_value = mock_server
             await send_email(
                 receiver_email="receiver@example.com",
@@ -1221,3 +1172,24 @@ async def test_post_mcp_call_hook_skips_opted_out_guardrail(restore_callbacks):
 
     assert guardrail.call_count == 0
     assert [item.text for item in returned.content] == ["jane@example.com"]
+
+
+class TestProxyHookCallbackRegistration:
+    """`_add_proxy_hooks` only registers hooks that want to be logging callbacks."""
+
+    def test_hook_opting_out_gets_its_slot_without_becoming_a_callback(self):
+        import litellm
+        from litellm.proxy.hooks.active_request_registry import ActiveRequestRegistry
+        from litellm.proxy.utils import ProxyLogging
+
+        proxy_logging = ProxyLogging(user_api_key_cache=SimpleNamespace())
+        before = list(litellm.callbacks)
+
+        proxy_logging._add_proxy_hooks()
+
+        registry = proxy_logging.get_proxy_hook("active_request_registry")
+        added = [callback for callback in litellm.callbacks if callback not in before]
+        assert isinstance(registry, ActiveRequestRegistry)
+        assert registry.register_as_litellm_callback is False
+        assert registry not in added
+        assert added, "hooks that do not opt out must still be registered as callbacks"

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -2,6 +2,7 @@ import datetime as real_datetime
 import os
 import smtplib
 import sys
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -12,9 +13,7 @@ from litellm.proxy._types import ProxyErrorTypes
 from litellm.proxy.utils import ProxyLogging
 from litellm.types.guardrails import GuardrailEventHooks
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
 
 from unittest.mock import MagicMock, patch
@@ -87,9 +86,7 @@ async def test_proxy_only_error_log_marks_no_upstream_llm_call():
     captured = {}
 
     def fake_pre_call(self, *args, **kwargs):
-        captured["flag"] = self.model_call_details.get(
-            LITELLM_LOGGING_NO_UPSTREAM_LLM_CALL
-        )
+        captured["flag"] = self.model_call_details.get(LITELLM_LOGGING_NO_UPSTREAM_LLM_CALL)
 
     from litellm.litellm_core_utils.litellm_logging import Logging
 
@@ -107,9 +104,7 @@ async def test_proxy_only_error_log_marks_no_upstream_llm_call():
                 "model": "gpt-4o",
                 "messages": [{"role": "user", "content": "hi"}],
             },
-            user_api_key_dict=UserAPIKeyAuth(
-                api_key="sk-bad", request_route="/v1/chat/completions"
-            ),
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-bad", request_route="/v1/chat/completions"),
             route="/v1/chat/completions",
             original_exception=Exception("bad key"),
         )
@@ -153,13 +148,9 @@ async def test_proxy_only_error_log_keeps_litellm_metadata_in_litellm_params():
             request_data={
                 "model": "gpt-4o",
                 "input": "blocked prompt",
-                "litellm_metadata": {
-                    "standard_logging_guardrail_information": guardrail_info
-                },
+                "litellm_metadata": {"standard_logging_guardrail_information": guardrail_info},
             },
-            user_api_key_dict=UserAPIKeyAuth(
-                api_key="sk-1234", request_route="/v1/responses"
-            ),
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-1234", request_route="/v1/responses"),
             route="/v1/responses",
             original_exception=HTTPException(status_code=400, detail="blocked"),
         )
@@ -168,12 +159,7 @@ async def test_proxy_only_error_log_keeps_litellm_metadata_in_litellm_params():
         Logging.pre_call = orig_pre_call
         Logging.async_failure_handler = orig_async_failure
 
-    assert (
-        captured["litellm_params"]["litellm_metadata"][
-            "standard_logging_guardrail_information"
-        ]
-        == guardrail_info
-    )
+    assert captured["litellm_params"]["litellm_metadata"]["standard_logging_guardrail_information"] == guardrail_info
     assert "litellm_metadata" not in captured["optional_params"]
 
 
@@ -211,9 +197,7 @@ def test_get_model_group_info_order():
 
 def test_join_paths_no_duplication():
     """Test that join_paths doesn't duplicate route when base_path already ends with it"""
-    result = join_paths(
-        base_path="http://0.0.0.0:4000/my-custom-path/", route="/my-custom-path"
-    )
+    result = join_paths(base_path="http://0.0.0.0:4000/my-custom-path/", route="/my-custom-path")
     assert result == "http://0.0.0.0:4000/my-custom-path"
 
 
@@ -498,9 +482,7 @@ def test_create_model_info_response_includes_max_tokens_from_lookup():
         model_id="some-model",
         provider="openai",
         llm_router=None,
-        get_model_info=lambda _model: _fake_model_info(
-            max_input_tokens=128000, max_output_tokens=16384
-        ),
+        get_model_info=lambda _model: _fake_model_info(max_input_tokens=128000, max_output_tokens=16384),
     )
 
     assert response["id"] == "some-model"
@@ -517,9 +499,7 @@ def test_create_model_info_response_does_not_call_router_group_info():
         model_id="some-model",
         provider="openai",
         llm_router=router,
-        get_model_info=lambda _model: _fake_model_info(
-            max_input_tokens=128000, max_output_tokens=16384
-        ),
+        get_model_info=lambda _model: _fake_model_info(max_input_tokens=128000, max_output_tokens=16384),
     )
 
     router.get_model_group_info.assert_not_called()
@@ -550,9 +530,7 @@ def test_create_model_info_response_deployment_limits_override_cost_map():
         model_id="gpt-4o",
         provider="openai",
         llm_router=router,
-        get_model_info=lambda _model: _fake_model_info(
-            max_input_tokens=128000, max_output_tokens=16384
-        ),
+        get_model_info=lambda _model: _fake_model_info(max_input_tokens=128000, max_output_tokens=16384),
     )
 
     assert response["max_input_tokens"] == 200000
@@ -590,9 +568,7 @@ def test_create_model_info_response_survives_malformed_cost_map_limits(bad_value
         model_id="some-model",
         provider="openai",
         llm_router=None,
-        get_model_info=lambda _model: _fake_model_info(
-            max_input_tokens=bad_value, max_output_tokens=bad_value
-        ),
+        get_model_info=lambda _model: _fake_model_info(max_input_tokens=bad_value, max_output_tokens=bad_value),
     )
 
     assert response["id"] == "some-model"
@@ -605,9 +581,7 @@ def test_create_model_info_response_keeps_valid_cost_map_limit_beside_malformed_
         model_id="some-model",
         provider="openai",
         llm_router=None,
-        get_model_info=lambda _model: _fake_model_info(
-            max_input_tokens="128,000", max_output_tokens=16384
-        ),
+        get_model_info=lambda _model: _fake_model_info(max_input_tokens="128,000", max_output_tokens=16384),
     )
 
     assert "max_input_tokens" not in response
@@ -650,9 +624,7 @@ def test_create_model_info_response_emits_integer_token_counts():
         model_id="some-model",
         provider="openai",
         llm_router=None,
-        get_model_info=lambda _model: _fake_model_info(
-            max_input_tokens=128000, max_output_tokens=16384
-        ),
+        get_model_info=lambda _model: _fake_model_info(max_input_tokens=128000, max_output_tokens=16384),
     )
 
     assert isinstance(response["max_input_tokens"], int)
@@ -701,9 +673,7 @@ def test_create_model_info_response_no_router_keeps_base_fields():
 
 
 def test_create_model_info_response_reads_real_cost_map():
-    response = create_model_info_response(
-        model_id="gpt-4o", provider="openai", llm_router=None
-    )
+    response = create_model_info_response(model_id="gpt-4o", provider="openai", llm_router=None)
 
     assert isinstance(response["max_input_tokens"], int)
     assert response["max_input_tokens"] > 0
@@ -787,10 +757,7 @@ class TestPostCallFailureHookLLMExceptionAlerting:
 
     @pytest.mark.asyncio
     async def test_http_exception_does_not_alert(self):
-        assert (
-            await self._alerted(HTTPException(status_code=400, detail="blocked"))
-            is False
-        )
+        assert await self._alerted(HTTPException(status_code=400, detail="blocked")) is False
 
     @pytest.mark.asyncio
     async def test_genuine_llm_api_error_still_alerts(self):
@@ -823,9 +790,7 @@ class TestPostCallFailureHookProxyExceptionLogging:
             await proxy_logging_obj.post_call_failure_hook(
                 request_data={},
                 original_exception=exc,
-                user_api_key_dict=UserAPIKeyAuth(
-                    api_key="sk-test", request_route=request_route
-                ),
+                user_api_key_dict=UserAPIKeyAuth(api_key="sk-test", request_route=request_route),
             )
         return handle_mock.await_count > 0
 
@@ -842,20 +807,12 @@ class TestPostCallFailureHookProxyExceptionLogging:
 
     @pytest.mark.asyncio
     async def test_proxy_exception_on_llm_route_is_logged(self):
-        assert (
-            await self._logged(self._block(), request_route="/v1/chat/completions")
-            is True
-        )
+        assert await self._logged(self._block(), request_route="/v1/chat/completions") is True
 
     @pytest.mark.asyncio
     async def test_generic_exception_on_llm_route_is_not_logged(self):
         # A raw provider/unknown exception is logged by the LLM call path, not here.
-        assert (
-            await self._logged(
-                Exception("upstream 503"), request_route="/v1/chat/completions"
-            )
-            is False
-        )
+        assert await self._logged(Exception("upstream 503"), request_route="/v1/chat/completions") is False
 
 
 class TestShouldUseSmtpSsl:
@@ -889,9 +846,7 @@ class TestCreateSmtpConnection:
             patch("smtplib.SMTP_SSL") as mock_smtp_ssl,
             patch("smtplib.SMTP") as mock_smtp,
         ):
-            result = _create_smtp_connection(
-                smtp_host="mail.example.com", smtp_port=465
-            )
+            result = _create_smtp_connection(smtp_host="mail.example.com", smtp_port=465)
 
         mock_smtp.assert_not_called()
         assert result is mock_smtp_ssl.return_value
@@ -911,9 +866,7 @@ class TestCreateSmtpConnection:
             patch("smtplib.SMTP_SSL") as mock_smtp_ssl,
             patch("smtplib.SMTP") as mock_smtp,
         ):
-            result = _create_smtp_connection(
-                smtp_host="mail.example.com", smtp_port=587
-            )
+            result = _create_smtp_connection(smtp_host="mail.example.com", smtp_port=587)
 
         mock_smtp_ssl.assert_not_called()
         assert result is mock_smtp.return_value
@@ -934,9 +887,7 @@ class TestSendEmailStartTls:
         monkeypatch.delenv("SMTP_USE_SSL", raising=False)
 
         mock_server = MagicMock(spec=smtplib.SMTP)
-        with patch(
-            "litellm.proxy.utils._create_smtp_connection"
-        ) as mock_create_connection:
+        with patch("litellm.proxy.utils._create_smtp_connection") as mock_create_connection:
             mock_create_connection.return_value.__enter__.return_value = mock_server
             await send_email(
                 receiver_email="receiver@example.com",
@@ -1161,3 +1112,24 @@ async def test_prisma_health_check_failure_redacts_database_credentials(caplog):
     assert emitted
     assert all("hunter2" not in message for message in emitted)
     assert any("postgresql://REDACTED@db.internal" in message for message in emitted)
+
+
+class TestProxyHookCallbackRegistration:
+    """`_add_proxy_hooks` only registers hooks that want to be logging callbacks."""
+
+    def test_hook_opting_out_gets_its_slot_without_becoming_a_callback(self):
+        import litellm
+        from litellm.proxy.hooks.active_request_registry import ActiveRequestRegistry
+        from litellm.proxy.utils import ProxyLogging
+
+        proxy_logging = ProxyLogging(user_api_key_cache=SimpleNamespace())
+        before = list(litellm.callbacks)
+
+        proxy_logging._add_proxy_hooks()
+
+        registry = proxy_logging.get_proxy_hook("active_request_registry")
+        added = [callback for callback in litellm.callbacks if callback not in before]
+        assert isinstance(registry, ActiveRequestRegistry)
+        assert registry.register_as_litellm_callback is False
+        assert registry not in added
+        assert added, "hooks that do not opt out must still be registered as callbacks"

--- a/ui/litellm-dashboard/src/app/(dashboard)/active-requests/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/active-requests/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import ActiveRequests from "@/components/ActiveRequests/ActiveRequests";
+
+export default function ActiveRequestsPage() {
+  const { accessToken } = useAuthorized();
+  return <ActiveRequests accessToken={accessToken} />;
+}

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestCharts.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestCharts.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { BarChart } from "@/components/shared/charts";
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { ActiveRequest } from "./activeRequestsApi";
+import { chartHeight, countBy, countByAge, GROUP_BY, magnitudeFills, type GroupBy } from "./activeRequestGrouping";
+import { useIsDarkMode } from "./useIsDarkMode";
+
+export interface ActiveRequestChartsProps {
+  items: readonly ActiveRequest[];
+  now: number;
+}
+
+export default function ActiveRequestCharts({ items, now }: ActiveRequestChartsProps) {
+  const [groupBy, setGroupBy] = useState<GroupBy>("model");
+  const dark = useIsDarkMode();
+
+  const grouped = useMemo(() => countBy(items, groupBy), [items, groupBy]);
+  const byAge = useMemo(() => countByAge(items, now), [items, now]);
+  const groupLabel = GROUP_BY.find((option) => option.value === groupBy)?.label ?? "Model";
+  const height = chartHeight(grouped.length);
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-12">
+      <Card className="lg:col-span-7">
+        <CardHeader>
+          <CardTitle>Running requests by {groupLabel.toLowerCase()}</CardTitle>
+          <CardAction>
+            <Tabs value={groupBy} onValueChange={(value) => setGroupBy(value as GroupBy)}>
+              <TabsList>
+                {GROUP_BY.map((option) => (
+                  <TabsTrigger key={option.value} value={option.value}>
+                    {option.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          {grouped.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No running requests on this page.</p>
+          ) : (
+            <BarChart
+              data={grouped}
+              index="label"
+              categories={["requests"]}
+              colors={magnitudeFills(grouped.length, { dark, ascending: true })}
+              colorByDatum
+              layout="vertical"
+              yAxisWidth={190}
+              maxBarSize={22}
+              showLegend={false}
+              valueFormatter={(value) => `${value}`}
+              style={{ height }}
+            />
+          )}
+        </CardContent>
+      </Card>
+      <Card className="lg:col-span-5">
+        <CardHeader>
+          <CardTitle>How long they have been running</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <BarChart
+            data={byAge}
+            index="label"
+            categories={["requests"]}
+            colors={magnitudeFills(byAge.length, { dark, ascending: false })}
+            colorByDatum
+            maxBarSize={44}
+            showLegend={false}
+            valueFormatter={(value) => `${value}`}
+            style={{ height }}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestColumns.test.ts
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestColumns.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { formatAge } from "./ActiveRequestColumns";
+
+const NOW_MS = 1_700_000_000_000;
+const startedSecondsAgo = (seconds: number) => NOW_MS / 1000 - seconds;
+
+describe("formatAge", () => {
+  it("should report a young request in seconds", () => {
+    expect(formatAge(startedSecondsAgo(12), NOW_MS)).toBe("12s");
+  });
+
+  it("should switch to minutes at the first full minute", () => {
+    expect(formatAge(startedSecondsAgo(59), NOW_MS)).toBe("59s");
+    expect(formatAge(startedSecondsAgo(60), NOW_MS)).toBe("1m 0s");
+    expect(formatAge(startedSecondsAgo(125), NOW_MS)).toBe("2m 5s");
+  });
+
+  it("should switch to hours at the first full hour and drop the seconds", () => {
+    expect(formatAge(startedSecondsAgo(3599), NOW_MS)).toBe("59m 59s");
+    expect(formatAge(startedSecondsAgo(3600), NOW_MS)).toBe("1h 0m");
+    expect(formatAge(startedSecondsAgo(7845), NOW_MS)).toBe("2h 10m");
+  });
+
+  it("should clamp a clock skew between proxy and browser to zero", () => {
+    expect(formatAge(startedSecondsAgo(-30), NOW_MS)).toBe("0s");
+  });
+});

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestColumns.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestColumns.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ColumnDef } from "@tanstack/react-table";
+import { useEffect, useState } from "react";
 import { DataTableSortHeader } from "@/components/shared/DataTable";
 import { Badge } from "@/components/ui/badge";
 import type { ActiveRequest } from "./activeRequestsApi";
@@ -20,7 +21,26 @@ const text = (value?: string | null) => (value ? <span>{value}</span> : <Dash />
 
 const AGE_WARNING_SECONDS = 60;
 
-export const getActiveRequestColumns = (now: number): ColumnDef<ActiveRequest>[] => [
+const AgeCell = ({ startedAt }: { startedAt: number }) => {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const stale = now / 1000 - startedAt > AGE_WARNING_SECONDS;
+  return (
+    <Badge
+      variant={stale ? "outline" : "secondary"}
+      className={stale ? "border-amber-500/50 text-amber-700 dark:text-amber-400" : undefined}
+    >
+      {formatAge(startedAt, now)}
+    </Badge>
+  );
+};
+
+export const activeRequestColumns: ColumnDef<ActiveRequest>[] = [
   {
     id: "age",
     accessorKey: "started_at",
@@ -29,17 +49,7 @@ export const getActiveRequestColumns = (now: number): ColumnDef<ActiveRequest>[]
     size: 110,
     enableSorting: true,
     sortingFn: (left, right) => right.original.started_at - left.original.started_at,
-    cell: ({ row }) => {
-      const stale = now / 1000 - row.original.started_at > AGE_WARNING_SECONDS;
-      return (
-        <Badge
-          variant={stale ? "outline" : "secondary"}
-          className={stale ? "border-amber-500/50 text-amber-700 dark:text-amber-400" : undefined}
-        >
-          {formatAge(row.original.started_at, now)}
-        </Badge>
-      );
-    },
+    cell: ({ row }) => <AgeCell startedAt={row.original.started_at} />,
   },
   {
     id: "model",

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestColumns.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestColumns.tsx
@@ -125,13 +125,23 @@ export const activeRequestColumns: ColumnDef<ActiveRequest>[] = [
     cell: ({ row }) => text(row.original.team_alias || row.original.team_id),
   },
   {
-    id: "key",
-    accessorFn: (row) => row.key_alias ?? row.key_fingerprint ?? "",
-    meta: { title: "Key" },
-    header: "Key",
+    id: "key_alias",
+    accessorFn: (row) => row.key_alias ?? "",
+    meta: { title: "Key Alias" },
+    header: "Key Alias",
     size: 170,
     enableSorting: false,
-    cell: ({ row }) => text(row.original.key_alias || row.original.key_fingerprint),
+    cell: ({ row }) => text(row.original.key_alias),
+  },
+  {
+    id: "key_hash",
+    accessorFn: (row) => row.key_hash ?? "",
+    meta: { title: "Key Hash" },
+    header: "Key Hash",
+    size: 200,
+    enableSorting: false,
+    cell: ({ row }) =>
+      row.original.key_hash ? <span className="truncate font-mono text-xs">{row.original.key_hash}</span> : <Dash />,
   },
   {
     id: "route",

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestColumns.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestColumns.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { DataTableSortHeader } from "@/components/shared/DataTable";
+import { Badge } from "@/components/ui/badge";
+import type { ActiveRequest } from "./activeRequestsApi";
+
+export const formatAge = (startedAt: number, now: number) => {
+  const seconds = Math.max(0, Math.floor(now / 1000 - startedAt));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${remainder}s`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+};
+
+const Dash = () => <span className="text-muted-foreground">—</span>;
+
+const text = (value?: string | null) => (value ? <span>{value}</span> : <Dash />);
+
+const AGE_WARNING_SECONDS = 60;
+
+export const getActiveRequestColumns = (now: number): ColumnDef<ActiveRequest>[] => [
+  {
+    id: "age",
+    accessorKey: "started_at",
+    meta: { title: "Age" },
+    header: ({ column }) => <DataTableSortHeader column={column} title="Age" />,
+    size: 110,
+    enableSorting: true,
+    sortingFn: (left, right) => right.original.started_at - left.original.started_at,
+    cell: ({ row }) => {
+      const stale = now / 1000 - row.original.started_at > AGE_WARNING_SECONDS;
+      return (
+        <Badge
+          variant={stale ? "outline" : "secondary"}
+          className={stale ? "border-amber-500/50 text-amber-700 dark:text-amber-400" : undefined}
+        >
+          {formatAge(row.original.started_at, now)}
+        </Badge>
+      );
+    },
+  },
+  {
+    id: "model",
+    accessorFn: (row) => row.model ?? "",
+    meta: { title: "Model" },
+    header: ({ column }) => <DataTableSortHeader column={column} title="Model" />,
+    size: 190,
+    enableSorting: true,
+    cell: ({ row }) => text(row.original.model),
+  },
+  {
+    id: "type",
+    accessorFn: (row) => row.call_type ?? "",
+    meta: { title: "Type" },
+    header: "Type",
+    size: 160,
+    enableSorting: false,
+    cell: ({ row }) => (
+      <div className="flex items-center gap-2">
+        {text(row.original.call_type)}
+        {row.original.streaming && <Badge variant="outline">stream</Badge>}
+      </div>
+    ),
+  },
+  {
+    id: "end_user_id",
+    accessorFn: (row) => row.end_user_id ?? "",
+    meta: { title: "End User" },
+    header: ({ column }) => <DataTableSortHeader column={column} title="End User" />,
+    size: 170,
+    enableSorting: true,
+    cell: ({ row }) => text(row.original.end_user_id),
+  },
+  {
+    id: "user",
+    accessorFn: (row) => row.user_id ?? "",
+    meta: { title: "User" },
+    header: ({ column }) => <DataTableSortHeader column={column} title="User" />,
+    size: 220,
+    enableSorting: true,
+    cell: ({ row }) => (
+      <div className="flex flex-col">
+        {text(row.original.user_id)}
+        {row.original.user_email && <span className="text-xs text-muted-foreground">{row.original.user_email}</span>}
+      </div>
+    ),
+  },
+  {
+    id: "organization",
+    accessorFn: (row) => row.organization_alias ?? row.organization_id ?? "",
+    meta: { title: "Organization" },
+    header: "Organization",
+    size: 170,
+    enableSorting: false,
+    cell: ({ row }) => text(row.original.organization_alias || row.original.organization_id),
+  },
+  {
+    id: "project",
+    accessorFn: (row) => row.project_alias ?? row.project_id ?? "",
+    meta: { title: "Project" },
+    header: "Project",
+    size: 170,
+    enableSorting: false,
+    cell: ({ row }) => text(row.original.project_alias || row.original.project_id),
+  },
+  {
+    id: "team",
+    accessorFn: (row) => row.team_alias ?? row.team_id ?? "",
+    meta: { title: "Team" },
+    header: "Team",
+    size: 170,
+    enableSorting: false,
+    cell: ({ row }) => text(row.original.team_alias || row.original.team_id),
+  },
+  {
+    id: "key",
+    accessorFn: (row) => row.key_alias ?? row.key_fingerprint ?? "",
+    meta: { title: "Key" },
+    header: "Key",
+    size: 170,
+    enableSorting: false,
+    cell: ({ row }) => text(row.original.key_alias || row.original.key_fingerprint),
+  },
+  {
+    id: "route",
+    accessorFn: (row) => row.route ?? "",
+    meta: { title: "Route" },
+    header: "Route",
+    size: 180,
+    enableSorting: false,
+    cell: ({ row }) => text(row.original.route),
+  },
+  {
+    id: "pod",
+    accessorFn: (row) => row.pod ?? "",
+    meta: { title: "Pod" },
+    header: "Pod",
+    size: 190,
+    enableSorting: false,
+    cell: ({ row }) => text(row.original.pod),
+  },
+  {
+    id: "request_id",
+    accessorKey: "request_id",
+    meta: { title: "Request ID" },
+    header: "Request ID",
+    size: 260,
+    enableSorting: false,
+    cell: ({ row }) => <span className="font-mono text-xs">{row.original.request_id || "—"}</span>,
+  },
+];

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestDetail.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestDetail.tsx
@@ -68,7 +68,7 @@ export default function ActiveRequestDetail({ request, now, onClose, onCancel, c
           <Button
             variant="outline"
             nativeButton={false}
-            render={<Link href={`/ui/logs?request_id=${request.request_id}`} />}
+            render={<Link href={`/ui/logs?request_id=${encodeURIComponent(request.request_id)}`} />}
           >
             Open in Logs
           </Button>

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestDetail.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestDetail.tsx
@@ -65,7 +65,11 @@ export default function ActiveRequestDetail({ request, now, onClose, onCancel, c
         </dl>
 
         <SheetFooter className="flex-row items-center justify-between gap-2">
-          <Button variant="outline" render={<Link href={`/ui/logs?request_id=${request.request_id}`} />}>
+          <Button
+            variant="outline"
+            nativeButton={false}
+            render={<Link href={`/ui/logs?request_id=${request.request_id}`} />}
+          >
             Open in Logs
           </Button>
           <Button variant="destructive" onClick={() => onCancel(request)} disabled={cancelling}>

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestDetail.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestDetail.tsx
@@ -24,8 +24,8 @@ const rows = (request: ActiveRequest): DetailRow[] => [
   { label: "Organization", value: request.organization_alias || request.organization_id },
   { label: "Project", value: request.project_alias || request.project_id },
   { label: "Team", value: request.team_alias || request.team_id },
-  { label: "Key", value: request.key_alias },
-  { label: "Key fingerprint", value: request.key_fingerprint, mono: true },
+  { label: "Key alias", value: request.key_alias },
+  { label: "Key hash", value: request.key_hash, mono: true },
   { label: "Worker", value: request.pod, mono: true },
 ];
 

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestDetail.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequestDetail.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import type { ActiveRequest } from "./activeRequestsApi";
+import { formatAge } from "./ActiveRequestColumns";
+
+interface DetailRow {
+  label: string;
+  value: string | null | undefined;
+  mono?: boolean;
+}
+
+const rows = (request: ActiveRequest): DetailRow[] => [
+  { label: "Request ID", value: request.request_id, mono: true },
+  { label: "Model", value: request.model },
+  { label: "Call type", value: request.call_type },
+  { label: "Route", value: request.route, mono: true },
+  { label: "End user", value: request.end_user_id },
+  { label: "User", value: request.user_id },
+  { label: "Email", value: request.user_email },
+  { label: "Organization", value: request.organization_alias || request.organization_id },
+  { label: "Project", value: request.project_alias || request.project_id },
+  { label: "Team", value: request.team_alias || request.team_id },
+  { label: "Key", value: request.key_alias },
+  { label: "Key fingerprint", value: request.key_fingerprint, mono: true },
+  { label: "Worker", value: request.pod, mono: true },
+];
+
+export interface ActiveRequestDetailProps {
+  request: ActiveRequest | null;
+  now: number;
+  onClose: () => void;
+  onCancel: (request: ActiveRequest) => void;
+  cancelling: boolean;
+}
+
+export default function ActiveRequestDetail({ request, now, onClose, onCancel, cancelling }: ActiveRequestDetailProps) {
+  if (!request) return null;
+
+  const started = new Date(request.started_at * 1000);
+
+  return (
+    <Sheet open onOpenChange={(open) => !open && onClose()}>
+      <SheetContent className="w-full gap-0 sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            Running for {formatAge(request.started_at, now)}
+            {request.streaming && <Badge variant="outline">stream</Badge>}
+          </SheetTitle>
+          <SheetDescription>Started {started.toLocaleString()}</SheetDescription>
+        </SheetHeader>
+
+        <dl className="grid gap-px overflow-y-auto bg-border px-(--card-spacing)">
+          {rows(request).map((row) => (
+            <div key={row.label} className="grid grid-cols-[10rem_1fr] gap-4 bg-background py-2">
+              <dt className="text-sm text-muted-foreground">{row.label}</dt>
+              <dd className={row.mono ? "min-w-0 truncate font-mono text-xs" : "min-w-0 truncate text-sm"}>
+                {row.value || <span className="text-muted-foreground">not set</span>}
+              </dd>
+            </div>
+          ))}
+        </dl>
+
+        <SheetFooter className="flex-row items-center justify-between gap-2">
+          <Button variant="outline" render={<Link href={`/ui/logs?request_id=${request.request_id}`} />}>
+            Open in Logs
+          </Button>
+          <Button variant="destructive" onClick={() => onCancel(request)} disabled={cancelling}>
+            {cancelling ? "Cancelling…" : "Cancel request"}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.integration.test.tsx
@@ -1,7 +1,7 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ActiveRequests from "./ActiveRequests";
-import { activeRequestsCall, type ActiveRequestsResponse } from "./activeRequestsApi";
+import { activeRequestsCall, cancelActiveRequestCall, type ActiveRequestsResponse } from "./activeRequestsApi";
 
 const mockReplace = vi.fn();
 const searchParams = new URLSearchParams();
@@ -17,6 +17,7 @@ vi.mock("./activeRequestsApi", () => ({
 }));
 
 const mockedActiveRequestsCall = vi.mocked(activeRequestsCall);
+const mockedCancelCall = vi.mocked(cancelActiveRequestCall);
 
 const page: ActiveRequestsResponse = {
   available: true,
@@ -49,6 +50,8 @@ const page: ActiveRequestsResponse = {
 describe("ActiveRequests", () => {
   beforeEach(() => {
     mockedActiveRequestsCall.mockReset();
+    mockedCancelCall.mockReset();
+    mockReplace.mockReset();
   });
 
   afterEach(() => {
@@ -86,5 +89,64 @@ describe("ActiveRequests", () => {
     await act(async () => vi.advanceTimersByTime(15000));
     expect(mockedActiveRequestsCall).toHaveBeenCalledTimes(1);
     unmount();
+  });
+
+  it("should cancel by registry id, not by request id", async () => {
+    mockedActiveRequestsCall.mockResolvedValue(page);
+    mockedCancelCall.mockResolvedValue({ cancelled: true, detail: "Cancellation sent to the worker" });
+
+    render(<ActiveRequests accessToken="token" />);
+    await waitFor(() => expect(screen.getByText("end-user-123")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("end-user-123"));
+    const panel = await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel request" }));
+
+    await waitFor(() => expect(mockedCancelCall).toHaveBeenCalledWith("reg-123"));
+    expect(panel).not.toBeInTheDocument();
+  });
+
+  it("should surface a failed cancellation instead of closing silently", async () => {
+    mockedActiveRequestsCall.mockResolvedValue(page);
+    mockedCancelCall.mockRejectedValue(new Error("That request is no longer running"));
+
+    render(<ActiveRequests accessToken="token" />);
+    await waitFor(() => expect(screen.getByText("end-user-123")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("end-user-123"));
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel request" }));
+
+    await waitFor(() => expect(screen.getByText("That request is no longer running")).toBeInTheDocument());
+  });
+
+  it("should stop polling while paused and resume afterwards", async () => {
+    vi.useFakeTimers();
+    mockedActiveRequestsCall.mockResolvedValue(page);
+
+    render(<ActiveRequests accessToken="token" />);
+    await act(async () => vi.advanceTimersByTime(0));
+    expect(mockedActiveRequestsCall).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("switch"));
+    await act(async () => vi.advanceTimersByTime(20000));
+    expect(mockedActiveRequestsCall).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("switch"));
+    await act(async () => vi.advanceTimersByTime(6000));
+    expect(mockedActiveRequestsCall.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("should put the active filters in the url so the view can be shared", async () => {
+    vi.useFakeTimers();
+    mockedActiveRequestsCall.mockResolvedValue(page);
+
+    render(<ActiveRequests accessToken="token" />);
+    await act(async () => vi.advanceTimersByTime(0));
+
+    fireEvent.change(screen.getByPlaceholderText("End User ID"), { target: { value: "end-user-9" } });
+    await act(async () => vi.advanceTimersByTime(400));
+
+    expect(mockReplace).toHaveBeenCalledWith("?end_user_id=end-user-9", { scroll: false });
   });
 });

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.integration.test.tsx
@@ -120,6 +120,56 @@ describe("ActiveRequests", () => {
     await waitFor(() => expect(screen.getByText("That request is no longer running")).toBeInTheDocument());
   });
 
+  it("should encode a client-provided request id in the logs link", async () => {
+    mockedActiveRequestsCall.mockResolvedValue({
+      ...page,
+      items: [{ ...page.items[0], request_id: "call-123&foo=1#fragment" }],
+    });
+
+    render(<ActiveRequests accessToken="token" />);
+    await waitFor(() => expect(screen.getByText("end-user-123")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("end-user-123"));
+
+    expect((await screen.findByText("Open in Logs")).closest("a")).toHaveAttribute(
+      "href",
+      "/ui/logs?request_id=call-123%26foo%3D1%23fragment",
+    );
+  });
+
+  it("should ask the proxy for the next page instead of paging the current one client side", async () => {
+    mockedActiveRequestsCall.mockResolvedValue({ ...page, total: 120 });
+
+    render(<ActiveRequests accessToken="token" />);
+    await waitFor(() => expect(screen.getByText("end-user-123")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Go to next page" }));
+
+    await waitFor(() =>
+      expect(mockedActiveRequestsCall).toHaveBeenLastCalledWith(
+        expect.objectContaining({ page: 2 }),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("should fall back to the last page when the running requests no longer fill the current one", async () => {
+    vi.useFakeTimers();
+    mockedActiveRequestsCall.mockResolvedValue({ ...page, total: 120 });
+
+    render(<ActiveRequests accessToken="token" />);
+    await act(async () => vi.advanceTimersByTime(400));
+
+    fireEvent.click(screen.getByRole("button", { name: "Go to last page" }));
+    await act(async () => vi.advanceTimersByTime(0));
+    expect(mockedActiveRequestsCall).toHaveBeenLastCalledWith(expect.objectContaining({ page: 3 }), expect.anything());
+
+    mockedActiveRequestsCall.mockResolvedValue({ ...page, total: 1 });
+    await act(async () => vi.advanceTimersByTime(5000));
+    await act(async () => vi.advanceTimersByTime(0));
+
+    expect(mockedActiveRequestsCall).toHaveBeenLastCalledWith(expect.objectContaining({ page: 1 }), expect.anything());
+  });
+
   it("should stop polling while paused and resume afterwards", async () => {
     vi.useFakeTimers();
     mockedActiveRequestsCall.mockResolvedValue(page);

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.integration.test.tsx
@@ -1,0 +1,90 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ActiveRequests from "./ActiveRequests";
+import { activeRequestsCall, type ActiveRequestsResponse } from "./activeRequestsApi";
+
+const mockReplace = vi.fn();
+const searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("./activeRequestsApi", () => ({
+  activeRequestsCall: vi.fn(),
+  cancelActiveRequestCall: vi.fn(),
+}));
+
+const mockedActiveRequestsCall = vi.mocked(activeRequestsCall);
+
+const page: ActiveRequestsResponse = {
+  available: true,
+  items: [
+    {
+      registry_id: "reg-123",
+      request_id: "call-123",
+      started_at: Date.now() / 1000 - 12,
+      model: "model-a",
+      streaming: true,
+      end_user_id: "end-user-123",
+      user_id: "user-1",
+      user_email: "user@example.test",
+      organization_id: "org-1",
+      project_id: "project-1",
+      team_alias: "AI Team",
+      key_alias: "production",
+      route: "/v1/chat/completions",
+      pod: "proxy-1",
+    },
+  ],
+  total: 1,
+  page: 1,
+  page_size: 50,
+  truncated: false,
+  reason: null,
+  generated_at: new Date().toISOString(),
+};
+
+describe("ActiveRequests", () => {
+  beforeEach(() => {
+    mockedActiveRequestsCall.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should render request ownership returned by the live registry", async () => {
+    mockedActiveRequestsCall.mockResolvedValue(page);
+
+    render(<ActiveRequests accessToken="token" />);
+
+    await waitFor(() => expect(screen.getByText("end-user-123")).toBeInTheDocument());
+    expect(screen.getByText("org-1")).toBeInTheDocument();
+    expect(screen.getByText("project-1")).toBeInTheDocument();
+    expect(screen.getByText("user@example.test")).toBeInTheDocument();
+  });
+
+  it("should show a safe error when refreshing fails", async () => {
+    mockedActiveRequestsCall.mockRejectedValue(new Error("Registry unavailable"));
+
+    render(<ActiveRequests accessToken="token" />);
+
+    await waitFor(() => expect(screen.getByText("Could not refresh active requests")).toBeInTheDocument());
+    expect(screen.getByText("Registry unavailable")).toBeInTheDocument();
+  });
+
+  it("should not overlap polling requests when the proxy is slow", async () => {
+    vi.useFakeTimers();
+    mockedActiveRequestsCall.mockImplementation(() => new Promise(() => {}));
+
+    const { unmount } = render(<ActiveRequests accessToken="token" />);
+    await act(async () => vi.advanceTimersByTime(0));
+    expect(mockedActiveRequestsCall).toHaveBeenCalledTimes(1);
+
+    await act(async () => vi.advanceTimersByTime(15000));
+    expect(mockedActiveRequestsCall).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+});

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.integration.test.tsx
@@ -35,6 +35,7 @@ const page: ActiveRequestsResponse = {
       project_id: "project-1",
       team_alias: "AI Team",
       key_alias: "production",
+      key_hash: "b8f1c0a9d2e34f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e",
       route: "/v1/chat/completions",
       pod: "proxy-1",
     },
@@ -63,10 +64,28 @@ describe("ActiveRequests", () => {
 
     render(<ActiveRequests accessToken="token" />);
 
-    await waitFor(() => expect(screen.getByText("end-user-123")).toBeInTheDocument());
+    expect(await screen.findByText("end-user-123")).toBeInTheDocument();
     expect(screen.getByText("org-1")).toBeInTheDocument();
     expect(screen.getByText("project-1")).toBeInTheDocument();
     expect(screen.getByText("user@example.test")).toBeInTheDocument();
+    expect(screen.getByText("production")).toBeInTheDocument();
+    expect(screen.getByText("b8f1c0a9d2e34f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e")).toBeInTheDocument();
+  });
+
+  it("should refresh on its own until an admin switches it off", async () => {
+    vi.useFakeTimers();
+    mockedActiveRequestsCall.mockResolvedValue(page);
+
+    render(<ActiveRequests accessToken="token" />);
+    await act(async () => vi.advanceTimersByTime(0));
+
+    const toggle = screen.getByRole("switch", { name: "Auto refresh" });
+    expect(toggle).toBeChecked();
+    expect(toggle.closest("div")?.querySelector(".lucide-play")).not.toBeNull();
+
+    fireEvent.click(toggle);
+    expect(screen.getByRole("switch", { name: "Auto refresh" })).not.toBeChecked();
+    expect(toggle.closest("div")?.querySelector(".lucide-pause")).not.toBeNull();
   });
 
   it("should show a safe error when refreshing fails", async () => {
@@ -74,7 +93,7 @@ describe("ActiveRequests", () => {
 
     render(<ActiveRequests accessToken="token" />);
 
-    await waitFor(() => expect(screen.getByText("Could not refresh active requests")).toBeInTheDocument());
+    expect(await screen.findByText("Could not refresh active requests")).toBeInTheDocument();
     expect(screen.getByText("Registry unavailable")).toBeInTheDocument();
   });
 
@@ -96,7 +115,7 @@ describe("ActiveRequests", () => {
     mockedCancelCall.mockResolvedValue({ cancelled: true, detail: "Cancellation sent to the worker" });
 
     render(<ActiveRequests accessToken="token" />);
-    await waitFor(() => expect(screen.getByText("end-user-123")).toBeInTheDocument());
+    expect(await screen.findByText("end-user-123")).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("end-user-123"));
     const panel = await screen.findByRole("dialog");
@@ -111,13 +130,13 @@ describe("ActiveRequests", () => {
     mockedCancelCall.mockRejectedValue(new Error("That request is no longer running"));
 
     render(<ActiveRequests accessToken="token" />);
-    await waitFor(() => expect(screen.getByText("end-user-123")).toBeInTheDocument());
+    expect(await screen.findByText("end-user-123")).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("end-user-123"));
     await screen.findByRole("dialog");
     fireEvent.click(screen.getByRole("button", { name: "Cancel request" }));
 
-    await waitFor(() => expect(screen.getByText("That request is no longer running")).toBeInTheDocument());
+    expect(await screen.findByText("That request is no longer running")).toBeInTheDocument();
   });
 
   it("should encode a client-provided request id in the logs link", async () => {
@@ -127,7 +146,7 @@ describe("ActiveRequests", () => {
     });
 
     render(<ActiveRequests accessToken="token" />);
-    await waitFor(() => expect(screen.getByText("end-user-123")).toBeInTheDocument());
+    expect(await screen.findByText("end-user-123")).toBeInTheDocument();
     fireEvent.click(screen.getByText("end-user-123"));
 
     expect((await screen.findByText("Open in Logs")).closest("a")).toHaveAttribute(
@@ -140,7 +159,7 @@ describe("ActiveRequests", () => {
     mockedActiveRequestsCall.mockResolvedValue({ ...page, total: 120 });
 
     render(<ActiveRequests accessToken="token" />);
-    await waitFor(() => expect(screen.getByText("end-user-123")).toBeInTheDocument());
+    expect(await screen.findByText("end-user-123")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Go to next page" }));
 
@@ -170,7 +189,7 @@ describe("ActiveRequests", () => {
     expect(mockedActiveRequestsCall).toHaveBeenLastCalledWith(expect.objectContaining({ page: 1 }), expect.anything());
   });
 
-  it("should stop polling while paused and resume afterwards", async () => {
+  it("should stop polling while auto refresh is off and resume afterwards", async () => {
     vi.useFakeTimers();
     mockedActiveRequestsCall.mockResolvedValue(page);
 

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.tsx
@@ -86,8 +86,8 @@ export default function ActiveRequests({ accessToken }: ActiveRequestsProps) {
   );
   const [draftFilters, setDraftFilters] = useState<ActiveRequestFilters>(filtersFromUrl);
   const [filters, setFilters] = useState<ActiveRequestFilters>(filtersFromUrl);
-  const [paused, setPaused] = useState(false);
-  const pausedRef = useRef(paused);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const autoRefreshRef = useRef(autoRefresh);
   const [selected, setSelected] = useState<ActiveRequest | null>(null);
   const [cancelling, setCancelling] = useState(false);
   const requestControllerRef = useRef<AbortController | null>(null);
@@ -119,16 +119,16 @@ export default function ActiveRequests({ accessToken }: ActiveRequestsProps) {
   }, [accessToken, filters, page]);
 
   useEffect(() => {
-    pausedRef.current = paused;
-  }, [paused]);
+    autoRefreshRef.current = autoRefresh;
+  }, [autoRefresh]);
 
   useEffect(() => {
     const timeout = window.setTimeout(() => void loadRequests(), 0);
     const interval = window.setInterval(() => {
-      if (!pausedRef.current && document.visibilityState === "visible") void loadRequests();
+      if (autoRefreshRef.current && document.visibilityState === "visible") void loadRequests();
     }, POLL_INTERVAL_MS);
     const handleVisibilityChange = () => {
-      if (!pausedRef.current && document.visibilityState === "visible") void loadRequests();
+      if (autoRefreshRef.current && document.visibilityState === "visible") void loadRequests();
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
@@ -239,10 +239,10 @@ export default function ActiveRequests({ accessToken }: ActiveRequestsProps) {
               Refresh
             </Button>
             <div className="flex items-center gap-2">
-              <Switch id="active-requests-pause" checked={paused} onCheckedChange={setPaused} />
-              <Label htmlFor="active-requests-pause" className="flex items-center gap-1.5">
-                {paused ? <Play className="size-3.5" aria-hidden /> : <Pause className="size-3.5" aria-hidden />}
-                {paused ? "Paused" : "Auto refresh"}
+              <Switch id="active-requests-auto-refresh" checked={autoRefresh} onCheckedChange={setAutoRefresh} />
+              <Label htmlFor="active-requests-auto-refresh" className="flex items-center gap-1.5">
+                {autoRefresh ? <Play className="size-3.5" aria-hidden /> : <Pause className="size-3.5" aria-hidden />}
+                Auto refresh
               </Label>
             </div>
           </div>

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.tsx
@@ -18,7 +18,7 @@ import {
 } from "./activeRequestsApi";
 import ActiveRequestCharts from "./ActiveRequestCharts";
 import ActiveRequestDetail from "./ActiveRequestDetail";
-import { formatAge, getActiveRequestColumns } from "./ActiveRequestColumns";
+import { activeRequestColumns, formatAge } from "./ActiveRequestColumns";
 
 const POLL_INTERVAL_MS = 5000;
 const PAGE_SIZE = 50;
@@ -163,8 +163,6 @@ export default function ActiveRequests({ accessToken }: ActiveRequestsProps) {
   const longestSeconds = useMemo(() => Math.max(0, ...items.map((item) => now / 1000 - item.started_at)), [items, now]);
   const distinctEndUsers = useMemo(() => new Set(items.map((item) => item.end_user_id).filter(Boolean)).size, [items]);
   const distinctModels = useMemo(() => new Set(items.map((item) => item.model).filter(Boolean)).size, [items]);
-  const columns = useMemo(() => getActiveRequestColumns(now), [now]);
-
   const pagination = useMemo<PaginationState>(() => ({ pageIndex: page - 1, pageSize: PAGE_SIZE }), [page]);
   const onPaginationChange = useCallback(
     (updater: PaginationState | ((old: PaginationState) => PaginationState)) => {
@@ -265,7 +263,7 @@ export default function ActiveRequests({ accessToken }: ActiveRequestsProps) {
         <CardContent>
           <DataTable
             data={items}
-            columns={columns}
+            columns={activeRequestColumns}
             getRowId={(item, index) => `${item.request_id}-${item.started_at}-${index}`}
             paginationMode="server"
             pagination={pagination}

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.tsx
@@ -87,6 +87,7 @@ export default function ActiveRequests({ accessToken }: ActiveRequestsProps) {
   const [draftFilters, setDraftFilters] = useState<ActiveRequestFilters>(filtersFromUrl);
   const [filters, setFilters] = useState<ActiveRequestFilters>(filtersFromUrl);
   const [paused, setPaused] = useState(false);
+  const pausedRef = useRef(paused);
   const [selected, setSelected] = useState<ActiveRequest | null>(null);
   const [cancelling, setCancelling] = useState(false);
   const requestControllerRef = useRef<AbortController | null>(null);
@@ -118,12 +119,16 @@ export default function ActiveRequests({ accessToken }: ActiveRequestsProps) {
   }, [accessToken, filters, page]);
 
   useEffect(() => {
+    pausedRef.current = paused;
+  }, [paused]);
+
+  useEffect(() => {
     const timeout = window.setTimeout(() => void loadRequests(), 0);
     const interval = window.setInterval(() => {
-      if (!paused && document.visibilityState === "visible") void loadRequests();
+      if (!pausedRef.current && document.visibilityState === "visible") void loadRequests();
     }, POLL_INTERVAL_MS);
     const handleVisibilityChange = () => {
-      if (!paused && document.visibilityState === "visible") void loadRequests();
+      if (!pausedRef.current && document.visibilityState === "visible") void loadRequests();
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
@@ -133,7 +138,7 @@ export default function ActiveRequests({ accessToken }: ActiveRequestsProps) {
       requestControllerRef.current?.abort();
       requestControllerRef.current = null;
     };
-  }, [loadRequests, paused]);
+  }, [loadRequests]);
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {

--- a/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.tsx
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/ActiveRequests.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { AlertTriangle, Pause, Play, RefreshCw } from "lucide-react";
+import type { PaginationState } from "@tanstack/react-table";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { DataTable } from "@/components/shared/DataTable";
+import { Button } from "@/components/ui/button";
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  type ActiveRequest,
+  type ActiveRequestFilters,
+  activeRequestsCall,
+  cancelActiveRequestCall,
+} from "./activeRequestsApi";
+import ActiveRequestCharts from "./ActiveRequestCharts";
+import ActiveRequestDetail from "./ActiveRequestDetail";
+import { formatAge, getActiveRequestColumns } from "./ActiveRequestColumns";
+
+const POLL_INTERVAL_MS = 5000;
+const PAGE_SIZE = 50;
+const FILTER_KEYS = ["model", "end_user_id", "user_id", "organization_id", "project_id"] as const;
+const FILTER_LABELS: Record<(typeof FILTER_KEYS)[number], string> = {
+  model: "Model",
+  end_user_id: "End User ID",
+  user_id: "User ID",
+  organization_id: "Organization ID",
+  project_id: "Project ID",
+};
+
+const DEFAULT_SORTING = [{ id: "age", desc: false }];
+
+const filtersEqual = (left: ActiveRequestFilters, right: ActiveRequestFilters) =>
+  FILTER_KEYS.every((key) => left[key] === right[key]);
+
+const Banner = ({ title, description }: { title: string; description: string }) => (
+  <div
+    role="alert"
+    className="flex items-start gap-3 rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3"
+  >
+    <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" aria-hidden />
+    <div className="min-w-0">
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </div>
+  </div>
+);
+
+const StatTile = ({ title, value }: { title: string; value: string | number }) => (
+  <Card>
+    <CardHeader>
+      <CardTitle className="text-sm font-normal text-muted-foreground">{title}</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <p className="text-2xl font-semibold tabular-nums">{value}</p>
+    </CardContent>
+  </Card>
+);
+
+interface ActiveRequestsProps {
+  accessToken: string | null;
+}
+
+export default function ActiveRequests({ accessToken }: ActiveRequestsProps) {
+  const [items, setItems] = useState<ActiveRequest[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [unavailableReason, setUnavailableReason] = useState<string | null>(null);
+  const [truncated, setTruncated] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const filtersFromUrl = useMemo<ActiveRequestFilters>(
+    () =>
+      FILTER_KEYS.reduce<ActiveRequestFilters>(
+        (acc, key) => ({ ...acc, [key]: searchParams.get(key) || undefined }),
+        {},
+      ),
+    [searchParams],
+  );
+  const [draftFilters, setDraftFilters] = useState<ActiveRequestFilters>(filtersFromUrl);
+  const [filters, setFilters] = useState<ActiveRequestFilters>(filtersFromUrl);
+  const [paused, setPaused] = useState(false);
+  const [selected, setSelected] = useState<ActiveRequest | null>(null);
+  const [cancelling, setCancelling] = useState(false);
+  const requestControllerRef = useRef<AbortController | null>(null);
+
+  const loadRequests = useCallback(async () => {
+    if (!accessToken || requestControllerRef.current) return;
+    const controller = new AbortController();
+    requestControllerRef.current = controller;
+    setLoading(true);
+    try {
+      const response = await activeRequestsCall({ ...filters, page, page_size: PAGE_SIZE }, controller.signal);
+      setItems(response.items);
+      setTotal(response.total);
+      setUnavailableReason(response.available ? null : response.reason || "Registry unavailable");
+      setTruncated(Boolean(response.truncated));
+      setLastUpdated(new Date(response.generated_at));
+      setError(null);
+      const lastPage = Math.max(1, Math.ceil(response.total / PAGE_SIZE));
+      if (page > lastPage) setPage(lastPage);
+    } catch (requestError) {
+      if (requestError instanceof DOMException && requestError.name === "AbortError") return;
+      setError(requestError instanceof Error ? requestError.message : "Failed to load active requests");
+    } finally {
+      if (requestControllerRef.current === controller) {
+        requestControllerRef.current = null;
+        setLoading(false);
+      }
+    }
+  }, [accessToken, filters, page]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => void loadRequests(), 0);
+    const interval = window.setInterval(() => {
+      if (!paused && document.visibilityState === "visible") void loadRequests();
+    }, POLL_INTERVAL_MS);
+    const handleVisibilityChange = () => {
+      if (!paused && document.visibilityState === "visible") void loadRequests();
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      window.clearTimeout(timeout);
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      requestControllerRef.current?.abort();
+      requestControllerRef.current = null;
+    };
+  }, [loadRequests, paused]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setPage(1);
+      setFilters((current) => (filtersEqual(current, draftFilters) ? current : draftFilters));
+      const params = new URLSearchParams();
+      FILTER_KEYS.forEach((key) => {
+        const value = draftFilters[key];
+        if (value) params.set(key, value);
+      });
+      const query = params.toString();
+      router.replace(query ? `?${query}` : "?", { scroll: false });
+    }, 350);
+    return () => window.clearTimeout(timeout);
+  }, [draftFilters, router]);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const longestSeconds = useMemo(() => Math.max(0, ...items.map((item) => now / 1000 - item.started_at)), [items, now]);
+  const distinctEndUsers = useMemo(() => new Set(items.map((item) => item.end_user_id).filter(Boolean)).size, [items]);
+  const distinctModels = useMemo(() => new Set(items.map((item) => item.model).filter(Boolean)).size, [items]);
+  const columns = useMemo(() => getActiveRequestColumns(now), [now]);
+
+  const pagination = useMemo<PaginationState>(() => ({ pageIndex: page - 1, pageSize: PAGE_SIZE }), [page]);
+  const onPaginationChange = useCallback(
+    (updater: PaginationState | ((old: PaginationState) => PaginationState)) => {
+      const next = typeof updater === "function" ? updater({ pageIndex: page - 1, pageSize: PAGE_SIZE }) : updater;
+      setPage(next.pageIndex + 1);
+    },
+    [page],
+  );
+
+  const updateFilter = (key: keyof ActiveRequestFilters, value: string) => {
+    setDraftFilters((current) => ({ ...current, [key]: value || undefined }));
+  };
+
+  const cancelRequest = useCallback(
+    async (request: ActiveRequest) => {
+      setCancelling(true);
+      try {
+        await cancelActiveRequestCall(request.registry_id);
+        setSelected(null);
+        await loadRequests();
+      } catch (cancelError) {
+        setError(cancelError instanceof Error ? cancelError.message : "Failed to cancel the request");
+      } finally {
+        setCancelling(false);
+      }
+    },
+    [loadRequests],
+  );
+
+  return (
+    <div className="flex flex-col gap-5 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Active Requests</h1>
+        <p className="text-sm text-muted-foreground">
+          Authenticated requests currently running across all LiteLLM replicas. Refreshes every 5 seconds.
+        </p>
+      </div>
+
+      {error && <Banner title="Could not refresh active requests" description={error} />}
+      {unavailableReason && <Banner title="Live registry unavailable" description={unavailableReason} />}
+      {truncated && (
+        <Banner
+          title="Filtered results are incomplete"
+          description="The active request index is larger than the scan limit. Narrow the filters or reduce LITELLM_ACTIVE_REQUEST_TTL_SECONDS."
+        />
+      )}
+
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatTile title="Active" value={total} />
+        <StatTile title="Longest on page" value={formatAge(now / 1000 - longestSeconds, now)} />
+        <StatTile title="End users on page" value={distinctEndUsers} />
+        <StatTile title="Models on page" value={distinctModels} />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Filters</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap items-end gap-3">
+            {FILTER_KEYS.map((key) => (
+              <div key={key} className="flex min-w-40 flex-1 flex-col gap-1.5">
+                <Label htmlFor={`active-requests-${key}`}>{FILTER_LABELS[key]}</Label>
+                <Input
+                  id={`active-requests-${key}`}
+                  placeholder={FILTER_LABELS[key]}
+                  value={draftFilters[key] ?? ""}
+                  onChange={(event) => updateFilter(key, event.target.value)}
+                />
+              </div>
+            ))}
+            <Button variant="outline" onClick={() => void loadRequests()} disabled={loading}>
+              <RefreshCw className={loading ? "animate-spin" : undefined} aria-hidden />
+              Refresh
+            </Button>
+            <div className="flex items-center gap-2">
+              <Switch id="active-requests-pause" checked={paused} onCheckedChange={setPaused} />
+              <Label htmlFor="active-requests-pause" className="flex items-center gap-1.5">
+                {paused ? <Play className="size-3.5" aria-hidden /> : <Pause className="size-3.5" aria-hidden />}
+                {paused ? "Paused" : "Auto refresh"}
+              </Label>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <ActiveRequestCharts items={items} now={now} />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Running requests</CardTitle>
+          <CardAction>
+            <span className="text-sm text-muted-foreground" aria-live="polite">
+              {lastUpdated ? `Updated ${lastUpdated.toLocaleTimeString()}` : "Waiting for data"}
+            </span>
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <DataTable
+            data={items}
+            columns={columns}
+            getRowId={(item, index) => `${item.request_id}-${item.started_at}-${index}`}
+            paginationMode="server"
+            pagination={pagination}
+            onPaginationChange={onPaginationChange}
+            rowCount={total}
+            pageSizeOptions={[PAGE_SIZE]}
+            isLoading={loading && items.length === 0}
+            loadingMessage="Loading active requests…"
+            noDataMessage="No authenticated requests are running right now."
+            size="compact"
+            sortingMode="client"
+            defaultSorting={DEFAULT_SORTING}
+            onRowClick={setSelected}
+          />
+        </CardContent>
+      </Card>
+
+      <ActiveRequestDetail
+        request={selected}
+        now={now}
+        onClose={() => setSelected(null)}
+        onCancel={(request) => void cancelRequest(request)}
+        cancelling={cancelling}
+      />
+    </div>
+  );
+}

--- a/ui/litellm-dashboard/src/components/ActiveRequests/activeRequestGrouping.test.ts
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/activeRequestGrouping.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { SEQUENTIAL_COLOR_RAMP } from "@/components/shared/charts";
+import type { ActiveRequest } from "./activeRequestsApi";
+import { chartHeight, countBy, countByAge, magnitudeFills, TOP_N, UNATTRIBUTED } from "./activeRequestGrouping";
+
+const NOW_MS = 1_700_000_000_000;
+const NOW_SECONDS = NOW_MS / 1000;
+
+const request = (overrides: Partial<ActiveRequest>): ActiveRequest =>
+  ({
+    request_id: "req",
+    started_at: NOW_SECONDS,
+    streaming: false,
+    ...overrides,
+  }) as ActiveRequest;
+
+describe("countBy", () => {
+  it("counts requests per value and orders them by count", () => {
+    const items = [
+      request({ model: "a" }),
+      request({ model: "b" }),
+      request({ model: "b" }),
+      request({ model: "c" }),
+      request({ model: "c" }),
+      request({ model: "c" }),
+    ];
+
+    expect(countBy(items, "model")).toEqual([
+      { label: "c", requests: 3 },
+      { label: "b", requests: 2 },
+      { label: "a", requests: 1 },
+    ]);
+  });
+
+  it("breaks count ties alphabetically so the order is stable across polls", () => {
+    const items = [request({ model: "zeta" }), request({ model: "alpha" })];
+
+    expect(countBy(items, "model").map((entry) => entry.label)).toEqual(["alpha", "zeta"]);
+  });
+
+  it("buckets missing and blank values as unattributed instead of dropping them", () => {
+    const items = [request({ end_user_id: null }), request({ end_user_id: "   " }), request({ end_user_id: "u1" })];
+
+    expect(countBy(items, "end_user_id")).toEqual([
+      { label: UNATTRIBUTED, requests: 2 },
+      { label: "u1", requests: 1 },
+    ]);
+  });
+
+  it("folds everything past the top N into a single Other entry that keeps the total intact", () => {
+    const items = Array.from({ length: TOP_N + 3 }, (_, index) =>
+      Array.from({ length: TOP_N + 3 - index }, () => request({ model: `m${index}` })),
+    ).flat();
+
+    const grouped = countBy(items, "model");
+    const total = grouped.reduce((sum, entry) => sum + entry.requests, 0);
+
+    expect(grouped).toHaveLength(TOP_N + 1);
+    expect(grouped[TOP_N].label).toBe("Other (3)");
+    expect(total).toBe(items.length);
+  });
+
+  it("returns nothing for an empty page", () => {
+    expect(countBy([], "model")).toEqual([]);
+  });
+});
+
+describe("countByAge", () => {
+  it("places each request in exactly one bin, upper bound exclusive", () => {
+    const items = [
+      request({ started_at: NOW_SECONDS - 1 }),
+      request({ started_at: NOW_SECONDS - 10 }),
+      request({ started_at: NOW_SECONDS - 30 }),
+      request({ started_at: NOW_SECONDS - 60 }),
+      request({ started_at: NOW_SECONDS - 3600 }),
+    ];
+
+    expect(countByAge(items, NOW_MS)).toEqual([
+      { label: "< 10s", requests: 1 },
+      { label: "10-30s", requests: 1 },
+      { label: "30-60s", requests: 1 },
+      { label: "1-5m", requests: 1 },
+      { label: "> 5m", requests: 1 },
+    ]);
+  });
+
+  it("keeps every bin present so the chart axis does not shift between polls", () => {
+    expect(countByAge([], NOW_MS).map((entry) => entry.label)).toEqual(["< 10s", "10-30s", "30-60s", "1-5m", "> 5m"]);
+  });
+
+  it("counts a clock skewed start time as the youngest bin rather than losing it", () => {
+    expect(countByAge([request({ started_at: NOW_SECONDS + 5 })], NOW_MS)[0].requests).toBe(0);
+  });
+});
+
+describe("magnitudeFills", () => {
+  it("gives the largest value the darkest step on a light surface", () => {
+    expect(magnitudeFills(3, { dark: false, ascending: true })[0]).toBe(SEQUENTIAL_COLOR_RAMP[0]);
+  });
+
+  it("flips the ramp in dark mode so the largest value stays visible", () => {
+    const fills = magnitudeFills(3, { dark: true, ascending: true });
+
+    expect(fills[0]).toBe(SEQUENTIAL_COLOR_RAMP[SEQUENTIAL_COLOR_RAMP.length - 1]);
+  });
+
+  it("clamps to the last ramp step when there are more rows than steps", () => {
+    const fills = magnitudeFills(SEQUENTIAL_COLOR_RAMP.length + 4, { dark: false, ascending: true });
+
+    expect(fills).toHaveLength(SEQUENTIAL_COLOR_RAMP.length + 4);
+    expect(fills[fills.length - 1]).toBe(SEQUENTIAL_COLOR_RAMP[SEQUENTIAL_COLOR_RAMP.length - 1]);
+  });
+});
+
+describe("chartHeight", () => {
+  it("grows with the row count between a floor and a ceiling", () => {
+    expect(chartHeight(0)).toBe(200);
+    expect(chartHeight(5)).toBe(258);
+    expect(chartHeight(100)).toBe(440);
+  });
+});

--- a/ui/litellm-dashboard/src/components/ActiveRequests/activeRequestGrouping.ts
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/activeRequestGrouping.ts
@@ -1,0 +1,69 @@
+import { SEQUENTIAL_COLOR_RAMP, type ChartColor } from "@/components/shared/charts";
+import type { ActiveRequest } from "./activeRequestsApi";
+
+export const GROUP_BY = [
+  { value: "model", label: "Model" },
+  { value: "end_user_id", label: "End User" },
+  { value: "user_id", label: "User" },
+  { value: "key_alias", label: "Key" },
+  { value: "pod", label: "Pod" },
+] as const;
+
+export type GroupBy = (typeof GROUP_BY)[number]["value"];
+
+export const AGE_BINS = [
+  { label: "< 10s", limit: 10 },
+  { label: "10-30s", limit: 30 },
+  { label: "30-60s", limit: 60 },
+  { label: "1-5m", limit: 300 },
+  { label: "> 5m", limit: Number.POSITIVE_INFINITY },
+] as const;
+
+export const TOP_N = 8;
+export const UNATTRIBUTED = "unattributed";
+
+export type GroupedCount = {
+  label: string;
+  requests: number;
+} & Record<string, unknown>;
+
+export const magnitudeFills = (
+  count: number,
+  options: { dark: boolean; ascending: boolean },
+): readonly ChartColor[] => {
+  const darkestFirst = options.ascending !== options.dark;
+  const ramp = darkestFirst ? [...SEQUENTIAL_COLOR_RAMP] : [...SEQUENTIAL_COLOR_RAMP].reverse();
+  return Array.from({ length: count }, (_, index) => ramp[Math.min(index, ramp.length - 1)]);
+};
+
+export const chartHeight = (rows: number): number => Math.max(200, Math.min(rows * 42 + 48, 440));
+
+export const countBy = (items: readonly ActiveRequest[], groupBy: GroupBy): GroupedCount[] => {
+  const counts = items.reduce<Map<string, number>>((acc, item) => {
+    const raw = item[groupBy];
+    const key = typeof raw === "string" && raw.trim() !== "" ? raw : UNATTRIBUTED;
+    return new Map(acc).set(key, (acc.get(key) ?? 0) + 1);
+  }, new Map());
+
+  const sorted = [...counts.entries()].sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]));
+  const head = sorted.slice(0, TOP_N);
+  const tail = sorted.slice(TOP_N);
+  const other = tail.reduce((sum, [, value]) => sum + value, 0);
+
+  return [
+    ...head.map(([label, requests]) => ({ label, requests })),
+    ...(other > 0 ? [{ label: `Other (${tail.length})`, requests: other }] : []),
+  ];
+};
+
+export const countByAge = (items: readonly ActiveRequest[], nowMs: number): GroupedCount[] => {
+  const nowSeconds = nowMs / 1000;
+  return AGE_BINS.map(({ label, limit }, index) => {
+    const lower = index === 0 ? 0 : AGE_BINS[index - 1].limit;
+    const requests = items.filter((item) => {
+      const age = nowSeconds - item.started_at;
+      return age >= lower && age < limit;
+    }).length;
+    return { label, requests };
+  });
+};

--- a/ui/litellm-dashboard/src/components/ActiveRequests/activeRequestsApi.test.ts
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/activeRequestsApi.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { activeRequestsCall, cancelActiveRequestCall } from "./activeRequestsApi";
+import { fetchClient } from "@/lib/http/api";
+
+vi.mock("@/lib/http/api", () => ({
+  fetchClient: { GET: vi.fn(), POST: vi.fn() },
+}));
+
+const mockedGet = vi.mocked(fetchClient.GET);
+const mockedPost = vi.mocked(fetchClient.POST);
+
+describe("activeRequestsApi", () => {
+  beforeEach(() => {
+    mockedGet.mockReset();
+    mockedPost.mockReset();
+  });
+
+  it("should raise the proxy's reason when a cancellation is refused", async () => {
+    mockedPost.mockResolvedValue({ error: { detail: "That request is no longer running" } } as never);
+
+    await expect(cancelActiveRequestCall("reg-1")).rejects.toThrow("That request is no longer running");
+  });
+
+  it("should raise a fallback when a refused cancellation carries no reason", async () => {
+    mockedPost.mockResolvedValue({ error: {} } as never);
+
+    await expect(cancelActiveRequestCall("reg-1")).rejects.toThrow("Failed to cancel the request");
+  });
+
+  it("should return the confirmation of an accepted cancellation", async () => {
+    mockedPost.mockResolvedValue({ data: { cancelled: true, detail: "Cancellation sent" } } as never);
+
+    await expect(cancelActiveRequestCall("reg-1")).resolves.toEqual({ cancelled: true, detail: "Cancellation sent" });
+    expect(mockedPost).toHaveBeenCalledWith("/global/active_requests/{registry_id}/cancel", {
+      params: { path: { registry_id: "reg-1" } },
+    });
+  });
+
+  it("should raise the proxy's reason when the list is refused", async () => {
+    mockedGet.mockResolvedValue({
+      error: { detail: "Only proxy administrators can view global active requests" },
+    } as never);
+
+    await expect(activeRequestsCall({ page: 1, page_size: 50 })).rejects.toThrow(
+      "Only proxy administrators can view global active requests",
+    );
+  });
+});

--- a/ui/litellm-dashboard/src/components/ActiveRequests/activeRequestsApi.ts
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/activeRequestsApi.ts
@@ -7,18 +7,26 @@ export type ActiveRequestQuery = NonNullable<
   operations["get_active_requests_global_active_requests_get"]["parameters"]["query"]
 >;
 export type ActiveRequestFilters = Omit<ActiveRequestQuery, "page" | "page_size">;
+export type CancelActiveRequestResponse = components["schemas"]["CancelActiveRequestResponse"];
+
+const detailOf = (error: unknown, fallback: string): string => {
+  const detail = (error as { detail?: unknown } | undefined)?.detail;
+  return typeof detail === "string" ? detail : fallback;
+};
 
 export const activeRequestsCall = async (
   query: ActiveRequestQuery,
   signal?: AbortSignal,
 ): Promise<ActiveRequestsResponse> => {
-  const { data } = await fetchClient.GET("/global/active_requests", { params: { query }, signal });
-  if (!data) throw new Error("Failed to load active requests");
+  const { data, error } = await fetchClient.GET("/global/active_requests", { params: { query }, signal });
+  if (!data) throw new Error(detailOf(error, "Failed to load active requests"));
   return data;
 };
 
-export const cancelActiveRequestCall = async (registryId: string): Promise<void> => {
-  await fetchClient.POST("/global/active_requests/{registry_id}/cancel", {
+export const cancelActiveRequestCall = async (registryId: string): Promise<CancelActiveRequestResponse> => {
+  const { data, error } = await fetchClient.POST("/global/active_requests/{registry_id}/cancel", {
     params: { path: { registry_id: registryId } },
   });
+  if (!data) throw new Error(detailOf(error, "Failed to cancel the request"));
+  return data;
 };

--- a/ui/litellm-dashboard/src/components/ActiveRequests/activeRequestsApi.ts
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/activeRequestsApi.ts
@@ -1,0 +1,24 @@
+import { fetchClient } from "@/lib/http/api";
+import type { components, operations } from "@/lib/http/schema";
+
+export type ActiveRequest = components["schemas"]["ActiveRequestRecord"];
+export type ActiveRequestsResponse = components["schemas"]["ActiveRequestsResponse"];
+export type ActiveRequestQuery = NonNullable<
+  operations["get_active_requests_global_active_requests_get"]["parameters"]["query"]
+>;
+export type ActiveRequestFilters = Omit<ActiveRequestQuery, "page" | "page_size">;
+
+export const activeRequestsCall = async (
+  query: ActiveRequestQuery,
+  signal?: AbortSignal,
+): Promise<ActiveRequestsResponse> => {
+  const { data } = await fetchClient.GET("/global/active_requests", { params: { query }, signal });
+  if (!data) throw new Error("Failed to load active requests");
+  return data;
+};
+
+export const cancelActiveRequestCall = async (registryId: string): Promise<void> => {
+  await fetchClient.POST("/global/active_requests/{registry_id}/cancel", {
+    params: { path: { registry_id: registryId } },
+  });
+};

--- a/ui/litellm-dashboard/src/components/ActiveRequests/useIsDarkMode.ts
+++ b/ui/litellm-dashboard/src/components/ActiveRequests/useIsDarkMode.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const subscribe = (onStoreChange: () => void): (() => void) => {
+  const observer = new MutationObserver(onStoreChange);
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+  return () => observer.disconnect();
+};
+
+const getSnapshot = (): boolean => document.documentElement.classList.contains("dark");
+
+const getServerSnapshot = (): boolean => false;
+
+export const useIsDarkMode = (): boolean => useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);

--- a/ui/litellm-dashboard/src/components/leftnav.test.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.test.tsx
@@ -11,6 +11,7 @@ vi.mock("../utils/roles", async (importOriginal) => {
     old_admin_roles: ["admin", "admin_viewer"],
     internalUserRoles: ["internal"],
     rolesWithWriteAccess: ["admin", "internal"],
+    proxyAdminRoles: ["admin", "admin_viewer"],
     rolesAllowedToViewWriteScopedPages: ["admin", "internal", "admin_viewer"],
     isAdminRole: (role: string) => role === "admin" || role === "admin_viewer",
     isUserTeamAdminForAnyTeam: () => false,

--- a/ui/litellm-dashboard/src/components/leftnav.test.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.test.tsx
@@ -8,6 +8,7 @@ vi.mock("../utils/roles", () => {
     all_admin_roles: ["admin", "admin_viewer"],
     internalUserRoles: ["internal"],
     rolesWithWriteAccess: ["admin", "internal"],
+    proxyAdminRoles: ["admin", "admin_viewer"],
     rolesAllowedToViewWriteScopedPages: ["admin", "internal", "admin_viewer"],
     isAdminRole: (role: string) => role === "admin" || role === "admin_viewer",
     isUserTeamAdminForAnyTeam: () => false,

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -55,6 +55,7 @@ import {
   ShieldCheck,
   Tags,
   Terminal,
+  Timer,
   User,
   Users,
   Wallet,
@@ -70,6 +71,7 @@ import {
   internalUserRoles,
   isAdminRole,
   isUserTeamAdminForAnyTeam,
+  proxyAdminRoles,
   rolesAllowedToViewWriteScopedPages,
   rolesWithWriteAccess,
 } from "../utils/roles";
@@ -212,6 +214,13 @@ const menuGroups: MenuGroup[] = [
         ),
       },
       { key: "logs", page: "logs", label: "Logs", icon: <Activity {...ICON} /> },
+      {
+        key: "active-requests",
+        page: "active-requests",
+        label: "Active Requests",
+        icon: <Timer {...ICON} />,
+        roles: proxyAdminRoles,
+      },
       {
         key: "guardrails-monitor",
         page: "guardrails-monitor",

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -55,6 +55,7 @@ import {
   ShieldCheck,
   Tags,
   Terminal,
+  Timer,
   User,
   Users,
   Wallet,
@@ -70,6 +71,7 @@ import {
   internalUserRoles,
   isAdminRole,
   isUserTeamAdminForAnyTeam,
+  proxyAdminRoles,
   rolesAllowedToViewWriteScopedPages,
   rolesWithWriteAccess,
 } from "../utils/roles";
@@ -201,6 +203,13 @@ const menuGroups: MenuGroup[] = [
         ),
       },
       { key: "logs", page: "logs", label: "Logs", icon: <Activity {...ICON} /> },
+      {
+        key: "active-requests",
+        page: "active-requests",
+        label: "Active Requests",
+        icon: <Timer {...ICON} />,
+        roles: proxyAdminRoles,
+      },
       {
         key: "guardrails-monitor",
         page: "guardrails-monitor",

--- a/ui/litellm-dashboard/src/components/page_metadata.ts
+++ b/ui/litellm-dashboard/src/components/page_metadata.ts
@@ -21,6 +21,7 @@ export const pageDescriptions: Record<string, string> = {
   new_usage: "View usage analytics and metrics",
   "cost-optimization": "Track and configure cost-saving features: prompt compression, caching, and auto routing",
   logs: "Access request and response logs",
+  "active-requests": "See which requests are running right now and who issued them",
   "guardrails-monitor": "Monitor guardrail performance and view logs",
   users: "Manage internal user accounts and permissions",
   teams: "Create and manage teams for access control",

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -4684,6 +4684,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/global/active_requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Active Requests */
+        get: operations["get_active_requests_global_active_requests_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/active_requests/{registry_id}/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Cancel Active Request */
+        post: operations["cancel_active_request_global_active_requests__registry_id__cancel_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/global/activity": {
         parameters: {
             query?: never;
@@ -21311,6 +21345,75 @@ export interface components {
             /** Description */
             description?: string | null;
         };
+        /** ActiveRequestRecord */
+        ActiveRequestRecord: {
+            /** Call Type */
+            call_type?: string | null;
+            /** End User Id */
+            end_user_id?: string | null;
+            /** Key Alias */
+            key_alias?: string | null;
+            /** Key Fingerprint */
+            key_fingerprint?: string | null;
+            /** Model */
+            model?: string | null;
+            /** Organization Alias */
+            organization_alias?: string | null;
+            /** Organization Id */
+            organization_id?: string | null;
+            /** Pod */
+            pod?: string | null;
+            /** Project Alias */
+            project_alias?: string | null;
+            /** Project Id */
+            project_id?: string | null;
+            /** Registry Id */
+            registry_id: string;
+            /** Request Id */
+            request_id: string;
+            /** Route */
+            route?: string | null;
+            /** Started At */
+            started_at: number;
+            /**
+             * Streaming
+             * @default false
+             */
+            streaming: boolean;
+            /** Team Alias */
+            team_alias?: string | null;
+            /** Team Id */
+            team_id?: string | null;
+            /** User Email */
+            user_email?: string | null;
+            /** User Id */
+            user_id?: string | null;
+        };
+        /** ActiveRequestsResponse */
+        ActiveRequestsResponse: {
+            /** Available */
+            available: boolean;
+            /**
+             * Generated At
+             * Format: date-time
+             */
+            generated_at: string;
+            /** Items */
+            items: components["schemas"]["ActiveRequestRecord"][];
+            /** Page */
+            page: number;
+            /** Page Size */
+            page_size: number;
+            /** Reason */
+            reason?: string | null;
+            /** Total */
+            total: number;
+            /**
+             * Truncated
+             * @default false
+             */
+            truncated: boolean;
+        };
         /**
          * ActiveUsersAnalyticsResponse
          * @description Response for active users analytics
@@ -23066,6 +23169,13 @@ export interface components {
             success: string[];
             /** Success And Failure */
             success_and_failure: string[];
+        };
+        /** CancelActiveRequestResponse */
+        CancelActiveRequestResponse: {
+            /** Cancelled */
+            cancelled: boolean;
+            /** Detail */
+            detail: string;
         };
         /**
          * CancelEvalResponse
@@ -43414,6 +43524,74 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_active_requests_global_active_requests_get: {
+        parameters: {
+            query?: {
+                model?: string | null;
+                user_id?: string | null;
+                end_user_id?: string | null;
+                organization_id?: string | null;
+                project_id?: string | null;
+                page?: number;
+                page_size?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActiveRequestsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_active_request_global_active_requests__registry_id__cancel_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                registry_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CancelActiveRequestResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -21353,8 +21353,8 @@ export interface components {
             end_user_id?: string | null;
             /** Key Alias */
             key_alias?: string | null;
-            /** Key Fingerprint */
-            key_fingerprint?: string | null;
+            /** Key Hash */
+            key_hash?: string | null;
             /** Model */
             model?: string | null;
             /** Organization Alias */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -4542,6 +4542,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/global/active_requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Active Requests */
+        get: operations["get_active_requests_global_active_requests_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/active_requests/{registry_id}/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Cancel Active Request */
+        post: operations["cancel_active_request_global_active_requests__registry_id__cancel_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/global/activity": {
         parameters: {
             query?: never;
@@ -20901,6 +20935,75 @@ export interface components {
             /** Description */
             description?: string | null;
         };
+        /** ActiveRequestRecord */
+        ActiveRequestRecord: {
+            /** Call Type */
+            call_type?: string | null;
+            /** End User Id */
+            end_user_id?: string | null;
+            /** Key Alias */
+            key_alias?: string | null;
+            /** Key Fingerprint */
+            key_fingerprint?: string | null;
+            /** Model */
+            model?: string | null;
+            /** Organization Alias */
+            organization_alias?: string | null;
+            /** Organization Id */
+            organization_id?: string | null;
+            /** Pod */
+            pod?: string | null;
+            /** Project Alias */
+            project_alias?: string | null;
+            /** Project Id */
+            project_id?: string | null;
+            /** Registry Id */
+            registry_id: string;
+            /** Request Id */
+            request_id: string;
+            /** Route */
+            route?: string | null;
+            /** Started At */
+            started_at: number;
+            /**
+             * Streaming
+             * @default false
+             */
+            streaming: boolean;
+            /** Team Alias */
+            team_alias?: string | null;
+            /** Team Id */
+            team_id?: string | null;
+            /** User Email */
+            user_email?: string | null;
+            /** User Id */
+            user_id?: string | null;
+        };
+        /** ActiveRequestsResponse */
+        ActiveRequestsResponse: {
+            /** Available */
+            available: boolean;
+            /**
+             * Generated At
+             * Format: date-time
+             */
+            generated_at: string;
+            /** Items */
+            items: components["schemas"]["ActiveRequestRecord"][];
+            /** Page */
+            page: number;
+            /** Page Size */
+            page_size: number;
+            /** Reason */
+            reason?: string | null;
+            /** Total */
+            total: number;
+            /**
+             * Truncated
+             * @default false
+             */
+            truncated: boolean;
+        };
         /**
          * ActiveUsersAnalyticsResponse
          * @description Response for active users analytics
@@ -22649,6 +22752,13 @@ export interface components {
             success: string[];
             /** Success And Failure */
             success_and_failure: string[];
+        };
+        /** CancelActiveRequestResponse */
+        CancelActiveRequestResponse: {
+            /** Cancelled */
+            cancelled: boolean;
+            /** Detail */
+            detail: string;
         };
         /**
          * CancelEvalResponse
@@ -42253,6 +42363,74 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_active_requests_global_active_requests_get: {
+        parameters: {
+            query?: {
+                model?: string | null;
+                user_id?: string | null;
+                end_user_id?: string | null;
+                organization_id?: string | null;
+                project_id?: string | null;
+                page?: number;
+                page_size?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActiveRequestsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_active_request_global_active_requests__registry_id__cancel_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                registry_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CancelActiveRequestResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/ui/litellm-dashboard/src/utils/migratedPages.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.ts
@@ -38,6 +38,7 @@ export const MIGRATED_PAGES: Record<string, string> = {
   "transform-request": "transform-request",
   "ui-theme": "ui-theme",
   logs: "logs",
+  "active-requests": "active-requests",
   "admin-panel": "admin-panel",
   "logging-and-alerts": "logging-and-alerts",
   "model-hub-table": "model-hub-table",

--- a/ui/litellm-dashboard/src/utils/roles.ts
+++ b/ui/litellm-dashboard/src/utils/roles.ts
@@ -7,23 +7,19 @@ interface OrganizationMembership {
   user_role?: string | null;
 }
 
-// Define admin roles and permissions
 export const old_admin_roles = ["Admin", "Admin Viewer"];
 export const v2_admin_role_names = ["proxy_admin", "proxy_admin_viewer", "org_admin"];
 export const all_admin_roles = [...old_admin_roles, ...v2_admin_role_names];
 
+export const proxyAdminRoles = [...old_admin_roles, "proxy_admin", "proxy_admin_viewer"];
+
 export const internalUserRoles = ["Internal User", "Internal Viewer", "internal_user", "internal_user_viewer"];
 export const rolesAllowedToSeeUsage = ["Admin", "Admin Viewer", "Internal User", "Internal Viewer"];
 export const rolesWithWriteAccess = ["Internal User", "Admin", "proxy_admin"];
-// Admin-tier read parity: Admin Viewer sees Models + Endpoints, Agents, and
-// other pages whose primary purpose is configuration/management read-only.
-// Per the Admin Viewer principle: read parity with Proxy Admin, no writes,
-// no cost-incurring actions (Playground stays gated by `rolesWithWriteAccess`).
 export const rolesAllowedToViewWriteScopedPages = [...rolesWithWriteAccess, "Admin Viewer", "proxy_admin_viewer"];
 export const viewOnlyRoles = ["Admin Viewer", "Internal Viewer"];
 export const isViewOnlyRole = (role: string): boolean => viewOnlyRoles.includes(role);
 
-// Helper function to check if a role is in all_admin_roles
 export const isAdminRole = (role: string): boolean => {
   return all_admin_roles.includes(role);
 };

--- a/ui/litellm-dashboard/src/utils/roles.ts
+++ b/ui/litellm-dashboard/src/utils/roles.ts
@@ -1,22 +1,18 @@
 import { Member, Team } from "@/components/networking";
 
-// Define admin roles and permissions
 export const old_admin_roles = ["Admin", "Admin Viewer"];
 export const v2_admin_role_names = ["proxy_admin", "proxy_admin_viewer", "org_admin"];
 export const all_admin_roles = [...old_admin_roles, ...v2_admin_role_names];
 
+export const proxyAdminRoles = [...old_admin_roles, "proxy_admin", "proxy_admin_viewer"];
+
 export const internalUserRoles = ["Internal User", "Internal Viewer", "internal_user", "internal_user_viewer"];
 export const rolesAllowedToSeeUsage = ["Admin", "Admin Viewer", "Internal User", "Internal Viewer"];
 export const rolesWithWriteAccess = ["Internal User", "Admin", "proxy_admin"];
-// Admin-tier read parity: Admin Viewer sees Models + Endpoints, Agents, and
-// other pages whose primary purpose is configuration/management read-only.
-// Per the Admin Viewer principle: read parity with Proxy Admin, no writes,
-// no cost-incurring actions (Playground stays gated by `rolesWithWriteAccess`).
 export const rolesAllowedToViewWriteScopedPages = [...rolesWithWriteAccess, "Admin Viewer", "proxy_admin_viewer"];
 export const viewOnlyRoles = ["Admin Viewer", "Internal Viewer"];
 export const isViewOnlyRole = (role: string): boolean => viewOnlyRoles.includes(role);
 
-// Helper function to check if a role is in all_admin_roles
 export const isAdminRole = (role: string): boolean => {
   return all_admin_roles.includes(role);
 };


### PR DESCRIPTION
## TLDR

Problem this solves:

There is no way to see what a proxy is serving right now, or for whom. A request that has not finished yet is in no spend log, traces show its spans without telling you who issued it, and `litellm_in_flight_requests` is a count with no identity attached. When one caller saturates a model you cannot answer "whose traffic is this" without waiting for the requests to finish.

How it solves it:

A Redis-backed registry records every authenticated request at pre-call time and removes it when the HTTP response finishes, so `GET /global/active_requests` can answer that question across replicas, and the admin UI gets a page that lists, sorts and filters the live set, opens any request's full detail, and cancels one that is stuck


https://github.com/user-attachments/assets/40cebc2f-c6ae-4a42-ae1c-7be88503fa1c


## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<img width="1600" height="1000" alt="1-running-requests-by-model" src="https://github.com/user-attachments/assets/4e9c5b2a-68b0-472b-859e-914a8ef90084" />

<img width="1600" height="1000" alt="2-request-detail-and-cancel" src="https://github.com/user-attachments/assets/a528b55a-133b-4fd2-8f27-43c7f976b860" />

<img width="1600" height="1000" alt="3-filtered-to-one-end-user" src="https://github.com/user-attachments/assets/4e7e1747-6702-4be1-991e-ba3aa72f3195" />

<img width="1600" height="1000" alt="4-dark-mode-and-age-warning" src="https://github.com/user-attachments/assets/692a1e6e-a9b2-4980-8a70-d5c72c31f309" />

Ran against a live proxy on `localhost:4000` in front of a self-hosted OpenAI-compatible inference endpoint, so these are real generations on real hardware rather than mocks. Six concurrent streaming completions were fired across two models, each asked for a 1500 word answer so they stay in flight long enough to read the endpoint:

```bash
for i in 1 2 3 4 5 6; do
  m=$([ $((i%2)) -eq 0 ] && echo Ministral-3-14B-Instruct-2512 || echo gpt-oss-120b)
  curl -s -o /dev/null -N http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d "{\"model\":\"$m\",\"stream\":true,\"max_tokens\":2000,\"user\":\"end-user-$i\",
         \"messages\":[{\"role\":\"user\",\"content\":\"Write a detailed 1500 word explanation of how a Redis sorted set works internally.\"}]}" &
done
```

While they run:

```bash
$ curl -s -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    "http://localhost:4000/global/active_requests?page_size=3" | jq
{
  "available": true,
  "reason": null,
  "items": [
    {
      "request_id": "b545affc-f1ae-4f54-9866-1eb424937000",
      "started_at": 1786002556.584499,
      "model": "Ministral-3-14B-Instruct-2512",
      "call_type": "acompletion",
      "streaming": true,
      "route": "/v1/chat/completions",
      "user_id": "default_user_id",
      "user_email": null,
      "end_user_id": "end-user-6",
      "organization_id": null,
      "organization_alias": null,
      "project_id": null,
      "project_alias": null,
      "team_id": null,
      "team_alias": null,
      "key_alias": null,
      "key_hash_prefix": "litellm_prox",
      "pod": null
    }
  ],
  "total": 6,
  "page": 1,
  "page_size": 3,
  "truncated": false,
  "generated_at": "2026-08-06T07:49:16.584Z"
}
```

`end_user_id` comes straight from the OpenAI standard `user` field on the request, so filtering by caller works without any extra configuration:

```bash
$ curl -s -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    "http://localhost:4000/global/active_requests?end_user_id=end-user-3" \
    | jq '{total, models: [.items[].model], end_users: [.items[].end_user_id]}'
{
  "total": 1,
  "models": ["gpt-oss-120b"],
  "end_users": ["end-user-3"]
}
```

After the six generations finished, the registry is empty again and so is the Redis index, which is the cleanup path running in the response `finally`:

```bash
$ curl -s -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    "http://localhost:4000/global/active_requests" | jq '.total'
0

$ redis-cli zcard "litellm:active_requests:index"
(integer) 0
```

Cancelling a request that was mid-generation on a real model:

```bash
$ curl -s -X POST -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    "http://localhost:4000/global/active_requests/$REGISTRY_ID/cancel" | jq
{
  "cancelled": true,
  "detail": "Cancellation sent to the worker serving the request"
}

$ curl -s -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    "http://localhost:4000/global/active_requests" | jq '{total, end_users: [.items[].end_user_id]}'
{
  "total": 2,
  "end_users": ["cancel-2", "cancel-1"]
}
```

Three were running, one was cancelled, two remain, and the cancelled one's entry is gone because the middleware's `finally` removed it as the task unwound.

For the UI, run `npm run dev` in `ui/litellm-dashboard`, log in as a proxy admin and open http://localhost:3000/active-requests/ while requests are in flight. The page sits under Observability in the sidebar. It shows the KPI row, a filter row, two charts (running requests grouped by model, end user, user, key or pod, and the age distribution) and the table. Sort by Age to find what has been running longest, click any row for the full detail panel with `Open in Logs` and `Cancel request`, type an end user id into the filter and watch it land in the URL so the view can be shared, and flip Auto refresh off when the table keeps moving while you read it. I can attach screenshots and a screen recording if you want them in the thread

## Load behaviour

Measured against a live proxy with 12000 entries seeded into the index, which is well past the 5000 scan cap:

| | |
| --- | --- |
| unfiltered `GET /global/active_requests` | 5 ms |
| filtered by end user | 35-46 ms, `truncated: true` |
| Redis `MGET` at the cap, server side | 4.5 ms per call |
| Redis `ZREVRANGE` of 5000 members | 0.9 ms per call |

The dashboard held up at that size. A Chrome DevTools trace over 13 poll cycles: every poll 14-34 ms round trip, the 5 s cadence never drifted or overlapped, 50 rows rendered, **zero long tasks**, CLS 0.00, and switching the grouping tab repainted both charts in 57 ms. Filtering to one end user narrowed the page to 121 matches and surfaced the truncation banner, which is the cap doing its job rather than the page silently lying about the total.

That is the reason for the cap. Without it the filtered path reads the whole index, and 4.5 ms of blocking on a single-threaded Redis per admin poll is the ceiling this accepts.

## Type

🆕 New Feature

## Changes

On the diff size: of the 2000 added lines, 812 are tests and 121 are generated API types, leaving 1067 of hand-written source, and 583 of those are the dashboard page. The backend is 484 lines across four files, 327 of them the registry itself. The rest of the backend is a 105-line endpoint plus 44 lines of wiring: the hook mapping entry, the `register_as_litellm_callback` opt-out, the pre-call call site and the removal in the middleware's `finally`.

The dashboard talks to the endpoint through the schema-bound client rather than a hand-written wrapper, so `schema.d.ts` is regenerated and the request and response types come from the OpenAPI spec. `networking.tsx` is deliberately untouched.

`litellm/proxy/hooks/active_request_registry.py` holds the registry. It writes one JSON item key per request plus a sorted-set index scored by start time, and reads them back with `MGET`. Records carry identity and routing metadata only, never prompts, bodies, headers or source IPs. `user_email` stays out unless `general_settings.active_request_include_user_email` is on, since these records live in Redis and Redis is frequently persisted to disk.

Redis comes from `InternalUsageCache` and is resolved lazily on every call, so nothing new has to be configured and the hook does not care whether it is constructed before or after `update_values(redis_cache=...)` runs. Without Redis the endpoint answers `available: false` instead of failing. Registration and removal swallow Redis errors on purpose: this is observability and it must not be able to fail a model request.

`GET /global/active_requests` in `litellm/proxy/management_endpoints/active_request_endpoints.py` is limited to `PROXY_ADMIN` and `PROXY_ADMIN_VIEW_ONLY` and returns 403 for everyone else, org admins included, because the view is cross-tenant by nature.

Both knobs live in `general_settings` rather than the environment: `active_request_ttl_seconds` and `active_request_include_user_email`. They are read at call time, since `general_settings` is populated after the hooks are constructed.

Two details worth a second look. Filtering happens in Python, so a filtered query has to read index members before it can match them; `MAX_SCAN_MEMBERS` caps that read and the response sets `truncated` so a large index cannot turn one admin request into an unbounded `MGET` against a single-threaded Redis. And the TTL is the only cleanup path left when a worker dies mid-request, which makes it the maximum age of a stale row as well, so it defaults to 30 minutes rather than something long.

`POST /global/active_requests/{registry_id}/cancel` is Proxy Admin only, not viewers, since it changes state. Only the worker serving a request can cancel it, so it keeps the asyncio task handle locally and the endpoint writes a short-lived flag in Redis that the owning worker picks up; a worker that is serving nothing stops polling. Polling rather than pub/sub on purpose: `REDIS_SOCKET_TIMEOUT` defaults to 100ms, which kills a blocking subscription immediately. When the admin call happens to land on the worker that owns the request, it cancels straight away without a round trip.

The registry is in `PROXY_HOOKS` for the hook mapping but sets `register_as_litellm_callback = False`, and `_add_proxy_hooks` now honours that flag. Without it the registry would be added to `litellm.callbacks` and run on every logging event for no reason.

`MGET` and the pipelines span several keys, so index, item and cancellation keys share the Redis Cluster hash tag `{active_requests}` and stay in one slot; standalone, Sentinel and Cluster all work.

## QA runbook

1. Start Redis and point `litellm_settings.cache_params` at it, then start the proxy with a master key
2. Fire several long streaming completions with different `user` values, as in the proof above
3. `curl` the endpoint and confirm every in-flight request appears once, with the right model, `streaming` flag and `end_user_id`
4. Add `?end_user_id=<one of them>` and confirm the result narrows to that caller
5. Let the requests finish and confirm `total` returns to 0 and `redis-cli zcard litellm:active_requests:index` is 0
6. Kill the client mid-stream and confirm the row disappears too, since cleanup hangs off the response `finally` rather than a success path
7. Call the endpoint with a non-admin key and confirm 403
8. Stop Redis, call the endpoint again and confirm `available: false` with a reason, and that model requests keep working
9. In the UI, open http://localhost:3000/active-requests/ as a proxy admin, switch the grouping tabs, sort by Age, open a row, and use the filters
10. Cancel a request from the detail panel and confirm the row disappears and the client sees the call end
11. Confirm a proxy admin viewer gets 403 from the cancel endpoint while still being able to read the list

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

`tests/e2e/ui/tests/proxy-admin/activeRequests.spec.ts` covers the page in the browser against the live proxy, no stubbed network: it fires a completion the mock upstream holds open (via an `e2e-hold-<n>s` marker in the prompt, the one addition to `fixtures/mock_llm_server/server.py`), asserts the row appears with its caller, and asserts it disappears once the completion finishes, which is the register and the cleanup path proven end to end. The other cases narrow by end user, regroup the chart, and check the poll keeps running while the page stays interactive. A non-admin does not get the nav entry.

The unit tests cover the paths that would silently break the feature rather than the happy path alone: registration is a no-op without Redis or without a call id, Redis failures are swallowed and return `None`, index members whose item key expired are dropped from the index and excluded from `total`, filters match exactly rather than by substring, a page past the end returns empty without losing `total`, the scan cap sets `truncated`, and `user_email` only appears with the flag set. There is a `fakeredis` test alongside the fake-client ones so the pipeline and pagination semantics are exercised against a real Redis implementation. The middleware test asserts that a finished response removes the entry, and the pre-call test asserts that a second registration for the same request reuses the id and start time instead of creating a duplicate row.

## Update: rebased and hardened by six weeks in production

The branch is rebased onto current `litellm_internal_staging`; the earlier revision was cut on August 6 and the two new lint gates (`LIT011`, `LIT012`) that landed since then now pass, with every record field qualified `ReadOnly[...]` and the pass-through payloads built as a typed `ActiveRequestCall`.

This has been serving a production proxy fleet for six weeks, which is where the third commit comes from. Pass-through requests were absent from the overview entirely: `pass_through_request()` now registers provider routes, and `/vllm/...` and `/azure/...` requests that name a router model take a branch which returns before ever reaching it, so `_register_router_passthrough()` covers those two exits and hands the same `litellm_call_id` to the router call, keeping the overview row and the log entry on one id.

The rest is failure paths that only production finds. Redis resolution sits inside the `try` in `register()`, `remove()` and `request_cancellation()`, since a cache that raises while resolving used to escape into the request path. `remove()` drops its local task handle in a `finally`, otherwise a failed cleanup leaves the cancel watcher polling for the life of the pod. The middleware catches `BaseException` around deregistration and decrements the in-flight counter behind its own `finally`, so neither a `CancelledError` nor a failing log handler can strand the counter that gates graceful shutdown. Unfiltered listing now refills a page after dropping expired members and counts the total after that cleanup, so a page cannot show fewer rows than it claims. Filtered listing keeps a bounded one second per-worker cache, which absorbs the five second UI poll. On the page, the age cell owns its own tick instead of the table rebuilding every column each second, and the logs link encodes the request id.

Two things in the run logs above predate this: the index key is now `litellm:{active_requests}:index`, and the key field is `key_hash` rather than the `key_hash_prefix` visible in that pasted response. Step 5 of the runbook reads `redis-cli zcard "litellm:{active_requests}:index"` accordingly.

## Review round

Greptile scored this 4/5 and raised four findings, all addressed:

The key column exposed the first 12 characters of `UserAPIKeyAuth.api_key`. Virtual keys arrive hashed, but custom auth can return the raw credential, so short credentials would have leaked in full to an admin viewer. The column now carries `key_hash`, which is what `UserAPIKeyAuth` has already hashed for virtual keys and JWTs and what the Logs page shows in its own Key Hash column, so a running request can be traced back to its key; anything that is neither a bare SHA-256 digest nor `hashed-jwt-<digest>` is hashed before it is published, so a raw credential from custom auth never reaches Redis or the page.

The scan cap was a class attribute that a test replaced globally. It is now constructor-injected, so the test builds a registry with its own limit instead of mutating shared process state.

`/v1/realtime` and the Responses WebSocket route call the shared pre-call helper with a synthetic `Request` whose state never reaches the WebSocket scope, and the in-flight middleware skips non-HTTP scopes, so those records would have lingered until the TTL. Registration now returns early for anything that is not an HTTP scope.

The explanatory comments are gone; the only ones left are the suppressions your own gates require, each with a reason.

Latest round
------------

Two things a reviewer of the running deployment caught, plus the two red checks.

The Key column carried the salted 12 character fingerprint, which is a value that appears nowhere else in the product, so there was no way to get from a running row to the key that issued it. The record now carries `key_hash` and the table has Key Alias and Key Hash as separate columns, matching Logs; pasting the hash into the Logs page's Key Hash filter finds the same request once it lands. `_key_hash()` publishes `UserAPIKeyAuth.api_key` unchanged when it is already a SHA-256 digest or `hashed-jwt-<digest>`, and hashes anything else, so a raw credential returned by custom auth is still never stored. Two tests cover both halves: an already hashed key has to pass through untouched, and a raw credential has to be absent from the record.

The Auto refresh switch was wired to pause. It started off, its label flipped between "Paused" and "Auto refresh", and the icon showed the opposite of the current state, so the control read as "enable pausing" while the page was in fact already refreshing. It now reads "Auto refresh" throughout, starts on because that is what the page does by default, and shows a play icon while it runs and a pause icon once it is off. The integration test asserts the initial checked state and the icon that goes with it, and both mutations (starting off, swapping the icons) turn it red.

The two failing checks are fixed with those: `register()` returns its id from an `else` block, which puts TRY300 back inside its ceiling, and the integration test uses `findByText` instead of `waitFor` plus `getByText` for the seven cases eslint flagged.
