### PR TITLE
fix(anthropic): order messages after system/tools in request body

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1935,11 +1935,6 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 output_key="top_k",
             )
 
-        # ``messages`` must be the last key in the serialized request body: Anthropic's
-        # prompt cache (observed on the Vertex AI global endpoint) keys off the raw
-        # request bytes, and a stable ``system``/``tools`` prefix only hits the cache
-        # on repeat turns when ``messages`` (the part that changes every turn) is
-        # ordered after them, not before.
         data: Final = {
             "model": model,
             **optional_params,

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1935,10 +1935,15 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 output_key="top_k",
             )
 
+        # ``messages`` must be the last key in the serialized request body: Anthropic's
+        # prompt cache (observed on the Vertex AI global endpoint) keys off the raw
+        # request bytes, and a stable ``system``/``tools`` prefix only hits the cache
+        # on repeat turns when ``messages`` (the part that changes every turn) is
+        # ordered after them, not before.
         data: Final = {
             "model": model,
-            "messages": anthropic_messages,
             **optional_params,
+            "messages": anthropic_messages,
         }
 
         self._apply_output_config(data=data, model=model, optional_params=optional_params)

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -916,6 +916,35 @@ def test_anthropic_chat_transform_request_includes_context_management():
     assert result["context_management"] == _sample_context_management_payload()
 
 
+def test_anthropic_chat_transform_request_orders_messages_last():
+    config = AnthropicConfig()
+    result = config.transform_request(
+        model="claude-sonnet-4-20250514",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ],
+        optional_params={
+            "tools": [
+                {
+                    "name": "get_weather",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ],
+            "max_tokens": 256,
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    keys = list(result.keys())
+    assert "system" in keys
+    assert "tools" in keys
+    assert keys.index("messages") > keys.index("system")
+    assert keys.index("messages") > keys.index("tools")
+    assert keys[-1] == "messages"
+
+
 def test_anthropic_structured_output_beta_header():
     from litellm.types.utils import CallTypes
     from litellm.utils import return_raw_request


### PR DESCRIPTION
## TLDR

Problem this solves:

- AnthropicConfig.transform_request built the request dict as {model, messages, **optional_params}, so system and tools (added via optional_params) landed after messages in the serialized JSON body
- On the Vertex AI global endpoint, Anthropic's prompt cache keys off the raw request bytes, so a stable system/tools prefix only hits the cache on repeat turns when messages, the part that changes every turn, is ordered last. With messages first, every turn after the first missed the cache and re-wrote the full prefix

How it solves it:

- Reorders the dict construction to {model, **optional_params, messages}, so messages is always the last key regardless of what optional_params contains
- Adds a regression test asserting messages sorts after both system and tools in the returned request dict

## Relevant issues

Fixes #35908

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Added test_anthropic_chat_transform_request_orders_messages_last to tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py. Confirmed it reproduces the exact reported symptom on the pre-fix code (messages at index 1, ahead of tools and system) and passes after the fix. Full test_anthropic_chat_transformation.py suite (311 tests) passes locally.

I did not run this against a live Vertex AI endpoint, since that requires real credentials and would incur real API cost. Happy to have a maintainer confirm against a live cache-hit scenario, or I can do it if given a test project to point at.

## Type

Bug Fix

## Changes

litellm/llms/anthropic/chat/transformation.py: swap key order in the transform_request request dict so messages is always last
tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py: new regression test

## QA runbook

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use cases are not possible after this PR