### PR TITLE
feat(model_registry): add DeepInfra google/gemma-4-31B-it-turbo and google/gemma-4-31B-it-Ultra

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -15046,6 +15046,32 @@
         "supports_tool_choice": true,
         "supports_function_calling": true
     },
+    "deepinfra/google/gemma-4-31B-it-turbo": {
+        "max_tokens": 262144,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "input_cost_per_token": 9e-08,
+        "output_cost_per_token": 3.4e-07,
+        "cache_read_input_token_cost": 5e-08,
+        "litellm_provider": "deepinfra",
+        "mode": "chat",
+        "supports_vision": true,
+        "supports_tool_choice": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true
+    },
+    "deepinfra/google/gemma-4-31B-it-Ultra": {
+        "max_tokens": 131072,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 2.7e-07,
+        "output_cost_per_token": 7.6e-07,
+        "litellm_provider": "deepinfra",
+        "mode": "chat",
+        "supports_vision": true,
+        "supports_tool_choice": true,
+        "supports_function_calling": true
+    },
     "deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct": {
         "max_tokens": 131072,
         "max_input_tokens": 131072,


### PR DESCRIPTION
## TLDR

**Gap:** Add two missing Google Gemma 4 models on DeepInfra to litellm pricing registry

**Wedge type:** `model_registry_staleness`

**Source:** https://api.deepinfra.com/v1/openai/models

## Changes

- `model_prices_and_context_window.json`

**Diff size:** 26 lines across 1 file

## What models are added

| Model | Context | Input | Output | Cache | Vision | Prompt Cache |
|-------|---------|-------|--------|-------|--------|--------------|
| `deepinfra/google/gemma-4-31B-it-turbo` | 262K | $0.09/M | $0.34/M | $0.05/M | ✅ | ✅ |
| `deepinfra/google/gemma-4-31B-it-Ultra` | 131K | $0.27/M | $0.76/M | — | ✅ | — |

Both models are listed in the DeepInfra API (`GET https://api.deepinfra.com/v1/openai/models`) but were missing from `model_prices_and_context_window.json`, causing `litellm.completion("deepinfra/google/gemma-4-31B-it-turbo", ...)` to fail with a model not found error.

## Pre-submission checklist

- [x] Minimal change — touches 1 file
- [x] JSON validated (2990 keys, all intact)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Pricing sourced directly from DeepInfra public API

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>
