### PR TITLE
test(router): assert the auto-router max_input_chars kwarg

### DIFF
--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -15,6 +15,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 from create_mock_standard_logging_payload import create_standard_logging_payload
 from litellm.types.utils import StandardLoggingPayload
 from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+from litellm.constants import DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS
 
 
 @pytest.fixture
@@ -1816,6 +1817,7 @@ def test_init_auto_router_deployment_success(mock_auto_router, model_list):
         default_model="gpt-5-mini",
         embedding_model="text-embedding-3-small",
         litellm_router_instance=router,
+        max_input_chars=DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS,
     )
 
     # Verify the auto-router was added to the router's auto_routers dict


### PR DESCRIPTION
## TLDR

Problem this solves:

- A test on `litellm_internal_staging` has been failing since #35956
- The AutoRouter mock assertion never learned about `max_input_chars`

How it solves it:

- Add the missing kwarg to the expected constructor call
- Assert the shared constant, not the literal `2000`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR is test-only. `git diff --stat c1fa15132b..HEAD` touches exactly one file under `tests/`, no runtime code, so there is no proxy behavior to curl before and after: the routing behavior the assertion guards is identical on both commits

Before, on `litellm_internal_staging` at `c1fa15132b` with no local changes:

```
$ PYTHONPATH=$PWD python -m pytest tests/router_unit_tests/test_router_helper_utils.py -q
FAILED tests/router_unit_tests/test_router_helper_utils.py::test_init_auto_router_deployment_success
1 failed, 141 passed, 8 warnings in 114.13s (0:01:54)
```

with

```
E  Expected: AutoRouter(..., litellm_router_instance=<litellm.router.Router object at 0x11dd68c20>)
E    Actual: AutoRouter(..., litellm_router_instance=<litellm.router.Router object at 0x11dd68c20>, max_input_chars=2000)
```

After, at `495eb7e7f4`:

```
$ PYTHONPATH=$PWD python -m pytest tests/router_unit_tests/test_router_helper_utils.py -q
142 passed, 8 warnings in 93.58s (0:01:33)
```

To confirm the updated assertion still has teeth rather than just matching whatever the code does, I dropped `max_input_chars=` from the `AutoRouter(...)` call in `litellm/router.py` at `495eb7e7f4` and reran, and the test went red again:

```
FAILED tests/router_unit_tests/test_router_helper_utils.py::test_init_auto_router_deployment_success
1 failed in 0.13s
```

## Type

✅ Test

## Changes

#35956 gave `AutoRouter.__init__` a `max_input_chars` parameter and started passing it from `Router.init_auto_router_deployment`, which caps how much of a prompt reaches the embedding model. That change was intentional and stays as is. What it missed was `tests/router_unit_tests/test_router_helper_utils.py`, whose `assert_called_once_with` on the constructor still spelled out the old kwarg set, so the test has been red on staging ever since and is unrelated to whatever branch a contributor happens to be on

The passthrough is already covered behaviorally by `TestAutoRouterMaxInputCharsWiring` in `tests/test_litellm/test_router.py`, which asserts both that a deployment's `auto_router_max_input_chars` reaches the registered AutoRouter and that omitting it falls back to the shared default. Duplicating that here would add no signal, so this PR only brings the stale expectation back in line. It asserts `DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS` instead of hardcoding `2000` so that tuning the default does not break this test a second time

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
