### PR TITLE
fix(ui): gate proxy-admin-only shell requests behind capabilities

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/healthReadiness/useHealthReadinessDetails.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/healthReadiness/useHealthReadinessDetails.test.ts
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React, { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHealthReadinessDetails } from "./useHealthReadinessDetails";
+
+vi.mock("@/components/networking", () => ({
+  getProxyBaseUrl: () => "http://proxy.test",
+  getGlobalLitellmHeaderName: () => "Authorization",
+}));
+
+const fetchMock = vi.fn();
+
+describe("useHealthReadinessDetails", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.clearAllMocks();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      statusText: "OK",
+      json: async () => ({ status: "healthy", litellm_version: "9.9.9" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  it.each(["Admin", "Admin Viewer", "proxy_admin", "proxy_admin_viewer"])(
+    "fetches /health/readiness/details for %s",
+    async (role) => {
+      const { result } = renderHook(() => useHealthReadinessDetails("sk-test", role), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith("http://proxy.test/health/readiness/details", expect.any(Object));
+      expect(result.current.data?.litellm_version).toBe("9.9.9");
+    },
+  );
+
+  it.each(["Internal User", "Internal Viewer", "Org Admin", "App User", "Unknown Role", ""])(
+    "never requests the admin-only readiness details for %s",
+    async (role) => {
+      const { result } = renderHook(() => useHealthReadinessDetails("sk-test", role), { wrapper });
+
+      // The query is disabled, so give React Query a tick to prove nothing fires.
+      await Promise.resolve();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(result.current.isFetched).toBe(false);
+      expect(result.current.data).toBeUndefined();
+    },
+  );
+
+  it("reports missing details as absent rather than as an error, so the shell renders normally", async () => {
+    const { result } = renderHook(() => useHealthReadinessDetails("sk-test", "Internal User"), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("stays inert in an unauthenticated shell, where there is no token and no role", async () => {
+    const { result } = renderHook(() => useHealthReadinessDetails(null, null), { wrapper });
+
+    await Promise.resolve();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("does not fetch for an admin whose token has not resolved yet", async () => {
+    renderHook(() => useHealthReadinessDetails(null, "Admin"), { wrapper });
+
+    await Promise.resolve();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/healthReadiness/useHealthReadinessDetails.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/healthReadiness/useHealthReadinessDetails.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { getGlobalLitellmHeaderName, getProxyBaseUrl } from "@/components/networking";
+import { hasCapability } from "@/utils/capabilities";
 import { createQueryKeys } from "../common/queryKeysFactory";
 
 const healthReadinessDetailsKeys = createQueryKeys("healthReadinessDetails");
@@ -31,21 +32,23 @@ const fetchHealthReadinessDetails = async (accessToken: string): Promise<HealthR
 };
 
 /**
- * Fetches the auth-gated detailed readiness payload.
+ * Fetches the admin-only detailed readiness payload.
  *
- * The caller passes its own `accessToken` so this hook stays usable in both
- * authed and unauthed shells (e.g. the public model hub renders the navbar
- * with a null token). When `accessToken` is falsy the query stays disabled
- * and `data` is undefined — consumers should treat that as "details
- * unavailable" rather than an error.
+ * The caller passes its own `accessToken` and `userRole` so this hook stays
+ * usable in both authed and unauthed shells (e.g. the public model hub renders
+ * the navbar with a null token and no role). When either is missing, or the
+ * role cannot read proxy diagnostics, the query stays disabled and `data` is
+ * undefined — consumers should treat that as "details unavailable" rather than
+ * an error.
  */
 export const useHealthReadinessDetails = (
   accessToken: string | null | undefined,
+  userRole: string | null | undefined,
 ): UseQueryResult<HealthReadinessDetailsResponse> => {
   return useQuery<HealthReadinessDetailsResponse>({
     queryKey: healthReadinessDetailsKeys.detail("readiness"),
     queryFn: () => fetchHealthReadinessDetails(accessToken!),
-    enabled: Boolean(accessToken),
+    enabled: Boolean(accessToken) && hasCapability(userRole, "viewProxyDiagnostics"),
     staleTime: 5 * 60 * 1000,
     // The response feeds a passive navbar tag and a debug banner — a failed
     // call (e.g. expired token → 401) shouldn't fan out into three retries.

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/license/useLicenseInfo.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/license/useLicenseInfo.test.ts
@@ -1,0 +1,74 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React, { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getLicenseInfo } from "@/components/networking";
+import { useLicenseInfo } from "./useLicenseInfo";
+
+vi.mock("@/components/networking", () => ({
+  getLicenseInfo: vi.fn(),
+}));
+
+const mockGetLicenseInfo = vi.mocked(getLicenseInfo);
+
+describe("useLicenseInfo", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.clearAllMocks();
+    mockGetLicenseInfo.mockResolvedValue({ has_license: true, expiration_date: "2030-01-01T00:00:00Z" } as Awaited<
+      ReturnType<typeof getLicenseInfo>
+    >);
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  it.each(["Admin", "Admin Viewer", "proxy_admin", "proxy_admin_viewer"])(
+    "fetches /health/license for %s",
+    async (role) => {
+      const { result } = renderHook(() => useLicenseInfo("sk-test", role), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockGetLicenseInfo).toHaveBeenCalledTimes(1);
+      expect(mockGetLicenseInfo).toHaveBeenCalledWith("sk-test");
+      expect(result.current.data?.has_license).toBe(true);
+    },
+  );
+
+  it.each(["Internal User", "Internal Viewer", "Org Admin", "App User", "Unknown Role", ""])(
+    "never requests the admin-only license info for %s",
+    async (role) => {
+      const { result } = renderHook(() => useLicenseInfo("sk-test", role), { wrapper });
+
+      await Promise.resolve();
+
+      expect(mockGetLicenseInfo).not.toHaveBeenCalled();
+      expect(result.current.isFetched).toBe(false);
+      expect(result.current.data).toBeUndefined();
+    },
+  );
+
+  it("reports missing license info as absent rather than as an error", async () => {
+    const { result } = renderHook(() => useLicenseInfo("sk-test", "Internal User"), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does not fetch for an admin whose token has not resolved yet", async () => {
+    renderHook(() => useLicenseInfo(null, "Admin"), { wrapper });
+
+    await Promise.resolve();
+
+    expect(mockGetLicenseInfo).not.toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/license/useLicenseInfo.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/license/useLicenseInfo.ts
@@ -1,14 +1,18 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { getLicenseInfo, LicenseInfo } from "@/components/networking";
+import { hasCapability } from "@/utils/capabilities";
 import { createQueryKeys } from "../common/queryKeysFactory";
 
 const licenseInfoKeys = createQueryKeys("licenseInfo");
 
-export const useLicenseInfo = (accessToken: string | null | undefined): UseQueryResult<LicenseInfo | null> => {
+export const useLicenseInfo = (
+  accessToken: string | null | undefined,
+  userRole: string | null | undefined,
+): UseQueryResult<LicenseInfo | null> => {
   const options = {
     queryKey: licenseInfoKeys.detail("license"),
     queryFn: () => getLicenseInfo(accessToken!),
-    enabled: Boolean(accessToken),
+    enabled: Boolean(accessToken) && hasCapability(userRole, "viewLicenseInfo"),
     staleTime: 5 * 60 * 1000,
     retry: false,
   };

--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
@@ -21,8 +21,12 @@ const pluginApiClient = createApiClient({ getBaseUrl: () => getProxyBaseUrl() ??
 // Wrapper so PluginModeProvider receives the live accessToken from auth context,
 // which means plugin data refreshes on login/logout without stale cookie reads.
 function PluginModeProviderWithAuth({ children }: { children: React.ReactNode }) {
-  const { accessToken } = useAuth();
-  return <PluginModeProvider accessToken={accessToken}>{children}</PluginModeProvider>;
+  const { accessToken, userRole } = useAuth();
+  return (
+    <PluginModeProvider accessToken={accessToken} userRole={userRole}>
+      {children}
+    </PluginModeProvider>
+  );
 }
 
 export function AgentControlPlaneView() {
@@ -99,7 +103,7 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
-  const { accessToken } = useAuth();
+  const { accessToken, userRole } = useAuth();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const { mode } = usePluginMode();
 
@@ -118,9 +122,9 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
   if (!isGateway) {
     return (
       <div className="flex h-screen flex-col overflow-hidden bg-background">
-        <Navbar accessToken={accessToken} isPublicPage={false} />
-        <DebugWarningBanner accessToken={accessToken} />
-        <LicenseExpiryBanner accessToken={accessToken} />
+        <Navbar accessToken={accessToken} userRole={userRole} isPublicPage={false} />
+        <DebugWarningBanner accessToken={accessToken} userRole={userRole} />
+        <LicenseExpiryBanner accessToken={accessToken} userRole={userRole} />
         <UserBanner accessToken={accessToken} />
         <main className="flex min-h-0 flex-1 overflow-hidden">
           <AgentControlPlaneView />
@@ -142,8 +146,8 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
       />
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         <DashboardHeader page={page} />
-        <DebugWarningBanner accessToken={accessToken} />
-        <LicenseExpiryBanner accessToken={accessToken} />
+        <DebugWarningBanner accessToken={accessToken} userRole={userRole} />
+        <LicenseExpiryBanner accessToken={accessToken} userRole={userRole} />
         <UserBanner accessToken={accessToken} />
         <main className="min-w-0 flex-1 overflow-y-auto">{children}</main>
       </div>

--- a/ui/litellm-dashboard/src/app/chat/layout.tsx
+++ b/ui/litellm-dashboard/src/app/chat/layout.tsx
@@ -28,7 +28,7 @@ function ChatLayoutContent({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider accessToken={accessToken}>
       <div className="flex h-screen flex-col">
-        <Navbar accessToken={accessToken} isPublicPage={false} />
+        <Navbar accessToken={accessToken} userRole={userRole} isPublicPage={false} />
         <div className="min-h-0 flex-1">
           <ChatShellProvider
             accessToken={accessToken ?? ""}

--- a/ui/litellm-dashboard/src/app/connect/layout.tsx
+++ b/ui/litellm-dashboard/src/app/connect/layout.tsx
@@ -5,14 +5,14 @@ import Navbar from "@/components/navbar";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 
 export default function ConnectLayout({ children }: { children: React.ReactNode }) {
-  const { accessToken, isAuthorized, isLoading } = useAuthorized();
+  const { accessToken, userRole, isAuthorized, isLoading } = useAuthorized();
 
   if (isLoading || !isAuthorized) return null;
 
   return (
     <ThemeProvider accessToken={accessToken}>
       <div className="flex h-screen flex-col">
-        <Navbar accessToken={accessToken} isPublicPage={false} />
+        <Navbar accessToken={accessToken} userRole={userRole} isPublicPage={false} />
         <div className="min-h-0 flex-1 overflow-auto">{children}</div>
       </div>
     </ThemeProvider>

--- a/ui/litellm-dashboard/src/components/DebugWarningBanner.test.tsx
+++ b/ui/litellm-dashboard/src/components/DebugWarningBanner.test.tsx
@@ -11,43 +11,49 @@ import { useHealthReadinessDetails } from "@/app/(dashboard)/hooks/healthReadine
 describe("DebugWarningBanner", () => {
   it("should render", () => {
     vi.mocked(useHealthReadinessDetails).mockReturnValue({ data: { is_detailed_debug: true } } as any);
-    renderWithProviders(<DebugWarningBanner accessToken="token" />);
+    renderWithProviders(<DebugWarningBanner accessToken="token" userRole="Admin" />);
     expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 
   it("should show warning when detailed debug mode is active", () => {
     vi.mocked(useHealthReadinessDetails).mockReturnValue({ data: { is_detailed_debug: true } } as any);
-    renderWithProviders(<DebugWarningBanner accessToken="token" />);
+    renderWithProviders(<DebugWarningBanner accessToken="token" userRole="Admin" />);
     expect(screen.getByText(/Performance Warning: Detailed Debug Mode Active/i)).toBeInTheDocument();
   });
 
   it("should mention LITELLM_LOG=DEBUG in the description", () => {
     vi.mocked(useHealthReadinessDetails).mockReturnValue({ data: { is_detailed_debug: true } } as any);
-    renderWithProviders(<DebugWarningBanner accessToken="token" />);
+    renderWithProviders(<DebugWarningBanner accessToken="token" userRole="Admin" />);
     expect(screen.getByText("LITELLM_LOG=DEBUG")).toBeInTheDocument();
   });
 
   it("should render nothing when is_detailed_debug is false", () => {
     vi.mocked(useHealthReadinessDetails).mockReturnValue({ data: { is_detailed_debug: false } } as any);
-    const { container } = renderWithProviders(<DebugWarningBanner accessToken="token" />);
+    const { container } = renderWithProviders(<DebugWarningBanner accessToken="token" userRole="Admin" />);
     expect(container).toBeEmptyDOMElement();
   });
 
   it("should render nothing when health data is undefined", () => {
     vi.mocked(useHealthReadinessDetails).mockReturnValue({ data: undefined } as any);
-    const { container } = renderWithProviders(<DebugWarningBanner accessToken="token" />);
+    const { container } = renderWithProviders(<DebugWarningBanner accessToken="token" userRole="Admin" />);
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("should pass accessToken to the readiness hook", () => {
+  it("should pass accessToken and userRole to the readiness hook", () => {
     vi.mocked(useHealthReadinessDetails).mockReturnValue({ data: undefined } as any);
-    renderWithProviders(<DebugWarningBanner accessToken="my-token" />);
-    expect(useHealthReadinessDetails).toHaveBeenCalledWith("my-token");
+    renderWithProviders(<DebugWarningBanner accessToken="my-token" userRole="Admin" />);
+    expect(useHealthReadinessDetails).toHaveBeenCalledWith("my-token", "Admin");
   });
 
   it("should pass a null accessToken through (disables the hook)", () => {
     vi.mocked(useHealthReadinessDetails).mockReturnValue({ data: undefined } as any);
-    renderWithProviders(<DebugWarningBanner accessToken={null} />);
-    expect(useHealthReadinessDetails).toHaveBeenCalledWith(null);
+    renderWithProviders(<DebugWarningBanner accessToken={null} userRole="Admin" />);
+    expect(useHealthReadinessDetails).toHaveBeenCalledWith(null, "Admin");
+  });
+
+  it("should pass a non-admin role through so the hook can gate the admin-only call", () => {
+    vi.mocked(useHealthReadinessDetails).mockReturnValue({ data: undefined } as any);
+    renderWithProviders(<DebugWarningBanner accessToken="my-token" userRole="Internal User" />);
+    expect(useHealthReadinessDetails).toHaveBeenCalledWith("my-token", "Internal User");
   });
 });

--- a/ui/litellm-dashboard/src/components/DebugWarningBanner.tsx
+++ b/ui/litellm-dashboard/src/components/DebugWarningBanner.tsx
@@ -6,10 +6,11 @@ import { useHealthReadinessDetails } from "@/app/(dashboard)/hooks/healthReadine
 
 interface DebugWarningBannerProps {
   accessToken: string | null;
+  userRole: string | null;
 }
 
-export const DebugWarningBanner: React.FC<DebugWarningBannerProps> = ({ accessToken }) => {
-  const { data: healthData } = useHealthReadinessDetails(accessToken);
+export const DebugWarningBanner: React.FC<DebugWarningBannerProps> = ({ accessToken, userRole }) => {
+  const { data: healthData } = useHealthReadinessDetails(accessToken, userRole);
 
   // Only show banner if detailed debug mode is explicitly enabled
   if (!healthData?.is_detailed_debug) {

--- a/ui/litellm-dashboard/src/components/LicenseExpiryBanner.tsx
+++ b/ui/litellm-dashboard/src/components/LicenseExpiryBanner.tsx
@@ -13,6 +13,7 @@ const salesLink = <a href={`mailto:${SALES_EMAIL}`}>{SALES_EMAIL}</a>;
 
 interface LicenseExpiryBannerProps {
   accessToken: string | null;
+  userRole: string | null;
 }
 
 interface LicenseExpiryBannerViewProps {
@@ -89,7 +90,7 @@ export const LicenseExpiryBannerView: React.FC<LicenseExpiryBannerViewProps> = (
   );
 };
 
-export const LicenseExpiryBanner: React.FC<LicenseExpiryBannerProps> = ({ accessToken }) => {
-  const { data } = useLicenseInfo(accessToken);
+export const LicenseExpiryBanner: React.FC<LicenseExpiryBannerProps> = ({ accessToken, userRole }) => {
+  const { data } = useLicenseInfo(accessToken, userRole);
   return <LicenseExpiryBannerView licenseInfo={data ?? null} />;
 };

--- a/ui/litellm-dashboard/src/components/SidebarAccountMenu/SidebarAccountMenu.test.tsx
+++ b/ui/litellm-dashboard/src/components/SidebarAccountMenu/SidebarAccountMenu.test.tsx
@@ -7,6 +7,7 @@ interface AuthMock {
   userId: string | null;
   userEmail: string | null;
   userRoleLabel: string;
+  userRole: string;
   premiumUser: boolean;
   accessToken: string;
 }
@@ -15,6 +16,7 @@ let mockUseAuthorizedImpl: () => AuthMock = () => ({
   userId: "test-user-id",
   userEmail: "test@example.com",
   userRoleLabel: "Admin",
+  userRole: "Admin",
   premiumUser: false,
   accessToken: "test-token",
 });
@@ -45,8 +47,13 @@ vi.mock("@/app/(dashboard)/hooks/useDisableBouncingIcon", () => ({
   useDisableBouncingIcon: () => mockUseDisableBouncingIconImpl(),
 }));
 
+const useHealthReadinessDetailsSpy = vi.hoisted(() => vi.fn());
+
 vi.mock("@/app/(dashboard)/hooks/healthReadiness/useHealthReadinessDetails", () => ({
-  useHealthReadinessDetails: () => ({ data: mockHealthDataImpl() }),
+  useHealthReadinessDetails: (accessToken: string | null, userRole: string | null) => {
+    useHealthReadinessDetailsSpy(accessToken, userRole);
+    return { data: mockHealthDataImpl() };
+  },
 }));
 
 vi.mock("@/utils/localStorageUtils", () => ({
@@ -75,6 +82,7 @@ describe("SidebarAccountMenu", () => {
       userId: "test-user-id",
       userEmail: "test@example.com",
       userRoleLabel: "Admin",
+      userRole: "Admin",
       premiumUser: false,
       accessToken: "test-token",
     });
@@ -128,6 +136,7 @@ describe("SidebarAccountMenu", () => {
       userId: "test-user-id",
       userEmail: "test@example.com",
       userRoleLabel: "Admin",
+      userRole: "Admin",
       premiumUser: true,
       accessToken: "test-token",
     });
@@ -148,6 +157,23 @@ describe("SidebarAccountMenu", () => {
     const versionLink = screen.getByRole("link", { name: /v1\.99\.0/ });
     expect(versionLink).toHaveAttribute("href", "https://docs.litellm.ai/release_notes");
     expect(versionLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("should forward the session role, not the display label, to the readiness hook", () => {
+    // proxy_admin_viewer is the one role where the two diverge: the session role
+    // is "Admin" while the label shown in the menu stays "Admin Viewer".
+    mockUseAuthorizedImpl = () => ({
+      userId: "test-user-id",
+      userEmail: "test@example.com",
+      userRoleLabel: "Admin Viewer",
+      userRole: "Admin",
+      premiumUser: false,
+      accessToken: "test-token",
+    });
+
+    renderWithProviders(<SidebarAccountMenu onLogout={mockOnLogout} />);
+
+    expect(useHealthReadinessDetailsSpy).toHaveBeenCalledWith("test-token", "Admin");
   });
 
   it("should not render the version badge when the version is unavailable", async () => {
@@ -274,6 +300,7 @@ describe("SidebarAccountMenu", () => {
       userId: "default_user_id",
       userEmail: null,
       userRoleLabel: "Admin",
+      userRole: "Admin",
       premiumUser: false,
       accessToken: "test-token",
     });
@@ -287,6 +314,7 @@ describe("SidebarAccountMenu", () => {
       userId: "test-user-id",
       userEmail: null,
       userRoleLabel: "Admin",
+      userRole: "Admin",
       premiumUser: false,
       accessToken: "test-token",
     });

--- a/ui/litellm-dashboard/src/components/SidebarAccountMenu/SidebarAccountMenu.tsx
+++ b/ui/litellm-dashboard/src/components/SidebarAccountMenu/SidebarAccountMenu.tsx
@@ -81,8 +81,15 @@ interface SidebarAccountMenuProps {
 }
 
 const SidebarAccountMenu: React.FC<SidebarAccountMenuProps> = ({ onLogout, collapsed = false }) => {
-  const { userId, userEmail, userRoleLabel: userRole, premiumUser, accessToken } = useAuthorized();
-  const { data: healthData } = useHealthReadinessDetails(accessToken);
+  const {
+    userId,
+    userEmail,
+    userRoleLabel: userRole,
+    userRole: sessionRole,
+    premiumUser,
+    accessToken,
+  } = useAuthorized();
+  const { data: healthData } = useHealthReadinessDetails(accessToken, sessionRole);
   const version = healthData?.litellm_version;
   const disableShowPrompts = useDisableShowPrompts();
   const disableBlogPosts = useDisableBlogPosts();

--- a/ui/litellm-dashboard/src/components/SidebarUsageCard.test.tsx
+++ b/ui/litellm-dashboard/src/components/SidebarUsageCard.test.tsx
@@ -68,7 +68,7 @@ describe("SidebarUsageCard", () => {
 
   it("renders an expanded seat meter reporting value and range when data loads", async () => {
     const { container } = renderWithClient(
-      <SidebarUsageCard accessToken="token" collapsed={false} onExpandRail={() => {}} />,
+      <SidebarUsageCard accessToken="token" userRole="Admin" collapsed={false} onExpandRail={() => {}} />,
     );
 
     await screen.findByText("Enterprise usage");
@@ -83,7 +83,9 @@ describe("SidebarUsageCard", () => {
 
   it("collapses the meter panel when the trigger is toggled", async () => {
     const user = userEvent.setup();
-    renderWithClient(<SidebarUsageCard accessToken="token" collapsed={false} onExpandRail={() => {}} />);
+    renderWithClient(
+      <SidebarUsageCard accessToken="token" userRole="Admin" collapsed={false} onExpandRail={() => {}} />,
+    );
 
     await screen.findByRole("meter");
     await user.click(screen.getByRole("button", { name: /Enterprise usage/i }));
@@ -95,7 +97,7 @@ describe("SidebarUsageCard", () => {
     mockGetRemainingUsers.mockResolvedValue(OVER_LIMIT_DATA);
 
     const { container } = renderWithClient(
-      <SidebarUsageCard accessToken="token" collapsed={false} onExpandRail={() => {}} />,
+      <SidebarUsageCard accessToken="token" userRole="Admin" collapsed={false} onExpandRail={() => {}} />,
     );
 
     await screen.findByRole("meter");
@@ -107,7 +109,9 @@ describe("SidebarUsageCard", () => {
   it("renders nothing when neither seat nor team limits are set", async () => {
     mockGetRemainingUsers.mockResolvedValue(NO_LIMITS_DATA);
 
-    renderWithClient(<SidebarUsageCard accessToken="token" collapsed={false} onExpandRail={() => {}} />);
+    renderWithClient(
+      <SidebarUsageCard accessToken="token" userRole="Admin" collapsed={false} onExpandRail={() => {}} />,
+    );
 
     await waitFor(() => expect(screen.queryByText("Enterprise usage")).not.toBeInTheDocument());
   });
@@ -116,7 +120,7 @@ describe("SidebarUsageCard", () => {
     mockUseLicenseInfo.mockReturnValue(licenseResult(null));
 
     const { container } = renderWithClient(
-      <SidebarUsageCard accessToken="token" collapsed={false} onExpandRail={() => {}} />,
+      <SidebarUsageCard accessToken="token" userRole="Admin" collapsed={false} onExpandRail={() => {}} />,
     );
 
     await waitFor(() => expect(mockGetRemainingUsers).toHaveBeenCalled());
@@ -127,7 +131,9 @@ describe("SidebarUsageCard", () => {
   it("shows the exact license expiration date as the subtitle instead of time remaining", async () => {
     mockUseLicenseInfo.mockReturnValue(licenseResult({ ...ACTIVE_LICENSE, expiration_date: "2099-12-31" }));
 
-    renderWithClient(<SidebarUsageCard accessToken="token" collapsed={false} onExpandRail={() => {}} />);
+    renderWithClient(
+      <SidebarUsageCard accessToken="token" userRole="Admin" collapsed={false} onExpandRail={() => {}} />,
+    );
 
     expect(await screen.findByText("Expires Dec 31, 2099")).toBeInTheDocument();
     expect(screen.queryByText(/(day|days|month|months) remaining/)).not.toBeInTheDocument();
@@ -136,21 +142,33 @@ describe("SidebarUsageCard", () => {
   it("shows the exact date as the subtitle when the license is expired", async () => {
     mockUseLicenseInfo.mockReturnValue(licenseResult({ ...ACTIVE_LICENSE, expiration_date: "2020-01-01" }));
 
-    renderWithClient(<SidebarUsageCard accessToken="token" collapsed={false} onExpandRail={() => {}} />);
+    renderWithClient(
+      <SidebarUsageCard accessToken="token" userRole="Admin" collapsed={false} onExpandRail={() => {}} />,
+    );
 
     expect(await screen.findByText("Expired Jan 1, 2020")).toBeInTheDocument();
   });
 
   it("falls back to Active plan when the license has no expiration date", async () => {
-    renderWithClient(<SidebarUsageCard accessToken="token" collapsed={false} onExpandRail={() => {}} />);
+    renderWithClient(
+      <SidebarUsageCard accessToken="token" userRole="Admin" collapsed={false} onExpandRail={() => {}} />,
+    );
 
     expect(await screen.findByText("Active plan")).toBeInTheDocument();
+  });
+
+  it("forwards the user role to the license hook, which gates the admin-only call", async () => {
+    renderWithClient(
+      <SidebarUsageCard accessToken="token" userRole="Internal User" collapsed={false} onExpandRail={() => {}} />,
+    );
+
+    await waitFor(() => expect(mockUseLicenseInfo).toHaveBeenCalledWith("token", "Internal User"));
   });
 
   it("shows a collapsed rail button that expands the sidebar", async () => {
     const onExpandRail = vi.fn();
     const user = userEvent.setup();
-    renderWithClient(<SidebarUsageCard accessToken="token" collapsed onExpandRail={onExpandRail} />);
+    renderWithClient(<SidebarUsageCard accessToken="token" userRole="Admin" collapsed onExpandRail={onExpandRail} />);
 
     const rail = await screen.findByTitle("Enterprise usage");
     await user.click(rail);

--- a/ui/litellm-dashboard/src/components/SidebarUsageCard.tsx
+++ b/ui/litellm-dashboard/src/components/SidebarUsageCard.tsx
@@ -9,6 +9,7 @@ import { getRemainingUsers } from "./networking";
 
 interface SidebarUsageCardProps {
   accessToken: string | null;
+  userRole: string | null;
   collapsed: boolean;
   onExpandRail: () => void;
 }
@@ -67,8 +68,8 @@ const buildMeters = (data: RemainingUsage | null): MeterData[] => {
  * plus the license expiry. There is no plan-level spend or request cap, so the
  * design's Spend / API-request meters are intentionally omitted.
  */
-export default function SidebarUsageCard({ accessToken, collapsed, onExpandRail }: SidebarUsageCardProps) {
-  const licenseInfo = useLicenseInfo(accessToken).data ?? null;
+export default function SidebarUsageCard({ accessToken, userRole, collapsed, onExpandRail }: SidebarUsageCardProps) {
+  const licenseInfo = useLicenseInfo(accessToken, userRole).data ?? null;
   const { data: usageData, isLoading } = useQuery(remainingUsersQuery(accessToken));
   const data = usageData ?? null;
 

--- a/ui/litellm-dashboard/src/components/leftnav.test.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.test.tsx
@@ -3,8 +3,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "../../tests/test-utils";
 import Sidebar, { menuGroups, getBreadcrumb } from "./leftnav";
 
-vi.mock("../utils/roles", () => {
+vi.mock("../utils/roles", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../utils/roles")>();
   return {
+    ...actual,
     all_admin_roles: ["admin", "admin_viewer"],
     internalUserRoles: ["internal"],
     rolesWithWriteAccess: ["admin", "internal"],
@@ -64,8 +66,12 @@ vi.mock("@/contexts/ThemeContext", () => ({
 }));
 
 // Version tag + logout target come from network hooks; keep them inert in unit tests.
+const useHealthReadinessDetailsSpy = vi.hoisted(() => vi.fn());
 vi.mock("@/app/(dashboard)/hooks/healthReadiness/useHealthReadinessDetails", () => ({
-  useHealthReadinessDetails: () => ({ data: undefined }),
+  useHealthReadinessDetails: (accessToken: string | null, userRole: string | null) => {
+    useHealthReadinessDetailsSpy(accessToken, userRole);
+    return { data: undefined };
+  },
 }));
 vi.mock("@/app/(dashboard)/hooks/useLogout", () => ({
   useLogout: () => vi.fn(),
@@ -243,6 +249,15 @@ describe("Sidebar (leftnav)", () => {
       await waitFor(() => {
         expect(screen.getByText("Tool Policies")).toBeInTheDocument();
       });
+    });
+
+    it("should forward the user role to the readiness hook so it can gate the admin-only call", () => {
+      mockUseAuthorized.mockReturnValue(internalAuth);
+      useHealthReadinessDetailsSpy.mockClear();
+
+      renderWithProviders(<Sidebar {...defaultProps} />);
+
+      expect(useHealthReadinessDetailsSpy).toHaveBeenCalledWith("test-access-token", "internal");
     });
   });
 

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -411,7 +411,7 @@ const Sidebar_: React.FC<SidebarProps> = ({
   const { data: organizations } = useOrganizations();
   const { data: teams } = useTeams();
   const { logoUrl } = useTheme();
-  const { data: healthData } = useHealthReadinessDetails(accessToken);
+  const { data: healthData } = useHealthReadinessDetails(accessToken, userRole);
   const logout = useLogout(accessToken);
 
   const baseUrl = getProxyBaseUrl();
@@ -637,6 +637,7 @@ const Sidebar_: React.FC<SidebarProps> = ({
         {isAdminRole(userRole) && (
           <SidebarUsageCard
             accessToken={accessToken}
+            userRole={userRole}
             collapsed={collapsed}
             onExpandRail={() => onToggleCollapsed?.()}
           />

--- a/ui/litellm-dashboard/src/components/navbar.test.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.test.tsx
@@ -110,8 +110,8 @@ vi.mock("@/contexts/ThemeContext", () => ({
 }));
 
 vi.mock("@/app/(dashboard)/hooks/healthReadiness/useHealthReadinessDetails", () => ({
-  useHealthReadinessDetails: (accessToken: string | null | undefined) => {
-    useHealthReadinessDetailsSpy(accessToken);
+  useHealthReadinessDetails: (accessToken: string | null | undefined, userRole: string | null | undefined) => {
+    useHealthReadinessDetailsSpy(accessToken, userRole);
     return mockUseHealthReadinessDetailsImpl();
   },
 }));
@@ -141,6 +141,7 @@ Object.defineProperty(window, "location", {
 describe("Navbar", () => {
   const defaultProps = {
     accessToken: "test-token",
+    userRole: "Admin",
     isPublicPage: false,
   };
 
@@ -222,12 +223,12 @@ describe("Navbar", () => {
     mockUseHealthReadinessDetailsImpl = () => ({ data: null });
   });
 
-  it("should forward accessToken to the readiness hook", () => {
+  it("should forward accessToken and userRole to the readiness hook", () => {
     useHealthReadinessDetailsSpy.mockClear();
 
     renderWithProviders(<Navbar {...defaultProps} accessToken="my-token" />);
 
-    expect(useHealthReadinessDetailsSpy).toHaveBeenCalledWith("my-token");
+    expect(useHealthReadinessDetailsSpy).toHaveBeenCalledWith("my-token", "Admin");
   });
 
   it("should forward a null accessToken to the readiness hook (disables the hook)", () => {
@@ -235,7 +236,15 @@ describe("Navbar", () => {
 
     renderWithProviders(<Navbar {...defaultProps} accessToken={null} />);
 
-    expect(useHealthReadinessDetailsSpy).toHaveBeenCalledWith(null);
+    expect(useHealthReadinessDetailsSpy).toHaveBeenCalledWith(null, "Admin");
+  });
+
+  it("should forward a non-admin role so the readiness hook can gate the admin-only call", () => {
+    useHealthReadinessDetailsSpy.mockClear();
+
+    renderWithProviders(<Navbar {...defaultProps} userRole="Internal User" />);
+
+    expect(useHealthReadinessDetailsSpy).toHaveBeenCalledWith("test-token", "Internal User");
   });
 
   it("should use custom logo from theme context", () => {

--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -22,6 +22,7 @@ import WorkerDropdown from "./Navbar/WorkerDropdown/WorkerDropdown";
 
 interface NavbarProps {
   accessToken: string | null;
+  userRole: string | null;
   isPublicPage: boolean;
   sidebarCollapsed?: boolean;
   onToggleSidebar?: () => void;
@@ -29,6 +30,7 @@ interface NavbarProps {
 
 const Navbar: React.FC<NavbarProps> = ({
   accessToken,
+  userRole,
   isPublicPage = false,
   sidebarCollapsed = false,
   onToggleSidebar,
@@ -36,7 +38,7 @@ const Navbar: React.FC<NavbarProps> = ({
   const baseUrl = getProxyBaseUrl();
   const proxySettings = useProxySettings(accessToken);
   const { logoUrl } = useTheme();
-  const { data: healthData } = useHealthReadinessDetails(accessToken);
+  const { data: healthData } = useHealthReadinessDetails(accessToken, userRole);
   const version = healthData?.litellm_version;
   const disableBouncingIcon = useDisableBouncingIcon();
   const hideCommunityLinks = useDisableShowPrompts();

--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -472,7 +472,7 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
     <ThemeProvider accessToken={accessToken}>
       <div className={isEmbedded ? "w-full" : "min-h-screen bg-white"}>
         {/* Navigation - only show when not embedded */}
-        {!isEmbedded && <Navbar accessToken={accessToken || null} isPublicPage={true} />}
+        {!isEmbedded && <Navbar accessToken={accessToken || null} userRole={null} isPublicPage={true} />}
 
         <div className={isEmbedded ? "w-full p-6" : "w-full px-8 py-12"}>
           {/* Embedded Explainer - only shown when embedded in dashboard */}

--- a/ui/litellm-dashboard/src/contexts/PluginModeContext.test.tsx
+++ b/ui/litellm-dashboard/src/contexts/PluginModeContext.test.tsx
@@ -20,13 +20,16 @@ function ModeProbe() {
   );
 }
 
-const renderWithPlugins = (plugins: Plugin[]) => {
-  getMock.mockResolvedValueOnce(plugins);
-  return render(
-    <PluginModeProvider accessToken="sk-test">
+const renderAs = (userRole: string | null) =>
+  render(
+    <PluginModeProvider accessToken="sk-test" userRole={userRole}>
       <ModeProbe />
     </PluginModeProvider>,
   );
+
+const renderWithPlugins = (plugins: Plugin[]) => {
+  getMock.mockResolvedValueOnce(plugins);
+  return renderAs("Admin");
 };
 
 describe("PluginModeProvider effectiveMode fallback", () => {
@@ -52,13 +55,34 @@ describe("PluginModeProvider effectiveMode fallback", () => {
 
   it("falls back to ai-gateway when the plugins fetch fails, never stranding the user", async () => {
     getMock.mockRejectedValueOnce(new Error("network down"));
-    render(
-      <PluginModeProvider accessToken="sk-test">
-        <ModeProbe />
-      </PluginModeProvider>,
-    );
+    renderAs("Admin");
 
     await waitFor(() => expect(getMock).toHaveBeenCalled());
     await waitFor(() => expect(screen.getByTestId("mode").textContent).toBe("ai-gateway"));
+  });
+});
+
+describe("PluginModeProvider role gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem("litellm_plugin_mode", "my-plugin");
+  });
+
+  it.each(["Internal User", "Internal Viewer", "Org Admin", "App User"])(
+    "never requests /api/plugins for %s, and still falls back to ai-gateway",
+    async (role) => {
+      renderAs(role);
+
+      await waitFor(() => expect(screen.getByTestId("mode").textContent).toBe("ai-gateway"));
+      expect(getMock).not.toHaveBeenCalled();
+      expect(screen.getByTestId("active").textContent).toBe("none");
+    },
+  );
+
+  it("holds the stored mode while the role is still resolving, so an admin does not flash to ai-gateway", async () => {
+    renderAs(null);
+
+    await waitFor(() => expect(screen.getByTestId("mode").textContent).toBe("my-plugin"));
+    expect(getMock).not.toHaveBeenCalled();
   });
 });

--- a/ui/litellm-dashboard/src/contexts/PluginModeContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/PluginModeContext.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useState, useEffect } from "react";
 import { createApiClient } from "@/lib/http/client";
 import { getProxyBaseUrl } from "@/components/networking";
+import { hasCapability } from "@/utils/capabilities";
 
 export type PluginMode = "ai-gateway" | string; // "ai-gateway" or a registered plugin name
 
@@ -49,16 +50,23 @@ interface PluginModeProviderProps {
   children: React.ReactNode;
   /** Pass the current access token from the app's auth context. */
   accessToken?: string | null;
+  /**
+   * Pass the current user role from the app's auth context. `/api/plugins` is a
+   * proxy-admin route, so a role without that capability never fetches; the
+   * provider then behaves exactly as it does for an empty plugin list.
+   */
+  userRole: string | null;
 }
 
-export function PluginModeProvider({ children, accessToken }: PluginModeProviderProps) {
+export function PluginModeProvider({ children, accessToken, userRole }: PluginModeProviderProps) {
   const [mode, setModeState] = useState<PluginMode>(readStoredMode);
   const [plugins, setPlugins] = useState<Plugin[]>([]);
   const [loaded, setLoaded] = useState(false);
+  const canViewPlugins = hasCapability(userRole, "viewPlugins");
 
   useEffect(() => {
     // Re-fetch whenever the auth token changes (handles login/logout cycles)
-    if (!accessToken) return;
+    if (!accessToken || !canViewPlugins) return;
     pluginApiClient
       .get("/api/plugins", { accessToken })
       .then((data: Plugin[]) => {
@@ -69,12 +77,19 @@ export function PluginModeProvider({ children, accessToken }: PluginModeProvider
       // ai-gateway; otherwise a failed fetch would strand the user on a blank
       // plugin view with no switcher to escape.
       .finally(() => setLoaded(true));
-  }, [accessToken]);
+  }, [accessToken, canViewPlugins]);
 
-  // Once plugins have loaded, fall back to ai-gateway if the persisted mode is
-  // no longer registered — including when the list came back empty (all plugins
-  // removed).  Derived rather than setState-in-effect to avoid cascading renders.
-  const effectiveMode = mode !== "ai-gateway" && loaded && !plugins.some((p) => p.name === mode) ? "ai-gateway" : mode;
+  // A role that can't read plugins settles without ever fetching, so a stored
+  // plugin mode still falls back below. Gated on the role having resolved so an
+  // admin doesn't flash to ai-gateway while auth is still loading.
+  const pluginListSettled = loaded || (Boolean(userRole) && !canViewPlugins);
+
+  // Once the plugin list has settled, fall back to ai-gateway if the persisted
+  // mode is no longer registered — including when the list came back empty (all
+  // plugins removed). Derived rather than setState-in-effect to avoid cascading
+  // renders.
+  const effectiveMode =
+    mode !== "ai-gateway" && pluginListSettled && !plugins.some((p) => p.name === mode) ? "ai-gateway" : mode;
 
   const setMode = (m: PluginMode) => {
     setModeState(m);

--- a/ui/litellm-dashboard/src/utils/capabilities.test.ts
+++ b/ui/litellm-dashboard/src/utils/capabilities.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, it } from "vitest";
 
-import { hasCapability, rolesWithCapability } from "./capabilities";
+import { Capability, hasCapability, rolesWithCapability } from "./capabilities";
+
+// `/health/readiness/details`, `/health/license` and `/api/plugins` are all
+// proxy-admin routes on the backend: org admins get a 401 there, unlike the
+// broader `all_admin_roles` set that gates tool policies.
+const proxyAdminOnlyCapabilities: Capability[] = ["viewProxyDiagnostics", "viewLicenseInfo", "viewPlugins"];
+
+describe.each(proxyAdminOnlyCapabilities)("hasCapability(%s)", (capability) => {
+  it.each(["Admin", "Admin Viewer", "proxy_admin", "proxy_admin_viewer"])("should grant to %s", (role) => {
+    expect(hasCapability(role, capability)).toBe(true);
+  });
+
+  it.each([
+    "Org Admin",
+    "org_admin",
+    "Internal User",
+    "internal_user",
+    "Internal Viewer",
+    "internal_user_viewer",
+    "App User",
+    "app_user",
+    "Unknown Role",
+    "",
+    null,
+    undefined,
+  ])("should deny to %s", (role) => {
+    expect(hasCapability(role, capability)).toBe(false);
+  });
+});
 
 describe("hasCapability", () => {
   it.each(["Admin", "Admin Viewer", "proxy_admin", "proxy_admin_viewer"])(

--- a/ui/litellm-dashboard/src/utils/capabilities.ts
+++ b/ui/litellm-dashboard/src/utils/capabilities.ts
@@ -1,7 +1,12 @@
-import { all_admin_roles } from "./roles";
+import { all_admin_roles, old_admin_roles } from "./roles";
+
+const proxyAdminOnlyRoles = [...old_admin_roles, "proxy_admin", "proxy_admin_viewer"];
 
 const CAPABILITY_ROLES = {
   viewToolPolicies: all_admin_roles,
+  viewProxyDiagnostics: proxyAdminOnlyRoles,
+  viewLicenseInfo: proxyAdminOnlyRoles,
+  viewPlugins: proxyAdminOnlyRoles,
 } as const satisfies Record<string, readonly string[]>;
 
 export type Capability = keyof typeof CAPABILITY_ROLES;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Non-admin users 401 on every dashboard page load
- Three admin-only calls fire regardless of role
- The plugin call swallows its own 401 silently

How it solves it:

- Adds three capabilities to the existing capability map
- Each fetch reads the same capability that gates rendering
- Role now flows into the hooks alongside the token

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before: `0acca3e86a`. After: `a0c62a9010`

### Setup, run once

Start the proxy and the dashboard dev server, then create a non-admin user to log in as

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

```bash
cd ui/litellm-dashboard && npm run dev
```

```bash
curl -sS -X POST http://localhost:4000/user/new -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"user_id":"gate-demo","user_email":"gate-demo@example.com","user_role":"internal_user"}'
```

```bash
curl -sS -X POST http://localhost:4000/user/update -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"user_id":"gate-demo","password":"GateDemo!2026"}'
```

### 1. The three routes really are proxy-admin only

Mint a key for that user and call each route with it. All three answer 401, which is the 401 the shell was collecting on every navigation

```bash
KEY=$(curl -sS -X POST http://localhost:4000/key/generate -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"user_id":"gate-demo"}' | python3 -c 'import json,sys; print(json.load(sys.stdin)["key"])')
for ep in /health/readiness/details /health/license /api/plugins; do printf '%-28s ' "$ep"; curl -sS -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $KEY" "http://localhost:4000$ep"; done
```

Same loop with the master key returns 200 on all three

```bash
for ep in /health/readiness/details /health/license /api/plugins; do printf '%-28s ' "$ep"; curl -sS -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $LITELLM_MASTER_KEY" "http://localhost:4000$ep"; done
```

### 2. Reproduce the bug on `0acca3e86a`

1. Check out the base commit and let the dev server rebuild
2. Open http://localhost:3000/?page=api-keys and log in as `gate-demo@example.com` / `GateDemo!2026`
3. Open DevTools, Network tab, filter on `readiness/details`, then repeat for `health/license` and `api/plugins`
4. Click through Virtual Keys, Usage, Logs, Teams, Models + Endpoints, MCP Servers in the left nav
5. Screenshot the Network tab: each of the three shows a request with status 401

### 3. Confirm the fix on `a0c62a9010`

1. Check out this branch and let the dev server rebuild
2. Reload http://localhost:3000/?page=api-keys, still signed in as `gate-demo@example.com`
3. Same three Network filters, same six pages in the left nav
4. Screenshot the Network tab: all three filters stay empty, no request and no 401
5. Open the account menu at the bottom of the left nav and confirm it opens normally with no error state

### 4. Confirm nothing regressed for an admin

1. Log out, log back in with the admin credentials
2. Reload and clear the Network tab, then walk the same six pages
3. Screenshot the Network tab: all three requests are present and return 200
4. Open the account menu and screenshot the version badge, it links to the release notes
5. Screenshot the plugin switcher at the top of the left nav, it still lists the gateway and any configured plugins
6. If the deployment runs a license with an expiry inside the warning window, the license banner still renders at the top of the page

### Cleanup

```bash
curl -sS -X POST http://localhost:4000/user/delete -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"user_ids":["gate-demo"]}'
```

## Type

🐛 Bug Fix

## Changes

`src/utils/capabilities.ts` gains `viewProxyDiagnostics`, `viewLicenseInfo` and `viewPlugins`, all mapped to the proxy-admin roles. `org_admin` is deliberately excluded because the proxy returns 401 to it on all three routes, so granting the capability would just move the 401 rather than remove it.

`useHealthReadinessDetails` and `useLicenseInfo` now take the role next to the token and fold `hasCapability` into `enabled`, so the fetch gate and the render gate read the same capability. Callers pass the role explicitly instead of reaching for `useCan`, because `useCan` composes `useAuthorized`, whose effect clears cookies and redirects to login. The navbar renders in the unauthenticated public model hub shell, where that redirect would be wrong, so the role arrives as a prop and a missing role keeps the query disabled rather than turning it into an error.

`PluginModeProvider` mounts above the auth context, so it takes `accessToken` and `userRole` as props from the dashboard layout and uses `hasCapability` directly. A role without the capability now settles into the same state as an empty plugin list instead of firing a request whose failure was swallowed by an empty `catch`.

On the version badge: gating `/health/readiness/details` does not take the badge away from anyone who can see it today. The route already 401s for exactly the roles being gated, so the badge and the debug-mode banner are already blank for them, and this change only stops the request that was failing. Exposing the version to non-admins would need a backend change to serve a non-admin-safe subset, which is a larger call than this fix, so it is left alone rather than folded in here.

Tests cover each gate at the level where it is enforced. The two hook specs render the real hooks against a real query client with `fetch` stubbed, and assert both that an admin role issues exactly one request to the right URL and that each non-admin role issues none. They also pin the two behaviours that are easy to break, that a disabled query reports absent data rather than an error, and that a null token with a null role stays inert. The provider spec asserts that a non-admin never calls `/api/plugins` and still falls back to the gateway mode, and that a not-yet-resolved role holds the stored mode so an admin does not flash. The capability map spec covers all four admin spellings and every non-admin role by name. Each of these fails if its gate is removed.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
