### PR TITLE
fix(guardrails): honor configured timeout in Zscaler AI Guard

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/__init__.py
@@ -18,6 +18,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
         send_user_api_key_alias=litellm_params.send_user_api_key_alias,
         send_user_api_key_user_id=litellm_params.send_user_api_key_user_id,
         send_user_api_key_team_id=litellm_params.send_user_api_key_team_id,
+        timeout=litellm_params.timeout,
         guardrail_name=guardrail.get("guardrail_name", ""),
         event_hook=litellm_params.mode,
         default_on=litellm_params.default_on,

--- a/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
@@ -22,9 +22,10 @@ from litellm.types.utils import GenericGuardrailAPIInputs
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+    from litellm.types.guardrails import LitellmParams
     from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
 
-GUARDRAIL_TIMEOUT: Final = 5
+DEFAULT_GUARDRAIL_TIMEOUT: Final = 5.0
 
 
 class ZscalerAIGuard(CustomGuardrail):
@@ -43,6 +44,7 @@ class ZscalerAIGuard(CustomGuardrail):
         send_user_api_key_alias: bool | None = None,
         send_user_api_key_user_id: bool | None = None,
         send_user_api_key_team_id: bool | None = None,
+        timeout: float | None = None,
         **kwargs,
     ):
         kwargs.setdefault("supported_event_hooks", list(self.get_supported_event_hooks()))
@@ -68,6 +70,7 @@ class ZscalerAIGuard(CustomGuardrail):
             if send_user_api_key_team_id is not None
             else os.getenv("SEND_USER_API_KEY_TEAM_ID", "False").lower() in ("true", "1")
         )
+        self.timeout = self._resolve_timeout(timeout)
 
         verbose_proxy_logger.debug(
             "send_user_api_key_alias: %s, \n            send_user_api_key_user_id:%s, \n            send_user_api_key_team_id:%s",
@@ -79,6 +82,29 @@ class ZscalerAIGuard(CustomGuardrail):
         super().__init__(**kwargs)
 
         verbose_proxy_logger.debug("ZscalerAIGuard Initializing ...")
+
+    @staticmethod
+    def _resolve_timeout(timeout: float | None) -> float:
+        """
+        Resolve the effective per-request timeout, falling back to the default
+        when it is unset or non-positive.
+        """
+        if timeout is None:
+            return DEFAULT_GUARDRAIL_TIMEOUT
+
+        if timeout <= 0:
+            verbose_proxy_logger.warning(
+                "Ignoring non-positive Zscaler AI Guard timeout %s, using %s seconds",
+                timeout,
+                DEFAULT_GUARDRAIL_TIMEOUT,
+            )
+            return DEFAULT_GUARDRAIL_TIMEOUT
+
+        return timeout
+
+    def update_in_memory_litellm_params(self, litellm_params: "LitellmParams") -> None:
+        super().update_in_memory_litellm_params(litellm_params)
+        self.timeout = self._resolve_timeout(litellm_params.timeout)
 
     @staticmethod
     def _resolve_metadata_value(request_data: dict | None, key: str) -> str | None:
@@ -267,7 +293,7 @@ class ZscalerAIGuard(CustomGuardrail):
             f"{url}",
             headers=headers,
             json=data,
-            timeout=GUARDRAIL_TIMEOUT,
+            timeout=self.timeout,
         )
         response.raise_for_status()
         return response

--- a/litellm/types/proxy/guardrails/guardrail_hooks/zscaler_ai_guard.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/zscaler_ai_guard.py
@@ -79,6 +79,15 @@ class ZscalerAIGuardConfigModel(GuardrailConfigModel):
         json_schema_extra={"ui_type": GuardrailParamUITypes.BOOL},
     )
 
+    timeout: float | None = Field(
+        default=None,
+        description=(
+            "Timeout for each Zscaler AI Guard API call, in seconds. Must be positive. "
+            "Raise it if scans fail under load with 'Connection timed out'. "
+            "Defaults to 5 seconds."
+        ),
+    )
+
     @model_validator(mode="after")
     def validate_endpoint_configuration(self) -> "ZscalerAIGuardConfigModel":
         """

--- a/tests/guardrails_tests/test_zscaler_ai_guard.py
+++ b/tests/guardrails_tests/test_zscaler_ai_guard.py
@@ -396,3 +396,122 @@ async def test_apply_guardrail_block_does_not_log_error(mock_api_call):
         mock_logger.error.assert_not_called()
 
     assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_send_request_uses_default_timeout_when_unconfigured():
+    """
+    Regression: unconfigured guardrails must keep the historical 5s timeout.
+    """
+    guardrail = ZscalerAIGuard(api_key="test_key", policy_id=1)
+
+    assert guardrail.timeout == 5.0
+
+    with patch(
+        "litellm.proxy.guardrails.guardrail_hooks.zscaler_ai_guard.zscaler_ai_guard.get_async_httpx_client"
+    ) as mock_get_client:
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=Mock(status_code=200))
+        mock_get_client.return_value = mock_client
+
+        await guardrail._send_request("http://example.com", {}, {})
+
+    assert mock_client.post.call_args.kwargs["timeout"] == 5.0
+
+
+@pytest.mark.asyncio
+async def test_send_request_uses_configured_timeout():
+    """
+    Regression for LIT-5222: a configured timeout must reach the HTTP call.
+
+    Before the fix _send_request passed a module-level constant, so a slow
+    upstream failed at 5s with `Timeout passed=5` no matter what was configured.
+    """
+    guardrail = ZscalerAIGuard(api_key="test_key", policy_id=1, timeout=30)
+
+    assert guardrail.timeout == 30
+
+    with patch(
+        "litellm.proxy.guardrails.guardrail_hooks.zscaler_ai_guard.zscaler_ai_guard.get_async_httpx_client"
+    ) as mock_get_client:
+        mock_client = Mock()
+        mock_client.post = AsyncMock(return_value=Mock(status_code=200))
+        mock_get_client.return_value = mock_client
+
+        await guardrail._send_request("http://example.com", {}, {})
+
+    assert mock_client.post.call_args.kwargs["timeout"] == 30
+
+
+def test_initialize_guardrail_forwards_configured_timeout():
+    """
+    Regression for LIT-5222: the `timeout` key from config.yaml must survive
+    initialization. It reaches LitellmParams already, but the initializer used
+    to drop it before it could reach the guardrail instance.
+    """
+    from litellm.proxy.guardrails.guardrail_hooks.zscaler_ai_guard import (
+        initialize_guardrail,
+    )
+    from litellm.types.guardrails import LitellmParams
+
+    litellm_params = LitellmParams(
+        guardrail="zscaler_ai_guard",
+        mode="pre_call",
+        api_key="test_key",
+        api_base="http://example.com",
+        policy_id=1,
+        timeout="30",
+    )
+
+    guardrail = initialize_guardrail(
+        litellm_params, {"guardrail_name": "zscaler-configured-timeout"}
+    )
+
+    assert guardrail.timeout == 30.0
+
+
+def test_config_model_exposes_timeout_to_dashboard():
+    """
+    The dashboard guardrail form is built from get_config_model(), so the field
+    has to be declared there for the setting to be reachable outside config.yaml.
+    """
+    config_model = ZscalerAIGuard.get_config_model()
+
+    assert config_model is not None
+    assert "timeout" in config_model.model_fields
+
+
+@pytest.mark.parametrize("bad_timeout", [0, -1])
+def test_non_positive_timeout_falls_back_to_default(bad_timeout):
+    """
+    Regression: httpx rejects a negative timeout and treats 0 as "fail
+    immediately", so a non-positive value would break every scan instead of
+    relaxing the limit the operator was trying to raise.
+    """
+    guardrail = ZscalerAIGuard(api_key="test_key", policy_id=1, timeout=bad_timeout)
+
+    assert guardrail.timeout == 5.0
+
+
+def test_update_in_memory_litellm_params_keeps_timeout_resolved():
+    """
+    Regression: the base implementation copies every LitellmParams attribute
+    onto the guardrail, so an unset timeout would overwrite the resolved value
+    with None and silently fall back to the shared client's 600s default.
+    """
+    from litellm.types.guardrails import LitellmParams
+
+    guardrail = ZscalerAIGuard(api_key="test_key", policy_id=1, timeout=30)
+    assert guardrail.timeout == 30
+
+    guardrail.update_in_memory_litellm_params(
+        LitellmParams(guardrail="zscaler_ai_guard", mode="pre_call", api_key="test_key")
+    )
+    assert guardrail.timeout == 5.0
+
+    guardrail.update_in_memory_litellm_params(
+        LitellmParams(
+            guardrail="zscaler_ai_guard", mode="pre_call", api_key="test_key", timeout=45
+        )
+    )
+    assert guardrail.timeout == 45.0


### PR DESCRIPTION
## TLDR

Problem this solves:

- The Zscaler AI Guard hook hardcoded a 5 second timeout, so a customer seeing scans fail under load had no way to raise it
- `timeout` already exists as a shared guardrail param on `BaseLitellmParams`, documented as "each guardrail handler chooses its own default when unset", but this handler dropped it on the floor. Setting it in `config.yaml` parsed fine and then changed nothing, which is worse than the knob not existing
- The value is passed to httpx as a scalar, so it governs connect, read, write and pool waits alike. Under load the pool-wait leg is the one that blows the 5 second budget, which is why raising it matters

How it solves it:

- `initialize_guardrail` forwards `litellm_params.timeout` into the guardrail, and `_send_request` sends `self.timeout` instead of the module constant
- Unset stays at 5 seconds, so existing deployments are untouched
- A non-positive timeout falls back to the default and logs a warning, since httpx rejects a negative value and treats 0 as "give up immediately". Both would have broken every scan rather than relaxing the limit the operator was trying to raise
- The field is declared on the config model so the dashboard guardrail form renders it, rather than leaving it reachable only from `config.yaml`

## Relevant issues

## Linear ticket

Resolves LIT-5222

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on `127.0.0.1:20222` with real Postgres and a real Gemini call behind the guardrail. We have no Zscaler AI Guard account, so the detection API is stood in for by a local HTTP server that sleeps 8 seconds and then returns the real ALLOW response shape. That reproduces the one property the ticket is about, an upstream slower than the guardrail's timeout. Everything else in the path is unmodified: the proxy, the guardrail hook, litellm's HTTP handler, and the downstream LLM call.

Four guardrails, identical except for `timeout`:

```yaml
guardrails:
  - guardrail_name: "zscaler-default"          # no timeout key
  - guardrail_name: "zscaler-slow-upstream"    # timeout: 30
  - guardrail_name: "zscaler-string-timeout"   # timeout: "15"
  - guardrail_name: "zscaler-zero-timeout"     # timeout: 0
```

Before, on `litellm_internal_staging`. The guardrail is configured with `timeout: 30` and still gives up at 5 seconds:

```
$ curl -sS -w "\nHTTP %{http_code} in %{time_total}s\n" http://127.0.0.1:20222/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"gemini-flash","messages":[{"role":"user","content":"Say OK"}],"guardrails":["zscaler-slow-upstream"]}'

{"error":{"message":"{\"error_type\": \"Zscaler AI Guard Error\", \"reason\": \"litellm.Timeout: Connection timed out. Timeout passed=5, time taken=5.002 seconds\", \"guardrail_name\": \"zscaler-slow-upstream\", \"guardrail_mode\": \"pre_call\"}", ... "code":"500"}}
HTTP 500 in 5.044228s
```

That `Timeout passed=5` is byte-for-byte the error from the report.

After, same rig, same requests:

```
$ for g in zscaler-zero-timeout zscaler-string-timeout zscaler-default zscaler-slow-upstream; do
    printf '%-26s ' "$g"
    curl -sS -o /tmp/body -w "HTTP %{http_code} in %{time_total}s" http://127.0.0.1:20222/v1/chat/completions \
      -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
      -d "{\"model\":\"gemini-flash\",\"messages\":[{\"role\":\"user\",\"content\":\"Say OK\"}],\"guardrails\":[\"$g\"]}"
    echo; grep -o 'Timeout passed=[0-9.]*' /tmp/body | head -1
    sleep 9
  done

zscaler-zero-timeout       HTTP 500 in 5.052592s
Timeout passed=5.0
zscaler-string-timeout     HTTP 200 in 8.492990s
zscaler-default            HTTP 500 in 5.041062s
Timeout passed=5.0
zscaler-slow-upstream      HTTP 200 in 8.496628s
```

The 8 second scan now completes when a longer timeout is configured, a numeric string is coerced and honored, an unconfigured guardrail still cuts off at 5 seconds, and `timeout: 0` falls back to the default with a warning in the proxy log rather than failing every request. Control call with no guardrail is `HTTP 200 in 0.58s`, so the roughly 8.5 seconds is the stubbed scan plus the real LLM call.

The dashboard form is generated from the config model, so declaring the field is what makes it reachable outside `config.yaml`:

```
$ curl -sS http://127.0.0.1:20222/guardrails/ui/provider_specific_params \
    -H "Authorization: Bearer sk-1234" | jq '.zscaler_ai_guard.timeout'

{
  "description": "Timeout for each Zscaler AI Guard API call, in seconds. Must be positive. Raise it if scans fail under load with 'Connection timed out'. Defaults to 5 seconds.",
  "required": false,
  "type": "number"
}
```

To see it in the UI, go to http://127.0.0.1:20222/ui/?page=guardrails, click "Add Guardrail", pick "Zscaler AI Guard" as the provider, and the Timeout field appears alongside Policy ID. Setting it there writes the same `timeout` key this PR reads.

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/__init__.py` forwards `litellm_params.timeout` into the constructor. Without this one line the config key is parsed and then discarded, since the initializer enumerates constructor arguments rather than passing params through.

`litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py` takes a `timeout` argument, resolves it through `_resolve_timeout`, and sends `self.timeout` on the API call. The module constant is renamed `GUARDRAIL_TIMEOUT` to `DEFAULT_GUARDRAIL_TIMEOUT` because it is now a fallback rather than the only value, matching the name Akto already uses. `update_in_memory_litellm_params` is overridden because the base implementation copies every `LitellmParams` attribute onto the guardrail, so an unset `timeout` would otherwise overwrite the resolved value with `None` and silently fall back to the shared HTTP client's 600 second default. Presidio, Model Armor and the tool-permission guardrail override it for the same reason.

`litellm/types/proxy/guardrails/guardrail_hooks/zscaler_ai_guard.py` declares the field so `/guardrails/ui/provider_specific_params` advertises it to the dashboard. Note this is a different class from the same-named one in `litellm/types/guardrails.py` that is mixed into `LitellmParams`; the one changed here is never instantiated and is only read to build the UI schema, so it cannot affect validation for any guardrail. `LitellmParams.model_json_schema()["properties"]["timeout"]` is byte-identical before and after.

No `ZSCALER_AI_GUARD_TIMEOUT` env var, even though the other params in this module have env fallbacks. Timeout is per-guardrail-instance state and a process-wide env var could not be set differently for two Zscaler guardrails on the same proxy, whereas `timeout:` can. The other params take env fallbacks because they are credentials and endpoints, which genuinely are proxy-wide. Vigil Guard and Singulr already ship `timeout` as a config-only param.

## Behavior changes

Deployments that do not set `timeout` are unaffected, the default is still 5 seconds.

One user-visible string change on that default path: the constant is now a float, so the timeout error reads `Timeout passed=5.0` where it previously read `Timeout passed=5`. Every configured value was already coerced to float by `LitellmParams`, so keeping the default an int made the message format depend on whether the value came from config. Anything alerting on the literal `Timeout passed=5` needs updating.

`timeout: 0` and negative values now fall back to 5 seconds with a warning instead of being ignored outright. There is no prior behavior to preserve here, since before this PR the key was never read.

## QA runbook

Point a Zscaler AI Guard guardrail at an endpoint slower than 5 seconds and confirm the scan fails, then set `timeout: 30` in that guardrail's `litellm_params`, restart, and confirm the same request succeeds. Confirm a guardrail with no `timeout` key still cuts off at 5 seconds. Then add the same guardrail from the Admin UI guardrails page and confirm the Timeout field is present and persists.

Two pre-existing issues in this file were found and deliberately left alone, since neither is on the timeout path. `_send_request` calls `response.raise_for_status()` after `AsyncHTTPHandler.post` has already raised for status, which makes the 429 and 5xx branches in `_handle_response` unreachable. The HTTP client is also fetched with `httpxSpecialProvider.LoggingCallback`, so this guardrail shares a connection pool with the logging integrations rather than with its peers, which use the guardrail provider. Both are worth a follow-up ticket.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/36110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Zscaler guardrail HTTP timeout behavior; default remains 5s and only error text may show `5.0` instead of `5` when unset.
> 
> **Overview**
> **Zscaler AI Guard** now respects the shared guardrail `timeout` from `config.yaml`, the dashboard, and in-memory param updates instead of always using a hardcoded 5s limit on detection HTTP calls.
> 
> Initialization passes `litellm_params.timeout` into the hook; `_send_request` uses `self.timeout` (default **5.0** when unset). Non-positive values fall back to the default with a warning. `update_in_memory_litellm_params` re-resolves timeout so unset updates do not wipe the resolved value. The provider config model adds a `timeout` field for the admin UI. Tests cover defaults, configured values, initializer wiring, invalid timeouts, and param refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55b733677e808716fc10e25c8aeaea6185a4c4cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->