### PR TITLE
feat(models): add dashscope/qwen3.8-max pricing and context window

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -13599,6 +13599,22 @@
             }
         ]
     },
+    "dashscope/qwen3.8-max": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "dashscope/qwq-plus": {
         "input_cost_per_token": 8e-07,
         "litellm_provider": "dashscope",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -13599,6 +13599,22 @@
             }
         ]
     },
+    "dashscope/qwen3.8-max": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "dashscope/qwq-plus": {
         "input_cost_per_token": 8e-07,
         "litellm_provider": "dashscope",

--- a/tests/test_litellm/llms/dashscope/test_dashscope_qwen38_max_metadata.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_qwen38_max_metadata.py
@@ -1,0 +1,47 @@
+"""Metadata regression test for dashscope/qwen3.8-max (Qwen3.8 Max, released 2026-08-03)."""
+
+import json
+from importlib.resources import files
+import pytest
+
+MODEL = "dashscope/qwen3.8-max"
+
+
+@pytest.fixture(scope="module")
+def local_cost_map():
+    mp = pytest.MonkeyPatch()
+    mp.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    import litellm
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+
+    orig = litellm.model_cost
+    litellm.model_cost = json.loads(
+        files("litellm").joinpath("model_prices_and_context_window_backup.json").read_text(encoding="utf-8")
+    )
+    litellm.get_model_info.cache_clear()
+    _invalidate_model_cost_lowercase_map()
+    try:
+        yield litellm
+    finally:
+        litellm.model_cost = orig
+        litellm.get_model_info.cache_clear()
+        _invalidate_model_cost_lowercase_map()
+        mp.undo()
+
+
+def test_qwen38_max_raw_entry(local_cost_map):
+    e = local_cost_map.model_cost[MODEL]
+    assert e["litellm_provider"] == "dashscope"
+    assert e["max_input_tokens"] == 1000000
+    assert e["max_output_tokens"] == 131072
+    assert e["input_cost_per_token"] == 2e-06
+    assert e["output_cost_per_token"] == 6e-06
+    assert e["supports_tool_choice"] is True
+    assert e["supports_function_calling"] is True
+
+
+def test_qwen38_max_get_model_info(local_cost_map):
+    info = local_cost_map.get_model_info(model=MODEL)
+    assert info["max_input_tokens"] == 1000000
+    assert info["max_output_tokens"] == 131072
+    assert info["supports_tool_choice"] is True


### PR DESCRIPTION
## TLDR

**Problem this solves:**

- LiteLLM has no registry entry for Alibaba Qwen3.8-Max
- `get_model_info`, cost tracking, and `tool_choice` gating can't resolve it

**How it solves it:**

- Adds `dashscope/qwen3.8-max` to the model map + packaged backup
- Values sourced from Alibaba Model Studio's official pricing page
- Adds a metadata regression test

## Relevant issues

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile runs automatically once the PR is opened)

## Screenshots / Proof of Fix

This is a model-registry (pricing/metadata) addition — no code-path change. Every value is sourced from **Alibaba Cloud Model Studio's official model-pricing page** (https://www.alibabacloud.com/help/en/model-studio/models): 1,000,000 context / 131,072 output; $2.00 in / $6.00 out per 1M (flat, no long-context tier); tools, reasoning, structured output, and vision supported.

The entry resolves through `get_model_info` and the regression test passes (at commit `253069b`):

```
$ uv run pytest tests/test_litellm/llms/dashscope/test_dashscope_qwen38_max_metadata.py -q
2 passed in 0.42s
```

`litellm.get_model_info("dashscope/qwen3.8-max")` now returns the registered pricing, context/output limits, and capability flags.

## Type

🆕 New Feature

## Changes

- Register `dashscope/qwen3.8-max` in `model_prices_and_context_window.json` and the packaged `litellm/model_prices_and_context_window_backup.json` (identical entry in both).
- Add `tests/test_litellm/llms/dashscope/test_dashscope_qwen38_max_metadata.py` — asserts provider, context (1M), output (131072), pricing ($2/$6), and `tool_choice` / `function_calling` support.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR