### PR TITLE
feat(helm): add command/args override for gateway, backend, and ui

### DIFF
--- a/helm/litellm/templates/backend/deployment.yaml
+++ b/helm/litellm/templates/backend/deployment.yaml
@@ -41,6 +41,14 @@ spec:
         - name: backend
           image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          {{- with .Values.backend.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backend.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.backend.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/helm/litellm/templates/gateway/deployment.yaml
+++ b/helm/litellm/templates/gateway/deployment.yaml
@@ -39,6 +39,14 @@ spec:
         - name: gateway
           image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+          {{- with .Values.gateway.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.gateway.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.gateway.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/helm/litellm/templates/ui/deployment.yaml
+++ b/helm/litellm/templates/ui/deployment.yaml
@@ -36,6 +36,14 @@ spec:
         - name: ui
           image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          {{- with .Values.ui.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.ui.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.ui.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/helm/litellm/tests/command_args_tests.yaml
+++ b/helm/litellm/tests/command_args_tests.yaml
@@ -1,0 +1,89 @@
+suite: test container command and args overrides
+templates:
+  - gateway/deployment.yaml
+  - gateway/configmap.yaml
+  - backend/deployment.yaml
+  - ui/deployment.yaml
+values:
+  - ./values/required.yaml
+tests:
+  - it: gateway omits command and args by default
+    template: gateway/deployment.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].command
+      - isNull:
+          path: spec.template.spec.containers[0].args
+
+  - it: gateway renders command and args when set
+    template: gateway/deployment.yaml
+    set:
+      gateway.command:
+        - .venv/bin/granian
+      gateway.args:
+        - gateway.main:app
+        - --http
+        - auto
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - .venv/bin/granian
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - gateway.main:app
+            - --http
+            - auto
+
+  - it: backend omits command and args by default
+    template: backend/deployment.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].command
+      - isNull:
+          path: spec.template.spec.containers[0].args
+
+  - it: backend renders command and args when set
+    template: backend/deployment.yaml
+    set:
+      backend.command:
+        - python
+      backend.args:
+        - -m
+        - litellm
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - python
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - -m
+            - litellm
+
+  - it: ui omits command and args by default
+    template: ui/deployment.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].command
+      - isNull:
+          path: spec.template.spec.containers[0].args
+
+  - it: ui renders command and args when set
+    template: ui/deployment.yaml
+    set:
+      ui.command:
+        - node
+      ui.args:
+        - server.js
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - node
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - server.js

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -202,6 +202,8 @@ gateway:
     repository: ghcr.io/berriai/litellm-gateway
     tag: ""              # defaults to .Chart.AppVersion
     pullPolicy: IfNotPresent
+  command: []
+  args: []
   service:
     type: ClusterIP
     port: 4000
@@ -298,6 +300,8 @@ backend:
     repository: ghcr.io/berriai/litellm-backend
     tag: ""
     pullPolicy: IfNotPresent
+  command: []
+  args: []
   service:
     type: ClusterIP
     port: 4001
@@ -358,6 +362,8 @@ ui:
     repository: ghcr.io/berriai/litellm-ui
     tag: ""
     pullPolicy: IfNotPresent
+  command: []
+  args: []
   service:
     type: ClusterIP
     port: 3000


### PR DESCRIPTION
## TLDR

Problem this solves:

- Helm chart has no way to override container entrypoint (command/args)
- Switching ASGI servers (e.g., Granian for HTTP/2) requires forking or ServerSideApply hacks

How it solves it:

- Add `command`/`args` fields to gateway, backend, and ui values
- Render them in the deployment templates when set; use image defaults when empty

## Relevant issues

No existing issue found.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

`helm template` with defaults — no `command`/`args` in output (unchanged behavior):

```bash
$ helm template test helm/litellm \
    --set database.writer.host=dummy --set database.writer.dbname=dummy \
    | grep -c "command:"
0
```

With overrides:

```yaml
gateway:
  command: [".venv/bin/granian"]
  args: ["gateway.main:app", "--http", "auto"]
```

```bash
$ helm template test helm/litellm --values override.yaml \
    --set database.writer.host=dummy --set database.writer.dbname=dummy \
    | grep -A4 "command:"
          command:
            - .venv/bin/granian
          args:
            - gateway.main:app
            - --http
```

Helm unittest:

```
$ helm unittest litellm -f 'tests/command_args_tests.yaml'
 PASS  test container command and args overrides
Tests: 6 passed, 6 total
```

## Type

🆕 New Feature

## Changes

- `gateway`, `backend`, `ui` deployment templates: render `command`/`args` via `{{- with }}` blocks
- `values.yaml`: add `command: []` and `args: []` defaults for all three components
- `tests/command_args_tests.yaml`: 6 tests covering default omission and override rendering for all three components