### PR TITLE
fix(streaming): close upstream stream when a /v1/responses or /v1/messages client disconnects

### DIFF
--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Final
 
+import anyio
 import httpx
 
 import litellm
@@ -117,6 +118,9 @@ class PassThroughStreamingHandler:
                     )
                 except Exception as e:
                     verbose_proxy_logger.error("Error scheduling chunk_processor logging: %s", e)
+
+            with anyio.CancelScope(shield=True):
+                await response.aclose()
 
     @staticmethod
     async def _route_streaming_logging_to_handler(

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -106,6 +106,17 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._accumulated_provider_specific_fields: dict[str, Any] = {}
         self._custom_tool_names: set[str] = extract_custom_tool_names(self.responses_api_request.get("tools"))
 
+    async def aclose(self) -> None:
+        """
+        Close the wrapped chat completions stream so the provider connection is released
+        when a bridged /v1/responses stream is abandoned, e.g. on client disconnect.
+
+        This class never calls ``BaseResponsesAPIStreamingIterator.__init__``, so it has
+        no ``self.response``; the upstream lives inside the ``CustomStreamWrapper``,
+        whose own ``aclose`` already shields against cancellation.
+        """
+        await self.litellm_custom_stream_wrapper.aclose()
+
     def _get_or_assign_tool_output_index(self, call_id: str) -> int:
         existing: Final = self._tool_output_index_by_call_id.get(call_id)
         if existing is not None:

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -326,6 +326,18 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         self._error_event_emitted = False
         self._last_sequence_number = 0
 
+    async def aclose(self) -> None:
+        """
+        Close the provider stream of the current tool-execution round.
+
+        This class bypasses ``BaseResponsesAPIStreamingIterator.__init__`` and swaps
+        ``base_iterator`` on every round, so the inherited close finds no
+        ``self.response`` and would leave the live upstream generating on disconnect.
+        """
+        base_iterator: Final = self.base_iterator
+        if isinstance(base_iterator, BaseResponsesAPIStreamingIterator):
+            await base_iterator.aclose()
+
     def _extract_mcp_headers_from_params(self) -> None:
         """Extract MCP headers from original request params to pass to tool calls"""
 

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal
 
+import anyio
 import httpx
 from openai._streaming import SSEDecoder
 from typing_extensions import TypeIs
@@ -147,6 +148,8 @@ class BaseResponsesAPIStreamingIterator:
     This class contains shared logic for both synchronous and asynchronous iterators.
     """
 
+    response: httpx.Response | None = None
+
     def __init__(
         self,
         response: httpx.Response,
@@ -194,6 +197,24 @@ class BaseResponsesAPIStreamingIterator:
         self._hidden_params["additional_headers"] = process_response_headers(
             self.response.headers or {}
         )  # GUARANTEE OPENAI HEADERS IN RESPONSE
+
+    async def aclose(self) -> None:
+        """
+        Release the upstream HTTP connection when the stream is abandoned before it is
+        exhausted, e.g. the client disconnected mid-stream and the proxy is unwinding.
+
+        httpx closes a streamed response only on natural exhaustion, so without this the
+        provider keeps decoding into a socket nobody reads. Mirrors
+        ``BaseModelResponseIterator.aclose`` on the chat completions path.
+
+        Subclasses that bypass ``__init__`` hold their upstream somewhere other than
+        ``self.response`` and override this.
+        """
+        response: Final = self.response
+        if response is None or response.is_closed:
+            return
+        with anyio.CancelScope(shield=True):
+            await response.aclose()
 
     def _check_max_streaming_duration(self) -> None:
         """Raise litellm.Timeout if the stream has exceeded LITELLM_MAX_STREAMING_DURATION_SECONDS."""

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
@@ -376,3 +376,86 @@ def test_convert_raw_bytes_survives_truncated_multibyte_sequence():
     lines = PassThroughStreamingHandler._convert_raw_bytes_to_str_lines(raw_bytes)
 
     assert any('"type": "message_delta"' in line for line in lines)
+
+
+class _RecordingByteStream(httpx.AsyncByteStream):
+    """Upstream provider body that records whether the connection was released."""
+
+    def __init__(self, chunks):
+        self.chunks = chunks
+        self.aclose_calls = 0
+
+    async def __aiter__(self):
+        for chunk in self.chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+
+
+def _run_chunk_processor(response):
+    return PassThroughStreamingHandler.chunk_processor(
+        response=response,
+        request_body={"model": "claude-haiku-4-5"},
+        litellm_logging_obj=MagicMock(),
+        endpoint_type=EndpointType.ANTHROPIC,
+        start_time=datetime.now(),
+        passthrough_success_handler_obj=MagicMock(),
+        url_route="/v1/messages",
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_closes_the_upstream_response():
+    """A /v1/messages client hanging up mid-stream must release the provider
+    connection. httpx auto-closes only on natural exhaustion, so abandoning the
+    generator otherwise leaves the backend decoding into a dead socket (#36123)."""
+    stream = _RecordingByteStream([b"chunk-1", b"chunk-2", b"chunk-3"])
+    response = httpx.Response(200, stream=stream)
+
+    with patch.object(PassThroughStreamingHandler, "_route_streaming_logging_to_handler", new=AsyncMock()):
+        generator = _run_chunk_processor(response)
+        assert await generator.__anext__() == b"chunk-1"
+        assert response.is_closed is False
+
+        await generator.aclose()
+
+    assert stream.aclose_calls == 1
+    assert response.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_disconnect_still_logs_partial_usage_before_closing():
+    """Closing the upstream must not cost us the LIT-2642 spend logging for the
+    bytes already streamed."""
+    stream = _RecordingByteStream([b"chunk-1", b"chunk-2"])
+    response = httpx.Response(200, stream=stream)
+
+    with patch.object(
+        PassThroughStreamingHandler,
+        "_route_streaming_logging_to_handler",
+        new=AsyncMock(),
+    ) as mock_route:
+        generator = _run_chunk_processor(response)
+        await generator.__anext__()
+        await generator.aclose()
+        await asyncio.sleep(0)
+
+    mock_route.assert_called_once()
+    assert mock_route.call_args.kwargs["raw_bytes"] == [b"chunk-1"]
+    assert response.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_exhausted_stream_needs_no_extra_close():
+    """httpx already closed the response on natural exhaustion, so the cleanup
+    must not fire a second aclose at the transport."""
+    stream = _RecordingByteStream([b"chunk-1", b"chunk-2"])
+    response = httpx.Response(200, stream=stream)
+
+    with patch.object(PassThroughStreamingHandler, "_route_streaming_logging_to_handler", new=AsyncMock()):
+        async for _ in _run_chunk_processor(response):
+            pass
+
+    assert stream.aclose_calls == 1
+    assert response.is_closed is True

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5280,6 +5280,97 @@ class TestStreamingClientDisconnectBilling:
         proxy_logging_obj._arelease_max_parallel_requests_on_disconnect.assert_awaited_once()
 
 
+class TestResponsesStreamDisconnectClosesUpstream:
+    """
+    Regression guard for #36123. The cleanup only closes the upstream when the
+    streamed object exposes ``aclose``; the /v1/responses iterators did not, so a
+    client disconnect left the provider generating into a socket nobody reads.
+    """
+
+    class _RecordingUpstreamStream:
+        def __init__(self):
+            self.aclose_calls = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+        async def aclose(self) -> None:
+            self.aclose_calls += 1
+
+    async def _finalize_on_disconnect(self, response) -> None:
+        await ProxyBaseLLMRequestProcessing._finalize_streaming_generator_cleanup(
+            request=None,
+            request_data={},
+            response=response,
+            stream_completed=False,
+            client_disconnected=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_bridged_responses_stream_closes_upstream(self):
+        from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+        from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+            LiteLLMCompletionStreamingIterator,
+        )
+
+        upstream = self._RecordingUpstreamStream()
+        logging_obj = litellm.litellm_core_utils.litellm_logging.Logging(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            call_type="acompletion",
+            start_time=datetime.datetime.now(),
+            litellm_call_id="test-call-id",
+            function_id="test-function-id",
+        )
+        response = LiteLLMCompletionStreamingIterator(
+            model="gpt-4o-mini",
+            litellm_custom_stream_wrapper=CustomStreamWrapper(
+                completion_stream=upstream,
+                model="gpt-4o-mini",
+                logging_obj=logging_obj,
+                custom_llm_provider="openai",
+            ),
+            request_input="hi",
+            responses_api_request={},
+        )
+
+        await self._finalize_on_disconnect(response)
+
+        assert upstream.aclose_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_native_responses_stream_closes_upstream(self):
+        from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
+
+        class _Stream(httpx.AsyncByteStream):
+            def __init__(self):
+                self.aclose_calls = 0
+
+            async def __aiter__(self):
+                yield b""
+
+            async def aclose(self) -> None:
+                self.aclose_calls += 1
+
+        stream = _Stream()
+        response = ResponsesAPIStreamingIterator(
+            response=httpx.Response(200, stream=stream),
+            model="gpt-4o-mini",
+            responses_api_provider_config=MagicMock(),
+            logging_obj=MagicMock(model_call_details={"litellm_params": {}}),
+            custom_llm_provider="openai",
+        )
+
+        await self._finalize_on_disconnect(response)
+
+        assert stream.aclose_calls == 1
+        assert response.response.is_closed is True
+
+
 def _apply_stream_usage_tracking(
     data: dict,
     general_settings: dict,

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_completion_streaming_iterator.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_completion_streaming_iterator.py
@@ -1,0 +1,76 @@
+"""Regression tests for #36123 — a bridged /v1/responses stream must release the
+upstream provider connection when the client goes away mid-stream."""
+
+from datetime import datetime
+
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+    LiteLLMCompletionStreamingIterator,
+)
+
+
+class _RecordingUpstreamStream:
+    """Stands in for the provider byte stream held by the CustomStreamWrapper."""
+
+    def __init__(self):
+        self.aclose_calls = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+
+
+def _make_bridge_iterator(upstream: _RecordingUpstreamStream) -> LiteLLMCompletionStreamingIterator:
+    logging_obj = LiteLLMLoggingObj(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="acompletion",
+        start_time=datetime.now(),
+        litellm_call_id="test-call-id",
+        function_id="test-function-id",
+    )
+    wrapper = CustomStreamWrapper(
+        completion_stream=upstream,
+        model="gpt-4o-mini",
+        logging_obj=logging_obj,
+        custom_llm_provider="openai",
+    )
+    return LiteLLMCompletionStreamingIterator(
+        model="gpt-4o-mini",
+        litellm_custom_stream_wrapper=wrapper,
+        request_input="hi",
+        responses_api_request={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_the_wrapped_chat_completions_stream():
+    """The bridge holds the closeable CustomStreamWrapper as an attribute. Without an
+    ``aclose`` of its own, the proxy's ``hasattr(response, "aclose")`` cleanup check
+    fails and the provider keeps generating after the client disconnects."""
+    upstream = _RecordingUpstreamStream()
+    iterator = _make_bridge_iterator(upstream)
+
+    await iterator.aclose()
+
+    assert upstream.aclose_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_idempotent():
+    upstream = _RecordingUpstreamStream()
+    iterator = _make_bridge_iterator(upstream)
+
+    await iterator.aclose()
+    await iterator.aclose()
+
+    assert upstream.aclose_calls == 1

--- a/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
+++ b/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
@@ -3,6 +3,7 @@ import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 from mcp.types import CallToolResult, TextContent
 
@@ -11,6 +12,7 @@ from litellm.responses.mcp.mcp_streaming_iterator import (
     MAX_MCP_TOOL_CALL_ROUNDS,
     MCPEnhancedStreamingIterator,
 )
+from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
 from litellm.types.llms.openai import ResponsesAPIResponse, ResponsesAPIStreamEvents
 
 # `litellm.__init__` re-exports a function named `responses`, which shadows the
@@ -257,3 +259,51 @@ async def test_initial_call_failure_is_stashed_for_eager_reraise(monkeypatch):
 
     assert iterator._initial_creation_error is not None
     assert "initial boom" in str(iterator._initial_creation_error)
+
+
+class _RecordingByteStream(httpx.AsyncByteStream):
+    def __init__(self):
+        self.aclose_calls = 0
+
+    async def __aiter__(self):
+        yield b""
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+
+
+def _responses_iterator_over(stream: _RecordingByteStream) -> ResponsesAPIStreamingIterator:
+    return ResponsesAPIStreamingIterator(
+        response=httpx.Response(200, stream=stream),
+        model="gpt-4o-mini",
+        responses_api_provider_config=MagicMock(),
+        logging_obj=MagicMock(model_call_details={"litellm_params": {}}),
+        custom_llm_provider="openai",
+    )
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_the_current_round_provider_stream():
+    """The MCP iterator swaps `base_iterator` per tool-execution round and holds no
+    `self.response`, so the inherited close is a no-op. Without an override, a client
+    disconnect leaves the round's provider stream generating (#36123)."""
+    stream = _RecordingByteStream()
+    iterator = _make_iterator([])
+    iterator.base_iterator = _responses_iterator_over(stream)
+
+    await iterator.aclose()
+
+    assert stream.aclose_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "base_iterator",
+    [None, ResponsesAPIResponse(id="resp-1", created_at=0, output=[])],
+    ids=["no_iterator_yet", "non_streaming_response"],
+)
+async def test_aclose_is_a_noop_when_no_provider_stream_is_live(base_iterator):
+    iterator = _make_iterator([])
+    iterator.base_iterator = base_iterator
+
+    await iterator.aclose()

--- a/tests/test_litellm/responses/test_streaming_iterator.py
+++ b/tests/test_litellm/responses/test_streaming_iterator.py
@@ -14,6 +14,7 @@ import pytest
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
 from litellm.responses.streaming_iterator import (
+    BaseResponsesAPIStreamingIterator,
     ResponsesAPIStreamingIterator,
     SyncResponsesAPIStreamingIterator,
 )
@@ -235,3 +236,66 @@ def test_sync_transport_error_before_completed_event_raises():
     with pytest.raises(httpx.ReadError):
         for _ in iterator:
             pass
+
+
+class _RecordingByteStream(httpx.AsyncByteStream):
+    """Upstream provider body that records whether the connection was released."""
+
+    def __init__(self, chunks: list[bytes]):
+        self.chunks = chunks
+        self.aclose_calls = 0
+
+    async def __aiter__(self):
+        for chunk in self.chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+
+
+def _make_iterator_over_real_response(stream: _RecordingByteStream) -> ResponsesAPIStreamingIterator:
+    return ResponsesAPIStreamingIterator(
+        response=httpx.Response(200, stream=stream),
+        model="gpt-4o-mini",
+        responses_api_provider_config=_mock_config(),
+        logging_obj=_logging_obj_stub(),
+        litellm_metadata={},
+        custom_llm_provider="openai",
+    )
+
+
+@pytest.mark.asyncio
+async def test_aclose_releases_upstream_connection_on_abandoned_stream():
+    """A /v1/responses stream abandoned mid-flight (client disconnect) must release the
+    provider connection. httpx only auto-closes on natural exhaustion, so leaving the
+    response open keeps vLLM/sglang decoding into a socket nobody reads (#36123)."""
+    stream = _RecordingByteStream([_sse_event({"type": "response.output_text.delta", "delta": "hi"})])
+    iterator = _make_iterator_over_real_response(stream)
+
+    await iterator.__anext__()
+    assert iterator.response.is_closed is False
+
+    await iterator.aclose()
+
+    assert stream.aclose_calls == 1
+    assert iterator.response.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_idempotent():
+    stream = _RecordingByteStream([_sse_event({"type": "response.output_text.delta", "delta": "hi"})])
+    iterator = _make_iterator_over_real_response(stream)
+
+    await iterator.aclose()
+    await iterator.aclose()
+
+    assert stream.aclose_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_a_noop_for_iterators_that_hold_no_upstream_response():
+    """Subclasses serving synthetic events (router fallback wrapper, MCP) bypass
+    ``__init__``, so ``aclose`` must not blow up on a missing ``self.response``."""
+    iterator = BaseResponsesAPIStreamingIterator.__new__(BaseResponsesAPIStreamingIterator)
+
+    await iterator.aclose()


### PR DESCRIPTION
Problem this solves:

- Client disconnect on /v1/responses and /v1/messages never closes the upstream
- Provider keeps generating, and billing, after nobody is listening

How it solves it:

- Give every /v1/responses iterator an `aclose()` that releases its upstream
- Close the httpx response in the /v1/messages pass-through handler's `finally`

## Relevant issues

Fixes #36123

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

There are no provider credentials in this environment, so the run below is the exact command list rather than captured output. Run it once on the parent commit and once on 566d184

1. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload 2>&1 | tee litellm.log`
2. Grab its pid: `PROXY_PID=$(pgrep -f "proxy_cli.py --config" | head -1)`
3. Start a long stream and hang up on it after two seconds:

```bash
curl -sN http://localhost:4000/v1/responses \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model": "anthropic-sonnet-5", "stream": true, "input": "Write a 2000 word essay on the history of the printing press"}' &
CURL_PID=$!
sleep 2
kill -9 $CURL_PID
```

4. Watch the upstream socket for the next 30 seconds: `for i in $(seq 1 10); do lsof -nP -p $PROXY_PID -i TCP -a | grep -c ESTABLISHED; sleep 3; done`

Before the fix the connection to the provider stays ESTABLISHED long after curl dies, and litellm.log keeps logging chunks for the dead request. After the fix the count drops within a second of the disconnect and the chunk logging stops with it

Repeating step 3 with `"model": "gpt-5.5"` exercises the native path, which never touches the completion bridge, and behaves the same way

For the /v1/messages half, repeat step 3 against that route:

```bash
curl -sN http://localhost:4000/v1/messages \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model": "anthropic-sonnet-5", "stream": true, "max_tokens": 4096, "messages": [{"role": "user", "content": "Write a 2000 word essay on the history of the printing press"}]}' &
CURL_PID=$!
sleep 2
kill -9 $CURL_PID
```

## Type

🐛 Bug Fix

## Changes

`_finalize_streaming_generator_cleanup` closes the upstream only when the streamed object exposes `aclose`. On /v1/responses that check has always been false. The native iterator holds the `httpx.Response` but defined no `aclose`, and the completion-bridge iterator holds a `CustomStreamWrapper` that does have one but never called it. So when a client hung up, the provider kept decoding into a socket nobody reads until the request timed out

`BaseResponsesAPIStreamingIterator.aclose` now closes `self.response` inside `anyio.CancelScope(shield=True)` so it survives the cancellation that triggered the cleanup, and no-ops when the response is already closed or absent. `LiteLLMCompletionStreamingIterator` overrides it to delegate to its wrapper, which does its own shielding. This also makes the Router's existing `source_iterator.aclose()` in the responses fallback path effective, since that was a `hasattr` no-op before

Three subclasses deliberately bypass that constructor, which is why `response` is declared at class level. `FallbackResponsesStreamWrapper` already had its own close. `MCPEnhancedStreamingIterator` swaps `base_iterator` per tool-execution round, so it now overrides `aclose` to close the round's live stream, closing the last /v1/responses leak

/v1/messages never reaches that cleanup at all. `AnthropicMessagesStreamingResponse.aclose` chains into `PassThroughStreamingHandler.chunk_processor`, whose `finally` only scheduled spend logging, and `chunk_processor` is where the upstream `httpx.Response` actually lives. Closing it there covers both /v1/messages routes at once, the managed one and the raw pass-through `StreamingResponse`. The close sits after the logging enqueue so a close error can never cost us the partial spend record from LIT-2642, and httpx's `aclose` is already a no-op once closed, so the natural-exhaustion path is untouched

Tests cover all three responses iterators, the proxy seam that was actually broken, and the pass-through handler: a disconnect now releases the provider stream on every /v1/responses and /v1/messages path. Every new test fails without its corresponding fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
