### PR TITLE
feat(ui): migrate playground chat to shadcn and fix MCP routing

### DIFF
--- a/ui/litellm-dashboard/PLAYGROUND_CHAT_SHADCN_MIGRATION.md
+++ b/ui/litellm-dashboard/PLAYGROUND_CHAT_SHADCN_MIGRATION.md
@@ -41,6 +41,8 @@ Migrate the Playground Chat tab and its rendered component tree from Ant Design,
 - [x] Migrate `MCPEventsDisplay.tsx` collapsibles (remove Ant Design Collapse and styled-jsx).
 - [x] Migrate `ResponseMetrics.tsx` tooltips and icons.
 - [x] Migrate `AdditionalModelSettings.tsx` checkbox, numeric inputs, range sliders, popover, tooltip, and typography.
+- [x] Migrate `ChatMessageBubble.tsx`, `ChatImageRenderer.tsx`, and `ResponsesImageRenderer.tsx` icons.
+- [x] Migrate the Playground page tabs from Tremor to shadcn tabs.
 
 ## Remaining Migration
 
@@ -48,9 +50,7 @@ Migrate the Playground Chat tab and its rendered component tree from Ant Design,
 - [ ] Migrate `ByokCredentialModal.tsx` to shadcn `Dialog`, inputs, and switch.
 - [ ] Migrate `RealtimePlayground.tsx` buttons, inputs, selects, typography, and icons.
 - [ ] Migrate remaining `ChatUI.tsx` Ant Design and Tremor buttons, inputs, dialogs, popovers, tool selectors, loading indicators, uploads, typography, cards, and icons.
-- [ ] Migrate `ChatMessageBubble.tsx`, `ChatImageRenderer.tsx`, and `ResponsesImageRenderer.tsx` icons.
 - [ ] Migrate `AgentBuilderView.tsx` if it remains in the Chat tab tree.
-- [ ] Migrate the Playground page tabs from Tremor to shadcn tabs.
 - [ ] Remove every `antd`, `@ant-design/icons`, and `@tremor/react` import from the Chat tab render tree.
 
 ## Behavior And Quality Gaps

--- a/ui/litellm-dashboard/PLAYGROUND_CHAT_SHADCN_MIGRATION.md
+++ b/ui/litellm-dashboard/PLAYGROUND_CHAT_SHADCN_MIGRATION.md
@@ -43,15 +43,17 @@ Migrate the Playground Chat tab and its rendered component tree from Ant Design,
 - [x] Migrate `AdditionalModelSettings.tsx` checkbox, numeric inputs, range sliders, popover, tooltip, and typography.
 - [x] Migrate `ChatMessageBubble.tsx`, `ChatImageRenderer.tsx`, and `ResponsesImageRenderer.tsx` icons.
 - [x] Migrate the Playground page tabs from Tremor to shadcn tabs.
+- [x] Migrate remaining `ChatUI.tsx` Ant Design and Tremor buttons, inputs, dialogs, popovers, tool selectors, loading indicators, uploads, typography, cards, and icons.
+- [x] Migrate MCP server multi/single selects in `ChatUI.tsx` to `MultiSelect` / `SearchSelect`.
+- [x] Update `ChatUI.test.tsx` off Ant Design selectors onto combobox/search-select queries.
 
 ## Remaining Migration
 
 - [ ] Migrate `MCPToolArgumentsForm.tsx` form controls.
 - [ ] Migrate `ByokCredentialModal.tsx` to shadcn `Dialog`, inputs, and switch.
 - [ ] Migrate `RealtimePlayground.tsx` buttons, inputs, selects, typography, and icons.
-- [ ] Migrate remaining `ChatUI.tsx` Ant Design and Tremor buttons, inputs, dialogs, popovers, tool selectors, loading indicators, uploads, typography, cards, and icons.
 - [ ] Migrate `AgentBuilderView.tsx` if it remains in the Chat tab tree.
-- [ ] Remove every `antd`, `@ant-design/icons`, and `@tremor/react` import from the Chat tab render tree.
+- [ ] Remove every `antd`, `@ant-design/icons`, and `@tremor/react` import from the Chat tab render tree (RealtimePlayground, AgentBuilderView, MCP form/modal, and Compare tab are still on legacy UI).
 
 ## Behavior And Quality Gaps
 
@@ -87,4 +89,6 @@ Migrate the Playground Chat tab and its rendered component tree from Ant Design,
   - `CodeInterpreterOutput.test.tsx`
   - `AdditionalModelSettings.test.tsx`
   - `ReasoningContent.test.tsx`
-- Remaining Ant Design / Tremor usage is concentrated in `ChatUI.tsx`, `RealtimePlayground.tsx`, image renderers, `ChatMessageBubble.tsx`, and `AgentBuilderView.tsx`.
+  - `ChatUI.test.tsx` (12 tests)
+- `ChatUI.tsx` has no remaining `antd`, `@ant-design/icons`, or `@tremor/react` imports.
+- Remaining Ant Design usage under the Playground Chat tree is mainly `RealtimePlayground.tsx`, `AgentBuilderView.tsx`, `MCPToolArgumentsForm.tsx`, and `ByokCredentialModal.tsx`.

--- a/ui/litellm-dashboard/PLAYGROUND_CHAT_SHADCN_MIGRATION.md
+++ b/ui/litellm-dashboard/PLAYGROUND_CHAT_SHADCN_MIGRATION.md
@@ -51,7 +51,8 @@ Migrate the Playground Chat tab and its rendered component tree from Ant Design,
 
 - [ ] Migrate `MCPToolArgumentsForm.tsx` form controls.
 - [ ] Migrate `ByokCredentialModal.tsx` to shadcn `Dialog`, inputs, and switch.
-- [ ] Migrate `RealtimePlayground.tsx` buttons, inputs, selects, typography, and icons.
+- [x] Migrate `RealtimePlayground.tsx` buttons, inputs, selects, typography, and icons; share ChatComposer; use realtime-safe voice list.
+- [x] Migrate Compare `MessageInput.tsx` to shared ChatComposer.
 - [ ] Migrate `AgentBuilderView.tsx` if it remains in the Chat tab tree.
 - [ ] Remove every `antd`, `@ant-design/icons`, and `@tremor/react` import from the Chat tab render tree (RealtimePlayground, AgentBuilderView, MCP form/modal, and Compare tab are still on legacy UI).
 

--- a/ui/litellm-dashboard/PLAYGROUND_CHAT_SHADCN_MIGRATION.md
+++ b/ui/litellm-dashboard/PLAYGROUND_CHAT_SHADCN_MIGRATION.md
@@ -1,0 +1,90 @@
+# Playground Chat Shadcn Migration
+
+## Scope
+
+Migrate the Playground Chat tab and its rendered component tree from Ant Design, Ant Design icons, and Tremor to the dashboard's shadcn/Base UI components and Lucide icons. Preserve behavior while fixing accessibility, responsiveness, state, validation, and test gaps discovered during migration.
+
+## Completed
+
+- [x] Audit the Playground Chat component tree and legacy UI dependencies.
+- [x] Rank migration work from lowest to highest implementation risk.
+- [x] Migrate `EndpointSelector.tsx` from Ant Design `Select` to the shared searchable `SearchSelect`.
+- [x] Migrate `SessionManagement.tsx` to shadcn `Switch`, `Button`, and `Tooltip` components.
+- [x] Add accessible labels and clipboard failure handling to session controls.
+- [x] Migrate `CodeInterpreterTool.tsx` to shadcn controls and Lucide icons.
+- [x] Migrate `SearchResultsDisplay.tsx` to keyboard-accessible shadcn collapsibles.
+- [x] Migrate `A2AMetrics.tsx` buttons, tooltips, collapsibles, and icons.
+- [x] Add `components/shared/MultiSelect.tsx` for searchable multi-value selection with removable chips.
+- [x] Migrate `TagSelector.tsx` to `MultiSelect`, including custom tag creation.
+- [x] Migrate `VectorStoreSelector.tsx` to `MultiSelect`.
+- [x] Migrate `GuardrailSelector.tsx` to `MultiSelect`.
+- [x] Migrate `PolicySelector.tsx` to `MultiSelect`.
+- [x] Migrate the Virtual Key Source selector in `ChatUI.tsx` to shadcn `Select`.
+- [x] Migrate the voice selector in `ChatUI.tsx` to shadcn `Select`.
+- [x] Migrate the model selector in `ChatUI.tsx` to searchable `SearchSelect`.
+- [x] Migrate the agent selector in `ChatUI.tsx` to searchable `SearchSelect`.
+- [x] Standardize migrated dropdown controls to a compact 32px height.
+- [x] Keep searchable dropdown menus below their fields instead of flipping above them.
+- [x] Remove the fixed `80vh` Chat layout and percentage-width columns.
+- [x] Add shrink, overflow, wrapping, and responsive behavior to the Playground shell, configuration panel, chat panel, composer, and message bubbles.
+- [x] Parse model-list entries using `model_group`, `id`, or `model_name` so database-backed and key-scoped models can be displayed.
+- [x] Deduplicate and alphabetically sort model results.
+- [x] Fetch models when switching between the current UI session and a custom Virtual Key.
+- [x] Add model loading, empty, missing-key, and request-failure states.
+- [x] Show all models returned for the active key rather than filtering the list down to the current endpoint.
+- [x] Automatically update the endpoint when a selected model has a known mode.
+- [x] Migrate `ChatImageUpload.tsx` and `ResponsesImageUpload.tsx` from Ant Design uploads to semantic file inputs and shadcn buttons.
+- [x] Enforce upload MIME type, extension, size, and count restrictions in application logic (`uploadValidation.ts`).
+- [x] Migrate `FilePreviewCard.tsx` icons and remove button to Lucide and shadcn.
+- [x] Migrate `CodeInterpreterOutput.tsx` collapsible, loading, and download controls.
+- [x] Migrate `ReasoningContent.tsx` collapsible and icons.
+- [x] Migrate `MCPEventsDisplay.tsx` collapsibles (remove Ant Design Collapse and styled-jsx).
+- [x] Migrate `ResponseMetrics.tsx` tooltips and icons.
+- [x] Migrate `AdditionalModelSettings.tsx` checkbox, numeric inputs, range sliders, popover, tooltip, and typography.
+
+## Remaining Migration
+
+- [ ] Migrate `MCPToolArgumentsForm.tsx` form controls.
+- [ ] Migrate `ByokCredentialModal.tsx` to shadcn `Dialog`, inputs, and switch.
+- [ ] Migrate `RealtimePlayground.tsx` buttons, inputs, selects, typography, and icons.
+- [ ] Migrate remaining `ChatUI.tsx` Ant Design and Tremor buttons, inputs, dialogs, popovers, tool selectors, loading indicators, uploads, typography, cards, and icons.
+- [ ] Migrate `ChatMessageBubble.tsx`, `ChatImageRenderer.tsx`, and `ResponsesImageRenderer.tsx` icons.
+- [ ] Migrate `AgentBuilderView.tsx` if it remains in the Chat tab tree.
+- [ ] Migrate the Playground page tabs from Tremor to shadcn tabs.
+- [ ] Remove every `antd`, `@ant-design/icons`, and `@tremor/react` import from the Chat tab render tree.
+
+## Behavior And Quality Gaps
+
+- [ ] Validate the selected model and endpoint requirements before adding a message or clearing the draft.
+- [ ] Prevent rapid duplicate submissions and stale chat-history updates.
+- [ ] Keep attachments available after request failure so the user can retry.
+- [ ] Add runtime validation and error handling for persisted Playground state.
+- [ ] Review storage of chat content, session identifiers, selections, and API keys.
+- [ ] Replace reversible Base64 API-key storage with an appropriate authentication/storage design.
+- [ ] Audit remaining icon-only controls for accessible names and state attributes.
+- [ ] Audit object URL lifecycle and revoke previews when removed or unmounted.
+- [ ] Reduce `ChatUI.tsx` complexity by extracting request/state logic into testable modules.
+
+## Tests And Verification
+
+- [x] Add unit tests for upload MIME, extension, size, and count validation.
+- [ ] Update tests that still target Ant Design selectors and DOM classes.
+- [ ] Add unit tests for model response normalization, deduplication, and fallback fields.
+- [ ] Add integration coverage for UI-session and Virtual Key model loading.
+- [ ] Add integration coverage for searchable model selection and endpoint synchronization.
+- [ ] Add integration coverage for upload validation and retry behavior.
+- [ ] Add Playwright coverage for the core Playground Chat flow and responsive layout.
+- [ ] Run the focused Vitest suites under the repository-required Node and npm versions.
+- [ ] Run the dashboard lint, formatting, type-check, and build commands.
+- [ ] Run ESLint with `--prune-suppressions` after resolving grandfathered warnings.
+
+## Current Verification Notes
+
+- Branch: `litellm_playground_chat_shadcn` from `litellm_internal_staging`.
+- Focused Vitest suites pass under Node `24.14.1` / npm `11.11.0`:
+  - `uploadValidation.test.ts`
+  - `FilePreviewCard.test.tsx`
+  - `CodeInterpreterOutput.test.tsx`
+  - `AdditionalModelSettings.test.tsx`
+  - `ReasoningContent.test.tsx`
+- Remaining Ant Design / Tremor usage is concentrated in `ChatUI.tsx`, `RealtimePlayground.tsx`, image renderers, `ChatMessageBubble.tsx`, and `AgentBuilderView.tsx`.

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/A2AMetrics.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/A2AMetrics.tsx
@@ -1,17 +1,19 @@
 import React, { useState } from "react";
-import { Tooltip, Button } from "antd";
 import {
-  CheckCircleOutlined,
-  ClockCircleOutlined,
-  LoadingOutlined,
-  ExclamationCircleOutlined,
-  CopyOutlined,
-  DownOutlined,
-  RightOutlined,
-  LinkOutlined,
-  FileTextOutlined,
-  RobotOutlined,
-} from "@ant-design/icons";
+  Bot,
+  CheckCircle,
+  ChevronDown,
+  ChevronRight,
+  CircleAlert,
+  Clock,
+  Copy,
+  FileText,
+  Link,
+  LoaderCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export interface A2ATaskMetadata {
   taskId?: string;
@@ -21,7 +23,7 @@ export interface A2ATaskMetadata {
     timestamp?: string;
     message?: string;
   };
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 interface A2AMetricsProps {
@@ -33,15 +35,15 @@ interface A2AMetricsProps {
 const getStatusIcon = (state?: string) => {
   switch (state) {
     case "completed":
-      return <CheckCircleOutlined className="text-green-500" />;
+      return <CheckCircle className="size-3 text-green-500" />;
     case "working":
     case "submitted":
-      return <LoadingOutlined className="text-blue-500" />;
+      return <LoaderCircle className="size-3 animate-spin text-blue-500" />;
     case "failed":
     case "canceled":
-      return <ExclamationCircleOutlined className="text-red-500" />;
+      return <CircleAlert className="size-3 text-red-500" />;
     default:
-      return <ClockCircleOutlined className="text-gray-500" />;
+      return <Clock className="size-3 text-gray-500" />;
   }
 };
 
@@ -91,7 +93,7 @@ const A2AMetrics: React.FC<A2AMetricsProps> = ({ a2aMetadata, timeToFirstToken, 
     <div className="a2a-metrics mt-3 pt-2 border-t border-gray-200 text-xs">
       {/* A2A Metadata Header */}
       <div className="flex items-center mb-2 text-gray-600">
-        <RobotOutlined className="mr-1.5 text-blue-500" />
+        <Bot className="mr-1.5 size-4 text-blue-500" />
         <span className="font-medium text-gray-700">A2A Metadata</span>
       </div>
 
@@ -109,28 +111,33 @@ const A2AMetrics: React.FC<A2AMetricsProps> = ({ a2aMetadata, timeToFirstToken, 
 
         {/* Timestamp */}
         {formattedTime && (
-          <Tooltip title={status?.timestamp}>
-            <span className="flex items-center">
-              <ClockCircleOutlined className="mr-1" />
+          <Tooltip>
+            <TooltipTrigger render={<span className="flex items-center" />}>
+              <Clock className="mr-1 size-3" />
               {formattedTime}
-            </span>
+            </TooltipTrigger>
+            <TooltipContent>{status?.timestamp}</TooltipContent>
           </Tooltip>
         )}
 
         {/* Latency */}
         {totalLatency !== undefined && (
-          <Tooltip title="Total latency">
-            <span className="flex items-center text-blue-600">
-              <ClockCircleOutlined className="mr-1" />
+          <Tooltip>
+            <TooltipTrigger render={<span className="flex items-center text-blue-600" />}>
+              <Clock className="mr-1 size-3" />
               {(totalLatency / 1000).toFixed(2)}s
-            </span>
+            </TooltipTrigger>
+            <TooltipContent>Total latency</TooltipContent>
           </Tooltip>
         )}
 
         {/* Time to first token */}
         {timeToFirstToken !== undefined && (
-          <Tooltip title="Time to first token">
-            <span className="flex items-center text-green-600">TTFT: {(timeToFirstToken / 1000).toFixed(2)}s</span>
+          <Tooltip>
+            <TooltipTrigger render={<span className="flex items-center text-green-600" />}>
+              TTFT: {(timeToFirstToken / 1000).toFixed(2)}s
+            </TooltipTrigger>
+            <TooltipContent>Time to first token</TooltipContent>
           </Tooltip>
         )}
       </div>
@@ -139,95 +146,133 @@ const A2AMetrics: React.FC<A2AMetricsProps> = ({ a2aMetadata, timeToFirstToken, 
       <div className="flex flex-wrap items-center gap-3 text-gray-500 ml-4 mt-1.5">
         {/* Task ID */}
         {taskId && (
-          <Tooltip title={`Click to copy: ${taskId}`}>
-            <span
-              className="flex items-center cursor-pointer hover:text-gray-700"
-              onClick={() => copyToClipboard(taskId)}
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  className="h-auto p-0 font-normal text-gray-500 hover:bg-transparent hover:text-gray-700"
+                  onClick={() => copyToClipboard(taskId)}
+                  aria-label={`Copy task ID ${taskId}`}
+                />
+              }
             >
-              <FileTextOutlined className="mr-1" />
+              <FileText className="size-3" />
               Task: {truncateId(taskId)}
-              <CopyOutlined className="ml-1 text-gray-400 hover:text-gray-600" />
-            </span>
+              <Copy className="size-3 text-gray-400" />
+            </TooltipTrigger>
+            <TooltipContent>Click to copy: {taskId}</TooltipContent>
           </Tooltip>
         )}
 
         {/* Context/Session ID */}
         {contextId && (
-          <Tooltip title={`Click to copy: ${contextId}`}>
-            <span
-              className="flex items-center cursor-pointer hover:text-gray-700"
-              onClick={() => copyToClipboard(contextId)}
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  className="h-auto p-0 font-normal text-gray-500 hover:bg-transparent hover:text-gray-700"
+                  onClick={() => copyToClipboard(contextId)}
+                  aria-label={`Copy session ID ${contextId}`}
+                />
+              }
             >
-              <LinkOutlined className="mr-1" />
+              <Link className="size-3" />
               Session: {truncateId(contextId)}
-              <CopyOutlined className="ml-1 text-gray-400 hover:text-gray-600" />
-            </span>
+              <Copy className="size-3 text-gray-400" />
+            </TooltipTrigger>
+            <TooltipContent>Click to copy: {contextId}</TooltipContent>
           </Tooltip>
         )}
 
         {/* Details toggle */}
         {(metadata || status?.message) && (
-          <Button
-            type="text"
-            size="small"
-            className="text-xs text-blue-500 hover:text-blue-700 p-0 h-auto"
-            onClick={() => setShowDetails(!showDetails)}
-          >
-            {showDetails ? <DownOutlined /> : <RightOutlined />}
-            <span className="ml-1">Details</span>
-          </Button>
+          <Collapsible open={showDetails} onOpenChange={setShowDetails}>
+            <CollapsibleTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  className="h-auto p-0 text-xs text-blue-500 hover:bg-transparent hover:text-blue-700"
+                />
+              }
+            >
+              {showDetails ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+              Details
+            </CollapsibleTrigger>
+          </Collapsible>
         )}
       </div>
 
       {/* Expandable details panel */}
-      {showDetails && (
-        <div className="mt-2 ml-4 p-3 bg-gray-50 rounded-md text-gray-600 border border-gray-200">
-          {/* Status message */}
-          {status?.message && (
-            <div className="mb-2">
-              <span className="font-medium text-gray-700">Status Message:</span>
-              <span className="ml-2">{status.message}</span>
-            </div>
-          )}
+      <Collapsible open={showDetails} onOpenChange={setShowDetails}>
+        <CollapsibleContent>
+          <div className="mt-2 ml-4 p-3 bg-gray-50 rounded-md text-gray-600 border border-gray-200">
+            {/* Status message */}
+            {status?.message && (
+              <div className="mb-2">
+                <span className="font-medium text-gray-700">Status Message:</span>
+                <span className="ml-2">{status.message}</span>
+              </div>
+            )}
 
-          {/* Full IDs */}
-          {taskId && (
-            <div className="mb-1.5 flex items-center">
-              <span className="font-medium text-gray-700 w-24">Task ID:</span>
-              <code className="ml-2 px-2 py-1 bg-white border border-gray-200 rounded-sm text-xs font-mono">
-                {taskId}
-              </code>
-              <CopyOutlined
-                className="ml-2 cursor-pointer text-gray-400 hover:text-blue-500"
-                onClick={() => copyToClipboard(taskId)}
-              />
-            </div>
-          )}
+            {/* Full IDs */}
+            {taskId && (
+              <div className="mb-1.5 flex items-center">
+                <span className="font-medium text-gray-700 w-24">Task ID:</span>
+                <code className="ml-2 px-2 py-1 bg-white border border-gray-200 rounded-sm text-xs font-mono">
+                  {taskId}
+                </code>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="ml-2 text-gray-400 hover:text-blue-500"
+                  onClick={() => copyToClipboard(taskId)}
+                  aria-label={`Copy task ID ${taskId}`}
+                >
+                  <Copy className="size-3" />
+                </Button>
+              </div>
+            )}
 
-          {contextId && (
-            <div className="mb-1.5 flex items-center">
-              <span className="font-medium text-gray-700 w-24">Session ID:</span>
-              <code className="ml-2 px-2 py-1 bg-white border border-gray-200 rounded-sm text-xs font-mono">
-                {contextId}
-              </code>
-              <CopyOutlined
-                className="ml-2 cursor-pointer text-gray-400 hover:text-blue-500"
-                onClick={() => copyToClipboard(contextId)}
-              />
-            </div>
-          )}
+            {contextId && (
+              <div className="mb-1.5 flex items-center">
+                <span className="font-medium text-gray-700 w-24">Session ID:</span>
+                <code className="ml-2 px-2 py-1 bg-white border border-gray-200 rounded-sm text-xs font-mono">
+                  {contextId}
+                </code>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="ml-2 text-gray-400 hover:text-blue-500"
+                  onClick={() => copyToClipboard(contextId)}
+                  aria-label={`Copy session ID ${contextId}`}
+                >
+                  <Copy className="size-3" />
+                </Button>
+              </div>
+            )}
 
-          {/* Metadata fields */}
-          {metadata && Object.keys(metadata).length > 0 && (
-            <div className="mt-3">
-              <span className="font-medium text-gray-700">Custom Metadata:</span>
-              <pre className="mt-1.5 p-2 bg-white border border-gray-200 rounded-sm text-xs font-mono overflow-x-auto whitespace-pre-wrap">
-                {JSON.stringify(metadata, null, 2)}
-              </pre>
-            </div>
-          )}
-        </div>
-      )}
+            {/* Metadata fields */}
+            {metadata && Object.keys(metadata).length > 0 && (
+              <div className="mt-3">
+                <span className="font-medium text-gray-700">Custom Metadata:</span>
+                <pre className="mt-1.5 p-2 bg-white border border-gray-200 rounded-sm text-xs font-mono overflow-x-auto whitespace-pre-wrap">
+                  {JSON.stringify(metadata, null, 2)}
+                </pre>
+              </div>
+            )}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/AdditionalModelSettings.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/AdditionalModelSettings.tsx
@@ -1,7 +1,10 @@
-import { InfoCircleOutlined } from "@ant-design/icons";
-import { Text } from "@tremor/react";
-import { Checkbox, InputNumber, Popover, Slider, Tooltip, Typography } from "antd";
-import React, { useEffect, useState } from "react";
+import { Info } from "lucide-react";
+import React, { useEffect, useId, useState } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/cva.config";
 
 interface AdditionalModelSettingsProps {
   temperature?: number;
@@ -15,6 +18,10 @@ interface AdditionalModelSettingsProps {
   streamingEnabled?: boolean;
   onStreamingChange?: (value: boolean) => void;
   showAdvancedParams?: boolean;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }
 
 const AdditionalModelSettings: React.FC<AdditionalModelSettingsProps> = ({
@@ -36,7 +43,12 @@ const AdditionalModelSettings: React.FC<AdditionalModelSettingsProps> = ({
   const [localTemperature, setLocalTemperature] = useState(temperature);
   const [localMaxTokens, setLocalMaxTokens] = useState(maxTokens);
 
-  // Sync local state with props when they change
+  const streamingId = useId();
+  const advancedId = useId();
+  const fallbacksId = useId();
+  const temperatureId = useId();
+  const maxTokensId = useId();
+
   useEffect(() => {
     setLocalTemperature(temperature);
   }, [temperature]);
@@ -45,20 +57,17 @@ const AdditionalModelSettings: React.FC<AdditionalModelSettingsProps> = ({
     setLocalMaxTokens(maxTokens);
   }, [maxTokens]);
 
-  const handleTemperatureChange = (value: number | null) => {
-    const newValue = value ?? 1.0;
+  const handleTemperatureChange = (value: number) => {
+    const newValue = clamp(Number.isFinite(value) ? value : 1.0, 0, 2);
     setLocalTemperature(newValue);
     onTemperatureChange?.(newValue);
   };
 
-  const handleMaxTokensChange = (value: number | null) => {
-    const newValue = value ?? 1000;
+  const handleMaxTokensChange = (value: number) => {
+    const newValue = clamp(Number.isFinite(value) ? Math.round(value) : 1000, 1, 32768);
     setLocalMaxTokens(newValue);
     onMaxTokensChange?.(newValue);
   };
-
-  const disabledOpacity = useAdvancedParams ? 1 : 0.4;
-  const disabledTextColor = useAdvancedParams ? "text-gray-700" : "text-gray-400";
 
   const handleUseAdvancedParamsChange = (checked: boolean) => {
     if (onUseAdvancedParamsChange) {
@@ -68,129 +77,176 @@ const AdditionalModelSettings: React.FC<AdditionalModelSettingsProps> = ({
     }
   };
 
+  const disabledTextColor = useAdvancedParams ? "text-gray-700" : "text-gray-400";
+
   return (
-    <div className="space-y-4 p-4 w-80">
+    <div className="w-80 space-y-4 p-4">
       {onStreamingChange && (
-        <div className="flex items-center gap-1">
-          <Checkbox checked={streamingEnabled} onChange={(e) => onStreamingChange(e.target.checked)}>
-            <span className="font-medium">Stream responses</span>
-          </Checkbox>
-          <Tooltip title="Streams the answer token by token. Uncheck to send a non-streaming request and render the full response at once.">
-            <InfoCircleOutlined
-              className="text-xs text-gray-400 cursor-pointer shrink-0 hover:text-gray-600"
-              aria-label="Help: Stream responses"
-            />
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id={streamingId}
+            checked={streamingEnabled}
+            onCheckedChange={(checked) => onStreamingChange(checked === true)}
+            aria-label="Stream responses"
+          />
+          <label htmlFor={streamingId} className="cursor-pointer text-sm font-medium">
+            Stream responses
+          </label>
+          <Tooltip>
+            <TooltipTrigger aria-label="Help: Stream responses">
+              <Info className="size-3 shrink-0 cursor-pointer text-gray-400 hover:text-gray-600" />
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              Streams the answer token by token. Uncheck to send a non-streaming request and render the full response at
+              once.
+            </TooltipContent>
           </Tooltip>
         </div>
       )}
 
       {showAdvancedParams && (
-        <Checkbox checked={useAdvancedParams} onChange={(e) => handleUseAdvancedParamsChange(e.target.checked)}>
-          <span className="font-medium">Use Advanced Parameters</span>
-        </Checkbox>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id={advancedId}
+            checked={useAdvancedParams}
+            onCheckedChange={(checked) => handleUseAdvancedParamsChange(checked === true)}
+            aria-label="Use Advanced Parameters"
+          />
+          <label htmlFor={advancedId} className="cursor-pointer text-sm font-medium">
+            Use Advanced Parameters
+          </label>
+        </div>
       )}
 
       {onMockTestFallbacksChange && (
-        <div className="flex items-center gap-1">
-          <Checkbox checked={mockTestFallbacks ?? false} onChange={(e) => onMockTestFallbacksChange(e.target.checked)}>
-            <span className="font-medium">Simulate failure to test fallbacks</span>
-          </Checkbox>
-          <Popover
-            trigger="hover"
-            placement="right"
-            content={
-              <div style={{ maxWidth: 340 }}>
-                <Typography.Paragraph className="text-sm" style={{ marginBottom: 8 }}>
-                  Causes the first request to fail so the router tries fallbacks (if configured). Use this to verify
-                  your fallback setup.
-                </Typography.Paragraph>
-                <Typography.Paragraph className="text-sm" style={{ marginBottom: 0 }}>
-                  Behavior can differ when keys, teams, or router settings are configured.{" "}
-                  <a
-                    href="https://docs.litellm.ai/docs/proxy/keys_teams_router_settings"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 hover:text-blue-800"
-                  >
-                    Learn more
-                  </a>
-                </Typography.Paragraph>
-              </div>
-            }
-          >
-            <InfoCircleOutlined
-              className="text-xs text-gray-400 cursor-pointer shrink-0 hover:text-gray-600"
-              aria-label="Help: Simulate failure to test fallbacks"
-            />
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id={fallbacksId}
+            checked={mockTestFallbacks ?? false}
+            onCheckedChange={(checked) => onMockTestFallbacksChange(checked === true)}
+            aria-label="Simulate failure to test fallbacks"
+          />
+          <label htmlFor={fallbacksId} className="cursor-pointer text-sm font-medium">
+            Simulate failure to test fallbacks
+          </label>
+          <Popover>
+            <PopoverTrigger aria-label="Help: Simulate failure to test fallbacks">
+              <Info className="size-3 shrink-0 cursor-pointer text-gray-400 hover:text-gray-600" />
+            </PopoverTrigger>
+            <PopoverContent side="right" className="max-w-[340px] gap-2 p-3 text-sm">
+              <p>
+                Causes the first request to fail so the router tries fallbacks (if configured). Use this to verify your
+                fallback setup.
+              </p>
+              <p>
+                Behavior can differ when keys, teams, or router settings are configured.{" "}
+                <a
+                  href="https://docs.litellm.ai/docs/proxy/keys_teams_router_settings"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:text-blue-800"
+                >
+                  Learn more
+                </a>
+              </p>
+            </PopoverContent>
           </Popover>
         </div>
       )}
 
       {showAdvancedParams && (
-        <div className="space-y-4 transition-opacity duration-200" style={{ opacity: disabledOpacity }}>
+        <div
+          className={cn("space-y-4 transition-opacity duration-200", useAdvancedParams ? "opacity-100" : "opacity-40")}
+        >
           <div>
-            <div className="flex items-center justify-between mb-2">
+            <div className="mb-2 flex items-center justify-between">
               <div className="flex items-center gap-1">
-                <Text className={`text-sm ${disabledTextColor}`}>Temperature</Text>
-                <Tooltip title="Controls randomness. Lower values make output more deterministic, higher values more creative.">
-                  <InfoCircleOutlined className={`text-xs ${disabledTextColor} cursor-help`} />
+                <label htmlFor={temperatureId} className={cn("text-sm", disabledTextColor)}>
+                  Temperature
+                </label>
+                <Tooltip>
+                  <TooltipTrigger aria-label="Help: Temperature">
+                    <Info className={cn("size-3 cursor-help", disabledTextColor)} />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    Controls randomness. Lower values make output more deterministic, higher values more creative.
+                  </TooltipContent>
                 </Tooltip>
               </div>
-              <InputNumber
+              <Input
+                id={`${temperatureId}-number`}
+                type="number"
                 min={0}
                 max={2}
                 step={0.1}
                 value={localTemperature}
-                onChange={handleTemperatureChange}
                 disabled={!useAdvancedParams}
-                precision={1}
-                className="w-20"
+                className="h-8 w-20"
+                onChange={(event) => handleTemperatureChange(Number(event.target.value))}
               />
             </div>
-            <Slider
+            <input
+              id={temperatureId}
+              type="range"
               min={0}
               max={2}
               step={0.1}
               value={localTemperature}
-              onChange={handleTemperatureChange}
               disabled={!useAdvancedParams}
-              marks={{
-                0: "0",
-                1: "1.0",
-                2: "2.0",
-              }}
+              aria-label="Temperature"
+              className="w-full accent-primary disabled:cursor-not-allowed"
+              onChange={(event) => handleTemperatureChange(Number(event.target.value))}
             />
+            <div className="mt-1 flex justify-between text-xs text-gray-400">
+              <span>0</span>
+              <span>1.0</span>
+              <span>2.0</span>
+            </div>
           </div>
 
           <div>
-            <div className="flex items-center justify-between mb-2">
+            <div className="mb-2 flex items-center justify-between">
               <div className="flex items-center gap-1">
-                <Text className={`text-sm ${disabledTextColor}`}>Max Tokens</Text>
-                <Tooltip title="Maximum number of tokens to generate in the response.">
-                  <InfoCircleOutlined className={`text-xs ${disabledTextColor} cursor-help`} />
+                <label htmlFor={maxTokensId} className={cn("text-sm", disabledTextColor)}>
+                  Max Tokens
+                </label>
+                <Tooltip>
+                  <TooltipTrigger aria-label="Help: Max Tokens">
+                    <Info className={cn("size-3 cursor-help", disabledTextColor)} />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    Maximum number of tokens to generate in the response.
+                  </TooltipContent>
                 </Tooltip>
               </div>
-              <InputNumber
+              <Input
+                id={`${maxTokensId}-number`}
+                type="number"
                 min={1}
                 max={32768}
                 step={1}
                 value={localMaxTokens}
-                onChange={handleMaxTokensChange}
                 disabled={!useAdvancedParams}
+                className="h-8 w-24"
+                onChange={(event) => handleMaxTokensChange(Number(event.target.value))}
               />
             </div>
-            <Slider
+            <input
+              id={maxTokensId}
+              type="range"
               min={1}
               max={32768}
               step={1}
               value={localMaxTokens}
-              onChange={handleMaxTokensChange}
               disabled={!useAdvancedParams}
-              marks={{
-                1: "1",
-                32768: "32768",
-              }}
+              aria-label="Max Tokens"
+              className="w-full accent-primary disabled:cursor-not-allowed"
+              onChange={(event) => handleMaxTokensChange(Number(event.target.value))}
             />
+            <div className="mt-1 flex justify-between text-xs text-gray-400">
+              <span>1</span>
+              <span>32768</span>
+            </div>
           </div>
         </div>
       )}

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatComposer.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatComposer.tsx
@@ -89,8 +89,12 @@ export function ChatComposer({
       >
         <InputGroup
           className={cn(
-            "h-auto min-h-[7.5rem] flex-col overflow-hidden rounded-2xl border border-border/40 bg-card shadow-sm",
-            "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/30",
+            "h-auto min-h-[7.5rem] flex-col overflow-hidden rounded-2xl border border-border bg-card",
+            "shadow-[0_1px_2px_rgba(0,0,0,0.06),0_8px_24px_rgba(0,0,0,0.08)] ring-1 ring-black/5",
+            "transition-[box-shadow,border-color,ring] duration-200",
+            "has-[[data-slot=input-group-control]:focus-visible]:border-ring",
+            "has-[[data-slot=input-group-control]:focus-visible]:shadow-[0_2px_8px_rgba(0,0,0,0.08),0_12px_32px_rgba(0,0,0,0.12)]",
+            "has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/40",
           )}
         >
           {body ? (

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatComposer.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatComposer.tsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useRef } from "react";
+import { ArrowUp, Code2, Square } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupTextarea } from "@/components/ui/input-group";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/cva.config";
+
+interface ChatComposerProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  onCancel?: () => void;
+  placeholder: string;
+  disabled?: boolean;
+  isLoading?: boolean;
+  submitDisabled?: boolean;
+  tools?: React.ReactNode;
+  body?: React.ReactNode;
+  suggestions?: string[];
+  showSuggestions?: boolean;
+  onSuggestionSelect?: (suggestion: string) => void;
+  className?: string;
+}
+
+export function ChatComposer({
+  value,
+  onChange,
+  onSubmit,
+  onCancel,
+  placeholder,
+  disabled = false,
+  isLoading = false,
+  submitDisabled = false,
+  tools,
+  body,
+  suggestions = [],
+  showSuggestions = false,
+  onSuggestionSelect,
+  className,
+}: ChatComposerProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el || body) {
+      return;
+    }
+    el.style.height = "0px";
+    el.style.height = `${Math.min(el.scrollHeight, 192)}px`;
+  }, [value, body]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+      event.preventDefault();
+      if (!submitDisabled && !isLoading) {
+        onSubmit();
+      }
+    }
+  };
+
+  return (
+    <div className={cn("relative flex w-full flex-col gap-3", className)}>
+      {showSuggestions && suggestions.length > 0 && (
+        <div
+          className="flex w-full gap-2 overflow-x-auto pb-1 sm:grid sm:grid-cols-2 sm:overflow-visible"
+          data-testid="chat-suggested-actions"
+        >
+          {suggestions.map((suggestion) => (
+            <button
+              key={suggestion}
+              type="button"
+              className="min-w-[200px] shrink-0 rounded-xl border border-border/50 bg-card/30 px-4 py-3 text-left text-[12px] leading-relaxed text-muted-foreground transition-all duration-200 hover:-translate-y-0.5 hover:bg-card/60 hover:text-foreground sm:min-w-0 sm:whitespace-normal sm:p-4 sm:text-[13px]"
+              onClick={() => onSuggestionSelect?.(suggestion)}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <form
+        className="w-full"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!submitDisabled && !isLoading) {
+            onSubmit();
+          }
+        }}
+      >
+        <InputGroup
+          className={cn(
+            "h-auto min-h-[7.5rem] flex-col overflow-hidden rounded-2xl border border-border/40 bg-card shadow-sm",
+            "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/30",
+          )}
+        >
+          {body ? (
+            <div className="max-h-48 min-h-24 w-full overflow-y-auto px-3 pt-3">{body}</div>
+          ) : (
+            <InputGroupTextarea
+              ref={textareaRef}
+              data-testid="chat-composer-input"
+              value={value}
+              disabled={disabled}
+              placeholder={placeholder}
+              rows={1}
+              className="min-h-24 max-h-48 resize-none border-0 bg-transparent px-4 pt-3.5 pb-1.5 text-[13px] leading-relaxed shadow-none placeholder:text-muted-foreground/50 focus-visible:ring-0"
+              onChange={(event) => onChange(event.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+          )}
+
+          <InputGroupAddon align="block-end" className="justify-between gap-2 px-3 pb-3 pt-1">
+            <div className="flex min-w-0 items-center gap-1">{tools}</div>
+
+            {isLoading && onCancel ? (
+              <InputGroupButton
+                type="button"
+                size="icon-sm"
+                aria-label="Stop request"
+                data-testid="chat-stop-button"
+                className="size-8 rounded-xl bg-foreground text-background hover:bg-foreground/90"
+                onClick={onCancel}
+              >
+                <Square className="size-3.5 fill-current" />
+              </InputGroupButton>
+            ) : (
+              <InputGroupButton
+                type="submit"
+                size="icon-sm"
+                aria-label="Send message"
+                data-testid="chat-send-button"
+                disabled={submitDisabled || isLoading}
+                className={cn(
+                  "size-8 rounded-xl transition-all duration-200",
+                  !submitDisabled && !isLoading
+                    ? "bg-foreground text-background hover:opacity-90 active:scale-95"
+                    : "cursor-not-allowed bg-muted text-muted-foreground/40",
+                )}
+              >
+                <ArrowUp className="size-4" />
+              </InputGroupButton>
+            )}
+          </InputGroupAddon>
+        </InputGroup>
+      </form>
+    </div>
+  );
+}
+
+interface CodeInterpreterToggleProps {
+  enabled: boolean;
+  onToggle: () => void;
+}
+
+export function CodeInterpreterToggle({ enabled, onToggle }: CodeInterpreterToggleProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className={cn(
+              "size-8 rounded-lg border border-border/40",
+              enabled
+                ? "border-blue-200 bg-blue-50 text-blue-600 hover:bg-blue-100"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+            aria-label={enabled ? "Code Interpreter enabled (click to disable)" : "Enable Code Interpreter"}
+            onClick={onToggle}
+          />
+        }
+      >
+        <Code2 className="size-4" />
+      </TooltipTrigger>
+      <TooltipContent>
+        {enabled ? "Code Interpreter enabled (click to disable)" : "Enable Code Interpreter"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export default ChatComposer;

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatImageRenderer.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatImageRenderer.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import Image from "next/image";
+import { FileText } from "lucide-react";
 import { MessageType } from "@/components/chat_ui/types";
 import { shouldShowChatAttachedImage } from "./ChatImageUtils";
-import { FilePdfOutlined } from "@ant-design/icons";
 
 interface ChatImageRendererProps {
   message: MessageType;
@@ -18,8 +18,8 @@ const ChatImageRenderer: React.FC<ChatImageRendererProps> = ({ message }) => {
   return (
     <div className="mb-2">
       {isPdf ? (
-        <div className="w-64 h-32 rounded-md border border-gray-200 bg-red-50 flex items-center justify-center">
-          <FilePdfOutlined style={{ fontSize: "48px", color: "#dc2626" }} />
+        <div className="flex h-32 w-64 items-center justify-center rounded-md border border-gray-200 bg-red-50">
+          <FileText className="size-12 text-red-600" aria-label="PDF attachment" />
         </div>
       ) : (
         <Image

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatImageUpload.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatImageUpload.tsx
@@ -1,43 +1,70 @@
-import React from "react";
-import { Upload, Tooltip } from "antd";
-import { PaperClipOutlined } from "@ant-design/icons";
-
-const { Dragger } = Upload;
+import React, { useId, useRef } from "react";
+import { Paperclip } from "lucide-react";
+import NotificationsManager from "@/components/molecules/notifications_manager";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { CHAT_ATTACHMENT_ACCEPT, validateChatAttachment } from "./uploadValidation";
 
 interface ChatImageUploadProps {
   chatUploadedImage: File | null;
   chatImagePreviewUrl: string | null;
-  onImageUpload: (file: File) => false;
+  onImageUpload: (file: File) => void;
   onRemoveImage: () => void;
+  disabled?: boolean;
 }
 
-const ChatImageUpload: React.FC<ChatImageUploadProps> = ({
-  chatUploadedImage,
-  chatImagePreviewUrl,
-  onImageUpload,
-  onRemoveImage,
-}) => {
+const ChatImageUpload: React.FC<ChatImageUploadProps> = ({ chatUploadedImage, onImageUpload, disabled = false }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const inputId = useId();
+
+  if (chatUploadedImage) {
+    return null;
+  }
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) {
+      return;
+    }
+    const result = validateChatAttachment(file);
+    if (!result.ok) {
+      NotificationsManager.error(result.error);
+      return;
+    }
+    onImageUpload(file);
+  };
+
   return (
     <>
-      {/* Subtle upload button - only show when no image */}
-      {!chatUploadedImage && (
-        <Dragger
-          beforeUpload={onImageUpload}
-          accept="image/*,.pdf"
-          showUploadList={false}
-          className="inline-block"
-          style={{ padding: 0, border: "none", background: "none" }}
-        >
-          <Tooltip title="Attach image or PDF">
-            <button
+      <input
+        id={inputId}
+        ref={inputRef}
+        type="file"
+        accept={CHAT_ATTACHMENT_ACCEPT}
+        className="sr-only"
+        tabIndex={-1}
+        disabled={disabled}
+        onChange={handleFileChange}
+      />
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
               type="button"
-              className="flex items-center justify-center w-8 h-8 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition-colors"
-            >
-              <PaperClipOutlined style={{ fontSize: "16px" }} />
-            </button>
-          </Tooltip>
-        </Dragger>
-      )}
+              variant="ghost"
+              size="icon-sm"
+              disabled={disabled}
+              aria-label="Attach image or PDF"
+              className="text-gray-400 hover:text-gray-600"
+              onClick={() => inputRef.current?.click()}
+            />
+          }
+        >
+          <Paperclip className="size-4" />
+        </TooltipTrigger>
+        <TooltipContent>Attach image or PDF</TooltipContent>
+      </Tooltip>
     </>
   );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatMessageBubble.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatMessageBubble.tsx
@@ -41,9 +41,9 @@ function ChatMessageBubble({
   const isUser = message.role === "user";
 
   return (
-    <div className={`mb-4 ${isUser ? "text-right" : "text-left"}`}>
+    <div className={`mb-4 min-w-0 ${isUser ? "text-right" : "text-left"}`}>
       <div
-        className="inline-block max-w-[80%] rounded-lg shadow-xs p-3.5 px-4"
+        className="inline-block min-w-0 max-w-[92%] overflow-hidden rounded-lg p-3 shadow-xs sm:max-w-[85%] sm:px-4"
         style={{
           backgroundColor: isUser ? "#f0f8ff" : "#ffffff",
           border: isUser ? "1px solid #e6f0fa" : "1px solid #f0f0f0",
@@ -51,7 +51,7 @@ function ChatMessageBubble({
         }}
       >
         {/* Header: role icon + name + model badge */}
-        <div className="flex items-center gap-2 mb-1.5">
+        <div className="mb-1.5 flex min-w-0 items-center gap-2">
           <div
             className="flex items-center justify-center w-6 h-6 rounded-full mr-1"
             style={{
@@ -66,7 +66,7 @@ function ChatMessageBubble({
           </div>
           <strong className="text-sm capitalize">{message.role}</strong>
           {message.role === "assistant" && message.model && (
-            <span className="text-xs px-2 py-0.5 rounded-sm bg-gray-100 text-gray-600 font-normal">
+            <span className="max-w-48 truncate rounded-sm bg-gray-100 px-2 py-0.5 text-xs font-normal text-gray-600 sm:max-w-80">
               {message.model}
             </span>
           )}

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatMessageBubble.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatMessageBubble.tsx
@@ -1,4 +1,4 @@
-import { RobotOutlined, UserOutlined } from "@ant-design/icons";
+import { Bot, User } from "lucide-react";
 import React from "react";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -59,9 +59,9 @@ function ChatMessageBubble({
             }}
           >
             {isUser ? (
-              <UserOutlined style={{ fontSize: "12px", color: "#2563eb" }} />
+              <User className="size-3 text-blue-600" aria-hidden="true" />
             ) : (
-              <RobotOutlined style={{ fontSize: "12px", color: "#4b5563" }} />
+              <Bot className="size-3 text-gray-600" aria-hidden="true" />
             )}
           </div>
           <strong className="text-sm capitalize">{message.role}</strong>

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -19,7 +19,14 @@ vi.mock("@/components/networking", () => ({
   getGuardrailsList: vi.fn().mockResolvedValue({ data: [] }),
   getPoliciesList: vi.fn().mockResolvedValue({ data: [] }),
   modelHubCall: vi.fn().mockResolvedValue({ data: [] }),
-  fetchMCPServers: vi.fn().mockResolvedValue([]),
+  fetchMCPServers: vi.fn().mockResolvedValue([
+    {
+      server_id: "mcp-server-1",
+      server_name: "Demo MCP Server",
+      alias: "Demo MCP Server",
+      description: "A demo MCP server",
+    },
+  ]),
   fetchMCPToolsets: vi.fn().mockResolvedValue([]),
   listMCPTools: vi.fn().mockResolvedValue({ tools: [] }),
   callMCPTool: vi.fn(),
@@ -234,6 +241,11 @@ describe("ChatUI", () => {
 
     await waitFor(() => {
       expect(mcpInput()).not.toBeDisabled();
+    });
+
+    await userEvent.setup().click(mcpInput());
+    await waitFor(() => {
+      expect(screen.getByText("Demo MCP Server")).toBeInTheDocument();
     });
   });
 
@@ -458,7 +470,7 @@ describe("ChatUI", () => {
 
     expect(screen.getByText("MCP Servers")).toBeInTheDocument();
 
-    const mcpInput = screen.getByLabelText("Select MCP servers");
+    const mcpInput = await screen.findByLabelText("Select MCP servers");
     expect(mcpInput).toBeInTheDocument();
     expect(mcpInput).not.toBeDisabled();
 
@@ -466,6 +478,7 @@ describe("ChatUI", () => {
 
     await waitFor(() => {
       expect(screen.getByText("All MCP Servers")).toBeInTheDocument();
+      expect(screen.getByText("Demo MCP Server")).toBeInTheDocument();
     });
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -249,6 +249,30 @@ describe("ChatUI", () => {
     });
   });
 
+  it("should enable the MCP tools selector for interactions", async () => {
+    render(
+      <ChatUI
+        accessToken="1234567890"
+        token="1234567890"
+        userRole="user"
+        userID="1234567890"
+        disabledPersonalKeyCreation={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Key")).toBeInTheDocument();
+    });
+
+    const mcpInput = () => screen.getByLabelText("Select MCP servers");
+
+    await selectComboboxOption("Select an endpoint", "/v1beta/interactions");
+
+    await waitFor(() => {
+      expect(mcpInput()).not.toBeDisabled();
+    });
+  });
+
   it("should show Simulate failure to test fallbacks in Model Settings when chat endpoint is selected", async () => {
     const user = userEvent.setup();
     render(

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -1,10 +1,10 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ChatUI from "./ChatUI";
 import * as fetchModelsModule from "@/components/llm_calls/fetch_models";
 import { makeOpenAIChatCompletionRequest } from "@/components/llm_calls/chat_completion";
 
-// Mock the fetchAvailableModels function
 vi.mock("@/components/llm_calls/fetch_models", () => ({
   fetchAvailableModels: vi.fn(),
 }));
@@ -13,15 +13,18 @@ vi.mock("@/components/llm_calls/chat_completion", () => ({
   makeOpenAIChatCompletionRequest: vi.fn().mockResolvedValue(undefined),
 }));
 
-// Mock other networking functions that cause errors
 vi.mock("@/components/networking", () => ({
-  tagListCall: vi.fn().mockResolvedValue({ data: [] }),
+  tagListCall: vi.fn().mockResolvedValue({}),
   vectorStoreListCall: vi.fn().mockResolvedValue({ data: [] }),
   getGuardrailsList: vi.fn().mockResolvedValue({ data: [] }),
+  getPoliciesList: vi.fn().mockResolvedValue({ data: [] }),
   modelHubCall: vi.fn().mockResolvedValue({ data: [] }),
+  fetchMCPServers: vi.fn().mockResolvedValue([]),
+  fetchMCPToolsets: vi.fn().mockResolvedValue([]),
+  listMCPTools: vi.fn().mockResolvedValue({ tools: [] }),
+  callMCPTool: vi.fn(),
 }));
 
-// Mock scrollIntoView which is not available in jsdom
 beforeEach(() => {
   Element.prototype.scrollIntoView = () => {};
 });
@@ -29,17 +32,27 @@ beforeEach(() => {
 const CHAT_REQUEST_ARG_COUNT = 26;
 const STREAMING_ENABLED_ARG_INDEX = 25;
 
+async function openComboboxByPlaceholder(placeholder: string) {
+  const user = userEvent.setup();
+  const combobox = screen.getByPlaceholderText(placeholder);
+  await user.click(combobox);
+  return combobox;
+}
+
+async function selectComboboxOption(placeholder: string, optionLabel: string) {
+  const user = userEvent.setup();
+  await openComboboxByPlaceholder(placeholder);
+  const option = await screen.findByText(optionLabel);
+  await user.click(option);
+}
+
 describe("ChatUI", () => {
   beforeEach(() => {
-    // Reset mocks before each test
     vi.clearAllMocks();
     sessionStorage.clear();
-
-    // Mock scrollIntoView which is not available in JSDOM
     Element.prototype.scrollIntoView = vi.fn();
 
-    // Mock the fetchAvailableModels to return test models
-    (fetchModelsModule.fetchAvailableModels as any).mockResolvedValue([
+    (fetchModelsModule.fetchAvailableModels as ReturnType<typeof vi.fn>).mockResolvedValue([
       { model_group: "Model 1", mode: "chat" },
       { model_group: "Model 2", mode: "chat" },
       { model_group: "Model 3", mode: "chat" },
@@ -47,7 +60,7 @@ describe("ChatUI", () => {
   });
 
   it("should render the chat UI", async () => {
-    const { getByText } = render(
+    render(
       <ChatUI
         accessToken="1234567890"
         token="1234567890"
@@ -56,11 +69,11 @@ describe("ChatUI", () => {
         disabledPersonalKeyCreation={false}
       />,
     );
-    expect(getByText("Test Key")).toBeInTheDocument();
+    expect(screen.getByText("Test Key")).toBeInTheDocument();
   });
 
   it("should show the voice selector when the endpoint type is audio_speech", async () => {
-    const { getByText } = render(
+    render(
       <ChatUI
         accessToken="1234567890"
         token="1234567890"
@@ -70,47 +83,20 @@ describe("ChatUI", () => {
       />,
     );
 
-    // Wait for the component to render
     await waitFor(() => {
-      expect(getByText("Test Key")).toBeInTheDocument();
+      expect(screen.getByText("Test Key")).toBeInTheDocument();
     });
 
-    // Find the endpoint selector by looking for the "Endpoint Type:" text and its associated Select
-    const endpointTypeText = getByText("Endpoint Type");
-    const selectContainer = endpointTypeText.parentElement;
-    const selectElement = selectContainer?.querySelector(".ant-select-selector");
+    await selectComboboxOption("Select an endpoint", "/v1/audio/speech");
 
-    expect(selectElement).toBeInTheDocument();
-
-    // Click on the select to open the dropdown
-    if (selectElement) {
-      fireEvent.mouseDown(selectElement);
-    }
-
-    // Wait for the dropdown to appear and find the audio_speech option
     await waitFor(() => {
-      const audioSpeechOption = screen.getByText("/v1/audio/speech");
-      expect(audioSpeechOption).toBeInTheDocument();
+      expect(screen.getByText("Voice")).toBeInTheDocument();
+      expect(screen.getByLabelText("Voice")).toBeInTheDocument();
     });
-
-    // Click on the audio_speech option
-    const audioSpeechOption = screen.getByText("/v1/audio/speech");
-    fireEvent.click(audioSpeechOption);
-
-    // Verify the voice selector appears
-    await waitFor(() => {
-      expect(getByText("Voice")).toBeInTheDocument();
-    });
-
-    // Verify the voice select component is present
-    const voiceText = getByText("Voice");
-    const voiceSelectContainer = voiceText.parentElement;
-    const voiceSelectElement = voiceSelectContainer?.querySelector(".ant-select");
-    expect(voiceSelectElement).toBeInTheDocument();
   });
 
   it("should allow the user to select a model", async () => {
-    const { getByText } = render(
+    render(
       <ChatUI
         accessToken="1234567890"
         token="1234567890"
@@ -120,35 +106,26 @@ describe("ChatUI", () => {
       />,
     );
 
-    // Wait for the component to render
     await waitFor(() => {
-      expect(getByText("Test Key")).toBeInTheDocument();
+      expect(screen.getByText("Test Key")).toBeInTheDocument();
     });
 
-    // Open the "Select Model" dropdown (AntD renders options in a portal)
-    const selectModelLabel = getByText("Select Model");
-    // The Select component is a sibling of the Text component, so we need to find it in the parent container
-    const modelSelectContainer = selectModelLabel.closest("div");
-    const modelSelect = modelSelectContainer?.querySelector(".ant-select-selector");
-    expect(modelSelect).toBeTruthy();
-
-    fireEvent.mouseDown(modelSelect!);
+    await openComboboxByPlaceholder("Select a Model");
 
     await waitFor(() => {
-      const model1Label = screen.getAllByText("Model 1");
-      expect(model1Label.length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Model 1").length).toBeGreaterThan(0);
     });
   });
 
-  it("shows only chat-compatible models when chat endpoint is selected", async () => {
-    (fetchModelsModule.fetchAvailableModels as any).mockResolvedValueOnce([
+  it("shows all models returned for the active key regardless of endpoint", async () => {
+    (fetchModelsModule.fetchAvailableModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       { model_group: "ChatModel", mode: "chat" },
       { model_group: "SpeechModel", mode: "audio_speech" },
       { model_group: "ImageModel", mode: "image_generation" },
       { model_group: "ResponsesModel", mode: "responses" },
     ]);
 
-    const { getByText } = render(
+    render(
       <ChatUI
         accessToken="1234567890"
         token="1234567890"
@@ -159,43 +136,22 @@ describe("ChatUI", () => {
     );
 
     await waitFor(() => {
-      expect(getByText("Test Key")).toBeInTheDocument();
+      expect(screen.getByText("Test Key")).toBeInTheDocument();
     });
 
-    // Open endpoint selector and explicitly select /v1/chat/completions
-    const endpointTypeText = getByText("Endpoint Type");
-    const endpointSelect = endpointTypeText.parentElement?.querySelector(".ant-select-selector");
-    expect(endpointSelect).toBeTruthy();
-    act(() => {
-      fireEvent.mouseDown(endpointSelect!);
-      fireEvent.click(screen.getByText("/v1/chat/completions"));
-    });
-
-    // Open model selector
-    const selectModelLabel = getByText("Select Model");
-    // The Select component is a sibling of the Text component, so we need to find it in the parent container
-    const modelSelectContainer = selectModelLabel.closest("div");
-    const modelSelect = modelSelectContainer?.querySelector(".ant-select-selector");
-    expect(modelSelect).toBeTruthy();
-    act(() => {
-      fireEvent.mouseDown(modelSelect!);
-    });
+    await selectComboboxOption("Select an endpoint", "/v1/chat/completions");
+    await openComboboxByPlaceholder("Select a Model");
 
     await waitFor(() => {
-      // Chat-compatible: ChatModel should be visible
       expect(screen.getAllByText("ChatModel").length).toBeGreaterThan(0);
-      expect(screen.queryByText("SpeechModel")).toBeNull();
-      expect(screen.queryByText("ImageModel")).toBeNull();
-      expect(screen.queryByText("ResponsesModel")).toBeNull();
+      expect(screen.getAllByText("SpeechModel").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("ImageModel").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("ResponsesModel").length).toBeGreaterThan(0);
     });
   });
 
-  /**
-   * Tests that the 'Enter custom model' option is available in the model selector dropdown.
-   * This ensures users can manually enter a model name if it's not in the list.
-   */
   it("should show 'Enter custom model' option in model selector", async () => {
-    const { getByText } = render(
+    render(
       <ChatUI
         accessToken="1234567890"
         token="1234567890"
@@ -205,24 +161,14 @@ describe("ChatUI", () => {
       />,
     );
 
-    // Wait for the component to render
     await waitFor(() => {
-      expect(getByText("Test Key")).toBeInTheDocument();
+      expect(screen.getByText("Test Key")).toBeInTheDocument();
     });
 
-    // Open the "Select Model" dropdown
-    const selectModelLabel = getByText("Select Model");
-    const modelSelectContainer = selectModelLabel.closest("div");
-    const modelSelect = modelSelectContainer?.querySelector(".ant-select-selector");
-
-    fireEvent.mouseDown(modelSelect!);
+    await openComboboxByPlaceholder("Select a Model");
 
     await waitFor(() => {
-      // Get all options in the dropdown (Ant Design renders these in a portal)
-      const options = document.querySelectorAll(".ant-select-item-option-content");
-      expect(options.length).toBeGreaterThan(0);
-      // Check if the first option is 'Enter custom model'
-      expect(options[0]).toHaveTextContent("Enter custom model");
+      expect(screen.getByText("Enter custom model")).toBeInTheDocument();
     });
   });
 
@@ -241,44 +187,23 @@ describe("ChatUI", () => {
       expect(screen.getByText("Test Key")).toBeInTheDocument();
     });
 
-    const endpointTypeText = screen.getByText("Endpoint Type");
-    const endpointSelect = endpointTypeText.parentElement?.querySelector(".ant-select-selector") as HTMLElement | null;
-    expect(endpointSelect).not.toBeNull();
+    const mcpInput = () => screen.getByLabelText("Select MCP servers");
 
-    const selectEndpointOption = async (label: string) => {
-      act(() => {
-        fireEvent.mouseDown(endpointSelect!);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText(label)).toBeInTheDocument();
-      });
-
-      act(() => {
-        fireEvent.click(screen.getByText(label));
-      });
-    };
-
-    const getMcpSelect = () =>
-      screen.getByText("MCP Servers").closest("div")?.querySelector(".ant-select") as HTMLElement | null;
-
-    await selectEndpointOption("/v1/embeddings");
-
-    const mcpSelect = getMcpSelect();
-    expect(mcpSelect).not.toBeNull();
+    await selectComboboxOption("Select an endpoint", "/v1/embeddings");
 
     await waitFor(() => {
-      expect(mcpSelect).toHaveClass("ant-select-disabled");
+      expect(mcpInput()).toBeDisabled();
     });
 
-    await selectEndpointOption("/v1/chat/completions");
+    await selectComboboxOption("Select an endpoint", "/v1/chat/completions");
 
     await waitFor(() => {
-      expect(mcpSelect).not.toHaveClass("ant-select-disabled");
+      expect(mcpInput()).not.toBeDisabled();
     });
   });
 
   it("should show Simulate failure to test fallbacks in Model Settings when chat endpoint is selected", async () => {
+    const user = userEvent.setup();
     render(
       <ChatUI
         accessToken="1234567890"
@@ -293,35 +218,13 @@ describe("ChatUI", () => {
       expect(screen.getByText("Test Key")).toBeInTheDocument();
     });
 
-    // Model Settings button only appears when a chat model is selected; select "Model 1" first
-    const selectModelLabel = screen.getByText("Select Model");
-    const modelSelectContainer = selectModelLabel.closest("div");
-    const modelSelect = modelSelectContainer?.querySelector(".ant-select-selector");
-    expect(modelSelect).toBeTruthy();
-
-    await act(async () => {
-      fireEvent.mouseDown(modelSelect!);
-    });
+    await selectComboboxOption("Select a Model", "Model 1");
 
     await waitFor(() => {
-      expect(screen.getAllByText("Model 1").length).toBeGreaterThan(0);
+      expect(screen.getByTestId("model-settings-button")).toBeInTheDocument();
     });
 
-    // Ant Design Select options may not have role="option"; click the dropdown option by text
-    const model1Options = screen.getAllByText("Model 1");
-    await act(async () => {
-      fireEvent.click(model1Options[model1Options.length - 1]);
-    });
-
-    await waitFor(() => {
-      const modelSettingsButton = screen.getByTestId("model-settings-button");
-      expect(modelSettingsButton).toBeInTheDocument();
-    });
-
-    const modelSettingsButton = screen.getByTestId("model-settings-button");
-    await act(async () => {
-      fireEvent.click(modelSettingsButton);
-    });
+    await user.click(screen.getByTestId("model-settings-button"));
 
     await waitFor(() => {
       expect(screen.getByText("Model Settings")).toBeInTheDocument();
@@ -333,9 +236,7 @@ describe("ChatUI", () => {
     });
     expect(fallbacksCheckbox).not.toBeChecked();
 
-    await act(async () => {
-      fireEvent.click(fallbacksCheckbox);
-    });
+    await user.click(fallbacksCheckbox);
 
     await waitFor(() => {
       expect(screen.getByRole("checkbox", { name: /Simulate failure to test fallbacks/i })).toBeChecked();
@@ -343,6 +244,7 @@ describe("ChatUI", () => {
   });
 
   it("should send the chat request non-streaming after Stream responses is unchecked", async () => {
+    const user = userEvent.setup();
     render(
       <ChatUI
         accessToken="1234567890"
@@ -357,35 +259,18 @@ describe("ChatUI", () => {
       expect(screen.getByText("Test Key")).toBeInTheDocument();
     });
 
-    const selectModelLabel = screen.getByText("Select Model");
-    const modelSelect = selectModelLabel.closest("div")?.querySelector(".ant-select-selector");
-    await act(async () => {
-      fireEvent.mouseDown(modelSelect!);
-    });
-
-    await waitFor(() => {
-      expect(screen.getAllByText("Model 1").length).toBeGreaterThan(0);
-    });
-
-    const model1Options = screen.getAllByText("Model 1");
-    await act(async () => {
-      fireEvent.click(model1Options[model1Options.length - 1]);
-    });
+    await selectComboboxOption("Select a Model", "Model 1");
 
     await waitFor(() => {
       expect(screen.getByTestId("model-settings-button")).toBeInTheDocument();
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByTestId("model-settings-button"));
-    });
+    await user.click(screen.getByTestId("model-settings-button"));
 
     const streamingCheckbox = await screen.findByRole("checkbox", { name: /Stream responses/i });
     expect(streamingCheckbox).toBeChecked();
 
-    await act(async () => {
-      fireEvent.click(streamingCheckbox);
-    });
+    await user.click(streamingCheckbox);
 
     await waitFor(() => {
       expect(screen.getByRole("checkbox", { name: /Stream responses/i })).not.toBeChecked();
@@ -446,7 +331,8 @@ describe("ChatUI", () => {
   });
 
   it("should offer the streaming toggle for a responses-only model without advanced params", async () => {
-    (fetchModelsModule.fetchAvailableModels as any).mockResolvedValue([
+    const user = userEvent.setup();
+    (fetchModelsModule.fetchAvailableModels as ReturnType<typeof vi.fn>).mockResolvedValue([
       { model_group: "ResponsesModel", mode: "responses" },
     ]);
 
@@ -464,37 +350,14 @@ describe("ChatUI", () => {
       expect(screen.getByText("Test Key")).toBeInTheDocument();
     });
 
-    const endpointTypeText = screen.getByText("Endpoint Type");
-    const endpointSelect = endpointTypeText.parentElement?.querySelector(".ant-select-selector");
-    await act(async () => {
-      fireEvent.mouseDown(endpointSelect!);
-    });
-    await act(async () => {
-      fireEvent.click(screen.getByText("/v1/responses"));
-    });
-
-    const selectModelLabel = screen.getByText("Select Model");
-    const modelSelect = selectModelLabel.closest("div")?.querySelector(".ant-select-selector");
-    await act(async () => {
-      fireEvent.mouseDown(modelSelect!);
-    });
-
-    await waitFor(() => {
-      expect(screen.getAllByText("ResponsesModel").length).toBeGreaterThan(0);
-    });
-
-    const modelOptions = screen.getAllByText("ResponsesModel");
-    await act(async () => {
-      fireEvent.click(modelOptions[modelOptions.length - 1]);
-    });
+    await selectComboboxOption("Select an endpoint", "/v1/responses");
+    await selectComboboxOption("Select a Model", "ResponsesModel");
 
     await waitFor(() => {
       expect(screen.getByTestId("model-settings-button")).toBeInTheDocument();
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByTestId("model-settings-button"));
-    });
+    await user.click(screen.getByTestId("model-settings-button"));
 
     expect(await screen.findByRole("checkbox", { name: /Stream responses/i })).toBeChecked();
     expect(screen.queryByText("Temperature")).not.toBeInTheDocument();
@@ -543,6 +406,7 @@ describe("ChatUI", () => {
   });
 
   it("should enable search functionality for MCP server selector", async () => {
+    const user = userEvent.setup();
     render(
       <ChatUI
         accessToken="1234567890"
@@ -557,27 +421,16 @@ describe("ChatUI", () => {
       expect(screen.getByText("Test Key")).toBeInTheDocument();
     });
 
-    const mcpServersText = screen.queryByText("MCP Servers");
-    expect(mcpServersText).toBeInTheDocument();
+    expect(screen.getByText("MCP Servers")).toBeInTheDocument();
 
-    if (mcpServersText) {
-      const selectContainer = mcpServersText.parentElement?.nextElementSibling;
-      const selectElement = selectContainer?.querySelector(".ant-select-selector");
-      expect(selectElement).toBeInTheDocument();
+    const mcpInput = screen.getByLabelText("Select MCP servers");
+    expect(mcpInput).toBeInTheDocument();
+    expect(mcpInput).not.toBeDisabled();
 
-      if (selectElement) {
-        fireEvent.mouseDown(selectElement);
+    await user.click(mcpInput);
 
-        await waitFor(() => {
-          const allServersOption = screen.queryByText("All MCP Servers");
-          if (allServersOption) {
-            expect(allServersOption).toBeInTheDocument();
-          }
-        });
-
-        const searchInput = document.querySelector(".ant-select-selection-search-input");
-        expect(searchInput).toBeInTheDocument();
-      }
-    }
+    await waitFor(() => {
+      expect(screen.getByText("All MCP Servers")).toBeInTheDocument();
+    });
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -117,12 +117,14 @@ describe("ChatUI", () => {
     });
   });
 
-  it("shows all models returned for the active key regardless of endpoint", async () => {
+  it("shows only endpoint-compatible models when chat endpoint is selected", async () => {
     (fetchModelsModule.fetchAvailableModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       { model_group: "ChatModel", mode: "chat" },
       { model_group: "SpeechModel", mode: "audio_speech" },
       { model_group: "ImageModel", mode: "image_generation" },
       { model_group: "ResponsesModel", mode: "responses" },
+      { model_group: "RealtimeModel", mode: "realtime" },
+      { model_group: "NoModeModel" },
     ]);
 
     render(
@@ -144,9 +146,42 @@ describe("ChatUI", () => {
 
     await waitFor(() => {
       expect(screen.getAllByText("ChatModel").length).toBeGreaterThan(0);
-      expect(screen.getAllByText("SpeechModel").length).toBeGreaterThan(0);
-      expect(screen.getAllByText("ImageModel").length).toBeGreaterThan(0);
-      expect(screen.getAllByText("ResponsesModel").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("NoModeModel").length).toBeGreaterThan(0);
+      expect(screen.queryByText("SpeechModel")).toBeNull();
+      expect(screen.queryByText("ImageModel")).toBeNull();
+      expect(screen.queryByText("ResponsesModel")).toBeNull();
+      expect(screen.queryByText("RealtimeModel")).toBeNull();
+    });
+  });
+
+  it("shows only realtime models when realtime endpoint is selected", async () => {
+    (fetchModelsModule.fetchAvailableModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { model_group: "ChatModel", mode: "chat" },
+      { model_group: "RealtimeModel", mode: "realtime" },
+      { model_group: "NoModeModel" },
+    ]);
+
+    render(
+      <ChatUI
+        accessToken="1234567890"
+        token="1234567890"
+        userRole="user"
+        userID="1234567890"
+        disabledPersonalKeyCreation={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Key")).toBeInTheDocument();
+    });
+
+    await selectComboboxOption("Select an endpoint", "/v1/realtime");
+    await openComboboxByPlaceholder("Select a Model");
+
+    await waitFor(() => {
+      expect(screen.getAllByText("RealtimeModel").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("NoModeModel").length).toBeGreaterThan(0);
+      expect(screen.queryByText("ChatModel")).toBeNull();
     });
   });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -181,6 +181,9 @@ const ChatUI: React.FC<ChatUIProps> = ({
     return disabledPersonalKeyCreation ? "custom" : "session";
   });
   const [apiKey, setApiKey] = useState<string>(() => getSecureItem("apiKey") || "");
+  const [debouncedCustomApiKey, setDebouncedCustomApiKey] = useState<string>(() =>
+    (getSecureItem("apiKey") || "").trim(),
+  );
   const [customProxyBaseUrl, setCustomProxyBaseUrl] = useState<string>(
     () => sessionStorage.getItem("customProxyBaseUrl") || "",
   );
@@ -401,42 +404,64 @@ const ChatUI: React.FC<ChatUIProps> = ({
   ]);
 
   useEffect(() => {
-    const userApiKey = apiKeySource === "session" ? accessToken : apiKey.trim();
+    if (apiKeySource === "session") {
+      return;
+    }
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedCustomApiKey(apiKey.trim());
+    }, 300);
+    return () => window.clearTimeout(timeoutId);
+  }, [apiKey, apiKeySource]);
+
+  useEffect(() => {
+    const userApiKey = apiKeySource === "session" ? accessToken : debouncedCustomApiKey;
     if (!userApiKey) {
       setModelInfo([]);
       setModelLoadError(false);
+      setIsLoadingModels(false);
       return;
     }
+
+    let cancelled = false;
 
     const loadModels = async () => {
       setIsLoadingModels(true);
       setModelLoadError(false);
       try {
         const uniqueModels = await fetchAvailableModels(userApiKey);
+        if (cancelled) {
+          return;
+        }
 
         setModelInfo(uniqueModels);
 
-        // check for selection overlap or empty model list
         const hasSelection = uniqueModels.some((m) => m.model_group === selectedModel);
-        if (!uniqueModels.length) {
-          setSelectedModel(undefined);
-        } else if (!hasSelection) {
+        if (!uniqueModels.length || !hasSelection) {
           setSelectedModel(undefined);
         }
       } catch (error) {
+        if (cancelled) {
+          return;
+        }
         console.error("Error fetching model info:", error);
         setModelInfo([]);
         setModelLoadError(true);
       } finally {
-        setIsLoadingModels(false);
+        if (!cancelled) {
+          setIsLoadingModels(false);
+        }
       }
     };
 
     if (!simplified) {
-      loadModels();
+      void loadModels();
     }
     loadMCPServers();
-  }, [accessToken, apiKeySource, apiKey, simplified]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [accessToken, apiKeySource, debouncedCustomApiKey, simplified]);
 
   // Load tools when MCP direct mode has a server (or toolset) selected
   useEffect(() => {
@@ -1188,15 +1213,30 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     </SelectContent>
                   </ShadcnSelect>
                   {apiKeySource === "custom" && (
-                    <div className="relative mt-2">
-                      <Key className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        className="h-8 pl-8"
-                        placeholder="Enter custom Virtual Key"
-                        type="password"
-                        onChange={(event) => setApiKey(event.target.value)}
-                        value={apiKey}
-                      />
+                    <div className="mt-2 space-y-1">
+                      <div className="relative">
+                        <Key className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                        <Input
+                          className="h-8 pl-8"
+                          placeholder="Enter custom Virtual Key"
+                          type="password"
+                          autoComplete="off"
+                          spellCheck={false}
+                          onChange={(event) => setApiKey(event.target.value)}
+                          onBlur={() => setDebouncedCustomApiKey(apiKey.trim())}
+                          value={apiKey}
+                          aria-label="Virtual Key"
+                        />
+                      </div>
+                      {isLoadingModels && apiKey.trim() !== "" && (
+                        <p className="text-xs text-muted-foreground">Loading models for this key...</p>
+                      )}
+                      {!isLoadingModels && apiKey.trim() !== "" && modelLoadError && (
+                        <p className="text-xs text-destructive">Unable to load models for this Virtual Key.</p>
+                      )}
+                      {!isLoadingModels && apiKey.trim() !== "" && !modelLoadError && modelInfo.length === 0 && (
+                        <p className="text-xs text-muted-foreground">No models available for this Virtual Key.</p>
+                      )}
                     </div>
                   )}
                 </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -66,7 +66,16 @@ import { MessageType } from "@/components/chat_ui/types";
 import { useCodeInterpreter } from "../../hooks/useCodeInterpreter";
 import { useChatHistory } from "../../hooks/useChatHistory";
 import { getSecureItem, setSecureItem } from "@/utils/secureStorage";
+import { SearchSelect } from "@/components/shared/SearchSelect";
+import { Select as ShadcnSelect, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useDebouncedCallback } from "@tanstack/react-pacer/debouncer";
+import {
+  AUDIO_ACCEPT,
+  IMAGE_EDIT_ACCEPT,
+  validateAudioFile,
+  validateChatAttachment,
+  validateImageEditFile,
+} from "./uploadValidation";
 
 const { TextArea } = Input;
 const { Dragger } = Upload;
@@ -177,6 +186,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
   const [selectedModel, setSelectedModel] = useState<string | undefined>(simplified ? fixedModel : undefined);
   const [showCustomModelInput, setShowCustomModelInput] = useState<boolean>(false);
   const [modelInfo, setModelInfo] = useState<ModelGroup[]>([]);
+  const [isLoadingModels, setIsLoadingModels] = useState(false);
+  const [modelLoadError, setModelLoadError] = useState(false);
   const [agentInfo, setAgentInfo] = useState<Agent[]>([]);
   const [selectedAgent, setSelectedAgent] = useState<string | undefined>(undefined);
   const debouncedSetSelectedModel = useDebouncedCallback((value: string) => setSelectedModel(value), {
@@ -388,17 +399,17 @@ const ChatUI: React.FC<ChatUIProps> = ({
   ]);
 
   useEffect(() => {
-    let userApiKey = apiKeySource === "session" ? accessToken : apiKey;
-    if (!userApiKey || !token || !userRole || !userID) {
+    const userApiKey = apiKeySource === "session" ? accessToken : apiKey.trim();
+    if (!userApiKey) {
+      setModelInfo([]);
+      setModelLoadError(false);
       return;
     }
 
-    // Fetch model info and set the default selected model (skip in simplified mode; we use fixedModel)
     const loadModels = async () => {
+      setIsLoadingModels(true);
+      setModelLoadError(false);
       try {
-        if (!userApiKey) {
-          return;
-        }
         const uniqueModels = await fetchAvailableModels(userApiKey);
 
         setModelInfo(uniqueModels);
@@ -412,6 +423,10 @@ const ChatUI: React.FC<ChatUIProps> = ({
         }
       } catch (error) {
         console.error("Error fetching model info:", error);
+        setModelInfo([]);
+        setModelLoadError(true);
+      } finally {
+        setIsLoadingModels(false);
       }
     };
 
@@ -419,7 +434,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
       loadModels();
     }
     loadMCPServers();
-  }, [accessToken, userID, userRole, apiKeySource, apiKey, token, simplified]);
+  }, [accessToken, apiKeySource, apiKey, simplified]);
 
   // Load tools when MCP direct mode has a server (or toolset) selected
   useEffect(() => {
@@ -494,13 +509,35 @@ const ChatUI: React.FC<ChatUIProps> = ({
     }
   };
 
-  const handleImageUpload = (file: File) => {
-    setUploadedImages((prev) => [...prev, file]);
+  const createBlobPreviewUrl = (file: File): string => {
     const rawPreviewUrl = URL.createObjectURL(file);
-    // Sanitize: only allow blob: URLs to prevent XSS via img src injection.
-    const previewUrl = rawPreviewUrl.startsWith("blob:") ? rawPreviewUrl : "";
-    setImagePreviewUrls((prev) => [...prev, previewUrl]);
-    return false; // Prevent default upload behavior
+    return rawPreviewUrl.startsWith("blob:") ? rawPreviewUrl : "";
+  };
+
+  const handleImageFiles = (files: File[]) => {
+    let nextCount = uploadedImages.length;
+    const accepted: File[] = [];
+    const previews: string[] = [];
+    for (const file of files) {
+      const result = validateImageEditFile(file, nextCount);
+      if (!result.ok) {
+        NotificationsManager.error(result.error);
+        continue;
+      }
+      accepted.push(file);
+      previews.push(createBlobPreviewUrl(file));
+      nextCount += 1;
+    }
+    if (accepted.length === 0) {
+      return;
+    }
+    setUploadedImages((prev) => [...prev, ...accepted]);
+    setImagePreviewUrls((prev) => [...prev, ...previews]);
+  };
+
+  const handleImageUpload = (file: File): false => {
+    handleImageFiles([file]);
+    return false;
   };
 
   const handleRemoveImage = (index: number) => {
@@ -519,11 +556,14 @@ const ChatUI: React.FC<ChatUIProps> = ({
     setImagePreviewUrls([]);
   };
 
-  const handleResponsesImageUpload = (file: File): false => {
+  const handleResponsesImageUpload = (file: File): void => {
+    const result = validateChatAttachment(file);
+    if (!result.ok) {
+      NotificationsManager.error(result.error);
+      return;
+    }
     setResponsesUploadedImage(file);
-    const previewUrl = URL.createObjectURL(file);
-    setResponsesImagePreviewUrl(previewUrl);
-    return false; // Prevent default upload behavior
+    setResponsesImagePreviewUrl(createBlobPreviewUrl(file));
   };
 
   const handleRemoveResponsesImage = () => {
@@ -534,11 +574,14 @@ const ChatUI: React.FC<ChatUIProps> = ({
     setResponsesImagePreviewUrl(null);
   };
 
-  const handleChatImageUpload = (file: File): false => {
+  const handleChatImageUpload = (file: File): void => {
+    const result = validateChatAttachment(file);
+    if (!result.ok) {
+      NotificationsManager.error(result.error);
+      return;
+    }
     setChatUploadedImage(file);
-    const previewUrl = URL.createObjectURL(file);
-    setChatImagePreviewUrl(previewUrl);
-    return false; // Prevent default upload behavior
+    setChatImagePreviewUrl(createBlobPreviewUrl(file));
   };
 
   const handleRemoveChatImage = () => {
@@ -550,8 +593,13 @@ const ChatUI: React.FC<ChatUIProps> = ({
   };
 
   const handleAudioUpload = (file: File): false => {
+    const result = validateAudioFile(file);
+    if (!result.ok) {
+      NotificationsManager.error(result.error);
+      return false;
+    }
     setUploadedAudio(file);
-    return false; // Prevent default upload behavior
+    return false;
   };
 
   const handleRemoveAudio = () => {
@@ -1002,8 +1050,12 @@ const ChatUI: React.FC<ChatUIProps> = ({
 
   const onModelChange = (value: string) => {
     setSelectedModel(value);
-
     setShowCustomModelInput(value === "custom");
+
+    const model = modelInfo.find((option) => option.model_group === value);
+    if (model?.mode) {
+      setEndpointType(getEndpointType(model.mode));
+    }
   };
 
   // Check if the selected model is a chat model
@@ -1020,35 +1072,43 @@ const ChatUI: React.FC<ChatUIProps> = ({
   };
 
   const supportsStreamingToggle = endpointType === EndpointType.CHAT || endpointType === EndpointType.RESPONSES;
+  let modelEmptyText = "No models available for this key";
+  if (modelLoadError) {
+    modelEmptyText = "Unable to load models for this key";
+  } else if (apiKeySource === "custom" && !apiKey.trim()) {
+    modelEmptyText = "Enter a Virtual Key to load models";
+  }
 
   const antIcon = <LoadingOutlined style={{ fontSize: 24 }} spin />;
 
   return (
-    <div className={`w-full bg-white ${simplified ? "h-full flex flex-col" : "p-4 pb-0"}`}>
-      <Card className={`w-full rounded-xl shadow-md overflow-hidden ${simplified ? "h-full flex flex-col" : ""}`}>
-        <div className={`flex w-full gap-4 ${simplified ? "h-full" : "h-[80vh]"}`}>
+    <div className={`min-h-0 min-w-0 bg-white ${simplified ? "flex h-full w-full flex-col" : "h-full w-full p-3"}`}>
+      <Card className="flex h-full min-h-0 min-w-0 w-full flex-col overflow-hidden rounded-xl shadow-md">
+        <div className="flex h-full min-h-0 min-w-0 w-full flex-col lg:flex-row">
           {/* Left Sidebar with Controls - hidden in simplified mode */}
           {!simplified && (
-            <div className="w-1/4 p-4 bg-gray-50 overflow-y-auto">
+            <div className="max-h-[42%] w-full shrink-0 overflow-y-auto border-b border-gray-200 bg-gray-50 p-4 lg:max-h-none lg:w-72 lg:border-r lg:border-b-0 xl:w-80">
               <Title className="text-xl font-semibold mb-6 mt-2">Configurations</Title>
               <div className="space-y-4">
                 <div>
                   <Text className="font-medium block mb-2 text-gray-700 flex items-center">
                     <KeyOutlined className="mr-2" /> Virtual Key Source
                   </Text>
-                  <Select
+                  <ShadcnSelect
                     disabled={disabledPersonalKeyCreation}
                     value={apiKeySource}
-                    style={{ width: "100%" }}
-                    onChange={(value) => {
+                    onValueChange={(value) => {
                       setApiKeySource(value as "session" | "custom");
                     }}
-                    options={[
-                      { value: "session", label: "Current UI Session" },
-                      { value: "custom", label: "Virtual Key" },
-                    ]}
-                    className="rounded-md"
-                  />
+                  >
+                    <SelectTrigger className="w-full" size="sm" aria-label="Virtual Key Source">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="session">Current UI Session</SelectItem>
+                      <SelectItem value="custom">Virtual Key</SelectItem>
+                    </SelectContent>
+                  </ShadcnSelect>
                   {apiKeySource === "custom" && (
                     <TextInput
                       className="mt-2"
@@ -1141,16 +1201,24 @@ const ChatUI: React.FC<ChatUIProps> = ({
                         <SoundOutlined className="mr-2" />
                         Voice
                       </Text>
-                      <Select
+                      <ShadcnSelect
                         value={selectedVoice}
-                        onChange={(value) => {
+                        onValueChange={(value) => {
                           setSelectedVoice(value);
                           sessionStorage.setItem("selectedVoice", value);
                         }}
-                        style={{ width: "100%" }}
-                        className="rounded-md"
-                        options={OPEN_AI_VOICE_SELECT_OPTIONS}
-                      />
+                      >
+                        <SelectTrigger className="w-full" size="sm" aria-label="Voice">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {OPEN_AI_VOICE_SELECT_OPTIONS.map((voice) => (
+                            <SelectItem key={voice.value} value={voice.value}>
+                              {voice.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </ShadcnSelect>
                     </div>
                   )}
 
@@ -1212,46 +1280,20 @@ const ChatUI: React.FC<ChatUIProps> = ({
                         </Tooltip>
                       )}
                     </Text>
-                    <Select
+                    <SearchSelect
                       value={selectedModel}
-                      placeholder="Select a Model"
-                      onChange={onModelChange}
+                      placeholder={isLoadingModels ? "Loading models..." : "Select a Model"}
+                      emptyText={modelEmptyText}
+                      disabled={isLoadingModels}
+                      onValueChange={onModelChange}
                       options={[
-                        { value: "custom", label: "Enter custom model", key: "custom" },
-                        ...Array.from(
-                          new Set(
-                            modelInfo
-                              .filter((option) => {
-                                if (!option.mode) {
-                                  //If no mode, show all models
-                                  return true;
-                                }
-                                const optionEndpoint = getEndpointType(option.mode);
-                                // Show chat models for responses/anthropic_messages/interactions endpoints as they are compatible
-                                if (
-                                  endpointType === EndpointType.RESPONSES ||
-                                  endpointType === EndpointType.ANTHROPIC_MESSAGES ||
-                                  endpointType === EndpointType.INTERACTIONS
-                                ) {
-                                  return optionEndpoint === endpointType || optionEndpoint === EndpointType.CHAT;
-                                }
-                                // Show image models for image_edits endpoint as they are compatible
-                                if (endpointType === EndpointType.IMAGE_EDITS) {
-                                  return optionEndpoint === endpointType || optionEndpoint === EndpointType.IMAGE;
-                                }
-                                return optionEndpoint === endpointType;
-                              })
-                              .map((option) => option.model_group),
-                          ),
-                        ).map((model_group, index) => ({
-                          value: model_group,
-                          label: model_group,
-                          key: index,
+                        { value: "custom", label: "Enter custom model" },
+                        ...modelInfo.map((model) => ({
+                          value: model.model_group,
+                          label: model.model_group,
+                          sublabel: model.mode ? `Mode: ${model.mode}` : undefined,
                         })),
                       ]}
-                      style={{ width: "100%" }}
-                      showSearch={true}
-                      className="rounded-md"
                     />
                     {showCustomModelInput && (
                       <TextInput
@@ -1269,35 +1311,16 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     <Text className="font-medium block mb-2 text-gray-700 flex items-center">
                       <RobotOutlined className="mr-2" /> Select Agent
                     </Text>
-                    <Select
+                    <SearchSelect
                       value={selectedAgent}
                       placeholder="Select an Agent"
-                      onChange={(value) => setSelectedAgent(value)}
+                      onValueChange={(value) => setSelectedAgent(value)}
                       options={agentInfo.map((agent) => ({
                         value: agent.agent_name,
                         label: agent.agent_name || agent.agent_id,
-                        key: agent.agent_id,
+                        sublabel: agent.agent_card_params?.description,
                       }))}
-                      style={{ width: "100%" }}
-                      showSearch={true}
-                      className="rounded-md"
-                      optionLabelProp="label"
-                    >
-                      {agentInfo.map((agent) => (
-                        <Select.Option
-                          key={agent.agent_id}
-                          value={agent.agent_name}
-                          label={agent.agent_name || agent.agent_id}
-                        >
-                          <div className="flex flex-col py-1">
-                            <span className="font-medium">{agent.agent_name || agent.agent_id}</span>
-                            {agent.agent_card_params?.description && (
-                              <span className="text-xs text-gray-500 mt-1">{agent.agent_card_params.description}</span>
-                            )}
-                          </div>
-                        </Select.Option>
-                      ))}
-                    </Select>
+                    />
                     {agentInfo.length === 0 && (
                       <Text className="text-xs text-gray-500 mt-2 block">
                         No agents found. Create agents via /v1/agents endpoint.
@@ -1697,7 +1720,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
           )}
 
           {/* Main Chat Area */}
-          <div className={`flex flex-col bg-white ${simplified ? "flex-1 w-full" : "w-3/4"}`}>
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-white">
             {endpointType === EndpointType.REALTIME ? (
               <RealtimePlayground
                 accessToken={apiKeySource === "session" ? accessToken || "" : apiKey}
@@ -1707,9 +1730,9 @@ const ChatUI: React.FC<ChatUIProps> = ({
               />
             ) : (
               <>
-                <div className="p-4 border-b border-gray-200 flex justify-between items-center">
+                <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-gray-200 p-3 sm:p-4">
                   <Title className="text-xl font-semibold mb-0">{simplified ? "Chat" : "Test Key"}</Title>
-                  <div className="flex gap-2">
+                  <div className="flex flex-wrap justify-end gap-2">
                     <TremorButton
                       onClick={clearChatHistory}
                       className="bg-gray-100 hover:bg-gray-200 text-gray-700 border-gray-300"
@@ -1728,7 +1751,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     )}
                   </div>
                 </div>
-                <div className="flex-1 overflow-auto p-4 pb-0">
+                <div className="min-h-0 min-w-0 flex-1 overflow-auto p-3 pb-0 sm:p-4 sm:pb-0">
                   {chatHistory.length === 0 && (
                     <div className="h-full flex flex-col items-center justify-center text-gray-400">
                       <RobotOutlined style={{ fontSize: "48px", marginBottom: "16px" }} />
@@ -1788,18 +1811,18 @@ const ChatUI: React.FC<ChatUIProps> = ({
                   <div ref={chatEndRef} style={{ height: "1px" }} />
                 </div>
 
-                <div className="p-4 border-t border-gray-200 bg-white">
+                <div className="max-h-[50%] shrink-0 overflow-y-auto border-t border-gray-200 bg-white p-3 sm:p-4">
                   {/* Image Upload Section for Image Edits */}
                   {endpointType === EndpointType.IMAGE_EDITS && (
                     <div className="mb-4">
                       {uploadedImages.length === 0 ? (
-                        <Dragger beforeUpload={handleImageUpload} accept="image/*" showUploadList={false}>
+                        <Dragger beforeUpload={handleImageUpload} accept={IMAGE_EDIT_ACCEPT} showUploadList={false}>
                           <p className="ant-upload-drag-icon">
                             <PictureOutlined style={{ fontSize: "24px", color: "#666" }} />
                           </p>
                           <p className="ant-upload-text text-sm">Click or drag images to upload</p>
                           <p className="ant-upload-hint text-xs text-gray-500">
-                            Support for PNG, JPG, JPEG formats. Multiple images supported.
+                            Support for PNG, JPG, JPEG, GIF, WebP. Multiple images supported.
                           </p>
                         </Dragger>
                       ) : (
@@ -1840,12 +1863,12 @@ const ChatUI: React.FC<ChatUIProps> = ({
                             <input
                               id="additional-image-upload"
                               type="file"
-                              accept="image/*"
+                              accept={IMAGE_EDIT_ACCEPT}
                               multiple
                               style={{ display: "none" }}
                               onChange={(e) => {
-                                const files = Array.from(e.target.files || []);
-                                files.forEach((file) => handleImageUpload(file));
+                                handleImageFiles(Array.from(e.target.files || []));
+                                e.target.value = "";
                               }}
                             />
                           </div>
@@ -1858,11 +1881,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                   {endpointType === EndpointType.TRANSCRIPTION && (
                     <div className="mb-4">
                       {!uploadedAudio ? (
-                        <Dragger
-                          beforeUpload={handleAudioUpload}
-                          accept="audio/*,.mp3,.mp4,.mpeg,.mpga,.m4a,.wav,.webm"
-                          showUploadList={false}
-                        >
+                        <Dragger beforeUpload={handleAudioUpload} accept={AUDIO_ACCEPT} showUploadList={false}>
                           <p className="ant-upload-drag-icon">
                             <SoundOutlined style={{ fontSize: "24px", color: "#666" }} />
                           </p>

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -1,27 +1,25 @@
 "use client";
 
 import {
-  ApiOutlined,
-  ArrowUpOutlined,
-  ClearOutlined,
-  CodeOutlined,
-  DatabaseOutlined,
-  DeleteOutlined,
-  InfoCircleOutlined,
-  KeyOutlined,
-  LinkOutlined,
-  LoadingOutlined,
-  PictureOutlined,
-  RobotOutlined,
-  SafetyOutlined,
-  SettingOutlined,
-  SoundOutlined,
-  TagsOutlined,
-  ToolOutlined,
-} from "@ant-design/icons";
-import { Card, Text, TextInput, Title, Button as TremorButton } from "@tremor/react";
-import { Button, Input, Modal, Popover, Select, Spin, Tooltip, Upload } from "antd";
-import React, { useEffect, useRef, useState } from "react";
+  ArrowUp,
+  Bot,
+  Code2,
+  Database,
+  Eraser,
+  Image as ImageIcon,
+  Info,
+  Key,
+  Link2,
+  Loader2,
+  Settings,
+  Shield,
+  Tags,
+  Trash2,
+  Volume2,
+  Wrench,
+  X,
+} from "lucide-react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { coy } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { v4 as uuidv4 } from "uuid";
@@ -66,8 +64,15 @@ import { MessageType } from "@/components/chat_ui/types";
 import { useCodeInterpreter } from "../../hooks/useCodeInterpreter";
 import { useChatHistory } from "../../hooks/useChatHistory";
 import { getSecureItem, setSecureItem } from "@/utils/secureStorage";
+import { MultiSelect, type MultiSelectOption } from "@/components/shared/MultiSelect";
 import { SearchSelect } from "@/components/shared/SearchSelect";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Select as ShadcnSelect, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useDebouncedCallback } from "@tanstack/react-pacer/debouncer";
 import {
   AUDIO_ACCEPT,
@@ -76,9 +81,6 @@ import {
   validateChatAttachment,
   validateImageEditFile,
 } from "./uploadValidation";
-
-const { TextArea } = Input;
-const { Dragger } = Upload;
 
 interface ChatUIProps {
   accessToken: string | null;
@@ -535,9 +537,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
     setImagePreviewUrls((prev) => [...prev, ...previews]);
   };
 
-  const handleImageUpload = (file: File): false => {
+  const handleImageUpload = (file: File): void => {
     handleImageFiles([file]);
-    return false;
   };
 
   const handleRemoveImage = (index: number) => {
@@ -592,14 +593,71 @@ const ChatUI: React.FC<ChatUIProps> = ({
     setChatImagePreviewUrl(null);
   };
 
-  const handleAudioUpload = (file: File): false => {
+  const handleAudioUpload = (file: File): void => {
     const result = validateAudioFile(file);
     if (!result.ok) {
       NotificationsManager.error(result.error);
-      return false;
+      return;
     }
     setUploadedAudio(file);
-    return false;
+  };
+
+  const mcpServerOptions = useMemo((): MultiSelectOption[] => {
+    const options: MultiSelectOption[] = [];
+    if (endpointType !== EndpointType.MCP) {
+      options.push({
+        value: "__all__",
+        label: "All MCP Servers",
+        description: "Use all available MCP servers",
+      });
+    }
+    for (const toolset of mcpToolsets) {
+      options.push({
+        value: `toolset:${toolset.toolset_id}`,
+        label: toolset.toolset_name,
+        description: toolset.description || `Toolset (${toolset.tools.length} tools)`,
+      });
+    }
+    for (const server of mcpServers) {
+      options.push({
+        value: server.server_id,
+        label: server.alias || server.server_name || server.server_id,
+        description: server.description,
+      });
+    }
+    return options;
+  }, [endpointType, mcpToolsets, mcpServers]);
+
+  const handleMcpServersChange = (value: string[]) => {
+    if (endpointType === EndpointType.MCP) {
+      const serverId = value[0];
+      setSelectedMCPServers(serverId ? [serverId] : []);
+      setSelectedMCPDirectTool(undefined);
+      if (serverId && !serverToolsMap[serverId]) {
+        loadServerTools(serverId);
+      }
+      return;
+    }
+
+    if (value.includes("__all__")) {
+      setSelectedMCPServers(["__all__"]);
+      setMCPServerToolRestrictions({});
+      return;
+    }
+
+    setSelectedMCPServers(value);
+    setMCPServerToolRestrictions((prev) => {
+      const updated = { ...prev };
+      Object.keys(updated).forEach((serverId) => {
+        if (!value.includes(serverId)) delete updated[serverId];
+      });
+      return updated;
+    });
+    value.forEach((serverId) => {
+      if (!serverToolsMap[serverId]) {
+        loadServerTools(serverId);
+      }
+    });
   };
 
   const handleRemoveAudio = () => {
@@ -1079,21 +1137,43 @@ const ChatUI: React.FC<ChatUIProps> = ({
     modelEmptyText = "Enter a Virtual Key to load models";
   }
 
-  const antIcon = <LoadingOutlined style={{ fontSize: 24 }} spin />;
+  const inputPlaceholder =
+    endpointType === EndpointType.CHAT ||
+    endpointType === EndpointType.EMBEDDINGS ||
+    endpointType === EndpointType.RESPONSES ||
+    endpointType === EndpointType.ANTHROPIC_MESSAGES ||
+    endpointType === EndpointType.INTERACTIONS
+      ? "Type your message... (Shift+Enter for new line)"
+      : endpointType === EndpointType.A2A_AGENTS
+        ? "Send a message to the A2A agent..."
+        : endpointType === EndpointType.IMAGE_EDITS
+          ? "Describe how you want to edit the image..."
+          : endpointType === EndpointType.SPEECH
+            ? "Enter text to convert to speech..."
+            : endpointType === EndpointType.TRANSCRIPTION
+              ? "Optional: Add context or prompt for transcription..."
+              : "Describe the image you want to generate...";
+
+  const sendDisabled =
+    isLoading ||
+    (endpointType === EndpointType.MCP
+      ? !(selectedMCPServers.length === 1 && selectedMCPServers[0] !== "__all__" && selectedMCPDirectTool)
+      : endpointType === EndpointType.TRANSCRIPTION
+        ? !uploadedAudio
+        : !inputMessage.trim());
 
   return (
     <div className={`min-h-0 min-w-0 bg-white ${simplified ? "flex h-full w-full flex-col" : "h-full w-full p-3"}`}>
-      <Card className="flex h-full min-h-0 min-w-0 w-full flex-col overflow-hidden rounded-xl shadow-md">
+      <div className="flex h-full min-h-0 min-w-0 w-full flex-col overflow-hidden rounded-xl bg-white shadow-md ring-1 ring-foreground/10">
         <div className="flex h-full min-h-0 min-w-0 w-full flex-col lg:flex-row">
-          {/* Left Sidebar with Controls - hidden in simplified mode */}
           {!simplified && (
             <div className="max-h-[42%] w-full shrink-0 overflow-y-auto border-b border-gray-200 bg-gray-50 p-4 lg:max-h-none lg:w-72 lg:border-r lg:border-b-0 xl:w-80">
-              <Title className="text-xl font-semibold mb-6 mt-2">Configurations</Title>
+              <h2 className="mb-6 mt-2 text-xl font-semibold">Configurations</h2>
               <div className="space-y-4">
                 <div>
-                  <Text className="font-medium block mb-2 text-gray-700 flex items-center">
-                    <KeyOutlined className="mr-2" /> Virtual Key Source
-                  </Text>
+                  <label className="mb-2 flex items-center text-sm font-medium text-gray-700">
+                    <Key className="mr-2 size-4" aria-hidden="true" /> Virtual Key Source
+                  </label>
                   <ShadcnSelect
                     disabled={disabledPersonalKeyCreation}
                     value={apiKeySource}
@@ -1110,79 +1190,84 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     </SelectContent>
                   </ShadcnSelect>
                   {apiKeySource === "custom" && (
-                    <TextInput
-                      className="mt-2"
-                      placeholder="Enter custom Virtual Key"
-                      type="password"
-                      onValueChange={setApiKey}
-                      value={apiKey}
-                      icon={KeyOutlined}
-                    />
+                    <div className="relative mt-2">
+                      <Key className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                      <Input
+                        className="h-8 pl-8"
+                        placeholder="Enter custom Virtual Key"
+                        type="password"
+                        onChange={(event) => setApiKey(event.target.value)}
+                        value={apiKey}
+                      />
+                    </div>
                   )}
                 </div>
 
                 <div>
-                  <div className="flex items-center justify-between mb-2">
-                    <Text className="font-medium block text-gray-700 flex items-center">
-                      <SettingOutlined className="mr-2" /> Custom Proxy Base URL
-                    </Text>
+                  <div className="mb-2 flex items-center justify-between">
+                    <label className="flex items-center text-sm font-medium text-gray-700">
+                      <Settings className="mr-2 size-4" aria-hidden="true" /> Custom Proxy Base URL
+                    </label>
                     {proxySettings?.LITELLM_UI_API_DOC_BASE_URL && !customProxyBaseUrl && (
                       <Button
-                        type="link"
-                        size="small"
-                        icon={<LinkOutlined />}
+                        type="button"
+                        variant="link"
+                        size="xs"
+                        className="h-auto p-0 text-gray-500 hover:text-gray-700"
                         onClick={() => {
                           setCustomProxyBaseUrl(proxySettings.LITELLM_UI_API_DOC_BASE_URL || "");
                           sessionStorage.setItem("customProxyBaseUrl", proxySettings.LITELLM_UI_API_DOC_BASE_URL || "");
                         }}
-                        className="text-gray-500 hover:text-gray-700"
                       >
+                        <Link2 className="size-3" />
                         Fill
                       </Button>
                     )}
                     {customProxyBaseUrl && (
                       <Button
-                        type="link"
-                        size="small"
-                        icon={<ClearOutlined />}
+                        type="button"
+                        variant="link"
+                        size="xs"
+                        className="h-auto p-0 text-gray-500 hover:text-gray-700"
                         onClick={() => {
                           setCustomProxyBaseUrl("");
                           sessionStorage.removeItem("customProxyBaseUrl");
                         }}
-                        className="text-gray-500 hover:text-gray-700"
                       >
+                        <Eraser className="size-3" />
                         Clear
                       </Button>
                     )}
                   </div>
-                  <TextInput
-                    placeholder="Optional: Enter custom proxy URL (e.g., http://localhost:5000)"
-                    onValueChange={(value) => {
-                      setCustomProxyBaseUrl(value);
-                      sessionStorage.setItem("customProxyBaseUrl", value);
-                    }}
-                    value={customProxyBaseUrl}
-                    icon={ApiOutlined}
-                  />
+                  <div className="relative">
+                    <Wrench className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                      className="h-8 pl-8"
+                      placeholder="Optional: Enter custom proxy URL (e.g., http://localhost:5000)"
+                      value={customProxyBaseUrl}
+                      onChange={(event) => {
+                        setCustomProxyBaseUrl(event.target.value);
+                        sessionStorage.setItem("customProxyBaseUrl", event.target.value);
+                      }}
+                    />
+                  </div>
                   {customProxyBaseUrl && (
-                    <Text className="text-xs text-gray-500 mt-1">API calls will be sent to: {customProxyBaseUrl}</Text>
+                    <p className="mt-1 text-xs text-gray-500">API calls will be sent to: {customProxyBaseUrl}</p>
                   )}
                 </div>
 
                 <div>
-                  <Text className="font-medium block mb-2 text-gray-700 flex items-center">
-                    <ApiOutlined className="mr-2" /> Endpoint Type
-                  </Text>
+                  <label className="mb-2 flex items-center text-sm font-medium text-gray-700">
+                    <Wrench className="mr-2 size-4" aria-hidden="true" /> Endpoint Type
+                  </label>
                   <EndpointSelector
                     endpointType={endpointType}
                     onEndpointChange={(value) => {
                       setEndpointType(value);
-                      // Clear model/agent selection when switching endpoint type
                       setSelectedModel(undefined);
                       setSelectedAgent(undefined);
                       setShowCustomModelInput(false);
                       setSelectedMCPDirectTool(undefined);
-                      // For MCP direct mode, require single server (clear __all__ or multiple)
                       if (value === EndpointType.MCP) {
                         setSelectedMCPServers((prev) => (prev.length === 1 && prev[0] !== "__all__" ? prev : []));
                       }
@@ -1194,13 +1279,12 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     className="mb-4"
                   />
 
-                  {/* Voice Selector for Speech Endpoint */}
                   {endpointType === EndpointType.SPEECH && (
                     <div className="mb-4">
-                      <Text className="font-medium block mb-2 text-gray-700 flex items-center">
-                        <SoundOutlined className="mr-2" />
+                      <label className="mb-2 flex items-center text-sm font-medium text-gray-700">
+                        <Volume2 className="mr-2 size-4" aria-hidden="true" />
                         Voice
-                      </Text>
+                      </label>
                       <ShadcnSelect
                         value={selectedVoice}
                         onValueChange={(value) => {
@@ -1222,7 +1306,6 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     </div>
                   )}
 
-                  {/* Session Management Component */}
                   <SessionManagement
                     endpointType={endpointType}
                     responsesSessionId={responsesSessionId}
@@ -1231,16 +1314,30 @@ const ChatUI: React.FC<ChatUIProps> = ({
                   />
                 </div>
 
-                {/* Model Selector - shown when NOT using A2A Agents or MCP direct mode */}
                 {endpointType !== EndpointType.A2A_AGENTS && endpointType !== EndpointType.MCP && (
                   <div>
-                    <Text className="font-medium block mb-2 text-gray-700 flex items-center justify-between">
+                    <div className="mb-2 flex items-center justify-between text-sm font-medium text-gray-700">
                       <span className="flex items-center">
-                        <RobotOutlined className="mr-2" /> Select Model
+                        <Bot className="mr-2 size-4" aria-hidden="true" /> Select Model
                       </span>
                       {isChatModel() || supportsStreamingToggle ? (
-                        <Popover
-                          content={
+                        <Popover>
+                          <PopoverTrigger
+                            render={
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-xs"
+                                className="text-gray-500 hover:text-gray-700"
+                                aria-label="Model Settings"
+                                data-testid="model-settings-button"
+                              />
+                            }
+                          >
+                            <Settings className="size-3.5" />
+                          </PopoverTrigger>
+                          <PopoverContent side="right" className="w-auto p-0">
+                            <div className="border-b border-border px-4 py-2 text-sm font-medium">Model Settings</div>
                             <AdditionalModelSettings
                               showAdvancedParams={isChatModel()}
                               temperature={temperature}
@@ -1254,32 +1351,30 @@ const ChatUI: React.FC<ChatUIProps> = ({
                               streamingEnabled={streamingEnabled}
                               onStreamingChange={supportsStreamingToggle ? setStreamingEnabled : undefined}
                             />
-                          }
-                          title="Model Settings"
-                          trigger="click"
-                          placement="right"
-                        >
-                          <Button
-                            type="text"
-                            size="small"
-                            icon={<SettingOutlined />}
-                            className="text-gray-500 hover:text-gray-700"
-                            aria-label="Model Settings"
-                            data-testid="model-settings-button"
-                          />
+                          </PopoverContent>
                         </Popover>
                       ) : (
-                        <Tooltip title="Advanced parameters are only supported for chat models currently">
-                          <Button
-                            type="text"
-                            size="small"
-                            icon={<SettingOutlined />}
-                            className="text-gray-300 cursor-not-allowed"
-                            disabled
-                          />
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-xs"
+                                className="cursor-not-allowed text-gray-300"
+                                disabled
+                                aria-label="Model Settings unavailable"
+                              />
+                            }
+                          >
+                            <Settings className="size-3.5" />
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            Advanced parameters are only supported for chat models currently
+                          </TooltipContent>
                         </Tooltip>
                       )}
-                    </Text>
+                    </div>
                     <SearchSelect
                       value={selectedModel}
                       placeholder={isLoadingModels ? "Loading models..." : "Select a Model"}
@@ -1296,21 +1391,20 @@ const ChatUI: React.FC<ChatUIProps> = ({
                       ]}
                     />
                     {showCustomModelInput && (
-                      <TextInput
-                        className="mt-2"
+                      <Input
+                        className="mt-2 h-8"
                         placeholder="Enter custom model name"
-                        onValueChange={debouncedSetSelectedModel}
+                        onChange={(event) => debouncedSetSelectedModel(event.target.value)}
                       />
                     )}
                   </div>
                 )}
 
-                {/* Agent Selector - shown ONLY for A2A Agents endpoint */}
                 {endpointType === EndpointType.A2A_AGENTS && (
                   <div>
-                    <Text className="font-medium block mb-2 text-gray-700 flex items-center">
-                      <RobotOutlined className="mr-2" /> Select Agent
-                    </Text>
+                    <label className="mb-2 flex items-center text-sm font-medium text-gray-700">
+                      <Bot className="mr-2 size-4" aria-hidden="true" /> Select Agent
+                    </label>
                     <SearchSelect
                       value={selectedAgent}
                       placeholder="Select an Agent"
@@ -1322,17 +1416,17 @@ const ChatUI: React.FC<ChatUIProps> = ({
                       }))}
                     />
                     {agentInfo.length === 0 && (
-                      <Text className="text-xs text-gray-500 mt-2 block">
+                      <p className="mt-2 text-xs text-gray-500">
                         No agents found. Create agents via /v1/agents endpoint.
-                      </Text>
+                      </p>
                     )}
                   </div>
                 )}
 
                 <div>
-                  <Text className="font-medium block mb-2 text-gray-700 flex items-center">
-                    <TagsOutlined className="mr-2" /> Tags
-                  </Text>
+                  <label className="mb-2 flex items-center text-sm font-medium text-gray-700">
+                    <Tags className="mr-2 size-4" aria-hidden="true" /> Tags
+                  </label>
                   <TagSelector
                     value={selectedTags}
                     onChange={setSelectedTags}
@@ -1341,165 +1435,57 @@ const ChatUI: React.FC<ChatUIProps> = ({
                   />
                 </div>
 
-                {/* MCP Server Selection */}
                 <div>
-                  <Text className="font-medium block mb-2 text-gray-700 flex items-center">
-                    <ToolOutlined className="mr-2" />
+                  <div className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-700">
+                    <Wrench className="mr-1 size-4" aria-hidden="true" />
                     {endpointType === EndpointType.MCP ? "MCP Server" : "MCP Servers"}
-                    <Tooltip
-                      className="ml-1"
-                      title={
-                        endpointType === EndpointType.MCP
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <button
+                            type="button"
+                            className="inline-flex"
+                            aria-label="About MCP servers and toolsets"
+                            onClick={() => setIsToolsetsInfoModalVisible(true)}
+                          />
+                        }
+                      >
+                        <Info className="size-3.5 cursor-pointer text-gray-400" />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-xs">
+                        {endpointType === EndpointType.MCP
                           ? "Select an MCP server or toolset to test tools directly."
-                          : "Select MCP servers or toolsets to use in your conversation."
-                      }
-                    >
-                      <InfoCircleOutlined
-                        className="cursor-pointer"
-                        onClick={() => setIsToolsetsInfoModalVisible(true)}
-                      />
+                          : "Select MCP servers or toolsets to use in your conversation."}
+                      </TooltipContent>
                     </Tooltip>
-                  </Text>
-                  <Select
-                    mode={endpointType === EndpointType.MCP ? undefined : "multiple"}
-                    style={{ width: "100%" }}
-                    placeholder={endpointType === EndpointType.MCP ? "Select MCP server" : "Select MCP servers"}
-                    value={
-                      endpointType === EndpointType.MCP
-                        ? selectedMCPServers[0] !== "__all__" && selectedMCPServers.length === 1
+                  </div>
+                  {endpointType === EndpointType.MCP ? (
+                    <SearchSelect
+                      value={
+                        selectedMCPServers[0] !== "__all__" && selectedMCPServers.length === 1
                           ? selectedMCPServers[0]
                           : undefined
-                        : selectedMCPServers
-                    }
-                    onChange={(value) => {
-                      if (endpointType === EndpointType.MCP) {
-                        const serverId = value as string | undefined;
-                        setSelectedMCPServers(serverId ? [serverId] : []);
-                        setSelectedMCPDirectTool(undefined);
-                        if (serverId && !serverToolsMap[serverId]) {
-                          loadServerTools(serverId);
-                        }
-                      } else {
-                        if ((value as string[]).includes("__all__")) {
-                          setSelectedMCPServers(["__all__"]);
-                          setMCPServerToolRestrictions({});
-                        } else {
-                          setSelectedMCPServers(value as string[]);
-                          setMCPServerToolRestrictions((prev) => {
-                            const updated = { ...prev };
-                            Object.keys(updated).forEach((serverId) => {
-                              if (!(value as string[]).includes(serverId)) delete updated[serverId];
-                            });
-                            return updated;
-                          });
-                          (value as string[]).forEach((serverId) => {
-                            if (!serverToolsMap[serverId]) {
-                              loadServerTools(serverId);
-                            }
-                          });
-                        }
                       }
-                    }}
-                    loading={isLoadingMCPServers}
-                    className="mb-2"
-                    allowClear
-                    showSearch
-                    optionLabelProp="label"
-                    disabled={!MCP_SUPPORTED_ENDPOINTS.has(endpointType as EndpointType)}
-                    maxTagCount={endpointType === EndpointType.MCP ? 1 : "responsive"}
-                    filterOption={(input, option) => {
-                      if (option?.value === "__all__") {
-                        return "All MCP Servers".toLowerCase().includes(input.toLowerCase());
-                      }
-                      const val = option?.value as string | undefined;
-                      if (val?.startsWith("toolset:")) {
-                        const toolsetId = val.slice("toolset:".length);
-                        const toolset = mcpToolsets.find((t) => t.toolset_id === toolsetId);
-                        if (!toolset) return false;
-                        return [toolset.toolset_name, toolset.description]
-                          .filter(Boolean)
-                          .join(" ")
-                          .toLowerCase()
-                          .includes(input.toLowerCase());
-                      }
-                      const server = mcpServers.find((s) => s.server_id === val);
-                      if (!server) return false;
-                      const searchText = [server.server_name, server.alias, server.server_id, server.description]
-                        .filter(Boolean)
-                        .join(" ")
-                        .toLowerCase();
-                      return searchText.includes(input.toLowerCase());
-                    }}
-                  >
-                    {/* All MCP Servers option - hidden for MCP direct mode */}
-                    {endpointType !== EndpointType.MCP && (
-                      <Select.Option key="__all__" value="__all__" label="All MCP Servers">
-                        <div className="flex flex-col py-1">
-                          <span className="font-medium">All MCP Servers</span>
-                          <span className="text-xs text-gray-500 mt-1">Use all available MCP servers</span>
-                        </div>
-                      </Select.Option>
-                    )}
+                      placeholder="Select MCP server"
+                      emptyText={isLoadingMCPServers ? "Loading..." : "No MCP servers"}
+                      disabled={!MCP_SUPPORTED_ENDPOINTS.has(endpointType as EndpointType) || isLoadingMCPServers}
+                      onValueChange={(value) => handleMcpServersChange(value ? [value] : [])}
+                      options={mcpServerOptions}
+                      className="mb-2"
+                    />
+                  ) : (
+                    <MultiSelect
+                      value={selectedMCPServers}
+                      onValueChange={handleMcpServersChange}
+                      placeholder="Select MCP servers"
+                      emptyText={isLoadingMCPServers ? "Loading..." : "No MCP servers"}
+                      disabled={!MCP_SUPPORTED_ENDPOINTS.has(endpointType as EndpointType)}
+                      loading={isLoadingMCPServers}
+                      options={mcpServerOptions}
+                      className="mb-2"
+                    />
+                  )}
 
-                    {/* Toolsets (purple badge) */}
-                    {mcpToolsets.length > 0 && (
-                      <Select.OptGroup label="Toolsets">
-                        {mcpToolsets.map((toolset) => (
-                          <Select.Option
-                            key={`toolset:${toolset.toolset_id}`}
-                            value={`toolset:${toolset.toolset_id}`}
-                            label={toolset.toolset_name}
-                            disabled={
-                              endpointType === EndpointType.MCP ? false : selectedMCPServers.includes("__all__")
-                            }
-                          >
-                            <div className="flex flex-col py-1">
-                              <div className="flex items-center gap-1">
-                                <span className="font-medium">{toolset.toolset_name}</span>
-                                <span
-                                  className="text-xs px-1 rounded-sm"
-                                  style={{ background: "#ede9fe", color: "#7c3aed" }}
-                                >
-                                  Toolset
-                                </span>
-                                <span className="text-xs text-gray-500">({toolset.tools.length} tools)</span>
-                              </div>
-                              {toolset.description && (
-                                <span className="text-xs text-gray-500 mt-1">{toolset.description}</span>
-                              )}
-                            </div>
-                          </Select.Option>
-                        ))}
-                      </Select.OptGroup>
-                    )}
-
-                    {/* Individual servers */}
-                    {mcpServers.length > 0 && (
-                      <Select.OptGroup label="Servers">
-                        {mcpServers.map((server) => (
-                          <Select.Option
-                            key={server.server_id}
-                            value={server.server_id}
-                            label={server.alias || server.server_name || server.server_id}
-                            disabled={
-                              endpointType === EndpointType.MCP ? false : selectedMCPServers.includes("__all__")
-                            }
-                          >
-                            <div className="flex flex-col py-1">
-                              <span className="font-medium">
-                                {server.alias || server.server_name || server.server_id}
-                              </span>
-                              {server.description && (
-                                <span className="text-xs text-gray-500 mt-1">{server.description}</span>
-                              )}
-                            </div>
-                          </Select.Option>
-                        ))}
-                      </Select.OptGroup>
-                    )}
-                  </Select>
-
-                  {/* MCP Tool selector - only for MCP direct mode */}
                   {endpointType === EndpointType.MCP &&
                     selectedMCPServers.length === 1 &&
                     selectedMCPServers[0] !== "__all__" &&
@@ -1517,28 +1503,25 @@ const ChatUI: React.FC<ChatUIProps> = ({
                           }));
                         }
                       } else {
-                        toolOptions = (serverToolsMap[rawSel] || []).map((tool: any) => ({
+                        toolOptions = (serverToolsMap[rawSel] || []).map((tool: { name: string }) => ({
                           value: tool.name,
                           label: tool.name,
                         }));
                       }
                       return (
                         <div className="mt-3">
-                          <Text className="text-xs text-gray-600 mb-1 block">Select Tool</Text>
-                          <Select
-                            style={{ width: "100%" }}
-                            placeholder="Select a tool to call"
+                          <p className="mb-1 block text-xs text-gray-600">Select Tool</p>
+                          <SearchSelect
                             value={selectedMCPDirectTool}
-                            onChange={(value) => setSelectedMCPDirectTool(value)}
+                            placeholder="Select a tool to call"
+                            onValueChange={(value) => setSelectedMCPDirectTool(value || undefined)}
                             options={toolOptions}
-                            allowClear
                             className="rounded-md"
                           />
                         </div>
                       );
                     })()}
 
-                  {/* Tool restrictions UI (optional) - hidden for MCP direct mode */}
                   {selectedMCPServers.length > 0 &&
                     !selectedMCPServers.includes("__all__") &&
                     endpointType !== EndpointType.MCP &&
@@ -1550,27 +1533,23 @@ const ChatUI: React.FC<ChatUIProps> = ({
                           if (tools.length === 0) return null;
 
                           return (
-                            <div key={serverId} className="border rounded-sm p-2">
-                              <Text className="text-xs text-gray-600 mb-1">
+                            <div key={serverId} className="rounded-sm border p-2">
+                              <p className="mb-1 text-xs text-gray-600">
                                 Limit tools for {server?.alias || server?.server_name || serverId}:
-                              </Text>
-                              <Select
-                                mode="multiple"
-                                size="small"
-                                style={{ width: "100%" }}
-                                placeholder="All tools (default)"
+                              </p>
+                              <MultiSelect
                                 value={mcpServerToolRestrictions[serverId] || []}
-                                onChange={(selectedTools) => {
+                                onValueChange={(selectedTools) => {
                                   setMCPServerToolRestrictions((prev) => ({
                                     ...prev,
                                     [serverId]: selectedTools,
                                   }));
                                 }}
-                                options={tools.map((tool) => ({
+                                placeholder="All tools (default)"
+                                options={tools.map((tool: { name: string }) => ({
                                   value: tool.name,
                                   label: tool.name,
                                 }))}
-                                maxTagCount={2}
                               />
                             </div>
                           );
@@ -1578,7 +1557,6 @@ const ChatUI: React.FC<ChatUIProps> = ({
                       </div>
                     )}
 
-                  {/* BYOK credential status for selected servers */}
                   {selectedMCPServers.length > 0 &&
                     !selectedMCPServers.includes("__all__") &&
                     selectedMCPServers.some((serverId) => {
@@ -1593,28 +1571,31 @@ const ChatUI: React.FC<ChatUIProps> = ({
                           return (
                             <div
                               key={serverId}
-                              className="border border-blue-100 rounded-sm p-2 bg-blue-50 flex items-center justify-between"
+                              className="flex items-center justify-between rounded-sm border border-blue-100 bg-blue-50 p-2"
                             >
-                              <Text className="text-xs text-blue-700">{serverName} requires your API key</Text>
+                              <p className="text-xs text-blue-700">{serverName} requires your API key</p>
                               {server.has_user_credential ? (
                                 <div className="flex items-center gap-2">
-                                  <span className="text-green-600 text-xs font-medium flex items-center gap-1">
-                                    <KeyOutlined /> Connected
+                                  <span className="flex items-center gap-1 text-xs font-medium text-green-600">
+                                    <Key className="size-3" /> Connected
                                   </span>
                                   <button
-                                    className="text-xs text-gray-400 hover:text-blue-500 underline"
+                                    type="button"
+                                    className="text-xs text-gray-400 underline hover:text-blue-500"
                                     onClick={() => setByokModalServer(server)}
                                   >
                                     Reconnect
                                   </button>
                                 </div>
                               ) : (
-                                <button
-                                  className="text-xs bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded-lg font-medium"
+                                <Button
+                                  type="button"
+                                  size="xs"
+                                  className="rounded-lg bg-blue-500 px-3 py-1 text-xs font-medium text-white hover:bg-blue-600"
                                   onClick={() => setByokModalServer(server)}
                                 >
                                   Connect
-                                </button>
+                                </Button>
                               )}
                             </div>
                           );
@@ -1624,23 +1605,21 @@ const ChatUI: React.FC<ChatUIProps> = ({
                 </div>
 
                 <div>
-                  <Text className="font-medium block mb-2 text-gray-700 flex items-center">
-                    <DatabaseOutlined className="mr-2" /> Vector Store
-                    <Tooltip
-                      className="ml-1"
-                      title={
-                        <span>
-                          Select vector store(s) to use for this LLM API call. You can set up your vector store{" "}
-                          <a href="?page=vector-stores" style={{ color: "#1890ff" }}>
-                            here
-                          </a>
-                          .
-                        </span>
-                      }
-                    >
-                      <InfoCircleOutlined />
+                  <div className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-700">
+                    <Database className="mr-1 size-4" aria-hidden="true" /> Vector Store
+                    <Tooltip>
+                      <TooltipTrigger aria-label="About vector stores">
+                        <Info className="size-3.5 text-gray-400" />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-xs">
+                        Select vector store(s) to use for this LLM API call. You can set up your vector store{" "}
+                        <a href="?page=vector-stores" className="text-blue-500 underline">
+                          here
+                        </a>
+                        .
+                      </TooltipContent>
                     </Tooltip>
-                  </Text>
+                  </div>
                   <VectorStoreSelector
                     value={selectedVectorStores}
                     onChange={setSelectedVectorStores}
@@ -1650,23 +1629,21 @@ const ChatUI: React.FC<ChatUIProps> = ({
                 </div>
 
                 <div>
-                  <Text className="font-medium block mb-2 text-gray-700 flex items-center">
-                    <SafetyOutlined className="mr-2" /> Guardrails
-                    <Tooltip
-                      className="ml-1"
-                      title={
-                        <span>
-                          Select guardrail(s) to use for this LLM API call. You can set up your guardrails{" "}
-                          <a href="?page=guardrails" style={{ color: "#1890ff" }}>
-                            here
-                          </a>
-                          .
-                        </span>
-                      }
-                    >
-                      <InfoCircleOutlined />
+                  <div className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-700">
+                    <Shield className="mr-1 size-4" aria-hidden="true" /> Guardrails
+                    <Tooltip>
+                      <TooltipTrigger aria-label="About guardrails">
+                        <Info className="size-3.5 text-gray-400" />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-xs">
+                        Select guardrail(s) to use for this LLM API call. You can set up your guardrails{" "}
+                        <a href="?page=guardrails" className="text-blue-500 underline">
+                          here
+                        </a>
+                        .
+                      </TooltipContent>
                     </Tooltip>
-                  </Text>
+                  </div>
                   <GuardrailSelector
                     value={selectedGuardrails}
                     onChange={setSelectedGuardrails}
@@ -1676,24 +1653,22 @@ const ChatUI: React.FC<ChatUIProps> = ({
                 </div>
 
                 <div>
-                  <Text className="font-medium block mb-2 text-gray-700 flex items-center">
-                    <SafetyOutlined className="mr-2" /> Policies
-                    <Tooltip
-                      className="ml-1"
-                      title={
-                        <span>
-                          Select policy/policies to apply to this LLM API call. Policies define which guardrails are
-                          applied based on conditions. You can set up your policies{" "}
-                          <a href="?page=policies" style={{ color: "#1890ff" }}>
-                            here
-                          </a>
-                          .
-                        </span>
-                      }
-                    >
-                      <InfoCircleOutlined />
+                  <div className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-700">
+                    <Shield className="mr-1 size-4" aria-hidden="true" /> Policies
+                    <Tooltip>
+                      <TooltipTrigger aria-label="About policies">
+                        <Info className="size-3.5 text-gray-400" />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-xs">
+                        Select policy/policies to apply to this LLM API call. Policies define which guardrails are
+                        applied based on conditions. You can set up your policies{" "}
+                        <a href="?page=policies" className="text-blue-500 underline">
+                          here
+                        </a>
+                        .
+                      </TooltipContent>
                     </Tooltip>
-                  </Text>
+                  </div>
                   <PolicySelector
                     value={selectedPolicies}
                     onChange={setSelectedPolicies}
@@ -1702,7 +1677,6 @@ const ChatUI: React.FC<ChatUIProps> = ({
                   />
                 </div>
 
-                {/* Code Interpreter Toggle - Only for Responses endpoint */}
                 {endpointType === EndpointType.RESPONSES && (
                   <div>
                     <CodeInterpreterTool
@@ -1719,7 +1693,6 @@ const ChatUI: React.FC<ChatUIProps> = ({
             </div>
           )}
 
-          {/* Main Chat Area */}
           <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-white">
             {endpointType === EndpointType.REALTIME ? (
               <RealtimePlayground
@@ -1731,31 +1704,25 @@ const ChatUI: React.FC<ChatUIProps> = ({
             ) : (
               <>
                 <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-gray-200 p-3 sm:p-4">
-                  <Title className="text-xl font-semibold mb-0">{simplified ? "Chat" : "Test Key"}</Title>
+                  <h2 className="mb-0 text-xl font-semibold">{simplified ? "Chat" : "Test Key"}</h2>
                   <div className="flex flex-wrap justify-end gap-2">
-                    <TremorButton
-                      onClick={clearChatHistory}
-                      className="bg-gray-100 hover:bg-gray-200 text-gray-700 border-gray-300"
-                      icon={ClearOutlined}
-                    >
+                    <Button type="button" variant="outline" size="sm" onClick={clearChatHistory}>
+                      <Eraser className="size-3.5" />
                       Clear Chat
-                    </TremorButton>
+                    </Button>
                     {!simplified && (
-                      <TremorButton
-                        onClick={() => setIsGetCodeModalVisible(true)}
-                        className="bg-gray-100 hover:bg-gray-200 text-gray-700 border-gray-300"
-                        icon={CodeOutlined}
-                      >
+                      <Button type="button" variant="outline" size="sm" onClick={() => setIsGetCodeModalVisible(true)}>
+                        <Code2 className="size-3.5" />
                         Get Code
-                      </TremorButton>
+                      </Button>
                     )}
                   </div>
                 </div>
                 <div className="min-h-0 min-w-0 flex-1 overflow-auto p-3 pb-0 sm:p-4 sm:pb-0">
                   {chatHistory.length === 0 && (
-                    <div className="h-full flex flex-col items-center justify-center text-gray-400">
-                      <RobotOutlined style={{ fontSize: "48px", marginBottom: "16px" }} />
-                      <Text>Start a conversation, generate an image, or handle audio</Text>
+                    <div className="flex h-full flex-col items-center justify-center text-gray-400">
+                      <Bot className="mb-4 size-12" aria-hidden="true" />
+                      <p className="text-sm">Start a conversation, generate an image, or handle audio</p>
                     </div>
                   )}
 
@@ -1772,29 +1739,26 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     </div>
                   ))}
 
-                  {/* Show MCP events during loading if no assistant message exists yet */}
                   {isLoading &&
                     mcpEvents.length > 0 &&
                     (endpointType === EndpointType.RESPONSES || endpointType === EndpointType.CHAT) &&
                     chatHistory.length > 0 &&
                     chatHistory[chatHistory.length - 1].role === "user" && (
-                      <div className="text-left mb-4">
+                      <div className="mb-4 text-left">
                         <div
-                          className="inline-block max-w-[80%] rounded-lg shadow-xs p-3.5 px-4"
+                          className="inline-block max-w-[80%] rounded-lg p-3.5 px-4 shadow-xs"
                           style={{
                             backgroundColor: "#ffffff",
                             border: "1px solid #f0f0f0",
                             textAlign: "left",
                           }}
                         >
-                          <div className="flex items-center gap-2 mb-1.5">
+                          <div className="mb-1.5 flex items-center gap-2">
                             <div
-                              className="flex items-center justify-center w-6 h-6 rounded-full mr-1"
-                              style={{
-                                backgroundColor: "#f5f5f5",
-                              }}
+                              className="mr-1 flex h-6 w-6 items-center justify-center rounded-full"
+                              style={{ backgroundColor: "#f5f5f5" }}
                             >
-                              <RobotOutlined style={{ fontSize: "12px", color: "#4b5563" }} />
+                              <Bot className="size-3 text-gray-600" aria-hidden="true" />
                             </div>
                             <strong className="text-sm capitalize">Assistant</strong>
                           </div>
@@ -1804,27 +1768,34 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     )}
 
                   {isLoading && (
-                    <div className="flex justify-center items-center my-4">
-                      <Spin indicator={antIcon} />
+                    <div className="my-4 flex items-center justify-center">
+                      <Loader2 className="size-6 animate-spin text-gray-500" aria-label="Loading" />
                     </div>
                   )}
                   <div ref={chatEndRef} style={{ height: "1px" }} />
                 </div>
 
                 <div className="max-h-[50%] shrink-0 overflow-y-auto border-t border-gray-200 bg-white p-3 sm:p-4">
-                  {/* Image Upload Section for Image Edits */}
                   {endpointType === EndpointType.IMAGE_EDITS && (
                     <div className="mb-4">
                       {uploadedImages.length === 0 ? (
-                        <Dragger beforeUpload={handleImageUpload} accept={IMAGE_EDIT_ACCEPT} showUploadList={false}>
-                          <p className="ant-upload-drag-icon">
-                            <PictureOutlined style={{ fontSize: "24px", color: "#666" }} />
-                          </p>
-                          <p className="ant-upload-text text-sm">Click or drag images to upload</p>
-                          <p className="ant-upload-hint text-xs text-gray-500">
+                        <label className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center hover:border-gray-400">
+                          <ImageIcon className="mb-2 size-6 text-gray-500" aria-hidden="true" />
+                          <p className="text-sm">Click or drag images to upload</p>
+                          <p className="text-xs text-gray-500">
                             Support for PNG, JPG, JPEG, GIF, WebP. Multiple images supported.
                           </p>
-                        </Dragger>
+                          <input
+                            type="file"
+                            accept={IMAGE_EDIT_ACCEPT}
+                            multiple
+                            className="sr-only"
+                            onChange={(event) => {
+                              handleImageFiles(Array.from(event.target.files || []));
+                              event.target.value = "";
+                            }}
+                          />
+                        </label>
                       ) : (
                         <div className="flex flex-wrap gap-2">
                           {uploadedImages.map((file, index) => (
@@ -1841,76 +1812,83 @@ const ChatUI: React.FC<ChatUIProps> = ({
                                   }
                                 })()}
                                 alt={`Upload preview ${index + 1}`}
-                                className="max-w-32 max-h-32 rounded-md border border-gray-200 object-cover"
+                                className="max-h-32 max-w-32 rounded-md border border-gray-200 object-cover"
                               />
-                              <button
-                                className="absolute top-1 right-1 bg-white shadow-xs border border-gray-200 rounded-sm px-1 py-1 text-red-500 hover:bg-red-50 text-xs"
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="icon-xs"
+                                className="absolute top-1 right-1 bg-white text-red-500 hover:bg-red-50"
+                                aria-label={`Remove ${file.name}`}
                                 onClick={() => handleRemoveImage(index)}
                               >
-                                <DeleteOutlined />
-                              </button>
+                                <X className="size-3" />
+                              </Button>
                             </div>
                           ))}
-                          {/* Add more images button */}
-                          <div
-                            className="flex items-center justify-center w-32 h-32 border-2 border-dashed border-gray-300 rounded-md hover:border-gray-400 cursor-pointer"
-                            onClick={() => document.getElementById("additional-image-upload")?.click()}
-                          >
-                            <div className="text-center">
-                              <PictureOutlined style={{ fontSize: "24px", color: "#666" }} />
-                              <p className="text-xs text-gray-500 mt-1">Add more</p>
-                            </div>
+                          <label className="flex h-32 w-32 cursor-pointer flex-col items-center justify-center rounded-md border-2 border-dashed border-gray-300 hover:border-gray-400">
+                            <ImageIcon className="size-6 text-gray-500" aria-hidden="true" />
+                            <p className="mt-1 text-xs text-gray-500">Add more</p>
                             <input
-                              id="additional-image-upload"
                               type="file"
                               accept={IMAGE_EDIT_ACCEPT}
                               multiple
-                              style={{ display: "none" }}
-                              onChange={(e) => {
-                                handleImageFiles(Array.from(e.target.files || []));
-                                e.target.value = "";
+                              className="sr-only"
+                              onChange={(event) => {
+                                handleImageFiles(Array.from(event.target.files || []));
+                                event.target.value = "";
                               }}
                             />
-                          </div>
+                          </label>
                         </div>
                       )}
                     </div>
                   )}
 
-                  {/* Audio Upload Section for Transcriptions */}
                   {endpointType === EndpointType.TRANSCRIPTION && (
                     <div className="mb-4">
                       {!uploadedAudio ? (
-                        <Dragger beforeUpload={handleAudioUpload} accept={AUDIO_ACCEPT} showUploadList={false}>
-                          <p className="ant-upload-drag-icon">
-                            <SoundOutlined style={{ fontSize: "24px", color: "#666" }} />
-                          </p>
-                          <p className="ant-upload-text text-sm">Click or drag audio file to upload</p>
-                          <p className="ant-upload-hint text-xs text-gray-500">
+                        <label className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center hover:border-gray-400">
+                          <Volume2 className="mb-2 size-6 text-gray-500" aria-hidden="true" />
+                          <p className="text-sm">Click or drag audio file to upload</p>
+                          <p className="text-xs text-gray-500">
                             Support for MP3, MP4, MPEG, MPGA, M4A, WAV, WEBM formats. Max file size: 25 MB.
                           </p>
-                        </Dragger>
+                          <input
+                            type="file"
+                            accept={AUDIO_ACCEPT}
+                            className="sr-only"
+                            onChange={(event) => {
+                              const file = event.target.files?.[0];
+                              if (file) handleAudioUpload(file);
+                              event.target.value = "";
+                            }}
+                          />
+                        </label>
                       ) : (
-                        <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg border border-gray-200">
-                          <div className="flex items-center gap-2 flex-1">
-                            <SoundOutlined style={{ fontSize: "20px", color: "#666" }} />
+                        <div className="flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
+                          <div className="flex flex-1 items-center gap-2">
+                            <Volume2 className="size-5 text-gray-500" aria-hidden="true" />
                             <span className="text-sm font-medium">{uploadedAudio.name}</span>
                             <span className="text-xs text-gray-500">
                               ({(uploadedAudio.size / 1024 / 1024).toFixed(2)} MB)
                             </span>
                           </div>
-                          <button
-                            className="bg-white shadow-xs border border-gray-200 rounded-sm px-2 py-1 text-red-500 hover:bg-red-50 text-xs"
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="xs"
+                            className="text-red-500"
                             onClick={handleRemoveAudio}
                           >
-                            <DeleteOutlined /> Remove
-                          </button>
+                            <Trash2 className="size-3" />
+                            Remove
+                          </Button>
                         </div>
                       )}
                     </div>
                   )}
 
-                  {/* Show file previews above input when files are uploaded */}
                   {endpointType === EndpointType.RESPONSES && responsesUploadedImage && (
                     <FilePreviewCard
                       file={responsesUploadedImage}
@@ -1927,31 +1905,30 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     />
                   )}
 
-                  {/* Code Interpreter indicator and sample prompts when enabled */}
                   {endpointType === EndpointType.RESPONSES && codeInterpreter.enabled && (
                     <div className="mb-2 space-y-2">
-                      <div className="px-3 py-2 bg-linear-to-r from-blue-50 to-purple-50 rounded-lg border border-blue-200 flex items-center justify-between">
+                      <div className="flex items-center justify-between rounded-lg border border-blue-200 bg-linear-to-r from-blue-50 to-purple-50 px-3 py-2">
                         <div className="flex items-center gap-2">
                           {isLoading ? (
                             <>
-                              <LoadingOutlined className="text-blue-500" spin />
-                              <span className="text-sm text-blue-700 font-medium">Running Python code...</span>
+                              <Loader2 className="size-4 animate-spin text-blue-500" aria-hidden="true" />
+                              <span className="text-sm font-medium text-blue-700">Running Python code...</span>
                             </>
                           ) : (
                             <>
-                              <CodeOutlined className="text-blue-500" />
-                              <span className="text-sm text-blue-700 font-medium">Code Interpreter Active</span>
+                              <Code2 className="size-4 text-blue-500" aria-hidden="true" />
+                              <span className="text-sm font-medium text-blue-700">Code Interpreter Active</span>
                             </>
                           )}
                         </div>
                         <button
+                          type="button"
                           className="text-xs text-blue-500 hover:text-blue-700"
                           onClick={() => codeInterpreter.setEnabled(false)}
                         >
                           Disable
                         </button>
                       </div>
-                      {/* Sample prompts - only show when not loading */}
                       {!isLoading && (
                         <div className="flex flex-wrap gap-2">
                           {[
@@ -1961,7 +1938,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
                           ].map((prompt, idx) => (
                             <button
                               key={idx}
-                              className="text-xs px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:bg-blue-50 hover:border-blue-300 hover:text-blue-600 transition-colors"
+                              type="button"
+                              className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-600"
                               onClick={() => setInputMessage(prompt)} // lgtm[js/xss-through-dom]
                             >
                               {prompt}
@@ -1972,9 +1950,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     </div>
                   )}
 
-                  {/* Suggested prompts - show when chat is empty and not loading (skip for MCP - uses structured form) */}
                   {chatHistory.length === 0 && !isLoading && endpointType !== EndpointType.MCP && (
-                    <div className="flex items-center gap-2 mb-3 overflow-x-auto">
+                    <div className="mb-3 flex items-center gap-2 overflow-x-auto">
                       {(endpointType === EndpointType.A2A_AGENTS
                         ? ["What can you help me with?", "Tell me about yourself", "What tasks can you perform?"]
                         : ["Write me a poem", "Explain quantum computing", "Draft a polite email requesting a meeting"]
@@ -1982,7 +1959,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                         <button
                           key={prompt}
                           type="button"
-                          className="shrink-0 rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-blue-50 hover:border-blue-300 hover:text-blue-600 cursor-pointer"
+                          className="shrink-0 cursor-pointer rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-600"
                           onClick={() => setInputMessage(prompt)} // lgtm[js/xss-through-dom]
                         >
                           {prompt}
@@ -1992,9 +1969,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
                   )}
 
                   <div className="flex items-center gap-2">
-                    <div className="flex items-center flex-1 bg-white border border-gray-300 rounded-xl px-3 py-1 min-h-[44px]">
-                      {/* Left: attachment and code interpreter icons */}
-                      <div className="shrink-0 mr-2 flex items-center gap-1">
+                    <div className="flex min-h-[44px] flex-1 items-center rounded-xl border border-gray-300 bg-white px-3 py-1">
+                      <div className="mr-2 flex shrink-0 items-center gap-1">
                         {endpointType === EndpointType.RESPONSES && !responsesUploadedImage && (
                           <ResponsesImageUpload
                             responsesUploadedImage={responsesUploadedImage}
@@ -2011,43 +1987,50 @@ const ChatUI: React.FC<ChatUIProps> = ({
                             onRemoveImage={handleRemoveChatImage}
                           />
                         )}
-                        {/* Quick Code Interpreter toggle for Responses */}
                         {endpointType === EndpointType.RESPONSES && (
-                          <Tooltip
-                            title={
-                              codeInterpreter.enabled
-                                ? "Code Interpreter enabled (click to disable)"
-                                : "Enable Code Interpreter"
-                            }
-                          >
-                            <button
-                              className={`p-1.5 rounded-md transition-colors ${
-                                codeInterpreter.enabled
-                                  ? "bg-blue-100 text-blue-600"
-                                  : "text-gray-400 hover:text-gray-600 hover:bg-gray-100"
-                              }`}
-                              onClick={() => {
-                                codeInterpreter.toggle();
-                                if (!codeInterpreter.enabled) {
-                                  NotificationsManager.success("Code Interpreter enabled!");
-                                }
-                              }}
+                          <Tooltip>
+                            <TooltipTrigger
+                              render={
+                                <button
+                                  type="button"
+                                  className={`rounded-md p-1.5 transition-colors ${
+                                    codeInterpreter.enabled
+                                      ? "bg-blue-100 text-blue-600"
+                                      : "text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+                                  }`}
+                                  aria-label={
+                                    codeInterpreter.enabled
+                                      ? "Code Interpreter enabled (click to disable)"
+                                      : "Enable Code Interpreter"
+                                  }
+                                  onClick={() => {
+                                    codeInterpreter.toggle();
+                                    if (!codeInterpreter.enabled) {
+                                      NotificationsManager.success("Code Interpreter enabled!");
+                                    }
+                                  }}
+                                />
+                              }
                             >
-                              <CodeOutlined style={{ fontSize: "16px" }} />
-                            </button>
+                              <Code2 className="size-4" />
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              {codeInterpreter.enabled
+                                ? "Code Interpreter enabled (click to disable)"
+                                : "Enable Code Interpreter"}
+                            </TooltipContent>
                           </Tooltip>
                         )}
                       </div>
 
-                      {/* Middle: input field or MCP structured form */}
                       {endpointType === EndpointType.MCP &&
                       selectedMCPServers.length === 1 &&
                       selectedMCPServers[0] !== "__all__" &&
                       selectedMCPDirectTool ? (
-                        <div className="flex-1 overflow-y-auto max-h-48 min-h-[44px] p-2 border border-gray-200 rounded-lg bg-gray-50/50">
+                        <div className="max-h-48 min-h-[44px] flex-1 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50/50 p-2">
                           {(() => {
                             const rawSel = selectedMCPServers[0];
-                            let toolPool: any[] = [];
+                            let toolPool: { name: string }[] = [];
                             if (rawSel.startsWith("toolset:")) {
                               const toolsetId = rawSel.slice("toolset:".length);
                               const toolset = mcpToolsets.find((t) => t.toolset_id === toolsetId);
@@ -2060,82 +2043,51 @@ const ChatUI: React.FC<ChatUIProps> = ({
                             } else {
                               toolPool = serverToolsMap[rawSel] || [];
                             }
-                            const mcpTool = toolPool.find((t: any) => t.name === selectedMCPDirectTool);
+                            const mcpTool = toolPool.find((t) => t.name === selectedMCPDirectTool);
                             return mcpTool ? (
                               <MCPToolArgumentsForm ref={mcpToolArgsFormRef} tool={mcpTool} className="space-y-2" />
                             ) : (
-                              <div className="flex items-center justify-center h-10 text-sm text-gray-500">
+                              <div className="flex h-10 items-center justify-center text-sm text-gray-500">
                                 Loading tool schema...
                               </div>
                             );
                           })()}
                         </div>
                       ) : (
-                        <TextArea
+                        <Textarea
                           value={inputMessage}
-                          onChange={(e) => setInputMessage(e.target.value)}
+                          onChange={(event) => setInputMessage(event.target.value)}
                           onKeyDown={handleKeyDown}
-                          placeholder={
-                            endpointType === EndpointType.CHAT ||
-                            endpointType === EndpointType.EMBEDDINGS ||
-                            endpointType === EndpointType.RESPONSES ||
-                            endpointType === EndpointType.ANTHROPIC_MESSAGES ||
-                            endpointType === EndpointType.INTERACTIONS
-                              ? "Type your message... (Shift+Enter for new line)"
-                              : endpointType === EndpointType.A2A_AGENTS
-                                ? "Send a message to the A2A agent..."
-                                : endpointType === EndpointType.IMAGE_EDITS
-                                  ? "Describe how you want to edit the image..."
-                                  : endpointType === EndpointType.SPEECH
-                                    ? "Enter text to convert to speech..."
-                                    : endpointType === EndpointType.TRANSCRIPTION
-                                      ? "Optional: Add context or prompt for transcription..."
-                                      : "Describe the image you want to generate..."
-                          }
+                          placeholder={inputPlaceholder}
                           disabled={isLoading}
-                          className="flex-1"
-                          autoSize={{ minRows: 1, maxRows: 4 }}
-                          style={{
-                            resize: "none",
-                            border: "none",
-                            boxShadow: "none",
-                            background: "transparent",
-                            padding: "4px 0",
-                            fontSize: "14px",
-                            lineHeight: "20px",
-                          }}
+                          rows={1}
+                          className="min-h-0 flex-1 resize-none border-0 bg-transparent px-0 py-1 text-sm shadow-none focus-visible:ring-0"
                         />
                       )}
 
-                      {/* Right: send button - matching blue theme */}
-                      <TremorButton
+                      <Button
+                        type="button"
+                        size="icon-sm"
                         onClick={handleSendMessage}
-                        disabled={
-                          isLoading ||
-                          (endpointType === EndpointType.MCP
-                            ? !(
-                                selectedMCPServers.length === 1 &&
-                                selectedMCPServers[0] !== "__all__" &&
-                                selectedMCPDirectTool
-                              )
-                            : endpointType === EndpointType.TRANSCRIPTION
-                              ? !uploadedAudio
-                              : !inputMessage.trim())
-                        }
-                        className="shrink-0 ml-2 w-8! h-8! min-w-8! p-0! rounded-full! bg-blue-600! hover:bg-blue-700! disabled:bg-gray-300! border-none! text-white! disabled:text-gray-500! flex! items-center! justify-center!"
+                        disabled={sendDisabled}
+                        className="ml-2 size-8 shrink-0 rounded-full bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 disabled:text-gray-500"
+                        aria-label="Send message"
                       >
-                        <ArrowUpOutlined style={{ fontSize: "14px" }} />
-                      </TremorButton>
+                        <ArrowUp className="size-3.5" />
+                      </Button>
                     </div>
 
                     {isLoading && (
-                      <TremorButton
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="border-red-200 bg-red-50 text-red-600 hover:bg-red-100"
                         onClick={handleCancelRequest}
-                        className="bg-red-50 hover:bg-red-100 text-red-600 border-red-200"
-                        icon={DeleteOutlined}
                       >
+                        <Trash2 className="size-3.5" />
                         Cancel
-                      </TremorButton>
+                      </Button>
                     )}
                   </div>
                 </div>
@@ -2143,50 +2095,55 @@ const ChatUI: React.FC<ChatUIProps> = ({
             )}
           </div>
         </div>
-      </Card>
-      <Modal
-        title="Generated Code"
-        open={isGetCodeModalVisible}
-        onCancel={() => setIsGetCodeModalVisible(false)}
-        footer={null}
-        width={800}
-      >
-        <div className="flex justify-between items-end my-4">
-          <div>
-            <Text className="font-medium block mb-1 text-gray-700">SDK Type</Text>
-            <Select
-              value={selectedSdk}
-              onChange={(value) => setSelectedSdk(value as "openai" | "azure")}
-              style={{ width: 150 }}
-              options={[
-                { value: "openai", label: "OpenAI SDK" },
-                { value: "azure", label: "Azure SDK" },
-              ]}
-            />
+      </div>
+
+      <Dialog open={isGetCodeModalVisible} onOpenChange={setIsGetCodeModalVisible}>
+        <DialogContent className="sm:max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Generated Code</DialogTitle>
+          </DialogHeader>
+          <div className="my-2 flex items-end justify-between gap-3">
+            <div>
+              <p className="mb-1 text-sm font-medium text-gray-700">SDK Type</p>
+              <ShadcnSelect value={selectedSdk} onValueChange={(value) => setSelectedSdk(value as "openai" | "azure")}>
+                <SelectTrigger className="w-[150px]" size="sm" aria-label="SDK Type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="openai">OpenAI SDK</SelectItem>
+                  <SelectItem value="azure">Azure SDK</SelectItem>
+                </SelectContent>
+              </ShadcnSelect>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                void navigator.clipboard.writeText(generatedCode).then(
+                  () => NotificationsManager.success("Copied to clipboard!"),
+                  () => NotificationsManager.error("Unable to copy to clipboard"),
+                );
+              }}
+            >
+              Copy to Clipboard
+            </Button>
           </div>
-          <Button
-            onClick={() => {
-              navigator.clipboard.writeText(generatedCode);
-              NotificationsManager.success("Copied to clipboard!");
+          <SyntaxHighlighter
+            language="python"
+            style={coy as Record<string, React.CSSProperties>}
+            wrapLines={true}
+            wrapLongLines={true}
+            className="rounded-md"
+            customStyle={{
+              maxHeight: "60vh",
+              overflowY: "auto",
             }}
           >
-            Copy to Clipboard
-          </Button>
-        </div>
-        <SyntaxHighlighter
-          language="python"
-          style={coy as any}
-          wrapLines={true}
-          wrapLongLines={true}
-          className="rounded-md"
-          customStyle={{
-            maxHeight: "60vh",
-            overflowY: "auto",
-          }}
-        >
-          {generatedCode}
-        </SyntaxHighlighter>
-      </Modal>
+            {generatedCode}
+          </SyntaxHighlighter>
+        </DialogContent>
+      </Dialog>
 
       {byokModalServer && (
         <ByokCredentialModal
@@ -2194,58 +2151,56 @@ const ChatUI: React.FC<ChatUIProps> = ({
           open={!!byokModalServer}
           onClose={() => setByokModalServer(null)}
           onSuccess={(_serverId) => {
-            // Refresh MCP servers to pick up updated has_user_credential
             loadMCPServers();
             setByokModalServer(null);
           }}
         />
       )}
 
-      {/* Toolsets info modal */}
-      <Modal
-        title="How Toolsets Work"
-        open={isToolsetsInfoModalVisible}
-        onCancel={() => setIsToolsetsInfoModalVisible(false)}
-        footer={[
-          <Button key="close" onClick={() => setIsToolsetsInfoModalVisible(false)}>
-            Close
-          </Button>,
-        ]}
-        width={600}
-      >
-        <div className="space-y-4 py-2">
-          <p className="text-gray-700">
-            <strong>Toolsets</strong> are named collections of specific tools from one or more MCP servers. Instead of
-            exposing all tools from a server, a toolset gives an agent exactly the tools it needs.
-          </p>
-          <div>
-            <h4 className="font-semibold text-gray-800 mb-2">How to use a toolset:</h4>
-            <ol className="list-decimal list-inside space-y-2 text-gray-700">
-              <li>
-                Select a <span style={{ color: "#7c3aed", fontWeight: 600 }}>Toolset</span> (purple badge) from the MCP
-                Servers dropdown.
-              </li>
-              <li>The tool picker will show only the tools included in that toolset.</li>
-              <li>Select a tool and fill in its parameters, then send.</li>
-              <li>The tool call is routed to the correct underlying MCP server automatically.</li>
-            </ol>
-          </div>
-          <div className="bg-purple-50 border border-purple-200 rounded-sm p-3">
-            <p className="text-sm text-purple-800">
-              <strong>Example:</strong> A &quot;GitHub Read-only&quot; toolset might include only{" "}
-              <code>list_repos</code> and <code>get_file</code> from a GitHub MCP server — preventing agents from making
-              writes.
+      <Dialog open={isToolsetsInfoModalVisible} onOpenChange={setIsToolsetsInfoModalVisible}>
+        <DialogContent className="sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>How Toolsets Work</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <p className="text-gray-700">
+              <strong>Toolsets</strong> are named collections of specific tools from one or more MCP servers. Instead of
+              exposing all tools from a server, a toolset gives an agent exactly the tools it needs.
             </p>
+            <div>
+              <h4 className="mb-2 font-semibold text-gray-800">How to use a toolset:</h4>
+              <ol className="list-inside list-decimal space-y-2 text-gray-700">
+                <li>
+                  Select a <span className="font-semibold text-violet-600">Toolset</span> (purple badge) from the MCP
+                  Servers dropdown.
+                </li>
+                <li>The tool picker will show only the tools included in that toolset.</li>
+                <li>Select a tool and fill in its parameters, then send.</li>
+                <li>The tool call is routed to the correct underlying MCP server automatically.</li>
+              </ol>
+            </div>
+            <div className="rounded-sm border border-purple-200 bg-purple-50 p-3">
+              <p className="text-sm text-purple-800">
+                <strong>Example:</strong> A &quot;GitHub Read-only&quot; toolset might include only{" "}
+                <code>list_repos</code> and <code>get_file</code> from a GitHub MCP server, preventing agents from
+                making writes.
+              </p>
+            </div>
+            <div>
+              <h4 className="mb-1 font-semibold text-gray-800">Creating toolsets:</h4>
+              <p className="text-sm text-gray-600">
+                Admins can create and manage toolsets from the <strong>MCP</strong> page → <strong>Toolsets</strong>{" "}
+                tab. Toolsets can then be assigned to keys and teams to scope their tool access.
+              </p>
+            </div>
           </div>
-          <div>
-            <h4 className="font-semibold text-gray-800 mb-1">Creating toolsets:</h4>
-            <p className="text-sm text-gray-600">
-              Admins can create and manage toolsets from the <strong>MCP</strong> page → <strong>Toolsets</strong> tab.
-              Toolsets can then be assigned to keys and teams to scope their tool access.
-            </p>
-          </div>
-        </div>
-      </Modal>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setIsToolsetsInfoModalVisible(false)}>
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -103,6 +103,7 @@ const MCP_SUPPORTED_ENDPOINTS = new Set<EndpointType>([
   EndpointType.RESPONSES,
   EndpointType.MCP,
   EndpointType.ANTHROPIC_MESSAGES,
+  EndpointType.INTERACTIONS,
 ]);
 
 const CUSTOM_MODEL_DEBOUNCE_WAIT_MS = 500;
@@ -1069,6 +1070,11 @@ const ChatUI: React.FC<ChatUIProps> = ({
             selectedTags,
             signal,
             customProxyBaseUrl || undefined,
+            undefined,
+            selectedMCPServers,
+            mcpServers,
+            mcpServerToolRestrictions,
+            mcpToolsets,
           );
         }
       }

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -2087,7 +2087,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
               <p className="mb-1 text-sm font-medium text-gray-700">SDK Type</p>
               <ShadcnSelect value={selectedSdk} onValueChange={(value) => setSelectedSdk(value as "openai" | "azure")}>
                 <SelectTrigger className="w-[150px]" size="sm" aria-label="SDK Type">
-                  <SelectValue />
+                  <SelectValue>{selectedSdk === "azure" ? "Azure SDK" : "OpenAI SDK"}</SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="openai">OpenAI SDK</SelectItem>

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  ArrowUp,
   Bot,
   Code2,
   Database,
@@ -47,6 +46,7 @@ import { makeOpenAIResponsesRequest } from "@/components/llm_calls/responses_api
 import { makeInteractionsRequest } from "../../llm_calls/interactions_api";
 import AdditionalModelSettings from "./AdditionalModelSettings";
 import { OPEN_AI_VOICE_SELECT_OPTIONS, OpenAIVoice } from "./chatConstants";
+import ChatComposer, { CodeInterpreterToggle } from "./ChatComposer";
 import ChatImageUpload from "./ChatImageUpload";
 import { createChatDisplayMessage, createChatMultimodalMessage } from "./ChatImageUtils";
 import CodeInterpreterTool from "./CodeInterpreterTool";
@@ -72,7 +72,6 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Select as ShadcnSelect, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useDebouncedCallback } from "@tanstack/react-pacer/debouncer";
 import {
@@ -494,14 +493,6 @@ const ChatUI: React.FC<ChatUIProps> = ({
       }, 100);
     }
   }, [chatHistory]);
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === "Enter" && !event.shiftKey) {
-      event.preventDefault(); // Prevent default to avoid newline
-      handleSendMessage();
-    }
-    // If Shift+Enter is pressed, the default behavior (inserting a newline) will occur
-  };
 
   const handleCancelRequest = () => {
     if (abortControllerRef.current) {
@@ -1957,27 +1948,24 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     </div>
                   )}
 
-                  {chatHistory.length === 0 && !isLoading && endpointType !== EndpointType.MCP && (
-                    <div className="mb-3 flex items-center gap-2 overflow-x-auto">
-                      {(endpointType === EndpointType.A2A_AGENTS
+                  <ChatComposer
+                    value={inputMessage}
+                    onChange={setInputMessage}
+                    onSubmit={handleSendMessage}
+                    onCancel={handleCancelRequest}
+                    placeholder={inputPlaceholder}
+                    disabled={isLoading}
+                    isLoading={isLoading}
+                    submitDisabled={sendDisabled}
+                    showSuggestions={chatHistory.length === 0 && !isLoading && endpointType !== EndpointType.MCP}
+                    suggestions={
+                      endpointType === EndpointType.A2A_AGENTS
                         ? ["What can you help me with?", "Tell me about yourself", "What tasks can you perform?"]
                         : ["Write me a poem", "Explain quantum computing", "Draft a polite email requesting a meeting"]
-                      ).map((prompt) => (
-                        <button
-                          key={prompt}
-                          type="button"
-                          className="shrink-0 cursor-pointer rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-600"
-                          onClick={() => setInputMessage(prompt)} // lgtm[js/xss-through-dom]
-                        >
-                          {prompt}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-
-                  <div className="flex items-center gap-2">
-                    <div className="flex min-h-[44px] flex-1 items-center rounded-xl border border-gray-300 bg-white px-3 py-1">
-                      <div className="mr-2 flex shrink-0 items-center gap-1">
+                    }
+                    onSuggestionSelect={setInputMessage}
+                    tools={
+                      <>
                         {endpointType === EndpointType.RESPONSES && !responsesUploadedImage && (
                           <ResponsesImageUpload
                             responsesUploadedImage={responsesUploadedImage}
@@ -1995,47 +1983,24 @@ const ChatUI: React.FC<ChatUIProps> = ({
                           />
                         )}
                         {endpointType === EndpointType.RESPONSES && (
-                          <Tooltip>
-                            <TooltipTrigger
-                              render={
-                                <button
-                                  type="button"
-                                  className={`rounded-md p-1.5 transition-colors ${
-                                    codeInterpreter.enabled
-                                      ? "bg-blue-100 text-blue-600"
-                                      : "text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-                                  }`}
-                                  aria-label={
-                                    codeInterpreter.enabled
-                                      ? "Code Interpreter enabled (click to disable)"
-                                      : "Enable Code Interpreter"
-                                  }
-                                  onClick={() => {
-                                    codeInterpreter.toggle();
-                                    if (!codeInterpreter.enabled) {
-                                      NotificationsManager.success("Code Interpreter enabled!");
-                                    }
-                                  }}
-                                />
+                          <CodeInterpreterToggle
+                            enabled={codeInterpreter.enabled}
+                            onToggle={() => {
+                              codeInterpreter.toggle();
+                              if (!codeInterpreter.enabled) {
+                                NotificationsManager.success("Code Interpreter enabled!");
                               }
-                            >
-                              <Code2 className="size-4" />
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              {codeInterpreter.enabled
-                                ? "Code Interpreter enabled (click to disable)"
-                                : "Enable Code Interpreter"}
-                            </TooltipContent>
-                          </Tooltip>
+                            }}
+                          />
                         )}
-                      </div>
-
-                      {endpointType === EndpointType.MCP &&
+                      </>
+                    }
+                    body={
+                      endpointType === EndpointType.MCP &&
                       selectedMCPServers.length === 1 &&
                       selectedMCPServers[0] !== "__all__" &&
-                      selectedMCPDirectTool ? (
-                        <div className="max-h-48 min-h-[44px] flex-1 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50/50 p-2">
-                          {(() => {
+                      selectedMCPDirectTool
+                        ? (() => {
                             const rawSel = selectedMCPServers[0];
                             let toolPool: { name: string }[] = [];
                             if (rawSel.startsWith("toolset:")) {
@@ -2058,45 +2023,10 @@ const ChatUI: React.FC<ChatUIProps> = ({
                                 Loading tool schema...
                               </div>
                             );
-                          })()}
-                        </div>
-                      ) : (
-                        <Textarea
-                          value={inputMessage}
-                          onChange={(event) => setInputMessage(event.target.value)}
-                          onKeyDown={handleKeyDown}
-                          placeholder={inputPlaceholder}
-                          disabled={isLoading}
-                          rows={1}
-                          className="min-h-0 flex-1 resize-none border-0 bg-transparent px-0 py-1 text-sm shadow-none focus-visible:ring-0"
-                        />
-                      )}
-
-                      <Button
-                        type="button"
-                        size="icon-sm"
-                        onClick={handleSendMessage}
-                        disabled={sendDisabled}
-                        className="ml-2 size-8 shrink-0 rounded-full bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 disabled:text-gray-500"
-                        aria-label="Send message"
-                      >
-                        <ArrowUp className="size-3.5" />
-                      </Button>
-                    </div>
-
-                    {isLoading && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="border-red-200 bg-red-50 text-red-600 hover:bg-red-100"
-                        onClick={handleCancelRequest}
-                      >
-                        <Trash2 className="size-3.5" />
-                        Cancel
-                      </Button>
-                    )}
-                  </div>
+                          })()
+                        : undefined
+                    }
+                  />
                 </div>
               </>
             )}

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -857,7 +857,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
 
           const requestProxyBaseUrl =
             simplified && proxySettings
-              ? proxySettings.LITELLM_UI_API_DOC_BASE_URL ?? proxySettings.PROXY_BASE_URL ?? undefined
+              ? (proxySettings.LITELLM_UI_API_DOC_BASE_URL ?? proxySettings.PROXY_BASE_URL ?? undefined)
               : customProxyBaseUrl || undefined;
           await makeOpenAIChatCompletionRequest(
             apiChatHistory,
@@ -1205,7 +1205,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     }}
                   >
                     <SelectTrigger className="w-full" size="sm" aria-label="Virtual Key Source">
-                      <SelectValue />
+                      <SelectValue>{apiKeySource === "custom" ? "Virtual Key" : "Current UI Session"}</SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="session">Current UI Session</SelectItem>
@@ -1331,7 +1331,10 @@ const ChatUI: React.FC<ChatUIProps> = ({
                         }}
                       >
                         <SelectTrigger className="w-full" size="sm" aria-label="Voice">
-                          <SelectValue />
+                          <SelectValue>
+                            {OPEN_AI_VOICE_SELECT_OPTIONS.find((voice) => voice.value === selectedVoice)?.label ??
+                              selectedVoice}
+                          </SelectValue>
                         </SelectTrigger>
                         <SelectContent>
                           {OPEN_AI_VOICE_SELECT_OPTIONS.map((voice) => (

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -52,6 +52,7 @@ import { createChatDisplayMessage, createChatMultimodalMessage } from "./ChatIma
 import CodeInterpreterTool from "./CodeInterpreterTool";
 import { generateCodeSnippet } from "@/components/chat_ui/CodeSnippets";
 import EndpointSelector from "./EndpointSelector";
+import { filterModelsForEndpoint } from "./EndpointUtils";
 import FilePreviewCard from "./FilePreviewCard";
 import ChatMessageBubble from "./ChatMessageBubble";
 import MCPEventsDisplay from "@/components/chat_ui/MCPEventsDisplay";
@@ -1130,11 +1131,17 @@ const ChatUI: React.FC<ChatUIProps> = ({
   };
 
   const supportsStreamingToggle = endpointType === EndpointType.CHAT || endpointType === EndpointType.RESPONSES;
+  const modelsForEndpoint = useMemo(
+    () => filterModelsForEndpoint(modelInfo, endpointType as EndpointType),
+    [modelInfo, endpointType],
+  );
   let modelEmptyText = "No models available for this key";
   if (modelLoadError) {
     modelEmptyText = "Unable to load models for this key";
   } else if (apiKeySource === "custom" && !apiKey.trim()) {
     modelEmptyText = "Enter a Virtual Key to load models";
+  } else if (modelInfo.length > 0 && modelsForEndpoint.length === 0) {
+    modelEmptyText = "No models available for this endpoint";
   }
 
   const inputPlaceholder =
@@ -1383,7 +1390,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                       onValueChange={onModelChange}
                       options={[
                         { value: "custom", label: "Enter custom model" },
-                        ...modelInfo.map((model) => ({
+                        ...modelsForEndpoint.map((model) => ({
                           value: model.model_group,
                           label: model.model_group,
                           sublabel: model.mode ? `Mode: ${model.mode}` : undefined,

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -274,21 +274,50 @@ const ChatUI: React.FC<ChatUIProps> = ({
 
   const chatEndRef = useRef<HTMLDivElement>(null);
 
+  const normalizeListResponse = <T,>(payload: unknown): T[] => {
+    if (Array.isArray(payload)) {
+      return payload as T[];
+    }
+    if (payload && typeof payload === "object") {
+      const record = payload as Record<string, unknown>;
+      if (Array.isArray(record.data)) {
+        return record.data as T[];
+      }
+      if (Array.isArray(record.servers)) {
+        return record.servers as T[];
+      }
+      if (Array.isArray(record.toolsets)) {
+        return record.toolsets as T[];
+      }
+    }
+    return [];
+  };
+
   // Fetch MCP servers and toolsets
-  const loadMCPServers = async () => {
-    const userApiKey = apiKeySource === "session" ? accessToken : apiKey;
-    if (!userApiKey) return;
+  const loadMCPServers = async (overrideKey?: string | null) => {
+    const userApiKey =
+      overrideKey !== undefined ? overrideKey : apiKeySource === "session" ? accessToken : apiKey.trim();
+    if (!userApiKey) {
+      setMCPServers([]);
+      setMCPToolsets([]);
+      return;
+    }
 
     setIsLoadingMCPServers(true);
     try {
-      const [servers, toolsets] = await Promise.all([
+      const [serversPayload, toolsetsPayload] = await Promise.all([
         fetchMCPServers(userApiKey),
         fetchMCPToolsets(userApiKey).catch(() => []),
       ]);
-      setMCPServers(Array.isArray(servers) ? servers : servers.data || []);
-      setMCPToolsets(Array.isArray(toolsets) ? toolsets : []);
+      const servers = normalizeListResponse<MCPServer>(serversPayload);
+      const toolsets = normalizeListResponse<MCPToolset>(toolsetsPayload);
+      setMCPServers(servers);
+      setMCPToolsets(toolsets);
     } catch (error) {
       console.error("Error fetching MCP servers:", error);
+      setMCPServers([]);
+      setMCPToolsets([]);
+      NotificationsManager.error("Unable to load MCP servers for this key");
     } finally {
       setIsLoadingMCPServers(false);
     }
@@ -456,7 +485,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
     if (!simplified) {
       void loadModels();
     }
-    loadMCPServers();
+    void loadMCPServers(userApiKey);
 
     return () => {
       cancelled = true;
@@ -629,17 +658,24 @@ const ChatUI: React.FC<ChatUIProps> = ({
       });
     }
     for (const toolset of mcpToolsets) {
+      if (!toolset?.toolset_id) {
+        continue;
+      }
+      const toolCount = Array.isArray(toolset.tools) ? toolset.tools.length : 0;
       options.push({
         value: `toolset:${toolset.toolset_id}`,
-        label: toolset.toolset_name,
-        description: toolset.description || `Toolset (${toolset.tools.length} tools)`,
+        label: toolset.toolset_name || toolset.toolset_id,
+        description: toolset.description || `Toolset (${toolCount} tools)`,
       });
     }
     for (const server of mcpServers) {
+      if (!server?.server_id) {
+        continue;
+      }
       options.push({
         value: server.server_id,
         label: server.alias || server.server_name || server.server_id,
-        description: server.description,
+        description: server.description || undefined,
       });
     }
     return options;
@@ -857,7 +893,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
 
           const requestProxyBaseUrl =
             simplified && proxySettings
-              ? (proxySettings.LITELLM_UI_API_DOC_BASE_URL ?? proxySettings.PROXY_BASE_URL ?? undefined)
+              ? proxySettings.LITELLM_UI_API_DOC_BASE_URL ?? proxySettings.PROXY_BASE_URL ?? undefined
               : customProxyBaseUrl || undefined;
           await makeOpenAIChatCompletionRequest(
             apiChatHistory,
@@ -1508,23 +1544,45 @@ const ChatUI: React.FC<ChatUIProps> = ({
                           : undefined
                       }
                       placeholder="Select MCP server"
-                      emptyText={isLoadingMCPServers ? "Loading..." : "No MCP servers"}
+                      emptyText={
+                        isLoadingMCPServers
+                          ? "Loading..."
+                          : mcpServerOptions.length === 0
+                            ? "No MCP servers configured"
+                            : "No matching MCP servers"
+                      }
                       disabled={!MCP_SUPPORTED_ENDPOINTS.has(endpointType as EndpointType) || isLoadingMCPServers}
                       onValueChange={(value) => handleMcpServersChange(value ? [value] : [])}
-                      options={mcpServerOptions}
+                      options={mcpServerOptions.map((option) => ({
+                        value: option.value,
+                        label: option.label,
+                        sublabel: option.description,
+                      }))}
                       className="mb-2"
                     />
                   ) : (
-                    <MultiSelect
-                      value={selectedMCPServers}
-                      onValueChange={handleMcpServersChange}
-                      placeholder="Select MCP servers"
-                      emptyText={isLoadingMCPServers ? "Loading..." : "No MCP servers"}
-                      disabled={!MCP_SUPPORTED_ENDPOINTS.has(endpointType as EndpointType)}
-                      loading={isLoadingMCPServers}
-                      options={mcpServerOptions}
-                      className="mb-2"
-                    />
+                    <div className="mb-2 space-y-1">
+                      <MultiSelect
+                        value={selectedMCPServers}
+                        onValueChange={handleMcpServersChange}
+                        placeholder="Select MCP servers"
+                        emptyText={
+                          isLoadingMCPServers
+                            ? "Loading..."
+                            : mcpServers.length === 0
+                              ? "No MCP servers configured"
+                              : "No matching MCP servers"
+                        }
+                        disabled={!MCP_SUPPORTED_ENDPOINTS.has(endpointType as EndpointType)}
+                        loading={isLoadingMCPServers}
+                        options={mcpServerOptions}
+                      />
+                      {!isLoadingMCPServers && mcpServers.length === 0 && (
+                        <p className="text-xs text-muted-foreground">
+                          No MCP servers available for this key. Add servers on the MCP page.
+                        </p>
+                      )}
+                    </div>
                   )}
 
                   {endpointType === EndpointType.MCP &&

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterOutput.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterOutput.tsx
@@ -1,15 +1,10 @@
-import React, { useState, useEffect } from "react";
-import { Collapse, Spin } from "antd";
-import {
-  CodeOutlined,
-  DownloadOutlined,
-  FileImageOutlined,
-  FileTextOutlined,
-  LoadingOutlined,
-} from "@ant-design/icons";
+import React, { useEffect, useState } from "react";
+import { Code, Download, FileImage, FileText, Loader2 } from "lucide-react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { coy } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { getProxyBaseUrl, getGlobalLitellmHeaderName } from "@/components/networking";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 
 interface ContainerFileCitation {
   type: "container_file_citation";
@@ -27,48 +22,60 @@ interface CodeInterpreterOutputProps {
   accessToken: string;
 }
 
-const CodeInterpreterOutput: React.FC<CodeInterpreterOutputProps> = ({
-  code,
-  containerId,
-  annotations = [],
-  accessToken,
-}) => {
+const IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif"] as const;
+
+function isImageFilename(filename: string | undefined): boolean {
+  if (!filename) {
+    return false;
+  }
+  const lower = filename.toLowerCase();
+  return IMAGE_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+const CodeInterpreterOutput: React.FC<CodeInterpreterOutputProps> = ({ code, annotations = [], accessToken }) => {
   const [imageUrls, setImageUrls] = useState<Record<string, string>>({});
   const [loadingImages, setLoadingImages] = useState<Record<string, boolean>>({});
+  const [codeOpen, setCodeOpen] = useState(false);
   const proxyBaseUrl = getProxyBaseUrl();
 
-  // Fetch images from container files API
   useEffect(() => {
+    const createdUrls: string[] = [];
+    let cancelled = false;
+
     const fetchImages = async () => {
       for (const annotation of annotations) {
-        const isImage =
-          annotation.filename?.toLowerCase().endsWith(".png") ||
-          annotation.filename?.toLowerCase().endsWith(".jpg") ||
-          annotation.filename?.toLowerCase().endsWith(".jpeg") ||
-          annotation.filename?.toLowerCase().endsWith(".gif");
+        if (!isImageFilename(annotation.filename) || !annotation.container_id || !annotation.file_id) {
+          continue;
+        }
 
-        if (isImage && annotation.container_id && annotation.file_id) {
+        if (!cancelled) {
           setLoadingImages((prev) => ({ ...prev, [annotation.file_id]: true }));
+        }
 
-          try {
-            // Fetch image content from container files API
-            const response = await fetch(
-              `${proxyBaseUrl}/v1/containers/${annotation.container_id}/files/${annotation.file_id}/content`,
-              {
-                headers: {
-                  [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
-                },
+        try {
+          const response = await fetch(
+            `${proxyBaseUrl}/v1/containers/${annotation.container_id}/files/${annotation.file_id}/content`,
+            {
+              headers: {
+                [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
               },
-            );
+            },
+          );
 
-            if (response.ok) {
-              const blob = await response.blob();
-              const url = URL.createObjectURL(blob);
+          if (response.ok) {
+            const blob = await response.blob();
+            const url = URL.createObjectURL(blob);
+            createdUrls.push(url);
+            if (!cancelled) {
               setImageUrls((prev) => ({ ...prev, [annotation.file_id]: url }));
+            } else {
+              URL.revokeObjectURL(url);
             }
-          } catch (error) {
-            console.error("Error fetching image:", error);
-          } finally {
+          }
+        } catch (error) {
+          console.error("Error fetching image:", error);
+        } finally {
+          if (!cancelled) {
             setLoadingImages((prev) => ({ ...prev, [annotation.file_id]: false }));
           }
         }
@@ -76,12 +83,12 @@ const CodeInterpreterOutput: React.FC<CodeInterpreterOutputProps> = ({
     };
 
     if (annotations.length > 0 && accessToken) {
-      fetchImages();
+      void fetchImages();
     }
 
-    // Cleanup URLs on unmount
     return () => {
-      Object.values(imageUrls).forEach((url) => URL.revokeObjectURL(url));
+      cancelled = true;
+      createdUrls.forEach((url) => URL.revokeObjectURL(url));
     };
   }, [annotations, accessToken, proxyBaseUrl]);
 
@@ -112,22 +119,8 @@ const CodeInterpreterOutput: React.FC<CodeInterpreterOutputProps> = ({
     }
   };
 
-  // Separate images and other files
-  const imageAnnotations = annotations.filter(
-    (a) =>
-      a.filename?.toLowerCase().endsWith(".png") ||
-      a.filename?.toLowerCase().endsWith(".jpg") ||
-      a.filename?.toLowerCase().endsWith(".jpeg") ||
-      a.filename?.toLowerCase().endsWith(".gif"),
-  );
-
-  const fileAnnotations = annotations.filter(
-    (a) =>
-      !a.filename?.toLowerCase().endsWith(".png") &&
-      !a.filename?.toLowerCase().endsWith(".jpg") &&
-      !a.filename?.toLowerCase().endsWith(".jpeg") &&
-      !a.filename?.toLowerCase().endsWith(".gif"),
-  );
+  const imageAnnotations = annotations.filter((a) => isImageFilename(a.filename));
+  const fileAnnotations = annotations.filter((a) => !isImageFilename(a.filename));
 
   if (!code && annotations.length === 0) {
     return null;
@@ -135,44 +128,46 @@ const CodeInterpreterOutput: React.FC<CodeInterpreterOutputProps> = ({
 
   return (
     <div className="mt-3 space-y-3">
-      {/* Executed Code - Collapsible */}
       {code && (
-        <Collapse
-          size="small"
-          items={[
-            {
-              key: "code",
-              label: (
-                <span className="flex items-center gap-2 text-sm text-gray-600">
-                  <CodeOutlined /> Python Code Executed
-                </span>
-              ),
-              children: (
-                <SyntaxHighlighter
-                  language="python"
-                  style={coy}
-                  customStyle={{
-                    margin: 0,
-                    borderRadius: "6px",
-                    fontSize: "12px",
-                    maxHeight: "300px",
-                    overflow: "auto",
-                  }}
-                >
-                  {code}
-                </SyntaxHighlighter>
-              ),
-            },
-          ]}
-        />
+        <Collapsible open={codeOpen} onOpenChange={setCodeOpen} className="rounded-md border border-gray-200">
+          <CollapsibleTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start gap-2 text-sm text-gray-600"
+              />
+            }
+          >
+            <Code className="size-4" />
+            Python Code Executed
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="border-t border-gray-200 p-2">
+              <SyntaxHighlighter
+                language="python"
+                style={coy}
+                customStyle={{
+                  margin: 0,
+                  borderRadius: "6px",
+                  fontSize: "12px",
+                  maxHeight: "300px",
+                  overflow: "auto",
+                }}
+              >
+                {code}
+              </SyntaxHighlighter>
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
       )}
 
-      {/* Generated Images */}
       {imageAnnotations.map((annotation) => (
-        <div key={annotation.file_id} className="rounded-lg border border-gray-200 overflow-hidden">
+        <div key={annotation.file_id} className="overflow-hidden rounded-lg border border-gray-200">
           {loadingImages[annotation.file_id] ? (
-            <div className="flex items-center justify-center p-8 bg-gray-50">
-              <Spin indicator={<LoadingOutlined spin />} />
+            <div className="flex items-center justify-center bg-gray-50 p-8">
+              <Loader2 className="size-4 animate-spin text-gray-500" aria-hidden="true" />
               <span className="ml-2 text-sm text-gray-500">Loading image...</span>
             </div>
           ) : imageUrls[annotation.file_id] ? (
@@ -180,42 +175,48 @@ const CodeInterpreterOutput: React.FC<CodeInterpreterOutputProps> = ({
               <img
                 src={imageUrls[annotation.file_id]}
                 alt={annotation.filename || "Generated chart"}
-                className="max-w-full"
-                style={{ maxHeight: "400px" }}
+                className="max-h-[400px] max-w-full"
               />
-              <div className="flex items-center justify-between px-3 py-2 bg-gray-50 border-t border-gray-200">
-                <span className="text-xs text-gray-500 flex items-center gap-1">
-                  <FileImageOutlined /> {annotation.filename}
+              <div className="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-3 py-2">
+                <span className="flex items-center gap-1 text-xs text-gray-500">
+                  <FileImage className="size-3" aria-hidden="true" />
+                  {annotation.filename}
                 </span>
-                <button
-                  onClick={() => handleDownload(annotation)}
-                  className="text-xs text-blue-500 hover:text-blue-700 flex items-center gap-1"
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  className="h-auto gap-1 px-1 py-0 text-xs text-blue-500 hover:text-blue-700"
+                  onClick={() => void handleDownload(annotation)}
                 >
-                  <DownloadOutlined /> Download
-                </button>
+                  <Download className="size-3" />
+                  Download
+                </Button>
               </div>
             </div>
           ) : (
-            <div className="flex items-center justify-center p-4 bg-gray-50">
+            <div className="flex items-center justify-center bg-gray-50 p-4">
               <span className="text-sm text-gray-400">Image not available</span>
             </div>
           )}
         </div>
       ))}
 
-      {/* Download Links for Other Files */}
       {fileAnnotations.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {fileAnnotations.map((annotation) => (
-            <button
+            <Button
               key={annotation.file_id}
-              onClick={() => handleDownload(annotation)}
-              className="flex items-center gap-2 px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 transition-colors"
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-auto gap-2 border-gray-200 bg-gray-50 px-3 py-2 hover:bg-gray-100"
+              onClick={() => void handleDownload(annotation)}
             >
-              <FileTextOutlined className="text-blue-500" />
+              <FileText className="size-4 text-blue-500" aria-hidden="true" />
               <span className="text-sm">{annotation.filename}</span>
-              <DownloadOutlined className="text-gray-400" />
-            </button>
+              <Download className="size-3 text-gray-400" aria-hidden="true" />
+            </Button>
           ))}
         </div>
       )}

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterTool.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterTool.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { Switch, Tooltip } from "antd";
 import MessageManager from "@/components/molecules/message_manager";
-import { CodeOutlined, InfoCircleOutlined, ExclamationCircleOutlined } from "@ant-design/icons";
-import { Text } from "@tremor/react";
+import { Code, Info, TriangleAlert } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface CodeInterpreterToolProps {
   accessToken: string;
@@ -49,25 +49,30 @@ const CodeInterpreterTool: React.FC<CodeInterpreterToolProps> = ({
     <div className="border border-gray-200 rounded-lg p-3 bg-linear-to-r from-blue-50 to-purple-50">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <CodeOutlined className="text-blue-500" />
-          <Text className="font-medium text-gray-700">Code Interpreter</Text>
-          <Tooltip title="Run Python code to generate files, charts, and analyze data. Container is created automatically.">
-            <InfoCircleOutlined className="text-gray-400 text-xs" />
+          <Code className="size-4 text-blue-500" />
+          <span className="font-medium text-gray-700">Code Interpreter</span>
+          <Tooltip>
+            <TooltipTrigger aria-label="About Code Interpreter">
+              <Info className="size-3 text-gray-400" />
+            </TooltipTrigger>
+            <TooltipContent>
+              Run Python code to generate files, charts, and analyze data. Container is created automatically.
+            </TooltipContent>
           </Tooltip>
         </div>
         <Switch
           checked={enabled && isOpenAI}
-          onChange={handleToggle}
+          onCheckedChange={handleToggle}
           disabled={isDisabled}
-          size="small"
-          className={enabled && isOpenAI ? "bg-blue-500" : ""}
+          size="sm"
+          aria-label="Enable Code Interpreter"
         />
       </div>
 
       {!isOpenAI && (
         <div className="mt-2 pt-2 border-t border-gray-200">
           <div className="flex items-start gap-2">
-            <ExclamationCircleOutlined className="text-amber-500 mt-0.5" />
+            <TriangleAlert className="mt-0.5 size-4 shrink-0 text-amber-500" />
             <div className="text-xs text-gray-600">
               <span>Code Interpreter is currently only supported for OpenAI models. </span>
               <a

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointSelector.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointSelector.tsx
@@ -1,4 +1,4 @@
-import { Select } from "antd";
+import { SearchSelect } from "@/components/shared/SearchSelect";
 import React from "react";
 import { ENDPOINT_OPTIONS } from "./chatConstants";
 
@@ -11,17 +11,11 @@ interface EndpointSelectorProps {
 const EndpointSelector: React.FC<EndpointSelectorProps> = ({ endpointType, onEndpointChange, className }) => {
   return (
     <div className={className}>
-      <Select
-        showSearch
+      <SearchSelect
         value={endpointType}
-        style={{ width: "100%" }}
-        onChange={onEndpointChange}
+        onValueChange={onEndpointChange}
         options={ENDPOINT_OPTIONS}
-        className="rounded-md"
-        filterOption={(input, option) =>
-          (option?.label ?? "").toLowerCase().includes(input.toLowerCase()) ||
-          (option?.value ?? "").toLowerCase().includes(input.toLowerCase())
-        }
+        placeholder="Select an endpoint"
       />
     </div>
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.test.tsx
@@ -1,37 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelGroup } from "@/components/llm_calls/fetch_models";
-import { determineEndpointType } from "./EndpointUtils";
+import { determineEndpointType, filterModelsForEndpoint, isModelCompatibleWithEndpoint } from "./EndpointUtils";
 import { EndpointType } from "@/components/chat_ui/mode_endpoint_mapping";
 
-// Mock the getEndpointType function
-vi.mock("@/components/chat_ui/mode_endpoint_mapping", () => ({
-  EndpointType: {
-    IMAGE: "image",
-    VIDEO: "video",
-    CHAT: "chat",
-    RESPONSES: "responses",
-    IMAGE_EDITS: "image_edits",
-    ANTHROPIC_MESSAGES: "anthropic_messages",
-    EMBEDDINGS: "embeddings",
-    SPEECH: "speech",
-    TRANSCRIPTION: "transcription",
-    A2A_AGENTS: "a2a_agents",
-  },
-  getEndpointType: vi.fn(),
-  ModelMode: {
-    AUDIO_SPEECH: "audio_speech",
-    AUDIO_TRANSCRIPTION: "audio_transcription",
-    IMAGE_GENERATION: "image_generation",
-    VIDEO_GENERATION: "video_generation",
-    CHAT: "chat",
-    RESPONSES: "responses",
-    IMAGE_EDITS: "image_edits",
-    ANTHROPIC_MESSAGES: "anthropic_messages",
-    EMBEDDING: "embedding",
-  },
-}));
+vi.mock("@/components/chat_ui/mode_endpoint_mapping", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/chat_ui/mode_endpoint_mapping")>();
+  return {
+    ...actual,
+    getEndpointType: vi.fn(actual.getEndpointType),
+  };
+});
 
-// Import the mocked function
 import { getEndpointType } from "@/components/chat_ui/mode_endpoint_mapping";
 
 describe("determineEndpointType", () => {
@@ -210,10 +189,61 @@ describe("determineEndpointType", () => {
 
     vi.mocked(getEndpointType).mockReturnValue(EndpointType.CHAT);
 
-    // Test with different case - should not match
     const result = determineEndpointType("gpt-3.5-turbo", mockModelInfo);
 
     expect(getEndpointType).not.toHaveBeenCalled();
     expect(result).toBe(EndpointType.CHAT);
+  });
+});
+
+describe("isModelCompatibleWithEndpoint / filterModelsForEndpoint", () => {
+  beforeEach(() => {
+    vi.mocked(getEndpointType).mockImplementation((mode: string) => {
+      const map: Record<string, EndpointType> = {
+        chat: EndpointType.CHAT,
+        responses: EndpointType.RESPONSES,
+        image_generation: EndpointType.IMAGE,
+        image_edits: EndpointType.IMAGE_EDITS,
+        audio_speech: EndpointType.SPEECH,
+        realtime: EndpointType.REALTIME,
+        embedding: EndpointType.EMBEDDINGS,
+      };
+      return map[mode] ?? EndpointType.CHAT;
+    });
+  });
+
+  it("keeps models with no mode for every endpoint", () => {
+    const model: ModelGroup = { model_group: "custom-proxy-model" };
+    expect(isModelCompatibleWithEndpoint(model, EndpointType.CHAT)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(model, EndpointType.REALTIME)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(model, EndpointType.SPEECH)).toBe(true);
+  });
+
+  it("keeps chat models for responses, anthropic messages, and interactions", () => {
+    const chatModel: ModelGroup = { model_group: "gpt-4o", mode: "chat" };
+    expect(isModelCompatibleWithEndpoint(chatModel, EndpointType.RESPONSES)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(chatModel, EndpointType.ANTHROPIC_MESSAGES)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(chatModel, EndpointType.INTERACTIONS)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(chatModel, EndpointType.SPEECH)).toBe(false);
+  });
+
+  it("keeps image models for image_edits", () => {
+    const imageModel: ModelGroup = { model_group: "dall-e-3", mode: "image_generation" };
+    expect(isModelCompatibleWithEndpoint(imageModel, EndpointType.IMAGE_EDITS)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(imageModel, EndpointType.IMAGE)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(imageModel, EndpointType.CHAT)).toBe(false);
+  });
+
+  it("keeps only realtime models for the realtime endpoint", () => {
+    const models: ModelGroup[] = [
+      { model_group: "gpt-4o", mode: "chat" },
+      { model_group: "gpt-realtime", mode: "realtime" },
+      { model_group: "no-mode" },
+    ];
+
+    expect(filterModelsForEndpoint(models, EndpointType.REALTIME).map((m) => m.model_group)).toEqual([
+      "gpt-realtime",
+      "no-mode",
+    ]);
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.tsx
@@ -1,22 +1,37 @@
 import { ModelGroup } from "@/components/llm_calls/fetch_models";
 import { EndpointType, getEndpointType } from "@/components/chat_ui/mode_endpoint_mapping";
 
-/**
- * Determines the appropriate endpoint type based on the selected model
- *
- * @param selectedModel - The model identifier string
- * @param modelInfo - Array of model information
- * @returns The appropriate endpoint type
- */
 export const determineEndpointType = (selectedModel: string, modelInfo: ModelGroup[]): EndpointType => {
-  // Find the model information for the selected model
   const selectedModelInfo = modelInfo.find((option) => option.model_group === selectedModel);
 
-  // If model info is found and it has a mode, determine the endpoint type
   if (selectedModelInfo?.mode) {
     return getEndpointType(selectedModelInfo.mode);
   }
 
-  // Default to chat endpoint if no match is found
   return EndpointType.CHAT;
 };
+
+export const isModelCompatibleWithEndpoint = (model: ModelGroup, endpointType: EndpointType): boolean => {
+  if (!model.mode) {
+    return true;
+  }
+
+  const optionEndpoint = getEndpointType(model.mode);
+
+  if (
+    endpointType === EndpointType.RESPONSES ||
+    endpointType === EndpointType.ANTHROPIC_MESSAGES ||
+    endpointType === EndpointType.INTERACTIONS
+  ) {
+    return optionEndpoint === endpointType || optionEndpoint === EndpointType.CHAT;
+  }
+
+  if (endpointType === EndpointType.IMAGE_EDITS) {
+    return optionEndpoint === endpointType || optionEndpoint === EndpointType.IMAGE;
+  }
+
+  return optionEndpoint === endpointType;
+};
+
+export const filterModelsForEndpoint = (models: ModelGroup[], endpointType: EndpointType): ModelGroup[] =>
+  models.filter((model) => isModelCompatibleWithEndpoint(model, endpointType));

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/FilePreviewCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/FilePreviewCard.tsx
@@ -1,4 +1,5 @@
-import { DeleteOutlined, FilePdfOutlined } from "@ant-design/icons";
+import { FileText, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface FilePreviewCardProps {
   file: File;
@@ -15,7 +16,7 @@ function FilePreviewCard({ file, previewUrl, onRemove }: FilePreviewCardProps) {
         <div className="relative inline-block">
           {isPdf ? (
             <div className="w-10 h-10 rounded-md bg-red-500 flex items-center justify-center">
-              <FilePdfOutlined style={{ fontSize: "16px", color: "white" }} />
+              <FileText className="size-4 text-white" aria-hidden="true" />
             </div>
           ) : (
             <img
@@ -29,12 +30,16 @@ function FilePreviewCard({ file, previewUrl, onRemove }: FilePreviewCardProps) {
           <div className="text-sm font-medium text-gray-900 truncate">{file.name}</div>
           <div className="text-xs text-gray-500">{isPdf ? "PDF" : "Image"}</div>
         </div>
-        <button
-          className="flex items-center justify-center w-6 h-6 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded-full transition-colors"
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label={`Remove ${file.name}`}
+          className="text-gray-400 hover:text-gray-600 hover:bg-gray-200"
           onClick={onRemove}
         >
-          <DeleteOutlined style={{ fontSize: "12px" }} />
-        </button>
+          <X className="size-3" />
+        </Button>
       </div>
     </div>
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/RealtimePlayground.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/RealtimePlayground.tsx
@@ -23,6 +23,32 @@ interface RealtimePlaygroundProps {
   selectedGuardrails?: string[];
 }
 
+type AssistantStreamSource = "none" | "audio_transcript" | "text";
+
+function extractCompletedAssistantText(response: {
+  output?: Array<{ content?: Array<{ type?: string; text?: string; transcript?: string }> }>;
+}): string {
+  const output = response.output || [];
+  const transcripts: string[] = [];
+  const texts: string[] = [];
+
+  for (const item of output) {
+    for (const part of item.content || []) {
+      if (part.transcript) {
+        transcripts.push(part.transcript);
+      } else if (part.text) {
+        texts.push(part.text);
+      }
+    }
+  }
+
+  // Prefer spoken transcript over text modality so we do not double-append both streams.
+  if (transcripts.length > 0) {
+    return transcripts.join("");
+  }
+  return texts.join("");
+}
+
 const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
   accessToken,
   selectedModel,
@@ -34,6 +60,7 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
   const [isConnected, setIsConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
+  const [isResponding, setIsResponding] = useState(false);
   const [selectedVoice, setSelectedVoice] = useState<OpenAIRealtimeVoice>("alloy");
   const wsRef = useRef<WebSocket | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
@@ -42,6 +69,16 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const nextPlayTimeRef = useRef(0);
   const configureSessionRef = useRef(false);
+  const responseInProgressRef = useRef(false);
+  const assistantStreamSourceRef = useRef<AssistantStreamSource>("none");
+  const pendingTextRef = useRef<string | null>(null);
+  const selectedVoiceRef = useRef(selectedVoice);
+  const flushPendingTextRef = useRef<() => void>(() => {});
+  const cancelActiveResponseRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    selectedVoiceRef.current = selectedVoice;
+  }, [selectedVoice]);
 
   const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -55,7 +92,26 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
     setMessages((prev) => [...prev, { role, content, timestamp: new Date() }]);
   }, []);
 
-  const appendAssistantText = useCallback((text: string) => {
+  const markResponseStarted = useCallback(() => {
+    responseInProgressRef.current = true;
+    assistantStreamSourceRef.current = "none";
+    setIsResponding(true);
+  }, []);
+
+  const markResponseFinished = useCallback(() => {
+    responseInProgressRef.current = false;
+    assistantStreamSourceRef.current = "none";
+    setIsResponding(false);
+  }, []);
+
+  const appendAssistantText = useCallback((text: string, source: Exclude<AssistantStreamSource, "none">) => {
+    // Stick to one stream per response so audio transcript + text deltas do not garble the bubble.
+    if (assistantStreamSourceRef.current === "none") {
+      assistantStreamSourceRef.current = source;
+    } else if (assistantStreamSourceRef.current !== source) {
+      return;
+    }
+
     setMessages((prev) => {
       const last = prev[prev.length - 1];
       if (last && last.role === "assistant") {
@@ -96,6 +152,60 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
     setIsRecording(false);
   }, []);
 
+  const createResponse = useCallback(() => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+    if (responseInProgressRef.current) {
+      return false;
+    }
+    markResponseStarted();
+    wsRef.current.send(JSON.stringify({ type: "response.create" }));
+    return true;
+  }, [markResponseStarted]);
+
+  const cancelActiveResponse = useCallback(() => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    if (!responseInProgressRef.current) {
+      return;
+    }
+    wsRef.current.send(JSON.stringify({ type: "response.cancel" }));
+  }, []);
+
+  const flushPendingText = useCallback(() => {
+    const pending = pendingTextRef.current;
+    if (!pending || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    if (responseInProgressRef.current) {
+      return;
+    }
+
+    pendingTextRef.current = null;
+    addMessage("user", pending);
+    wsRef.current.send(
+      JSON.stringify({
+        type: "conversation.item.create",
+        item: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: pending }],
+        },
+      }),
+    );
+    createResponse();
+  }, [addMessage, createResponse]);
+
+  useEffect(() => {
+    flushPendingTextRef.current = flushPendingText;
+  }, [flushPendingText]);
+
+  useEffect(() => {
+    cancelActiveResponseRef.current = cancelActiveResponse;
+  }, [cancelActiveResponse]);
+
   const connect = useCallback(async () => {
     if (wsRef.current) return;
     if (!selectedModel) {
@@ -103,6 +213,9 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
       return;
     }
     setIsConnecting(true);
+    markResponseFinished();
+    pendingTextRef.current = null;
+    configureSessionRef.current = false;
 
     try {
       audioContextRef.current = new AudioContext({ sampleRate: 24000 });
@@ -131,7 +244,7 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
             raw = new TextDecoder().decode(raw);
           }
           const data = JSON.parse(raw);
-          const type = data.type;
+          const type = data.type as string;
 
           if (type === "session.created") {
             ws.send(
@@ -140,7 +253,7 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
                 session: {
                   type: "realtime",
                   modalities: ["text", "audio"],
-                  voice: selectedVoice,
+                  voice: selectedVoiceRef.current,
                   input_audio_format: "pcm16",
                   output_audio_format: "pcm16",
                   input_audio_transcription: { model: "gpt-4o-mini-transcribe" },
@@ -148,36 +261,51 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
                 },
               }),
             );
+          } else if (type === "response.created") {
+            markResponseStarted();
           } else if (type === "response.output_audio.delta" || type === "response.audio.delta") {
             if (data.delta) playAudioChunk(data.delta);
-          } else if (
-            type === "response.output_text.delta" ||
-            type === "response.output_audio_transcript.delta" ||
-            type === "response.audio_transcript.delta" ||
-            type === "response.text.delta"
-          ) {
-            if (data.delta) appendAssistantText(data.delta);
+          } else if (type === "response.output_audio_transcript.delta" || type === "response.audio_transcript.delta") {
+            if (data.delta) appendAssistantText(data.delta, "audio_transcript");
+          } else if (type === "response.output_text.delta" || type === "response.text.delta") {
+            if (data.delta) appendAssistantText(data.delta, "text");
           } else if (type === "conversation.item.input_audio_transcription.completed") {
             if (data.transcript) addMessage("user", data.transcript);
-          } else if (type === "response.done") {
-            setMessages((prev) => {
-              const last = prev[prev.length - 1];
-              if (last && last.role === "assistant" && last.content) return prev;
-              const output = data.response?.output || [];
-              const texts: string[] = [];
-              for (const item of output) {
-                for (const c of item.content || []) {
-                  const t = c.text || c.transcript;
-                  if (t) texts.push(t);
-                }
+          } else if (type === "response.done" || type === "response.cancelled") {
+            if (type === "response.done") {
+              const completed = extractCompletedAssistantText(data.response || {});
+              if (completed) {
+                setMessages((prev) => {
+                  const last = prev[prev.length - 1];
+                  if (last && last.role === "assistant") {
+                    // Keep the longer of streamed vs final payload without concatenating both streams.
+                    if (last.content.length >= completed.length) {
+                      return prev;
+                    }
+                    return [...prev.slice(0, -1), { ...last, content: completed }];
+                  }
+                  return [...prev, { role: "assistant", content: completed, timestamp: new Date() }];
+                });
               }
-              if (texts.length > 0) {
-                return [...prev, { role: "assistant" as const, content: texts.join(""), timestamp: new Date() }];
-              }
-              return prev;
-            });
+            }
+            markResponseFinished();
+            flushPendingTextRef.current();
           } else if (type === "error") {
-            addMessage("status", `Error: ${data.error?.message || JSON.stringify(data.error)}`);
+            const errorMessage = data.error?.message || JSON.stringify(data.error);
+            const activeResponseError =
+              typeof errorMessage === "string" && errorMessage.toLowerCase().includes("active response in progress");
+
+            if (activeResponseError) {
+              // Stale client state vs server: cancel and unlock the composer.
+              responseInProgressRef.current = true;
+              setIsResponding(true);
+              cancelActiveResponseRef.current();
+              addMessage("status", "Waited for an in-progress response. Try sending again.");
+            } else {
+              addMessage("status", `Error: ${errorMessage}`);
+              markResponseFinished();
+              flushPendingTextRef.current();
+            }
           }
         } catch {
           // ignore parse errors
@@ -188,12 +316,15 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
         addMessage("status", "WebSocket error");
         setIsConnected(false);
         setIsConnecting(false);
+        markResponseFinished();
       };
 
       ws.onclose = () => {
         addMessage("status", "Disconnected");
         setIsConnected(false);
         setIsConnecting(false);
+        markResponseFinished();
+        pendingTextRef.current = null;
         wsRef.current = null;
       };
 
@@ -202,20 +333,24 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
       const message = err instanceof Error ? err.message : "Unknown error";
       addMessage("status", `Connection failed: ${message}`);
       setIsConnecting(false);
+      markResponseFinished();
     }
   }, [
     accessToken,
     selectedModel,
-    selectedVoice,
     customProxyBaseUrl,
     selectedGuardrails,
     addMessage,
     appendAssistantText,
     playAudioChunk,
+    markResponseFinished,
+    markResponseStarted,
   ]);
 
   const disconnect = useCallback(() => {
     stopRecording();
+    pendingTextRef.current = null;
+    markResponseFinished();
     wsRef.current?.close();
     wsRef.current = null;
     audioContextRef.current?.close();
@@ -223,10 +358,14 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
     nextPlayTimeRef.current = 0;
     configureSessionRef.current = false;
     setIsConnected(false);
-  }, [stopRecording]);
+  }, [stopRecording, markResponseFinished]);
 
   const startRecording = useCallback(async () => {
     if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+    if (responseInProgressRef.current) {
+      addMessage("status", "Wait for the current response to finish before using the mic.");
+      return;
+    }
 
     wsRef.current.send(
       JSON.stringify({
@@ -300,6 +439,7 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
     if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
     if (configureSessionRef.current) return;
     configureSessionRef.current = true;
+    // Text turns use manual response.create; disable server VAD so mic barge-in cannot race it.
     wsRef.current.send(
       JSON.stringify({
         type: "session.update",
@@ -318,11 +458,22 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
 
   const sendTextMessage = useCallback(() => {
     if (!inputText.trim() || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+
+    // Stop mic first so server VAD cannot open a competing response.
+    stopRecording();
     ensureTextSession();
+
     const text = inputText.trim();
-    addMessage("user", text);
     setInputText("");
 
+    if (responseInProgressRef.current) {
+      pendingTextRef.current = text;
+      cancelActiveResponse();
+      addMessage("status", "Finishing the previous response, then sending your message...");
+      return;
+    }
+
+    addMessage("user", text);
     wsRef.current.send(
       JSON.stringify({
         type: "conversation.item.create",
@@ -333,8 +484,8 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
         },
       }),
     );
-    wsRef.current.send(JSON.stringify({ type: "response.create" }));
-  }, [inputText, addMessage, ensureTextSession]);
+    createResponse();
+  }, [inputText, addMessage, ensureTextSession, stopRecording, cancelActiveResponse, createResponse]);
 
   useEffect(() => {
     return () => {
@@ -356,10 +507,19 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
             <p className="font-semibold text-gray-800">Realtime Voice Chat</p>
             <div className="flex items-center gap-2 text-xs text-gray-500">
               <span
-                className={cn("inline-block size-2 rounded-full", isConnected ? "bg-green-500" : "bg-gray-300")}
+                className={cn(
+                  "inline-block size-2 rounded-full",
+                  isConnected ? (isResponding ? "bg-amber-500" : "bg-green-500") : "bg-gray-300",
+                )}
                 aria-hidden="true"
               />
-              {isConnected ? "Connected" : isConnecting ? "Connecting..." : "Disconnected"}
+              {!isConnected
+                ? isConnecting
+                  ? "Connecting..."
+                  : "Disconnected"
+                : isResponding
+                  ? "AI responding..."
+                  : "Connected"}
               {selectedModel ? <span className="truncate">· {selectedModel}</span> : null}
             </div>
           </div>
@@ -442,11 +602,21 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
               Listening. Speak into your microphone. Server VAD will detect when you stop.
             </div>
           )}
+          {isResponding && (
+            <div className="mb-3 flex items-center gap-2 text-xs text-amber-600">
+              <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+              AI is responding. New messages wait until this turn finishes.
+            </div>
+          )}
           <ChatComposer
             value={inputText}
             onChange={setInputText}
             onSubmit={sendTextMessage}
-            placeholder="Type a message or use the mic..."
+            placeholder={
+              isResponding
+                ? "AI is responding... you can still type; send will queue"
+                : "Type a message or use the mic..."
+            }
             submitDisabled={!inputText.trim()}
             tools={
               <Tooltip>
@@ -458,6 +628,7 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
                       size="icon-sm"
                       className={cn("size-8 rounded-lg border border-border/40", isRecording && "animate-pulse")}
                       aria-label={isRecording ? "Stop recording" : "Start recording"}
+                      disabled={isResponding && !isRecording}
                       onClick={() => {
                         if (isRecording) {
                           stopRecording();
@@ -470,7 +641,13 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
                 >
                   {isRecording ? <MicOff className="size-4" /> : <Mic className="size-4" />}
                 </TooltipTrigger>
-                <TooltipContent>{isRecording ? "Stop recording" : "Start recording"}</TooltipContent>
+                <TooltipContent>
+                  {isResponding && !isRecording
+                    ? "Wait for the AI to finish before using the mic"
+                    : isRecording
+                      ? "Stop recording"
+                      : "Start recording"}
+                </TooltipContent>
               </Tooltip>
             }
           />

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/RealtimePlayground.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/RealtimePlayground.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { AudioMutedOutlined, AudioOutlined, CloseCircleOutlined, SendOutlined, SoundOutlined } from "@ant-design/icons";
-import { Button, Input, Select, Typography } from "antd";
+import { Loader2, Mic, MicOff, Phone, PhoneOff, Volume2 } from "lucide-react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { getProxyBaseUrl } from "@/components/networking";
-import { OPEN_AI_VOICE_SELECT_OPTIONS } from "./chatConstants";
-
-const { Text } = Typography;
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/cva.config";
+import ChatComposer from "./ChatComposer";
+import { OPEN_AI_REALTIME_VOICE_SELECT_OPTIONS, type OpenAIRealtimeVoice } from "./chatConstants";
 
 interface RealtimeMessage {
   role: "user" | "assistant" | "system" | "status";
@@ -32,13 +34,14 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
   const [isConnected, setIsConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
-  const [selectedVoice, setSelectedVoice] = useState("alloy");
+  const [selectedVoice, setSelectedVoice] = useState<OpenAIRealtimeVoice>("alloy");
   const wsRef = useRef<WebSocket | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
   const processorRef = useRef<ScriptProcessorNode | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const nextPlayTimeRef = useRef(0);
+  const configureSessionRef = useRef(false);
 
   const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -85,6 +88,14 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
     nextPlayTimeRef.current = startTime + buffer.duration;
   }, []);
 
+  const stopRecording = useCallback(() => {
+    processorRef.current?.disconnect();
+    processorRef.current = null;
+    mediaStreamRef.current?.getTracks().forEach((t) => t.stop());
+    mediaStreamRef.current = null;
+    setIsRecording(false);
+  }, []);
+
   const connect = useCallback(async () => {
     if (wsRef.current) return;
     if (!selectedModel) {
@@ -123,7 +134,6 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
           const type = data.type;
 
           if (type === "session.created") {
-            // GA: session.type is required ("realtime" | "transcription")
             ws.send(
               JSON.stringify({
                 type: "session.update",
@@ -138,17 +148,9 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
                 },
               }),
             );
-          } else if (type === "session.updated") {
-            // session configured
-          } else if (
-            // GA: response.output_audio.delta  |  beta: response.audio.delta
-            type === "response.output_audio.delta" ||
-            type === "response.audio.delta"
-          ) {
+          } else if (type === "response.output_audio.delta" || type === "response.audio.delta") {
             if (data.delta) playAudioChunk(data.delta);
           } else if (
-            // GA: response.output_text.delta / response.output_audio_transcript.delta
-            // beta: response.text.delta / response.audio_transcript.delta
             type === "response.output_text.delta" ||
             type === "response.output_audio_transcript.delta" ||
             type === "response.audio_transcript.delta" ||
@@ -158,8 +160,6 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
           } else if (type === "conversation.item.input_audio_transcription.completed") {
             if (data.transcript) addMessage("user", data.transcript);
           } else if (type === "response.done") {
-            // Ensure we have the full text if deltas were missed.
-            // Accept both beta (type=text/audio) and GA (type=output_text/output_audio) content.
             setMessages((prev) => {
               const last = prev[prev.length - 1];
               if (last && last.role === "assistant" && last.content) return prev;
@@ -167,8 +167,6 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
               const texts: string[] = [];
               for (const item of output) {
                 for (const c of item.content || []) {
-                  // beta: c.text (type=text), c.transcript (type=audio)
-                  // GA:   c.text (type=output_text), c.transcript (type=output_audio)
                   const t = c.text || c.transcript;
                   if (t) texts.push(t);
                 }
@@ -200,8 +198,9 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
       };
 
       wsRef.current = ws;
-    } catch (err: any) {
-      addMessage("status", `Connection failed: ${err.message}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      addMessage("status", `Connection failed: ${message}`);
       setIsConnecting(false);
     }
   }, [
@@ -224,13 +223,11 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
     nextPlayTimeRef.current = 0;
     configureSessionRef.current = false;
     setIsConnected(false);
-  }, []);
+  }, [stopRecording]);
 
   const startRecording = useCallback(async () => {
     if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
 
-    // Switch to server VAD mode for voice input
-    // GA: session.type is required
     wsRef.current.send(
       JSON.stringify({
         type: "session.update",
@@ -261,7 +258,6 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
         if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
         const input = e.inputBuffer.getChannelData(0);
 
-        // Resample to 24kHz if needed
         const sampleRate = ctx.sampleRate;
         const targetRate = 24000;
         let samples: Float32Array;
@@ -276,46 +272,34 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
           samples = input;
         }
 
-        // Convert to PCM16
         const pcm16 = new Int16Array(samples.length);
         for (let i = 0; i < samples.length; i++) {
           const s = Math.max(-1, Math.min(1, samples[i]));
           pcm16[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
         }
 
-        // Base64 encode and send
         const bytes = new Uint8Array(pcm16.buffer);
         let binary = "";
         for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
         const b64 = btoa(binary);
 
-        wsRef.current!.send(JSON.stringify({ type: "input_audio_buffer.append", audio: b64 }));
+        wsRef.current.send(JSON.stringify({ type: "input_audio_buffer.append", audio: b64 }));
       };
 
       source.connect(processor);
       processor.connect(ctx.destination);
       setIsRecording(true);
-      addMessage("status", "🎙️ Listening...");
-    } catch (err: any) {
-      addMessage("status", `Microphone error: ${err.message}`);
+      addMessage("status", "Listening...");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      addMessage("status", `Microphone error: ${message}`);
     }
-  }, [addMessage]);
-
-  const stopRecording = useCallback(() => {
-    processorRef.current?.disconnect();
-    processorRef.current = null;
-    mediaStreamRef.current?.getTracks().forEach((t) => t.stop());
-    mediaStreamRef.current = null;
-    setIsRecording(false);
-  }, []);
-
-  const configureSessionRef = useRef(false);
+  }, [addMessage, selectedVoice]);
 
   const ensureTextSession = useCallback(() => {
     if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
     if (configureSessionRef.current) return;
     configureSessionRef.current = true;
-    // GA: session.type is required
     wsRef.current.send(
       JSON.stringify({
         type: "session.update",
@@ -334,6 +318,7 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
 
   const sendTextMessage = useCallback(() => {
     if (!inputText.trim() || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+    ensureTextSession();
     const text = inputText.trim();
     addMessage("user", text);
     setInputText("");
@@ -359,68 +344,89 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
     };
   }, []);
 
+  const voiceLabel =
+    OPEN_AI_REALTIME_VOICE_SELECT_OPTIONS.find((voice) => voice.value === selectedVoice)?.label ?? selectedVoice;
+
   return (
-    <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 bg-gray-50">
-        <div className="flex items-center gap-3">
-          <SoundOutlined className="text-lg text-blue-500" />
-          <Text className="font-semibold text-gray-800">Realtime Voice Chat</Text>
-          <span className={`inline-block w-2 h-2 rounded-full ${isConnected ? "bg-green-500" : "bg-gray-300"}`} />
-          <Text className="text-xs text-gray-500">
-            {isConnected ? "Connected" : isConnecting ? "Connecting..." : "Disconnected"}
-          </Text>
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-gray-200 bg-gray-50 px-4 py-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <Volume2 className="size-5 shrink-0 text-blue-500" aria-hidden="true" />
+          <div className="min-w-0">
+            <p className="font-semibold text-gray-800">Realtime Voice Chat</p>
+            <div className="flex items-center gap-2 text-xs text-gray-500">
+              <span
+                className={cn("inline-block size-2 rounded-full", isConnected ? "bg-green-500" : "bg-gray-300")}
+                aria-hidden="true"
+              />
+              {isConnected ? "Connected" : isConnecting ? "Connecting..." : "Disconnected"}
+              {selectedModel ? <span className="truncate">· {selectedModel}</span> : null}
+            </div>
+          </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Select
-            size="small"
             value={selectedVoice}
-            onChange={setSelectedVoice}
-            options={OPEN_AI_VOICE_SELECT_OPTIONS}
-            style={{ width: 220 }}
-            disabled={isConnected}
-          />
+            onValueChange={(value) => setSelectedVoice(value as OpenAIRealtimeVoice)}
+            disabled={isConnected || isConnecting}
+          >
+            <SelectTrigger className="w-[220px]" size="sm" aria-label="Realtime voice">
+              <SelectValue>{voiceLabel}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              {OPEN_AI_REALTIME_VOICE_SELECT_OPTIONS.map((voice) => (
+                <SelectItem key={voice.value} value={voice.value}>
+                  {voice.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           {!isConnected ? (
-            <Button type="primary" onClick={connect} loading={isConnecting} size="small">
+            <Button type="button" size="sm" onClick={() => void connect()} disabled={isConnecting || !selectedModel}>
+              {isConnecting ? <Loader2 className="size-3.5 animate-spin" /> : <Phone className="size-3.5" />}
               Connect
             </Button>
           ) : (
-            <Button danger onClick={disconnect} size="small" icon={<CloseCircleOutlined />}>
+            <Button type="button" size="sm" variant="destructive" onClick={disconnect}>
+              <PhoneOff className="size-3.5" />
               Disconnect
             </Button>
           )}
         </div>
       </div>
 
-      {/* Messages */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
         {messages.length === 0 && !isConnected && (
-          <div className="flex flex-col items-center justify-center h-full text-gray-400 gap-3">
-            <SoundOutlined style={{ fontSize: 48 }} />
-            <Text className="text-lg text-gray-500">Realtime Voice Playground</Text>
-            <Text className="text-sm text-gray-400 text-center max-w-md">
-              Click <b>Connect</b> to start a realtime session. You can speak using your microphone or type messages.
-              The AI will respond with voice and text.
-            </Text>
+          <div className="flex h-full flex-col items-center justify-center gap-3 text-gray-400">
+            <Volume2 className="size-12" aria-hidden="true" />
+            <p className="text-lg text-gray-500">Realtime Voice Playground</p>
+            <p className="max-w-md text-center text-sm text-gray-400">
+              Select a realtime model, pick a voice, then click <b>Connect</b>. You can speak with the mic or type
+              messages. The model responds with voice and text.
+            </p>
           </div>
         )}
         {messages.map((msg, i) => (
           <div
-            key={i}
-            className={`flex ${msg.role === "user" ? "justify-end" : msg.role === "status" ? "justify-center" : "justify-start"}`}
+            key={`${msg.timestamp.toISOString()}-${i}`}
+            className={cn(
+              "flex",
+              msg.role === "user" ? "justify-end" : msg.role === "status" ? "justify-center" : "justify-start",
+            )}
           >
             {msg.role === "status" ? (
-              <div className="text-xs text-gray-400 italic px-3 py-1">{msg.content}</div>
+              <div className="px-3 py-1 text-xs italic text-gray-400">{msg.content}</div>
             ) : (
               <div
-                className={`max-w-[75%] rounded-2xl px-4 py-2.5 ${
+                className={cn(
+                  "max-w-[75%] rounded-2xl px-4 py-2.5",
                   msg.role === "user"
-                    ? "bg-blue-500 text-white rounded-br-md"
-                    : "bg-gray-100 text-gray-800 rounded-bl-md"
-                }`}
+                    ? "rounded-br-md bg-blue-500 text-white"
+                    : "rounded-bl-md bg-gray-100 text-gray-800",
+                )}
               >
-                <div className="text-xs font-medium mb-0.5 opacity-70">{msg.role === "user" ? "You" : "AI"}</div>
-                <div className="text-sm whitespace-pre-wrap">{msg.content}</div>
+                <div className="mb-0.5 text-xs font-medium opacity-70">{msg.role === "user" ? "You" : "AI"}</div>
+                <div className="whitespace-pre-wrap text-sm">{msg.content}</div>
               </div>
             )}
           </div>
@@ -428,42 +434,46 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
         <div ref={messagesEndRef} />
       </div>
 
-      {/* Input area */}
       {isConnected && (
-        <div className="border-t border-gray-200 p-3 bg-white">
-          <div className="flex items-center gap-2">
-            <Button
-              shape="circle"
-              size="large"
-              type={isRecording ? "primary" : "default"}
-              danger={isRecording}
-              icon={isRecording ? <AudioMutedOutlined /> : <AudioOutlined />}
-              onClick={isRecording ? stopRecording : startRecording}
-              title={isRecording ? "Stop recording" : "Start recording"}
-              className={isRecording ? "animate-pulse" : ""}
-            />
-            <Input
-              placeholder="Type a message or use the mic..."
-              value={inputText}
-              onChange={(e) => setInputText(e.target.value)}
-              onPressEnter={sendTextMessage}
-              className="flex-1"
-              size="large"
-            />
-            <Button
-              type="primary"
-              icon={<SendOutlined />}
-              onClick={sendTextMessage}
-              disabled={!inputText.trim()}
-              size="large"
-            />
-          </div>
+        <div className="shrink-0 border-t border-gray-200 bg-white p-3 sm:p-4">
           {isRecording && (
-            <div className="mt-2 flex items-center gap-2 text-red-500 text-xs">
-              <span className="inline-block w-2 h-2 rounded-full bg-red-500 animate-pulse" />
-              Listening — speak into your microphone. Server VAD will detect when you stop.
+            <div className="mb-3 flex items-center gap-2 text-xs text-red-500">
+              <span className="inline-block size-2 animate-pulse rounded-full bg-red-500" aria-hidden="true" />
+              Listening. Speak into your microphone. Server VAD will detect when you stop.
             </div>
           )}
+          <ChatComposer
+            value={inputText}
+            onChange={setInputText}
+            onSubmit={sendTextMessage}
+            placeholder="Type a message or use the mic..."
+            submitDisabled={!inputText.trim()}
+            tools={
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      type="button"
+                      variant={isRecording ? "destructive" : "ghost"}
+                      size="icon-sm"
+                      className={cn("size-8 rounded-lg border border-border/40", isRecording && "animate-pulse")}
+                      aria-label={isRecording ? "Stop recording" : "Start recording"}
+                      onClick={() => {
+                        if (isRecording) {
+                          stopRecording();
+                        } else {
+                          void startRecording();
+                        }
+                      }}
+                    />
+                  }
+                >
+                  {isRecording ? <MicOff className="size-4" /> : <Mic className="size-4" />}
+                </TooltipTrigger>
+                <TooltipContent>{isRecording ? "Stop recording" : "Start recording"}</TooltipContent>
+              </Tooltip>
+            }
+          />
         </div>
       )}
     </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ResponsesImageRenderer.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ResponsesImageRenderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
+import { FileText } from "lucide-react";
 import { MessageType } from "@/components/chat_ui/types";
 import { shouldShowAttachedImage } from "./ResponsesImageUtils";
-import { FilePdfOutlined } from "@ant-design/icons";
 
 interface ResponsesImageRendererProps {
   message: MessageType;
@@ -17,15 +17,14 @@ const ResponsesImageRenderer: React.FC<ResponsesImageRendererProps> = ({ message
   return (
     <div className="mb-2">
       {isPdf ? (
-        <div className="w-64 h-32 rounded-md border border-gray-200 bg-red-50 flex items-center justify-center">
-          <FilePdfOutlined style={{ fontSize: "48px", color: "#dc2626" }} />
+        <div className="flex h-32 w-64 items-center justify-center rounded-md border border-gray-200 bg-red-50">
+          <FileText className="size-12 text-red-600" aria-label="PDF attachment" />
         </div>
       ) : (
         <img
           src={message.imagePreviewUrl}
           alt="User uploaded image"
-          className="max-w-64 rounded-md border border-gray-200 shadow-xs"
-          style={{ maxHeight: "200px" }}
+          className="max-h-[200px] max-w-64 rounded-md border border-gray-200 shadow-xs"
         />
       )}
     </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ResponsesImageUpload.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ResponsesImageUpload.tsx
@@ -1,43 +1,74 @@
-import React from "react";
-import { Upload, Tooltip } from "antd";
-import { PaperClipOutlined } from "@ant-design/icons";
-
-const { Dragger } = Upload;
+import React, { useId, useRef } from "react";
+import { Paperclip } from "lucide-react";
+import NotificationsManager from "@/components/molecules/notifications_manager";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { CHAT_ATTACHMENT_ACCEPT, validateChatAttachment } from "./uploadValidation";
 
 interface ResponsesImageUploadProps {
   responsesUploadedImage: File | null;
   responsesImagePreviewUrl: string | null;
-  onImageUpload: (file: File) => false;
+  onImageUpload: (file: File) => void;
   onRemoveImage: () => void;
+  disabled?: boolean;
 }
 
 const ResponsesImageUpload: React.FC<ResponsesImageUploadProps> = ({
   responsesUploadedImage,
-  responsesImagePreviewUrl,
   onImageUpload,
-  onRemoveImage,
+  disabled = false,
 }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const inputId = useId();
+
+  if (responsesUploadedImage) {
+    return null;
+  }
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) {
+      return;
+    }
+    const result = validateChatAttachment(file);
+    if (!result.ok) {
+      NotificationsManager.error(result.error);
+      return;
+    }
+    onImageUpload(file);
+  };
+
   return (
     <>
-      {/* Subtle upload button - only show when no image */}
-      {!responsesUploadedImage && (
-        <Dragger
-          beforeUpload={onImageUpload}
-          accept="image/*,.pdf"
-          showUploadList={false}
-          className="inline-block"
-          style={{ padding: 0, border: "none", background: "none" }}
-        >
-          <Tooltip title="Attach image or PDF">
-            <button
+      <input
+        id={inputId}
+        ref={inputRef}
+        type="file"
+        accept={CHAT_ATTACHMENT_ACCEPT}
+        className="sr-only"
+        tabIndex={-1}
+        disabled={disabled}
+        onChange={handleFileChange}
+      />
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
               type="button"
-              className="flex items-center justify-center w-8 h-8 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition-colors"
-            >
-              <PaperClipOutlined style={{ fontSize: "16px" }} />
-            </button>
-          </Tooltip>
-        </Dragger>
-      )}
+              variant="ghost"
+              size="icon-sm"
+              disabled={disabled}
+              aria-label="Attach image or PDF"
+              className="text-gray-400 hover:text-gray-600"
+              onClick={() => inputRef.current?.click()}
+            />
+          }
+        >
+          <Paperclip className="size-4" />
+        </TooltipTrigger>
+        <TooltipContent>Attach image or PDF</TooltipContent>
+      </Tooltip>
     </>
   );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/SearchResultsDisplay.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/SearchResultsDisplay.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
-import { Button } from "antd";
 import { VectorStoreSearchResponse } from "@/components/chat_ui/types";
-import { DatabaseOutlined, FileTextOutlined, DownOutlined, RightOutlined } from "@ant-design/icons";
+import { ChevronDown, ChevronRight, Database, FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 
 interface SearchResultsDisplayProps {
   searchResults: VectorStoreSearchResponse[];
@@ -27,95 +28,94 @@ export function SearchResultsDisplay({ searchResults }: SearchResultsDisplayProp
 
   return (
     <div className="search-results-content mt-1 mb-2">
-      <Button
-        type="text"
-        className="flex items-center text-xs text-gray-500 hover:text-gray-700"
-        onClick={() => setIsExpanded(!isExpanded)}
-        icon={<DatabaseOutlined />}
-      >
-        {isExpanded ? "Hide sources" : `Show sources (${totalResults})`}
-        {isExpanded ? <DownOutlined className="ml-1" /> : <RightOutlined className="ml-1" />}
-      </Button>
+      <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+        <CollapsibleTrigger
+          render={
+            <Button type="button" variant="ghost" size="sm" className="text-xs text-gray-500 hover:text-gray-700" />
+          }
+        >
+          <Database className="size-4" />
+          {isExpanded ? "Hide sources" : `Show sources (${totalResults})`}
+          {isExpanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+        </CollapsibleTrigger>
 
-      {isExpanded && (
-        <div className="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-md text-sm">
-          <div className="space-y-3">
-            {searchResults.map((resultPage, pageIndex) => (
-              <div key={pageIndex}>
-                <div className="text-xs text-gray-600 mb-2 flex items-center gap-2">
-                  <span className="font-medium">Query:</span>
-                  <span className="italic">&quot;{resultPage.search_query}&quot;</span>
-                  <span className="text-gray-400">•</span>
-                  <span className="text-gray-500">
-                    {resultPage.data.length} result{resultPage.data.length !== 1 ? "s" : ""}
-                  </span>
-                </div>
+        <CollapsibleContent>
+          <div className="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-md text-sm">
+            <div className="space-y-3">
+              {searchResults.map((resultPage, pageIndex) => (
+                <div key={pageIndex}>
+                  <div className="text-xs text-gray-600 mb-2 flex items-center gap-2">
+                    <span className="font-medium">Query:</span>
+                    <span className="italic">&quot;{resultPage.search_query}&quot;</span>
+                    <span className="text-gray-400">•</span>
+                    <span className="text-gray-500">
+                      {resultPage.data.length} result{resultPage.data.length !== 1 ? "s" : ""}
+                    </span>
+                  </div>
 
-                <div className="space-y-2">
-                  {resultPage.data.map((result, resultIndex) => {
-                    const isResultExpanded = expandedResults[`${pageIndex}-${resultIndex}`] || false;
+                  <div className="space-y-2">
+                    {resultPage.data.map((result, resultIndex) => {
+                      const isResultExpanded = expandedResults[`${pageIndex}-${resultIndex}`] || false;
 
-                    return (
-                      <div key={resultIndex} className="border border-gray-200 rounded-md overflow-hidden bg-white">
-                        <div
-                          className="flex items-center justify-between p-2 cursor-pointer hover:bg-gray-50 transition-colors"
-                          onClick={() => toggleResult(pageIndex, resultIndex)}
+                      return (
+                        <Collapsible
+                          key={resultIndex}
+                          open={isResultExpanded}
+                          onOpenChange={() => toggleResult(pageIndex, resultIndex)}
+                          className="overflow-hidden rounded-md border border-gray-200 bg-white"
                         >
-                          <div className="flex items-center gap-2 flex-1 min-w-0">
-                            <svg
-                              className={`w-4 h-4 text-gray-400 transition-transform shrink-0 ${isResultExpanded ? "transform rotate-90" : ""}`}
-                              fill="none"
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
-                            >
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                            </svg>
-                            <FileTextOutlined className="text-gray-400 shrink-0" style={{ fontSize: "12px" }} />
-                            <span className="text-xs font-medium text-gray-700 truncate">
-                              {result.filename || result.file_id || `Result ${resultIndex + 1}`}
-                            </span>
-                            <span className="text-xs px-2 py-0.5 rounded-sm bg-blue-100 text-blue-700 font-mono shrink-0">
-                              {result.score.toFixed(3)}
-                            </span>
-                          </div>
-                        </div>
-
-                        {isResultExpanded && (
-                          <div className="border-t border-gray-200 bg-white">
-                            <div className="p-3 space-y-2">
-                              {result.content.map((content, contentIndex) => (
-                                <div key={contentIndex}>
-                                  <div className="text-xs font-mono bg-gray-50 p-2 rounded-sm text-gray-800 whitespace-pre-wrap wrap-break-word">
-                                    {content.text}
-                                  </div>
-                                </div>
-                              ))}
-
-                              {result.attributes && Object.keys(result.attributes).length > 0 && (
-                                <div className="mt-2 pt-2 border-t border-gray-100">
-                                  <div className="text-xs text-gray-500 mb-1 font-medium">Metadata:</div>
-                                  <div className="space-y-1">
-                                    {Object.entries(result.attributes).map(([key, value]) => (
-                                      <div key={key} className="text-xs flex gap-2">
-                                        <span className="text-gray-500 font-medium">{key}:</span>
-                                        <span className="text-gray-700 font-mono break-all">{String(value)}</span>
-                                      </div>
-                                    ))}
-                                  </div>
-                                </div>
-                              )}
+                          <CollapsibleTrigger className="flex w-full items-center justify-between p-2 text-left transition-colors hover:bg-gray-50">
+                            <div className="flex items-center gap-2 flex-1 min-w-0">
+                              <ChevronRight
+                                className={`size-4 shrink-0 text-gray-400 transition-transform ${isResultExpanded ? "rotate-90" : ""}`}
+                              />
+                              <FileText className="size-3 shrink-0 text-gray-400" />
+                              <span className="text-xs font-medium text-gray-700 truncate">
+                                {result.filename || result.file_id || `Result ${resultIndex + 1}`}
+                              </span>
+                              <span className="text-xs px-2 py-0.5 rounded-sm bg-blue-100 text-blue-700 font-mono shrink-0">
+                                {result.score.toFixed(3)}
+                              </span>
                             </div>
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
+                          </CollapsibleTrigger>
+
+                          <CollapsibleContent>
+                            <div className="border-t border-gray-200 bg-white">
+                              <div className="p-3 space-y-2">
+                                {result.content.map((content, contentIndex) => (
+                                  <div key={contentIndex}>
+                                    <div className="text-xs font-mono bg-gray-50 p-2 rounded-sm text-gray-800 whitespace-pre-wrap wrap-break-word">
+                                      {content.text}
+                                    </div>
+                                  </div>
+                                ))}
+
+                                {result.attributes && Object.keys(result.attributes).length > 0 && (
+                                  <div className="mt-2 pt-2 border-t border-gray-100">
+                                    <div className="text-xs text-gray-500 mb-1 font-medium">Metadata:</div>
+                                    <div className="space-y-1">
+                                      {Object.entries(result.attributes).map(([key, value]) => (
+                                        <div key={key} className="text-xs flex gap-2">
+                                          <span className="text-gray-500 font-medium">{key}:</span>
+                                          <span className="text-gray-700 font-mono break-all">{String(value)}</span>
+                                        </div>
+                                      ))}
+                                    </div>
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          </CollapsibleContent>
+                        </Collapsible>
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
-        </div>
-      )}
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 }

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/SessionManagement.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/SessionManagement.tsx
@@ -1,8 +1,10 @@
 import React from "react";
-import { Switch, Tooltip } from "antd";
-import { InfoCircleOutlined, CopyOutlined } from "@ant-design/icons";
+import { Copy, Info } from "lucide-react";
 import { EndpointType } from "@/components/chat_ui/mode_endpoint_mapping";
 import NotificationsManager from "@/components/molecules/notifications_manager";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface SessionManagementProps {
   endpointType: string;
@@ -21,10 +23,14 @@ const SessionManagement: React.FC<SessionManagementProps> = ({
     return null;
   }
 
-  const handleCopySessionId = () => {
+  const handleCopySessionId = async () => {
     if (responsesSessionId) {
-      navigator.clipboard.writeText(responsesSessionId);
-      NotificationsManager.success("Response ID copied to clipboard!");
+      try {
+        await navigator.clipboard.writeText(responsesSessionId);
+        NotificationsManager.success("Response ID copied to clipboard!");
+      } catch {
+        NotificationsManager.error("Unable to copy response ID");
+      }
     }
   };
 
@@ -56,17 +62,26 @@ const SessionManagement: React.FC<SessionManagementProps> = ({
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-gray-700">Session Management</span>
-          <Tooltip title="Choose between LiteLLM API session management (using previous_response_id) or UI-based session management (using chat history)">
-            <InfoCircleOutlined className="text-gray-400" style={{ fontSize: "12px" }} />
+          <Tooltip>
+            <TooltipTrigger aria-label="About session management">
+              <Info className="size-3 text-gray-400" />
+            </TooltipTrigger>
+            <TooltipContent>
+              Choose between LiteLLM API session management (using previous_response_id) or UI-based session management
+              (using chat history)
+            </TooltipContent>
           </Tooltip>
         </div>
-        <Switch
-          checked={useApiSessionManagement}
-          onChange={onToggleSessionManagement}
-          checkedChildren="API"
-          unCheckedChildren="UI"
-          size="small"
-        />
+        <div className="flex items-center gap-2 text-xs text-gray-600">
+          <span aria-hidden="true">UI</span>
+          <Switch
+            checked={useApiSessionManagement}
+            onCheckedChange={onToggleSessionManagement}
+            aria-label="Use API session management"
+            size="sm"
+          />
+          <span aria-hidden="true">API</span>
+        </div>
       </div>
 
       {/* Session Status Indicator */}
@@ -79,12 +94,26 @@ const SessionManagement: React.FC<SessionManagementProps> = ({
       >
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1">
-            <InfoCircleOutlined style={{ fontSize: "12px" }} />
+            <Info className="size-3" />
             {getSessionDisplay()}
           </div>
           {responsesSessionId && (
-            <Tooltip
-              title={
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={handleCopySessionId}
+                    aria-label="Copy response ID"
+                    className="ml-2 hover:bg-green-100"
+                  />
+                }
+              >
+                <Copy className="size-3" />
+              </TooltipTrigger>
+              <TooltipContent className="max-w-lg">
                 <div className="text-xs">
                   <div className="mb-1">Copy response ID to continue session:</div>
                   <div className="bg-gray-800 text-gray-100 p-2 rounded-sm font-mono text-xs whitespace-pre-wrap">
@@ -99,15 +128,7 @@ const SessionManagement: React.FC<SessionManagementProps> = ({
   }'`}
                   </div>
                 </div>
-              }
-              overlayStyle={{ maxWidth: "500px" }}
-            >
-              <button
-                onClick={handleCopySessionId}
-                className="ml-2 p-1 hover:bg-green-100 rounded-sm transition-colors"
-              >
-                <CopyOutlined style={{ fontSize: "12px" }} />
-              </button>
+              </TooltipContent>
             </Tooltip>
           )}
         </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/chatConstants.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/chatConstants.ts
@@ -33,6 +33,39 @@ export const OPEN_AI_VOICE_SELECT_OPTIONS = Object.entries(OPEN_AI_VOICES).map((
   label: OPEN_AI_VOICE_LABELS[key as keyof typeof OPEN_AI_VOICE_LABELS],
 }));
 
+export const OPEN_AI_REALTIME_VOICES = {
+  ALLOY: "alloy",
+  ASH: "ash",
+  BALLAD: "ballad",
+  CORAL: "coral",
+  ECHO: "echo",
+  SAGE: "sage",
+  SHIMMER: "shimmer",
+  VERSE: "verse",
+  MARIN: "marin",
+  CEDAR: "cedar",
+} as const;
+
+export type OpenAIRealtimeVoice = (typeof OPEN_AI_REALTIME_VOICES)[keyof typeof OPEN_AI_REALTIME_VOICES];
+
+export const OPEN_AI_REALTIME_VOICE_LABELS: Record<keyof typeof OPEN_AI_REALTIME_VOICES, string> = {
+  ALLOY: "Alloy - Professional and confident",
+  ASH: "Ash - Casual and relaxed",
+  BALLAD: "Ballad - Smooth and melodic",
+  CORAL: "Coral - Warm and engaging",
+  ECHO: "Echo - Friendly and conversational",
+  SAGE: "Sage - Wise and measured",
+  SHIMMER: "Shimmer - Bright and cheerful",
+  VERSE: "Verse - Expressive and clear",
+  MARIN: "Marin - Calm and natural",
+  CEDAR: "Cedar - Warm and steady",
+};
+
+export const OPEN_AI_REALTIME_VOICE_SELECT_OPTIONS = Object.entries(OPEN_AI_REALTIME_VOICES).map(([key, voice]) => ({
+  value: voice,
+  label: OPEN_AI_REALTIME_VOICE_LABELS[key as keyof typeof OPEN_AI_REALTIME_VOICE_LABELS],
+}));
+
 export const ENDPOINT_OPTIONS = [
   { value: EndpointType.CHAT, label: "/v1/chat/completions" },
   { value: EndpointType.RESPONSES, label: "/v1/responses" },

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/uploadValidation.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/uploadValidation.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_AUDIO_BYTES,
+  MAX_CHAT_ATTACHMENT_BYTES,
+  MAX_IMAGE_EDIT_COUNT,
+  validateAudioFile,
+  validateChatAttachment,
+  validateImageEditFile,
+} from "./uploadValidation";
+
+function makeFile(name: string, type: string, sizeBytes = 1024): File {
+  const content = new Uint8Array(sizeBytes);
+  return new File([content], name, { type });
+}
+
+describe("validateChatAttachment", () => {
+  it("accepts supported image types", () => {
+    expect(validateChatAttachment(makeFile("a.png", "image/png"))).toEqual({ ok: true });
+    expect(validateChatAttachment(makeFile("a.jpg", "image/jpeg"))).toEqual({ ok: true });
+    expect(validateChatAttachment(makeFile("a.webp", "image/webp"))).toEqual({ ok: true });
+  });
+
+  it("accepts PDF by mime type or extension", () => {
+    expect(validateChatAttachment(makeFile("doc.pdf", "application/pdf"))).toEqual({ ok: true });
+    expect(validateChatAttachment(makeFile("doc.PDF", ""))).toEqual({ ok: true });
+  });
+
+  it("rejects unsupported types", () => {
+    const result = validateChatAttachment(makeFile("notes.txt", "text/plain"));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("not a supported attachment");
+    }
+  });
+
+  it("rejects files over the size limit", () => {
+    const result = validateChatAttachment(makeFile("huge.png", "image/png", MAX_CHAT_ATTACHMENT_BYTES + 1));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("too large");
+    }
+  });
+});
+
+describe("validateImageEditFile", () => {
+  it("accepts images under the count limit", () => {
+    expect(validateImageEditFile(makeFile("a.png", "image/png"), 0)).toEqual({ ok: true });
+  });
+
+  it("rejects when the count limit is reached", () => {
+    const result = validateImageEditFile(makeFile("a.png", "image/png"), MAX_IMAGE_EDIT_COUNT);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain(`at most ${MAX_IMAGE_EDIT_COUNT}`);
+    }
+  });
+
+  it("rejects PDFs for image edits", () => {
+    const result = validateImageEditFile(makeFile("doc.pdf", "application/pdf"), 0);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("not a supported image");
+    }
+  });
+});
+
+describe("validateAudioFile", () => {
+  it("accepts common audio types", () => {
+    expect(validateAudioFile(makeFile("a.mp3", "audio/mpeg"))).toEqual({ ok: true });
+    expect(validateAudioFile(makeFile("a.wav", "audio/wav"))).toEqual({ ok: true });
+    expect(validateAudioFile(makeFile("a.webm", ""))).toEqual({ ok: true });
+  });
+
+  it("rejects non-audio files and oversized files", () => {
+    expect(validateAudioFile(makeFile("a.png", "image/png")).ok).toBe(false);
+    expect(validateAudioFile(makeFile("a.mp3", "audio/mpeg", MAX_AUDIO_BYTES + 1)).ok).toBe(false);
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/uploadValidation.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/uploadValidation.ts
@@ -1,0 +1,97 @@
+export type UploadValidationResult = { ok: true } | { ok: false; error: string };
+
+export const CHAT_ATTACHMENT_ACCEPT = "image/png,image/jpeg,image/jpg,image/gif,image/webp,application/pdf,.pdf";
+export const IMAGE_EDIT_ACCEPT = "image/png,image/jpeg,image/jpg,image/gif,image/webp";
+export const AUDIO_ACCEPT = "audio/*,.mp3,.mp4,.mpeg,.mpga,.m4a,.wav,.webm";
+
+export const MAX_CHAT_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+export const MAX_IMAGE_EDIT_BYTES = 20 * 1024 * 1024;
+export const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
+export const MAX_IMAGE_EDIT_COUNT = 10;
+export const MAX_CHAT_ATTACHMENT_COUNT = 1;
+
+const IMAGE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp"]);
+const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
+const PDF_MIME_TYPES = new Set(["application/pdf"]);
+const PDF_EXTENSIONS = new Set([".pdf"]);
+const AUDIO_MIME_PREFIX = "audio/";
+const AUDIO_EXTENSIONS = new Set([".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm"]);
+
+function getExtension(fileName: string): string {
+  const dot = fileName.lastIndexOf(".");
+  if (dot < 0) {
+    return "";
+  }
+  return fileName.slice(dot).toLowerCase();
+}
+
+function formatMb(bytes: number): string {
+  return `${Math.round(bytes / (1024 * 1024))} MB`;
+}
+
+function isImageFile(file: File): boolean {
+  if (IMAGE_MIME_TYPES.has(file.type)) {
+    return true;
+  }
+  return IMAGE_EXTENSIONS.has(getExtension(file.name));
+}
+
+function isPdfFile(file: File): boolean {
+  if (PDF_MIME_TYPES.has(file.type)) {
+    return true;
+  }
+  return PDF_EXTENSIONS.has(getExtension(file.name));
+}
+
+function isAudioFile(file: File): boolean {
+  if (file.type.startsWith(AUDIO_MIME_PREFIX)) {
+    return true;
+  }
+  return AUDIO_EXTENSIONS.has(getExtension(file.name));
+}
+
+function validateSize(file: File, maxBytes: number): UploadValidationResult {
+  if (file.size <= maxBytes) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    error: `"${file.name}" is too large. Maximum size is ${formatMb(maxBytes)}.`,
+  };
+}
+
+export function validateChatAttachment(file: File): UploadValidationResult {
+  if (!isImageFile(file) && !isPdfFile(file)) {
+    return {
+      ok: false,
+      error: `"${file.name}" is not a supported attachment. Use PNG, JPEG, GIF, WebP, or PDF.`,
+    };
+  }
+  return validateSize(file, MAX_CHAT_ATTACHMENT_BYTES);
+}
+
+export function validateImageEditFile(file: File, currentCount: number): UploadValidationResult {
+  if (currentCount >= MAX_IMAGE_EDIT_COUNT) {
+    return {
+      ok: false,
+      error: `You can upload at most ${MAX_IMAGE_EDIT_COUNT} images.`,
+    };
+  }
+  if (!isImageFile(file)) {
+    return {
+      ok: false,
+      error: `"${file.name}" is not a supported image. Use PNG, JPEG, GIF, or WebP.`,
+    };
+  }
+  return validateSize(file, MAX_IMAGE_EDIT_BYTES);
+}
+
+export function validateAudioFile(file: File): UploadValidationResult {
+  if (!isAudioFile(file)) {
+    return {
+      ok: false,
+      error: `"${file.name}" is not a supported audio file. Use MP3, MP4, MPEG, MPGA, M4A, WAV, or WEBM.`,
+    };
+  }
+  return validateSize(file, MAX_AUDIO_BYTES);
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/compareUI/components/MessageInput.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/compareUI/components/MessageInput.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-import { Input, Button } from "antd";
-import { ArrowUpOutlined } from "@ant-design/icons";
-
-const { TextArea } = Input;
+import ChatComposer from "../../chat_ui/ChatComposer";
 
 interface MessageInputProps {
   value: string;
@@ -16,39 +13,15 @@ interface MessageInputProps {
 export function MessageInput({ value, onChange, onSend, disabled, hasAttachment, uploadComponent }: MessageInputProps) {
   const canSend = !disabled && (value.trim().length > 0 || Boolean(hasAttachment));
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      if (canSend) {
-        onSend();
-      }
-    }
-  };
-
   return (
-    <div className="flex items-center gap-2">
-      <div className="flex items-center flex-1 bg-white border border-gray-300 rounded-xl px-3 py-1 min-h-[44px]">
-        {uploadComponent && <div className="shrink-0 mr-2">{uploadComponent}</div>}
-        <TextArea
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="Type your message... (Shift+Enter for new line)"
-          disabled={disabled}
-          className="flex-1"
-          autoSize={{ minRows: 1, maxRows: 4 }}
-          style={{
-            resize: "none",
-            border: "none",
-            boxShadow: "none",
-            background: "transparent",
-            padding: "4px 0",
-            fontSize: "14px",
-            lineHeight: "20px",
-          }}
-        />
-        <Button onClick={onSend} disabled={!canSend} icon={<ArrowUpOutlined />} shape="circle" />
-      </div>
-    </div>
+    <ChatComposer
+      value={value}
+      onChange={onChange}
+      onSubmit={onSend}
+      placeholder="Type your message... (Shift+Enter for new line)"
+      disabled={disabled}
+      submitDisabled={!canSend}
+      tools={uploadComponent}
+    />
   );
 }

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/interactions_api.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/interactions_api.tsx
@@ -1,5 +1,7 @@
 import NotificationManager from "@/components/molecules/notifications_manager";
 import { getGlobalLitellmHeaderName, getProxyBaseUrl } from "@/components/networking";
+import { buildMcpToolBlocks } from "@/components/llm_calls/mcp_tool_blocks";
+import type { MCPServer, MCPToolset } from "@/components/mcp_tools/types";
 
 export async function makeInteractionsRequest(
   input: string,
@@ -10,6 +12,10 @@ export async function makeInteractionsRequest(
   signal?: AbortSignal,
   customBaseUrl?: string,
   previousInteractionId?: string,
+  selectedMCPServers?: string[],
+  mcpServers?: MCPServer[],
+  mcpServerToolRestrictions?: Record<string, string[]>,
+  mcpToolsets?: MCPToolset[],
 ): Promise<void> {
   if (!accessToken) {
     throw new Error("Virtual Key is required");
@@ -32,10 +38,18 @@ export async function makeInteractionsRequest(
     headers["x-litellm-tags"] = tags.join(",");
   }
 
+  const tools = buildMcpToolBlocks({
+    selectedMCPServers,
+    mcpServers,
+    mcpToolsets,
+    mcpServerToolRestrictions,
+  });
+
   const body: Record<string, unknown> = {
     model: selectedModel,
     input,
     stream: true,
+    ...(tools.length > 0 ? { tools } : {}),
   };
   if (previousInteractionId) {
     body.previous_interaction_id = previousInteractionId;

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/page.tsx
@@ -47,16 +47,16 @@ export default function PlaygroundPage() {
   }
 
   return (
-    <div className="h-full w-full flex flex-col">
-      <TabGroup className="w-full" style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
-        <TabList className="mb-0">
+    <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
+      <TabGroup className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <TabList className="mb-0 shrink-0 overflow-x-auto">
           <Tab>Chat</Tab>
           <Tab>Compare</Tab>
           <Tab>Compliance</Tab>
           <Tab>Agent Builder (Experimental)</Tab>
         </TabList>
-        <TabPanels className="h-full">
-          <TabPanel className="h-full">
+        <TabPanels className="min-h-0 min-w-0 flex-1 overflow-hidden">
+          <TabPanel className="h-full min-h-0 min-w-0 overflow-hidden">
             <ChatUI
               accessToken={accessToken}
               token={token}

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/page.tsx
@@ -5,10 +5,10 @@ import AgentBuilderView from "@/app/(dashboard)/playground/components/chat_ui/Ag
 import ChatUI from "@/app/(dashboard)/playground/components/chat_ui/ChatUI";
 import CompareUI from "@/app/(dashboard)/playground/components/compareUI/CompareUI";
 import ComplianceUI from "@/app/(dashboard)/playground/components/complianceUI/ComplianceUI";
-import { TabGroup, TabList, Tab, TabPanels, TabPanel } from "@tremor/react";
 import { DeprecationBanner } from "@/components/DeprecationBanner";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { fetchProxySettings } from "@/utils/proxyUtils";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 interface ProxySettings {
   PROXY_BASE_URL?: string;
@@ -48,44 +48,53 @@ export default function PlaygroundPage() {
 
   return (
     <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
-      <TabGroup className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-        <TabList className="mb-0 shrink-0 overflow-x-auto">
-          <Tab>Chat</Tab>
-          <Tab>Compare</Tab>
-          <Tab>Compliance</Tab>
-          <Tab>Agent Builder (Experimental)</Tab>
-        </TabList>
-        <TabPanels className="min-h-0 min-w-0 flex-1 overflow-hidden">
-          <TabPanel className="h-full min-h-0 min-w-0 overflow-hidden">
-            <ChatUI
-              accessToken={accessToken}
-              token={token}
-              userRole={userRole}
-              userID={userId}
-              disabledPersonalKeyCreation={disabledPersonalKeyCreation}
-              proxySettings={proxySettings}
-            />
-          </TabPanel>
-          <TabPanel className="h-full">
-            <CompareUI accessToken={accessToken} disabledPersonalKeyCreation={disabledPersonalKeyCreation} />
-          </TabPanel>
-          <TabPanel className="h-full">
-            <ComplianceUI accessToken={accessToken} disabledPersonalKeyCreation={disabledPersonalKeyCreation} />
-          </TabPanel>
-          <TabPanel className="h-full">
-            <DeprecationBanner featureName="The Playground's Agent Builder" />
-            <AgentBuilderView
-              accessToken={accessToken}
-              token={token}
-              userID={userId}
-              userRole={userRole}
-              disabledPersonalKeyCreation={disabledPersonalKeyCreation}
-              proxySettings={proxySettings}
-              customProxyBaseUrl={proxySettings?.LITELLM_UI_API_DOC_BASE_URL ?? proxySettings?.PROXY_BASE_URL}
-            />
-          </TabPanel>
-        </TabPanels>
-      </TabGroup>
+      <Tabs defaultValue="chat" className="flex min-h-0 min-w-0 flex-1 flex-col gap-0 overflow-hidden">
+        <TabsList
+          variant="line"
+          className="mb-0 h-auto w-full shrink-0 justify-start overflow-x-auto rounded-none border-b border-border bg-transparent p-0"
+        >
+          <TabsTrigger value="chat" className="flex-none rounded-none px-4 py-2">
+            Chat
+          </TabsTrigger>
+          <TabsTrigger value="compare" className="flex-none rounded-none px-4 py-2">
+            Compare
+          </TabsTrigger>
+          <TabsTrigger value="compliance" className="flex-none rounded-none px-4 py-2">
+            Compliance
+          </TabsTrigger>
+          <TabsTrigger value="agent-builder" className="flex-none rounded-none px-4 py-2">
+            Agent Builder (Experimental)
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="chat" className="mt-0 h-full min-h-0 min-w-0 overflow-hidden data-hidden:hidden">
+          <ChatUI
+            accessToken={accessToken}
+            token={token}
+            userRole={userRole}
+            userID={userId}
+            disabledPersonalKeyCreation={disabledPersonalKeyCreation}
+            proxySettings={proxySettings}
+          />
+        </TabsContent>
+        <TabsContent value="compare" className="mt-0 h-full data-hidden:hidden">
+          <CompareUI accessToken={accessToken} disabledPersonalKeyCreation={disabledPersonalKeyCreation} />
+        </TabsContent>
+        <TabsContent value="compliance" className="mt-0 h-full data-hidden:hidden">
+          <ComplianceUI accessToken={accessToken} disabledPersonalKeyCreation={disabledPersonalKeyCreation} />
+        </TabsContent>
+        <TabsContent value="agent-builder" className="mt-0 h-full data-hidden:hidden">
+          <DeprecationBanner featureName="The Playground's Agent Builder" />
+          <AgentBuilderView
+            accessToken={accessToken}
+            token={token}
+            userID={userId}
+            userRole={userRole}
+            disabledPersonalKeyCreation={disabledPersonalKeyCreation}
+            proxySettings={proxySettings}
+            customProxyBaseUrl={proxySettings?.LITELLM_UI_API_DOC_BASE_URL ?? proxySettings?.PROXY_BASE_URL}
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/ui/litellm-dashboard/src/components/chat_ui/MCPEventsDisplay.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/MCPEventsDisplay.tsx
@@ -1,12 +1,23 @@
-import React from "react";
-import { Collapse } from "antd";
+import React, { useState } from "react";
+import { ChevronRight } from "lucide-react";
 import type { MCPEvent } from "@/components/mcp_tools/types";
-
-const { Panel } = Collapse;
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/cva.config";
 
 interface MCPEventsDisplayProps {
   events: MCPEvent[];
   className?: string;
+}
+
+function formatArguments(raw: string | undefined): string {
+  if (!raw) {
+    return "";
+  }
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
 }
 
 const MCPEventsDisplay: React.FC<MCPEventsDisplayProps> = ({ events, className }) => {
@@ -14,211 +25,151 @@ const MCPEventsDisplay: React.FC<MCPEventsDisplayProps> = ({ events, className }
     return null;
   }
 
-  // Find the list tools event
-  const toolsEvent = events.find(
-    (event) =>
-      event.type === "response.output_item.done" &&
-      event.item?.type === "mcp_list_tools" &&
-      event.item.tools &&
-      event.item.tools.length > 0,
-  );
+  const isListToolsEvent = (event: MCPEvent): boolean => {
+    if (event.type !== "response.output_item.done") {
+      return false;
+    }
+    if (event.item?.type !== "mcp_list_tools") {
+      return false;
+    }
+    return Boolean(event.item.tools && event.item.tools.length > 0);
+  };
 
-  // Find MCP call events
-  const mcpCallEvents = events.filter(
-    (event) => event.type === "response.output_item.done" && event.item?.type === "mcp_call",
-  );
+  const isMcpCallEvent = (event: MCPEvent): boolean =>
+    event.type === "response.output_item.done" && event.item?.type === "mcp_call";
+
+  const toolsEvent = events.find(isListToolsEvent);
+  const mcpCallEvents = events.filter(isMcpCallEvent);
 
   if (!toolsEvent && mcpCallEvents.length === 0) {
     return null;
   }
 
-  return (
-    <div className={`mcp-events-display ${className || ""}`}>
-      <style jsx>{`
-        .openai-mcp-tools {
-          position: relative;
-          margin: 0;
-          padding: 0;
-        }
-        .openai-mcp-tools .ant-collapse {
-          background: transparent !important;
-          border: none !important;
-        }
-        .openai-mcp-tools .ant-collapse-item {
-          border: none !important;
-          background: transparent !important;
-        }
-        .openai-mcp-tools .ant-collapse-header {
-          padding: 0 0 0 20px !important;
-          background: transparent !important;
-          border: none !important;
-          font-size: 14px !important;
-          color: #9ca3af !important;
-          font-weight: 400 !important;
-          line-height: 20px !important;
-          min-height: 20px !important;
-        }
-        .openai-mcp-tools .ant-collapse-header:hover {
-          background: transparent !important;
-          color: #6b7280 !important;
-        }
-        .openai-mcp-tools .ant-collapse-content {
-          border: none !important;
-          background: transparent !important;
-        }
-        .openai-mcp-tools .ant-collapse-content-box {
-          padding: 4px 0 0 20px !important;
-        }
-        .openai-mcp-tools .ant-collapse-expand-icon {
-          position: absolute !important;
-          left: 2px !important;
-          top: 2px !important;
-          color: #9ca3af !important;
-          font-size: 10px !important;
-          width: 16px !important;
-          height: 16px !important;
-          display: flex !important;
-          align-items: center !important;
-          justify-content: center !important;
-        }
-        .openai-mcp-tools .ant-collapse-expand-icon:hover {
-          color: #6b7280 !important;
-        }
-        .openai-vertical-line {
-          position: absolute;
-          left: 9px;
-          top: 18px;
-          bottom: 0;
-          width: 0.5px;
-          background-color: #f3f4f6;
-          opacity: 0.8;
-        }
-        .tool-item {
-          font-family: ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New",
-            monospace;
-          font-size: 13px;
-          color: #4b5563;
-          line-height: 18px;
-          padding: 0;
-          margin: 0;
-          background: white;
-          position: relative;
-          z-index: 1;
-        }
-        .mcp-section {
-          margin-bottom: 12px;
-          background: white;
-          position: relative;
-          z-index: 1;
-        }
-        .mcp-section:last-child {
-          margin-bottom: 0;
-        }
-        .mcp-section-header {
-          font-size: 13px;
-          color: #6b7280;
-          font-weight: 500;
-          margin-bottom: 4px;
-        }
-        .mcp-code-block {
-          background: #f9fafb;
-          border: 1px solid #f3f4f6;
-          border-radius: 6px;
-          padding: 8px;
-          font-size: 12px;
-        }
-        .mcp-json {
-          font-family: ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New",
-            monospace;
-          color: #374151;
-          margin: 0;
-          white-space: pre-wrap;
-          word-wrap: break-word;
-        }
-        .mcp-approved {
-          display: flex;
-          align-items: center;
-          font-size: 13px;
-          color: #6b7280;
-        }
-        .mcp-checkmark {
-          color: #10b981;
-          margin-right: 6px;
-          font-weight: bold;
-        }
-        .mcp-response-content {
-          font-size: 13px;
-          color: #374151;
-          line-height: 1.5;
-          white-space: pre-wrap;
-          font-family: ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas, "Liberation Mono", "Courier New",
-            monospace;
-        }
-      `}</style>
-      <div className="openai-mcp-tools">
-        <div className="openai-vertical-line"></div>
-        <Collapse
-          ghost
-          size="small"
-          expandIconPosition="start"
-          defaultActiveKey={toolsEvent ? ["list-tools"] : mcpCallEvents.map((_, index) => `mcp-call-${index}`)}
-        >
-          {/* List Tools Panel */}
-          {toolsEvent && (
-            <Panel header="List tools" key="list-tools">
-              <div>
-                {toolsEvent.item?.tools?.map((tool, index) => (
-                  <div key={index} className="tool-item">
-                    {tool.name}
-                  </div>
-                ))}
-              </div>
-            </Panel>
-          )}
+  const defaultOpenKeys = new Set<string>(
+    toolsEvent ? ["list-tools"] : mcpCallEvents.map((_, index) => `mcp-call-${index}`),
+  );
 
-          {/* MCP Call Panels */}
-          {mcpCallEvents.map((callEvent, index) => (
-            <Panel header={callEvent.item?.name || "Tool call"} key={`mcp-call-${index}`}>
+  return (
+    <div className={cn("mcp-events-display", className)}>
+      <MCPEventsPanels toolsEvent={toolsEvent} mcpCallEvents={mcpCallEvents} defaultOpenKeys={defaultOpenKeys} />
+    </div>
+  );
+};
+
+interface MCPEventsPanelsProps {
+  toolsEvent: MCPEvent | undefined;
+  mcpCallEvents: MCPEvent[];
+  defaultOpenKeys: Set<string>;
+}
+
+function MCPEventsPanels({ toolsEvent, mcpCallEvents, defaultOpenKeys }: MCPEventsPanelsProps) {
+  const [openKeys, setOpenKeys] = useState<Set<string>>(defaultOpenKeys);
+
+  const toggleKey = (key: string, open: boolean) => {
+    setOpenKeys((prev) => {
+      const next = new Set(prev);
+      if (open) {
+        next.add(key);
+      } else {
+        next.delete(key);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="relative m-0 p-0">
+      <div className="absolute bottom-0 left-[9px] top-[18px] w-px bg-gray-100 opacity-80" aria-hidden="true" />
+
+      <div className="space-y-1">
+        {toolsEvent && (
+          <MCPEventPanel
+            panelKey="list-tools"
+            title="List tools"
+            open={openKeys.has("list-tools")}
+            onOpenChange={(open) => toggleKey("list-tools", open)}
+          >
+            <div>
+              {toolsEvent.item?.tools?.map((tool, index) => (
+                <div key={index} className="relative z-[1] bg-white font-mono text-[13px] leading-[18px] text-gray-600">
+                  {tool.name}
+                </div>
+              ))}
+            </div>
+          </MCPEventPanel>
+        )}
+
+        {mcpCallEvents.map((callEvent, index) => {
+          const key = `mcp-call-${index}`;
+          return (
+            <MCPEventPanel
+              key={key}
+              panelKey={key}
+              title={callEvent.item?.name || "Tool call"}
+              open={openKeys.has(key)}
+              onOpenChange={(open) => toggleKey(key, open)}
+            >
               <div>
-                {/* Request section */}
-                <div className="mcp-section">
-                  <div className="mcp-section-header">Request</div>
-                  <div className="mcp-code-block">
+                <div className="relative z-[1] mb-3 bg-white last:mb-0">
+                  <div className="mb-1 text-[13px] font-medium text-gray-500">Request</div>
+                  <div className="rounded-md border border-gray-100 bg-gray-50 p-2 text-xs">
                     {callEvent.item?.arguments && (
-                      <pre className="mcp-json">
-                        {(() => {
-                          try {
-                            return JSON.stringify(JSON.parse(callEvent.item.arguments), null, 2);
-                          } catch (e) {
-                            return callEvent.item.arguments;
-                          }
-                        })()}
+                      <pre className="m-0 whitespace-pre-wrap break-words font-mono text-gray-700">
+                        {formatArguments(callEvent.item.arguments)}
                       </pre>
                     )}
                   </div>
                 </div>
 
-                {/* Approved section */}
-                <div className="mcp-section">
-                  <div className="mcp-approved">
-                    <span className="mcp-checkmark">✓</span> Approved
+                <div className="relative z-[1] mb-3 bg-white last:mb-0">
+                  <div className="flex items-center text-[13px] text-gray-500">
+                    <span className="mr-1.5 font-bold text-emerald-500" aria-hidden="true">
+                      ✓
+                    </span>
+                    Approved
                   </div>
                 </div>
 
-                {/* Response section */}
                 {callEvent.item?.output && (
-                  <div className="mcp-section">
-                    <div className="mcp-section-header">Response</div>
-                    <div className="mcp-response-content">{callEvent.item.output}</div>
+                  <div className="relative z-[1] mb-3 bg-white last:mb-0">
+                    <div className="mb-1 text-[13px] font-medium text-gray-500">Response</div>
+                    <div className="whitespace-pre-wrap font-mono text-[13px] leading-normal text-gray-700">
+                      {callEvent.item.output}
+                    </div>
                   </div>
                 )}
               </div>
-            </Panel>
-          ))}
-        </Collapse>
+            </MCPEventPanel>
+          );
+        })}
       </div>
     </div>
   );
-};
+}
+
+interface MCPEventPanelProps {
+  panelKey: string;
+  title: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+function MCPEventPanel({ title, open, onOpenChange, children }: MCPEventPanelProps) {
+  return (
+    <Collapsible open={open} onOpenChange={onOpenChange}>
+      <CollapsibleTrigger className="relative flex min-h-5 w-full items-center gap-1 pl-5 text-left text-sm font-normal leading-5 text-gray-400 hover:text-gray-500">
+        <ChevronRight
+          className={cn("absolute left-0.5 top-0.5 size-4 text-gray-400 transition-transform", open && "rotate-90")}
+          aria-hidden="true"
+        />
+        {title}
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="pt-1 pl-5">{children}</div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
 
 export default MCPEventsDisplay;

--- a/ui/litellm-dashboard/src/components/chat_ui/ReasoningContent.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/ReasoningContent.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
-import { Button } from "antd";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { coy } from "react-syntax-highlighter/dist/esm/styles/prism";
-import { DownOutlined, RightOutlined, BulbOutlined } from "@ant-design/icons";
+import { ChevronDown, ChevronRight, Lightbulb } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 
 interface ReasoningContentProps {
   reasoningContent: string;
@@ -16,63 +17,65 @@ const ReasoningContent: React.FC<ReasoningContentProps> = ({ reasoningContent })
 
   return (
     <div className="reasoning-content mt-1 mb-2">
-      <Button
-        type="text"
-        className="flex items-center text-xs text-gray-500 hover:text-gray-700"
-        onClick={() => setIsExpanded(!isExpanded)}
-        icon={<BulbOutlined />}
-      >
-        {isExpanded ? "Hide reasoning" : "Show reasoning"}
-        {isExpanded ? <DownOutlined className="ml-1" /> : <RightOutlined className="ml-1" />}
-      </Button>
-
-      {isExpanded && (
-        <div
-          className="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-md text-sm text-gray-700 max-w-full overflow-x-auto whitespace-pre-wrap break-words"
-          style={{ wordBreak: "break-word", overflowWrap: "break-word" }}
+      <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+        <CollapsibleTrigger
+          render={
+            <Button type="button" variant="ghost" size="sm" className="text-xs text-gray-500 hover:text-gray-700" />
+          }
         >
-          <ReactMarkdown
-            components={{
-              code({
-                node,
-                inline,
-                className,
-                children,
-                ...props
-              }: React.ComponentPropsWithoutRef<"code"> & {
-                inline?: boolean;
-                node?: any;
-              }) {
-                const match = /language-(\w+)/.exec(className || "");
-                return !inline && match ? (
-                  <SyntaxHighlighter
-                    style={coy as any}
-                    language={match[1]}
-                    PreTag="div"
-                    className="rounded-md my-2"
-                    wrapLines={true}
-                    wrapLongLines={true}
-                    {...props}
-                  >
-                    {String(children).replace(/\n$/, "")}
-                  </SyntaxHighlighter>
-                ) : (
-                  <code
-                    className={`${className} px-1.5 py-0.5 rounded-sm bg-gray-100 text-sm font-mono`}
-                    style={{ wordBreak: "break-word" }}
-                    {...props}
-                  >
-                    {children}
-                  </code>
-                );
-              },
-              pre: ({ node, ...props }) => <pre style={{ overflowX: "auto", maxWidth: "100%" }} {...props} />,
-            }}
+          <Lightbulb className="size-3.5" />
+          {isExpanded ? "Hide reasoning" : "Show reasoning"}
+          {isExpanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          <div
+            className="mt-2 max-w-full overflow-x-auto whitespace-pre-wrap break-words rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700"
+            style={{ wordBreak: "break-word", overflowWrap: "break-word" }}
           >
-            {reasoningContent}
-          </ReactMarkdown>
-        </div>
-      )}
+            <ReactMarkdown
+              components={{
+                code({
+                  node,
+                  inline,
+                  className,
+                  children,
+                  ...props
+                }: React.ComponentPropsWithoutRef<"code"> & {
+                  inline?: boolean;
+                  node?: unknown;
+                }) {
+                  const match = /language-(\w+)/.exec(className || "");
+                  return !inline && match ? (
+                    <SyntaxHighlighter
+                      style={coy as Record<string, React.CSSProperties>}
+                      language={match[1]}
+                      PreTag="div"
+                      className="my-2 rounded-md"
+                      wrapLines={true}
+                      wrapLongLines={true}
+                      {...props}
+                    >
+                      {String(children).replace(/\n$/, "")}
+                    </SyntaxHighlighter>
+                  ) : (
+                    <code
+                      className={`${className ?? ""} rounded-sm bg-gray-100 px-1.5 py-0.5 font-mono text-sm`}
+                      style={{ wordBreak: "break-word" }}
+                      {...props}
+                    >
+                      {children}
+                    </code>
+                  );
+                },
+                pre: ({ node, ...props }) => <pre style={{ overflowX: "auto", maxWidth: "100%" }} {...props} />,
+              }}
+            >
+              {reasoningContent}
+            </ReactMarkdown>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/components/chat_ui/ResponseMetrics.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/ResponseMetrics.tsx
@@ -1,14 +1,6 @@
 import React from "react";
-import { Tooltip } from "antd";
-import {
-  ClockCircleOutlined,
-  NumberOutlined,
-  ImportOutlined,
-  ExportOutlined,
-  BulbOutlined,
-  ToolOutlined,
-  DollarOutlined,
-} from "@ant-design/icons";
+import { ArrowDownToLine, ArrowUpFromLine, Clock, DollarSign, Hash, Lightbulb, Wrench } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export interface TokenUsage {
   completionTokens?: number;
@@ -25,81 +17,102 @@ interface ResponseMetricsProps {
   toolName?: string;
 }
 
+interface MetricItemProps {
+  label: string;
+  tooltip: string;
+  icon: React.ReactNode;
+  value: string;
+}
+
+function MetricItem({ label, tooltip, icon, value }: MetricItemProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger render={<div className="flex items-center gap-1" aria-label={`${label}: ${value}`} />}>
+        {icon}
+        <span>
+          {label}: {value}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
+
 const ResponseMetrics: React.FC<ResponseMetricsProps> = ({ timeToFirstToken, totalLatency, usage, toolName }) => {
   if (!timeToFirstToken && !totalLatency && !usage) return null;
 
   return (
-    <div className="response-metrics mt-2 pt-2 border-t border-gray-100 text-xs text-gray-500 flex flex-wrap gap-3">
+    <div className="response-metrics mt-2 flex flex-wrap gap-3 border-t border-gray-100 pt-2 text-xs text-gray-500">
       {timeToFirstToken !== undefined && (
-        <Tooltip title="Time to first token">
-          <div className="flex items-center">
-            <ClockCircleOutlined className="mr-1" />
-            <span>TTFT: {(timeToFirstToken / 1000).toFixed(2)}s</span>
-          </div>
-        </Tooltip>
+        <MetricItem
+          label="TTFT"
+          tooltip="Time to first token"
+          icon={<Clock className="size-3" aria-hidden="true" />}
+          value={`${(timeToFirstToken / 1000).toFixed(2)}s`}
+        />
       )}
 
       {totalLatency !== undefined && (
-        <Tooltip title="Total latency">
-          <div className="flex items-center">
-            <ClockCircleOutlined className="mr-1" />
-            <span>Total Latency: {(totalLatency / 1000).toFixed(2)}s</span>
-          </div>
-        </Tooltip>
+        <MetricItem
+          label="Total Latency"
+          tooltip="Total latency"
+          icon={<Clock className="size-3" aria-hidden="true" />}
+          value={`${(totalLatency / 1000).toFixed(2)}s`}
+        />
       )}
 
       {usage?.promptTokens !== undefined && (
-        <Tooltip title="Prompt tokens">
-          <div className="flex items-center">
-            <ImportOutlined className="mr-1" />
-            <span>In: {usage.promptTokens}</span>
-          </div>
-        </Tooltip>
+        <MetricItem
+          label="In"
+          tooltip="Prompt tokens"
+          icon={<ArrowDownToLine className="size-3" aria-hidden="true" />}
+          value={String(usage.promptTokens)}
+        />
       )}
 
       {usage?.completionTokens !== undefined && (
-        <Tooltip title="Completion tokens">
-          <div className="flex items-center">
-            <ExportOutlined className="mr-1" />
-            <span>Out: {usage.completionTokens}</span>
-          </div>
-        </Tooltip>
+        <MetricItem
+          label="Out"
+          tooltip="Completion tokens"
+          icon={<ArrowUpFromLine className="size-3" aria-hidden="true" />}
+          value={String(usage.completionTokens)}
+        />
       )}
 
       {usage?.reasoningTokens !== undefined && (
-        <Tooltip title="Reasoning tokens">
-          <div className="flex items-center">
-            <BulbOutlined className="mr-1" />
-            <span>Reasoning: {usage.reasoningTokens}</span>
-          </div>
-        </Tooltip>
+        <MetricItem
+          label="Reasoning"
+          tooltip="Reasoning tokens"
+          icon={<Lightbulb className="size-3" aria-hidden="true" />}
+          value={String(usage.reasoningTokens)}
+        />
       )}
 
       {usage?.totalTokens !== undefined && (
-        <Tooltip title="Total tokens">
-          <div className="flex items-center">
-            <NumberOutlined className="mr-1" />
-            <span>Total: {usage.totalTokens}</span>
-          </div>
-        </Tooltip>
+        <MetricItem
+          label="Total"
+          tooltip="Total tokens"
+          icon={<Hash className="size-3" aria-hidden="true" />}
+          value={String(usage.totalTokens)}
+        />
       )}
 
       {usage?.cost !== undefined && (
-        <Tooltip title="Cost">
-          <div className="flex items-center">
-            <DollarOutlined className="mr-1" />
-            <span>${usage.cost.toFixed(6)}</span>
-          </div>
-        </Tooltip>
+        <MetricItem
+          label="Cost"
+          tooltip="Cost"
+          icon={<DollarSign className="size-3" aria-hidden="true" />}
+          value={`$${usage.cost.toFixed(6)}`}
+        />
       )}
 
       {toolName && (
-        <Tooltip title="Tool used">
-          <div className="flex items-center">
-            <ToolOutlined className="mr-1" />
-            <span>Tool: {toolName}</span>
-          </div>
-        </Tooltip>
+        <MetricItem
+          label="Tool"
+          tooltip="Tool used"
+          icon={<Wrench className="size-3" aria-hidden="true" />}
+          value={toolName}
+        />
       )}
     </div>
   );

--- a/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.tsx
@@ -11,7 +11,7 @@ export enum ModelMode {
   IMAGE_EDITS = "image_edits",
   ANTHROPIC_MESSAGES = "anthropic_messages",
   EMBEDDING = "embedding",
-  // add additional modes as needed
+  REALTIME = "realtime",
 }
 
 // Define an enum for the endpoint types your UI calls
@@ -42,6 +42,7 @@ export const litellmModeMapping: Record<ModelMode, EndpointType> = {
   [ModelMode.AUDIO_SPEECH]: EndpointType.SPEECH,
   [ModelMode.AUDIO_TRANSCRIPTION]: EndpointType.TRANSCRIPTION,
   [ModelMode.EMBEDDING]: EndpointType.EMBEDDINGS,
+  [ModelMode.REALTIME]: EndpointType.REALTIME,
 };
 
 export const getEndpointType = (mode: string): EndpointType => {

--- a/ui/litellm-dashboard/src/components/guardrails/GuardrailSelector.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/GuardrailSelector.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { Select } from "antd";
 import { Guardrail } from "./types";
 import { getGuardrailsList } from "../networking";
+import { MultiSelect } from "@/components/shared/MultiSelect";
 
 interface GuardrailSelectorProps {
   onChange: (selectedGuardrails: string[]) => void;
@@ -40,25 +40,20 @@ const GuardrailSelector: React.FC<GuardrailSelectorProps> = ({ onChange, value, 
   };
 
   return (
-    <div>
-      <Select
-        mode="multiple"
+    <div className="min-w-0">
+      <MultiSelect
         disabled={disabled}
         placeholder={disabled ? "Setting guardrails is a premium feature." : "Select guardrails"}
-        onChange={handleGuardrailChange}
+        onValueChange={handleGuardrailChange}
         value={value}
         loading={loading}
         className={className}
-        allowClear
         options={guardrails.map((guardrail) => {
           return {
             label: `${guardrail.guardrail_name}`,
             value: guardrail.guardrail_name,
           };
         })}
-        optionFilterProp="label"
-        showSearch
-        style={{ width: "100%" }}
       />
     </div>
   );

--- a/ui/litellm-dashboard/src/components/llm_calls/chat_completion.test.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/chat_completion.test.tsx
@@ -172,23 +172,22 @@ describe("chat_completion", () => {
 
     const callArgs = mockCreate.mock.calls[0][0];
     expect(callArgs.tool_choice).toBe("auto");
-    expect(callArgs.tools).toHaveLength(2);
-
-    // Check first tool
-    const firstTool = callArgs.tools[0];
-    expect(firstTool.type).toBe("mcp");
-    expect(firstTool.server_label).toBe("litellm");
-    expect(firstTool.server_url).toBe("litellm_proxy/mcp/alpha");
-    expect(firstTool.require_approval).toBe("never");
-    expect(firstTool.allowed_tools).toEqual(["toolA", "toolB"]);
-
-    // Check second tool
-    const secondTool = callArgs.tools[1];
-    expect(secondTool.type).toBe("mcp");
-    expect(secondTool.server_label).toBe("litellm");
-    expect(secondTool.server_url).toBe("litellm_proxy/mcp/Beta");
-    expect(secondTool.require_approval).toBe("never");
-    expect(secondTool.allowed_tools).toEqual(["toolC"]);
+    expect(callArgs.tools).toEqual([
+      {
+        type: "mcp",
+        server_label: "Alpha",
+        server_url: "litellm_proxy/mcp/Alpha",
+        require_approval: "never",
+        allowed_tools: ["toolA", "toolB"],
+      },
+      {
+        type: "mcp",
+        server_label: "Beta",
+        server_url: "litellm_proxy/mcp/Beta",
+        require_approval: "never",
+        allowed_tools: ["toolC"],
+      },
+    ]);
   });
 
   it("should include mock_testing_fallbacks in request body when mockTestFallbacks is true", async () => {

--- a/ui/litellm-dashboard/src/components/llm_calls/chat_completion.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/chat_completion.tsx
@@ -4,6 +4,7 @@ import { TokenUsage } from "../chat_ui/ResponseMetrics";
 import { VectorStoreSearchResponse } from "../chat_ui/types";
 import { getProxyBaseUrl } from "@/components/networking";
 import { MCPServer, MCPToolset, type MCPEvent } from "@/components/mcp_tools/types";
+import { buildMcpToolBlocks } from "./mcp_tool_blocks";
 
 const completionAsSingleChunk = (completion: ChatCompletion): ChatCompletionChunk =>
   ({
@@ -81,48 +82,12 @@ export async function makeOpenAIChatCompletionRequest(
     } = {};
     let mcpListToolsProcessed = false;
 
-    // Build tools array
-    const tools: any[] = [];
-
-    // Add MCP servers if selected
-    if (selectedMCPServers && selectedMCPServers.length > 0) {
-      if (selectedMCPServers.includes("__all__")) {
-        // All MCP Servers selected
-        tools.push({
-          type: "mcp",
-          server_label: "litellm",
-          server_url: "litellm_proxy/mcp",
-          require_approval: "never",
-        });
-      } else {
-        // Individual servers/toolsets selected - create one entry per item
-        selectedMCPServers.forEach((serverId) => {
-          if (serverId.startsWith("toolset:")) {
-            const toolsetId = serverId.slice("toolset:".length);
-            const toolset = mcpToolsets?.find((t) => t.toolset_id === toolsetId);
-            const toolsetName = toolset?.toolset_name || toolsetId;
-            tools.push({
-              type: "mcp",
-              server_label: toolsetName,
-              server_url: `litellm_proxy/mcp/${encodeURIComponent(toolsetName)}`,
-              require_approval: "never",
-            });
-          } else {
-            const server = mcpServers?.find((s) => s.server_id === serverId);
-            const serverName = server?.alias || server?.server_name || serverId;
-            const allowedTools = mcpServerToolRestrictions?.[serverId] || [];
-
-            tools.push({
-              type: "mcp",
-              server_label: "litellm",
-              server_url: `litellm_proxy/mcp/${serverName}`,
-              require_approval: "never",
-              ...(allowedTools.length > 0 ? { allowed_tools: allowedTools } : {}),
-            });
-          }
-        });
-      }
-    }
+    const tools = buildMcpToolBlocks({
+      selectedMCPServers,
+      mcpServers,
+      mcpToolsets,
+      mcpServerToolRestrictions,
+    });
 
     const requestBody = {
       model: selectedModel,

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.test.ts
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchAvailableModels } from "./fetch_models";
+
+vi.mock("@/components/networking", () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from "@/components/networking";
+
+const mockGet = vi.mocked(apiClient.get);
+
+describe("fetchAvailableModels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns key-scoped models from /v1/models and attaches modes from model_group/info", async () => {
+    mockGet.mockImplementation(async (path: string) => {
+      if (path === "/model_group/info") {
+        return {
+          data: [
+            { model_group: "anthropic-haiku-4-5", mode: "chat" },
+            { model_group: "gpt-realtime", mode: "realtime" },
+          ],
+        };
+      }
+      if (path === "/v1/models") {
+        return {
+          data: [{ id: "anthropic-haiku-4-5" }],
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const models = await fetchAvailableModels("sk-virtual-key");
+
+    expect(models).toEqual([{ model_group: "anthropic-haiku-4-5", mode: "chat" }]);
+    expect(mockGet).toHaveBeenCalledWith("/v1/models", { accessToken: "sk-virtual-key" });
+  });
+
+  it("falls back to model_group/info when /v1/models is empty", async () => {
+    mockGet.mockImplementation(async (path: string) => {
+      if (path === "/model_group/info") {
+        return {
+          data: [
+            { model_group: "gpt-4o", mode: "chat" },
+            { id: "legacy-model", mode: "chat" },
+          ],
+        };
+      }
+      if (path === "/v1/models") {
+        return { data: [] };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const models = await fetchAvailableModels("sk-admin");
+    expect(models.map((m) => m.model_group)).toEqual(["gpt-4o", "legacy-model"]);
+  });
+
+  it("still returns /v1/models when model_group/info fails", async () => {
+    mockGet.mockImplementation(async (path: string) => {
+      if (path === "/model_group/info") {
+        throw new Error("forbidden");
+      }
+      if (path === "/v1/models") {
+        return { data: [{ id: "only-from-key" }] };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const models = await fetchAvailableModels("sk-virtual-key");
+    expect(models).toEqual([{ model_group: "only-from-key", mode: undefined }]);
+  });
+});

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
@@ -7,6 +7,13 @@ export interface ModelGroup {
   mode?: string;
 }
 
+interface AvailableModel {
+  model_group?: string | null;
+  model_name?: string | null;
+  id?: string | null;
+  mode?: string | null;
+}
+
 /**
  * Fetches available models using modelHubCall and formats them for the selection dropdown.
  */
@@ -15,14 +22,15 @@ export const fetchAvailableModels = async (accessToken: string): Promise<ModelGr
     const fetchedModels = await modelHubCall(accessToken);
 
     if (fetchedModels?.data.length > 0) {
-      const models: ModelGroup[] = fetchedModels.data.map((item: any) => ({
-        model_group: item.model_group, // Display the model_group to the user
-        mode: item?.mode, // Save the mode for auto-selection of endpoint type
-      }));
+      const models: ModelGroup[] = fetchedModels.data
+        .map((item: AvailableModel) => ({
+          model_group: item.model_group || item.id || item.model_name || "",
+          mode: item.mode || undefined,
+        }))
+        .filter((model: ModelGroup) => model.model_group !== "");
 
-      // Sort models alphabetically by label
       models.sort((a, b) => a.model_group.localeCompare(b.model_group));
-      return models;
+      return Array.from(new Map(models.map((model) => [model.model_group, model])).values());
     }
     return [];
   } catch (error) {

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
@@ -1,40 +1,86 @@
-// fetch_models.ts
-
-import { modelHubCall } from "@/components/networking";
+import { apiClient } from "@/components/networking";
 
 export interface ModelGroup {
   model_group: string;
   mode?: string;
 }
 
-interface AvailableModel {
+interface ModelGroupInfoItem {
   model_group?: string | null;
   model_name?: string | null;
   id?: string | null;
   mode?: string | null;
 }
 
+interface OpenAIModelItem {
+  id?: string | null;
+}
+
+const modelNameFromGroupItem = (item: ModelGroupInfoItem): string =>
+  (item.model_group || item.id || item.model_name || "").trim();
+
+const dedupeAndSort = (models: ModelGroup[]): ModelGroup[] => {
+  const unique = Array.from(new Map(models.map((model) => [model.model_group, model])).values());
+  unique.sort((a, b) => a.model_group.localeCompare(b.model_group));
+  return unique;
+};
+
 /**
- * Fetches available models using modelHubCall and formats them for the selection dropdown.
+ * Loads models available to the given key.
+ *
+ * Prefers OpenAI-compatible `/v1/models` (scoped to the key's access) and enriches
+ * entries with `mode` from `/model_group/info` when that endpoint is available.
+ * Falls back to `/model_group/info` alone if `/v1/models` is empty or fails.
  */
 export const fetchAvailableModels = async (accessToken: string): Promise<ModelGroup[]> => {
+  const modeByName = new Map<string, string | undefined>();
+
   try {
-    const fetchedModels = await modelHubCall(accessToken);
-
-    if (fetchedModels?.data.length > 0) {
-      const models: ModelGroup[] = fetchedModels.data
-        .map((item: AvailableModel) => ({
-          model_group: item.model_group || item.id || item.model_name || "",
-          mode: item.mode || undefined,
-        }))
-        .filter((model: ModelGroup) => model.model_group !== "");
-
-      models.sort((a, b) => a.model_group.localeCompare(b.model_group));
-      return Array.from(new Map(models.map((model) => [model.model_group, model])).values());
+    const groupInfo = await apiClient.get<{ data?: ModelGroupInfoItem[] }>("/model_group/info", {
+      accessToken,
+    });
+    for (const item of groupInfo?.data ?? []) {
+      const name = modelNameFromGroupItem(item);
+      if (name) {
+        modeByName.set(name, item.mode || undefined);
+      }
     }
-    return [];
   } catch (error) {
-    console.error("Error fetching model info:", error);
-    throw error;
+    console.error("Error fetching model group info:", error);
   }
+
+  try {
+    const listed = await apiClient.get<{ data?: OpenAIModelItem[] }>("/v1/models", {
+      accessToken,
+    });
+    const fromList = (listed?.data ?? [])
+      .map((item) => {
+        const name = (item.id || "").trim();
+        if (!name) {
+          return null;
+        }
+        return {
+          model_group: name,
+          mode: modeByName.get(name),
+        } satisfies ModelGroup;
+      })
+      .filter((model): model is ModelGroup => model != null);
+
+    if (fromList.length > 0) {
+      return dedupeAndSort(fromList);
+    }
+  } catch (error) {
+    console.error("Error fetching /v1/models:", error);
+  }
+
+  if (modeByName.size > 0) {
+    return dedupeAndSort(
+      Array.from(modeByName.entries()).map(([model_group, mode]) => ({
+        model_group,
+        mode,
+      })),
+    );
+  }
+
+  return [];
 };

--- a/ui/litellm-dashboard/src/components/llm_calls/responses_api.test.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/responses_api.test.tsx
@@ -280,14 +280,14 @@ describe("responses_api", () => {
       {
         type: "mcp",
         server_label: "Alpha",
-        server_url: "https://example.com/mcp/Alpha",
+        server_url: "litellm_proxy/mcp/Alpha",
         require_approval: "never",
         allowed_tools: ["toolA"],
       },
       {
         type: "mcp",
         server_label: "Beta",
-        server_url: "https://example.com/mcp/Beta",
+        server_url: "litellm_proxy/mcp/Beta",
         require_approval: "never",
         allowed_tools: ["toolB", "toolC"],
       },

--- a/ui/litellm-dashboard/src/components/llm_calls/responses_api.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/responses_api.tsx
@@ -11,6 +11,7 @@ import {
   handleCodeInterpreterCall,
   handleCodeInterpreterOutput,
 } from "./code_interpreter_handler";
+import { buildMcpToolBlocks } from "./mcp_tool_blocks";
 
 export type { CodeInterpreterResult } from "./code_interpreter_handler";
 
@@ -134,53 +135,15 @@ export async function makeOpenAIResponsesRequest(
       };
     });
 
-    // Build tools array
-    const tools: any[] = [];
+    const tools: Array<Record<string, unknown>> = [
+      ...buildMcpToolBlocks({
+        selectedMCPServers,
+        mcpServers,
+        mcpToolsets,
+        mcpServerToolRestrictions,
+      }),
+    ];
 
-    // Add MCP servers if selected
-    if (selectedMCPServers && selectedMCPServers.length > 0) {
-      if (selectedMCPServers.includes("__all__")) {
-        // All MCP Servers selected
-        tools.push({
-          type: "mcp",
-          server_label: "litellm",
-          server_url: `${proxyBaseUrl}/mcp`,
-          require_approval: "never",
-        });
-      } else {
-        // Individual servers/toolsets selected - create one entry per item
-        selectedMCPServers.forEach((serverId) => {
-          if (serverId.startsWith("toolset:")) {
-            // Toolset: same /{name}/mcp pattern as individual servers
-            const toolsetId = serverId.slice("toolset:".length);
-            const toolset = mcpToolsets?.find((t) => t.toolset_id === toolsetId);
-            const toolsetName = toolset?.toolset_name || toolsetId;
-            tools.push({
-              type: "mcp",
-              server_label: toolsetName,
-              server_url: `${proxyBaseUrl}/mcp/${encodeURIComponent(toolsetName)}`,
-              require_approval: "never",
-            });
-          } else {
-            const server = mcpServers?.find((s) => s.server_id === serverId);
-            // Use server_name for both routing and labelling. server_name is the
-            // unique registered identifier; aliases can collide across servers.
-            const routeName = server?.server_name || serverId;
-            const allowedTools = mcpServerToolRestrictions?.[serverId] || [];
-
-            tools.push({
-              type: "mcp",
-              server_label: routeName, // unique per request — collisions cause silent tool-routing failures
-              server_url: `${proxyBaseUrl}/mcp/${encodeURIComponent(routeName)}`,
-              require_approval: "never",
-              ...(allowedTools.length > 0 ? { allowed_tools: allowedTools } : {}),
-            });
-          }
-        });
-      }
-    }
-
-    // Add code_interpreter tool if enabled (OpenAI auto-creates container)
     if (codeInterpreterEnabled) {
       tools.push({
         type: "code_interpreter",

--- a/ui/litellm-dashboard/src/components/policies/PolicySelector.tsx
+++ b/ui/litellm-dashboard/src/components/policies/PolicySelector.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { Select } from "antd";
 import { Policy } from "./types";
 import { getPoliciesList } from "../networking";
+import { MultiSelect } from "@/components/shared/MultiSelect";
 
 /** Prefix for policy version IDs in request body; must match backend POLICY_VERSION_ID_PREFIX. */
 export const POLICY_VERSION_ID_PREFIX = "policy_";
@@ -80,22 +80,17 @@ const PolicySelector: React.FC<PolicySelectorProps> = ({
   };
 
   return (
-    <div>
-      <Select
-        mode="multiple"
+    <div className="min-w-0">
+      <MultiSelect
         disabled={disabled}
         placeholder={
           disabled ? "Setting policies is a premium feature." : "Select policies (production or published versions)"
         }
-        onChange={handlePolicyChange}
+        onValueChange={handlePolicyChange}
         value={value}
         loading={loading}
         className={className}
-        allowClear
         options={getPolicyOptionEntries(policies)}
-        optionFilterProp="label"
-        showSearch
-        style={{ width: "100%" }}
       />
     </div>
   );

--- a/ui/litellm-dashboard/src/components/shared/MultiSelect.tsx
+++ b/ui/litellm-dashboard/src/components/shared/MultiSelect.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxValue,
+} from "@/components/ui/combobox";
+
+export interface MultiSelectOption {
+  label: string;
+  value: string;
+  description?: string;
+}
+
+interface MultiSelectProps {
+  options: MultiSelectOption[];
+  value?: string[];
+  onValueChange: (value: string[]) => void;
+  placeholder?: string;
+  emptyText?: string;
+  disabled?: boolean;
+  loading?: boolean;
+  allowCustomValues?: boolean;
+  className?: string;
+}
+
+const matchesQuery = (option: MultiSelectOption, query: string): boolean => {
+  const normalizedQuery = query.trim().toLowerCase();
+  return (
+    !normalizedQuery ||
+    option.label.toLowerCase().includes(normalizedQuery) ||
+    option.value.toLowerCase().includes(normalizedQuery) ||
+    (option.description?.toLowerCase().includes(normalizedQuery) ?? false)
+  );
+};
+
+export function MultiSelect({
+  options,
+  value = [],
+  onValueChange,
+  placeholder = "Select options",
+  emptyText = "No options found",
+  disabled = false,
+  loading = false,
+  allowCustomValues = false,
+  className,
+}: MultiSelectProps) {
+  const [query, setQuery] = useState("");
+  const selectedOptions = value.map(
+    (selectedValue) =>
+      options.find((option) => option.value === selectedValue) ?? {
+        label: selectedValue,
+        value: selectedValue,
+      },
+  );
+  const customOption = query.trim();
+  const customOptionExists = options.some((option) => option.value.toLowerCase() === customOption.toLowerCase());
+  const items =
+    allowCustomValues && customOption && !customOptionExists
+      ? [...options, { label: `Create "${customOption}"`, value: customOption }]
+      : options;
+
+  return (
+    <Combobox
+      multiple
+      items={items}
+      value={selectedOptions}
+      onValueChange={(selected: MultiSelectOption[]) => {
+        onValueChange(selected.map((option) => option.value));
+        setQuery("");
+      }}
+      inputValue={query}
+      onInputValueChange={setQuery}
+      isItemEqualToValue={(option: MultiSelectOption, selected: MultiSelectOption) => option.value === selected.value}
+      itemToStringLabel={(option: MultiSelectOption) => option.label}
+      filter={matchesQuery}
+      disabled={disabled || loading}
+    >
+      <ComboboxChips className={`min-h-8 py-1 text-sm ${className ?? ""}`}>
+        <ComboboxValue>
+          {(selected: MultiSelectOption[]) =>
+            selected.map((option) => (
+              <ComboboxChip key={option.value} aria-label={option.label}>
+                {option.label}
+              </ComboboxChip>
+            ))
+          }
+        </ComboboxValue>
+        <ComboboxChipsInput
+          placeholder={loading ? "Loading..." : placeholder}
+          className="h-5 min-w-24 flex-1 border-0 bg-transparent py-0 text-sm"
+          aria-label={placeholder}
+        />
+      </ComboboxChips>
+      <ComboboxContent>
+        <ComboboxEmpty>{emptyText}</ComboboxEmpty>
+        <ComboboxList>
+          {(option: MultiSelectOption) => (
+            <ComboboxItem key={option.value} value={option}>
+              <span className="min-w-0">
+                <span className="block truncate">{option.label}</span>
+                {option.description && (
+                  <span className="block truncate text-xs text-muted-foreground">{option.description}</span>
+                )}
+              </span>
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}

--- a/ui/litellm-dashboard/src/components/shared/MultiSelect.tsx
+++ b/ui/litellm-dashboard/src/components/shared/MultiSelect.tsx
@@ -53,19 +53,25 @@ export function MultiSelect({
   className,
 }: MultiSelectProps) {
   const [query, setQuery] = useState("");
-  const selectedOptions = value.map(
-    (selectedValue) =>
-      options.find((option) => option.value === selectedValue) ?? {
-        label: selectedValue,
-        value: selectedValue,
-      },
+  const safeOptions = options.filter(
+    (option): option is MultiSelectOption =>
+      option != null && typeof option.value === "string" && option.value.length > 0,
   );
+  const selectedOptions = value
+    .filter((selectedValue): selectedValue is string => typeof selectedValue === "string" && selectedValue.length > 0)
+    .map(
+      (selectedValue) =>
+        safeOptions.find((option) => option.value === selectedValue) ?? {
+          label: selectedValue,
+          value: selectedValue,
+        },
+    );
   const customOption = query.trim();
-  const customOptionExists = options.some((option) => option.value.toLowerCase() === customOption.toLowerCase());
+  const customOptionExists = safeOptions.some((option) => option.value.toLowerCase() === customOption.toLowerCase());
   const items =
     allowCustomValues && customOption && !customOptionExists
-      ? [...options, { label: `Create "${customOption}"`, value: customOption }]
-      : options;
+      ? [...safeOptions, { label: `Create "${customOption}"`, value: customOption }]
+      : safeOptions;
 
   return (
     <Combobox

--- a/ui/litellm-dashboard/src/components/shared/MultiSelect.tsx
+++ b/ui/litellm-dashboard/src/components/shared/MultiSelect.tsx
@@ -11,6 +11,7 @@ import {
   ComboboxItem,
   ComboboxList,
   ComboboxValue,
+  useComboboxAnchor,
 } from "@/components/ui/combobox";
 
 export interface MultiSelectOption {
@@ -33,12 +34,13 @@ interface MultiSelectProps {
 
 const matchesQuery = (option: MultiSelectOption, query: string): boolean => {
   const normalizedQuery = query.trim().toLowerCase();
-  return (
-    !normalizedQuery ||
-    option.label.toLowerCase().includes(normalizedQuery) ||
-    option.value.toLowerCase().includes(normalizedQuery) ||
-    (option.description?.toLowerCase().includes(normalizedQuery) ?? false)
-  );
+  if (!normalizedQuery) {
+    return true;
+  }
+  const label = option.label?.toLowerCase() ?? "";
+  const value = option.value?.toLowerCase() ?? "";
+  const description = option.description?.toLowerCase() ?? "";
+  return label.includes(normalizedQuery) || value.includes(normalizedQuery) || description.includes(normalizedQuery);
 };
 
 export function MultiSelect({
@@ -53,10 +55,17 @@ export function MultiSelect({
   className,
 }: MultiSelectProps) {
   const [query, setQuery] = useState("");
-  const safeOptions = options.filter(
-    (option): option is MultiSelectOption =>
-      option != null && typeof option.value === "string" && option.value.length > 0,
-  );
+  const anchor = useComboboxAnchor();
+  const safeOptions = options
+    .filter(
+      (option): option is MultiSelectOption =>
+        option != null && typeof option.value === "string" && option.value.length > 0,
+    )
+    .map((option) => ({
+      value: option.value,
+      label: option.label?.trim() || option.value,
+      description: option.description || undefined,
+    }));
   const selectedOptions = value
     .filter((selectedValue): selectedValue is string => typeof selectedValue === "string" && selectedValue.length > 0)
     .map(
@@ -79,17 +88,18 @@ export function MultiSelect({
       items={items}
       value={selectedOptions}
       onValueChange={(selected: MultiSelectOption[]) => {
-        onValueChange(selected.map((option) => option.value));
+        onValueChange(selected.map((option) => option.value).filter(Boolean));
         setQuery("");
       }}
       inputValue={query}
       onInputValueChange={setQuery}
       isItemEqualToValue={(option: MultiSelectOption, selected: MultiSelectOption) => option.value === selected.value}
       itemToStringLabel={(option: MultiSelectOption) => option.label}
+      itemToStringValue={(option: MultiSelectOption) => option.value}
       filter={matchesQuery}
       disabled={disabled || loading}
     >
-      <ComboboxChips className={`min-h-8 py-1 text-sm ${className ?? ""}`}>
+      <ComboboxChips ref={anchor} className={`min-h-8 w-full py-1 text-sm ${className ?? ""}`}>
         <ComboboxValue>
           {(selected: MultiSelectOption[]) =>
             selected.map((option) => (
@@ -105,16 +115,20 @@ export function MultiSelect({
           aria-label={placeholder}
         />
       </ComboboxChips>
-      <ComboboxContent>
+      <ComboboxContent
+        anchor={anchor}
+        side="bottom"
+        collisionAvoidance={{ side: "shift", align: "shift", fallbackAxisSide: "none" }}
+      >
         <ComboboxEmpty>{emptyText}</ComboboxEmpty>
         <ComboboxList>
           {(option: MultiSelectOption) => (
             <ComboboxItem key={option.value} value={option}>
               <span className="min-w-0">
                 <span className="block truncate">{option.label}</span>
-                {option.description && (
+                {option.description ? (
                   <span className="block truncate text-xs text-muted-foreground">{option.description}</span>
-                )}
+                ) : null}
               </span>
             </ComboboxItem>
           )}

--- a/ui/litellm-dashboard/src/components/shared/SearchSelect.tsx
+++ b/ui/litellm-dashboard/src/components/shared/SearchSelect.tsx
@@ -56,9 +56,9 @@ export function SearchSelect({
       <ComboboxInput
         placeholder={placeholder}
         showClear={value != null && value !== ""}
-        className={`w-full ${className ?? ""}`}
+        className={`h-8 w-full text-sm ${className ?? ""}`}
       />
-      <ComboboxContent>
+      <ComboboxContent side="bottom" collisionAvoidance={{ side: "shift", align: "shift", fallbackAxisSide: "none" }}>
         <ComboboxEmpty>{emptyText}</ComboboxEmpty>
         <ComboboxList>
           {(item: SearchSelectOption) => (

--- a/ui/litellm-dashboard/src/components/tag_management/TagSelector.tsx
+++ b/ui/litellm-dashboard/src/components/tag_management/TagSelector.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { Select } from "antd";
 import { Tag } from "./types";
 import { tagListCall } from "../networking";
+import { MultiSelect } from "@/components/shared/MultiSelect";
 
 interface TagSelectorProps {
   onChange: (selectedTags: string[]) => void;
@@ -17,6 +17,7 @@ const TagSelector: React.FC<TagSelectorProps> = ({ onChange, value, className, a
   useEffect(() => {
     const fetchTags = async () => {
       if (!accessToken) return;
+      setLoading(true);
       try {
         const response = await tagListCall(accessToken);
         setTags(Object.values(response));
@@ -31,24 +32,18 @@ const TagSelector: React.FC<TagSelectorProps> = ({ onChange, value, className, a
   }, [accessToken]);
 
   return (
-    <Select
-      mode="tags"
-      showSearch
+    <MultiSelect
       placeholder="Select or create tags"
-      onChange={onChange}
+      onValueChange={onChange}
       value={value}
       loading={loading}
       className={className}
+      allowCustomValues
       options={tags.map((tag) => ({
         label: tag.name,
         value: tag.name,
-        title: tag.description || tag.name,
+        description: tag.description || undefined,
       }))}
-      optionFilterProp="label"
-      tokenSeparators={[","]}
-      maxTagCount="responsive"
-      allowClear
-      style={{ width: "100%" }}
     />
   );
 };

--- a/ui/litellm-dashboard/src/components/ui/combobox.tsx
+++ b/ui/litellm-dashboard/src/components/ui/combobox.tsx
@@ -83,10 +83,14 @@ function ComboboxContent({
   sideOffset = 6,
   align = "start",
   alignOffset = 0,
+  collisionAvoidance,
   anchor,
   ...props
 }: ComboboxPrimitive.Popup.Props &
-  Pick<ComboboxPrimitive.Positioner.Props, "side" | "align" | "sideOffset" | "alignOffset" | "anchor">) {
+  Pick<
+    ComboboxPrimitive.Positioner.Props,
+    "side" | "align" | "sideOffset" | "alignOffset" | "collisionAvoidance" | "anchor"
+  >) {
   return (
     <ComboboxPrimitive.Portal>
       <ComboboxPrimitive.Positioner
@@ -94,6 +98,7 @@ function ComboboxContent({
         sideOffset={sideOffset}
         align={align}
         alignOffset={alignOffset}
+        collisionAvoidance={collisionAvoidance}
         anchor={anchor}
         className="isolate z-50"
       >

--- a/ui/litellm-dashboard/src/components/ui/combobox.tsx
+++ b/ui/litellm-dashboard/src/components/ui/combobox.tsx
@@ -190,12 +190,13 @@ function ComboboxSeparator({ className, ...props }: ComboboxPrimitive.Separator.
   );
 }
 
-function ComboboxChips({
-  className,
-  ...props
-}: React.ComponentPropsWithRef<typeof ComboboxPrimitive.Chips> & ComboboxPrimitive.Chips.Props) {
+const ComboboxChips = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<typeof ComboboxPrimitive.Chips> & ComboboxPrimitive.Chips.Props
+>(({ className, ...props }, ref) => {
   return (
     <ComboboxPrimitive.Chips
+      ref={ref}
       data-slot="combobox-chips"
       className={cn(
         "flex min-h-9 flex-wrap items-center gap-1.5 rounded-md border border-input bg-transparent bg-clip-padding px-2.5 py-1.5 text-sm shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50 has-aria-invalid:border-destructive has-aria-invalid:ring-3 has-aria-invalid:ring-destructive/20 has-data-[slot=combobox-chip]:px-1.5 dark:bg-input/30 dark:has-aria-invalid:border-destructive/50 dark:has-aria-invalid:ring-destructive/40",
@@ -204,7 +205,8 @@ function ComboboxChips({
       {...props}
     />
   );
-}
+});
+ComboboxChips.displayName = "ComboboxChips";
 
 function ComboboxChip({
   className,

--- a/ui/litellm-dashboard/src/components/vector_store_management/VectorStoreSelector.tsx
+++ b/ui/litellm-dashboard/src/components/vector_store_management/VectorStoreSelector.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { Select } from "antd";
 import { VectorStore } from "./types";
 import { vectorStoreListCall } from "../networking";
+import { MultiSelect } from "@/components/shared/MultiSelect";
 interface VectorStoreSelectorProps {
   onChange: (selectedVectorStores: string[]) => void;
   value?: string[];
@@ -43,24 +43,19 @@ const VectorStoreSelector: React.FC<VectorStoreSelectorProps> = ({
   }, [accessToken]);
 
   return (
-    <div>
-      <Select
-        mode="multiple"
+    <div className="min-w-0">
+      <MultiSelect
         placeholder={placeholder}
-        onChange={onChange}
+        onValueChange={onChange}
         value={value}
         loading={loading}
         className={className}
-        allowClear
+        disabled={disabled}
         options={vectorStores.map((store) => ({
           label: `${store.vector_store_name || store.vector_store_id} (${store.vector_store_id})`,
           value: store.vector_store_id,
-          title: store.vector_store_description || store.vector_store_id,
+          description: store.vector_store_description || undefined,
         }))}
-        optionFilterProp="label"
-        showSearch
-        style={{ width: "100%" }}
-        disabled={disabled}
       />
     </div>
   );


### PR DESCRIPTION
## TLDR

Problem this solves:

- Playground chat still relied on Ant Design and Tremor
- MCP tools failed or stayed disabled across endpoints and models
- Virtual key model loading, labels, and realtime composer needed fixes

How it solves it:

- Migrates ChatUI controls, tabs, and bubbles toward shadcn/Base UI
- Shares a Vercel-style ChatComposer across chat, compare, and realtime
- Builds MCP tool blocks via one helper for all tool-capable endpoints

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

UI walkthrough (proxy on :4000, Admin UI on :3000):

1. Open http://localhost:3000/ui/?page=playground (or http://localhost:4000/ui/?page=playground)
2. Confirm the chat composer has a clearer border/shadow and the endpoint, model, and virtual key controls render with shadcn selects
3. With a virtual key selected, open the model dropdown and confirm models load via `/v1/models` plus mode info
4. Switch endpoint among `/v1/chat/completions`, `/v1/responses`, Anthropic messages, and `/v1beta/interactions` and confirm MCP Servers stays enabled
5. Select one or more MCP servers, pick a model, send a prompt that should call a tool, and confirm tool activity shows in the assistant turn
6. Switch endpoint to embeddings and confirm MCP Servers is disabled
7. Open realtime, connect, send a message, and confirm the shared composer works and concurrent responses do not garble the transcript

Unit coverage (not a substitute for the UI steps above): ChatUI MCP enablement, chat_completion and responses_api MCP tool payload shape, mcp_tool_blocks routing by server_name

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

Playground ChatUI moves off Ant Design/Tremor for chat controls, message chrome, MCP events, metrics, and selectors, using shared SearchSelect/MultiSelect and Lucide icons

A shared ChatComposer (border, shadow, attach/send actions) is used for chat, compare, and realtime so the input surface is consistent

Model filtering by endpoint is restored, virtual keys load models from `/v1/models` + model group info, and virtual key / session selects show human labels instead of raw `session`/`custom`

MCP tool blocks for chat, responses, anthropic messages, and interactions all go through `buildMcpToolBlocks` with `litellm_proxy/mcp/<server_name>`, unique labels, and no percent-encoding. Interactions gains MCP support in the selector and request body. The MultiSelect chip anchor fix keeps the MCP server list openable

Realtime uses the shared composer, a correct voice list, and single-stream response handling so concurrent response races do not scramble transcripts

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR