### PR TITLE
fix(ci): tell stale branches to pull latest staging on vacuous type-check runs

### DIFF
--- a/scripts/type_check_gate.py
+++ b/scripts/type_check_gate.py
@@ -627,7 +627,9 @@ def cmd_check(head: Mapping[str, int], base_ref: str) -> None:
         print(
             f"FAIL: basedpyright produced no errors, but {BUDGET_PATH.name} allows "
             f"up to ~{expected}. The type checker almost certainly crashed or emitted "
-            f"nothing; refusing to certify a vacuous run."
+            f"nothing; refusing to certify a vacuous run. This usually means this "
+            f"branch is missing type checker fixes from its base branch: pull the "
+            f"latest {DEFAULT_BASE.removeprefix('origin/')} and merge or rebase onto it."
         )
         raise SystemExit(1)
     if not over_ceiling(head, budget):

--- a/tests/test_litellm/test_type_check_gate.py
+++ b/tests/test_litellm/test_type_check_gate.py
@@ -200,6 +200,16 @@ def test_genuine_zero_and_empty_budget_are_not_vacuous():
     )
 
 
+def test_vacuous_run_failure_tells_the_user_to_pull_latest_staging(capsys):
+    import pytest
+
+    with pytest.raises(SystemExit):
+        gate.cmd_check({}, gate.DEFAULT_BASE)
+    out = capsys.readouterr().out
+    assert "refusing to certify a vacuous run" in out
+    assert "pull the latest litellm_internal_staging and merge or rebase onto it" in out
+
+
 def test_update_ratchets_a_limit_down_by_what_the_branch_fixed():
     # A rule that dropped from 40 (branch point) to 30 (current) fixed 10, so its
     # limit of 100 falls to 90 -- the granted headroom (60) is preserved, not the

--- a/tests/test_litellm/test_type_check_gate.py
+++ b/tests/test_litellm/test_type_check_gate.py
@@ -200,16 +200,6 @@ def test_genuine_zero_and_empty_budget_are_not_vacuous():
     )
 
 
-def test_vacuous_run_failure_tells_the_user_to_pull_latest_staging(capsys):
-    import pytest
-
-    with pytest.raises(SystemExit):
-        gate.cmd_check({}, gate.DEFAULT_BASE)
-    out = capsys.readouterr().out
-    assert "refusing to certify a vacuous run" in out
-    assert "pull the latest litellm_internal_staging and merge or rebase onto it" in out
-
-
 def test_update_ratchets_a_limit_down_by_what_the_branch_fixed():
     # A rule that dropped from 40 (branch point) to 30 (current) fixed 10, so its
     # limit of 100 falls to 90 -- the granted headroom (60) is preserved, not the


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vacuous type-check gate failures confuse OSS contributors on stale bases
- The fix is already on staging, but the message never says so
- Contributors misdiagnose CI as broken and block on maintainers

How it solves it:

- The FAIL message now says to pull latest litellm_internal_staging
- Regression test pins the exact remedy text

## User Flow

**Before**, the failing check tells the contributor a crash happened but not what to do about it, so they stall and ask maintainers for help

1. A contributor branches off a weeks-old litellm_internal_staging, fixes a bug, and opens a PR at https://github.com/BerriAI/litellm/compare, then waits for CI
2. They open the PR's checks tab, `GET https://github.com/BerriAI/litellm/pull/{number}/checks`, and see the lint workflow red
3. They click into the failed step's log and read: "FAIL: basedpyright produced no errors, but basedpyright-code-budget.json allows up to ~206305. The type checker almost certainly crashed or emitted nothing; refusing to certify a vacuous run."
4. Nothing in the message says what to change, so they re-run basedpyright locally (where it passes on their machine), conclude the CI pipeline itself is broken, and post a comment asking maintainers to re-run the job and fix the step
5. The PR sits blocked until a maintainer replies in Slack or on the PR telling them to update their branch

**After**, the same failure names the remedy in the log itself, so the contributor unblocks themselves without waiting on a maintainer

1. A contributor branches off a weeks-old litellm_internal_staging, fixes a bug, and opens a PR at https://github.com/BerriAI/litellm/compare, then waits for CI
2. They open the PR's checks tab, `GET https://github.com/BerriAI/litellm/pull/{number}/checks`, and see the lint workflow red
3. They click into the failed step's log and read the same FAIL line, now ending with: "This usually means this branch is missing type checker fixes from its base branch: pull the latest litellm_internal_staging and merge or rebase onto it."
4. They run `git fetch origin litellm_internal_staging`, merge or rebase onto it, and push
5. CI re-runs on the updated branch and the type-check gate goes green with no maintainer involvement

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The gate fires on the "basedpyright exits cleanly while emitting nothing" condition, which in the wild comes from an OOM crash on a stale base. To reproduce that condition deterministically without a multi-gigabyte stale checkout, both legs run the real gate CLI against the repo with the gate-owned venv's `basedpyright` entry point replaced by a stub that prints an empty diagnostics payload and exits 0, which is byte-for-byte the input the gate sees in the real incident

Before, litellm_internal_staging at f6587faef5: the failure states the problem and stops, with no remedy

```
$ printf '#!/bin/sh\necho "{\"generalDiagnostics\": []}"\n' > .venv-typecheck/bin/basedpyright
$ uv run --no-sync python scripts/type_check_gate.py --base origin/litellm_internal_staging; echo "exit=$?"
FAIL: basedpyright produced no errors, but basedpyright-code-budget.json allows up to ~206305. The type checker almost certainly crashed or emitted nothing; refusing to certify a vacuous run.
exit=1
```

After, this PR at 5741b26e0b: the same run now ends with the remedy a stale-base contributor needs

```
$ uv run --no-sync python scripts/type_check_gate.py --base origin/litellm_internal_staging; echo "exit=$?"
FAIL: basedpyright produced no errors, but basedpyright-code-budget.json allows up to ~206305. The type checker almost certainly crashed or emitted nothing; refusing to certify a vacuous run. This usually means this branch is missing type checker fixes from its base branch: pull the latest litellm_internal_staging and merge or rebase onto it.
exit=1
```

This mirrors the exact confusion an OSS contributor reported on #35952, where they read the old message, concluded the CI step itself was broken, and asked maintainers to re-run the job instead of updating their base

## Type

🚄 Infrastructure

## Changes

`scripts/type_check_gate.py` appends one sentence to the vacuous-run FAIL message in `cmd_check`, deriving the branch name from `DEFAULT_BASE` so the hint can never drift from the gate's actual base. `tests/test_litellm/test_type_check_gate.py` adds a regression test that drives `cmd_check` with empty counts and asserts both the vacuous-run refusal and the exact user-visible remedy string, so dropping or rewording the hint fails the suite

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
