### PR TITLE
feat(proxy): add experimental LiteLLM Headroom gateway

### DIFF
--- a/litellm/proxy/experimental_codex_gateway/README.md
+++ b/litellm/proxy/experimental_codex_gateway/README.md
@@ -1,0 +1,103 @@
+# Experimental Codex Gateway for Headroom
+
+This gateway adds an opt-in LiteLLM experiment layer in front of an existing local Headroom proxy:
+
+```text
+Codex CLI -> LiteLLM on 127.0.0.1:4000 -> Headroom on 127.0.0.1:8787 -> ChatGPT Codex endpoint
+```
+
+The direct Codex-to-Headroom configuration remains the default and rollback path. Headroom remains responsible for
+OAuth routing, selecting the final ChatGPT endpoint, and context compression. The gateway does not route directly to
+OpenAI, refresh or cache OAuth credentials, retry authentication failures, rewrite rate limits, or compress requests.
+
+This experiment is based on LiteLLM PR #34678 at commit
+`01cf5748d6e7feb27c62af5f404fd379ff81d3f3`, whose parent is
+`998a372417654f5ec18554e17b8cbe1854d9c683`.
+
+## Start the chain
+
+Start Headroom first:
+
+```bash
+/home/neil-king/.local/bin/headroom proxy --port 8787
+```
+
+Set a separate random local gateway key. Do not reuse or place the ChatGPT OAuth bearer in this variable:
+
+```bash
+export LOCAL_CODEX_GATEWAY_KEY='<local-random-value>'
+export HEADROOM_BASE_URL='http://127.0.0.1:8787/v1'
+uv run litellm-codex-gateway
+```
+
+The gateway binds to `127.0.0.1:4000` by default. `CODEX_GATEWAY_HOST` accepts only `127.0.0.1`, `::1`, or
+`localhost`. `HEADROOM_BASE_URL` must also resolve syntactically to a loopback address.
+
+Add this opt-in provider to `~/.codex/config.toml` without changing the active default:
+
+```toml
+[model_providers.litellm_headroom]
+name = "LiteLLM via Headroom"
+base_url = "http://127.0.0.1:4000/v1"
+wire_api = "responses"
+requires_openai_auth = true
+supports_websockets = false
+env_http_headers = { "x-litellm-api-key" = "LOCAL_CODEX_GATEWAY_KEY" }
+```
+
+Codex 0.134.0 and later loads named profiles from separate files. Create
+`~/.codex/litellm_headroom.config.toml` with:
+
+```toml
+model_provider = "litellm_headroom"
+```
+
+Run only experimental sessions through the chain:
+
+```bash
+codex --profile litellm_headroom
+```
+
+Run `codex` without that profile to use the existing direct Headroom path.
+
+## Operational endpoints
+
+- `GET /healthz` returns a content-free local process health response
+- `GET /readyz` probes Headroom's `/livez` endpoint without forwarding credentials
+- `GET /metrics` requires `x-litellm-api-key`
+- `GET /debug/traces/{trace_id}/export` requires `x-litellm-api-key`
+- `/v1/responses` and its subpaths support HTTP and SSE passthrough
+
+WebSocket passthrough is intentionally disabled. Keep `supports_websockets = false` until the Codex handshake has been
+captured safely and a separate transport-completeness milestone is implemented.
+
+## Capture
+
+Capture is disabled by default. Enable it only for a bounded local experiment:
+
+```bash
+export CODEX_GATEWAY_CAPTURE=true
+```
+
+Optional controls are `CODEX_GATEWAY_TRACE_DIR`, `CODEX_GATEWAY_MAX_TRACE_BYTES`,
+`CODEX_GATEWAY_MAX_TRACE_STORAGE_BYTES`, and `CODEX_GATEWAY_TRACE_RETENTION_SECONDS`. Defaults are 10 MiB per trace,
+100 MiB total, and seven days. Trace directories and files are restricted to owner access. Requests and responses that
+exceed their capture budget omit content at the truncation boundary rather than storing partial secrets.
+
+Capture and storage failures do not change the request sent to Headroom. Redaction is defense in depth, not permission
+to retain sensitive production traffic. Keep capture off unless the resulting artifacts are required, inspect exports
+before sharing them, and delete them according to the experiment's data-handling policy.
+
+## Environment reference
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `LOCAL_CODEX_GATEWAY_KEY` | required | Separate local LiteLLM authentication key |
+| `HEADROOM_BASE_URL` | `http://127.0.0.1:8787/v1` | Exclusive downstream API base |
+| `HEADROOM_READINESS_PATH` | `/livez` | Credential-free readiness path |
+| `CODEX_GATEWAY_HOST` | `127.0.0.1` | Loopback gateway bind address |
+| `CODEX_GATEWAY_PORT` | `4000` | Gateway port |
+| `CODEX_GATEWAY_CAPTURE` | off | Enables bounded redacted trace capture |
+
+Do not set an OpenAI API key for this flow. The ChatGPT OAuth bearer supplied by Codex is preserved for Headroom, while
+the local LiteLLM key, cookies, host, caller content length, and hop-by-hop headers are removed before forwarding.

--- a/litellm/proxy/experimental_codex_gateway/__init__.py
+++ b/litellm/proxy/experimental_codex_gateway/__init__.py
@@ -1,0 +1,4 @@
+from litellm.proxy.experimental_codex_gateway.app import create_gateway_app
+from litellm.proxy.experimental_codex_gateway.settings import GatewaySettings
+
+__all__ = ("GatewaySettings", "create_gateway_app")

--- a/litellm/proxy/experimental_codex_gateway/app.py
+++ b/litellm/proxy/experimental_codex_gateway/app.py
@@ -1,0 +1,268 @@
+import hmac
+import os
+import time
+from dataclasses import dataclass
+from typing import Protocol
+from urllib.parse import unquote
+
+from asgiref.typing import (
+    ASGI3Application,
+    ASGIReceiveCallable,
+    ASGIReceiveEvent,
+    ASGISendCallable,
+    ASGISendEvent,
+    HTTPDisconnectEvent,
+    HTTPRequestEvent,
+    HTTPResponseBodyEvent,
+    HTTPResponseStartEvent,
+    HTTPScope,
+    Scope,
+    WebSocketCloseEvent,
+)
+from httpx import AsyncClient, HTTPError
+from pydantic import TypeAdapter
+
+from litellm.proxy.experimental_codex_gateway.capture import TraceRecorder, TraceStore
+from litellm.proxy.experimental_codex_gateway.metrics import GatewayMetrics
+from litellm.proxy.experimental_codex_gateway.pipeline import InspectionStage, RequestPipeline, StageOutcome
+from litellm.proxy.experimental_codex_gateway.settings import GatewaySettings
+
+_PUBLIC_RESPONSES_PATH = "/v1/responses"
+_INTERNAL_RESPONSES_PATH = "/chatgpt/responses"
+_ASGI_APP_ADAPTER: TypeAdapter[ASGI3Application] = TypeAdapter(ASGI3Application)
+
+
+def map_responses_path(path: str, raw_path: bytes | None = None) -> str | None:
+    if path != _PUBLIC_RESPONSES_PATH and not path.startswith(f"{_PUBLIC_RESPONSES_PATH}/"):
+        return None
+    decoded_path = unquote((raw_path or path.encode()).decode("latin-1"))
+    suffix = path[len(_PUBLIC_RESPONSES_PATH) :]
+    decoded_suffix = decoded_path[len(_PUBLIC_RESPONSES_PATH) :]
+    segments = tuple(segment for segment in decoded_suffix.split("/") if segment)
+    if "\\" in decoded_suffix or any(segment in {".", ".."} for segment in segments):
+        return None
+    return f"{_INTERNAL_RESPONSES_PATH}{suffix}"
+
+
+def _headers(scope: HTTPScope) -> tuple[tuple[bytes, bytes], ...]:
+    return tuple(scope["headers"])
+
+
+def _header(scope: HTTPScope, name: bytes) -> str | None:
+    return next((value.decode("latin-1") for key, value in _headers(scope) if key.lower() == name), None)
+
+
+async def _response(send: ASGISendCallable, status: int, body: bytes = b"", content_type: bytes | None = None) -> None:
+    headers = ((b"content-length", str(len(body)).encode()),)
+    resolved_headers = headers if content_type is None else (*headers, (b"content-type", content_type))
+    response_start = HTTPResponseStartEvent(
+        type="http.response.start", status=status, headers=resolved_headers, trailers=False
+    )
+    response_body = HTTPResponseBodyEvent(type="http.response.body", body=body, more_body=False)
+    await send(response_start)
+    await send(response_body)
+
+
+async def _read_request_body(receive: ASGIReceiveCallable) -> tuple[bytes, bool]:
+    chunks: tuple[bytes, ...] = ()
+    while True:
+        message = await receive()
+        if message["type"] == "http.disconnect":
+            return b"".join(chunks), True
+        if message["type"] != "http.request":
+            continue
+        chunks = (*chunks, message.get("body", b""))
+        if not message.get("more_body", False):
+            return b"".join(chunks), False
+
+
+class ReplayedReceive:
+    def __init__(self, body: bytes, disconnected: bool, receive: ASGIReceiveCallable) -> None:
+        self._body = body
+        self._disconnected = disconnected
+        self._receive = receive
+        self._sent = False
+
+    async def __call__(self) -> ASGIReceiveEvent:
+        if not self._sent:
+            self._sent = True
+            return HTTPRequestEvent(type="http.request", body=self._body, more_body=False)
+        if self._disconnected:
+            return HTTPDisconnectEvent(type="http.disconnect")
+        return await self._receive()
+
+
+class ReadinessProbe(Protocol):
+    async def reachable(self, url: str) -> bool: ...
+
+
+@dataclass(frozen=True, slots=True)
+class HttpReadinessProbe:
+    timeout_seconds: float = 2.0
+
+    async def reachable(self, url: str) -> bool:
+        try:
+            async with AsyncClient(timeout=self.timeout_seconds) as client:
+                await client.get(url, headers={"accept": "application/json"})
+        except HTTPError:
+            return False
+        return True
+
+
+class ResponseMonitor:
+    def __init__(self, started: float, recorder: TraceRecorder | None, send: ASGISendCallable) -> None:
+        self.status = 500
+        self.first_byte_seconds: float | None = None
+        self._started = started
+        self._recorder = recorder
+        self._send = send
+
+    async def __call__(self, message: ASGISendEvent) -> None:
+        if message["type"] == "http.response.start":
+            self.status = message["status"]
+            if self._recorder is not None:
+                self._recorder.response_start(self.status, tuple(message["headers"]))
+        if message["type"] == "http.response.body":
+            body = message["body"]
+            if body and self.first_byte_seconds is None:
+                self.first_byte_seconds = time.monotonic() - self._started
+            if self._recorder is not None:
+                self._recorder.response_body(body)
+        await self._send(message)
+
+
+class CodexGateway:
+    def __init__(
+        self,
+        inner_app: ASGI3Application,
+        settings: GatewaySettings,
+        pipeline: RequestPipeline,
+        metrics: GatewayMetrics,
+        trace_store: TraceStore,
+        readiness_probe: ReadinessProbe,
+    ) -> None:
+        self._inner_app = inner_app
+        self._settings = settings
+        self._pipeline = pipeline
+        self._metrics = metrics
+        self._trace_store = trace_store
+        self._readiness_probe = readiness_probe
+
+    def _authorized(self, scope: HTTPScope) -> bool:
+        supplied = _header(scope, b"x-litellm-api-key")
+        return supplied is not None and hmac.compare_digest(supplied, self._settings.local_key)
+
+    async def _operational_route(self, scope: HTTPScope, send: ASGISendCallable) -> bool:
+        path = scope["path"]
+        if path == "/healthz":
+            await _response(send, 204)
+            return True
+        if path == "/readyz":
+            ready = await self._readiness_probe.reachable(self._settings.readiness_url)
+            await _response(send, 204 if ready else 503)
+            return True
+        if path == "/metrics":
+            if not self._authorized(scope):
+                await _response(send, 401)
+                return True
+            await _response(send, 200, await self._metrics.render(), b"text/plain; version=0.0.4")
+            return True
+        prefix = "/debug/traces/"
+        suffix = "/export"
+        if path.startswith(prefix) and path.endswith(suffix):
+            if not self._authorized(scope):
+                await _response(send, 401)
+                return True
+            trace_id = path[len(prefix) : -len(suffix)].strip("/")
+            trace = self._trace_store.read(trace_id)
+            await _response(send, 404 if trace is None else 200, trace or b"", b"application/json")
+            return True
+        return False
+
+    async def __call__(self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        if scope["type"] == "websocket":
+            await send(WebSocketCloseEvent(type="websocket.close", code=4404, reason=""))
+            return
+        if scope["type"] != "http":
+            await self._inner_app(scope, receive, send)
+            return
+        if await self._operational_route(scope, send):
+            return
+        mapped_path = map_responses_path(scope["path"], scope["raw_path"])
+        if mapped_path is None:
+            await _response(send, 404)
+            return
+        original_body, disconnected = await _read_request_body(receive)
+        content_type = _header(scope, b"content-type") or ""
+        try:
+            pipeline_result = self._pipeline.process(original_body, content_type)
+        except Exception:  # noqa: BLE001  # extension stages must fail open on any implementation error
+            pipeline_result = RequestPipeline(()).process(original_body, content_type)
+            await self._metrics.record_fail_open()
+        if pipeline_result.outcome is StageOutcome.FAILED:
+            await self._metrics.record_fail_open()
+        rewritten_scope: HTTPScope = {**scope, "path": mapped_path, "raw_path": mapped_path.encode()}
+        recorder = (
+            TraceRecorder(
+                method=scope["method"],
+                path=scope["path"],
+                query_string=scope["query_string"],
+                request_headers=_headers(scope),
+                pipeline_result=pipeline_result,
+                local_key=self._settings.local_key,
+                max_trace_bytes=self._settings.max_trace_bytes,
+            )
+            if self._settings.capture_enabled
+            else None
+        )
+        started = time.monotonic()
+        monitored_send = ResponseMonitor(started, recorder, send)
+        try:
+            await self._inner_app(
+                rewritten_scope,
+                ReplayedReceive(pipeline_result.body, disconnected, receive),
+                monitored_send,
+            )
+        finally:
+            elapsed = time.monotonic() - started
+            await self._metrics.record_request(monitored_send.status, elapsed, monitored_send.first_byte_seconds)
+            if recorder is not None:
+                try:
+                    stored = self._trace_store.write(recorder.export())
+                    if not stored:
+                        await self._metrics.record_capture_drop()
+                except Exception:  # noqa: BLE001  # capture failures must never alter the forwarded response
+                    await self._metrics.record_capture_drop()
+
+
+def create_gateway_app(
+    settings: GatewaySettings | None = None,
+    inner_app: ASGI3Application | None = None,
+    pipeline: RequestPipeline | None = None,
+    metrics: GatewayMetrics | None = None,
+    trace_store: TraceStore | None = None,
+    readiness_probe: ReadinessProbe | None = None,
+) -> CodexGateway:
+    resolved_settings = settings or GatewaySettings.from_environment()
+    os.environ["CHATGPT_API_BASE"] = resolved_settings.headroom_base_url
+    os.environ.setdefault("LITELLM_MASTER_KEY", resolved_settings.local_key)
+    if inner_app is None:
+        from litellm.proxy.proxy_server import app as litellm_app
+
+        resolved_inner_app = _ASGI_APP_ADAPTER.validate_python(litellm_app)
+    else:
+        resolved_inner_app = inner_app
+    resolved_trace_store = trace_store or TraceStore(
+        directory=resolved_settings.trace_directory,
+        max_trace_bytes=resolved_settings.max_trace_bytes,
+        max_storage_bytes=resolved_settings.max_trace_storage_bytes,
+        retention_seconds=resolved_settings.trace_retention_seconds,
+    )
+    return CodexGateway(
+        inner_app=resolved_inner_app,
+        settings=resolved_settings,
+        pipeline=pipeline or RequestPipeline((InspectionStage(),)),
+        metrics=metrics or GatewayMetrics(),
+        trace_store=resolved_trace_store,
+        readiness_probe=readiness_probe or HttpReadinessProbe(),
+    )

--- a/litellm/proxy/experimental_codex_gateway/capture.py
+++ b/litellm/proxy/experimental_codex_gateway/capture.py
@@ -1,0 +1,346 @@
+import base64
+import hashlib
+import json
+import os
+import re
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import Lock
+from typing import Mapping
+
+from pydantic import TypeAdapter, ValidationError
+
+from litellm.proxy.experimental_codex_gateway.pipeline import PipelineResult
+from litellm.proxy.experimental_codex_gateway.types import JsonValue
+
+_SENSITIVE_KEYS = frozenset(
+    {
+        "account",
+        "account_id",
+        "api_key",
+        "authorization",
+        "chatgpt-account-id",
+        "cookie",
+        "local_key",
+        "password",
+        "secret",
+        "token",
+        "x-litellm-api-key",
+    }
+)
+_TEXT_SECRET_PATTERNS = (
+    re.compile(r"(?i)bearer\s+[^\s\"',]+"),
+    re.compile(r"(?i)\bsk-[a-z0-9_-]{8,}\b"),
+    re.compile(r"(?i)\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b"),
+    re.compile(r"(?<!\w)(?:\+?\d[\d .()-]{7,}\d)(?!\w)"),
+    re.compile(r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b"),
+)
+_BYTE_SECRET_PATTERNS = tuple(
+    re.compile(pattern.pattern.encode(), pattern.flags & ~re.UNICODE) for pattern in _TEXT_SECRET_PATTERNS
+)
+_BYTE_SENSITIVE_FIELD = re.compile(
+    rb'(?i)("(?:account|account_id|api_key|authorization|chatgpt-account-id|cookie|local_key|password|secret|token|x-litellm-api-key)"\s*:\s*")([^"\\]*)(")'
+)
+_TRACE_ID_PATTERN = re.compile(r"^[0-9a-f]{32}$")
+_JSON_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
+_TRACE_ADAPTER = TypeAdapter(dict[str, JsonValue])
+_REQUEST_HEADER_ALLOWLIST = frozenset(
+    {"accept", "content-type", "originator", "traceparent", "tracestate", "user-agent"}
+)
+_RESPONSE_HEADER_ALLOWLIST = frozenset(
+    {
+        "content-type",
+        "retry-after",
+        "x-ratelimit-limit-requests",
+        "x-ratelimit-limit-tokens",
+        "x-ratelimit-remaining-requests",
+        "x-ratelimit-remaining-tokens",
+        "x-ratelimit-reset-requests",
+        "x-ratelimit-reset-tokens",
+    }
+)
+
+
+def _masked_text(value: str, local_key: str) -> str:
+    key_redacted = value.replace(local_key, "*" * len(local_key)) if local_key else value
+    result = key_redacted
+    for pattern in _TEXT_SECRET_PATTERNS:
+        result = pattern.sub(lambda match: "*" * len(match.group(0)), result)
+    return result
+
+
+def _redacted_json(value: JsonValue, local_key: str) -> JsonValue:
+    if isinstance(value, dict):
+        return {
+            key: "<redacted>" if key.lower() in _SENSITIVE_KEYS else _redacted_json(child, local_key)
+            for key, child in value.items()
+        }
+    if isinstance(value, list):
+        return [_redacted_json(child, local_key) for child in value]
+    if isinstance(value, str):
+        return _masked_text(value, local_key)
+    return value
+
+
+def redact_json_bytes(body: bytes, local_key: str, limit: int) -> JsonValue:
+    if len(body) > limit:
+        return {"omitted": True, "truncated": True}
+    bounded_body = body[:limit]
+    try:
+        parsed = _JSON_ADAPTER.validate_json(bounded_body)
+    except ValidationError:
+        return {
+            "base64": base64.b64encode(redact_bytes(bounded_body, local_key)).decode(),
+            "truncated": len(body) > limit,
+        }
+    return _redacted_json(parsed, local_key)
+
+
+def redact_bytes(value: bytes, local_key: str) -> bytes:
+    key_bytes = local_key.encode()
+    result = value.replace(key_bytes, b"*" * len(key_bytes)) if key_bytes else value
+    for pattern in _BYTE_SECRET_PATTERNS:
+        result = pattern.sub(lambda match: b"*" * len(match.group(0)), result)
+    return _BYTE_SENSITIVE_FIELD.sub(
+        lambda match: match.group(1) + (b"*" * len(match.group(2))) + match.group(3),
+        result,
+    )
+
+
+def _safe_headers(
+    headers: tuple[tuple[bytes, bytes], ...], allowlist: frozenset[str], local_key: str
+) -> dict[str, JsonValue]:
+    return {
+        key.decode("latin-1").lower(): _masked_text(value.decode("latin-1"), local_key)
+        for key, value in headers
+        if key.decode("latin-1").lower() in allowlist
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class ResponseChunk:
+    offset_ms: int
+    body: bytes
+
+
+class TraceRecorder:
+    def __init__(
+        self,
+        method: str,
+        path: str,
+        query_string: bytes,
+        request_headers: tuple[tuple[bytes, bytes], ...],
+        pipeline_result: PipelineResult,
+        local_key: str,
+        max_trace_bytes: int,
+    ) -> None:
+        self.trace_id = uuid.uuid4().hex
+        self._started = time.monotonic()
+        self._method = method
+        self._path = path
+        self._query_hash = hashlib.sha256(query_string).hexdigest()
+        self._request_headers = request_headers
+        self._pipeline_result = pipeline_result
+        self._local_key = local_key
+        self._capture_budget = max_trace_bytes // 3
+        self._captured_bytes = 0
+        self._response_status = 500
+        self._response_headers: tuple[tuple[bytes, bytes], ...] = ()
+        self._response_chunks: list[ResponseChunk] = []
+        self._response_hash = hashlib.sha256()
+        self._first_byte_seconds: float | None = None
+        self._truncated = False
+
+    def response_start(self, status: int, headers: tuple[tuple[bytes, bytes], ...]) -> None:
+        self._response_status = status
+        self._response_headers = headers
+
+    def response_body(self, body: bytes) -> None:
+        self._response_hash.update(body)
+        elapsed = time.monotonic() - self._started
+        if body and self._first_byte_seconds is None:
+            self._first_byte_seconds = elapsed
+        remaining = self._capture_budget - self._captured_bytes
+        captured = body[: max(remaining, 0)]
+        if captured:
+            self._response_chunks.append(ResponseChunk(offset_ms=round(elapsed * 1000), body=captured))
+            self._captured_bytes += len(captured)
+        self._truncated = self._truncated or len(captured) != len(body)
+
+    @property
+    def first_byte_seconds(self) -> float | None:
+        return self._first_byte_seconds
+
+    def export(self) -> dict[str, JsonValue]:
+        elapsed = time.monotonic() - self._started
+        joined_response = b"".join(chunk.body for chunk in self._response_chunks)
+        redacted_response = b"" if self._truncated else redact_bytes(joined_response, self._local_key)
+        chunk_lengths = tuple(len(chunk.body) for chunk in self._response_chunks)
+        boundaries = tuple(sum(chunk_lengths[:index]) for index in range(len(chunk_lengths) + 1))
+        response_chunks: list[JsonValue] = (
+            []
+            if self._truncated
+            else [
+                {
+                    "offset_ms": chunk.offset_ms,
+                    "base64": base64.b64encode(redacted_response[boundaries[index] : boundaries[index + 1]]).decode(),
+                }
+                for index, chunk in enumerate(self._response_chunks)
+            ]
+        )
+        request_limit = self._capture_budget
+        pipeline = self._pipeline_result
+        request: dict[str, JsonValue] = {
+            "method": self._method,
+            "path": _masked_text(self._path, self._local_key),
+            "query_sha256": self._query_hash,
+            "headers": _safe_headers(self._request_headers, _REQUEST_HEADER_ALLOWLIST, self._local_key),
+            "body_sha256": hashlib.sha256(pipeline.original_body).hexdigest(),
+            "body": redact_json_bytes(pipeline.original_body, self._local_key, request_limit),
+            "forwarded_body_sha256": hashlib.sha256(pipeline.body).hexdigest(),
+        }
+        stage_audits: list[JsonValue] = [
+            {
+                "stage": _masked_text(audit.stage, self._local_key),
+                "outcome": audit.outcome.value,
+                "findings": [_masked_text(finding, self._local_key) for finding in audit.findings],
+            }
+            for audit in pipeline.audit
+        ]
+        pipeline_details: dict[str, JsonValue] = {
+            "outcome": pipeline.outcome.value,
+            "stages": stage_audits,
+        }
+        response: dict[str, JsonValue] = {
+            "status": self._response_status,
+            "headers": _safe_headers(self._response_headers, _RESPONSE_HEADER_ALLOWLIST, self._local_key),
+            "body_sha256": self._response_hash.hexdigest(),
+            "chunks": response_chunks,
+            "truncated": self._truncated,
+        }
+        timing: dict[str, JsonValue] = {
+            "first_byte_ms": None if self._first_byte_seconds is None else round(self._first_byte_seconds * 1000),
+            "total_ms": round(elapsed * 1000),
+        }
+        return {
+            "schema": "litellm-codex-gateway.trace.v1",
+            "trace_id": self.trace_id,
+            "request": request,
+            "pipeline": pipeline_details,
+            "response": response,
+            "timing": timing,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TraceStore:
+    directory: Path
+    max_trace_bytes: int
+    max_storage_bytes: int
+    retention_seconds: int
+    _lock: Lock = field(default_factory=Lock, init=False, repr=False, compare=False)
+
+    def write(self, trace: Mapping[str, JsonValue]) -> bool:
+        with self._lock:
+            return self._write(trace)
+
+    def _write(self, trace: Mapping[str, JsonValue]) -> bool:
+        trace_id = trace.get("trace_id")
+        if (
+            trace.get("schema") != "litellm-codex-gateway.trace.v1"
+            or not isinstance(trace_id, str)
+            or _TRACE_ID_PATTERN.fullmatch(trace_id) is None
+        ):
+            return False
+        encoded = json.dumps(trace, sort_keys=True, separators=(",", ":")).encode()
+        if len(encoded) > self.max_trace_bytes:
+            return False
+        self.directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(self.directory, 0o700)
+        with tempfile.NamedTemporaryFile(mode="wb", dir=self.directory, delete=False) as temporary:
+            temporary.write(encoded)
+            temporary_path = Path(temporary.name)
+        os.chmod(temporary_path, 0o600)
+        temporary_path.replace(self.directory / f"{trace_id}.json")
+        self._evict()
+        return True
+
+    def read(self, trace_id: str) -> bytes | None:
+        with self._lock:
+            return self._read(trace_id)
+
+    def _read(self, trace_id: str) -> bytes | None:
+        if _TRACE_ID_PATTERN.fullmatch(trace_id) is None:
+            return None
+        path = self.directory / f"{trace_id}.json"
+        try:
+            if path.stat().st_size > self.max_trace_bytes:
+                return None
+            encoded = path.read_bytes()
+        except FileNotFoundError:
+            return None
+        try:
+            trace = _TRACE_ADAPTER.validate_json(encoded)
+        except ValidationError:
+            return None
+        if trace.get("schema") != "litellm-codex-gateway.trace.v1" or trace.get("trace_id") != trace_id:
+            return None
+        return encoded
+
+    def evict(self) -> None:
+        with self._lock:
+            self._evict()
+
+    def _evict(self) -> None:
+        now = time.time()
+        files = tuple(
+            sorted(
+                (path for path in self.directory.glob("*.json") if path.is_file()),
+                key=lambda path: path.stat().st_mtime,
+            )
+        )
+        retained = tuple(path for path in files if now - path.stat().st_mtime <= self.retention_seconds)
+        expired = tuple(path for path in files if path not in retained)
+        for path in expired:
+            path.unlink(missing_ok=True)
+        total = sum(path.stat().st_size for path in retained)
+        for path in retained:
+            if total <= self.max_storage_bytes:
+                break
+            size = path.stat().st_size
+            path.unlink(missing_ok=True)
+            total -= size
+
+
+def _decode_response_chunk(value: JsonValue) -> bytes | None:
+    if not isinstance(value, dict):
+        return None
+    encoded = value.get("base64")
+    if not isinstance(encoded, str):
+        return None
+    try:
+        return base64.b64decode(encoded, validate=True)
+    except ValueError:
+        return None
+
+
+def replay_response_chunks(trace: bytes) -> tuple[bytes, ...] | None:
+    try:
+        payload = _TRACE_ADAPTER.validate_json(trace)
+    except ValidationError:
+        return None
+    if payload.get("schema") != "litellm-codex-gateway.trace.v1":
+        return None
+    response = payload.get("response")
+    if not isinstance(response, dict):
+        return None
+    chunks = response.get("chunks")
+    if not isinstance(chunks, list):
+        return None
+    decoded = tuple(_decode_response_chunk(chunk) for chunk in chunks)
+    if any(chunk is None for chunk in decoded):
+        return None
+    return tuple(chunk for chunk in decoded if chunk is not None)

--- a/litellm/proxy/experimental_codex_gateway/cli.py
+++ b/litellm/proxy/experimental_codex_gateway/cli.py
@@ -1,0 +1,15 @@
+import os
+
+from uvicorn import run as run_uvicorn
+
+from litellm.proxy.experimental_codex_gateway.app import create_gateway_app
+from litellm.proxy.experimental_codex_gateway.settings import GatewaySettings
+
+
+def main() -> None:
+    settings = GatewaySettings.from_environment()
+    host = os.environ.get("CODEX_GATEWAY_HOST", "127.0.0.1")
+    if host not in {"127.0.0.1", "::1", "localhost"}:
+        raise ValueError("CODEX_GATEWAY_HOST must be a loopback address")
+    port = int(os.environ.get("CODEX_GATEWAY_PORT", "4000"))
+    run_uvicorn(create_gateway_app(settings=settings), host=host, port=port, access_log=False)

--- a/litellm/proxy/experimental_codex_gateway/metrics.py
+++ b/litellm/proxy/experimental_codex_gateway/metrics.py
@@ -1,0 +1,61 @@
+import asyncio
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class MetricsSnapshot:
+    requests: int
+    failures: int
+    fail_open: int
+    capture_drops: int
+    downstream_seconds: float
+    first_byte_seconds: float
+
+
+class GatewayMetrics:
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._requests = 0
+        self._failures = 0
+        self._fail_open = 0
+        self._capture_drops = 0
+        self._downstream_seconds = 0.0
+        self._first_byte_seconds = 0.0
+
+    async def record_request(self, status: int, downstream_seconds: float, first_byte_seconds: float | None) -> None:
+        async with self._lock:
+            self._requests += 1
+            self._failures += int(status >= 500)
+            self._downstream_seconds += downstream_seconds
+            self._first_byte_seconds += first_byte_seconds or 0.0
+
+    async def record_fail_open(self) -> None:
+        async with self._lock:
+            self._fail_open += 1
+
+    async def record_capture_drop(self) -> None:
+        async with self._lock:
+            self._capture_drops += 1
+
+    async def snapshot(self) -> MetricsSnapshot:
+        async with self._lock:
+            return MetricsSnapshot(
+                requests=self._requests,
+                failures=self._failures,
+                fail_open=self._fail_open,
+                capture_drops=self._capture_drops,
+                downstream_seconds=self._downstream_seconds,
+                first_byte_seconds=self._first_byte_seconds,
+            )
+
+    async def render(self) -> bytes:
+        snapshot = await self.snapshot()
+        values = (
+            ("litellm_codex_gateway_requests_total", snapshot.requests),
+            ("litellm_codex_gateway_failures_total", snapshot.failures),
+            ("litellm_codex_gateway_fail_open_total", snapshot.fail_open),
+            ("litellm_codex_gateway_capture_drops_total", snapshot.capture_drops),
+            ("litellm_codex_gateway_downstream_seconds_total", snapshot.downstream_seconds),
+            ("litellm_codex_gateway_first_byte_seconds_total", snapshot.first_byte_seconds),
+        )
+        return "".join(f"{name} {value}\n" for name, value in values).encode()

--- a/litellm/proxy/experimental_codex_gateway/pipeline.py
+++ b/litellm/proxy/experimental_codex_gateway/pipeline.py
@@ -1,0 +1,120 @@
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol, TypeAlias
+
+from pydantic import TypeAdapter, ValidationError
+
+from litellm.proxy.experimental_codex_gateway.types import JsonValue
+
+
+class StageOutcome(str, Enum):
+    UNCHANGED = "unchanged"
+    TRANSFORMED = "transformed"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class StageAudit:
+    stage: str
+    outcome: StageOutcome
+    findings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class Unchanged:
+    body: bytes
+    audit: StageAudit
+
+
+@dataclass(frozen=True, slots=True)
+class Transformed:
+    body: bytes
+    audit: StageAudit
+
+
+@dataclass(frozen=True, slots=True)
+class Failed:
+    original_body: bytes
+    audit: StageAudit
+
+
+StageResult: TypeAlias = Unchanged | Transformed | Failed
+
+
+class RequestStage(Protocol):
+    def apply(self, body: bytes, content_type: str) -> StageResult: ...
+
+
+_SECRET_PATTERN = re.compile(r"(?i)(bearer\s+\S+|sk-[a-z0-9_-]{8,}|api[_-]?key|password|secret)")
+_EMAIL_PATTERN = re.compile(r"(?i)\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b")
+_PHONE_PATTERN = re.compile(r"(?<!\w)(?:\+?\d[\d .()-]{7,}\d)(?!\w)")
+_INJECTION_PATTERN = re.compile(r"(?i)(ignore (?:all |the )?previous|system prompt|developer message)")
+_JSON_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
+
+
+@dataclass(frozen=True, slots=True)
+class InspectionStage:
+    name: str = "request_inspection"
+
+    def apply(self, body: bytes, content_type: str) -> StageResult:
+        if "json" not in content_type.lower() or not body:
+            return Unchanged(body=body, audit=StageAudit(stage=self.name, outcome=StageOutcome.UNCHANGED))
+        try:
+            parsed = _JSON_ADAPTER.validate_json(body)
+        except ValidationError:
+            return Failed(
+                original_body=body,
+                audit=StageAudit(stage=self.name, outcome=StageOutcome.FAILED, findings=("invalid_json",)),
+            )
+        serialized = json.dumps(parsed, ensure_ascii=False, separators=(",", ":"))
+        findings = tuple(
+            finding
+            for finding, pattern in (
+                ("secret", _SECRET_PATTERN),
+                ("pii_email", _EMAIL_PATTERN),
+                ("pii_phone", _PHONE_PATTERN),
+                ("prompt_injection", _INJECTION_PATTERN),
+            )
+            if pattern.search(serialized)
+        )
+        return Unchanged(
+            body=body,
+            audit=StageAudit(stage=self.name, outcome=StageOutcome.UNCHANGED, findings=findings),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineResult:
+    original_body: bytes
+    body: bytes
+    outcome: StageOutcome
+    audit: tuple[StageAudit, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RequestPipeline:
+    stages: tuple[RequestStage, ...]
+
+    def process(self, body: bytes, content_type: str) -> PipelineResult:
+        current = body
+        audits: tuple[StageAudit, ...] = ()
+        outcome = StageOutcome.UNCHANGED
+        for stage in self.stages:
+            result = stage.apply(current, content_type)
+            audits = (*audits, result.audit)
+            match result:
+                case Failed():
+                    return PipelineResult(
+                        original_body=body,
+                        body=body,
+                        outcome=StageOutcome.FAILED,
+                        audit=audits,
+                    )
+                case Transformed():
+                    current = result.body
+                    outcome = StageOutcome.TRANSFORMED
+                case Unchanged():
+                    current = result.body
+        return PipelineResult(original_body=body, body=current, outcome=outcome, audit=audits)

--- a/litellm/proxy/experimental_codex_gateway/settings.py
+++ b/litellm/proxy/experimental_codex_gateway/settings.py
@@ -1,0 +1,79 @@
+import ipaddress
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+from urllib.parse import urlsplit, urlunsplit
+
+
+def _boolean(value: str | None) -> bool:
+    return value is not None and value.lower() in {"1", "true", "yes", "on"}
+
+
+def _positive_integer(value: str | None, default: int) -> int:
+    resolved = default if value is None else int(value)
+    if resolved <= 0:
+        raise ValueError("gateway limits must be positive")
+    return resolved
+
+
+def _loopback_base_url(value: str) -> str:
+    parsed = urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or parsed.hostname is None or parsed.query or parsed.fragment:
+        raise ValueError("HEADROOM_BASE_URL must be an HTTP(S) base URL without a query or fragment")
+    hostname = parsed.hostname
+    is_loopback = hostname == "localhost"
+    if not is_loopback:
+        try:
+            is_loopback = ipaddress.ip_address(hostname).is_loopback
+        except ValueError:
+            is_loopback = False
+    if not is_loopback:
+        raise ValueError("HEADROOM_BASE_URL must point to a loopback Headroom instance")
+    return value.rstrip("/")
+
+
+def _readiness_url(base_url: str, readiness_path: str) -> str:
+    parsed = urlsplit(base_url)
+    path = readiness_path if readiness_path.startswith("/") else f"/{readiness_path}"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+@dataclass(frozen=True, slots=True)
+class GatewaySettings:
+    local_key: str
+    headroom_base_url: str = "http://127.0.0.1:8787/v1"
+    readiness_path: str = "/livez"
+    capture_enabled: bool = False
+    trace_directory: Path = Path("~/.local/state/litellm-codex-gateway/traces")
+    max_trace_bytes: int = 10 * 1024 * 1024
+    max_trace_storage_bytes: int = 100 * 1024 * 1024
+    trace_retention_seconds: int = 7 * 24 * 60 * 60
+
+    def __post_init__(self) -> None:
+        if not self.local_key:
+            raise ValueError("LOCAL_CODEX_GATEWAY_KEY is required")
+        object.__setattr__(self, "headroom_base_url", _loopback_base_url(self.headroom_base_url))
+        object.__setattr__(self, "trace_directory", self.trace_directory.expanduser())
+
+    @property
+    def readiness_url(self) -> str:
+        return _readiness_url(self.headroom_base_url, self.readiness_path)
+
+    @classmethod
+    def from_environment(cls, environment: Mapping[str, str] | None = None) -> "GatewaySettings":
+        source = os.environ if environment is None else environment
+        return cls(
+            local_key=source.get("LOCAL_CODEX_GATEWAY_KEY", ""),
+            headroom_base_url=source.get("HEADROOM_BASE_URL", "http://127.0.0.1:8787/v1"),
+            readiness_path=source.get("HEADROOM_READINESS_PATH", "/livez"),
+            capture_enabled=_boolean(source.get("CODEX_GATEWAY_CAPTURE")),
+            trace_directory=Path(source.get("CODEX_GATEWAY_TRACE_DIR", "~/.local/state/litellm-codex-gateway/traces")),
+            max_trace_bytes=_positive_integer(source.get("CODEX_GATEWAY_MAX_TRACE_BYTES"), 10 * 1024 * 1024),
+            max_trace_storage_bytes=_positive_integer(
+                source.get("CODEX_GATEWAY_MAX_TRACE_STORAGE_BYTES"), 100 * 1024 * 1024
+            ),
+            trace_retention_seconds=_positive_integer(
+                source.get("CODEX_GATEWAY_TRACE_RETENTION_SECONDS"), 7 * 24 * 60 * 60
+            ),
+        )

--- a/litellm/proxy/experimental_codex_gateway/types.py
+++ b/litellm/proxy/experimental_codex_gateway/types.py
@@ -1,0 +1,3 @@
+from pydantic import JsonValue
+
+__all__ = ("JsonValue",)

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -46,6 +46,7 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
     LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
+    LITELLM_PASS_THROUGH_RAW_QUERY_STATE_KEY,
 )
 from litellm.proxy.utils import is_known_model
 from litellm.proxy.vector_store_endpoints.utils import (
@@ -2025,7 +2026,22 @@ class BaseOpenAIPassThroughHandler:
 
 
 CHATGPT_CREDENTIAL_COOKIE = "litellm_api_key"
-CHATGPT_STRIPPED_REQUEST_HEADERS = frozenset({"cookie", "x-litellm-api-key", "content-length", "host"})
+CHATGPT_STRIPPED_REQUEST_HEADERS = frozenset(
+    {
+        "connection",
+        "content-length",
+        "cookie",
+        "host",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+        "x-litellm-api-key",
+    }
+)
 
 
 def get_chatgpt_gateway_credential(request: Request) -> str | None:
@@ -2036,10 +2052,14 @@ def get_chatgpt_gateway_credential(request: Request) -> str | None:
 
 
 def build_chatgpt_forward_headers(request: Request) -> dict[str, str]:
+    request_headers = _safe_get_request_headers(request)
+    connection_headers = frozenset(
+        header_name.strip().lower() for header_name in request_headers.get("connection", "").split(",")
+    )
     return {
         header_name: header_value
-        for header_name, header_value in _safe_get_request_headers(request).items()
-        if header_name.lower() not in CHATGPT_STRIPPED_REQUEST_HEADERS
+        for header_name, header_value in request_headers.items()
+        if header_name.lower() not in CHATGPT_STRIPPED_REQUEST_HEADERS and header_name.lower() not in connection_headers
     }
 
 
@@ -2086,6 +2106,9 @@ async def chatgpt_proxy_route(
     )
 
     is_streaming_request = await is_streaming_request_fn(request)
+    raw_request_body = await request.body()
+    setattr(request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY, raw_request_body)
+    setattr(request.state, LITELLM_PASS_THROUGH_RAW_QUERY_STATE_KEY, request.scope.get("query_string", b""))
 
     endpoint_func = create_pass_through_route(
         endpoint=endpoint,
@@ -2093,6 +2116,7 @@ async def chatgpt_proxy_route(
         custom_headers=build_chatgpt_forward_headers(request),
         custom_llm_provider=LlmProviders.CHATGPT.value,
         is_streaming_request=is_streaming_request,
+        query_params=dict(request.query_params),
     )
     return await endpoint_func(
         request,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -74,6 +74,7 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
     LITELLM_PASS_THROUGH_ENDPOINT_MARKER,
     LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
+    LITELLM_PASS_THROUGH_RAW_QUERY_STATE_KEY,
     EndpointType,
     PassthroughStandardLoggingPayload,
 )
@@ -856,6 +857,14 @@ async def pass_through_request(
         )
         if state_raw_body is not None and not isinstance(state_raw_body, (str, bytes, bytearray)):
             state_raw_body = None
+        state_raw_query = (
+            getattr(_request_state, LITELLM_PASS_THROUGH_RAW_QUERY_STATE_KEY, None)
+            if _request_state is not None
+            else None
+        )
+        if isinstance(state_raw_query, bytes):
+            url = url.copy_with(query=state_raw_query)
+            requested_query_params = None
 
         # Skip body parsing for multipart requests - make_multipart_http_request will handle it
         # But if custom_body is provided (e.g., JSON parsed despite multipart content-type), use it
@@ -1798,6 +1807,8 @@ def create_pass_through_route(
                     delattr(request.state, LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY)
                 if hasattr(request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY):
                     delattr(request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY)
+                if hasattr(request.state, LITELLM_PASS_THROUGH_RAW_QUERY_STATE_KEY):
+                    delattr(request.state, LITELLM_PASS_THROUGH_RAW_QUERY_STATE_KEY)
 
     setattr(endpoint_func, LITELLM_PASS_THROUGH_ENDPOINT_MARKER, True)
     return endpoint_func

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -1,6 +1,8 @@
+import asyncio
 from datetime import datetime
 from typing import List, Optional, Tuple
 
+import anyio
 import httpx
 
 import litellm
@@ -93,6 +95,13 @@ class PassThroughStreamingHandler:
             verbose_proxy_logger.error(f"Error in chunk_processor: {str(e)}")
             raise
         finally:
+            with anyio.CancelScope(shield=True):
+                try:
+                    await response.aclose()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    verbose_proxy_logger.debug("Error closing passthrough response: %s", e)
             # GeneratorExit (raised on client disconnect) is not caught by
             # `except Exception`; the finally block ensures partial usage
             # still gets logged for spend tracking. See LIT-2642.

--- a/litellm/types/passthrough_endpoints/pass_through_endpoints.py
+++ b/litellm/types/passthrough_endpoints/pass_through_endpoints.py
@@ -10,6 +10,7 @@ LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY = "litellm_pass_through_custom_body"
 # Request.state key for programmatic pass-through callers that must preserve an
 # exact byte/string body, such as AWS SigV4-signed requests.
 LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY = "litellm_pass_through_raw_body"
+LITELLM_PASS_THROUGH_RAW_QUERY_STATE_KEY = "litellm_pass_through_raw_query"
 
 # Attribute set on the FastAPI endpoint function of every user-defined pass-through
 # route. Auth reads it off the dispatched endpoint (``request.scope["endpoint"]``) to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ proxy-runtime = [
 litellm = "litellm:run_server"
 lite = "litellm.proxy.client.cli:cli"
 litellm-proxy = "litellm.proxy.client.cli:cli"
+litellm-codex-gateway = "litellm.proxy.experimental_codex_gateway.cli:main"
 
 [dependency-groups]
 dev = [

--- a/tests/test_litellm/proxy/experimental_codex_gateway/test_app.py
+++ b/tests/test_litellm/proxy/experimental_codex_gateway/test_app.py
@@ -1,0 +1,716 @@
+import asyncio
+import hashlib
+import json
+import os
+import stat
+import time
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from starlette.types import Message, Receive, Scope, Send
+
+from litellm.proxy.experimental_codex_gateway.app import ReplayedReceive, create_gateway_app, map_responses_path
+from litellm.proxy.experimental_codex_gateway.capture import TraceStore, replay_response_chunks
+from litellm.proxy.experimental_codex_gateway.pipeline import RequestPipeline, StageResult
+from litellm.proxy.experimental_codex_gateway.settings import GatewaySettings
+
+
+class FakeInnerApp:
+    def __init__(self, status: int = 200, chunks: tuple[bytes, ...] = (b"ok",)) -> None:
+        self.status = status
+        self.chunks = chunks
+        self.scope: Scope | None = None
+        self.body = b""
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        self.scope = scope
+        request = await receive()
+        self.body = request.get("body", b"")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": self.status,
+                "headers": ((b"content-type", b"text/event-stream"), (b"retry-after", b"3")),
+            }
+        )
+        for index, chunk in enumerate(self.chunks):
+            await send({"type": "http.response.body", "body": chunk, "more_body": index < len(self.chunks) - 1})
+
+
+class EchoInnerApp:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        request = await receive()
+        body = request.get("body", b"")
+        await asyncio.sleep(0)
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": ((b"content-type", b"application/json"),),
+            }
+        )
+        await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+class FragmentedStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: tuple[bytes, ...]) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        return None
+
+
+class BlockingStream(httpx.AsyncByteStream):
+    def __init__(self) -> None:
+        self.blocked = asyncio.Event()
+        self.cancelled = asyncio.Event()
+        self.closed = asyncio.Event()
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield b"event: response.created\ndata: {}\n\n"
+        self.blocked.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+
+    async def aclose(self) -> None:
+        self.closed.set()
+
+
+@dataclass(frozen=True, slots=True)
+class FakeReadinessProbe:
+    result: bool
+
+    async def reachable(self, url: str) -> bool:
+        return self.result
+
+
+@dataclass(frozen=True, slots=True)
+class RaisingStage:
+    def apply(self, body: bytes, content_type: str) -> StageResult:
+        raise RuntimeError("stage failed")
+
+
+@dataclass(frozen=True, slots=True)
+class RaisingSecretStage:
+    message: str
+
+    def apply(self, body: bytes, content_type: str) -> StageResult:
+        raise RuntimeError(self.message)
+
+
+def _settings(tmp_path: Path, capture: bool = False) -> GatewaySettings:
+    return GatewaySettings(
+        local_key="local-gateway-key-123",
+        capture_enabled=capture,
+        trace_directory=tmp_path,
+        max_trace_bytes=10_000,
+        max_trace_storage_bytes=20_000,
+        trace_retention_seconds=60,
+    )
+
+
+def test_map_responses_path_and_reject_traversal() -> None:
+    assert map_responses_path("/v1/responses") == "/chatgpt/responses"
+    assert map_responses_path("/v1/responses/resp_1/cancel") == "/chatgpt/responses/resp_1/cancel"
+    assert map_responses_path("/v1/chat/completions") is None
+    assert map_responses_path("/v1/responses/../secrets") is None
+    assert map_responses_path("/v1/responses/%2e%2e/secrets", b"/v1/responses/%2e%2e/secrets") is None
+
+
+@pytest.mark.asyncio
+async def test_maps_request_and_preserves_body_query_and_stream_chunks(tmp_path: Path) -> None:
+    body = b'{ "model": "gpt-5.3-codex", "stream": true }'
+    chunks = (b"event: response.created\n", b"data: {}\n\n", b"event: response.completed\n\n")
+    inner = FakeInnerApp(chunks=chunks)
+    app = create_gateway_app(settings=_settings(tmp_path), inner_app=inner)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+        response = await client.post(
+            "/v1/responses/resp_1/cancel?mode=exact",
+            content=body,
+            headers={
+                "content-type": "application/json",
+                "authorization": "Bearer oauth-secret",
+                "chatgpt-account-id": "account-secret",
+                "x-litellm-api-key": "local-gateway-key-123",
+            },
+        )
+    assert response.status_code == 200
+    assert response.content == b"".join(chunks)
+    assert inner.body == body
+    assert inner.scope is not None
+    assert inner.scope["path"] == "/chatgpt/responses/resp_1/cancel"
+    assert inner.scope["query_string"] == b"mode=exact"
+    assert dict(inner.scope["headers"])[b"authorization"] == b"Bearer oauth-secret"
+    assert dict(inner.scope["headers"])[b"chatgpt-account-id"] == b"account-secret"
+
+
+@pytest.mark.parametrize("status_code", (401, 429, 503))
+@pytest.mark.asyncio
+async def test_real_chatgpt_route_relays_headroom_failures_without_gateway_credentials(
+    tmp_path: Path, status_code: int
+) -> None:
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import app as litellm_app
+
+    request_body = b'{ "model": "gpt-5.3-codex", "stream": false, "unknown": {"encrypted_reasoning":"opaque"} }'
+    response_body = json.dumps({"error": {"status": status_code}}, separators=(",", ":")).encode()
+    downstream_requests: list[httpx.Request] = []
+
+    async def headroom_transport(request: httpx.Request) -> httpx.Response:
+        downstream_requests.append(request)
+        return httpx.Response(
+            status_code=status_code,
+            headers={"content-type": "application/json", "retry-after": "7"},
+            content=response_body,
+            request=request,
+        )
+
+    downstream_client = httpx.AsyncClient(transport=httpx.MockTransport(headroom_transport))
+    app = create_gateway_app(settings=_settings(tmp_path), inner_app=litellm_app)
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.user_api_key_auth",
+            new=AsyncMock(return_value=UserAPIKeyAuth(api_key="hashed")),
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client",
+            return_value=SimpleNamespace(client=downstream_client),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.pre_call_hook",
+            new=AsyncMock(side_effect=lambda **kwargs: kwargs["data"]),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_response_headers_hook",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_endpoint_logging.pass_through_async_success_handler",
+            new=AsyncMock(),
+        ),
+    ):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+            response = await client.post(
+                "/v1/responses?include=usage&include=trace&flag=&encoded=a%2Fb",
+                content=request_body,
+                headers={
+                    "content-type": "application/json",
+                    "authorization": "Bearer oauth-secret",
+                    "chatgpt-account-id": "account-secret",
+                    "cookie": "session=cookie-secret",
+                    "x-litellm-api-key": "local-gateway-key-123",
+                    "connection": "x-remove-me",
+                    "x-remove-me": "hop-secret",
+                    "content-length": "999",
+                    "traceparent": "00-trace-parent",
+                },
+            )
+    await downstream_client.aclose()
+
+    assert response.status_code == status_code
+    assert response.content == response_body
+    assert response.headers["retry-after"] == "7"
+    assert len(downstream_requests) == 1
+    downstream = downstream_requests[0]
+    assert str(downstream.url) == ("http://127.0.0.1:8787/v1/responses?include=usage&include=trace&flag=&encoded=a%2Fb")
+    assert downstream.content == request_body
+    assert downstream.headers["authorization"] == "Bearer oauth-secret"
+    assert downstream.headers["chatgpt-account-id"] == "account-secret"
+    assert downstream.headers["traceparent"] == "00-trace-parent"
+    assert downstream.headers["content-length"] == str(len(request_body))
+    assert "x-litellm-api-key" not in downstream.headers
+    assert "cookie" not in downstream.headers
+    assert "x-remove-me" not in downstream.headers
+
+
+@pytest.mark.asyncio
+async def test_real_chatgpt_route_preserves_fragmented_sse_events(tmp_path: Path) -> None:
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import app as litellm_app
+
+    request_body = b'{"model":"gpt-5.3-codex","stream":true}'
+    chunks = (
+        b'event: response.output_item.added\ndata: {"item":{"type":"function_call","call_id":"call_1"}}\n\n',
+        b'event: response.reasoning.delta\ndata: {"encrypted_content":"opaque"}\n\n',
+        b'event: vendor.unknown\ndata: {"future":true}\n\n',
+    )
+    downstream_requests: list[httpx.Request] = []
+
+    async def headroom_transport(request: httpx.Request) -> httpx.Response:
+        downstream_requests.append(request)
+        return httpx.Response(
+            status_code=200,
+            headers={"content-type": "text/event-stream"},
+            stream=FragmentedStream(chunks),
+            request=request,
+        )
+
+    downstream_client = httpx.AsyncClient(transport=httpx.MockTransport(headroom_transport))
+    app = create_gateway_app(settings=_settings(tmp_path), inner_app=litellm_app)
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.user_api_key_auth",
+            new=AsyncMock(return_value=UserAPIKeyAuth(api_key="hashed")),
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client",
+            return_value=SimpleNamespace(client=downstream_client),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.pre_call_hook",
+            new=AsyncMock(side_effect=lambda **kwargs: kwargs["data"]),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_response_headers_hook",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_endpoint_logging.pass_through_async_success_handler",
+            new=AsyncMock(),
+        ),
+    ):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+            response = await client.post(
+                "/v1/responses",
+                content=request_body,
+                headers={
+                    "content-type": "application/json",
+                    "authorization": "Bearer oauth-secret",
+                    "x-litellm-api-key": "local-gateway-key-123",
+                },
+            )
+    await downstream_client.aclose()
+
+    assert response.status_code == 200
+    assert response.content == b"".join(chunks)
+    assert len(downstream_requests) == 1
+    assert downstream_requests[0].content == request_body
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_cancels_and_closes_in_flight_headroom_stream(tmp_path: Path) -> None:
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import app as litellm_app
+
+    request_body = b'{"model":"gpt-5.3-codex","stream":true}'
+    downstream_stream = BlockingStream()
+
+    async def headroom_transport(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code=200,
+            headers={"content-type": "text/event-stream"},
+            stream=downstream_stream,
+            request=request,
+        )
+
+    downstream_client = httpx.AsyncClient(transport=httpx.MockTransport(headroom_transport))
+    app = create_gateway_app(settings=_settings(tmp_path), inner_app=litellm_app)
+    request_delivered = False
+    sent_messages: list[Message] = []
+
+    async def receive() -> Message:
+        nonlocal request_delivered
+        if not request_delivered:
+            request_delivered = True
+            return {"type": "http.request", "body": request_body, "more_body": False}
+        await downstream_stream.blocked.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: Message) -> None:
+        sent_messages.append(message)
+
+    scope: Scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/v1/responses",
+        "raw_path": b"/v1/responses",
+        "query_string": b"",
+        "root_path": "",
+        "headers": (
+            (b"content-type", b"application/json"),
+            (b"authorization", b"Bearer oauth-secret"),
+            (b"x-litellm-api-key", b"local-gateway-key-123"),
+        ),
+        "client": ("127.0.0.1", 12345),
+        "server": ("127.0.0.1", 4000),
+    }
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.user_api_key_auth",
+            new=AsyncMock(return_value=UserAPIKeyAuth(api_key="hashed")),
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client",
+            return_value=SimpleNamespace(client=downstream_client),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.pre_call_hook",
+            new=AsyncMock(side_effect=lambda **kwargs: kwargs["data"]),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_response_headers_hook",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_endpoint_logging.pass_through_async_success_handler",
+            new=AsyncMock(),
+        ),
+    ):
+        await asyncio.wait_for(app(scope, receive, send), timeout=3)
+
+    assert any(message["type"] == "http.response.start" for message in sent_messages)
+    assert downstream_stream.cancelled.is_set()
+    assert downstream_stream.closed.is_set()
+    await downstream_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_operational_routes_and_local_key_auth(tmp_path: Path) -> None:
+    app = create_gateway_app(
+        settings=_settings(tmp_path),
+        inner_app=FakeInnerApp(),
+        readiness_probe=FakeReadinessProbe(result=False),
+    )
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+        health = await client.get("/healthz")
+        ready = await client.get("/readyz")
+        unauthorized_metrics = await client.get("/metrics")
+        metrics = await client.get("/metrics", headers={"x-litellm-api-key": "local-gateway-key-123"})
+    assert health.status_code == 204 and health.content == b""
+    assert ready.status_code == 503 and ready.content == b""
+    assert unauthorized_metrics.status_code == 401
+    assert metrics.status_code == 200
+    assert b"litellm_codex_gateway_requests_total" in metrics.content
+
+
+@pytest.mark.asyncio
+async def test_capture_redacts_credentials_across_chunks_and_replays_deterministically(tmp_path: Path) -> None:
+    chunks = (b'data: {"token":"Bearer oauth-', b'secret","email":"person@example.com"}\n\n')
+    inner = FakeInnerApp(status=429, chunks=chunks)
+    settings = _settings(tmp_path, capture=True)
+    app = create_gateway_app(settings=settings, inner_app=inner)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+        response = await client.post(
+            "/v1/responses",
+            content=json.dumps(
+                {
+                    "input": "contact person@example.com",
+                    "authorization": "Bearer request-secret",
+                    "local_key": settings.local_key,
+                    "owner": "785d0158-2d4e-4ba4-b290-a15b042af9a0",
+                }
+            ),
+            headers={
+                "content-type": "application/json",
+                "authorization": "Bearer oauth-secret",
+                "chatgpt-account-id": "account-secret",
+                "cookie": "session=cookie-secret",
+                "x-litellm-api-key": settings.local_key,
+                "traceparent": "Bearer trace-secret",
+            },
+        )
+    assert response.status_code == 429
+    trace_path = next(tmp_path.glob("*.json"))
+    trace = trace_path.read_bytes()
+    for secret in (
+        b"oauth-secret",
+        b"request-secret",
+        b"account-secret",
+        b"cookie-secret",
+        settings.local_key.encode(),
+        b"person@example.com",
+        b"785d0158-2d4e-4ba4-b290-a15b042af9a0",
+        b"trace-secret",
+    ):
+        assert secret not in trace
+    replayed = replay_response_chunks(trace)
+    assert replayed is not None
+    assert b"".join(replayed) != b"".join(chunks)
+    assert len(replayed) == len(chunks)
+    exported = json.loads(trace)
+    trace_id = exported["trace_id"]
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+        unauthorized = await client.get(f"/debug/traces/{trace_id}/export")
+        authorized = await client.get(
+            f"/debug/traces/{trace_id}/export", headers={"x-litellm-api-key": settings.local_key}
+        )
+    assert unauthorized.status_code == 401
+    assert authorized.content == trace
+
+
+@pytest.mark.asyncio
+async def test_seeded_secrets_absent_from_traces_metrics_logs_and_stage_exceptions(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    settings = _settings(tmp_path, capture=True)
+    secrets = (
+        "oauth-seeded-value",
+        "sk-seeded-api-key",
+        "account-seeded-value",
+        "cookie-seeded-value",
+        settings.local_key,
+        "seeded.person@example.com",
+        "+1 (415) 555-0182",
+        "785d0158-2d4e-4ba4-b290-a15b042af9a0",
+    )
+    request_body = json.dumps(
+        {
+            "authorization": f"Bearer {secrets[0]}",
+            "api_key": secrets[1],
+            "account_id": secrets[2],
+            "cookie": secrets[3],
+            "local_key": secrets[4],
+            "email": secrets[5],
+            "phone": secrets[6],
+            "owner": secrets[7],
+        },
+        separators=(",", ":"),
+    ).encode()
+    response_body = json.dumps(
+        {
+            "authorization": f"Bearer {secrets[0]}",
+            "api_key": secrets[1],
+            "account_id": secrets[2],
+            "cookie": secrets[3],
+        },
+        separators=(",", ":"),
+    ).encode()
+    app = create_gateway_app(
+        settings=settings,
+        inner_app=FakeInnerApp(chunks=(response_body,)),
+        pipeline=RequestPipeline((RaisingSecretStage("forced stage exception: " + " ".join(secrets)),)),
+    )
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+        response = await client.post(
+            "/v1/responses",
+            content=request_body,
+            headers={
+                "content-type": "application/json",
+                "authorization": f"Bearer {secrets[0]}",
+                "chatgpt-account-id": secrets[2],
+                "cookie": f"session={secrets[3]}",
+                "x-litellm-api-key": settings.local_key,
+                "traceparent": f"Bearer {secrets[0]}",
+            },
+        )
+        metrics = await client.get("/metrics", headers={"x-litellm-api-key": settings.local_key})
+
+    captured = capsys.readouterr()
+    traces = b"\n".join(path.read_bytes() for path in tmp_path.glob("*.json"))
+    artifacts = b"\n".join(
+        (traces, metrics.content, caplog.text.encode(), captured.out.encode(), captured.err.encode())
+    )
+    assert response.content == response_body
+    assert b"litellm_codex_gateway_fail_open_total 1" in metrics.content
+    assert traces
+    for secret in secrets:
+        assert secret.encode() not in artifacts
+
+
+@pytest.mark.asyncio
+async def test_concurrent_captures_remain_isolated_and_complete(tmp_path: Path) -> None:
+    request_bodies = tuple(
+        json.dumps({"index": index, "secret": f"Bearer concurrent-secret-{index}"}, separators=(",", ":")).encode()
+        for index in range(16)
+    )
+    settings = GatewaySettings(
+        local_key="local-gateway-key-123",
+        capture_enabled=True,
+        trace_directory=tmp_path,
+        max_trace_bytes=10_000,
+        max_trace_storage_bytes=100_000,
+        trace_retention_seconds=60,
+    )
+    app = create_gateway_app(settings=settings, inner_app=EchoInnerApp())
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+        responses = await asyncio.gather(
+            *(
+                client.post(
+                    "/v1/responses",
+                    content=body,
+                    headers={"content-type": "application/json", "x-litellm-api-key": settings.local_key},
+                )
+                for body in request_bodies
+            )
+        )
+        metrics = await client.get("/metrics", headers={"x-litellm-api-key": settings.local_key})
+
+    traces = tuple(json.loads(path.read_bytes()) for path in tmp_path.glob("*.json"))
+    expected_hashes = {hashlib.sha256(body).hexdigest() for body in request_bodies}
+    captured_hashes = {trace["request"]["body_sha256"] for trace in traces}
+    assert tuple(response.content for response in responses) == request_bodies
+    assert len(traces) == len(request_bodies)
+    assert len({trace["trace_id"] for trace in traces}) == len(request_bodies)
+    assert captured_hashes == expected_hashes
+    assert all("concurrent-secret" not in json.dumps(trace) for trace in traces)
+    assert b"litellm_codex_gateway_requests_total 16" in metrics.content
+    assert b"litellm_codex_gateway_capture_drops_total 0" in metrics.content
+
+
+@pytest.mark.asyncio
+async def test_capture_redacts_escaped_json_secrets_and_rejects_malformed_export(tmp_path: Path) -> None:
+    inner = FakeInnerApp()
+    settings = _settings(tmp_path, capture=True)
+    app = create_gateway_app(settings=settings, inner_app=inner)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+        response = await client.post(
+            "/v1/responses",
+            content=b'{"note":"Bearer escaped\\u002dsecret","password":"quoted\\u002dsecret"}',
+            headers={"content-type": "application/json", "x-litellm-api-key": settings.local_key},
+        )
+        trace_path = next(tmp_path.glob("*.json"))
+        trace = trace_path.read_bytes()
+        trace_id = json.loads(trace)["trace_id"]
+        trace_path.write_bytes(b'{"schema":"litellm-codex-gateway.trace.v1","trace_id":')
+        malformed = await client.get(
+            f"/debug/traces/{trace_id}/export", headers={"x-litellm-api-key": settings.local_key}
+        )
+
+    assert response.status_code == 200
+    assert b"escaped-secret" not in trace
+    assert b"quoted-secret" not in trace
+    assert malformed.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_stage_exception_fails_open_with_original_body(tmp_path: Path) -> None:
+    body = b'{"unknown":{"encrypted_reasoning":"opaque"}}'
+    inner = FakeInnerApp()
+    app = create_gateway_app(
+        settings=_settings(tmp_path),
+        inner_app=inner,
+        pipeline=RequestPipeline((RaisingStage(),)),
+    )
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+        response = await client.post(
+            "/v1/responses",
+            content=body,
+            headers={"content-type": "application/json", "x-litellm-api-key": "local-gateway-key-123"},
+        )
+        metrics = await client.get("/metrics", headers={"x-litellm-api-key": "local-gateway-key-123"})
+    assert response.status_code == 200
+    assert inner.body == body
+    assert b"litellm_codex_gateway_fail_open_total 1" in metrics.content
+
+
+@pytest.mark.asyncio
+async def test_oversized_capture_drops_trace_without_changing_response(tmp_path: Path) -> None:
+    chunks = (b"z" * 500,)
+    inner = FakeInnerApp(chunks=chunks)
+    settings = GatewaySettings(
+        local_key="local-gateway-key-123",
+        capture_enabled=True,
+        trace_directory=tmp_path,
+        max_trace_bytes=100,
+        max_trace_storage_bytes=1_000,
+        trace_retention_seconds=60,
+    )
+    app = create_gateway_app(settings=settings, inner_app=inner)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+        response = await client.post(
+            "/v1/responses",
+            content=b'{"input":"unchanged"}',
+            headers={"content-type": "application/json", "x-litellm-api-key": settings.local_key},
+        )
+        metrics = await client.get("/metrics", headers={"x-litellm-api-key": settings.local_key})
+    assert response.content == b"".join(chunks)
+    assert not tuple(tmp_path.glob("*.json"))
+    assert b"litellm_codex_gateway_capture_drops_total 1" in metrics.content
+
+
+@pytest.mark.asyncio
+async def test_capture_omits_truncated_request_and_response_content(tmp_path: Path) -> None:
+    secret = b"boundary-secret-value"
+    body = (b"x" * 3_300) + secret + (b"y" * 800)
+    chunks = ((b"z" * 3_300) + secret + (b"w" * 800),)
+    inner = FakeInnerApp(chunks=chunks)
+    settings = _settings(tmp_path, capture=True)
+    app = create_gateway_app(settings=settings, inner_app=inner)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+        response = await client.post(
+            "/v1/responses",
+            content=body,
+            headers={"content-type": "application/octet-stream", "x-litellm-api-key": settings.local_key},
+        )
+
+    assert response.content == b"".join(chunks)
+    trace = json.loads(next(tmp_path.glob("*.json")).read_bytes())
+    assert trace["request"]["body"] == {"omitted": True, "truncated": True}
+    assert trace["response"]["chunks"] == []
+    assert trace["response"]["truncated"] is True
+    assert secret not in json.dumps(trace).encode()
+
+
+@pytest.mark.asyncio
+async def test_malformed_non_utf8_request_fails_open_and_captures_redacted_bytes(tmp_path: Path) -> None:
+    body = b'\xff\xfe{"authorization":"Bearer malformed-secret"'
+    inner = FakeInnerApp()
+    settings = _settings(tmp_path, capture=True)
+    app = create_gateway_app(settings=settings, inner_app=inner)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://gateway") as client:
+        response = await client.post(
+            "/v1/responses",
+            content=body,
+            headers={"content-type": "application/json", "x-litellm-api-key": settings.local_key},
+        )
+        metrics = await client.get("/metrics", headers={"x-litellm-api-key": settings.local_key})
+
+    trace = json.loads(next(tmp_path.glob("*.json")).read_bytes())
+    assert response.status_code == 200
+    assert inner.body == body
+    assert trace["pipeline"]["outcome"] == "failed"
+    assert b"malformed-secret" not in json.dumps(trace).encode()
+    assert b"litellm_codex_gateway_fail_open_total 1" in metrics.content
+
+
+@pytest.mark.asyncio
+async def test_replayed_receive_propagates_disconnect_after_body() -> None:
+    async def disconnected_receive() -> Message:
+        return {"type": "http.disconnect"}
+
+    receive = ReplayedReceive(b'{"input":"preserved"}', False, disconnected_receive)
+    assert await receive() == {"type": "http.request", "body": b'{"input":"preserved"}', "more_body": False}
+    assert await receive() == {"type": "http.disconnect"}
+
+
+def test_trace_store_evicts_oldest_files(tmp_path: Path) -> None:
+    store = TraceStore(directory=tmp_path, max_trace_bytes=1_000, max_storage_bytes=180, retention_seconds=60)
+    first = {"schema": "litellm-codex-gateway.trace.v1", "trace_id": "a" * 32, "payload": "x" * 30}
+    second = {"schema": "litellm-codex-gateway.trace.v1", "trace_id": "b" * 32, "payload": "y" * 30}
+    assert store.write(first)
+    assert store.write(second)
+    assert store.read("a" * 32) is None
+    assert store.read("b" * 32) is not None
+
+
+def test_trace_store_enforces_permissions_and_retention(tmp_path: Path) -> None:
+    trace_directory = tmp_path / "world-readable"
+    trace_directory.mkdir(mode=0o755)
+    os.chmod(trace_directory, 0o755)
+    store = TraceStore(directory=trace_directory, max_trace_bytes=1_000, max_storage_bytes=1_000, retention_seconds=10)
+    trace_id = "c" * 32
+    assert store.write({"schema": "litellm-codex-gateway.trace.v1", "trace_id": trace_id, "payload": "safe"})
+    trace_path = trace_directory / f"{trace_id}.json"
+    assert stat.S_IMODE(trace_directory.stat().st_mode) == 0o700
+    assert stat.S_IMODE(trace_path.stat().st_mode) == 0o600
+    expired = time.time() - 11
+    os.utime(trace_path, (expired, expired))
+    store.evict()
+    assert store.read(trace_id) is None

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3029,12 +3029,17 @@ class TestChatGPTProxyRoute:
     Tests for the Codex Sign-in-with-ChatGPT (SIWC) passthrough (/chatgpt)
     """
 
-    def _build_request(self, headers: dict, cookies: dict, body: dict) -> MagicMock:
+    def _build_request(
+        self, headers: dict, cookies: dict, body: dict, query_params: dict | None = None
+    ) -> MagicMock:
         mock_request = MagicMock(spec=Request)
         mock_request.method = "POST"
         mock_request.headers = headers
         mock_request.cookies = cookies
-        mock_request.query_params = {}
+        mock_request.query_params = query_params or {}
+        mock_request.scope = {"query_string": b"include=usage" if query_params else b""}
+        mock_request.body = AsyncMock(return_value=json.dumps(body).encode())
+        mock_request.state = MagicMock()
         return mock_request
 
     def _codex_headers(self, extra: dict) -> dict:
@@ -3097,6 +3102,7 @@ class TestChatGPTProxyRoute:
         assert call_args["target"] == "https://chatgpt.com/backend-api/codex/responses"
         assert call_args["custom_llm_provider"] == "chatgpt"
         assert call_args["is_streaming_request"] is True
+        assert call_args["query_params"] == {}
 
         forwarded = call_args["custom_headers"]
         assert forwarded["authorization"] == "Bearer chatgpt-oauth-access-token"
@@ -3108,6 +3114,43 @@ class TestChatGPTProxyRoute:
         assert "host" not in forwarded
         assert "content-length" not in forwarded
         assert result == {"id": "resp_1"}
+
+    @pytest.mark.asyncio
+    async def test_preserves_raw_body_query_and_strips_hop_by_hop_headers(self):
+        from litellm.types.passthrough_endpoints.pass_through_endpoints import (
+            LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
+            LITELLM_PASS_THROUGH_RAW_QUERY_STATE_KEY,
+        )
+
+        body = {"model": "gpt-5.3-codex", "unknown": {"encrypted_reasoning": "opaque"}}
+        mock_request = self._build_request(
+            headers=self._codex_headers(
+                {
+                    "x-litellm-api-key": "sk-litellm-virtual-key",
+                    "connection": "keep-alive, x-remove-me",
+                    "keep-alive": "timeout=5",
+                    "transfer-encoding": "chunked",
+                    "x-remove-me": "dynamic-hop-header",
+                    "traceparent": "00-trace-parent",
+                }
+            ),
+            cookies={},
+            body=body,
+            query_params={"include": "usage"},
+        )
+
+        _, _, mock_create_route = await self._call_route(mock_request, body)
+
+        call_args = mock_create_route.call_args[1]
+        assert call_args["query_params"] == {"include": "usage"}
+        forwarded = call_args["custom_headers"]
+        assert forwarded["traceparent"] == "00-trace-parent"
+        assert "connection" not in forwarded
+        assert "keep-alive" not in forwarded
+        assert "transfer-encoding" not in forwarded
+        assert "x-remove-me" not in forwarded
+        assert getattr(mock_request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY) == json.dumps(body).encode()
+        assert getattr(mock_request.state, LITELLM_PASS_THROUGH_RAW_QUERY_STATE_KEY) == b"include=usage"
 
     @pytest.mark.asyncio
     async def test_auth_from_cookie(self):

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
@@ -88,6 +88,7 @@ async def test_chunk_processor_logs_on_client_disconnect():
         await asyncio.sleep(0)
 
     assert first == chunks[0]
+    response.aclose.assert_awaited_once()
     mock_route.assert_called_once()
     call_kwargs = mock_route.call_args.kwargs
     assert call_kwargs["raw_bytes"] == [chunks[0]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Add an opt-in LiteLLM gateway before a local Headroom proxy
- Keep the existing direct Headroom path as the rollback path

How it solves it:

- Adds a loopback-only ASGI gateway with health and readiness endpoints
- Preserves Codex responses, SSE, credentials, and downstream errors
- Adds bounded optional redacted capture and focused tests

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The gateway is opt-in and documented in `litellm/proxy/experimental_codex_gateway/README.md`. Focused unit coverage is included; no live provider proof was captured for this PR

## Type

🆕 New Feature

## Changes

Adds the experimental gateway, CLI entry point, loopback and credential safeguards, optional trace capture, metrics, readiness checks, and passthrough integration. The PR is based on `litellm_codex_siwc_passthrough` so the base passthrough work remains separate from this change

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR