### PR TITLE
fix(logging): fall back to litellm_metadata when metadata is empty

### DIFF
--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -115,8 +115,11 @@ def get_litellm_params(
     litellm_request_debug: bool | None = None,
     **kwargs,
 ) -> dict:
+    _litellm_metadata_dict: Final = litellm_metadata if isinstance(litellm_metadata, dict) else None
+    resolved_metadata: Final = _litellm_metadata_dict.copy() if not metadata and _litellm_metadata_dict else metadata
+
     # Derive litellm_session_id / litellm_trace_id from metadata when not provided (call chaining)
-    _meta: Final = metadata or {}
+    _meta: Final = resolved_metadata or {}
     if litellm_session_id is None:
         litellm_session_id = _meta.get("session_id") or _meta.get("trace_id")
     if litellm_trace_id is None:
@@ -139,7 +142,7 @@ def get_litellm_params(
         "model_alias_map": model_alias_map,
         "completion_call_id": completion_call_id,
         "aembedding": aembedding,
-        "metadata": metadata,
+        "metadata": resolved_metadata,
         "model_info": model_info,
         "proxy_server_request": proxy_server_request,
         "preset_cache_key": preset_cache_key,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -585,8 +585,8 @@ class Logging(LiteLLMLoggingBaseClass):
         """
         base_litellm_params: Final[dict[str, Any]] = {}
 
-        if "metadata" in kwargs:
-            base_litellm_params["metadata"] = kwargs["metadata"]
+        if isinstance(kwargs.get("metadata"), dict):
+            base_litellm_params["metadata"] = kwargs["metadata"].copy()
         if "litellm_metadata" in kwargs and isinstance(kwargs["litellm_metadata"], dict):
             base_litellm_params["litellm_metadata"] = kwargs["litellm_metadata"]
             if "metadata" not in base_litellm_params:

--- a/tests/test_litellm/litellm_core_utils/test_get_litellm_params.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_litellm_params.py
@@ -162,3 +162,56 @@ class TestGetLitellmParamsDataResidency:
             api_base="https://eu.api.openai.com/v1",
         )
         assert result["data_residency"] is None
+
+
+class TestMetadataFallsBackToLitellmMetadata:
+    def test_metadata_falls_back_to_litellm_metadata_when_absent(self):
+        result = get_litellm_params(litellm_metadata={"trace_id": "trace-1"})
+        assert result["metadata"] == {"trace_id": "trace-1"}
+        assert result["litellm_metadata"] == {"trace_id": "trace-1"}
+
+    def test_empty_metadata_falls_back_to_litellm_metadata(self):
+        result = get_litellm_params(metadata={}, litellm_metadata={"trace_id": "trace-1"})
+        assert result["metadata"] == {"trace_id": "trace-1"}
+
+    def test_metadata_wins_when_both_present(self):
+        result = get_litellm_params(
+            metadata={"trace_id": "from-metadata"},
+            litellm_metadata={"trace_id": "from-litellm-metadata"},
+        )
+        assert result["metadata"] == {"trace_id": "from-metadata"}
+
+    @pytest.mark.parametrize("bad_value", ["not-json-a-string", 12345, ["a"], True])
+    def test_non_dict_litellm_metadata_is_ignored(self, bad_value):
+        result = get_litellm_params(litellm_metadata=bad_value)
+        assert result["metadata"] is None
+
+    def test_metadata_stays_none_without_litellm_metadata(self):
+        result = get_litellm_params(api_key="test-key")
+        assert result["metadata"] is None
+
+    def test_session_and_trace_id_derived_from_litellm_metadata(self):
+        result = get_litellm_params(
+            litellm_metadata={"trace_id": "trace-1", "session_id": "session-1"},
+        )
+        assert result["litellm_session_id"] == "session-1"
+        assert result["litellm_trace_id"] == "trace-1"
+
+    def test_explicit_session_and_trace_id_are_not_overridden(self):
+        result = get_litellm_params(
+            litellm_session_id="explicit-session",
+            litellm_trace_id="explicit-trace",
+            litellm_metadata={"trace_id": "trace-1", "session_id": "session-1"},
+        )
+        assert result["litellm_session_id"] == "explicit-session"
+        assert result["litellm_trace_id"] == "explicit-trace"
+
+    def test_litellm_metadata_fallback_is_copied_not_aliased(self):
+        litellm_metadata = {"trace_id": "trace-1"}
+
+        result = get_litellm_params(litellm_metadata=litellm_metadata)
+
+        assert result["metadata"] == litellm_metadata
+        assert result["metadata"] is not litellm_metadata
+        result["metadata"].pop("trace_id")
+        assert litellm_metadata == {"trace_id": "trace-1"}

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -526,6 +526,26 @@ class TestUpdateFromKwargs:
         )
         assert logging_obj.litellm_params["litellm_call_id"] == "call-empty"
 
+    @pytest.mark.parametrize("caller_metadata", [None, "not-a-dict", 42])
+    def test_non_dict_caller_metadata_does_not_break_the_merge(self, logging_obj, caller_metadata):
+        logging_obj.update_from_kwargs(
+            kwargs={"metadata": caller_metadata, "litellm_metadata": {"user_api_key_hash": "hashed"}},
+            litellm_params={"metadata": {"user_api_key_hash": "hashed", "litellm_api_version": "1.0"}},
+        )
+
+        assert logging_obj.litellm_params["metadata"]["user_api_key_hash"] == "hashed"
+
+    def test_does_not_mutate_caller_metadata_dict(self, logging_obj):
+        caller_metadata: dict = {}
+
+        logging_obj.update_from_kwargs(
+            kwargs={"metadata": caller_metadata, "litellm_metadata": {"user_api_key_hash": "hashed"}},
+            litellm_params={"metadata": {"user_api_key_hash": "hashed", "litellm_api_version": "1.0"}},
+        )
+
+        assert caller_metadata == {}
+        assert logging_obj.litellm_params["metadata"]["user_api_key_hash"] == "hashed"
+
 
 def test_logging_prevent_double_logging(logging_obj):
     """


### PR DESCRIPTION
## TLDR

Problem this solves:

- `get_litellm_params` returned `metadata=None` whenever a caller supplied only `litellm_metadata`, overwriting a fallback `function_setup` had already applied correctly and leaving `litellm_params["metadata"]` empty
- Every provider without a native Responses API config reaches `/v1/responses` through the chat-completions bridge, and on that path this discarded the caller's trace fields a second time, after the proxy had already promoted them in #35866
- `Logging.update_from_kwargs` merges proxy-internal fields into whatever dict it is handed and was aliasing rather than copying it. On these routes that dict is the caller's provider-bound `metadata`, so once the merged value stopped being `None` it would write `user_api_key_hash` and `user_api_key_auth` into an outbound request body

How it solves it:

- Resolve `metadata` to a copy of `litellm_metadata` when `metadata` is empty, which is the same fallback `litellm/utils.py` already applies two frames up
- Guard on `isinstance`, since the proxy deliberately leaves an unparseable string `litellm_metadata` in place and `str` has no `copy`
- Copy in `update_from_kwargs` instead of aliasing, so the merge cannot reach the caller's dict

## Relevant issues

Second half of the fix for https://github.com/BerriAI/litellm/issues/34226. Stacked on #35866, which promotes the caller's trace fields into `litellm_metadata` for routes that track proxy state there. #35866 covers providers with a native Responses API config; this covers the rest, so both are needed to close the issue

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy, real Postgres, real Gemini traffic, Langfuse pointed at a local ingestion endpoint so the raw `trace-create` body is visible. `/v1/responses` against a provider with no native Responses API config, so the request takes the completion-transformation bridge:

```bash
TID=22662678-30c1-41a1-a24b-216d6e5fb83d; SID=218af06c-28a2-4705-8a0a-5f9970d39326
curl -sS localhost:4000/v1/responses -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' \
  -d "{\"model\":\"gemini-flash\",\"input\":\"say bridge\",\"metadata\":{\"trace_id\":\"$TID\",\"session_id\":\"$SID\",\"trace_user_id\":\"user-123\",\"trace_metadata\":{\"tenant_id\":\"tenant-1\"}}}"
```

```console
# with #35866 alone, the bridge still loses the fields
{"name": "litellm-aresponses", "id": "bb6a5f83-862c-4907-989a-f77011b757fe", "sessionId": null, "userId": null, "metadata": null}

# with this PR on top
{"name": "litellm-aresponses", "id": "22662678-30c1-41a1-a24b-216d6e5fb83d", "sessionId": "218af06c-28a2-4705-8a0a-5f9970d39326", "userId": "user-123", "metadata": {"tenant_id": "tenant-1"}}
```

The aliasing half, reproduced directly against the resolved params rather than through a route, since `_aresponses_websocket` is the reachable entry point and takes `metadata` through `**kwargs`:

```console
# before: the caller's own metadata dict is mutated by logging setup
caller metadata dict AFTER logging setup: ['litellm_api_version', 'requester_metadata', 'user_api_key_auth', 'user_api_key_hash']

# after
caller metadata dict AFTER logging setup: []
```

And the malformed-input guard, which is the regression the isinstance check prevents:

```console
litellm_metadata='not-json-a-string'   -> metadata=None
litellm_metadata=12345                 -> metadata=None
litellm_metadata=['a']                 -> metadata=None
litellm_metadata={'trace_id': 't'}     -> metadata={'trace_id': 't'}
```

Without the guard the first three raise `AttributeError: 'str' object has no attribute 'copy'`, which surfaces as a 500 on a request that previously succeeded

## Type

🐛 Bug Fix

## Changes

`get_litellm_params` resolves `metadata` to a copy of `litellm_metadata` when `metadata` is empty and `litellm_metadata` is a dict. The same value feeds the `litellm_session_id` and `litellm_trace_id` derivation directly above it, so call chaining now works on these routes too.

`Logging.update_from_kwargs` copies `kwargs["metadata"]` rather than aliasing it. The merge below it writes proxy-internal fields into that dict, and on `litellm_metadata` routes it is the caller's provider-bound object.

`base_model` still derives from the raw `metadata` rather than the resolved one. The final value is unchanged either way because `_get_base_model_from_metadata` in `litellm/utils.py` already falls back to `litellm_metadata`, so it is left alone to keep the change scoped.

## Behavior changes

All three below follow from one thing: on the routes that pass `litellm_metadata` with no `metadata`, meaning the `/v1/responses` bridge, `/files`, metadata-less `/batches` and bedrock passthrough, `litellm_params["metadata"]` changes from `None` to a copy of the `litellm_metadata` dict. Code that reads that dict had been failing into a swallowing `try` and now runs. Each was confirmed on a base-vs-head proxy A/B rather than reasoned about.

**Worth a release note.** `max_budget_per_session` starts being enforced on these routes. Its pre-call gate already read both metadata dicts, but the spend increment reads `litellm_params["metadata"]["session_id"]`, which never existed there, so the counter never incremented and the limit was inert. With an agent-scoped request the handler sees `session_id=None agent_id=None` on base and returns early; on head it sees both and increments. An operator who configured this months ago has been running without it on these routes, and after this change requests that used to succeed can start returning 429 with no config change on their side. Correct behavior, but it arrives without warning.

**Data change, no action needed.** The SpendLogs `session_id` column changes from a per-request UUID to the caller's session id when one is supplied, because `litellm_session_id` and `litellm_trace_id` can now be derived on these routes. The column is named for what it now holds, and a random per-request value made session grouping useless there, so this is the intended repair. The `x-litellm-session-id` header already produced this same value on every route. Dashboards that group by that column will see the grouping start working.

**Strict repair.** Callbacks on these routes now receive the same proxy metadata that `/chat/completions` and the native `/v1/responses` path have always sent, including the `user_api_key_*` fields. A Lago-style bare index on `litellm_params["metadata"]["user_api_key_user_id"]` raises `TypeError` on base and returns the value on head, which is the shape PromptLayer and Slack alerting use too. These integrations were simply broken on these routes before.

Correction to an earlier revision of this description, recorded rather than silently removed: it also listed the v1 parallel-request limiter's success handler as newly running. That was wrong. Only `_PROXY_MaxParallelRequestsHandler_v3` is registered in a default deployment, `parallel_request_limiter.py` never appears in the proxy log, and the v3 handler does not read `litellm_params["metadata"]`.

## QA runbook

Run the curl above against a model whose provider has no native Responses API config, with the langfuse success callback enabled and `LANGFUSE_HOST` pointed at any server that accepts `POST /api/public/ingestion` and returns 207. The captured `trace-create` body should carry the caller's `trace_id` with `sessionId`, `userId` and `metadata` populated. Then repeat with `"litellm_metadata": "not-json"` in the body and confirm the request still succeeds rather than returning a 500

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/36105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change on litellm_metadata-only routes: spend/session limits, SpendLogs session_id, and callbacks may start seeing metadata that was previously null; logging no longer mutates caller dicts but downstream code that relied on that side effect could differ.
> 
> **Overview**
> **Fixes trace/metadata loss and accidental mutation on routes that only pass `litellm_metadata` (e.g. `/v1/responses` chat bridge).**
> 
> `get_litellm_params` now sets `metadata` to a **copy** of `litellm_metadata` when `metadata` is missing or empty and `litellm_metadata` is a dict (non-dicts are ignored so unparseable proxy strings do not 500). That resolved dict drives `litellm_params["metadata"]` and session/trace ID derivation, aligning with the fallback already applied higher in `litellm/utils.py`.
> 
> `Logging.update_from_kwargs` only treats `kwargs["metadata"]` as metadata when it is a dict and **copies** it before merging proxy fields, so logging setup no longer writes `user_api_key_*` into the caller’s outbound provider metadata object.
> 
> New unit tests cover fallback precedence, malformed `litellm_metadata`, copy-vs-alias behavior, and logging merge edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 749b8237e36c8217feb02c8cd32d5f753776d313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


