### PR TITLE
fix(anthropic): use native structured output for Sonnet 5

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -11680,6 +11680,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_native_structured_output": true,
         "supports_sampling_params": false,
         "supports_tool_choice": true,
         "supports_vision": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11680,6 +11680,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_native_structured_output": true,
         "supports_sampling_params": false,
         "supports_tool_choice": true,
         "supports_vision": true,

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1042,6 +1042,31 @@ def test_native_structured_output_uses_bundled_capability_when_remote_map_lags(
     assert "tools" not in optional_params
 
 
+def test_claude_sonnet_5_uses_native_structured_output() -> None:
+    optional_params = AnthropicConfig().map_openai_params(
+        non_default_params={
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "answer",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"answer": {"type": "string"}},
+                        "required": ["answer"],
+                    },
+                },
+            }
+        },
+        optional_params={},
+        model="claude-sonnet-5",
+        drop_params=False,
+    )
+
+    assert "output_format" in optional_params
+    assert "tools" not in optional_params
+    assert "tool_choice" not in optional_params
+
+
 def test_non_structured_output_model_uses_tool_workaround():
     """
     Test that models NOT in the native structured output list still use the


### PR DESCRIPTION
## TLDR

Problem this solves:

- Sonnet 5 structured responses can leak tool envelopes

How it solves it:

- Route Sonnet 5 through Anthropic native output_format

## Relevant issues

Fixes #35677

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Not available in this environment because Anthropic credentials are not configured

## Type

Bug Fix

## Changes

Adds `supports_native_structured_output` to the direct Anthropic `claude-sonnet-5` entry in both model maps and adds a regression test covering Responses structured output routing

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR