### PR TITLE
feat(router): add opt-out for clearing configured params on a client-supplied endpoint

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -315,6 +315,7 @@ ssl_certificate: Optional[str] = None
 user_url_validation: bool = True
 user_url_allowed_hosts: List[str] = []
 provider_url_destination_allowed_hosts: List[str] = []
+forward_configured_params_on_clientside_base_override: bool = False
 ssl_ecdh_curve: Optional[str] = None  # Set to 'X25519' to disable PQC and improve performance
 disable_streaming_logging: bool = False
 disable_token_counter: bool = False

--- a/litellm/router_utils/clientside_credential_handler.py
+++ b/litellm/router_utils/clientside_credential_handler.py
@@ -13,6 +13,8 @@ Ensures cooldowns are applied correctly.
 
 from typing import Final
 
+import litellm
+
 clientside_credential_keys: Final = ["api_key", "api_base", "base_url"]
 
 
@@ -81,11 +83,18 @@ def get_dynamic_litellm_params(litellm_params: dict, request_kwargs: dict) -> di
     - litellm_params: dict
 
     for generating a unique model_id.
+
+    ``litellm.forward_configured_params_on_clientside_base_override`` keeps the
+    deployment's configured provider fields on a client-overridden endpoint, for
+    deployments that cannot reach their upstream without them.
     """
     # update litellm_params with clientside credentials
     for key in clientside_credential_keys:
         if key in request_kwargs:
             litellm_params[key] = request_kwargs[key]
+
+    if litellm.forward_configured_params_on_clientside_base_override:
+        return litellm_params
 
     # If the caller redirected api_base/base_url to a client-controlled value,
     # don't forward the admin's organization / extra_body / region / token /

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -1820,6 +1820,91 @@ class TestGetDynamicLitellmParamsClearsAdminConfigOnBaseOverride:
         assert "sk-admin-secret" not in str(out)
 
 
+class TestForwardConfiguredParamsOnClientsideBaseOverrideOptOut:
+    """
+    Clearing the deployment's configured fields on a client-supplied endpoint
+    breaks deployments that cannot reach any upstream without them: Azure needs
+    ``api_version``, Bedrock needs ``aws_region_name``, Vertex needs
+    ``vertex_project`` / ``vertex_location``. Operators who accept the exposure
+    for their own trusted endpoints opt out with
+    ``litellm.forward_configured_params_on_clientside_base_override``.
+    """
+
+    AZURE_DEPLOYMENT = {
+        "model": "azure/gpt-4",
+        "api_key": "sk-admin-key",
+        "api_base": "https://admin.openai.azure.com",
+        "api_version": "2026-04-01",
+        "organization": "org-admin-corp",
+        "extra_body": {"user_tier": "gold"},
+    }
+    CLIENT_ENDPOINT = {"api_base": "https://my-own-azure.example"}
+
+    def test_default_is_off_so_configured_params_are_still_cleared(self):
+        import litellm
+        from litellm.router_utils.clientside_credential_handler import (
+            get_dynamic_litellm_params,
+        )
+
+        assert litellm.forward_configured_params_on_clientside_base_override is False
+        out = get_dynamic_litellm_params(
+            litellm_params=dict(self.AZURE_DEPLOYMENT),
+            request_kwargs=dict(self.CLIENT_ENDPOINT),
+        )
+        assert "api_version" not in out
+        assert "organization" not in out
+        assert "extra_body" not in out
+
+    def test_opt_out_keeps_configured_params_reaching_the_client_endpoint(self, monkeypatch):
+        import litellm
+        from litellm.router_utils.clientside_credential_handler import (
+            get_dynamic_litellm_params,
+        )
+
+        monkeypatch.setattr(litellm, "forward_configured_params_on_clientside_base_override", True)
+        out = get_dynamic_litellm_params(
+            litellm_params=dict(self.AZURE_DEPLOYMENT),
+            request_kwargs=dict(self.CLIENT_ENDPOINT),
+        )
+        assert out["api_version"] == "2026-04-01"
+        assert out["organization"] == "org-admin-corp"
+        assert out["extra_body"] == {"user_tier": "gold"}
+
+    def test_opt_out_still_lets_the_request_choose_the_endpoint_and_key(self, monkeypatch):
+        import litellm
+        from litellm.router_utils.clientside_credential_handler import (
+            get_dynamic_litellm_params,
+        )
+
+        monkeypatch.setattr(litellm, "forward_configured_params_on_clientside_base_override", True)
+        out = get_dynamic_litellm_params(
+            litellm_params=dict(self.AZURE_DEPLOYMENT),
+            request_kwargs={**self.CLIENT_ENDPOINT, "api_key": "sk-client-byok"},
+        )
+        assert out["api_base"] == "https://my-own-azure.example"
+        assert out["api_key"] == "sk-client-byok"
+        assert "sk-admin-key" not in str(out)
+
+    def test_opt_out_is_scoped_to_base_override_and_changes_nothing_otherwise(self, monkeypatch):
+        import litellm
+        from litellm.router_utils.clientside_credential_handler import (
+            get_dynamic_litellm_params,
+        )
+
+        request_kwargs = {"api_key": "sk-byok"}
+        without_opt_out = get_dynamic_litellm_params(
+            litellm_params=dict(self.AZURE_DEPLOYMENT),
+            request_kwargs=dict(request_kwargs),
+        )
+        monkeypatch.setattr(litellm, "forward_configured_params_on_clientside_base_override", True)
+        with_opt_out = get_dynamic_litellm_params(
+            litellm_params=dict(self.AZURE_DEPLOYMENT),
+            request_kwargs=dict(request_kwargs),
+        )
+        assert without_opt_out == with_opt_out
+        assert with_opt_out["api_base"] == "https://admin.openai.azure.com"
+
+
 _OPENAI_CHAT_RESPONSE = {
     "id": "chatcmpl-x",
     "object": "chat.completion",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Deployments lose their configured provider fields when a request sets `api_base`
- Azure needs `api_version`, Bedrock needs `aws_region_name`, Vertex needs `vertex_project`
- Those deployments stop reaching any upstream, with no way back

How it solves it:

- New `litellm_settings` flag keeps the configured params on that path
- Off by default, so current behaviour is unchanged
- One early return in `get_dynamic_litellm_params`, nothing else moves

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

🆕 New Feature

## Changes

`get_dynamic_litellm_params` clears the deployment's configured provider fields when a
request supplies its own `api_base` / `base_url`. Some deployments cannot address any
upstream once those are gone, so the setting below keeps them:

```yaml
litellm_settings:
  forward_configured_params_on_clientside_base_override: true
```

It defaults to `false`, which leaves today's behaviour exactly as it is. Operators who
need the configured params to travel with a request-supplied endpoint opt in explicitly.

The flag binds through the existing `litellm_settings` loader, so no new proxy wiring was
needed. The request still chooses the endpoint and the credential it sends, with or
without the setting.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
