### PR TITLE
Fix: gpt-image edits price input image tokens at text rate when input_tokens_details is a dict

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -979,8 +979,8 @@ def calculate_image_response_cost_from_usage(
     prompt_tokens_details: PromptTokensDetailsWrapper | None = None
     if input_tokens_details is not None:
         prompt_tokens_details = PromptTokensDetailsWrapper(
-            text_tokens=getattr(input_tokens_details, "text_tokens", None),
-            image_tokens=getattr(input_tokens_details, "image_tokens", None),
+            text_tokens=_get_token_detail_value(input_tokens_details, "text_tokens"),
+            image_tokens=_get_token_detail_value(input_tokens_details, "image_tokens"),
             cached_tokens=0,
         )
 

--- a/tests/test_litellm/test_gpt_image_cost_calculator.py
+++ b/tests/test_litellm/test_gpt_image_cost_calculator.py
@@ -469,5 +469,37 @@ class TestGPTImage2OutputImageTokensNoBreakdown:
         assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
 
 
+class TestGPTImage2DictInputTokensDetails:
+    def test_gpt_image_2_dict_input_tokens_details_priced_at_image_rate(self):
+        from litellm.llms.openai.image_generation.cost_calculator import (
+            cost_calculator,
+        )
+
+        usage = Usage(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=3363,
+            input_tokens=1607,
+            output_tokens=1756,
+            input_tokens_details={"text_tokens": 163, "image_tokens": 1444},
+        )
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(b64_json="test")],
+        )
+        image_response.usage = usage
+        image_response._hidden_params = {"custom_llm_provider": "openai"}
+
+        cost = cost_calculator(
+            model="gpt-image-2",
+            image_response=image_response,
+            custom_llm_provider="openai",
+        )
+
+        expected_cost = 163 * 5e-6 + 1444 * 8e-6 + 1756 * 3e-5
+        assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## TLDR

Problem this solves:

- gpt-image edits: input image tokens billed at text rate ($5/1M vs $8/1M)
- `input_tokens_details` arrives as a plain dict on the edits path
- `getattr()` on a dict returns None, so the text/image split is dropped

How it solves it:

- Read input details with the existing dict-safe `_get_token_detail_value`
- Same helper the output token details already use a few lines below

## Relevant issues

Related to the gpt-image cost-tracking family: #13847, #14819, #26876 (this is a distinct remaining case: the input-side split is lost when the usage details are a dict).

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Real `litellm.aimage_edit()` call to OpenAI gpt-image-2 (actual $ spent), run against this branch:

```
usage: input=268 (text=12, image=256) output=196
input_tokens_details type: dict          <-- the bug precondition, on a real response
litellm computed cost:  0.007988
expected (OpenAI rates): 0.007988  [text@$5/1M + image-in@$8/1M + image-out@$30/1M]
pre-fix (flat text-rate input): 0.007220
```

On `main` the same call logs `0.007220` — every input token priced at `input_cost_per_token` because `getattr(dict, "text_tokens", None)` is `None`, so `calculate_image_response_cost_from_usage` builds a `PromptTokensDetailsWrapper` with no split and `generic_cost_per_token` falls back to billing the full `prompt_tokens` as text.

Production corroboration from a LiteLLM proxy (v1.92.0) spend DB — a real gpt-image-2 edit row where the logged `usage_object` HAS the split but spend was computed flat:

```
spend=0.060715  prompt_tokens=1607  completion_tokens=1756
usage_object.prompt_tokens_details = {"text_tokens": 163, "image_tokens": 1444}
flat  (all input @ $5/1M):            1607*5e-6 + 1756*3e-5 = 0.060715  <-- what was billed
split (163 text + 1444 image @ $8/1M): 163*5e-6 + 1444*8e-6 + 1756*3e-5 = 0.065047  <-- correct
```

Unit tests: new regression test fails on `main` (`0.060715 != 0.065047`), passes with the fix; the full `tests/test_litellm/litellm_core_utils/llm_cost_calc/` + `tests/test_litellm/test_gpt_image_cost_calculator.py` suites pass (181 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHGpqmg9knnWYUhAD53GXo
