### PR TITLE
fix(proxy): re-assert the authenticated identity on passthrough requests

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -565,6 +565,9 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
         # real parent span.
         _metadata["user_api_key"] = user_api_key_dict.api_key
         _metadata["litellm_parent_otel_span"] = user_api_key_dict.parent_otel_span
+        _metadata.update(
+            LiteLLMProxyRequestSetup.get_sanitized_user_information_from_key(user_api_key_dict=user_api_key_dict)
+        )
 
         kwargs: Final = {
             "litellm_params": {

--- a/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
+++ b/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
@@ -652,3 +652,59 @@ def test_custom_pricing_used_in_cost_calculation():
 
     print(f"Cache-aware cost: {cache_cost}")
     print("✅ Custom pricing parameters are correctly used in cost calculation")
+
+
+def test_init_kwargs_client_metadata_cannot_spoof_authenticated_identity(
+    mock_request, mock_user_api_key_dict
+):
+    request = mock_request()
+    passthrough_payload = PassthroughStandardLoggingPayload(
+        url="https://test.com",
+        request_body={},
+    )
+    authenticated_key = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        team_id="test-team",
+        end_user_id="test-user",
+        key_alias="real-key",
+        team_alias="Real Team",
+        user_email="real@example.com",
+        org_id="real-org",
+    )
+
+    result = HttpPassThroughEndpointHelpers._init_kwargs_for_pass_through_endpoint(
+        request=request,
+        user_api_key_dict=authenticated_key,
+        passthrough_logging_payload=passthrough_payload,
+        litellm_call_id="test-call-id",
+        logging_obj=LiteLLMLoggingObj(
+            model="test-model",
+            messages=[],
+            stream=False,
+            call_type="test-call-type",
+            start_time=datetime.now(),
+            litellm_call_id="test-call-id",
+            function_id="test-function-id",
+        ),
+        _parsed_body={
+            "litellm_metadata": {
+                "user_api_key_org_id": "victim-org",
+                "user_api_key_end_user_id": "victim-end-user",
+                "user_api_key_user_id": "victim-user",
+                "user_api_key_team_id": "victim-team",
+                "user_api_key_team_alias": "Victim Team",
+                "user_api_key_alias": "victim-key",
+                "user_api_key_user_email": "victim@example.com",
+            }
+        },
+    )
+
+    metadata = result["litellm_params"]["metadata"]
+    assert metadata["user_api_key_user_id"] == "test-user"
+    assert metadata["user_api_key_team_id"] == "test-team"
+    assert metadata["user_api_key_team_alias"] == "Real Team"
+    assert metadata["user_api_key_alias"] == "real-key"
+    assert metadata["user_api_key_user_email"] == "real@example.com"
+    assert metadata["user_api_key_org_id"] == "real-org"
+    assert metadata["user_api_key_end_user_id"] == "test-user"

--- a/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
+++ b/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
@@ -30,6 +30,7 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
 )
 from fastapi import Request
 from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     _update_metadata_with_tags_in_header,
     HttpPassThroughEndpointHelpers,
@@ -708,3 +709,63 @@ def test_init_kwargs_client_metadata_cannot_spoof_authenticated_identity(
     assert metadata["user_api_key_user_email"] == "real@example.com"
     assert metadata["user_api_key_org_id"] == "real-org"
     assert metadata["user_api_key_end_user_id"] == "test-user"
+
+
+def test_init_kwargs_no_authenticated_identity_field_is_client_settable(
+    mock_request, mock_user_api_key_dict
+):
+    authenticated_key = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        team_id="test-team",
+        end_user_id="test-end-user",
+        key_alias="real-key",
+        team_alias="Real Team",
+        user_email="real@example.com",
+        org_id="real-org",
+        organization_alias="Real Org",
+        project_id="real-project",
+        project_alias="Real Project",
+        spend=1.5,
+        max_budget=10.0,
+        user_spend=2.5,
+        user_max_budget=20.0,
+        team_spend=3.5,
+        team_max_budget=30.0,
+        metadata={"real": "auth-metadata"},
+    )
+    expected = dict(
+        LiteLLMProxyRequestSetup.get_sanitized_user_information_from_key(
+            user_api_key_dict=authenticated_key
+        )
+    )
+    assert len(expected) >= 20
+
+    spoofed = {key: f"SPOOFED-{key}" for key in expected}
+
+    result = HttpPassThroughEndpointHelpers._init_kwargs_for_pass_through_endpoint(
+        request=mock_request(),
+        user_api_key_dict=authenticated_key,
+        passthrough_logging_payload=PassthroughStandardLoggingPayload(
+            url="https://test.com", request_body={}
+        ),
+        litellm_call_id="test-call-id",
+        logging_obj=LiteLLMLoggingObj(
+            model="test-model",
+            messages=[],
+            stream=False,
+            call_type="test-call-type",
+            start_time=datetime.now(),
+            litellm_call_id="test-call-id",
+            function_id="test-function-id",
+        ),
+        _parsed_body={"litellm_metadata": dict(spoofed), "metadata": dict(spoofed)},
+    )
+
+    metadata = result["litellm_params"]["metadata"]
+    survived = {
+        key: metadata.get(key)
+        for key in expected
+        if metadata.get(key) != expected[key]
+    }
+    assert survived == {}, f"client-supplied values survived for: {sorted(survived)}"


