### PR TITLE
docs(keys): document /key/info fields and clarify budget_reset_at is the next reset

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3528,11 +3528,27 @@ async def info_key_fn(
 ):
     """
     Retrieve information about a key.
+
     Parameters:
-        key: Optional[str] = Query parameter representing the key in the request
-        user_api_key_dict: UserAPIKeyAuth = Dependency representing the user's API key
+    - key: str | None (query parameter) - The key to look up. Accepts the plaintext key or its hash. Defaults to the key in the Authorization header.
+
     Returns:
-        Dict containing the key and its associated information
+    - key: str - The key that was looked up, echoed back as it was passed in
+    - info: dict - The key's row, minus the hashed token
+        - key_alias: str | None - User-friendly key alias
+        - spend: float - Amount spent by the key. When budget_duration is set this covers only the current budget window, not the key's lifetime
+        - max_budget: float | None - Max budget for the key, enforced against spend
+        - budget_duration: str | None - Budget reset period ("30d", "1h", etc.)
+        - budget_reset_at: datetime | None - When the current budget window ends and spend is next reset to 0, not when it was last reset. The window it closes started at budget_reset_at minus budget_duration
+        - model_max_budget: dict - Per-model budgets, e.g. {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}
+        - model_max_budget_usage: dict | None - Current-window spend per model, present only when the key has per-model budgets
+        - models: list - Model_name's the key is allowed to call
+        - tpm_limit / rpm_limit: int | None - Tokens and requests per minute limits
+        - metadata: dict - Metadata for the key, e.g. {"team": "core-infra"}
+        - blocked: bool | None - Whether the key is blocked
+        - expires: datetime | None - When the key stops authenticating requests
+        - last_active: datetime | None - When the key was last used
+        - object_permission: dict | None - Resolved vector store / MCP permissions when the key has an object_permission_id
 
     Example Curl:
     ```

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3530,25 +3530,32 @@ async def info_key_fn(
     Retrieve information about a key.
 
     Parameters:
-    - key: str | None (query parameter) - The key to look up. Accepts the plaintext key or its hash. Defaults to the key in the Authorization header.
+    - key: str | None (query parameter) - The key to look up. Accepts the plaintext key or its hash.
+      Defaults to the key in the Authorization header.
 
     Returns:
     - key: str - The key that was looked up, echoed back as it was passed in
     - info: dict - The key's row, minus the hashed token
         - key_alias: str | None - User-friendly key alias
-        - spend: float - Amount spent by the key. When budget_duration is set this covers only the current budget window, not the key's lifetime
+        - spend: float - Amount spent by the key. When budget_duration is set this covers only the
+          current budget window, not the key's lifetime
         - max_budget: float | None - Max budget for the key, enforced against spend
         - budget_duration: str | None - Budget reset period ("30d", "1h", etc.)
-        - budget_reset_at: datetime | None - When the current budget window ends and spend is next reset to 0, not when it was last reset. The window it closes started at budget_reset_at minus budget_duration
+        - budget_reset_at: datetime | None - When the current budget window ends and spend is next
+          reset to 0, not when it was last reset. Reset times snap to standard boundaries in the
+          configured timezone (30d and 1mo land on the 1st of the month, 7d on Monday, 1h on the
+          hour), so subtracting budget_duration from it does not give the window's start
         - model_max_budget: dict - Per-model budgets, e.g. {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}
-        - model_max_budget_usage: dict | None - Current-window spend per model, present only when the key has per-model budgets
+        - model_max_budget_usage: dict | None - Current-window spend per model, present only when
+          the key has per-model budgets
         - models: list - Model_name's the key is allowed to call
         - tpm_limit / rpm_limit: int | None - Tokens and requests per minute limits
         - metadata: dict - Metadata for the key, e.g. {"team": "core-infra"}
         - blocked: bool | None - Whether the key is blocked
         - expires: datetime | None - When the key stops authenticating requests
         - last_active: datetime | None - When the key was last used
-        - object_permission: dict | None - Resolved vector store / MCP permissions when the key has an object_permission_id
+        - object_permission: dict | None - Resolved vector store / MCP permissions when the key has
+          an object_permission_id
 
     Example Curl:
     ```


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/key/info` Swagger docs say nothing about the fields it returns
- `budget_reset_at` reads like the last reset, it's the next one
- Readers assume `info.spend` is lifetime spend for the key

How it solves it:

- Hand-written docstring listing the notable `info` fields
- Spells out that `spend` covers only the current budget window
- Warns that reset times snap to standard boundaries, so you can't derive the window start by subtracting `budget_duration`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (docstring-only change, nothing executable to assert on)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Captured at 06e789cd66 against a live proxy

```bash
curl -s "http://localhost:4111/openapi.json" | python -c "import json,sys; print(json.load(sys.stdin)['paths']['/key/info']['get']['description'])"
```

```
Retrieve information about a key.

Parameters:
- key: str | None (query parameter) - The key to look up. Accepts the plaintext key or its hash.
  Defaults to the key in the Authorization header.

Returns:
- key: str - The key that was looked up, echoed back as it was passed in
- info: dict - The key's row, minus the hashed token
    - key_alias: str | None - User-friendly key alias
    - spend: float - Amount spent by the key. When budget_duration is set this covers only the
      current budget window, not the key's lifetime
    - max_budget: float | None - Max budget for the key, enforced against spend
    - budget_duration: str | None - Budget reset period ("30d", "1h", etc.)
    - budget_reset_at: datetime | None - When the current budget window ends and spend is next
      reset to 0, not when it was last reset. Reset times snap to standard boundaries in the
      configured timezone (30d and 1mo land on the 1st of the month, 7d on Monday, 1h on the
      hour), so subtracting budget_duration from it does not give the window's start
    ...
```

The same text renders as the endpoint description in Swagger at the proxy root, under `GET /key/info`

Generating a key on Aug 6 with a 30d budget shows why the boundary warning is there. The window it reports closes on Sep 1, and Sep 1 minus 30d lands on Aug 2, which is neither the creation time nor the real window start

```bash
KEY=$(curl -s -X POST http://localhost:4111/key/generate \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"key_alias":"reset-boundary-demo","max_budget":10,"budget_duration":"30d"}' | jq -r .key)
curl -s "http://localhost:4111/key/info?key=$KEY" -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  | jq '.info | {created_at, budget_duration, budget_reset_at}'
```

```json
{
  "created_at": "2026-08-06T23:10:19.956000+00:00",
  "budget_duration": "30d",
  "budget_reset_at": "2026-09-01T00:00:00+00:00"
}
```

## Type

📖 Documentation

## Changes

Only the `info_key_fn` docstring changes, so the rendered description under `GET /key/info` now lists the `info` payload the endpoint actually returns instead of "Dict containing the key and its associated information". The fields that mislead people get called out directly: `budget_reset_at` is when the current window ends and `spend` next zeroes rather than when it last reset, `spend` therefore covers only that window rather than the key's lifetime, and the reset instant comes from `get_next_standardized_reset_time`, which snaps to calendar boundaries instead of creation time plus the duration

No behavior, response shape, or type changes

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
