### PR TITLE
fix(core): merge mixed system message content

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -18,6 +18,7 @@ from litellm import verbose_logger
 from litellm._uuid import uuid
 from litellm.litellm_core_utils.url_utils import async_safe_get, safe_get
 from litellm.llms.custom_httpx.http_handler import HTTPHandler, get_async_httpx_client
+from litellm.types.completion import ChatCompletionContentPartTextParam
 from litellm.types.files import get_file_extension_from_mime_type
 from litellm.types.llms.anthropic import *
 from litellm.types.llms.bedrock import CachePointBlock
@@ -107,7 +108,20 @@ def map_system_message_pt(messages: list) -> list:
                 next_role = next_m["role"]
                 if next_role == "user" or next_role == "assistant":  # Next message is a user or assistant message
                     # Merge system prompt into the next message
-                    next_m["content"] = m["content"] + " " + next_m["content"]
+                    system_content = m["content"]
+                    next_content = next_m["content"]
+                    if isinstance(system_content, list):
+                        next_m["content"] = tuple(system_content) + (
+                            tuple(next_content)
+                            if isinstance(next_content, list)
+                            else (ChatCompletionContentPartTextParam(type="text", text=next_content),)
+                        )
+                    elif isinstance(next_content, list):
+                        next_m["content"] = (
+                            ChatCompletionContentPartTextParam(type="text", text=system_content),
+                        ) + tuple(next_content)
+                    else:
+                        next_m["content"] = system_content + " " + next_content
                 elif next_role == "system":  # Next message is a system message
                     # Append a user message instead of the system message
                     new_message = {"role": "user", "content": m["content"]}

--- a/tests/llm_translation/test_optional_params.py
+++ b/tests/llm_translation/test_optional_params.py
@@ -56,6 +56,53 @@ def test_supports_system_message():
 
 
 @pytest.mark.parametrize(
+    "system_content,user_content,expected_content",
+    [
+        (
+            [{"type": "text", "text": "Follow these instructions."}],
+            [{"type": "text", "text": "Hello there!"}],
+            (
+                {"type": "text", "text": "Follow these instructions."},
+                {"type": "text", "text": "Hello there!"},
+            ),
+        ),
+        (
+            [{"type": "text", "text": "Follow these instructions."}],
+            "Hello there!",
+            (
+                {"type": "text", "text": "Follow these instructions."},
+                {"type": "text", "text": "Hello there!"},
+            ),
+        ),
+        (
+            "Follow these instructions.",
+            [{"type": "text", "text": "Hello there!"}],
+            (
+                {"type": "text", "text": "Follow these instructions."},
+                {"type": "text", "text": "Hello there!"},
+            ),
+        ),
+        (
+            "Follow these instructions.",
+            "Hello there!",
+            "Follow these instructions. Hello there!",
+        ),
+    ],
+)
+def test_map_system_message_with_mixed_content_types(
+    system_content, user_content, expected_content
+):
+    messages = [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_content},
+    ]
+
+    new_messages = map_system_message_pt(messages=messages)
+
+    assert new_messages == [{"role": "user", "content": expected_content}]
+
+
+@pytest.mark.parametrize(
     "stop_sequence, expected_count", [("\n", 0), (["\n"], 0), (["finish_reason"], 1)]
 )
 def test_anthropic_optional_params(stop_sequence, expected_count):


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Start a Claude Code session through a LiteLLM model configured with `supports_system_message: false`, then spawn a teammate. The teammate now starts successfully when Claude Code sends the system message as content blocks followed by a string user message

## Type

🐛 Bug Fix

## Changes

`map_system_message_pt` previously concatenated every system and user message as strings. Requests failed with a `TypeError` when either message used structured content blocks

This preserves structured content by converting the string side to a text block before merging. Regression coverage includes string/string, list/list, list/string, and string/list content combinations
