### PR TITLE
fix(pricing): correct xai/grok-4.5 cached input price to $0.30/1M

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -40070,8 +40070,8 @@
         "supports_web_search": true
     },
     "xai/grok-4.5": {
-        "cache_read_input_token_cost": 5e-07,
-        "cache_read_input_token_cost_above_200k_tokens": 1e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_above_200k_tokens": 4e-06,
         "litellm_provider": "xai",
@@ -40081,7 +40081,7 @@
         "mode": "chat",
         "output_cost_per_token": 6e-06,
         "output_cost_per_token_above_200k_tokens": 1.2e-05,
-        "source": "https://docs.x.ai/docs/models",
+        "source": "https://docs.x.ai/developers/pricing",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
@@ -40091,8 +40091,8 @@
         "supports_web_search": true
     },
     "xai/grok-4.5-latest": {
-        "cache_read_input_token_cost": 5e-07,
-        "cache_read_input_token_cost_above_200k_tokens": 1e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_above_200k_tokens": 4e-06,
         "litellm_provider": "xai",
@@ -40102,7 +40102,7 @@
         "mode": "chat",
         "output_cost_per_token": 6e-06,
         "output_cost_per_token_above_200k_tokens": 1.2e-05,
-        "source": "https://docs.x.ai/docs/models",
+        "source": "https://docs.x.ai/developers/pricing",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -40161,8 +40161,8 @@
         "supports_web_search": true
     },
     "xai/grok-4.5": {
-        "cache_read_input_token_cost": 5e-07,
-        "cache_read_input_token_cost_above_200k_tokens": 1e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_above_200k_tokens": 4e-06,
         "litellm_provider": "xai",
@@ -40172,7 +40172,7 @@
         "mode": "chat",
         "output_cost_per_token": 6e-06,
         "output_cost_per_token_above_200k_tokens": 1.2e-05,
-        "source": "https://docs.x.ai/docs/models",
+        "source": "https://docs.x.ai/developers/pricing",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
@@ -40182,8 +40182,8 @@
         "supports_web_search": true
     },
     "xai/grok-4.5-latest": {
-        "cache_read_input_token_cost": 5e-07,
-        "cache_read_input_token_cost_above_200k_tokens": 1e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_above_200k_tokens": 4e-06,
         "litellm_provider": "xai",
@@ -40193,7 +40193,7 @@
         "mode": "chat",
         "output_cost_per_token": 6e-06,
         "output_cost_per_token_above_200k_tokens": 1.2e-05,
-        "source": "https://docs.x.ai/docs/models",
+        "source": "https://docs.x.ai/developers/pricing",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,

--- a/tests/test_litellm/llms/xai/test_xai_cost_calculator.py
+++ b/tests/test_litellm/llms/xai/test_xai_cost_calculator.py
@@ -471,3 +471,24 @@ class TestXAICostCalculator:
 
         assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-10)
         assert math.isclose(completion_cost, expected_completion_cost, rel_tol=1e-10)
+    def test_grok_4_5_cached_input_matches_published_pricing(self):
+        """Cached input rates for grok-4.5, per xAI's published pricing table.
+
+        https://docs.x.ai/developers/pricing lists grok-4.5 as
+        $2.00 input / $0.30 cached / $6.00 output for short context, and
+        $4.00 / $0.60 / $12.00 once a prompt reaches the 200k long-context
+        threshold. The cached figures had been recorded as $0.50 and $1.00,
+        which are 0.25x the input rate rather than the published numbers -- the
+        cited source at the time was the models page, which carries no cached
+        column at all.
+        """
+        for model in ("xai/grok-4.5", "xai/grok-4.5-latest"):
+            info = litellm.model_cost[model]
+            assert info["cache_read_input_token_cost"] == 3e-07
+            assert info["cache_read_input_token_cost_above_200k_tokens"] == 6e-07
+            # Uncached rates were already correct; asserted here so a future
+            # edit cannot fix one column by breaking another.
+            assert info["input_cost_per_token"] == 2e-06
+            assert info["output_cost_per_token"] == 6e-06
+            assert info["input_cost_per_token_above_200k_tokens"] == 4e-06
+            assert info["output_cost_per_token_above_200k_tokens"] == 1.2e-05


### PR DESCRIPTION
## Problem

`xai/grok-4.5` and `xai/grok-4.5-latest` overcharge cached tokens by 67%.

xAI's [pricing table](https://docs.x.ai/developers/pricing) lists, per 1M tokens:

| Model | Context | Short: Input / Cached / Output | Long (≥200k): Input / Cached / Output |
|---|---|---|---|
| grok-4.5 | 500k | $2.00 / **$0.30** / $6.00 | $4.00 / **$0.60** / $12.00 |
| grok-4.3 | 1M | $1.25 / $0.20 / $2.50 | $2.50 / $0.40 / $5.00 |

The map had `cache_read_input_token_cost: 5e-07` ($0.50) and `cache_read_input_token_cost_above_200k_tokens: 1e-06` ($1.00) — both exactly 0.25× the input rate, rather than the published figures.

## Why I'm confident this is a transcription error and not my misreading the columns

- **`grok-4.3` in the adjacent row is already correct** here (`2e-07` / `4e-07` = $0.20 / $0.40), and it comes from the same table with the same column layout. Same columns, right answer — so the layout reading is confirmed by the file itself.
- **Every uncached field on grok-4.5 already matches** the vendor exactly: `2e-06` / `6e-06` short, `4e-06` / `1.2e-05` long. Only the two cached fields diverge.
- **The cited source explains the cause.** Both entries carried `"source": "https://docs.x.ai/docs/models"`, which lists context windows and capabilities and has **no cached-price column at all**. The cached values appear to have been inferred as 0.25× input rather than read. This PR repoints `source` at `/developers/pricing`, where the figures actually live.

## Changes

Four values across two model keys, applied to both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`:

```
xai/grok-4.5, xai/grok-4.5-latest
  cache_read_input_token_cost:                     5e-07 -> 3e-07
  cache_read_input_token_cost_above_200k_tokens:   1e-06 -> 6e-07
  source: .../docs/models -> .../developers/pricing
```

Uncached rates are untouched.

## Test

Adds `test_grok_4_5_cached_input_matches_published_pricing` to the existing `tests/test_litellm/llms/xai/test_xai_cost_calculator.py`. It pins both cached bands to the published figures, and also asserts the four uncached rates so a later edit cannot correct one column by breaking another. The assertion fails against the previous values.

## Scope

Deliberately one problem. I also noticed `deepseek-v4-*` carries `max_output_tokens: 8192` against DeepSeek's published 384K — but #31018, #32107 and #32417 already propose that fix, so it is not bundled here.