### PR TITLE
fix(proxy): declare drop_params on GenericLiteLLMParams

### DIFF
--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -230,6 +230,8 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     ## LOGGING PARAMS ##
     litellm_trace_id: str | None = None
 
+    drop_params: bool | None = None
+
     max_file_size_mb: float | None = None
 
     # Proxy-wide default rate limits applied to any API key using this deployment

--- a/tests/test_litellm/test_drop_params_on_generic_params.py
+++ b/tests/test_litellm/test_drop_params_on_generic_params.py
@@ -1,0 +1,18 @@
+"""Regression: drop_params must be a declared GenericLiteLLMParams field."""
+
+from litellm.types.router import GenericLiteLLMParams
+
+
+def test_generic_litellm_params_declares_drop_params() -> None:
+    assert "drop_params" in GenericLiteLLMParams.model_fields
+    params = GenericLiteLLMParams(drop_params=True)
+    assert params.drop_params is True
+    dumped = params.model_dump(exclude_none=True)
+    assert dumped.get("drop_params") is True
+
+
+def test_partial_generic_params_default_drop_params_to_none() -> None:
+    patch = GenericLiteLLMParams(api_base="https://example.com")
+    dumped = patch.model_dump()
+    assert "drop_params" in dumped
+    assert dumped["drop_params"] is None

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -26784,6 +26784,8 @@ export interface components {
             default_api_key_rpm_limit?: number | null;
             /** Default Api Key Tpm Limit */
             default_api_key_tpm_limit?: number | null;
+            /** Drop Params */
+            drop_params?: boolean | null;
             /** Gcs Bucket Name */
             gcs_bucket_name?: string | null;
             /** Input Cost Per Audio Per Second */
@@ -35388,6 +35390,8 @@ export interface components {
             default_api_key_rpm_limit?: number | null;
             /** Default Api Key Tpm Limit */
             default_api_key_tpm_limit?: number | null;
+            /** Drop Params */
+            drop_params?: boolean | null;
             /** Gcs Bucket Name */
             gcs_bucket_name?: string | null;
             /** Input Cost Per Audio Per Second */


### PR DESCRIPTION
## Summary
`/model/update` merges `litellm_params` by iterating declared fields on `GenericLiteLLMParams`. `drop_params` was only on `LiteLLMParamsTypedDict`, so a PATCH that omitted it silently removed the stored value.

## Changes
- Declare `drop_params` on `GenericLiteLLMParams`
- Add a small regression test

Fixes #35842

## Test plan
- [x] `pytest tests/test_litellm/test_drop_params_on_generic_params.py`
