### PR TITLE
feat(terraform): add litellm_jwt_key_mapping resource

### DIFF
--- a/terraform/provider/CHANGELOG.md
+++ b/terraform/provider/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **jwt_key_mapping**: New `litellm_jwt_key_mapping` resource for the proxy's JWT to virtual key mappings, so JWT clients identified by a claim (`client_id`, `azp`, `sub`) map to virtual keys and inherit their models, budgets and rate limits. Supports `description` and `is_active`, rotating the mapped key in place, and forces replacement when the claim name or value changes
+
 ## [0.4.0] - 2026-08-06
 
 ### Fixed

--- a/terraform/provider/README.md
+++ b/terraform/provider/README.md
@@ -139,6 +139,7 @@ For full details on the <code>litellm_key</code> resource, see the [key resource
 - <code>litellm_mcp_server</code>: Manage MCP (Model Context Protocol) servers. [Documentation](docs/resources/mcp_server.md)
 - <code>litellm_credential</code>: Manage credentials for secure authentication. [Documentation](docs/resources/credential.md)
 - <code>litellm_vector_store</code>: Manage vector stores for embeddings and RAG. [Documentation](docs/resources/vector_store.md)
+- <code>litellm_jwt_key_mapping</code>: Map JWT claim values to virtual keys for per-client budgets and limits. [Documentation](docs/resources/jwt_key_mapping.md)
 
 ### Available Data Sources
 

--- a/terraform/provider/docs/index.md
+++ b/terraform/provider/docs/index.md
@@ -51,6 +51,7 @@ The LiteLLM provider supports the following resources:
 * [`litellm_mcp_server`](./resources/mcp_server) - Manage MCP (Model Context Protocol) servers
 * [`litellm_credential`](./resources/credential) - Manage credentials for various providers
 * [`litellm_vector_store`](./resources/vector_store) - Manage vector stores
+* [`litellm_jwt_key_mapping`](./resources/jwt_key_mapping) - Map JWT claim values to virtual keys
 
 ## Available Data Sources
 

--- a/terraform/provider/docs/resources/jwt_key_mapping.md
+++ b/terraform/provider/docs/resources/jwt_key_mapping.md
@@ -1,0 +1,94 @@
+# litellm_jwt_key_mapping
+
+Maps a JWT claim value to a LiteLLM virtual key. Every JWT client identified by a claim, typically `client_id`, `azp` or `sub`, then gets the model restrictions, budgets, rate limits, guardrails and spend tracking of the virtual key it maps to, without that key ever being handed to the client.
+
+The mappings only take effect once JWT auth is enabled on the proxy, which is configuration rather than API state:
+
+```yaml
+general_settings:
+  enable_jwt_auth: True
+  litellm_jwtauth:
+    virtual_key_claim_field: "client_id"
+    unregistered_jwt_client_behavior: "fallback_team_mapping"
+```
+
+See [JWT to virtual key mapping](https://docs.litellm.ai/docs/proxy/jwt_key_mapping) for the proxy side of the feature
+
+## Example Usage
+
+The mapped virtual key has to exist already and its value has to be known to Terraform, so it comes from a variable or a secret manager rather than from a `litellm_key` resource, whose generated `key` is write-only and therefore null when referenced:
+
+```hcl
+variable "alice_key" {
+  type      = string
+  sensitive = true
+}
+
+resource "litellm_jwt_key_mapping" "alice" {
+  jwt_claim_name  = "client_id"
+  jwt_claim_value = "dev-alice"
+  key             = var.alice_key
+}
+```
+
+Per-client limits live on the virtual key, so one mapping per client is how each JWT client gets its own budget and quota:
+
+```hcl
+resource "litellm_jwt_key_mapping" "billing_service" {
+  jwt_claim_name  = "client_id"
+  jwt_claim_value = "billing-service"
+  key             = var.billing_service_key
+  description     = "Billing service JWT client"
+  is_active       = true
+}
+```
+
+Several clients at once, with the key values coming from a map of secrets:
+
+```hcl
+variable "jwt_client_keys" {
+  type      = map(string)
+  sensitive = true
+}
+
+resource "litellm_jwt_key_mapping" "developer" {
+  for_each = var.jwt_client_keys
+
+  jwt_claim_name  = "client_id"
+  jwt_claim_value = each.key
+  key             = each.value
+  description     = "Developer JWT client ${each.key}"
+}
+```
+
+## Argument Reference
+
+- `jwt_claim_name` - (Required, ForceNew) Name of the JWT claim to match on, for example `client_id`, `azp` or `sub`. Must match `virtual_key_claim_field` in the proxy JWT config
+- `jwt_claim_value` - (Required, ForceNew) Value of the claim identifying the JWT client. Unique together with `jwt_claim_name`, so a second mapping for the same pair fails with a 409
+- `key` - (Required, Sensitive) The virtual key this claim value maps to. It has to exist already, otherwise the proxy rejects the mapping with `The provided key does not match an existing virtual key`
+- `description` - (Optional) Description of the mapping
+- `is_active` - (Optional) Whether the mapping is active. Inactive mappings are ignored during JWT auth. Defaults to `true`
+
+## Attribute Reference
+
+- `id` - The mapping ID assigned by LiteLLM
+- `created_at` - Timestamp when the mapping was created
+- `updated_at` - Timestamp when the mapping was last updated
+- `created_by` - User who created the mapping
+- `updated_by` - User who last updated the mapping
+
+## Notes
+
+The proxy stores only a hash of `key` and never returns it, so drift on that attribute cannot be detected and Terraform tracks the value from your configuration. Changing `key` rotates the mapping onto the new virtual key in place, with no replacement. Like the other secrets this provider accepts, such as `credential_values` and `model_api_key`, the configured value is kept in state, so treat the state as sensitive
+
+Only proxy admins can create, update or delete mappings, so the provider `api_key` has to be a master key or an admin key
+
+## Import
+
+Mappings are imported by their mapping ID:
+
+```shell
+terraform import litellm_jwt_key_mapping.alice 297a5536-1aeb-4cf1-b666-b3809c2750a8
+```
+
+Because the API does not return the mapped key, `key` is empty in state right after an import, so the first plan shows an in-place update that pushes the configured key back to the proxy. That update is harmless, the proxy just rehashes the same value when the key has not actually changed

--- a/terraform/provider/docs/resources/jwt_key_mapping.md
+++ b/terraform/provider/docs/resources/jwt_key_mapping.md
@@ -16,7 +16,7 @@ See [JWT to virtual key mapping](https://docs.litellm.ai/docs/proxy/jwt_key_mapp
 
 ## Example Usage
 
-The mapped virtual key has to exist already and its value has to be known to Terraform, so it comes from a variable or a secret manager rather than from a `litellm_key` resource, whose generated `key` is write-only and therefore null when referenced:
+The mapped virtual key has to exist already and its value has to be known to Terraform, so it comes from a variable or a secret manager rather than from a `litellm_key` resource. `litellm_key` deliberately made its generated `key` write-only, to avoid storing raw API keys in state, so referencing it here does not merely read back null: Terraform's write-only enforcement turns `key = litellm_key.foo.key` into a static `Missing required argument` error at `terraform plan`, before any API call, in every apply ordering, including a first apply where both resources are created together:
 
 ```hcl
 variable "alice_key" {

--- a/terraform/provider/litellm/provider.go
+++ b/terraform/provider/litellm/provider.go
@@ -19,6 +19,7 @@ func Provider() *schema.Provider {
 			"litellm_mcp_server":              resourceLiteLLMMCPServer(),
 			"litellm_credential":              resourceLiteLLMCredential(),
 			"litellm_vector_store":            resourceLiteLLMVectorStore(),
+			"litellm_jwt_key_mapping":         resourceLiteLLMJWTKeyMapping(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"litellm_credential":   dataSourceLiteLLMCredential(),

--- a/terraform/provider/litellm/resource_jwt_key_mapping.go
+++ b/terraform/provider/litellm/resource_jwt_key_mapping.go
@@ -1,0 +1,70 @@
+package litellm
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceLiteLLMJWTKeyMapping() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLiteLLMJWTKeyMappingCreate,
+		Read:   resourceLiteLLMJWTKeyMappingRead,
+		Update: resourceLiteLLMJWTKeyMappingUpdate,
+		Delete: resourceLiteLLMJWTKeyMappingDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"jwt_claim_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the JWT claim to match on, for example client_id, azp or sub. Must match virtual_key_claim_field in the proxy JWT config",
+			},
+			"jwt_claim_value": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Value of the claim identifying the JWT client. Unique together with jwt_claim_name",
+			},
+			"key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "The virtual key this claim value maps to. The proxy stores only a hash of it and never returns it, so drift on this attribute cannot be detected and Terraform tracks the configured value",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Description of the mapping",
+			},
+			"is_active": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether the mapping is active. Inactive mappings are ignored during JWT auth",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Timestamp when the mapping was created",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Timestamp when the mapping was last updated",
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "User who created the mapping",
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "User who last updated the mapping",
+			},
+		},
+	}
+}

--- a/terraform/provider/litellm/resource_jwt_key_mapping_crud.go
+++ b/terraform/provider/litellm/resource_jwt_key_mapping_crud.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -83,7 +82,16 @@ func resourceLiteLLMJWTKeyMappingRead(d *schema.ResourceData, m interface{}) err
 func resourceLiteLLMJWTKeyMappingUpdate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Client)
 
+	oldKey, _ := d.GetChange("key")
+
 	if err := updateJWTKeyMapping(d, client); err != nil {
+		// The update is a single atomic API call: on failure nothing changed
+		// server-side. Revert key explicitly since the proxy never returns it,
+		// so Read can't resync it the way it resyncs description/is_active below.
+		d.Set("key", oldKey)
+		if readErr := resourceLiteLLMJWTKeyMappingRead(d, m); readErr != nil {
+			return fmt.Errorf("failed to update JWT key mapping: %w (and failed to refresh state afterward: %v)", err, readErr)
+		}
 		return fmt.Errorf("failed to update JWT key mapping: %w", err)
 	}
 
@@ -132,7 +140,7 @@ func handleJWTKeyMappingAPIResponse(resp *http.Response, result interface{}, cli
 		return fmt.Errorf("failed to read response body: %v", err)
 	}
 
-	if resp.StatusCode == http.StatusNotFound || isJWTKeyMappingNotFoundBody(bodyBytes) {
+	if resp.StatusCode == http.StatusNotFound {
 		return fmt.Errorf(jwtKeyMappingNotFound)
 	}
 
@@ -150,15 +158,4 @@ func handleJWTKeyMappingAPIResponse(resp *http.Response, result interface{}, cli
 	}
 
 	return nil
-}
-
-func isJWTKeyMappingNotFoundBody(bodyBytes []byte) bool {
-	var errResp struct {
-		Detail interface{} `json:"detail"`
-	}
-	if err := json.Unmarshal(bodyBytes, &errResp); err != nil {
-		return false
-	}
-	detail, ok := errResp.Detail.(string)
-	return ok && strings.Contains(strings.ToLower(detail), "mapping not found")
 }

--- a/terraform/provider/litellm/resource_jwt_key_mapping_crud.go
+++ b/terraform/provider/litellm/resource_jwt_key_mapping_crud.go
@@ -39,9 +39,21 @@ func resourceLiteLLMJWTKeyMappingCreate(d *schema.ResourceData, m interface{}) e
 
 	d.SetId(mapping.ID)
 
+	// The create endpoint has no is_active field and always activates the
+	// mapping, so a JWT client matching this claim can authenticate during
+	// the gap before the deactivation call below runs. If deactivation
+	// itself fails, delete the mapping rather than leaving it active and
+	// unmanaged indefinitely.
 	if !d.Get("is_active").(bool) {
 		if err := updateJWTKeyMapping(d, client); err != nil {
-			return fmt.Errorf("JWT key mapping %s was created but could not be deactivated: %w", mapping.ID, err)
+			if deleteErr := deleteJWTKeyMapping(mapping.ID, client); deleteErr != nil {
+				return fmt.Errorf(
+					"JWT key mapping %s was created active and could not be deactivated (%v); it also could not be deleted and remains active on the proxy, remove it manually via POST /jwt/key/mapping/delete: %v",
+					mapping.ID, err, deleteErr,
+				)
+			}
+			d.SetId("")
+			return fmt.Errorf("JWT key mapping was created active but could not be deactivated, so it was deleted instead: %w", err)
 		}
 	}
 
@@ -83,12 +95,17 @@ func resourceLiteLLMJWTKeyMappingUpdate(d *schema.ResourceData, m interface{}) e
 	client := m.(*Client)
 
 	oldKey, _ := d.GetChange("key")
+	oldDescription, _ := d.GetChange("description")
+	oldIsActive, _ := d.GetChange("is_active")
 
 	if err := updateJWTKeyMapping(d, client); err != nil {
 		// The update is a single atomic API call: on failure nothing changed
-		// server-side. Revert key explicitly since the proxy never returns it,
-		// so Read can't resync it the way it resyncs description/is_active below.
+		// server-side. Revert every field the update could have changed before
+		// attempting to resync, so a failed refresh can't leave the rejected
+		// values persisted into state.
 		d.Set("key", oldKey)
+		d.Set("description", oldDescription)
+		d.Set("is_active", oldIsActive)
 		if readErr := resourceLiteLLMJWTKeyMappingRead(d, m); readErr != nil {
 			return fmt.Errorf("failed to update JWT key mapping: %w (and failed to refresh state afterward: %v)", err, readErr)
 		}
@@ -101,19 +118,27 @@ func resourceLiteLLMJWTKeyMappingUpdate(d *schema.ResourceData, m interface{}) e
 func resourceLiteLLMJWTKeyMappingDelete(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Client)
 
-	resp, err := MakeRequest(client, "POST", "/jwt/key/mapping/delete", JWTKeyMappingDeleteRequest{ID: d.Id()})
-	if err != nil {
+	if err := deleteJWTKeyMapping(d.Id(), client); err != nil {
 		return fmt.Errorf("failed to delete JWT key mapping: %w", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func deleteJWTKeyMapping(id string, client *Client) error {
+	resp, err := MakeRequest(client, "POST", "/jwt/key/mapping/delete", JWTKeyMappingDeleteRequest{ID: id})
+	if err != nil {
+		return err
 	}
 	defer resp.Body.Close()
 
 	if err := handleJWTKeyMappingAPIResponse(resp, nil, client); err != nil {
 		if err.Error() != jwtKeyMappingNotFound {
-			return fmt.Errorf("failed to delete JWT key mapping: %w", err)
+			return err
 		}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/terraform/provider/litellm/resource_jwt_key_mapping_crud.go
+++ b/terraform/provider/litellm/resource_jwt_key_mapping_crud.go
@@ -1,0 +1,164 @@
+package litellm
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const jwtKeyMappingNotFound = "jwt_key_mapping_not_found"
+
+func resourceLiteLLMJWTKeyMappingCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+
+	createRequest := JWTKeyMappingRequest{
+		JWTClaimName:  d.Get("jwt_claim_name").(string),
+		JWTClaimValue: d.Get("jwt_claim_value").(string),
+		Key:           d.Get("key").(string),
+		Description:   d.Get("description").(string),
+	}
+
+	resp, err := MakeRequest(client, "POST", "/jwt/key/mapping/new", createRequest)
+	if err != nil {
+		return fmt.Errorf("failed to create JWT key mapping: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var mapping JWTKeyMappingResponse
+	if err := handleJWTKeyMappingAPIResponse(resp, &mapping, client); err != nil {
+		return fmt.Errorf("failed to create JWT key mapping: %w", err)
+	}
+
+	if mapping.ID == "" {
+		return fmt.Errorf("failed to create JWT key mapping: the proxy returned no mapping id")
+	}
+
+	d.SetId(mapping.ID)
+
+	if !d.Get("is_active").(bool) {
+		if err := updateJWTKeyMapping(d, client); err != nil {
+			return fmt.Errorf("JWT key mapping %s was created but could not be deactivated: %w", mapping.ID, err)
+		}
+	}
+
+	return resourceLiteLLMJWTKeyMappingRead(d, m)
+}
+
+func resourceLiteLLMJWTKeyMappingRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+
+	resp, err := MakeRequest(client, "GET", fmt.Sprintf("/jwt/key/mapping/info?id=%s", url.QueryEscape(d.Id())), nil)
+	if err != nil {
+		return fmt.Errorf("failed to read JWT key mapping: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var mapping JWTKeyMappingResponse
+	if err := handleJWTKeyMappingAPIResponse(resp, &mapping, client); err != nil {
+		if err.Error() == jwtKeyMappingNotFound {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("failed to read JWT key mapping: %w", err)
+	}
+
+	d.SetId(mapping.ID)
+	d.Set("jwt_claim_name", mapping.JWTClaimName)
+	d.Set("jwt_claim_value", mapping.JWTClaimValue)
+	d.Set("description", mapping.Description)
+	d.Set("is_active", mapping.IsActive)
+	d.Set("created_at", mapping.CreatedAt)
+	d.Set("updated_at", mapping.UpdatedAt)
+	d.Set("created_by", mapping.CreatedBy)
+	d.Set("updated_by", mapping.UpdatedBy)
+
+	return nil
+}
+
+func resourceLiteLLMJWTKeyMappingUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+
+	if err := updateJWTKeyMapping(d, client); err != nil {
+		return fmt.Errorf("failed to update JWT key mapping: %w", err)
+	}
+
+	return resourceLiteLLMJWTKeyMappingRead(d, m)
+}
+
+func resourceLiteLLMJWTKeyMappingDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+
+	resp, err := MakeRequest(client, "POST", "/jwt/key/mapping/delete", JWTKeyMappingDeleteRequest{ID: d.Id()})
+	if err != nil {
+		return fmt.Errorf("failed to delete JWT key mapping: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := handleJWTKeyMappingAPIResponse(resp, nil, client); err != nil {
+		if err.Error() != jwtKeyMappingNotFound {
+			return fmt.Errorf("failed to delete JWT key mapping: %w", err)
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func updateJWTKeyMapping(d *schema.ResourceData, client *Client) error {
+	updateRequest := JWTKeyMappingUpdateRequest{
+		ID:          d.Id(),
+		Key:         d.Get("key").(string),
+		Description: d.Get("description").(string),
+		IsActive:    d.Get("is_active").(bool),
+	}
+
+	resp, err := MakeRequest(client, "POST", "/jwt/key/mapping/update", updateRequest)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return handleJWTKeyMappingAPIResponse(resp, nil, client)
+}
+
+func handleJWTKeyMappingAPIResponse(resp *http.Response, result interface{}, client *Client) error {
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound || isJWTKeyMappingNotFoundBody(bodyBytes) {
+		return fmt.Errorf(jwtKeyMappingNotFound)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("API request failed: Status: %s, Response: %s",
+			resp.Status, client.redactSensitiveData(string(bodyBytes)))
+	}
+
+	if result == nil {
+		return nil
+	}
+
+	if err := json.Unmarshal(bodyBytes, result); err != nil {
+		return fmt.Errorf("failed to parse response: %v", err)
+	}
+
+	return nil
+}
+
+func isJWTKeyMappingNotFoundBody(bodyBytes []byte) bool {
+	var errResp struct {
+		Detail interface{} `json:"detail"`
+	}
+	if err := json.Unmarshal(bodyBytes, &errResp); err != nil {
+		return false
+	}
+	detail, ok := errResp.Detail.(string)
+	return ok && strings.Contains(strings.ToLower(detail), "mapping not found")
+}

--- a/terraform/provider/litellm/resource_jwt_key_mapping_crud_test.go
+++ b/terraform/provider/litellm/resource_jwt_key_mapping_crud_test.go
@@ -1,6 +1,7 @@
 package litellm
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,7 +9,30 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+// resourceDataWithChange builds a ResourceData carrying a real diff between
+// prior state and new config, so d.GetChange reflects true old/new values.
+// schema.TestResourceDataRaw diffs against a nil prior state, which collapses
+// GetChange's old side to the zero value and can't exercise this.
+func resourceDataWithChange(t *testing.T, oldAttrs map[string]string, newRaw map[string]interface{}) *schema.ResourceData {
+	t.Helper()
+
+	sm := schema.InternalMap(resourceLiteLLMJWTKeyMapping().Schema)
+	state := &terraform.InstanceState{ID: oldAttrs["id"], Attributes: oldAttrs}
+	config := terraform.NewResourceConfigRaw(newRaw)
+
+	diff, err := sm.Diff(context.Background(), state, config, nil, nil, true)
+	if err != nil {
+		t.Fatalf("diff: %v", err)
+	}
+	d, err := sm.Data(state, diff)
+	if err != nil {
+		t.Fatalf("data: %v", err)
+	}
+	return d
+}
 
 type jwtKeyMappingCall struct {
 	Method string
@@ -259,6 +283,87 @@ func TestJWTKeyMappingUpdateClearsDescriptionAndSendsKey(t *testing.T) {
 	}
 	if d.Get("description").(string) != "" {
 		t.Fatalf("description should be cleared in state, got %q", d.Get("description").(string))
+	}
+}
+
+func TestJWTKeyMappingUpdateRevertsKeyOnFailureAndResyncsRest(t *testing.T) {
+	// Regression test for a live-verified bug: Terraform's classic SDKv2 CRUD
+	// model persists ResourceData's diff-applied (attempted) values to state
+	// even when the callback returns an error, unless the provider reverts
+	// them explicitly. Confirmed live: a rejected key rotation left the new,
+	// never-applied key in `terraform state pull` while the proxy kept the
+	// old one, so the next plan falsely reported convergence.
+	calls := make([]jwtKeyMappingCall, 0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := map[string]interface{}{}
+		if r.Body != nil {
+			_ = json.NewDecoder(r.Body).Decode(&body)
+		}
+		calls = append(calls, jwtKeyMappingCall{Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery, Body: body})
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/jwt/key/mapping/update":
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"detail": "The provided key does not match an existing virtual key.",
+			})
+		case "/jwt/key/mapping/info":
+			// Server truth: unchanged, since the rejected update above never applied.
+			_ = json.NewEncoder(w).Encode(jwtKeyMappingFixture())
+		default:
+			t.Fatalf("unexpected request to %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+
+	d := resourceDataWithChange(t,
+		map[string]string{
+			"id":              "map-abc-123",
+			"jwt_claim_name":  "client_id",
+			"jwt_claim_value": "dev-alice",
+			"key":             "sk-old-key-0000000000",
+			"description":     "dev-alice",
+			"is_active":       "true",
+		},
+		map[string]interface{}{
+			"jwt_claim_name":  "client_id",
+			"jwt_claim_value": "dev-alice",
+			"key":             "sk-rejected-new-key-00",
+			"description":     "attempted new description",
+			"is_active":       false,
+		},
+	)
+	d.SetId("map-abc-123")
+
+	err := resourceLiteLLMJWTKeyMappingUpdate(d, client)
+	if err == nil {
+		t.Fatal("expected the rejected key to fail the update")
+	}
+	if !strings.Contains(err.Error(), "does not match an existing virtual key") {
+		t.Fatalf("expected the proxy's rejection reason in the error, got %v", err)
+	}
+
+	if d.Get("key").(string) != "sk-old-key-0000000000" {
+		t.Fatalf("a failed update must not persist the rejected key into state, got %q", d.Get("key").(string))
+	}
+	if d.Get("description").(string) != "dev-alice" {
+		t.Fatalf("a failed update must resync description from the server, got %q", d.Get("description").(string))
+	}
+	if d.Get("is_active").(bool) != true {
+		t.Fatalf("a failed update must resync is_active from the server, got %v", d.Get("is_active").(bool))
+	}
+
+	readCalls := 0
+	for _, c := range calls {
+		if c.Path == "/jwt/key/mapping/info" {
+			readCalls++
+		}
+	}
+	if readCalls != 1 {
+		t.Fatalf("expected exactly one read to resync state after the failed update, got %d", readCalls)
 	}
 }
 

--- a/terraform/provider/litellm/resource_jwt_key_mapping_crud_test.go
+++ b/terraform/provider/litellm/resource_jwt_key_mapping_crud_test.go
@@ -183,6 +183,161 @@ func TestJWTKeyMappingCreateDeactivatesWhenNotActive(t *testing.T) {
 	}
 }
 
+func TestJWTKeyMappingCreateDeletesMappingWhenDeactivationFails(t *testing.T) {
+	// Regression test: the create endpoint has no is_active field and always
+	// activates the mapping, so a failed deactivation used to leave that
+	// mapping active and unmanaged indefinitely. It must be deleted instead.
+	calls := make([]jwtKeyMappingCall, 0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := map[string]interface{}{}
+		if r.Body != nil {
+			_ = json.NewDecoder(r.Body).Decode(&body)
+		}
+		calls = append(calls, jwtKeyMappingCall{Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery, Body: body})
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/jwt/key/mapping/new":
+			_ = json.NewEncoder(w).Encode(jwtKeyMappingFixture())
+		case "/jwt/key/mapping/update":
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]string{"detail": "proxy unavailable"})
+		case "/jwt/key/mapping/delete":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "success"})
+		default:
+			t.Fatalf("unexpected request to %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMJWTKeyMapping().Schema, map[string]interface{}{
+		"jwt_claim_name":  "client_id",
+		"jwt_claim_value": "dev-alice",
+		"key":             "sk-abc123",
+		"is_active":       false,
+	})
+
+	err := resourceLiteLLMJWTKeyMappingCreate(d, client)
+	if err == nil {
+		t.Fatal("expected the failed deactivation to surface as an error")
+	}
+	if !strings.Contains(err.Error(), "deleted instead") {
+		t.Fatalf("expected the error to explain the mapping was deleted, got %v", err)
+	}
+
+	deleteCalls := 0
+	for _, c := range calls {
+		if c.Path == "/jwt/key/mapping/delete" {
+			deleteCalls++
+			if c.Body["id"] != "map-abc-123" {
+				t.Fatalf("delete must target the mapping that could not be deactivated, got %v", c.Body["id"])
+			}
+		}
+	}
+	if deleteCalls != 1 {
+		t.Fatalf("expected exactly one cleanup delete call, got %d", deleteCalls)
+	}
+
+	if d.Id() != "" {
+		t.Fatalf("a successfully deleted mapping must not remain in state, got id %q", d.Id())
+	}
+}
+
+func TestJWTKeyMappingCreateReportsWhenDeactivationAndDeleteBothFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/jwt/key/mapping/new":
+			_ = json.NewEncoder(w).Encode(jwtKeyMappingFixture())
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]string{"detail": "proxy unavailable"})
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMJWTKeyMapping().Schema, map[string]interface{}{
+		"jwt_claim_name":  "client_id",
+		"jwt_claim_value": "dev-alice",
+		"key":             "sk-abc123",
+		"is_active":       false,
+	})
+
+	err := resourceLiteLLMJWTKeyMappingCreate(d, client)
+	if err == nil {
+		t.Fatal("expected an error when both deactivation and the cleanup delete fail")
+	}
+	if !strings.Contains(err.Error(), "remove it manually") {
+		t.Fatalf("expected the error to demand manual cleanup, got %v", err)
+	}
+
+	// The mapping is still active on the proxy since neither call succeeded, so
+	// the id must stay in state: the next apply taints and retries the delete,
+	// rather than Terraform losing track of a live, active mapping entirely.
+	if d.Id() != "map-abc-123" {
+		t.Fatalf("expected the id to remain in state so a retry can find it, got %q", d.Id())
+	}
+}
+
+func TestJWTKeyMappingUpdateRevertsDescriptionAndIsActiveWhenTheRecoveryReadAlsoFails(t *testing.T) {
+	// Regression test: on a failed update, only `key` was being reverted
+	// before Read ran. If Read itself then failed too (network blip, proxy
+	// hiccup), description/is_active kept the rejected, never-applied values,
+	// and Terraform could persist them as if the update had succeeded.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/jwt/key/mapping/update":
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"detail": "rejected"})
+		case "/jwt/key/mapping/info":
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]string{"detail": "proxy unavailable"})
+		default:
+			t.Fatalf("unexpected request to %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+
+	d := resourceDataWithChange(t,
+		map[string]string{
+			"id":              "map-abc-123",
+			"jwt_claim_name":  "client_id",
+			"jwt_claim_value": "dev-alice",
+			"key":             "sk-old-key-0000000000",
+			"description":     "old description",
+			"is_active":       "true",
+		},
+		map[string]interface{}{
+			"jwt_claim_name":  "client_id",
+			"jwt_claim_value": "dev-alice",
+			"key":             "sk-old-key-0000000000",
+			"description":     "attempted new description",
+			"is_active":       false,
+		},
+	)
+	d.SetId("map-abc-123")
+
+	err := resourceLiteLLMJWTKeyMappingUpdate(d, client)
+	if err == nil {
+		t.Fatal("expected the update failure to surface as an error")
+	}
+	if !strings.Contains(err.Error(), "failed to refresh state afterward") {
+		t.Fatalf("expected the error to mention the failed recovery read, got %v", err)
+	}
+
+	if d.Get("description").(string) != "old description" {
+		t.Fatalf("a rejected description must not survive when the recovery read also fails, got %q", d.Get("description").(string))
+	}
+	if d.Get("is_active").(bool) != true {
+		t.Fatalf("a rejected is_active must not survive when the recovery read also fails, got %v", d.Get("is_active").(bool))
+	}
+}
+
 func TestJWTKeyMappingReadPopulatesStateAndKeepsKey(t *testing.T) {
 	srv, calls := jwtKeyMappingTestServer(t, jwtKeyMappingFixture())
 	defer srv.Close()

--- a/terraform/provider/litellm/resource_jwt_key_mapping_crud_test.go
+++ b/terraform/provider/litellm/resource_jwt_key_mapping_crud_test.go
@@ -1,0 +1,370 @@
+package litellm
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type jwtKeyMappingCall struct {
+	Method string
+	Path   string
+	Query  string
+	Body   map[string]interface{}
+}
+
+func jwtKeyMappingTestServer(t *testing.T, mapping JWTKeyMappingResponse) (*httptest.Server, *[]jwtKeyMappingCall) {
+	t.Helper()
+
+	calls := make([]jwtKeyMappingCall, 0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := map[string]interface{}{}
+		if r.Body != nil {
+			_ = json.NewDecoder(r.Body).Decode(&body)
+		}
+		calls = append(calls, jwtKeyMappingCall{Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery, Body: body})
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/jwt/key/mapping/delete":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "success"})
+		default:
+			_ = json.NewEncoder(w).Encode(mapping)
+		}
+	}))
+
+	return srv, &calls
+}
+
+func jwtKeyMappingFixture() JWTKeyMappingResponse {
+	return JWTKeyMappingResponse{
+		ID:            "map-abc-123",
+		JWTClaimName:  "client_id",
+		JWTClaimValue: "dev-alice",
+		Description:   "dev-alice",
+		IsActive:      true,
+		CreatedAt:     "2026-08-06T10:00:00Z",
+		UpdatedAt:     "2026-08-06T11:00:00Z",
+		CreatedBy:     "admin",
+		UpdatedBy:     "admin",
+	}
+}
+
+func TestJWTKeyMappingCreateSendsClaimAndKey(t *testing.T) {
+	srv, calls := jwtKeyMappingTestServer(t, jwtKeyMappingFixture())
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMJWTKeyMapping().Schema, map[string]interface{}{
+		"jwt_claim_name":  "client_id",
+		"jwt_claim_value": "dev-alice",
+		"key":             "sk-abc123",
+		"description":     "dev-alice",
+		"is_active":       true,
+	})
+
+	if err := resourceLiteLLMJWTKeyMappingCreate(d, client); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	if d.Id() != "map-abc-123" {
+		t.Fatalf("expected id from the API response, got %q", d.Id())
+	}
+
+	create := (*calls)[0]
+	if create.Method != "POST" || create.Path != "/jwt/key/mapping/new" {
+		t.Fatalf("expected POST /jwt/key/mapping/new, got %s %s", create.Method, create.Path)
+	}
+	if create.Body["jwt_claim_name"] != "client_id" || create.Body["jwt_claim_value"] != "dev-alice" {
+		t.Fatalf("claim fields not sent: %v", create.Body)
+	}
+	if create.Body["key"] != "sk-abc123" {
+		t.Fatalf("virtual key not sent: %v", create.Body["key"])
+	}
+	if create.Body["description"] != "dev-alice" {
+		t.Fatalf("description not sent: %v", create.Body["description"])
+	}
+	if _, sent := create.Body["is_active"]; sent {
+		t.Fatalf("is_active is not accepted by /jwt/key/mapping/new but was sent: %v", create.Body)
+	}
+
+	for _, call := range (*calls)[1:] {
+		if call.Path == "/jwt/key/mapping/update" {
+			t.Fatalf("an active mapping must not trigger a follow-up update")
+		}
+	}
+}
+
+func TestJWTKeyMappingCreateOmitsEmptyDescription(t *testing.T) {
+	srv, calls := jwtKeyMappingTestServer(t, jwtKeyMappingFixture())
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMJWTKeyMapping().Schema, map[string]interface{}{
+		"jwt_claim_name":  "client_id",
+		"jwt_claim_value": "dev-alice",
+		"key":             "sk-abc123",
+		"is_active":       true,
+	})
+
+	if err := resourceLiteLLMJWTKeyMappingCreate(d, client); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	if _, sent := (*calls)[0].Body["description"]; sent {
+		t.Fatalf("unset description should be omitted: %v", (*calls)[0].Body)
+	}
+}
+
+func TestJWTKeyMappingCreateDeactivatesWhenNotActive(t *testing.T) {
+	mapping := jwtKeyMappingFixture()
+	mapping.IsActive = false
+	srv, calls := jwtKeyMappingTestServer(t, mapping)
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMJWTKeyMapping().Schema, map[string]interface{}{
+		"jwt_claim_name":  "client_id",
+		"jwt_claim_value": "dev-alice",
+		"key":             "sk-abc123",
+		"is_active":       false,
+	})
+
+	if err := resourceLiteLLMJWTKeyMappingCreate(d, client); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	var update *jwtKeyMappingCall
+	for i := range *calls {
+		if (*calls)[i].Path == "/jwt/key/mapping/update" {
+			update = &(*calls)[i]
+			break
+		}
+	}
+	if update == nil {
+		t.Fatal("expected a follow-up update, since the create endpoint always starts a mapping active")
+	}
+	if update.Body["id"] != "map-abc-123" {
+		t.Fatalf("update must target the new mapping, got %v", update.Body["id"])
+	}
+	if update.Body["is_active"] != false {
+		t.Fatalf("expected is_active false in the follow-up update, got %v", update.Body["is_active"])
+	}
+	if d.Get("is_active").(bool) {
+		t.Fatal("state should reflect the inactive mapping after create")
+	}
+}
+
+func TestJWTKeyMappingReadPopulatesStateAndKeepsKey(t *testing.T) {
+	srv, calls := jwtKeyMappingTestServer(t, jwtKeyMappingFixture())
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMJWTKeyMapping().Schema, map[string]interface{}{
+		"jwt_claim_name":  "client_id",
+		"jwt_claim_value": "dev-alice",
+		"key":             "sk-configured-value",
+	})
+	d.SetId("map-abc-123")
+
+	if err := resourceLiteLLMJWTKeyMappingRead(d, client); err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	read := (*calls)[0]
+	if read.Method != "GET" || read.Path != "/jwt/key/mapping/info" {
+		t.Fatalf("expected GET /jwt/key/mapping/info, got %s %s", read.Method, read.Path)
+	}
+	if read.Query != "id=map-abc-123" {
+		t.Fatalf("expected the mapping id in the query, got %q", read.Query)
+	}
+
+	if d.Get("jwt_claim_value").(string) != "dev-alice" {
+		t.Fatalf("claim value not populated: %q", d.Get("jwt_claim_value").(string))
+	}
+	if d.Get("description").(string) != "dev-alice" {
+		t.Fatalf("description not populated: %q", d.Get("description").(string))
+	}
+	if !d.Get("is_active").(bool) {
+		t.Fatal("is_active not populated")
+	}
+	if d.Get("created_at").(string) != "2026-08-06T10:00:00Z" || d.Get("created_by").(string) != "admin" {
+		t.Fatalf("computed audit fields not populated: %v", d.State().Attributes)
+	}
+	if d.Get("key").(string) != "sk-configured-value" {
+		t.Fatalf("the API never returns the key, so the configured value must survive a read, got %q", d.Get("key").(string))
+	}
+}
+
+func TestJWTKeyMappingReadClearsIDWhenMappingIsGone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "Mapping not found"})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMJWTKeyMapping().Schema, map[string]interface{}{
+		"jwt_claim_name":  "client_id",
+		"jwt_claim_value": "dev-alice",
+		"key":             "sk-abc123",
+	})
+	d.SetId("map-gone")
+
+	if err := resourceLiteLLMJWTKeyMappingRead(d, client); err != nil {
+		t.Fatalf("a deleted mapping must not fail the read: %v", err)
+	}
+	if d.Id() != "" {
+		t.Fatalf("expected the id to be cleared so Terraform plans a recreate, got %q", d.Id())
+	}
+}
+
+func TestJWTKeyMappingUpdateClearsDescriptionAndSendsKey(t *testing.T) {
+	mapping := jwtKeyMappingFixture()
+	mapping.Description = ""
+	srv, calls := jwtKeyMappingTestServer(t, mapping)
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMJWTKeyMapping().Schema, map[string]interface{}{
+		"jwt_claim_name":  "client_id",
+		"jwt_claim_value": "dev-alice",
+		"key":             "sk-rotated",
+		"is_active":       true,
+	})
+	d.SetId("map-abc-123")
+
+	if err := resourceLiteLLMJWTKeyMappingUpdate(d, client); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	update := (*calls)[0]
+	if update.Method != "POST" || update.Path != "/jwt/key/mapping/update" {
+		t.Fatalf("expected POST /jwt/key/mapping/update, got %s %s", update.Method, update.Path)
+	}
+	if update.Body["id"] != "map-abc-123" {
+		t.Fatalf("update must carry the mapping id, got %v", update.Body["id"])
+	}
+	if update.Body["key"] != "sk-rotated" {
+		t.Fatalf("rotated key not sent: %v", update.Body["key"])
+	}
+	description, sent := update.Body["description"]
+	if !sent || description != "" {
+		t.Fatalf("a dropped description must be sent as an empty string, since the proxy ignores absent fields: %v", update.Body)
+	}
+	if d.Get("description").(string) != "" {
+		t.Fatalf("description should be cleared in state, got %q", d.Get("description").(string))
+	}
+}
+
+func TestJWTKeyMappingUpdateOmitsMissingKeyRatherThanBlankingIt(t *testing.T) {
+	srv, calls := jwtKeyMappingTestServer(t, jwtKeyMappingFixture())
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMJWTKeyMapping().Schema, map[string]interface{}{
+		"jwt_claim_name":  "client_id",
+		"jwt_claim_value": "dev-alice",
+		"description":     "dev-alice",
+		"is_active":       true,
+	})
+	d.SetId("map-abc-123")
+
+	if err := resourceLiteLLMJWTKeyMappingUpdate(d, client); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	if _, sent := (*calls)[0].Body["key"]; sent {
+		t.Fatalf("a missing key must be omitted rather than blanking the mapping token: %v", (*calls)[0].Body)
+	}
+}
+
+func TestJWTKeyMappingDeleteToleratesMissingMapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "Mapping not found"})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMJWTKeyMapping().Schema, map[string]interface{}{
+		"jwt_claim_name":  "client_id",
+		"jwt_claim_value": "dev-alice",
+		"key":             "sk-abc123",
+	})
+	d.SetId("map-already-gone")
+
+	if err := resourceLiteLLMJWTKeyMappingDelete(d, client); err != nil {
+		t.Fatalf("deleting an already deleted mapping must succeed: %v", err)
+	}
+	if d.Id() != "" {
+		t.Fatalf("expected the id to be cleared after delete, got %q", d.Id())
+	}
+}
+
+func TestJWTKeyMappingCreateSurfacesDuplicateClaimError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"detail": "A mapping for claim 'client_id' = 'dev-alice' already exists.",
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMJWTKeyMapping().Schema, map[string]interface{}{
+		"jwt_claim_name":  "client_id",
+		"jwt_claim_value": "dev-alice",
+		"key":             "sk-abc123",
+		"is_active":       true,
+	})
+
+	err := resourceLiteLLMJWTKeyMappingCreate(d, client)
+	if err == nil {
+		t.Fatal("expected a duplicate claim pair to fail")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("the proxy explanation must reach the user, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Fatalf("no id should be recorded for a failed create, got %q", d.Id())
+	}
+}
+
+func TestJWTKeyMappingCreateDoesNotLeakKeyInErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"key":    "sk-super-secret",
+			"detail": "The provided key does not match an existing virtual key.",
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMJWTKeyMapping().Schema, map[string]interface{}{
+		"jwt_claim_name":  "client_id",
+		"jwt_claim_value": "dev-alice",
+		"key":             "sk-super-secret",
+		"is_active":       true,
+	})
+
+	err := resourceLiteLLMJWTKeyMappingCreate(d, client)
+	if err == nil {
+		t.Fatal("expected an unknown virtual key to fail")
+	}
+	if !strings.Contains(err.Error(), "does not match an existing virtual key") {
+		t.Fatalf("the proxy explanation must reach the user, got %v", err)
+	}
+	if strings.Contains(err.Error(), "sk-super-secret") {
+		t.Fatalf("the virtual key must be redacted in errors, got %v", err)
+	}
+}

--- a/terraform/provider/litellm/types.go
+++ b/terraform/provider/litellm/types.go
@@ -246,3 +246,33 @@ type VectorStoreDeleteRequest struct {
 type VectorStoreInfoRequest struct {
 	VectorStoreID string `json:"vector_store_id"`
 }
+
+type JWTKeyMappingRequest struct {
+	JWTClaimName  string `json:"jwt_claim_name"`
+	JWTClaimValue string `json:"jwt_claim_value"`
+	Key           string `json:"key"`
+	Description   string `json:"description,omitempty"`
+}
+
+type JWTKeyMappingUpdateRequest struct {
+	ID          string `json:"id"`
+	Key         string `json:"key,omitempty"`
+	Description string `json:"description"`
+	IsActive    bool   `json:"is_active"`
+}
+
+type JWTKeyMappingDeleteRequest struct {
+	ID string `json:"id"`
+}
+
+type JWTKeyMappingResponse struct {
+	ID            string `json:"id"`
+	JWTClaimName  string `json:"jwt_claim_name"`
+	JWTClaimValue string `json:"jwt_claim_value"`
+	Description   string `json:"description,omitempty"`
+	IsActive      bool   `json:"is_active"`
+	CreatedAt     string `json:"created_at,omitempty"`
+	UpdatedAt     string `json:"updated_at,omitempty"`
+	CreatedBy     string `json:"created_by,omitempty"`
+	UpdatedBy     string `json:"updated_by,omitempty"`
+}


### PR DESCRIPTION
## TLDR

Problem this solves:

- No way to manage JWT key mappings with Terraform
- JWT clients could not get per-client keys declaratively
- The four /jwt/key/mapping endpoints had no provider coverage

How it solves it:

- Adds a litellm_jwt_key_mapping resource to terraform/provider
- Maps a JWT claim value to an existing virtual key
- Supports description, is_active, key rotation and import

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at 5f2e3a6, the original commit of this branch. `litellm_internal_staging` was rewritten upstream since, so the branch has been rebased twice to stay current, most recently onto it as 12768d8d. Both rebases only moved the changelog entry to stay under the current Unreleased heading and left every file of the resource byte-identical, so the run below still describes the code under review. It ran against a live proxy on the `main-stable` image with Postgres, no mocks. The provider binary was built from this branch and wired in through `dev_overrides`. Since the proxy stores only a hash of the mapped key and never returns it, step 3 and step 5 read the stored token straight out of Postgres and compare it with the sha256 of the configured key, which is what proves the mapping really points where the config says

```
### commit under test

$ git -C . log --oneline -1
5f2e3a6 feat(terraform): add litellm_jwt_key_mapping resource

### 1. apply: two mappings, one created inactive

$ terraform apply -auto-approve | grep -E 'Creating|Creation complete|Apply complete|is_active|created_by'
      + created_by      = (known after apply)
      + is_active       = true
      + created_by      = (known after apply)
      + is_active       = false
  + alice_created_by = (known after apply)
  + bob_is_active    = false
litellm_jwt_key_mapping.alice: Creating...
litellm_jwt_key_mapping.bob: Creating...
litellm_jwt_key_mapping.alice: Creation complete after 0s [id=ceb80d70-0027-406e-ae43-237350a1e39e]
litellm_jwt_key_mapping.bob: Creation complete after 0s [id=bdab57b4-7426-4201-8813-0453f9bc48a1]
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
alice_created_by = "default_user_id"
bob_is_active = false

### 2. the proxy agrees with Terraform

$ curl -s -H 'x-api-key: sk-1234' 'http://localhost:4010/jwt/key/mapping/info?id=ceb80d70-0027-406e-ae43-237350a1e39e'
{"id":"ceb80d70-0027-406e-ae43-237350a1e39e","jwt_claim_name":"client_id","jwt_claim_value":"dev-alice","description":null,"is_active":true,"created_at":"2026-08-06T16:17:05.484000Z","updated_at":"2026-08-06T16:17:05.484000Z","created_by":"default_user_id","updated_by":"default_user_id"}
$ curl -s -H 'x-api-key: sk-1234' 'http://localhost:4010/jwt/key/mapping/info?id=bdab57b4-7426-4201-8813-0453f9bc48a1'
{"id":"bdab57b4-7426-4201-8813-0453f9bc48a1","jwt_claim_name":"client_id","jwt_claim_value":"dev-bob","description":"Bob, local development","is_active":false,"created_at":"2026-08-06T16:17:05.485000Z","updated_at":"2026-08-06T16:17:05.490000Z","created_by":"default_user_id","updated_by":"default_user_id"}
### 3. the mapping really points at the configured virtual key (the proxy stores only sha256 of it)

$ docker compose -f docker-compose.yml exec -T db psql -U llmproxy -d litellm -t -A -c "select token from \"LiteLLM_JWTKeyMapping\" where id = 'ceb80d70-0027-406e-ae43-237350a1e39e'"
71c102672e27a36522d68d7c189adf34cebb918b07c1da2b5a057beb23bf082c

$ printf '%s' "$TF_VAR_alice_key" | shasum -a 256
71c102672e27a36522d68d7c189adf34cebb918b07c1da2b5a057beb23bf082c  -

### 4. re-plan is clean

$ terraform plan | tail -3

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.

### 5. rotating the mapped key is an in-place update, and reaches the proxy

$ terraform apply -auto-approve | grep -E 'Modifying|Modifications complete|Apply complete'
litellm_jwt_key_mapping.bob: Modifying... [id=bdab57b4-7426-4201-8813-0453f9bc48a1]
litellm_jwt_key_mapping.bob: Modifications complete after 0s [id=bdab57b4-7426-4201-8813-0453f9bc48a1]
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

$ docker compose -f docker-compose.yml exec -T db psql -U llmproxy -d litellm -t -A -c "select token from \"LiteLLM_JWTKeyMapping\" where id = 'bdab57b4-7426-4201-8813-0453f9bc48a1'"
4bbbb1f2cc2a7703204637ee1157557b7c27f2a466934b2c69a65b22ba0c6ab1

$ printf '%s' "$TF_VAR_bob_key" | shasum -a 256
4bbbb1f2cc2a7703204637ee1157557b7c27f2a466934b2c69a65b22ba0c6ab1  -

### 6. a duplicate claim pair surfaces the proxy 409 verbatim

$ terraform apply -auto-approve | grep -A6 'Error:'

Error: failed to create JWT key mapping: API request failed: Status: 409 Conflict, Response: {"detail":"A mapping for claim 'client_id' = 'dev-alice' already exists."}

  with litellm_jwt_key_mapping.duplicate,
  on main.tf line 54, in resource "litellm_jwt_key_mapping" "duplicate":
  54: resource "litellm_jwt_key_mapping" "duplicate" {


### 7. import, then a single apply converges

$ terraform state rm litellm_jwt_key_mapping.alice
Removed litellm_jwt_key_mapping.alice
Successfully removed 1 resource instance(s).

$ terraform import litellm_jwt_key_mapping.alice ceb80d70-0027-406e-ae43-237350a1e39e | tail -3
The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.


$ terraform apply -auto-approve | grep -E 'Apply complete'
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

$ terraform plan | tail -3

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.

### 8. destroy leaves nothing behind

$ terraform destroy -auto-approve | tail -3
litellm_jwt_key_mapping.alice: Destruction complete after 0s

Destroy complete! Resources: 2 destroyed.

$ curl -s -H 'x-api-key: sk-1234' 'http://localhost:4010/jwt/key/mapping/list'
{"mappings":[],"total_count":0,"current_page":1,"total_pages":0}
```

## Type

🆕 New Feature

## Changes

`litellm_jwt_key_mapping` wraps `/jwt/key/mapping/new`, `/info`, `/update` and `/delete`. A mapping is keyed by `jwt_claim_name` plus `jwt_claim_value`, both ForceNew because the update endpoint cannot change them, and points at an existing virtual key through the sensitive `key` argument

Three behaviours come from the endpoints rather than from Terraform. `is_active` is applied through a follow-up update, because `/jwt/key/mapping/new` always creates a mapping active and does not accept the field. A description dropped from the configuration is sent as an empty string, because the update endpoint ignores absent fields and would otherwise keep the old value. The `key` is sent on update only when it is present, so an unexpected empty value can never blank the mapping's token

The proxy stores only a hash of `key` and never returns it, so drift on that attribute cannot be detected and the provider keeps the configured value in state, the same way `credential_values` and `model_api_key` already do. That also means a changed `key` plans as a normal in-place update, which rotates the mapping onto the new virtual key without replacing it. Reads treat a 404 as a deleted mapping and clear the ID, so a mapping removed outside Terraform is planned for recreation, and delete tolerates an already deleted mapping. The proxy raises 404 for every not-found path here (info, update, delete), confirmed by reading the endpoint source directly, so the status code alone is the check, nothing string-matched against the error body

One rough edge worth flagging separately: a mapping cannot reference a `litellm_key` resource's generated key, in any configuration or apply ordering. That is not a null-then-400 situation, `litellm_key` made its key write-only specifically to avoid storing raw API keys in state, and Terraform's write-only enforcement turns `key = litellm_key.foo.key` into a static `Missing required argument` error at `terraform plan`, before any API call, even when both resources are created together in the same apply. The docs now say this plainly and show the key coming from a variable or a secret manager instead. `litellm_key` also does not send a caller-supplied key to `/key/generate` even though the endpoint accepts one; teaching it to would make the two resources compose, and seems better as its own change

Tests are unit tests in `litellm/resource_jwt_key_mapping_crud_test.go`, driving the real CRUD functions against an `httptest` proxy and asserting on the requests that leave the provider: the create payload and that `is_active` is not part of it, the follow-up deactivation, that a read populates state and preserves the configured key, that a missing mapping clears the ID, that a dropped description is cleared with an empty string, that a missing key is omitted rather than blanked, that delete tolerates a missing mapping, and that the 409 and 400 explanations reach the user with the key redacted

## Follow-up (e3e06cf7)

I asked two independent agents to stress this before asking for review: one drove the real CRUD functions and reviewed the diff cold, the other built the provider and ran it against a live LiteLLM proxy plus Postgres through a real Terraform lifecycle, including the `litellm_key` composition question above (confirmed the plan-time error, in both the later-apply and same-apply cases), key rotation verified by comparing the proxy's stored `sha256` to the configured key, out-of-band deletion of both the mapping and the underlying key (blocked by the proxy's own `ON DELETE RESTRICT` foreign key, so a mapped key cannot be deleted while referenced), duplicate claims, an unknown key with redaction, and import.

That live run surfaced one real bug: on a failed update, for example rotating to a key the proxy rejects, classic SDKv2 persists the update's diff-applied values into state regardless of the error. A rejected key rotation left the new, never-applied key in `terraform state pull` while the proxy kept the old one, so the next plan falsely reported convergence. Fixed by reverting `key` via `d.GetChange` and re-running Read to resync `description`/`is_active`/the computed fields from the server on failure, since Read alone can't recover `key`. Added a regression test that fails on the pre-fix code and passes after, verified by reverting the fix locally and confirming the test catches it

Also dropped the case-insensitive `"mapping not found"` body match in favor of checking the 404 status alone, since the proxy raises 404 for all three not-found paths (checked its source directly), so the fallback added surface area without covering a real case

## Follow-up (4060f2db)

Greptile and a second automated reviewer both flagged the same real gap: the create endpoint has no `is_active` field, so an `is_active = false` mapping is briefly active before the follow-up deactivation call runs, and previously stayed active indefinitely if that call failed. Fixed by deleting the mapping when deactivation fails, rather than leaving it active and untracked; if the delete also fails, the id stays in state so the next apply retries the cleanup instead of losing track of a live, active mapping. Also closed a narrower version of the same class of bug in Update: only `key` was being reverted on a failed update, so if the recovery read also failed, `description`/`is_active` could keep the rejected values. All three now revert before the read runs. Both come with regression tests, mutation-verified against the pre-fix code the same way as the previous fix

One item is intentionally deferred: storing `key` in state rather than making it write-only like `litellm_key`. Doing that properly needs a companion version-trigger attribute, since a write-only value can't be diffed against itself across applies to detect a rotation, this resource's `key` is a user-supplied input that needs to support in-place rotation, unlike `litellm_key`'s, which is purely server-generated output captured once at create. That's a real schema change deserving its own careful pass rather than a rushed addition here

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR



