### PR TITLE
fix(ui): make playground MCP work across tool-capable endpoints

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -19,7 +19,14 @@ vi.mock("@/components/networking", () => ({
   getGuardrailsList: vi.fn().mockResolvedValue({ data: [] }),
   getPoliciesList: vi.fn().mockResolvedValue({ data: [] }),
   modelHubCall: vi.fn().mockResolvedValue({ data: [] }),
-  fetchMCPServers: vi.fn().mockResolvedValue([]),
+  fetchMCPServers: vi.fn().mockResolvedValue([
+    {
+      server_id: "mcp-server-1",
+      server_name: "Demo MCP Server",
+      alias: "Demo MCP Server",
+      description: "A demo MCP server",
+    },
+  ]),
   fetchMCPToolsets: vi.fn().mockResolvedValue([]),
   listMCPTools: vi.fn().mockResolvedValue({ tools: [] }),
   callMCPTool: vi.fn(),
@@ -234,6 +241,11 @@ describe("ChatUI", () => {
 
     await waitFor(() => {
       expect(mcpInput()).not.toBeDisabled();
+    });
+
+    await userEvent.setup().click(mcpInput());
+    await waitFor(() => {
+      expect(screen.getByText("Demo MCP Server")).toBeInTheDocument();
     });
   });
 
@@ -458,7 +470,7 @@ describe("ChatUI", () => {
 
     expect(screen.getByText("MCP Servers")).toBeInTheDocument();
 
-    const mcpInput = screen.getByLabelText("Select MCP servers");
+    const mcpInput = await screen.findByLabelText("Select MCP servers");
     expect(mcpInput).toBeInTheDocument();
     expect(mcpInput).not.toBeDisabled();
 
@@ -466,6 +478,7 @@ describe("ChatUI", () => {
 
     await waitFor(() => {
       expect(screen.getByText("All MCP Servers")).toBeInTheDocument();
+      expect(screen.getByText("Demo MCP Server")).toBeInTheDocument();
     });
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -249,6 +249,30 @@ describe("ChatUI", () => {
     });
   });
 
+  it("should enable the MCP tools selector for interactions", async () => {
+    render(
+      <ChatUI
+        accessToken="1234567890"
+        token="1234567890"
+        userRole="user"
+        userID="1234567890"
+        disabledPersonalKeyCreation={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Key")).toBeInTheDocument();
+    });
+
+    const mcpInput = () => screen.getByLabelText("Select MCP servers");
+
+    await selectComboboxOption("Select an endpoint", "/v1beta/interactions");
+
+    await waitFor(() => {
+      expect(mcpInput()).not.toBeDisabled();
+    });
+  });
+
   it("should show Simulate failure to test fallbacks in Model Settings when chat endpoint is selected", async () => {
     const user = userEvent.setup();
     render(

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -274,21 +274,50 @@ const ChatUI: React.FC<ChatUIProps> = ({
 
   const chatEndRef = useRef<HTMLDivElement>(null);
 
+  const normalizeListResponse = <T,>(payload: unknown): T[] => {
+    if (Array.isArray(payload)) {
+      return payload as T[];
+    }
+    if (payload && typeof payload === "object") {
+      const record = payload as Record<string, unknown>;
+      if (Array.isArray(record.data)) {
+        return record.data as T[];
+      }
+      if (Array.isArray(record.servers)) {
+        return record.servers as T[];
+      }
+      if (Array.isArray(record.toolsets)) {
+        return record.toolsets as T[];
+      }
+    }
+    return [];
+  };
+
   // Fetch MCP servers and toolsets
-  const loadMCPServers = async () => {
-    const userApiKey = apiKeySource === "session" ? accessToken : apiKey;
-    if (!userApiKey) return;
+  const loadMCPServers = async (overrideKey?: string | null) => {
+    const userApiKey =
+      overrideKey !== undefined ? overrideKey : apiKeySource === "session" ? accessToken : apiKey.trim();
+    if (!userApiKey) {
+      setMCPServers([]);
+      setMCPToolsets([]);
+      return;
+    }
 
     setIsLoadingMCPServers(true);
     try {
-      const [servers, toolsets] = await Promise.all([
+      const [serversPayload, toolsetsPayload] = await Promise.all([
         fetchMCPServers(userApiKey),
         fetchMCPToolsets(userApiKey).catch(() => []),
       ]);
-      setMCPServers(Array.isArray(servers) ? servers : servers.data || []);
-      setMCPToolsets(Array.isArray(toolsets) ? toolsets : []);
+      const servers = normalizeListResponse<MCPServer>(serversPayload);
+      const toolsets = normalizeListResponse<MCPToolset>(toolsetsPayload);
+      setMCPServers(servers);
+      setMCPToolsets(toolsets);
     } catch (error) {
       console.error("Error fetching MCP servers:", error);
+      setMCPServers([]);
+      setMCPToolsets([]);
+      NotificationsManager.error("Unable to load MCP servers for this key");
     } finally {
       setIsLoadingMCPServers(false);
     }
@@ -456,7 +485,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
     if (!simplified) {
       void loadModels();
     }
-    void loadMCPServers();
+    void loadMCPServers(userApiKey);
 
     return () => {
       cancelled = true;
@@ -629,17 +658,24 @@ const ChatUI: React.FC<ChatUIProps> = ({
       });
     }
     for (const toolset of mcpToolsets) {
+      if (!toolset?.toolset_id) {
+        continue;
+      }
+      const toolCount = Array.isArray(toolset.tools) ? toolset.tools.length : 0;
       options.push({
         value: `toolset:${toolset.toolset_id}`,
-        label: toolset.toolset_name,
-        description: toolset.description || `Toolset (${toolset.tools.length} tools)`,
+        label: toolset.toolset_name || toolset.toolset_id,
+        description: toolset.description || `Toolset (${toolCount} tools)`,
       });
     }
     for (const server of mcpServers) {
+      if (!server?.server_id) {
+        continue;
+      }
       options.push({
         value: server.server_id,
         label: server.alias || server.server_name || server.server_id,
-        description: server.description,
+        description: server.description || undefined,
       });
     }
     return options;
@@ -858,7 +894,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
 
           const requestProxyBaseUrl =
             simplified && proxySettings
-              ? (proxySettings.LITELLM_UI_API_DOC_BASE_URL ?? proxySettings.PROXY_BASE_URL ?? undefined)
+              ? proxySettings.LITELLM_UI_API_DOC_BASE_URL ?? proxySettings.PROXY_BASE_URL ?? undefined
               : customProxyBaseUrl || undefined;
           await makeOpenAIChatCompletionRequest(
             apiChatHistory,
@@ -1509,23 +1545,45 @@ const ChatUI: React.FC<ChatUIProps> = ({
                           : undefined
                       }
                       placeholder="Select MCP server"
-                      emptyText={isLoadingMCPServers ? "Loading..." : "No MCP servers"}
+                      emptyText={
+                        isLoadingMCPServers
+                          ? "Loading..."
+                          : mcpServerOptions.length === 0
+                            ? "No MCP servers configured"
+                            : "No matching MCP servers"
+                      }
                       disabled={!MCP_SUPPORTED_ENDPOINTS.has(endpointType as EndpointType) || isLoadingMCPServers}
                       onValueChange={(value) => handleMcpServersChange(value ? [value] : [])}
-                      options={mcpServerOptions}
+                      options={mcpServerOptions.map((option) => ({
+                        value: option.value,
+                        label: option.label,
+                        sublabel: option.description,
+                      }))}
                       className="mb-2"
                     />
                   ) : (
-                    <MultiSelect
-                      value={selectedMCPServers}
-                      onValueChange={handleMcpServersChange}
-                      placeholder="Select MCP servers"
-                      emptyText={isLoadingMCPServers ? "Loading..." : "No MCP servers"}
-                      disabled={!MCP_SUPPORTED_ENDPOINTS.has(endpointType as EndpointType)}
-                      loading={isLoadingMCPServers}
-                      options={mcpServerOptions}
-                      className="mb-2"
-                    />
+                    <div className="mb-2 space-y-1">
+                      <MultiSelect
+                        value={selectedMCPServers}
+                        onValueChange={handleMcpServersChange}
+                        placeholder="Select MCP servers"
+                        emptyText={
+                          isLoadingMCPServers
+                            ? "Loading..."
+                            : mcpServers.length === 0
+                              ? "No MCP servers configured"
+                              : "No matching MCP servers"
+                        }
+                        disabled={!MCP_SUPPORTED_ENDPOINTS.has(endpointType as EndpointType)}
+                        loading={isLoadingMCPServers}
+                        options={mcpServerOptions}
+                      />
+                      {!isLoadingMCPServers && mcpServers.length === 0 && (
+                        <p className="text-xs text-muted-foreground">
+                          No MCP servers available for this key. Add servers on the MCP page.
+                        </p>
+                      )}
+                    </div>
                   )}
 
                   {endpointType === EndpointType.MCP &&

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -103,6 +103,7 @@ const MCP_SUPPORTED_ENDPOINTS = new Set<EndpointType>([
   EndpointType.RESPONSES,
   EndpointType.MCP,
   EndpointType.ANTHROPIC_MESSAGES,
+  EndpointType.INTERACTIONS,
 ]);
 
 const CUSTOM_MODEL_DEBOUNCE_WAIT_MS = 500;
@@ -1070,6 +1071,11 @@ const ChatUI: React.FC<ChatUIProps> = ({
             selectedTags,
             signal,
             customProxyBaseUrl || undefined,
+            undefined,
+            selectedMCPServers,
+            mcpServers,
+            mcpServerToolRestrictions,
+            mcpToolsets,
           );
         }
       }

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/interactions_api.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/interactions_api.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeInteractionsRequest } from "./interactions_api";
+import type { MCPServer } from "@/components/mcp_tools/types";
+
+vi.mock("@/components/networking", () => ({
+  getGlobalLitellmHeaderName: vi.fn(() => "Authorization"),
+  getProxyBaseUrl: vi.fn(() => "https://example.com"),
+}));
+
+vi.mock("@/components/molecules/notifications_manager", () => ({
+  default: { fromBackend: vi.fn() },
+}));
+
+describe("makeInteractionsRequest", () => {
+  const mockUpdateUI = vi.fn();
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+        }),
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("forwards MCP tool blocks in the interactions request body", async () => {
+    const selectedMCPServers = ["server-1"];
+    const mcpServers = [
+      {
+        server_id: "server-1",
+        server_name: "deepwiki",
+        alias: "wiki",
+        url: "http://example.com",
+        created_at: "2024-01-01",
+        created_by: "test",
+        updated_at: "2024-01-01",
+        updated_by: "test",
+      },
+    ] as MCPServer[];
+
+    await makeInteractionsRequest(
+      "list tools",
+      mockUpdateUI,
+      "gpt-4o",
+      "test-token",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      selectedMCPServers,
+      mcpServers,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body)) as {
+      model: string;
+      input: string;
+      tools: Array<Record<string, unknown>>;
+    };
+
+    expect(body.model).toBe("gpt-4o");
+    expect(body.input).toBe("list tools");
+    expect(body.tools).toEqual([
+      {
+        type: "mcp",
+        server_label: "deepwiki",
+        server_url: "litellm_proxy/mcp/deepwiki",
+        require_approval: "never",
+      },
+    ]);
+  });
+
+  it("omits tools when no MCP servers are selected", async () => {
+    await makeInteractionsRequest("hello", mockUpdateUI, "gpt-4o", "test-token");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(body.tools).toBeUndefined();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/interactions_api.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/interactions_api.tsx
@@ -1,5 +1,7 @@
 import NotificationManager from "@/components/molecules/notifications_manager";
 import { getGlobalLitellmHeaderName, getProxyBaseUrl } from "@/components/networking";
+import { buildMcpToolBlocks } from "@/components/llm_calls/mcp_tool_blocks";
+import type { MCPServer, MCPToolset } from "@/components/mcp_tools/types";
 
 export async function makeInteractionsRequest(
   input: string,
@@ -10,6 +12,10 @@ export async function makeInteractionsRequest(
   signal?: AbortSignal,
   customBaseUrl?: string,
   previousInteractionId?: string,
+  selectedMCPServers?: string[],
+  mcpServers?: MCPServer[],
+  mcpServerToolRestrictions?: Record<string, string[]>,
+  mcpToolsets?: MCPToolset[],
 ): Promise<void> {
   if (!accessToken) {
     throw new Error("Virtual Key is required");
@@ -32,10 +38,18 @@ export async function makeInteractionsRequest(
     headers["x-litellm-tags"] = tags.join(",");
   }
 
+  const tools = buildMcpToolBlocks({
+    selectedMCPServers,
+    mcpServers,
+    mcpToolsets,
+    mcpServerToolRestrictions,
+  });
+
   const body: Record<string, unknown> = {
     model: selectedModel,
     input,
     stream: true,
+    ...(tools.length > 0 ? { tools } : {}),
   };
   if (previousInteractionId) {
     body.previous_interaction_id = previousInteractionId;

--- a/ui/litellm-dashboard/src/components/llm_calls/chat_completion.test.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/chat_completion.test.tsx
@@ -172,23 +172,22 @@ describe("chat_completion", () => {
 
     const callArgs = mockCreate.mock.calls[0][0];
     expect(callArgs.tool_choice).toBe("auto");
-    expect(callArgs.tools).toHaveLength(2);
-
-    // Check first tool
-    const firstTool = callArgs.tools[0];
-    expect(firstTool.type).toBe("mcp");
-    expect(firstTool.server_label).toBe("litellm");
-    expect(firstTool.server_url).toBe("litellm_proxy/mcp/alpha");
-    expect(firstTool.require_approval).toBe("never");
-    expect(firstTool.allowed_tools).toEqual(["toolA", "toolB"]);
-
-    // Check second tool
-    const secondTool = callArgs.tools[1];
-    expect(secondTool.type).toBe("mcp");
-    expect(secondTool.server_label).toBe("litellm");
-    expect(secondTool.server_url).toBe("litellm_proxy/mcp/Beta");
-    expect(secondTool.require_approval).toBe("never");
-    expect(secondTool.allowed_tools).toEqual(["toolC"]);
+    expect(callArgs.tools).toEqual([
+      {
+        type: "mcp",
+        server_label: "Alpha",
+        server_url: "litellm_proxy/mcp/Alpha",
+        require_approval: "never",
+        allowed_tools: ["toolA", "toolB"],
+      },
+      {
+        type: "mcp",
+        server_label: "Beta",
+        server_url: "litellm_proxy/mcp/Beta",
+        require_approval: "never",
+        allowed_tools: ["toolC"],
+      },
+    ]);
   });
 
   it("should include mock_testing_fallbacks in request body when mockTestFallbacks is true", async () => {

--- a/ui/litellm-dashboard/src/components/llm_calls/chat_completion.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/chat_completion.tsx
@@ -4,6 +4,7 @@ import { TokenUsage } from "../chat_ui/ResponseMetrics";
 import { VectorStoreSearchResponse } from "../chat_ui/types";
 import { getProxyBaseUrl } from "@/components/networking";
 import { MCPServer, MCPToolset, type MCPEvent } from "@/components/mcp_tools/types";
+import { buildMcpToolBlocks } from "./mcp_tool_blocks";
 
 const completionAsSingleChunk = (completion: ChatCompletion): ChatCompletionChunk =>
   ({
@@ -81,48 +82,12 @@ export async function makeOpenAIChatCompletionRequest(
     } = {};
     let mcpListToolsProcessed = false;
 
-    // Build tools array
-    const tools: any[] = [];
-
-    // Add MCP servers if selected
-    if (selectedMCPServers && selectedMCPServers.length > 0) {
-      if (selectedMCPServers.includes("__all__")) {
-        // All MCP Servers selected
-        tools.push({
-          type: "mcp",
-          server_label: "litellm",
-          server_url: "litellm_proxy/mcp",
-          require_approval: "never",
-        });
-      } else {
-        // Individual servers/toolsets selected - create one entry per item
-        selectedMCPServers.forEach((serverId) => {
-          if (serverId.startsWith("toolset:")) {
-            const toolsetId = serverId.slice("toolset:".length);
-            const toolset = mcpToolsets?.find((t) => t.toolset_id === toolsetId);
-            const toolsetName = toolset?.toolset_name || toolsetId;
-            tools.push({
-              type: "mcp",
-              server_label: toolsetName,
-              server_url: `litellm_proxy/mcp/${encodeURIComponent(toolsetName)}`,
-              require_approval: "never",
-            });
-          } else {
-            const server = mcpServers?.find((s) => s.server_id === serverId);
-            const serverName = server?.alias || server?.server_name || serverId;
-            const allowedTools = mcpServerToolRestrictions?.[serverId] || [];
-
-            tools.push({
-              type: "mcp",
-              server_label: "litellm",
-              server_url: `litellm_proxy/mcp/${serverName}`,
-              require_approval: "never",
-              ...(allowedTools.length > 0 ? { allowed_tools: allowedTools } : {}),
-            });
-          }
-        });
-      }
-    }
+    const tools = buildMcpToolBlocks({
+      selectedMCPServers,
+      mcpServers,
+      mcpToolsets,
+      mcpServerToolRestrictions,
+    });
 
     const requestBody = {
       model: selectedModel,

--- a/ui/litellm-dashboard/src/components/llm_calls/responses_api.test.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/responses_api.test.tsx
@@ -280,14 +280,14 @@ describe("responses_api", () => {
       {
         type: "mcp",
         server_label: "Alpha",
-        server_url: "https://example.com/mcp/Alpha",
+        server_url: "litellm_proxy/mcp/Alpha",
         require_approval: "never",
         allowed_tools: ["toolA"],
       },
       {
         type: "mcp",
         server_label: "Beta",
-        server_url: "https://example.com/mcp/Beta",
+        server_url: "litellm_proxy/mcp/Beta",
         require_approval: "never",
         allowed_tools: ["toolB", "toolC"],
       },

--- a/ui/litellm-dashboard/src/components/llm_calls/responses_api.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/responses_api.tsx
@@ -11,6 +11,7 @@ import {
   handleCodeInterpreterCall,
   handleCodeInterpreterOutput,
 } from "./code_interpreter_handler";
+import { buildMcpToolBlocks } from "./mcp_tool_blocks";
 
 export type { CodeInterpreterResult } from "./code_interpreter_handler";
 
@@ -134,53 +135,15 @@ export async function makeOpenAIResponsesRequest(
       };
     });
 
-    // Build tools array
-    const tools: any[] = [];
+    const tools: Array<Record<string, unknown>> = [
+      ...buildMcpToolBlocks({
+        selectedMCPServers,
+        mcpServers,
+        mcpToolsets,
+        mcpServerToolRestrictions,
+      }),
+    ];
 
-    // Add MCP servers if selected
-    if (selectedMCPServers && selectedMCPServers.length > 0) {
-      if (selectedMCPServers.includes("__all__")) {
-        // All MCP Servers selected
-        tools.push({
-          type: "mcp",
-          server_label: "litellm",
-          server_url: `${proxyBaseUrl}/mcp`,
-          require_approval: "never",
-        });
-      } else {
-        // Individual servers/toolsets selected - create one entry per item
-        selectedMCPServers.forEach((serverId) => {
-          if (serverId.startsWith("toolset:")) {
-            // Toolset: same /{name}/mcp pattern as individual servers
-            const toolsetId = serverId.slice("toolset:".length);
-            const toolset = mcpToolsets?.find((t) => t.toolset_id === toolsetId);
-            const toolsetName = toolset?.toolset_name || toolsetId;
-            tools.push({
-              type: "mcp",
-              server_label: toolsetName,
-              server_url: `${proxyBaseUrl}/mcp/${encodeURIComponent(toolsetName)}`,
-              require_approval: "never",
-            });
-          } else {
-            const server = mcpServers?.find((s) => s.server_id === serverId);
-            // Use server_name for both routing and labelling. server_name is the
-            // unique registered identifier; aliases can collide across servers.
-            const routeName = server?.server_name || serverId;
-            const allowedTools = mcpServerToolRestrictions?.[serverId] || [];
-
-            tools.push({
-              type: "mcp",
-              server_label: routeName, // unique per request — collisions cause silent tool-routing failures
-              server_url: `${proxyBaseUrl}/mcp/${encodeURIComponent(routeName)}`,
-              require_approval: "never",
-              ...(allowedTools.length > 0 ? { allowed_tools: allowedTools } : {}),
-            });
-          }
-        });
-      }
-    }
-
-    // Add code_interpreter tool if enabled (OpenAI auto-creates container)
     if (codeInterpreterEnabled) {
       tools.push({
         type: "code_interpreter",

--- a/ui/litellm-dashboard/src/components/shared/MultiSelect.tsx
+++ b/ui/litellm-dashboard/src/components/shared/MultiSelect.tsx
@@ -11,6 +11,7 @@ import {
   ComboboxItem,
   ComboboxList,
   ComboboxValue,
+  useComboboxAnchor,
 } from "@/components/ui/combobox";
 
 export interface MultiSelectOption {
@@ -33,12 +34,13 @@ interface MultiSelectProps {
 
 const matchesQuery = (option: MultiSelectOption, query: string): boolean => {
   const normalizedQuery = query.trim().toLowerCase();
-  return (
-    !normalizedQuery ||
-    option.label.toLowerCase().includes(normalizedQuery) ||
-    option.value.toLowerCase().includes(normalizedQuery) ||
-    (option.description?.toLowerCase().includes(normalizedQuery) ?? false)
-  );
+  if (!normalizedQuery) {
+    return true;
+  }
+  const label = option.label?.toLowerCase() ?? "";
+  const value = option.value?.toLowerCase() ?? "";
+  const description = option.description?.toLowerCase() ?? "";
+  return label.includes(normalizedQuery) || value.includes(normalizedQuery) || description.includes(normalizedQuery);
 };
 
 export function MultiSelect({
@@ -53,10 +55,17 @@ export function MultiSelect({
   className,
 }: MultiSelectProps) {
   const [query, setQuery] = useState("");
-  const safeOptions = options.filter(
-    (option): option is MultiSelectOption =>
-      option != null && typeof option.value === "string" && option.value.length > 0,
-  );
+  const anchor = useComboboxAnchor();
+  const safeOptions = options
+    .filter(
+      (option): option is MultiSelectOption =>
+        option != null && typeof option.value === "string" && option.value.length > 0,
+    )
+    .map((option) => ({
+      value: option.value,
+      label: option.label?.trim() || option.value,
+      description: option.description || undefined,
+    }));
   const selectedOptions = value
     .filter((selectedValue): selectedValue is string => typeof selectedValue === "string" && selectedValue.length > 0)
     .map(
@@ -79,17 +88,18 @@ export function MultiSelect({
       items={items}
       value={selectedOptions}
       onValueChange={(selected: MultiSelectOption[]) => {
-        onValueChange(selected.map((option) => option.value));
+        onValueChange(selected.map((option) => option.value).filter(Boolean));
         setQuery("");
       }}
       inputValue={query}
       onInputValueChange={setQuery}
       isItemEqualToValue={(option: MultiSelectOption, selected: MultiSelectOption) => option.value === selected.value}
       itemToStringLabel={(option: MultiSelectOption) => option.label}
+      itemToStringValue={(option: MultiSelectOption) => option.value}
       filter={matchesQuery}
       disabled={disabled || loading}
     >
-      <ComboboxChips className={`min-h-8 py-1 text-sm ${className ?? ""}`}>
+      <ComboboxChips ref={anchor} className={`min-h-8 w-full py-1 text-sm ${className ?? ""}`}>
         <ComboboxValue>
           {(selected: MultiSelectOption[]) =>
             selected.map((option) => (
@@ -105,16 +115,20 @@ export function MultiSelect({
           aria-label={placeholder}
         />
       </ComboboxChips>
-      <ComboboxContent>
+      <ComboboxContent
+        anchor={anchor}
+        side="bottom"
+        collisionAvoidance={{ side: "shift", align: "shift", fallbackAxisSide: "none" }}
+      >
         <ComboboxEmpty>{emptyText}</ComboboxEmpty>
         <ComboboxList>
           {(option: MultiSelectOption) => (
             <ComboboxItem key={option.value} value={option}>
               <span className="min-w-0">
                 <span className="block truncate">{option.label}</span>
-                {option.description && (
+                {option.description ? (
                   <span className="block truncate text-xs text-muted-foreground">{option.description}</span>
-                )}
+                ) : null}
               </span>
             </ComboboxItem>
           )}

--- a/ui/litellm-dashboard/src/components/ui/combobox.tsx
+++ b/ui/litellm-dashboard/src/components/ui/combobox.tsx
@@ -190,12 +190,13 @@ function ComboboxSeparator({ className, ...props }: ComboboxPrimitive.Separator.
   );
 }
 
-function ComboboxChips({
-  className,
-  ...props
-}: React.ComponentPropsWithRef<typeof ComboboxPrimitive.Chips> & ComboboxPrimitive.Chips.Props) {
+const ComboboxChips = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<typeof ComboboxPrimitive.Chips> & ComboboxPrimitive.Chips.Props
+>(({ className, ...props }, ref) => {
   return (
     <ComboboxPrimitive.Chips
+      ref={ref}
       data-slot="combobox-chips"
       className={cn(
         "flex min-h-9 flex-wrap items-center gap-1.5 rounded-md border border-input bg-transparent bg-clip-padding px-2.5 py-1.5 text-sm shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50 has-aria-invalid:border-destructive has-aria-invalid:ring-3 has-aria-invalid:ring-destructive/20 has-data-[slot=combobox-chip]:px-1.5 dark:bg-input/30 dark:has-aria-invalid:border-destructive/50 dark:has-aria-invalid:ring-destructive/40",
@@ -204,7 +205,8 @@ function ComboboxChips({
       {...props}
     />
   );
-}
+});
+ComboboxChips.displayName = "ComboboxChips";
 
 function ComboboxChip({
   className,


### PR DESCRIPTION
## TLDR

Problem this solves:

- MCP server multi-select could open empty or fail to anchor chips
- Chat/responses built MCP tool blocks incorrectly, so tools failed across models
- Interactions never sent MCP tools

How it solves it:

- Fixes MultiSelect combobox anchor/ref so server options render
- Routes chat, responses, anthropic, and interactions through `buildMcpToolBlocks`
- Enables the MCP selector on all tool-capable playground endpoints

## Stack

PR 6/6. Base: `litellm_playground_realtime` (PR 5)

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

1. Open playground with a key that has MCP servers configured
2. Open MCP Servers multi-select and confirm servers appear
3. Select a server, use `/v1/chat/completions` with any tool-capable model, and send a tool-triggering prompt
4. Repeat on `/v1/responses`, Anthropic messages, and `/v1beta/interactions`
5. Switch to embeddings and confirm MCP selector is disabled

## Type

🐛 Bug Fix

## Changes

MultiSelect/combobox anchor fix for MCP options; shared `buildMcpToolBlocks` for chat and responses; interactions MCP wiring; MCP enabled for chat, responses, anthropic messages, and interactions

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR