### PR TITLE
chore: ignore the mechanical lint and typing sweeps in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -17,3 +17,24 @@
 
 # style: unify ruff format width on 120 (#31518)
 48b5a5a0cc5a694a11219416ee0b6eb6e620e74e
+
+# refactor(imports): move collections.abc names out of typing (#35495)
+397e8e4918777e4e60a7f5e88699e0a9a7dabb3d
+
+# refactor(lint): apply every safe ruff autofix and zero 28 strict-rule budgets (#35495)
+b604e2b20c6db2099085a2f0e59b7e99e87eed6f
+
+# refactor(logging): drop redundant !s conversion flags from f-strings (#35546)
+7b2d3440cba3160277470f7a0180098ae9b87864
+
+# perf: build log messages lazily so filtered-out log records cost nothing (#35703)
+c9887a1f94bc1e7e4bdfe64d640f0509a0bc19dd
+
+# feat(lint): enforce Final on locals and freeze function parameters (#35807)
+2708620d6a599cc73c1950a942d26ac26a7ed3d4
+
+# chore(lint): remove litellm/types from the ruff lint exclusion (#35926)
+4e32a8bf6a1e1af1e04b67c759841ccef44b2235
+
+# chore(lint): strip inert type: ignore comments and zero LIT009/LIT010/LIT011 headroom (#35928)
+338e411103ad5d7003e97f34f04fa36bca542dbe


### PR DESCRIPTION
## TLDR

Problem this solves:

- Recent lint sweeps rewrote ~162k lines mechanically
- `git blame` now points at those sweeps, not real authors
- GitHub Blame is misleading on most of `litellm/`

How it solves it:

- Add the seven sweep commits to `.git-blame-ignore-revs`
- GitHub Blame picks the file up automatically, no config needed

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

There is no code here to test, so the tests box stays unchecked rather than get a checkmark it did not earn. What the file claims is checkable though, and the proof section below verifies it: every listed SHA resolves, and blame attribution actually moves off the sweep and back onto the commit that wrote the logic

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured on this branch at `2c91166d3`, with the parent `b66d4e696` standing in for the before state (the ignore file is what changes, so before is simply blame with the entries absent)

The end user here is anyone opening GitHub Blame or running `git blame` locally, so the proof is that command, before and after

Before, `litellm/router.py:273` is credited to the LIT010 `: Final` sweep even though the line's logic predates it:

```
$ git blame -L 271,275 --date=short litellm/router.py
9f4e3c6009 (Tin Chi Lo  2026-07-27 271)     if model_info is None:
9f4e3c6009 (Tin Chi Lo  2026-07-27 272)         return True
2708620d6a (mateo-berri 2026-08-04 273)     supported_environments: Final = model_info.get("supported_environments")
9f4e3c6009 (Tin Chi Lo  2026-07-27 274)     if supported_environments is None:
9f4e3c6009 (Tin Chi Lo  2026-07-27 275)         return True
```

After wiring the file in, the line goes back to the commit that wrote it:

```
$ git config blame.ignoreRevsFile .git-blame-ignore-revs

$ git blame -L 271,275 --date=short litellm/router.py
9f4e3c6009 (Tin Chi Lo 2026-07-27 271)     if model_info is None:
9f4e3c6009 (Tin Chi Lo 2026-07-27 272)         return True
9f4e3c6009 (Tin Chi Lo 2026-07-27 273)     supported_environments: Final = model_info.get("supported_environments")
9f4e3c6009 (Tin Chi Lo 2026-07-27 274)     if supported_environments is None:
9f4e3c6009 (Tin Chi Lo 2026-07-27 275)         return True
```

Same story for the lazy log message sweep in `litellm/_redis.py`, before:

```
$ git blame -L 806,811 --date=short litellm/_redis.py
^f717e3b2f (Krrish Dholakia 2026-07-11 806)         # Fallback to simple logging if rich is not available
^f717e3b2f (Krrish Dholakia 2026-07-11 807)         masker = SensitiveDataMasker()
^f717e3b2f (Krrish Dholakia 2026-07-11 808)         masked_redis_kwargs = masker.mask_dict(redis_kwargs)
c9887a1f94 (Classic298      2026-08-04 809)         verbose_logger.info("Redis configuration: %s", masked_redis_kwargs)
^f717e3b2f (Krrish Dholakia 2026-07-11 810)     except Exception as e:
c9887a1f94 (Classic298      2026-08-04 811)         verbose_logger.error("Error pretty printing Redis configuration: %s", e)
```

and after:

```
$ git blame -L 806,811 --date=short litellm/_redis.py
^f717e3b2f (Krrish Dholakia 2026-07-11 806)         # Fallback to simple logging if rich is not available
^f717e3b2f (Krrish Dholakia 2026-07-11 807)         masker = SensitiveDataMasker()
^f717e3b2f (Krrish Dholakia 2026-07-11 808)         masked_redis_kwargs = masker.mask_dict(redis_kwargs)
^f717e3b2f (Krrish Dholakia 2026-07-11 809)         verbose_logger.info("Redis configuration: %s", masked_redis_kwargs)
^f717e3b2f (Krrish Dholakia 2026-07-11 810)     except Exception as e:
^f717e3b2f (Krrish Dholakia 2026-07-11 811)         verbose_logger.error("Error pretty printing Redis configuration: %s", e)
```

Every new SHA also resolves to a real commit that is an ancestor of `litellm_internal_staging`, so blame will not choke on a bad entry:

```
$ while read -r sha; do case "$sha" in ''|\#*) continue;; esac; \
    git merge-base --is-ancestor "$sha" origin/litellm_internal_staging \
      && printf "ok  %.8s  %s\n" "$sha" "$(git log -1 --format=%s "$sha")"; \
  done < .git-blame-ignore-revs
ok  48b5a5a0  style: unify ruff format width on 120 (#31518)
ok  397e8e49  refactor(imports): move collections.abc names out of typing and ratchet the lint budgets
ok  b604e2b2  refactor(lint): apply every safe ruff autofix and zero 28 strict-rule budgets
ok  7b2d3440  refactor(logging): drop redundant !s conversion flags from f-strings
ok  c9887a1f  perf: build log messages lazily so filtered-out log records cost nothing (#35703)
ok  2708620d  feat(lint): enforce Final on locals and freeze function parameters (LIT010, LIT011)
ok  4e32a8bf  chore(lint): remove litellm/types from the ruff lint exclusion
ok  338e4111  chore(lint): strip inert type: ignore comments and zero LIT009, LIT010, LIT011 headroom
```

(the three pre-existing entries older than this shallow clone's history are skipped by the loop, not failures)

## Type

🚄 Infrastructure

## Changes

Seven commits landed since the last entry (`#31518`) that rewrote a large fraction of the tree without changing what it does. Together they touch roughly 4,700 files and 162k lines, which is enough to make blame on `litellm/` mostly useless: annotations, imports, f-strings, and log call shapes all moved, so the sweep author sits on top of lines they never wrote

| commit | what it did | files | lines |
| --- | --- | ---: | ---: |
| `397e8e49` | move `collections.abc` names out of `typing` (#35495) | 322 | 1.5k |
| `b604e2b2` | apply every safe ruff autofix, zero 28 strict-rule budgets (#35495) | 1,457 | 62k |
| `7b2d3440` | drop redundant `!s` conversion flags from f-strings (#35546) | 262 | 2.1k |
| `c9887a1f` | build log messages lazily (#35703) | 419 | 7.1k |
| `2708620d` | enforce `Final` on locals, freeze function parameters (#35807) | 1,587 | 74k |
| `4e32a8bf` | remove `litellm/types` from the ruff lint exclusion (#35926) | 184 | 9.7k |
| `338e4111` | strip inert `type: ignore` comments, zero LIT009/010/011 headroom (#35928) | 443 | 5.2k |

`c9887a1f` is the one entry not from the lint budget series, and it earns its place the same way: a `perf:` change applied uniformly across 419 files, rewriting f-string log calls into `%`-args without touching a line of logic

Left out on purpose are the smaller budget-ratchet commits (`075babd0`, `cdfefd7f`, `6c76f5f9` and friends), each a few hundred lines at most; the `chore(typing)` commits that replaced `Any` with TypedDicts and Protocols, since those are design decisions worth blaming; the recurring Next.js build artifact commits, because blame on generated output means nothing either way; and `72bcb748`, which is a pure deletion and so leaves no surviving lines to misattribute. Listing that long tail would grow the file faster than it buys back accuracy

Ordering and comment style follow what was already in the file: chronological, one blank-line-separated block per entry, commit subject and PR number above the full 40-character SHA

## QA runbook

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR