### PR TITLE
fix(ui): match auto-router preset models against wildcard-expanded model groups

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -636,8 +636,11 @@ describe("AddAutoRouterTab", () => {
       expect(labels).toEqual(["Anthropic Family", "OpenAI Family", "Custom Configuration"]);
     });
 
-    it("never lets a wildcard deployment satisfy a preset", async () => {
-      const wildcard = [{ model_name: "openai-wild", litellm_params: { model: "openai/*" } }];
+    it.each([
+      ["a wildcard group", "openai/*"],
+      ["a plain group over a wildcard underlying model", "openai-wild"],
+    ])("never lets %s satisfy a preset when the hub lists no expansions", async (_label, modelName) => {
+      const wildcard = [{ model_name: modelName, litellm_params: { model: "openai/*" } }];
       mockFetchAvailableModels.mockResolvedValue(groupsFor(wildcard));
       mockFetchAllModelDeployments.mockResolvedValue(wildcard);
 
@@ -648,6 +651,61 @@ describe("AddAutoRouterTab", () => {
         expect(optionByLabel("OpenAI Family")!.textContent).toContain("Missing:");
       });
       expect(isOptionDisabled(optionByLabel("OpenAI Family")!)).toBe(true);
+    });
+  });
+
+  describe("wildcard-matched presets", () => {
+    const WILDCARD_DEPLOYMENTS = [{ model_name: "someprovider/*", litellm_params: { model: "someprovider/*" } }];
+
+    const expandedGroupFor = (model: string): string => `someprovider/${model}`;
+
+    const EXPANDED_HUB_GROUPS: ModelGroup[] = [
+      { model_group: "someprovider/*", mode: "chat" },
+      ...[...new Set(getAllPresets().flatMap((preset) => [...getRequiredModelsInPreset(preset)]))].map((model) => ({
+        model_group: expandedGroupFor(model),
+        mode: "chat",
+      })),
+    ];
+
+    it("enables a preset whose models exist only as wildcard-expanded groups, labeling the match", async () => {
+      mockFetchAvailableModels.mockResolvedValue(EXPANDED_HUB_GROUPS);
+      mockFetchAllModelDeployments.mockResolvedValue(WILDCARD_DEPLOYMENTS);
+
+      renderWithProviders(<Harness />);
+      openTemplateDropdown();
+
+      await waitFor(() => {
+        expect(isOptionDisabled(optionByLabel("Anthropic Family")!)).toBe(false);
+      });
+      expect(optionByLabel("Anthropic Family")!.textContent).toContain("Matches your deployments");
+    });
+
+    it("prefills the expanded group names and submits them", async () => {
+      const user = userEvent.setup();
+      mockFetchAvailableModels.mockResolvedValue(EXPANDED_HUB_GROUPS);
+      mockFetchAllModelDeployments.mockResolvedValue(WILDCARD_DEPLOYMENTS);
+
+      renderWithProviders(<Harness />);
+      openTemplateDropdown();
+      await waitFor(() => {
+        expect(isOptionDisabled(optionByLabel("Anthropic Family")!)).toBe(false);
+      });
+      fireEvent.click(optionByLabel("Anthropic Family")!);
+
+      await user.type(screen.getByPlaceholderText(/smart_router/i), "wildcard-router");
+      await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+      await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+      expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0]).toMatchObject({
+        complexity_router_config: {
+          tiers: {
+            SIMPLE: ANTHROPIC_TIERS.SIMPLE.map(expandedGroupFor),
+            MEDIUM: ANTHROPIC_TIERS.MEDIUM.map(expandedGroupFor),
+            COMPLEX: ANTHROPIC_TIERS.COMPLEX.map(expandedGroupFor),
+            REASONING: ANTHROPIC_TIERS.REASONING.map(expandedGroupFor),
+          },
+        },
+      });
     });
   });
 });

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -191,6 +191,148 @@ describe("autorouter_presets", () => {
     );
   });
 
+  describe("wildcard deployment matching (expanded model groups)", () => {
+    const wildcardDeployment = (pattern: string) => ({ modelGroup: pattern, underlyingModels: [pattern] });
+
+    const simpleTierConfig = (presetModel: string) => ({
+      tiers: { SIMPLE: [presetModel], MEDIUM: [], COMPLEX: [], REASONING: [] },
+      classifier_type: "heuristic" as const,
+      session_affinity: false,
+    });
+
+    it("resolves a preset model to a group expanded from a wildcard deployment", () => {
+      const availability = buildModelAvailability(
+        ["anthropic/*", "anthropic/claude-opus-5", "bedrock/anthropic.claude-opus-5"],
+        [wildcardDeployment("anthropic/*")],
+      );
+      const config = simpleTierConfig("claude-opus-5");
+      expect(getMissingModels(config, availability)).toEqual([]);
+      expect(buildPresetPrefill(config, availability).complexityRouterConfig.tiers.SIMPLE).toEqual([
+        "anthropic/claude-opus-5",
+      ]);
+    });
+
+    it("normalizes an expanded group's namespaced own name the same way as a deployment's", () => {
+      const availability = buildModelAvailability(
+        ["bedrock/*", "bedrock/us.anthropic.claude-sonnet-5"],
+        [wildcardDeployment("bedrock/*")],
+      );
+      expect(getMissingModels(simpleTierConfig("claude-sonnet-5"), availability)).toEqual([]);
+    });
+
+    it("anchors a partial wildcard pattern and treats its dots literally", () => {
+      const availability = buildModelAvailability(
+        ["bedrock/us.anthropic.claude-opus-5", "bedrock/usXanthropic.claude-fable-5"],
+        [wildcardDeployment("bedrock/us.*")],
+      );
+      expect(getMissingModels(simpleTierConfig("claude-opus-5"), availability)).toEqual([]);
+      expect(getMissingModels(simpleTierConfig("claude-fable-5"), availability)).toEqual(["claude-fable-5"]);
+    });
+
+    it.each([
+      ["gpt-5.4", "openai/gpt-5.4-mini"],
+      ["gpt-5.4-mini", "openai/gpt-5.4"],
+      ["o3", "openai/o3-mini"],
+    ])("never lets %s be satisfied by the expanded group %s", (presetModel, expandedGroup) => {
+      const availability = buildModelAvailability(["openai/*", expandedGroup], [wildcardDeployment("openai/*")]);
+      expect(getMissingModels(simpleTierConfig(presetModel), availability)).toEqual([presetModel]);
+    });
+
+    it("anchors the pattern's suffix and keeps middle segments in order", () => {
+      const availability = buildModelAvailability(
+        ["bedrock/us.anthropic.claude-opus-5", "bedrock/anthropic.us.claude-sonnet-5"],
+        [wildcardDeployment("bedrock/*.anthropic.*")],
+      );
+      expect(getMissingModels(simpleTierConfig("claude-opus-5"), availability)).toEqual([]);
+      expect(getMissingModels(simpleTierConfig("claude-sonnet-5"), availability)).toEqual(["claude-sonnet-5"]);
+    });
+
+    it("matches a pathological many-star pattern in linear time instead of backtracking", () => {
+      const hostile = `prov/a*${"a*".repeat(30)}b`;
+      const nonMatching = `prov/${"a".repeat(120)}`;
+      const availability = buildModelAvailability([nonMatching], [wildcardDeployment(hostile)]);
+      expect(availability.underlyingIndex.size).toBe(0);
+    });
+
+    it("expands a bare-star model_name through its underlying wildcard, not as match-all", () => {
+      const availability = buildModelAvailability(
+        ["openai/gpt-5.4", "team-a/claude-opus-5"],
+        [{ modelGroup: "*", underlyingModels: ["openai/*"] }],
+      );
+      expect(getMissingModels(simpleTierConfig("gpt-5.4"), availability)).toEqual([]);
+      expect(getMissingModels(simpleTierConfig("claude-opus-5"), availability)).toEqual(["claude-opus-5"]);
+    });
+
+    it.each([
+      ["a bare-star underlying", "*"],
+      ["a non-wildcard underlying", "openai/gpt-4o"],
+      ["a slashless wildcard underlying", "gpt*"],
+    ])("derives no pattern from a bare-star model_name with %s", (_label, underlying) => {
+      const availability = buildModelAvailability(
+        ["openai/gpt-5.4"],
+        [{ modelGroup: "*", underlyingModels: [underlying] }],
+      );
+      expect(availability.underlyingIndex.size).toBe(0);
+    });
+
+    it("derives no pattern from a slashless wildcard model_name", () => {
+      const availability = buildModelAvailability(["gpt-5.4"], [wildcardDeployment("gpt*")]);
+      expect(availability.underlyingIndex.size).toBe(0);
+    });
+
+    it("does not trust a group's name when no wildcard deployment covers it", () => {
+      const availability = buildModelAvailability(
+        ["team-a/claude-opus-5", "openai/*"],
+        [wildcardDeployment("openai/*")],
+      );
+      expect(getMissingModels(simpleTierConfig("claude-opus-5"), availability)).toEqual(["claude-opus-5"]);
+    });
+
+    it("never resolves to the wildcard group itself when the hub lists no expansions", () => {
+      const availability = buildModelAvailability(["openai/*"], [wildcardDeployment("openai/*")]);
+      expect(getMissingModels(simpleTierConfig("gpt-5.4"), availability)).toEqual(["gpt-5.4"]);
+      expect(availability.underlyingIndex.size).toBe(0);
+    });
+
+    it("applies a wildcard deployment's pattern even when the wildcard group is not itself listed", () => {
+      const availability = buildModelAvailability(["anthropic/claude-opus-5"], [wildcardDeployment("anthropic/*")]);
+      expect(getMissingModels(simpleTierConfig("claude-opus-5"), availability)).toEqual([]);
+    });
+
+    it("keeps the groups-only availability strict even when expanded groups are listed", () => {
+      const availability = groupsOnly(["anthropic/*", "anthropic/claude-opus-5"]);
+      expect(getMissingModels(simpleTierConfig("claude-opus-5"), availability)).toEqual(["claude-opus-5"]);
+    });
+
+    it("prefers the alphabetically first covered group when several expansions serve the model", () => {
+      const availability = buildModelAvailability(
+        ["bedrock/us.anthropic.claude-opus-5", "anthropic/claude-opus-5", "bedrock/anthropic.claude-opus-5"],
+        [wildcardDeployment("anthropic/*"), wildcardDeployment("bedrock/*")],
+      );
+      const config = simpleTierConfig("claude-opus-5");
+      expect(buildPresetPrefill(config, availability).complexityRouterConfig.tiers.SIMPLE).toEqual([
+        "anthropic/claude-opus-5",
+      ]);
+    });
+
+    it.each(getAllPresets().map((preset) => [preset.key, preset] as const))(
+      "fully resolves the %s preset through wildcard-expanded groups only",
+      (_key, preset) => {
+        const required = [...getRequiredModelsInPreset(preset)];
+        const expandedGroups = required.map((model) => `someprovider/${model}`);
+        const availability = buildModelAvailability(
+          ["someprovider/*", ...expandedGroups],
+          [wildcardDeployment("someprovider/*")],
+        );
+        expect(getMissingModelsInPreset(preset, availability)).toEqual([]);
+        const prefilled = buildPresetPrefill(preset.complexity_router_config, availability);
+        const prefilledModels = Object.values(prefilled.complexityRouterConfig.tiers).flat();
+        expect(prefilledModels.length).toBeGreaterThan(0);
+        for (const model of prefilledModels) expect(expandedGroups).toContain(model);
+      },
+    );
+  });
+
   describe("deploymentRefsFromModelInfo", () => {
     it("keeps litellm_params.model and model_info.base_model, drops rows with neither or no name", () => {
       const refs = deploymentRefsFromModelInfo([

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.ts
@@ -77,12 +77,30 @@ const normalizeUnderlyingModel = (model: string): string | null => {
   return stripped.toLowerCase() || null;
 };
 
+// A linear glob scan rather than a RegExp: patterns are admin-controlled model_name values, and a
+// backtracking regex built from one ("a*a*a*...") can freeze another admin's dashboard.
+const matchesWildcard = (pattern: string, name: string): boolean => {
+  const parts = pattern.split("*");
+  if (parts.length === 1) return pattern === name;
+  const head = parts[0];
+  const tail = parts[parts.length - 1];
+  if (!name.startsWith(head) || !name.endsWith(tail)) return false;
+  if (name.length < head.length + tail.length) return false;
+  const scanEnd = name.length - tail.length;
+  const scanResult = parts.slice(1, -1).reduce((searchFrom: number, part: string) => {
+    if (searchFrom < 0) return -1;
+    const found = name.indexOf(part, searchFrom);
+    return found === -1 || found + part.length > scanEnd ? -1 : found + part.length;
+  }, head.length);
+  return scanResult >= 0;
+};
+
 export const buildModelAvailability = (
   modelGroups: Iterable<string>,
   deployments: readonly DeploymentModelRef[],
 ): ModelAvailability => {
   const groups = new Set(modelGroups);
-  const entries = deployments
+  const literalEntries = deployments
     .filter((deployment) => groups.has(deployment.modelGroup))
     .flatMap((deployment) =>
       deployment.underlyingModels
@@ -90,6 +108,22 @@ export const buildModelAvailability = (
         .filter((key): key is string => key !== null)
         .map((key) => ({ key, modelGroup: deployment.modelGroup })),
     );
+  // Mirrors get_known_models_from_wildcard: a bare "*" model_name expands via its underlying
+  // wildcard (or not at all), and a wildcard without a "/" expands to nothing.
+  const wildcardPatterns = Array.from(
+    new Set(
+      deployments
+        .flatMap((deployment) =>
+          deployment.modelGroup === "*" ? deployment.underlyingModels : [deployment.modelGroup],
+        )
+        .filter((pattern) => pattern !== "*" && pattern.includes("*") && pattern.includes("/")),
+    ),
+  );
+  const wildcardEntries = Array.from(groups)
+    .filter((group) => !group.includes("*") && wildcardPatterns.some((pattern) => matchesWildcard(pattern, group)))
+    .map((group) => ({ key: normalizeUnderlyingModel(group), modelGroup: group }))
+    .filter((entry): entry is { key: string; modelGroup: string } => entry.key !== null);
+  const entries = [...literalEntries, ...wildcardEntries];
   const grouped = new Map<string, Set<string>>();
   for (const entry of entries) {
     const groupsForKey = grouped.get(entry.key) ?? new Set<string>();


### PR DESCRIPTION
## TLDR

Problem this solves:

- An admin whose models are wildcard deployments (`anthropic/*`, `openai/*`, `bedrock/*`) opens Add Auto Router and both family templates are greyed out with "Missing: claude-opus-5, claude-sonnet-5, ..." even though the tier picker right below offers `anthropic/claude-opus-5` and friends
- The template check and the tier dropdown read different model universes: the dropdown uses `/model_group/info`, which expands wildcards into concrete groups, while the availability check resolves against `/v2/model/info` deployments, which keep wildcard rows verbatim, and `normalizeUnderlyingModel` drops anything containing `*`

How it solves it:

- `buildModelAvailability` now collects the wildcard patterns from deployments' `model_name`s and indexes every concrete, user-visible model group a pattern covers under its normalized own name, merged into the existing underlying-model index
- A preset model like `claude-opus-5` then resolves to `anthropic/claude-opus-5` exactly like a renamed deployment already did, prefills that group name on apply, and gets the same "Matches your deployments" label
- Submit validation is untouched: it builds availability with no deployments, so it stays exact-group-name strict, and a bare preset name that the pattern router cannot route still blocks submit

## Relevant issues

- Auto-router preset templates report their models missing when the models are only reachable through wildcard deployments
- Follow-up to #35972, which added deployment matching for renamed literal deployments but left wildcards unmatched
- UI only; no backend or API change

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live rig: proxy from this branch on `localhost:4000` with a fresh Postgres and a config of three models mirroring the report (`anthropic/*`, `openai/*`, one bedrock alias), dashboard dev server on `localhost:3100`.

The two endpoints disagree on the same proxy, which is the whole bug:

```
curl -s http://localhost:4000/model_group/info -H "Authorization: Bearer sk-1234" \
  | jq '[.data[].model_group | select(test("opus-5|sonnet-5"))]'
```

```json
["anthropic/claude-opus-5", "anthropic/claude-sonnet-5"]
```

```
curl -s http://localhost:4000/v2/model/info -H "Authorization: Bearer sk-1234" \
  | jq '[.data[] | {model_name, model: .litellm_params.model}]'
```

```json
[
  {"model_name": "anthropic/*", "model": "anthropic/*"},
  {"model_name": "openai/*", "model": "openai/*"},
  {"model_name": "claude-code-opus-4-7-invoke", "model": "bedrock/global.anthropic.claude-opus-4-7-20250115-v1:0"}
]
```

Before (this branch minus this commit): Models + Endpoints -> Auto-Routers -> Add Auto Router -> Template dropdown shows both templates disabled, "Missing: claude-fable-5, claude-haiku-4-5, claude-opus-5, claude-sonnet-5" and "Missing: gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, o3", while the Simple tier picker in the same dialog offers `anthropic/claude-opus-5`.

After (this commit, same rig, same clicks): both templates are enabled and show the green "Matches your deployments" hint; applying Anthropic Family prefills the tiers with the expanded group names.

Screenshots to be attached below.

## Type

🐛 Bug Fix

## Changes

- `buildModelAvailability` gains wildcard support: patterns from wildcard `model_name`s are matched (anchored, `*`-only wildcard, all other regex chars escaped) against the caller-visible model groups, and each covered group is indexed by `normalizeUnderlyingModel` of its own name
- Resolution precedence, tie-breaks, prefill rewriting, and the strict groups-only availability used by submit validation are all unchanged
- Unit tests pin the new matching, the whole-name trap (`gpt-5.4` never satisfied by `openai/gpt-5.4-mini`), pattern anchoring and dot escaping, the untrusted-alias case (a group named `team-a/claude-opus-5` with no covering wildcard stays missing), and groups-only strictness
- Tab tests: a wildcard deployment with expanded hub groups enables the preset, labels it "Matches your deployments", and submits the expanded names; a wildcard with no expansions in the hub still disables the preset

## QA runbook

1. Run a proxy whose `model_list` has wildcard entries, e.g. `model_name: anthropic/*` with `model: anthropic/*` (and no literal `claude-*` groups), plus the dashboard from this branch
2. Go to Models + Endpoints -> Auto-Routers -> Add Auto Router and open the Template dropdown: Anthropic Family and OpenAI Family are selectable and show "Matches your deployments" instead of red "Missing: ..." text
3. Select Anthropic Family: Detailed Configuration expands and the four tiers are prefilled with `anthropic/claude-haiku-4-5`, `anthropic/claude-sonnet-5`, `anthropic/claude-opus-5`, `anthropic/claude-fable-5`
4. Name the router and click Add Auto Router: it is created, and the tier models are the expanded group names the tier dropdown itself offers
5. Negative check: on a proxy with no wildcard and no claude models, the templates stay disabled with the same "Missing" text as before

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only preset availability logic with broad tests; submit validation path unchanged and remains exact-group strict.
> 
> **Overview**
> **Auto-router family templates** were incorrectly marked missing when models only appeared as concrete groups expanded from wildcard deployments (`anthropic/*`, etc.), because availability used deployment rows verbatim while the tier picker used expanded hub groups.
> 
> `buildModelAvailability` now derives wildcard patterns from deployment `model_name`s (including bare `*` via underlying wildcards), matches them against visible model groups with a **linear `*` glob** (avoiding regex backtracking on admin-controlled patterns), and indexes each covered group under the same normalized keys used for renamed deployments. Presets can enable with **"Matches your deployments"**, prefill expanded group names, and submit those names; **groups-only** submit validation stays strict.
> 
> Tests extend unit coverage (anchoring, near-miss models, untrusted aliases, hostile patterns) and Add Auto Router tab flows for wildcard-expanded presets vs hub-without-expansions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a91b95e03c6d9f13aec107805cae208ae13d4a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->