### PR DESCRIPTION
## TLDR

Problem this solves:

- A passthrough request body can redirect its own spend and budget onto another user, team, organization, or end user
- The metadata the spend pipeline reads is merged from the client body, and only two of its fields are re-asserted afterwards

How it solves it:

- Re-assert the full sanitized identity from the authenticated key after the client merge, so a body that mirrors those fields cannot win

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`HttpPassThroughEndpointHelpers._init_kwargs_for_pass_through_endpoint` builds the request metadata from the authenticated key, merges the client's `litellm_metadata` and `metadata` over it, and then re-asserts `user_api_key` and `litellm_parent_otel_span`. The comment above those two lines says a request body mirroring them cannot clobber the authenticated key, which holds for those two fields only.

The other identity fields are the ones the spend and budget pipeline reads. `_PROXY_track_cost_callback` takes `user_api_key_user_id`, `user_api_key_team_id`, `user_api_key_org_id` and `user_api_key_end_user_id` straight out of this metadata to write the spend row and to move the user, team, team member and organization counters that the budget checks then enforce. A request that sets any of them in its body is billed to that identity rather than to the key that authenticated it.

This re-applies `get_sanitized_user_information_from_key` after the merge. That helper is already the source of the pre-merge values, so the authenticated key's own identity simply wins, and metadata keys outside the identity set (including client tags) are untouched.

This is the shape the ordinary LLM path already uses, so the passthrough is being brought in line rather than given new hardening. `LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata` does the same two steps in the same order at `litellm/proxy/litellm_pre_call_utils.py:1131`:

```python
user_api_key_logged_metadata = LiteLLMProxyRequestSetup.get_sanitized_user_information_from_key(
    user_api_key_dict=user_api_key_dict
)
data[_metadata_variable_name].update(user_api_key_logged_metadata)
data[_metadata_variable_name]["user_api_key"] = user_api_key_dict.api_key
```

The ordering matches too. On that path `data[_metadata_variable_name]` starts out as whatever the client body sent, since line 1514 only defaults it to `{}` when the body omitted it, and the re-assertion above runs later at line 1684. A `/chat/completions` request has therefore always had its identity fields overwritten from the authenticated key after its own metadata was taken in. The passthrough implemented half of that, re-asserting `user_api_key` and the parent span while the comment above those lines described the whole property.

Re-asserting the helper rather than naming individual fields is deliberate. It covers every field the helper owns, including `user_api_key_max_budget`, `user_api_key_team_max_budget` and `user_api_key_team_spend`, which feed budget limits and are as useful to spoof as the team id; and it does not need revisiting when a field is added to `StandardLoggingUserAPIKeyMetadata`.

No first-party producer sets any of these fields in a request body. Every `litellm_metadata.get("user_api_key_*")` reference under `litellm/` (router, guardrail hooks, spend utils) reads the value; none write it. The proxy itself assigns them from `user_api_key_dict` in more than ten places, which is the same direction this change enforces.

## Behavior changes

- On every passthrough route, a request body can no longer redirect spend or budget to another user, team, organization, or end user through `litellm_metadata` or `metadata`
- A request that was relying on setting these fields in its body will now be attributed to its own key. No first-party producer sets them; they are populated by auth, and the ordinary LLM path already overwrites them the same way

## QA runbook

1. Point a proxy at a Postgres database and configure any passthrough provider
2. Create two virtual keys, one on team A and one on team B
3. Send a passthrough request with team A's key and a body containing `"litellm_metadata": {"user_api_key_team_id": "<team B id>", "user_api_key_user_id": "someone-else"}`
4. `GET /spend/logs`: the row is attributed to team A and to team A's key, not to team B or the named user
5. Repeat with `user_api_key_org_id` and `user_api_key_end_user_id` and confirm the same

## Testing

`test_init_kwargs_client_metadata_cannot_spoof_authenticated_identity` covers seven named identity fields, individually and together, and asserts that a non-identity metadata key the client sent still survives the re-assertion.

`test_init_kwargs_no_authenticated_identity_field_is_client_settable` derives its field list from `get_sanitized_user_information_from_key` itself rather than naming fields, spoofs every key it returns through both `litellm_metadata` and `metadata`, and asserts none survives. That is twenty fields today, and a field added to `StandardLoggingUserAPIKeyMetadata` is covered without touching the test. It also caught two fields the named-field test missed, one of them `user_api_key_hash`, which is distinct from `user_api_key` and was client settable.

Both were confirmed to fail on the parent commit and pass with the fix. On the parent commit the second test reports the full set:

```
AssertionError: client-supplied values survived for: ['user_api_key_alias',
'user_api_key_auth_metadata', 'user_api_key_budget_reset_at', 'user_api_key_end_user_id',
'user_api_key_hash', 'user_api_key_max_budget', 'user_api_key_org_alias',
'user_api_key_org_id', 'user_api_key_project_alias', 'user_api_key_project_id',
'user_api_key_request_route', 'user_api_key_spend', 'user_api_key_team_alias',
'user_api_key_team_id', 'user_api_key_team_max_budget', 'user_api_key_team_spend',
'user_api_key_user_email', 'user_api_key_user_id', 'user_api_key_user_max_budget',
'user_api_key_user_spend']
```

## Live proxy verification

Two proxies from two worktrees, base at `f6587faef5` and head, each with its own Postgres, the same config and the same scenarios in the same order. Real Gemini passthrough calls, no mocks. Every scenario returned 200 on both sides, so the difference is entirely in what was attributed.

A key on team A sends `litellm_metadata` naming team B, another user, another org and another end user. Spend rows read back from `LiteLLM_SpendLogs`:

```
BASE (f6587faef5)   teamA=tA-06adfc  teamB=tB-9714c0  user=u-379714
 n |   team    |     usr     | end_user  | org
---+-----------+-------------+-----------+------------
 1 | tB-9714c0 | u-379714    |           |             <- S1 team spoofed
 2 | tA-06adfc | victim-user |           |             <- S2 user spoofed
 3 | tA-06adfc | u-379714    |           | victim-org  <- S3 org spoofed
 4 | tA-06adfc | u-379714    | victim-eu |             <- S4 end user spoofed
 6 | tB-9714c0 | victim-user | victim-eu | victim-org  <- S6 all at once
 8 | tA-06adfc | u-379714    |           |             <- S8 header tags
 9 | tA-06adfc | u-379714    |           |             <- S9 clean request

HEAD                teamA=tA-2a0b4e  teamB=tB-e4982c  user=u-601d80
 every row: team=tA-2a0b4e  usr=u-601d80  end_user=(null)  org=(null)
```

It is not only the log row. On the base the victim team's balance actually moved:

```
BASE  LiteLLM_TeamTable   tA-06adfc  0.00395100
                          tB-9714c0  0.00116850   <- billed by team A's key
HEAD  LiteLLM_TeamTable   tA-2a0b4e  0.00541950
                          tB-e4982c  0.00000000
```

Three scenarios exist to show nothing else moved, and they are identical on both sides: header tags still arrive as `["hdr-tag-1", "hdr-tag-2"]` (S8), a clean request is attributed the same way (S9), and a request carrying an unrelated client metadata key behaves the same (S7). Note that arbitrary client metadata keys do not reach the spend log's `metadata` column on either side, since that column is a filtered subset; the survival of unrelated keys is asserted on the metadata dict in the unit test rather than in the spend row.

Not covered live: the WebSocket call site, which shares the helper but was not driven; and providers other than Gemini, which is the funded key here. The change sits above provider dispatch, so it is provider independent.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/36121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Fixes incorrect spend/budget attribution on passthrough routes (billing integrity); behavior change for any client that relied on spoofing identity in the body.
> 
> **Overview**
> Fixes a security issue where passthrough request bodies could **redirect spend and budget** to another user, team, org, or end user by setting `user_api_key_*` fields in `litellm_metadata` or `metadata`. Only `user_api_key` and the parent OTEL span were re-applied after the client merge; the spend pipeline reads the other identity fields from that same metadata.
> 
> After merging client metadata, **`get_sanitized_user_information_from_key`** is applied again so every sanitized identity field from the authenticated key wins—aligned with the ordinary LLM proxy path in `add_user_api_key_auth_to_request_metadata`. Non-identity client metadata (e.g. tags) is unchanged.
> 
> Unit tests assert spoofed identity fields cannot survive and that all fields returned by the helper stay server-controlled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa469bf5bdf70f45ee67be58ff8020fd7adb3b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

