### PR TITLE
test(conftest): roll back runtime model cost registrations between tests

### DIFF
--- a/tests/test_litellm/conftest.py
+++ b/tests/test_litellm/conftest.py
@@ -19,6 +19,7 @@ sys.path.insert(
 import asyncio
 
 import litellm
+from litellm import utils as litellm_utils
 from litellm._logging import ALL_LOGGERS
 from litellm.litellm_core_utils.prompt_templates import (
     image_handling as image_handling_module,
@@ -257,6 +258,9 @@ def isolate_litellm_state():
     had_module_level_aclient = "module_level_aclient" in litellm.__dict__
     original_module_level_client = litellm.__dict__.get("module_level_client")
     original_module_level_aclient = litellm.__dict__.get("module_level_aclient")
+    original_runtime_registered_model_cost = dict(
+        litellm_utils._runtime_registered_model_cost
+    )
 
     # Flush cache before test (critical for respx mocks)
     if hasattr(litellm, "in_memory_llm_clients_cache"):
@@ -316,6 +320,10 @@ def isolate_litellm_state():
         logger.filters = list(original_logger_state["filters"])
 
     tool_registry_writer_module._tool_policy_registry = original_tool_policy_registry
+    litellm_utils._runtime_registered_model_cost.clear()
+    litellm_utils._runtime_registered_model_cost.update(
+        original_runtime_registered_model_cost
+    )
     if current_module_level_client is not original_module_level_client:
         _close_handler_if_needed(current_module_level_client)
     if current_module_level_aclient is not original_module_level_aclient:

--- a/tests/test_litellm/test_router_model_cost_isolation.py
+++ b/tests/test_litellm/test_router_model_cost_isolation.py
@@ -1471,3 +1471,22 @@ def test_replay_live_router_model_cost_rebuilds_every_live_router():
     finally:
         litellm.model_cost = saved_model_cost
         _invalidate_model_cost_lowercase_map()
+
+
+def test_runtime_model_cost_ledger_a_records_registration_during_test():
+    from litellm import utils as litellm_utils
+
+    original_entry = litellm.model_cost.get("ledger-isolation-model")
+    try:
+        litellm.register_model(
+            {"ledger-isolation-model": {"input_cost_per_token": 0.001, "litellm_provider": "openai"}}
+        )
+        assert "ledger-isolation-model" in litellm_utils._runtime_registered_model_cost
+    finally:
+        _restore_model_cost_entries({"ledger-isolation-model": original_entry})
+
+
+def test_runtime_model_cost_ledger_b_sees_the_ledger_rolled_back():
+    from litellm import utils as litellm_utils
+
+    assert "ledger-isolation-model" not in litellm_utils._runtime_registered_model_cost


### PR DESCRIPTION
## TLDR

Problem this solves:

- The required proxy-infra CI check fails intermittently on the price data reload test, on PRs that touch nothing related
- Commit 347798b80e (#35491) added a process-global ledger that records every `register_model` call and replays it over any newly adopted cost map, so any earlier test on the same xdist worker that registered `gpt-3.5-turbo` balloons the reload test's sparse mock entry into a ~106-key ModelInfo dict and breaks its exact-equality assert; whether it fails depends only on which tests loadscope happens to co-schedule onto that worker

How it solves it:

- The per-test isolation fixture now snapshots the ledger before each test and restores it afterwards, so registrations made inside one test can never leak into another

## User Flow

Before, the flow breaks at step 3, where a required check fails on code the PR never touched:

1. Push a branch and open a PR against `litellm_internal_staging` at `https://github.com/BerriAI/litellm/pulls`, touching anything at all
2. Wait for the required checks on the PR's checks tab
3. "Unit Tests: Proxy Infrastructure" comes back red after about 13 minutes, showing one failed test about model pricing whose expected sparse dict got padded out with ~100 extra null fields
4. Click re-run on the failed job and it sometimes turns green, because the failure depends on which other tests happened to share the worker, so contributors burn a CI cycle per red roll

After, the same walk succeeds with no rerun:

1. Push a branch and open a PR against `litellm_internal_staging` at `https://github.com/BerriAI/litellm/pulls`, touching anything at all
2. Wait for the required checks on the PR's checks tab
3. "Unit Tests: Proxy Infrastructure" comes back green regardless of how tests were distributed across workers

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR changes only test infrastructure, so the proof is the CI flake reproduced deterministically instead of a live proxy run. The flake needs a polluting test that sorts before the target on the same worker, which this simulates with a throwaway test file mimicking what many router and spend tests do

```bash
cat > tests/test_litellm/test_aaa_ledger_polluter.py <<'EOF'
import litellm


def test_aaa_registers_gpt35_like_many_router_tests_do():
    litellm.register_model({"gpt-3.5-turbo": {"input_cost_per_token": 0.002, "litellm_provider": "openai"}})
EOF
PYTEST_XDIST_WORKER=gw0 python -m pytest tests/test_litellm/test_aaa_ledger_polluter.py \
  "tests/test_litellm/proxy/test_proxy_server.py::TestPriceDataReloadIntegration::test_distributed_reload_check_function" -q
```

Before this PR's conftest change, that pairing fails every time, reproducing the CI failure exactly

```
FAILED tests/test_litellm/proxy/test_proxy_server.py::TestPriceDataReloadIntegration::test_distributed_reload_check_function
1 failed, 1 passed, 1 warning in 1.80s
```

At this PR's head 6560d3ce69, the same pairing passes

```
2 passed, 1 warning in 1.56s
```

The new regression pair shows the same before and after: on the unfixed fixture the second test finds the first test's registration still in the ledger

```
FAILED tests/test_litellm/test_router_model_cost_isolation.py::test_runtime_model_cost_ledger_b_sees_the_ledger_rolled_back
1 failed, 1 passed, 36 deselected in 0.21s
```

and with the fix

```
2 passed, 36 deselected in 0.09s
```

The full isolation file plus the reload test class stay green (55 passed), as do the ledger replay tests in test_utils.py

## Type

✅ Test

## Changes

`tests/test_litellm/conftest.py`'s autouse `isolate_litellm_state` fixture now snapshots `litellm.utils._runtime_registered_model_cost` before each test and clears/restores it afterwards. That ledger was added by #35491 as intended production behavior (price data reloads must not erase runtime registrations), but in the test suite it is process-global state shared by every test on an xdist worker, and the suite's own price reload test asserts exact equality against a sparse mock map that the replay then pads out. The rollback happens in the same fixture that already restores callbacks, routing globals, and logger state, so each test's registrations die with it. The two sibling tests from #35491 that already patched the ledger locally keep working unchanged; their monkeypatch is undone before the fixture teardown runs

`tests/test_litellm/test_router_model_cost_isolation.py` gains a two-test regression pair: the first registers a uniquely named model and asserts it landed in the ledger, the second (named to sort after it) asserts the ledger no longer contains it. Without the fixture rollback the second test fails, which is exactly the leak that made the proxy-infra check flaky

## QA runbook

1. Check out the parent commit of this PR's head
2. Run the polluter pairing from the proof section: the reload test fails
3. Check out this PR's head and rerun: both pass, and the polluter file can be deleted

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
