### PR TITLE
fix(ui): load virtual key models and show human select labels

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatComposer.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatComposer.tsx
@@ -89,8 +89,12 @@ export function ChatComposer({
       >
         <InputGroup
           className={cn(
-            "h-auto min-h-[7.5rem] flex-col overflow-hidden rounded-2xl border border-border/40 bg-card shadow-sm",
-            "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/30",
+            "h-auto min-h-[7.5rem] flex-col overflow-hidden rounded-2xl border border-border bg-card",
+            "shadow-[0_1px_2px_rgba(0,0,0,0.06),0_8px_24px_rgba(0,0,0,0.08)] ring-1 ring-black/5",
+            "transition-[box-shadow,border-color,ring] duration-200",
+            "has-[[data-slot=input-group-control]:focus-visible]:border-ring",
+            "has-[[data-slot=input-group-control]:focus-visible]:shadow-[0_2px_8px_rgba(0,0,0,0.08),0_12px_32px_rgba(0,0,0,0.12)]",
+            "has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/40",
           )}
         >
           {body ? (

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatComposer.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatComposer.tsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useRef } from "react";
+import { ArrowUp, Code2, Square } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupTextarea } from "@/components/ui/input-group";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/cva.config";
+
+interface ChatComposerProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  onCancel?: () => void;
+  placeholder: string;
+  disabled?: boolean;
+  isLoading?: boolean;
+  submitDisabled?: boolean;
+  tools?: React.ReactNode;
+  body?: React.ReactNode;
+  suggestions?: string[];
+  showSuggestions?: boolean;
+  onSuggestionSelect?: (suggestion: string) => void;
+  className?: string;
+}
+
+export function ChatComposer({
+  value,
+  onChange,
+  onSubmit,
+  onCancel,
+  placeholder,
+  disabled = false,
+  isLoading = false,
+  submitDisabled = false,
+  tools,
+  body,
+  suggestions = [],
+  showSuggestions = false,
+  onSuggestionSelect,
+  className,
+}: ChatComposerProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el || body) {
+      return;
+    }
+    el.style.height = "0px";
+    el.style.height = `${Math.min(el.scrollHeight, 192)}px`;
+  }, [value, body]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+      event.preventDefault();
+      if (!submitDisabled && !isLoading) {
+        onSubmit();
+      }
+    }
+  };
+
+  return (
+    <div className={cn("relative flex w-full flex-col gap-3", className)}>
+      {showSuggestions && suggestions.length > 0 && (
+        <div
+          className="flex w-full gap-2 overflow-x-auto pb-1 sm:grid sm:grid-cols-2 sm:overflow-visible"
+          data-testid="chat-suggested-actions"
+        >
+          {suggestions.map((suggestion) => (
+            <button
+              key={suggestion}
+              type="button"
+              className="min-w-[200px] shrink-0 rounded-xl border border-border/50 bg-card/30 px-4 py-3 text-left text-[12px] leading-relaxed text-muted-foreground transition-all duration-200 hover:-translate-y-0.5 hover:bg-card/60 hover:text-foreground sm:min-w-0 sm:whitespace-normal sm:p-4 sm:text-[13px]"
+              onClick={() => onSuggestionSelect?.(suggestion)}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <form
+        className="w-full"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!submitDisabled && !isLoading) {
+            onSubmit();
+          }
+        }}
+      >
+        <InputGroup
+          className={cn(
+            "h-auto min-h-[7.5rem] flex-col overflow-hidden rounded-2xl border border-border/40 bg-card shadow-sm",
+            "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/30",
+          )}
+        >
+          {body ? (
+            <div className="max-h-48 min-h-24 w-full overflow-y-auto px-3 pt-3">{body}</div>
+          ) : (
+            <InputGroupTextarea
+              ref={textareaRef}
+              data-testid="chat-composer-input"
+              value={value}
+              disabled={disabled}
+              placeholder={placeholder}
+              rows={1}
+              className="min-h-24 max-h-48 resize-none border-0 bg-transparent px-4 pt-3.5 pb-1.5 text-[13px] leading-relaxed shadow-none placeholder:text-muted-foreground/50 focus-visible:ring-0"
+              onChange={(event) => onChange(event.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+          )}
+
+          <InputGroupAddon align="block-end" className="justify-between gap-2 px-3 pb-3 pt-1">
+            <div className="flex min-w-0 items-center gap-1">{tools}</div>
+
+            {isLoading && onCancel ? (
+              <InputGroupButton
+                type="button"
+                size="icon-sm"
+                aria-label="Stop request"
+                data-testid="chat-stop-button"
+                className="size-8 rounded-xl bg-foreground text-background hover:bg-foreground/90"
+                onClick={onCancel}
+              >
+                <Square className="size-3.5 fill-current" />
+              </InputGroupButton>
+            ) : (
+              <InputGroupButton
+                type="submit"
+                size="icon-sm"
+                aria-label="Send message"
+                data-testid="chat-send-button"
+                disabled={submitDisabled || isLoading}
+                className={cn(
+                  "size-8 rounded-xl transition-all duration-200",
+                  !submitDisabled && !isLoading
+                    ? "bg-foreground text-background hover:opacity-90 active:scale-95"
+                    : "cursor-not-allowed bg-muted text-muted-foreground/40",
+                )}
+              >
+                <ArrowUp className="size-4" />
+              </InputGroupButton>
+            )}
+          </InputGroupAddon>
+        </InputGroup>
+      </form>
+    </div>
+  );
+}
+
+interface CodeInterpreterToggleProps {
+  enabled: boolean;
+  onToggle: () => void;
+}
+
+export function CodeInterpreterToggle({ enabled, onToggle }: CodeInterpreterToggleProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className={cn(
+              "size-8 rounded-lg border border-border/40",
+              enabled
+                ? "border-blue-200 bg-blue-50 text-blue-600 hover:bg-blue-100"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+            aria-label={enabled ? "Code Interpreter enabled (click to disable)" : "Enable Code Interpreter"}
+            onClick={onToggle}
+          />
+        }
+      >
+        <Code2 className="size-4" />
+      </TooltipTrigger>
+      <TooltipContent>
+        {enabled ? "Code Interpreter enabled (click to disable)" : "Enable Code Interpreter"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export default ChatComposer;

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatComposer.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatComposer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import { ArrowUp, Code2, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupTextarea } from "@/components/ui/input-group";
@@ -38,17 +38,6 @@ export function ChatComposer({
   onSuggestionSelect,
   className,
 }: ChatComposerProps) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  useEffect(() => {
-    const el = textareaRef.current;
-    if (!el || body) {
-      return;
-    }
-    el.style.height = "0px";
-    el.style.height = `${Math.min(el.scrollHeight, 192)}px`;
-  }, [value, body]);
-
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
       event.preventDefault();
@@ -101,13 +90,12 @@ export function ChatComposer({
             <div className="max-h-48 min-h-24 w-full overflow-y-auto px-3 pt-3">{body}</div>
           ) : (
             <InputGroupTextarea
-              ref={textareaRef}
               data-testid="chat-composer-input"
               value={value}
               disabled={disabled}
               placeholder={placeholder}
               rows={1}
-              className="min-h-24 max-h-48 resize-none border-0 bg-transparent px-4 pt-3.5 pb-1.5 text-[13px] leading-relaxed shadow-none placeholder:text-muted-foreground/50 focus-visible:ring-0"
+              className="min-h-24 max-h-48 resize-none overflow-y-auto border-0 bg-transparent px-4 pt-3.5 pb-1.5 text-[13px] leading-relaxed shadow-none placeholder:text-muted-foreground/50 focus-visible:ring-0 [field-sizing:content]"
               onChange={(event) => onChange(event.target.value)}
               onKeyDown={handleKeyDown}
             />

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -117,6 +117,74 @@ describe("ChatUI", () => {
     });
   });
 
+  it("shows only endpoint-compatible models when chat endpoint is selected", async () => {
+    (fetchModelsModule.fetchAvailableModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { model_group: "ChatModel", mode: "chat" },
+      { model_group: "SpeechModel", mode: "audio_speech" },
+      { model_group: "ImageModel", mode: "image_generation" },
+      { model_group: "ResponsesModel", mode: "responses" },
+      { model_group: "RealtimeModel", mode: "realtime" },
+      { model_group: "NoModeModel" },
+    ]);
+
+    render(
+      <ChatUI
+        accessToken="1234567890"
+        token="1234567890"
+        userRole="user"
+        userID="1234567890"
+        disabledPersonalKeyCreation={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Key")).toBeInTheDocument();
+    });
+
+    await selectComboboxOption("Select an endpoint", "/v1/chat/completions");
+    await openComboboxByPlaceholder("Select a Model");
+
+    await waitFor(() => {
+      expect(screen.getAllByText("ChatModel").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("NoModeModel").length).toBeGreaterThan(0);
+      expect(screen.queryByText("SpeechModel")).toBeNull();
+      expect(screen.queryByText("ImageModel")).toBeNull();
+      expect(screen.queryByText("ResponsesModel")).toBeNull();
+      expect(screen.queryByText("RealtimeModel")).toBeNull();
+    });
+  });
+
+  it("shows only realtime models when realtime endpoint is selected", async () => {
+    (fetchModelsModule.fetchAvailableModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { model_group: "ChatModel", mode: "chat" },
+      { model_group: "RealtimeModel", mode: "realtime" },
+      { model_group: "NoModeModel" },
+    ]);
+
+    render(
+      <ChatUI
+        accessToken="1234567890"
+        token="1234567890"
+        userRole="user"
+        userID="1234567890"
+        disabledPersonalKeyCreation={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Key")).toBeInTheDocument();
+    });
+
+    await selectComboboxOption("Select an endpoint", "/v1/realtime");
+    await openComboboxByPlaceholder("Select a Model");
+
+    await waitFor(() => {
+      expect(screen.getAllByText("RealtimeModel").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("NoModeModel").length).toBeGreaterThan(0);
+      expect(screen.queryByText("ChatModel")).toBeNull();
+    });
+  });
+
   it("should show 'Enter custom model' option in model selector", async () => {
     render(
       <ChatUI

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -181,6 +181,9 @@ const ChatUI: React.FC<ChatUIProps> = ({
     return disabledPersonalKeyCreation ? "custom" : "session";
   });
   const [apiKey, setApiKey] = useState<string>(() => getSecureItem("apiKey") || "");
+  const [debouncedCustomApiKey, setDebouncedCustomApiKey] = useState<string>(() =>
+    (getSecureItem("apiKey") || "").trim(),
+  );
   const [customProxyBaseUrl, setCustomProxyBaseUrl] = useState<string>(
     () => sessionStorage.getItem("customProxyBaseUrl") || "",
   );
@@ -401,10 +404,21 @@ const ChatUI: React.FC<ChatUIProps> = ({
   ]);
 
   useEffect(() => {
-    const userApiKey = apiKeySource === "session" ? accessToken : apiKey.trim();
+    if (apiKeySource === "session") {
+      return;
+    }
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedCustomApiKey(apiKey.trim());
+    }, 300);
+    return () => window.clearTimeout(timeoutId);
+  }, [apiKey, apiKeySource]);
+
+  useEffect(() => {
+    const userApiKey = apiKeySource === "session" ? accessToken : debouncedCustomApiKey;
     if (!userApiKey) {
       setModelInfo([]);
       setModelLoadError(false);
+      setIsLoadingModels(false);
       return;
     }
 
@@ -442,12 +456,12 @@ const ChatUI: React.FC<ChatUIProps> = ({
     if (!simplified) {
       void loadModels();
     }
-    void loadMCPServers();
+    void loadMCPServers(userApiKey);
 
     return () => {
       cancelled = true;
     };
-  }, [accessToken, apiKeySource, apiKey, simplified]);
+  }, [accessToken, apiKeySource, debouncedCustomApiKey, simplified]);
 
   // Load tools when MCP direct mode has a server (or toolset) selected
   useEffect(() => {
@@ -1199,15 +1213,30 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     </SelectContent>
                   </ShadcnSelect>
                   {apiKeySource === "custom" && (
-                    <div className="relative mt-2">
-                      <Key className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        className="h-8 pl-8"
-                        placeholder="Enter custom Virtual Key"
-                        type="password"
-                        onChange={(event) => setApiKey(event.target.value)}
-                        value={apiKey}
-                      />
+                    <div className="mt-2 space-y-1">
+                      <div className="relative">
+                        <Key className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                        <Input
+                          className="h-8 pl-8"
+                          placeholder="Enter custom Virtual Key"
+                          type="password"
+                          autoComplete="off"
+                          spellCheck={false}
+                          onChange={(event) => setApiKey(event.target.value)}
+                          onBlur={() => setDebouncedCustomApiKey(apiKey.trim())}
+                          value={apiKey}
+                          aria-label="Virtual Key"
+                        />
+                      </div>
+                      {isLoadingModels && apiKey.trim() !== "" && (
+                        <p className="text-xs text-muted-foreground">Loading models for this key...</p>
+                      )}
+                      {!isLoadingModels && apiKey.trim() !== "" && modelLoadError && (
+                        <p className="text-xs text-destructive">Unable to load models for this Virtual Key.</p>
+                      )}
+                      {!isLoadingModels && apiKey.trim() !== "" && !modelLoadError && modelInfo.length === 0 && (
+                        <p className="text-xs text-muted-foreground">No models available for this Virtual Key.</p>
+                      )}
                     </div>
                   )}
                 </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -2087,7 +2087,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
               <p className="mb-1 text-sm font-medium text-gray-700">SDK Type</p>
               <ShadcnSelect value={selectedSdk} onValueChange={(value) => setSelectedSdk(value as "openai" | "azure")}>
                 <SelectTrigger className="w-[150px]" size="sm" aria-label="SDK Type">
-                  <SelectValue />
+                  <SelectValue>{selectedSdk === "azure" ? "Azure SDK" : "OpenAI SDK"}</SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="openai">OpenAI SDK</SelectItem>

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -857,7 +857,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
 
           const requestProxyBaseUrl =
             simplified && proxySettings
-              ? proxySettings.LITELLM_UI_API_DOC_BASE_URL ?? proxySettings.PROXY_BASE_URL ?? undefined
+              ? (proxySettings.LITELLM_UI_API_DOC_BASE_URL ?? proxySettings.PROXY_BASE_URL ?? undefined)
               : customProxyBaseUrl || undefined;
           await makeOpenAIChatCompletionRequest(
             apiChatHistory,
@@ -1205,7 +1205,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     }}
                   >
                     <SelectTrigger className="w-full" size="sm" aria-label="Virtual Key Source">
-                      <SelectValue />
+                      <SelectValue>{apiKeySource === "custom" ? "Virtual Key" : "Current UI Session"}</SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="session">Current UI Session</SelectItem>
@@ -1331,7 +1331,10 @@ const ChatUI: React.FC<ChatUIProps> = ({
                         }}
                       >
                         <SelectTrigger className="w-full" size="sm" aria-label="Voice">
-                          <SelectValue />
+                          <SelectValue>
+                            {OPEN_AI_VOICE_SELECT_OPTIONS.find((voice) => voice.value === selectedVoice)?.label ??
+                              selectedVoice}
+                          </SelectValue>
                         </SelectTrigger>
                         <SelectContent>
                           {OPEN_AI_VOICE_SELECT_OPTIONS.map((voice) => (

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -455,7 +455,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
     if (!simplified) {
       void loadModels();
     }
-    void loadMCPServers(userApiKey);
+    void loadMCPServers();
 
     return () => {
       cancelled = true;
@@ -794,7 +794,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
       return;
     }
 
-    const effectiveApiKey = simplified ? accessToken : apiKeySource === "session" ? accessToken : apiKey;
+    const effectiveApiKey =
+      simplified || apiKeySource === "session" ? accessToken : debouncedCustomApiKey || apiKey.trim();
 
     if (!effectiveApiKey) {
       NotificationsManager.fromBackend("Please provide a Virtual Key or select Current UI Session");

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  ArrowUp,
   Bot,
   Code2,
   Database,
@@ -47,6 +46,7 @@ import { makeOpenAIResponsesRequest } from "@/components/llm_calls/responses_api
 import { makeInteractionsRequest } from "../../llm_calls/interactions_api";
 import AdditionalModelSettings from "./AdditionalModelSettings";
 import { OPEN_AI_VOICE_SELECT_OPTIONS, OpenAIVoice } from "./chatConstants";
+import ChatComposer, { CodeInterpreterToggle } from "./ChatComposer";
 import ChatImageUpload from "./ChatImageUpload";
 import { createChatDisplayMessage, createChatMultimodalMessage } from "./ChatImageUtils";
 import CodeInterpreterTool from "./CodeInterpreterTool";
@@ -72,7 +72,6 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Select as ShadcnSelect, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useDebouncedCallback } from "@tanstack/react-pacer/debouncer";
 import {
@@ -504,14 +503,6 @@ const ChatUI: React.FC<ChatUIProps> = ({
       }, 100);
     }
   }, [chatHistory]);
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === "Enter" && !event.shiftKey) {
-      event.preventDefault(); // Prevent default to avoid newline
-      handleSendMessage();
-    }
-    // If Shift+Enter is pressed, the default behavior (inserting a newline) will occur
-  };
 
   const handleCancelRequest = () => {
     if (abortControllerRef.current) {
@@ -1975,27 +1966,24 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     </div>
                   )}
 
-                  {chatHistory.length === 0 && !isLoading && endpointType !== EndpointType.MCP && (
-                    <div className="mb-3 flex items-center gap-2 overflow-x-auto">
-                      {(endpointType === EndpointType.A2A_AGENTS
+                  <ChatComposer
+                    value={inputMessage}
+                    onChange={setInputMessage}
+                    onSubmit={handleSendMessage}
+                    onCancel={handleCancelRequest}
+                    placeholder={inputPlaceholder}
+                    disabled={isLoading}
+                    isLoading={isLoading}
+                    submitDisabled={sendDisabled}
+                    showSuggestions={chatHistory.length === 0 && !isLoading && endpointType !== EndpointType.MCP}
+                    suggestions={
+                      endpointType === EndpointType.A2A_AGENTS
                         ? ["What can you help me with?", "Tell me about yourself", "What tasks can you perform?"]
                         : ["Write me a poem", "Explain quantum computing", "Draft a polite email requesting a meeting"]
-                      ).map((prompt) => (
-                        <button
-                          key={prompt}
-                          type="button"
-                          className="shrink-0 cursor-pointer rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-600"
-                          onClick={() => setInputMessage(prompt)} // lgtm[js/xss-through-dom]
-                        >
-                          {prompt}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-
-                  <div className="flex items-center gap-2">
-                    <div className="flex min-h-[44px] flex-1 items-center rounded-xl border border-gray-300 bg-white px-3 py-1">
-                      <div className="mr-2 flex shrink-0 items-center gap-1">
+                    }
+                    onSuggestionSelect={setInputMessage}
+                    tools={
+                      <>
                         {endpointType === EndpointType.RESPONSES && !responsesUploadedImage && (
                           <ResponsesImageUpload
                             responsesUploadedImage={responsesUploadedImage}
@@ -2013,47 +2001,24 @@ const ChatUI: React.FC<ChatUIProps> = ({
                           />
                         )}
                         {endpointType === EndpointType.RESPONSES && (
-                          <Tooltip>
-                            <TooltipTrigger
-                              render={
-                                <button
-                                  type="button"
-                                  className={`rounded-md p-1.5 transition-colors ${
-                                    codeInterpreter.enabled
-                                      ? "bg-blue-100 text-blue-600"
-                                      : "text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-                                  }`}
-                                  aria-label={
-                                    codeInterpreter.enabled
-                                      ? "Code Interpreter enabled (click to disable)"
-                                      : "Enable Code Interpreter"
-                                  }
-                                  onClick={() => {
-                                    codeInterpreter.toggle();
-                                    if (!codeInterpreter.enabled) {
-                                      NotificationsManager.success("Code Interpreter enabled!");
-                                    }
-                                  }}
-                                />
+                          <CodeInterpreterToggle
+                            enabled={codeInterpreter.enabled}
+                            onToggle={() => {
+                              codeInterpreter.toggle();
+                              if (!codeInterpreter.enabled) {
+                                NotificationsManager.success("Code Interpreter enabled!");
                               }
-                            >
-                              <Code2 className="size-4" />
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              {codeInterpreter.enabled
-                                ? "Code Interpreter enabled (click to disable)"
-                                : "Enable Code Interpreter"}
-                            </TooltipContent>
-                          </Tooltip>
+                            }}
+                          />
                         )}
-                      </div>
-
-                      {endpointType === EndpointType.MCP &&
+                      </>
+                    }
+                    body={
+                      endpointType === EndpointType.MCP &&
                       selectedMCPServers.length === 1 &&
                       selectedMCPServers[0] !== "__all__" &&
-                      selectedMCPDirectTool ? (
-                        <div className="max-h-48 min-h-[44px] flex-1 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50/50 p-2">
-                          {(() => {
+                      selectedMCPDirectTool
+                        ? (() => {
                             const rawSel = selectedMCPServers[0];
                             let toolPool: MCPTool[] = [];
                             if (rawSel.startsWith("toolset:")) {
@@ -2076,45 +2041,10 @@ const ChatUI: React.FC<ChatUIProps> = ({
                                 Loading tool schema...
                               </div>
                             );
-                          })()}
-                        </div>
-                      ) : (
-                        <Textarea
-                          value={inputMessage}
-                          onChange={(event) => setInputMessage(event.target.value)}
-                          onKeyDown={handleKeyDown}
-                          placeholder={inputPlaceholder}
-                          disabled={isLoading}
-                          rows={1}
-                          className="min-h-0 flex-1 resize-none border-0 bg-transparent px-0 py-1 text-sm shadow-none focus-visible:ring-0"
-                        />
-                      )}
-
-                      <Button
-                        type="button"
-                        size="icon-sm"
-                        onClick={handleSendMessage}
-                        disabled={sendDisabled}
-                        className="ml-2 size-8 shrink-0 rounded-full bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 disabled:text-gray-500"
-                        aria-label="Send message"
-                      >
-                        <ArrowUp className="size-3.5" />
-                      </Button>
-                    </div>
-
-                    {isLoading && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="border-red-200 bg-red-50 text-red-600 hover:bg-red-100"
-                        onClick={handleCancelRequest}
-                      >
-                        <Trash2 className="size-3.5" />
-                        Cancel
-                      </Button>
-                    )}
-                  </div>
+                          })()
+                        : undefined
+                    }
+                  />
                 </div>
               </>
             )}

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -456,7 +456,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
     if (!simplified) {
       void loadModels();
     }
-    void loadMCPServers(userApiKey);
+    void loadMCPServers();
 
     return () => {
       cancelled = true;
@@ -764,7 +764,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
       return;
     }
 
-    const effectiveApiKey = simplified ? accessToken : apiKeySource === "session" ? accessToken : apiKey;
+    const effectiveApiKey =
+      simplified || apiKeySource === "session" ? accessToken : debouncedCustomApiKey || apiKey.trim();
 
     if (!effectiveApiKey) {
       NotificationsManager.fromBackend("Please provide a Virtual Key or select Current UI Session");

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -2094,7 +2094,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
               <p className="mb-1 text-sm font-medium text-gray-700">SDK Type</p>
               <ShadcnSelect value={selectedSdk} onValueChange={(value) => setSelectedSdk(value as "openai" | "azure")}>
                 <SelectTrigger className="w-[150px]" size="sm" aria-label="SDK Type">
-                  <SelectValue />
+                  <SelectValue>{selectedSdk === "azure" ? "Azure SDK" : "OpenAI SDK"}</SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="openai">OpenAI SDK</SelectItem>

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -181,6 +181,9 @@ const ChatUI: React.FC<ChatUIProps> = ({
     return disabledPersonalKeyCreation ? "custom" : "session";
   });
   const [apiKey, setApiKey] = useState<string>(() => getSecureItem("apiKey") || "");
+  const [debouncedCustomApiKey, setDebouncedCustomApiKey] = useState<string>(() =>
+    (getSecureItem("apiKey") || "").trim(),
+  );
   const [customProxyBaseUrl, setCustomProxyBaseUrl] = useState<string>(
     () => sessionStorage.getItem("customProxyBaseUrl") || "",
   );
@@ -401,10 +404,21 @@ const ChatUI: React.FC<ChatUIProps> = ({
   ]);
 
   useEffect(() => {
-    const userApiKey = apiKeySource === "session" ? accessToken : apiKey.trim();
+    if (apiKeySource === "session") {
+      return;
+    }
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedCustomApiKey(apiKey.trim());
+    }, 300);
+    return () => window.clearTimeout(timeoutId);
+  }, [apiKey, apiKeySource]);
+
+  useEffect(() => {
+    const userApiKey = apiKeySource === "session" ? accessToken : debouncedCustomApiKey;
     if (!userApiKey) {
       setModelInfo([]);
       setModelLoadError(false);
+      setIsLoadingModels(false);
       return;
     }
 
@@ -441,12 +455,12 @@ const ChatUI: React.FC<ChatUIProps> = ({
     if (!simplified) {
       void loadModels();
     }
-    void loadMCPServers();
+    void loadMCPServers(userApiKey);
 
     return () => {
       cancelled = true;
     };
-  }, [accessToken, apiKeySource, apiKey, simplified]);
+  }, [accessToken, apiKeySource, debouncedCustomApiKey, simplified]);
 
   // Load tools when MCP direct mode has a server (or toolset) selected
   useEffect(() => {
@@ -1229,15 +1243,30 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     </SelectContent>
                   </ShadcnSelect>
                   {apiKeySource === "custom" && (
-                    <div className="relative mt-2">
-                      <Key className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        className="h-8 pl-8"
-                        placeholder="Enter custom Virtual Key"
-                        type="password"
-                        onChange={(event) => setApiKey(event.target.value)}
-                        value={apiKey}
-                      />
+                    <div className="mt-2 space-y-1">
+                      <div className="relative">
+                        <Key className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                        <Input
+                          className="h-8 pl-8"
+                          placeholder="Enter custom Virtual Key"
+                          type="password"
+                          autoComplete="off"
+                          spellCheck={false}
+                          onChange={(event) => setApiKey(event.target.value)}
+                          onBlur={() => setDebouncedCustomApiKey(apiKey.trim())}
+                          value={apiKey}
+                          aria-label="Virtual Key"
+                        />
+                      </div>
+                      {isLoadingModels && apiKey.trim() !== "" && (
+                        <p className="text-xs text-muted-foreground">Loading models for this key...</p>
+                      )}
+                      {!isLoadingModels && apiKey.trim() !== "" && modelLoadError && (
+                        <p className="text-xs text-destructive">Unable to load models for this Virtual Key.</p>
+                      )}
+                      {!isLoadingModels && apiKey.trim() !== "" && !modelLoadError && modelInfo.length === 0 && (
+                        <p className="text-xs text-muted-foreground">No models available for this Virtual Key.</p>
+                      )}
                     </div>
                   )}
                 </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -52,6 +52,7 @@ import { createChatDisplayMessage, createChatMultimodalMessage } from "./ChatIma
 import CodeInterpreterTool from "./CodeInterpreterTool";
 import { generateCodeSnippet } from "@/components/chat_ui/CodeSnippets";
 import EndpointSelector from "./EndpointSelector";
+import { filterModelsForEndpoint } from "./EndpointUtils";
 import FilePreviewCard from "./FilePreviewCard";
 import ChatMessageBubble from "./ChatMessageBubble";
 import MCPEventsDisplay from "@/components/chat_ui/MCPEventsDisplay";
@@ -1171,11 +1172,17 @@ const ChatUI: React.FC<ChatUIProps> = ({
   };
 
   const supportsStreamingToggle = endpointType === EndpointType.CHAT || endpointType === EndpointType.RESPONSES;
+  const modelsForEndpoint = useMemo(
+    () => filterModelsForEndpoint(modelInfo, endpointType as EndpointType),
+    [modelInfo, endpointType],
+  );
   let modelEmptyText = "No models available for this key";
   if (modelLoadError) {
     modelEmptyText = "Unable to load models for this key";
   } else if (apiKeySource === "custom" && !apiKey.trim()) {
     modelEmptyText = "Enter a Virtual Key to load models";
+  } else if (modelInfo.length > 0 && modelsForEndpoint.length === 0) {
+    modelEmptyText = "No models available for this endpoint";
   }
 
   const inputPlaceholder =
@@ -1405,7 +1412,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                       onValueChange={onModelChange}
                       options={[
                         { value: "custom", label: "Enter custom model" },
-                        ...modelInfo.map((model) => ({
+                        ...modelsForEndpoint.map((model) => ({
                           value: model.model_group,
                           label: model.model_group,
                           sublabel: model.mode ? `Mode: ${model.mode}` : undefined,

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -887,7 +887,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
 
           const requestProxyBaseUrl =
             simplified && proxySettings
-              ? proxySettings.LITELLM_UI_API_DOC_BASE_URL ?? proxySettings.PROXY_BASE_URL ?? undefined
+              ? (proxySettings.LITELLM_UI_API_DOC_BASE_URL ?? proxySettings.PROXY_BASE_URL ?? undefined)
               : customProxyBaseUrl || undefined;
           await makeOpenAIChatCompletionRequest(
             apiChatHistory,
@@ -1235,7 +1235,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     }}
                   >
                     <SelectTrigger className="w-full" size="sm" aria-label="Virtual Key Source">
-                      <SelectValue />
+                      <SelectValue>{apiKeySource === "custom" ? "Virtual Key" : "Current UI Session"}</SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="session">Current UI Session</SelectItem>
@@ -1342,7 +1342,10 @@ const ChatUI: React.FC<ChatUIProps> = ({
                       </label>
                       <ShadcnSelect value={selectedVoice} onValueChange={handleVoiceChange}>
                         <SelectTrigger className="w-full" size="sm" aria-label="Voice">
-                          <SelectValue />
+                          <SelectValue>
+                            {OPEN_AI_VOICE_SELECT_OPTIONS.find((voice) => voice.value === selectedVoice)?.label ??
+                              selectedVoice}
+                          </SelectValue>
                         </SelectTrigger>
                         <SelectContent>
                           {OPEN_AI_VOICE_SELECT_OPTIONS.map((voice) => (

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.test.tsx
@@ -246,4 +246,12 @@ describe("isModelCompatibleWithEndpoint / filterModelsForEndpoint", () => {
       "no-mode",
     ]);
   });
+
+  it("excludes unknown modes from conversational endpoints", () => {
+    const batchModel: ModelGroup = { model_group: "batch-job", mode: "batch" };
+    const rerankModel: ModelGroup = { model_group: "reranker", mode: "rerank" };
+    expect(isModelCompatibleWithEndpoint(batchModel, EndpointType.CHAT)).toBe(false);
+    expect(isModelCompatibleWithEndpoint(rerankModel, EndpointType.RESPONSES)).toBe(false);
+    expect(isModelCompatibleWithEndpoint(batchModel, EndpointType.REALTIME)).toBe(false);
+  });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.test.tsx
@@ -1,37 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelGroup } from "@/components/llm_calls/fetch_models";
-import { determineEndpointType } from "./EndpointUtils";
+import { determineEndpointType, filterModelsForEndpoint, isModelCompatibleWithEndpoint } from "./EndpointUtils";
 import { EndpointType } from "@/components/chat_ui/mode_endpoint_mapping";
 
-// Mock the getEndpointType function
-vi.mock("@/components/chat_ui/mode_endpoint_mapping", () => ({
-  EndpointType: {
-    IMAGE: "image",
-    VIDEO: "video",
-    CHAT: "chat",
-    RESPONSES: "responses",
-    IMAGE_EDITS: "image_edits",
-    ANTHROPIC_MESSAGES: "anthropic_messages",
-    EMBEDDINGS: "embeddings",
-    SPEECH: "speech",
-    TRANSCRIPTION: "transcription",
-    A2A_AGENTS: "a2a_agents",
-  },
-  getEndpointType: vi.fn(),
-  ModelMode: {
-    AUDIO_SPEECH: "audio_speech",
-    AUDIO_TRANSCRIPTION: "audio_transcription",
-    IMAGE_GENERATION: "image_generation",
-    VIDEO_GENERATION: "video_generation",
-    CHAT: "chat",
-    RESPONSES: "responses",
-    IMAGE_EDITS: "image_edits",
-    ANTHROPIC_MESSAGES: "anthropic_messages",
-    EMBEDDING: "embedding",
-  },
-}));
+vi.mock("@/components/chat_ui/mode_endpoint_mapping", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/chat_ui/mode_endpoint_mapping")>();
+  return {
+    ...actual,
+    getEndpointType: vi.fn(actual.getEndpointType),
+  };
+});
 
-// Import the mocked function
 import { getEndpointType } from "@/components/chat_ui/mode_endpoint_mapping";
 
 describe("determineEndpointType", () => {
@@ -210,10 +189,61 @@ describe("determineEndpointType", () => {
 
     vi.mocked(getEndpointType).mockReturnValue(EndpointType.CHAT);
 
-    // Test with different case - should not match
     const result = determineEndpointType("gpt-3.5-turbo", mockModelInfo);
 
     expect(getEndpointType).not.toHaveBeenCalled();
     expect(result).toBe(EndpointType.CHAT);
+  });
+});
+
+describe("isModelCompatibleWithEndpoint / filterModelsForEndpoint", () => {
+  beforeEach(() => {
+    vi.mocked(getEndpointType).mockImplementation((mode: string) => {
+      const map: Record<string, EndpointType> = {
+        chat: EndpointType.CHAT,
+        responses: EndpointType.RESPONSES,
+        image_generation: EndpointType.IMAGE,
+        image_edits: EndpointType.IMAGE_EDITS,
+        audio_speech: EndpointType.SPEECH,
+        realtime: EndpointType.REALTIME,
+        embedding: EndpointType.EMBEDDINGS,
+      };
+      return map[mode] ?? EndpointType.CHAT;
+    });
+  });
+
+  it("keeps models with no mode for every endpoint", () => {
+    const model: ModelGroup = { model_group: "custom-proxy-model" };
+    expect(isModelCompatibleWithEndpoint(model, EndpointType.CHAT)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(model, EndpointType.REALTIME)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(model, EndpointType.SPEECH)).toBe(true);
+  });
+
+  it("keeps chat models for responses, anthropic messages, and interactions", () => {
+    const chatModel: ModelGroup = { model_group: "gpt-4o", mode: "chat" };
+    expect(isModelCompatibleWithEndpoint(chatModel, EndpointType.RESPONSES)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(chatModel, EndpointType.ANTHROPIC_MESSAGES)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(chatModel, EndpointType.INTERACTIONS)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(chatModel, EndpointType.SPEECH)).toBe(false);
+  });
+
+  it("keeps image models for image_edits", () => {
+    const imageModel: ModelGroup = { model_group: "dall-e-3", mode: "image_generation" };
+    expect(isModelCompatibleWithEndpoint(imageModel, EndpointType.IMAGE_EDITS)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(imageModel, EndpointType.IMAGE)).toBe(true);
+    expect(isModelCompatibleWithEndpoint(imageModel, EndpointType.CHAT)).toBe(false);
+  });
+
+  it("keeps only realtime models for the realtime endpoint", () => {
+    const models: ModelGroup[] = [
+      { model_group: "gpt-4o", mode: "chat" },
+      { model_group: "gpt-realtime", mode: "realtime" },
+      { model_group: "no-mode" },
+    ];
+
+    expect(filterModelsForEndpoint(models, EndpointType.REALTIME).map((m) => m.model_group)).toEqual([
+      "gpt-realtime",
+      "no-mode",
+    ]);
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.tsx
@@ -1,5 +1,7 @@
 import { ModelGroup } from "@/components/llm_calls/fetch_models";
-import { EndpointType, getEndpointType } from "@/components/chat_ui/mode_endpoint_mapping";
+import { EndpointType, getEndpointType, ModelMode } from "@/components/chat_ui/mode_endpoint_mapping";
+
+const KNOWN_MODEL_MODES = new Set<string>(Object.values(ModelMode));
 
 export const determineEndpointType = (selectedModel: string, modelInfo: ModelGroup[]): EndpointType => {
   const selectedModelInfo = modelInfo.find((option) => option.model_group === selectedModel);
@@ -14,6 +16,10 @@ export const determineEndpointType = (selectedModel: string, modelInfo: ModelGro
 export const isModelCompatibleWithEndpoint = (model: ModelGroup, endpointType: EndpointType): boolean => {
   if (!model.mode) {
     return true;
+  }
+
+  if (!KNOWN_MODEL_MODES.has(model.mode)) {
+    return false;
   }
 
   const optionEndpoint = getEndpointType(model.mode);

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.tsx
@@ -1,22 +1,37 @@
 import { ModelGroup } from "@/components/llm_calls/fetch_models";
 import { EndpointType, getEndpointType } from "@/components/chat_ui/mode_endpoint_mapping";
 
-/**
- * Determines the appropriate endpoint type based on the selected model
- *
- * @param selectedModel - The model identifier string
- * @param modelInfo - Array of model information
- * @returns The appropriate endpoint type
- */
 export const determineEndpointType = (selectedModel: string, modelInfo: ModelGroup[]): EndpointType => {
-  // Find the model information for the selected model
   const selectedModelInfo = modelInfo.find((option) => option.model_group === selectedModel);
 
-  // If model info is found and it has a mode, determine the endpoint type
   if (selectedModelInfo?.mode) {
     return getEndpointType(selectedModelInfo.mode);
   }
 
-  // Default to chat endpoint if no match is found
   return EndpointType.CHAT;
 };
+
+export const isModelCompatibleWithEndpoint = (model: ModelGroup, endpointType: EndpointType): boolean => {
+  if (!model.mode) {
+    return true;
+  }
+
+  const optionEndpoint = getEndpointType(model.mode);
+
+  if (
+    endpointType === EndpointType.RESPONSES ||
+    endpointType === EndpointType.ANTHROPIC_MESSAGES ||
+    endpointType === EndpointType.INTERACTIONS
+  ) {
+    return optionEndpoint === endpointType || optionEndpoint === EndpointType.CHAT;
+  }
+
+  if (endpointType === EndpointType.IMAGE_EDITS) {
+    return optionEndpoint === endpointType || optionEndpoint === EndpointType.IMAGE;
+  }
+
+  return optionEndpoint === endpointType;
+};
+
+export const filterModelsForEndpoint = (models: ModelGroup[], endpointType: EndpointType): ModelGroup[] =>
+  models.filter((model) => isModelCompatibleWithEndpoint(model, endpointType));

--- a/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.tsx
@@ -11,7 +11,7 @@ export enum ModelMode {
   IMAGE_EDITS = "image_edits",
   ANTHROPIC_MESSAGES = "anthropic_messages",
   EMBEDDING = "embedding",
-  // add additional modes as needed
+  REALTIME = "realtime",
 }
 
 // Define an enum for the endpoint types your UI calls
@@ -42,6 +42,7 @@ export const litellmModeMapping: Record<ModelMode, EndpointType> = {
   [ModelMode.AUDIO_SPEECH]: EndpointType.SPEECH,
   [ModelMode.AUDIO_TRANSCRIPTION]: EndpointType.TRANSCRIPTION,
   [ModelMode.EMBEDDING]: EndpointType.EMBEDDINGS,
+  [ModelMode.REALTIME]: EndpointType.REALTIME,
 };
 
 export const getEndpointType = (mode: string): EndpointType => {

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.test.ts
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchAvailableModels } from "./fetch_models";
+
+vi.mock("@/components/networking", () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from "@/components/networking";
+
+const mockGet = vi.mocked(apiClient.get);
+
+describe("fetchAvailableModels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns key-scoped models from /v1/models and attaches modes from model_group/info", async () => {
+    mockGet.mockImplementation(async (path: string) => {
+      if (path === "/model_group/info") {
+        return {
+          data: [
+            { model_group: "anthropic-haiku-4-5", mode: "chat" },
+            { model_group: "gpt-realtime", mode: "realtime" },
+          ],
+        };
+      }
+      if (path === "/v1/models") {
+        return {
+          data: [{ id: "anthropic-haiku-4-5" }],
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const models = await fetchAvailableModels("sk-virtual-key");
+
+    expect(models).toEqual([{ model_group: "anthropic-haiku-4-5", mode: "chat" }]);
+    expect(mockGet).toHaveBeenCalledWith("/v1/models", { accessToken: "sk-virtual-key" });
+  });
+
+  it("falls back to model_group/info when /v1/models is empty", async () => {
+    mockGet.mockImplementation(async (path: string) => {
+      if (path === "/model_group/info") {
+        return {
+          data: [
+            { model_group: "gpt-4o", mode: "chat" },
+            { id: "legacy-model", mode: "chat" },
+          ],
+        };
+      }
+      if (path === "/v1/models") {
+        return { data: [] };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const models = await fetchAvailableModels("sk-admin");
+    expect(models.map((m) => m.model_group)).toEqual(["gpt-4o", "legacy-model"]);
+  });
+
+  it("still returns /v1/models when model_group/info fails", async () => {
+    mockGet.mockImplementation(async (path: string) => {
+      if (path === "/model_group/info") {
+        throw new Error("forbidden");
+      }
+      if (path === "/v1/models") {
+        return { data: [{ id: "only-from-key" }] };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const models = await fetchAvailableModels("sk-virtual-key");
+    expect(models).toEqual([{ model_group: "only-from-key", mode: undefined }]);
+  });
+});

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.test.ts
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.test.ts
@@ -74,4 +74,12 @@ describe("fetchAvailableModels", () => {
     const models = await fetchAvailableModels("sk-virtual-key");
     expect(models).toEqual([{ model_group: "only-from-key", mode: undefined }]);
   });
+
+  it("throws when both model endpoints fail", async () => {
+    mockGet.mockImplementation(async () => {
+      throw new Error("network down");
+    });
+
+    await expect(fetchAvailableModels("sk-virtual-key")).rejects.toThrow("network down");
+  });
 });

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
@@ -25,15 +25,10 @@ const dedupeAndSort = (models: ModelGroup[]): ModelGroup[] => {
   return unique;
 };
 
-/**
- * Loads models available to the given key.
- *
- * Prefers OpenAI-compatible `/v1/models` (scoped to the key's access) and enriches
- * entries with `mode` from `/model_group/info` when that endpoint is available.
- * Falls back to `/model_group/info` alone if `/v1/models` is empty or fails.
- */
 export const fetchAvailableModels = async (accessToken: string): Promise<ModelGroup[]> => {
   const modeByName = new Map<string, string | undefined>();
+  let groupInfoError: unknown;
+  let listModelsError: unknown;
 
   try {
     const groupInfo = await apiClient.get<{ data?: ModelGroupInfoItem[] }>("/model_group/info", {
@@ -46,6 +41,7 @@ export const fetchAvailableModels = async (accessToken: string): Promise<ModelGr
       }
     }
   } catch (error) {
+    groupInfoError = error;
     console.error("Error fetching model group info:", error);
   }
 
@@ -70,6 +66,7 @@ export const fetchAvailableModels = async (accessToken: string): Promise<ModelGr
       return dedupeAndSort(fromList);
     }
   } catch (error) {
+    listModelsError = error;
     console.error("Error fetching /v1/models:", error);
   }
 
@@ -80,6 +77,12 @@ export const fetchAvailableModels = async (accessToken: string): Promise<ModelGr
         mode,
       })),
     );
+  }
+
+  if (groupInfoError && listModelsError) {
+    throw listModelsError instanceof Error
+      ? listModelsError
+      : new Error("Failed to load models from /v1/models and /model_group/info");
   }
 
   return [];

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
@@ -1,40 +1,86 @@
-// fetch_models.ts
-
-import { modelHubCall } from "@/components/networking";
+import { apiClient } from "@/components/networking";
 
 export interface ModelGroup {
   model_group: string;
   mode?: string;
 }
 
-interface AvailableModel {
+interface ModelGroupInfoItem {
   model_group?: string | null;
   model_name?: string | null;
   id?: string | null;
   mode?: string | null;
 }
 
+interface OpenAIModelItem {
+  id?: string | null;
+}
+
+const modelNameFromGroupItem = (item: ModelGroupInfoItem): string =>
+  (item.model_group || item.id || item.model_name || "").trim();
+
+const dedupeAndSort = (models: ModelGroup[]): ModelGroup[] => {
+  const unique = Array.from(new Map(models.map((model) => [model.model_group, model])).values());
+  unique.sort((a, b) => a.model_group.localeCompare(b.model_group));
+  return unique;
+};
+
 /**
- * Fetches available models using modelHubCall and formats them for the selection dropdown.
+ * Loads models available to the given key.
+ *
+ * Prefers OpenAI-compatible `/v1/models` (scoped to the key's access) and enriches
+ * entries with `mode` from `/model_group/info` when that endpoint is available.
+ * Falls back to `/model_group/info` alone if `/v1/models` is empty or fails.
  */
 export const fetchAvailableModels = async (accessToken: string): Promise<ModelGroup[]> => {
+  const modeByName = new Map<string, string | undefined>();
+
   try {
-    const fetchedModels = await modelHubCall(accessToken);
-
-    if (fetchedModels?.data.length > 0) {
-      const models: ModelGroup[] = fetchedModels.data
-        .map((item: AvailableModel) => ({
-          model_group: item.model_group || item.id || item.model_name || "",
-          mode: item.mode || undefined,
-        }))
-        .filter((model: ModelGroup) => model.model_group !== "");
-
-      models.sort((a, b) => a.model_group.localeCompare(b.model_group));
-      return Array.from(new Map(models.map((model) => [model.model_group, model])).values());
+    const groupInfo = await apiClient.get<{ data?: ModelGroupInfoItem[] }>("/model_group/info", {
+      accessToken,
+    });
+    for (const item of groupInfo?.data ?? []) {
+      const name = modelNameFromGroupItem(item);
+      if (name) {
+        modeByName.set(name, item.mode || undefined);
+      }
     }
-    return [];
   } catch (error) {
-    console.error("Error fetching model info:", error);
-    throw error;
+    console.error("Error fetching model group info:", error);
   }
+
+  try {
+    const listed = await apiClient.get<{ data?: OpenAIModelItem[] }>("/v1/models", {
+      accessToken,
+    });
+    const fromList = (listed?.data ?? [])
+      .map((item) => {
+        const name = (item.id || "").trim();
+        if (!name) {
+          return null;
+        }
+        return {
+          model_group: name,
+          mode: modeByName.get(name),
+        } satisfies ModelGroup;
+      })
+      .filter((model): model is ModelGroup => model != null);
+
+    if (fromList.length > 0) {
+      return dedupeAndSort(fromList);
+    }
+  } catch (error) {
+    console.error("Error fetching /v1/models:", error);
+  }
+
+  if (modeByName.size > 0) {
+    return dedupeAndSort(
+      Array.from(modeByName.entries()).map(([model_group, mode]) => ({
+        model_group,
+        mode,
+      })),
+    );
+  }
+
+  return [];
 };


### PR DESCRIPTION
## TLDR

Problem this solves:

- Virtual keys often showed an empty model list in the playground
- SDK type and key source selects showed raw values like session/custom

How it solves it:

- Loads models for virtual keys via `/v1/models` plus model group info
- Renders human labels for virtual key source and SDK type selects

## Stack

PR 4/6. Base: `litellm_playground_chat_composer` (PR 3)

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

1. Open playground and choose a virtual key (not Current UI Session)
2. Open the model dropdown and confirm models populate
3. Confirm the key source select shows Virtual Key / Current UI Session labels
4. Confirm SDK type select shows readable labels rather than raw enum values

## Type

🐛 Bug Fix

## Changes

Updates `fetch_models` for virtual-key listing, ChatUI model load path, and SelectValue children for human-readable labels

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR