### PR TITLE
test(docker): gate the componentized gateway and backend images on an arbitrary-uid offline boot

### DIFF
--- a/.github/ci-coverage-allowlist.yml
+++ b/.github/ci-coverage-allowlist.yml
@@ -137,13 +137,6 @@ test_paths:
 
 dockerfiles:
   - reason: >-
-      The componentized images the microservices chart deploys are built by no job; wiring both into
-      the scan workflow costs a full image build each and is deferred to a change that prices the
-      whole set
-    paths:
-      - backend/Dockerfile
-      - gateway/Dockerfile
-  - reason: >-
       The dashboard container is a static Next.js export served by nginx, and the dashboard build
       and lint workflows already exercise that output, so building the image adds no signal about it
     paths:

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -12,6 +12,11 @@ on:
       - docker/Dockerfile.non_root
       - migrations/Dockerfile
       - migrations/run.py
+      - gateway/Dockerfile
+      - gateway/main.py
+      - backend/Dockerfile
+      - backend/main.py
+      - docker/component_entrypoint.sh
       - litellm-proxy-extras/**
       - tests/proxy_migration_tests/**
       - uv.lock
@@ -147,3 +152,63 @@ jobs:
         run: |
           python -m pip install "pytest==9.0.3"
           python -m pytest tests/proxy_migration_tests/test_offline_image_migration.py -v
+
+  gateway-image:
+    name: gateway-image
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Build gateway image
+        run: docker build -f gateway/Dockerfile -t litellm-gateway-scan:${{ github.sha }} .
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify the gateway serves offline as a non-root uid
+        env:
+          LITELLM_IMAGE: litellm-gateway-scan:${{ github.sha }}
+          LITELLM_COMPONENT_PORT: "4000"
+        run: |
+          python -m pip install "pytest==9.0.3"
+          python -m pytest tests/proxy_migration_tests/test_component_image_serves_offline.py -v
+
+  backend-image:
+    name: backend-image
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Build backend image
+        run: docker build -f backend/Dockerfile -t litellm-backend-scan:${{ github.sha }} .
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify the backend serves offline as a non-root uid
+        env:
+          LITELLM_IMAGE: litellm-backend-scan:${{ github.sha }}
+          LITELLM_COMPONENT_PORT: "4001"
+        run: |
+          python -m pip install "pytest==9.0.3"
+          python -m pytest tests/proxy_migration_tests/test_component_image_serves_offline.py -v

--- a/tests/proxy_migration_tests/test_component_image_serves_offline.py
+++ b/tests/proxy_migration_tests/test_component_image_serves_offline.py
@@ -1,0 +1,187 @@
+"""Image-level regression net for the prisma bake in the componentized images.
+
+The gateway and backend serve requests; they never shell out to the Prisma CLI
+(``PrismaManager.setup_database`` is reachable only from ``proxy_cli.py``, which
+uvicorn'ing ``gateway.main:app`` bypasses). What they do need is the generated
+client's baked query engine, and prisma-python resolves those baked paths
+eagerly, with an existence check that propagates EACCES rather than skipping the
+candidate. An engine baked under a build-time ``HOME`` is therefore unreadable to
+any other runtime uid, and the process dies during startup before
+``PRISMA_QUERY_ENGINE_BINARY`` is ever consulted.
+
+That is what an OpenShift ``restricted-v2`` namespace produces: the image
+``USER`` is ignored and an arbitrary uid in GID 0 is assigned instead. The
+symptom is not a degraded proxy, it is a proxy that does not serve at all.
+
+Booting the image the way that deployment does, and requiring it to answer a
+request with a live database connection, is what catches the whole class:
+a boot as the default uid, or one that reaches the internet, passes even when
+the bake is unusable everywhere it actually ships.
+
+Gated on LITELLM_IMAGE (the tag of the image to exercise) so it is skipped in
+the normal unit-test run and exercised only where an image has been built (the
+image-scan workflow). Requires a working docker CLI.
+"""
+
+import json
+import shutil
+import subprocess
+import time
+import uuid
+
+import os
+import pytest
+
+IMAGE = os.getenv("LITELLM_IMAGE")
+POSTGRES_IMAGE = os.getenv("LITELLM_TEST_POSTGRES_IMAGE", "postgres:16-alpine")
+CURL_IMAGE = os.getenv("LITELLM_TEST_CURL_IMAGE", "curlimages/curl:8.11.1")
+COMPONENT_PORT = os.getenv("LITELLM_COMPONENT_PORT", "4000")
+NON_ROOT_UID = "12345:0"
+STARTUP_TIMEOUT_SECONDS = int(os.getenv("LITELLM_COMPONENT_STARTUP_TIMEOUT", "180"))
+
+pytestmark = [
+    pytest.mark.skipif(IMAGE is None, reason="requires a built image (set LITELLM_IMAGE)"),
+    pytest.mark.skipif(shutil.which("docker") is None, reason="requires the docker CLI"),
+]
+
+
+def _docker(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["docker", *args], capture_output=True, text=True, check=check
+    )
+
+
+@pytest.fixture()
+def offline_stack():
+    """A component container and a fresh Postgres on a network with no egress.
+
+    NON_ROOT_UID is an arbitrary uid in GID 0, the shape OpenShift restricted-v2
+    assigns. Postgres and curl are pulled while egress still exists, because the
+    ``--internal`` network below has none: that is what makes a prisma engine
+    download (binaries.prisma.sh / npm) fail rather than mask a bake that is not
+    self-contained.
+
+    The container runs with DISABLE_SCHEMA_UPDATE, since applying the schema is
+    the migration job's responsibility in this topology and needs the Prisma CLI
+    these images deliberately omit, and with LITELLM_LOCAL_MODEL_COST_MAP, or the
+    proxy spends the whole startup budget timing out on a cost-map fetch over the
+    network it does not have.
+
+    Yields (network_name, component_container). Both are torn down afterwards.
+    """
+    run_id = f"componentserve-{uuid.uuid4().hex[:8]}"
+    network = f"{run_id}-net"
+    pg = f"{run_id}-pg"
+    component = f"{run_id}-app"
+
+    _docker("pull", "--quiet", POSTGRES_IMAGE)
+    _docker("pull", "--quiet", CURL_IMAGE)
+    _docker("network", "create", "--internal", network)
+    try:
+        _docker(
+            "run", "-d", "--name", pg, "--network", network,
+            "-e", "POSTGRES_PASSWORD=pw", "-e", "POSTGRES_DB=litellm",
+            POSTGRES_IMAGE,
+        )
+        _wait_until_postgres_ready(pg)
+        assert IMAGE is not None
+        _docker(
+            "run", "-d", "--name", component, "--network", network,
+            "--user", NON_ROOT_UID,
+            "-e", f"DATABASE_URL=postgresql://postgres:pw@{pg}:5432/litellm",
+            "-e", "LITELLM_MASTER_KEY=sk-component-serve-test",
+            "-e", "DISABLE_SCHEMA_UPDATE=true",
+            "-e", "LITELLM_LOCAL_MODEL_COST_MAP=True",
+            IMAGE,
+        )
+        yield network, component
+    finally:
+        _docker("logs", component, check=False)
+        _docker("rm", "-f", component, check=False)
+        _docker("rm", "-f", pg, check=False)
+        _docker("network", "rm", network, check=False)
+
+
+def _wait_until_postgres_ready(pg: str, attempts: int = 60) -> None:
+    for _ in range(attempts):
+        running = _docker(
+            "ps", "--filter", f"name={pg}", "--filter", "status=running",
+            "--format", "{{.Names}}", check=False,
+        ).stdout
+        if pg not in running:
+            logs = _docker("logs", pg, check=False)
+            pytest.fail(f"postgres container is not running:\n{logs.stdout}\n{logs.stderr}")
+        ready = _docker(
+            "exec", pg, "pg_isready", "-U", "postgres", "-d", "litellm", check=False
+        )
+        if ready.returncode == 0:
+            return
+        time.sleep(1)
+    pytest.fail(f"postgres never became ready after {attempts}s")
+
+
+def _container_logs(container: str) -> str:
+    logs = _docker("logs", container, check=False)
+    return f"stdout:\n{logs.stdout}\nstderr:\n{logs.stderr}"
+
+
+def _is_running(container: str) -> bool:
+    return bool(
+        _docker(
+            "ps", "--filter", f"name={container}", "--filter", "status=running",
+            "--format", "{{.Names}}", check=False,
+        ).stdout.strip()
+    )
+
+
+def _readiness(network: str, component: str) -> subprocess.CompletedProcess:
+    """Ask the component for its readiness, from a peer on the same egress-less network."""
+    return _docker(
+        "run", "--rm", "--network", network, CURL_IMAGE,
+        "--silent", "--max-time", "10",
+        f"http://{component}:{COMPONENT_PORT}/health/readiness",
+        check=False,
+    )
+
+
+def test_component_serves_offline_as_non_root_uid(offline_stack):
+    """The component answers a request with a live DB connection, offline, as an arbitrary uid.
+
+    On the pre-fix image this never gets a response: the engine baked under
+    /home/nonroot (mode 0700, owned by uid 65532) raises
+    ``PermissionError: .../query-engine-linux-...`` out of pathlib and uvicorn
+    reports ``Application startup failed. Exiting.``. A bake at the fixed,
+    world-readable /opt/prisma is what lets any uid start the client.
+
+    `db: connected` is the load-bearing part of the assertion: it means the
+    query engine binary was found, executed, and reached Postgres. A liveness
+    probe alone would pass on an image whose engine never resolved.
+    """
+    network, component = offline_stack
+
+    deadline = time.time() + STARTUP_TIMEOUT_SECONDS
+    probe = None
+    while time.time() < deadline:
+        if not _is_running(component):
+            pytest.fail(
+                f"the component exited during startup as uid {NON_ROOT_UID} with no egress. "
+                "The prisma bake is not readable to a uid other than the one that built it, "
+                "so the proxy does not serve at all.\n"
+                f"{_container_logs(component)}"
+            )
+        probe = _readiness(network, component)
+        if probe.returncode == 0 and probe.stdout.strip():
+            break
+        time.sleep(2)
+
+    assert probe is not None and probe.returncode == 0 and probe.stdout.strip(), (
+        f"/health/readiness never answered within {STARTUP_TIMEOUT_SECONDS}s as uid "
+        f"{NON_ROOT_UID} with no egress.\n{_container_logs(component)}"
+    )
+
+    payload = json.loads(probe.stdout)
+    assert payload.get("db") == "connected", (
+        f"the component answered but its database is {payload.get('db')!r}, so the baked "
+        f"query engine did not resolve as uid {NON_ROOT_UID}.\nresponse: {probe.stdout}\n"
+        f"{_container_logs(component)}"
+    )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gateway and backend images have no CI image job at all
- Nothing in CI references `gateway/Dockerfile` or `backend/Dockerfile`
- The arbitrary-uid prisma bake fix ships completely untested
- A revert of it would break OpenShift silently

How it solves it:

- Boot each image as an arbitrary uid, no egress, fresh Postgres
- Require `/health/readiness` to report a live DB connection
- Add `gateway-image` and `backend-image` jobs to image-scan
- Add the missing trigger paths so edits actually run them
- Drop the now-false CI coverage allowlist deferral for both

## Relevant issues

## Linear ticket

Resolves LIT-5031

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The regression this gate exists for is real and reproducible. `/health/readiness` reporting `db: connected` is the load-bearing assertion: it means the baked query engine was found, executed, and reached Postgres, which is exactly what an engine baked under a build-time `HOME` cannot do for any other uid

Both runs use a `--internal` docker network, which has no route to the internet, so a runtime engine or Node download fails rather than papering over a bake that is not self-contained

### Before, gateway built at `2dc49a913c` (the commit before the bake moved to /opt/prisma)

```
$ git show 7bd3a5e6ab^:gateway/Dockerfile > /tmp/gateway.prefix.Dockerfile
$ grep -c "opt/prisma" /tmp/gateway.prefix.Dockerfile
0
$ docker build -f /tmp/gateway.prefix.Dockerfile -t lit5031/gateway:prefix .
$ docker network create --internal lit5031-net
$ docker run -d --name lit5031-pg --network lit5031-net -e POSTGRES_PASSWORD=pw -e POSTGRES_DB=litellm postgres:16-alpine
$ docker run -d --name lit5031-gwpre --network lit5031-net --user 12345:0 \
    -e DATABASE_URL=postgresql://postgres:pw@lit5031-pg:5432/litellm \
    -e LITELLM_MASTER_KEY=sk-test -e DISABLE_SCHEMA_UPDATE=true \
    -e LITELLM_LOCAL_MODEL_COST_MAP=True lit5031/gateway:prefix
$ docker logs lit5031-gwpre
LiteLLM Prisma Client Exception connect(): [Errno 13] Permission denied: '/home/nonroot/.cache/prisma-python/binaries/5.4.2/ac9d7041ed77bcc8a8dbd2ab6616b39013829574/node_modules/prisma/query-engine-linux-arm64-openssl-3.0.x'
...
prisma.engine.errors.NotConnectedError: Not connected to the query engine

ERROR:    Application startup failed. Exiting.
```

The new test fails on that image, naming the customer-visible symptom:

```
$ LITELLM_IMAGE=lit5031/gateway:prefix LITELLM_COMPONENT_PORT=4000 \
    pytest tests/proxy_migration_tests/test_component_image_serves_offline.py -v

tests/proxy_migration_tests/test_component_image_serves_offline.py::test_component_serves_offline_as_non_root_uid FAILED
E   Failed: the component exited during startup as uid 12345:0 with no egress. The prisma bake is
E   not readable to a uid other than the one that built it, so the proxy does not serve at all.
E   ERROR:    Application startup failed. Exiting.

============================== 1 failed in 15.01s ==============================
```

### After, gateway and backend built at `f6587faef5` (this branch changes no Dockerfile)

```
$ docker run -d --name lit5031-gw --network lit5031-net --user 1001200000:0 \
    -e DATABASE_URL=postgresql://postgres:pw@lit5031-pg:5432/litellm \
    -e LITELLM_MASTER_KEY=sk-test -e DISABLE_SCHEMA_UPDATE=true \
    -e LITELLM_LOCAL_MODEL_COST_MAP=True lit5031/gateway:head
$ docker logs lit5031-gw
INFO:     Started server process [1]
INFO:     Waiting for application startup.
query-engine ac9d7041ed77bcc8a8dbd2ab6616b39013829574
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:4000 (Press CTRL+C to quit)

$ docker run --rm --network lit5031-net curlimages/curl:8.11.1 -s http://lit5031-gw:4000/health/readiness
{"status":"healthy","db":"connected"}
```

`1001200000` is the uid from the customer's OpenShift namespace range. The test itself uses `12345:0`, matching the existing migrations gate

Both images pass the new gate:

```
$ LITELLM_IMAGE=lit5031/gateway:head LITELLM_COMPONENT_PORT=4000 \
    pytest tests/proxy_migration_tests/test_component_image_serves_offline.py -v
tests/proxy_migration_tests/test_component_image_serves_offline.py::test_component_serves_offline_as_non_root_uid PASSED
============================== 1 passed in 13.17s ==============================

$ LITELLM_IMAGE=lit5031/backend:head LITELLM_COMPONENT_PORT=4001 \
    pytest tests/proxy_migration_tests/test_component_image_serves_offline.py -v
tests/proxy_migration_tests/test_component_image_serves_offline.py::test_component_serves_offline_as_non_root_uid PASSED
============================== 1 passed in 10.67s ==============================
```

And with no image built it skips, so the normal unit run is unaffected:

```
$ pytest tests/proxy_migration_tests/test_component_image_serves_offline.py -v
tests/proxy_migration_tests/test_component_image_serves_offline.py::test_component_serves_offline_as_non_root_uid SKIPPED
============================== 1 skipped in 0.01s ==============================
```

### The new jobs are green on this PR's own head, and they really ran

A job that exits 0 having skipped everything looks identical to one that passed, and this test skips when `LITELLM_IMAGE` is unset, so a wiring mistake would go unnoticed. Both job logs at `11b5108` show it collected and executed:

```
gateway-image   collected 1 item
                test_component_serves_offline_as_non_root_uid PASSED
                1 passed, 2 warnings in 24.50s

backend-image   collected 1 item
                test_component_serves_offline_as_non_root_uid PASSED
                1 passed, 2 warnings in 23.98s
```

That is also the amd64 confirmation. The local before/after above was captured on arm64, so the engine name differs (`query-engine-linux-arm64-openssl-3.0.x`), while CI exercises the architecture we actually ship

### The migrations image half of the ticket already holds

Confirmed at `f6587faef5`, uid `1001200000:0`, no egress: all 145 migrations applied

```
$ docker run --rm --network lit5031-net --user 1001200000:0 \
    -e DATABASE_URL=postgresql://postgres:pw@lit5031-pg:5432/litellm \
    -e LITELLM_MASTER_KEY=sk-test lit5031/migrations:head
Using custom Prisma CLI at /opt/prisma/binaries/node_modules/.bin/prisma
Prisma CLI toolchain ready
145 migrations found in prisma/migrations
Applying migration `20250326162113_baseline`
...
All migrations have been successfully applied.
Migration job completed successfully.
```

The shipped `ghcr.io/berriai/litellm-migrations:v1.94.1` still fails the same run with the original `PermissionError` on `/home/nonroot/.cache/prisma-python/binaries/...`, so the fix is in the tree but not yet in a release

## Type

🚄 Infrastructure
✅ Test

## Changes

`.github/workflows/image-scan.yml`

- New `gateway-image` and `backend-image` jobs, mirroring the existing `migrations-image` job
- `paths:` gains `gateway/Dockerfile`, `gateway/main.py`, `backend/Dockerfile`, `backend/main.py` and `docker/component_entrypoint.sh`. Before this, editing either component Dockerfile triggered no image job anywhere in the repo

`.github/ci-coverage-allowlist.yml`

- Drops the `dockerfiles:` entry exempting `backend/Dockerfile` and `gateway/Dockerfile`. Its reason said wiring them in "is deferred to a change that prices the whole set", which is this change, so leaving the entry would ship a justification that is now false
- The gate is real, not a rubber stamp. With the two new build lines removed, `.github/scripts/assert_ci_coverage.py` fails with `backend/Dockerfile: built by no job` and `gateway/Dockerfile: built by no job`; with them present it reports `OK: 2364 test files and 10 Dockerfiles are each invoked by at least one job`

`tests/proxy_migration_tests/test_component_image_serves_offline.py`

- Boots a component image as an arbitrary uid in GID 0 on an egress-less network against a fresh Postgres, and requires `/health/readiness` to answer with `db: connected`
- Fails fast with the container logs if the process exits during startup, which is the pre-fix shape
- Gated on `LITELLM_IMAGE`, so it only runs where an image has been built

Scope note: the gateway and backend serve requests and never shell out to the Prisma CLI. `PrismaManager.setup_database` is reachable only from `litellm/proxy/proxy_cli.py`, which uvicorn'ing `gateway.main:app` bypasses. So the Node toolchain the migrations image needs is deliberately not part of this contract, and these two images are not gated on it

## CI note

`osv-scan` is red here and it is not from this PR. It fails on `uv.lock` (h2 4.3.0, GHSA-6hr6-w5qg-qmwg) and `ui/litellm-dashboard/package-lock.json` (js-yaml dev, GHSA-5p4m-2wfm-xmqj). This diff is three files and touches no lockfile, and the same check is failing on `litellm_internal_staging` itself at `b7749f67f1` and on other open PRs. It needs a dependency bump of its own

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test-only changes; no runtime application or image Dockerfile logic modified in this diff.
> 
> **Overview**
> Adds **CI coverage** for the componentized **gateway** and **backend** Docker images, which previously had no image jobs and were exempt from `assert_ci_coverage`.
> 
> The **image-scan** workflow gains **`gateway-image`** and **`backend-image`** jobs (mirroring migrations-image): build each image, then run a new Docker-based pytest that boots the container as an arbitrary uid (`12345:0`) on an **egress-less** network with Postgres and asserts **`/health/readiness`** returns **`db: connected`**. That catches Prisma query-engine bake permission failures (e.g. OpenShift restricted-v2) that prevent startup entirely. PR path filters now include the gateway/backend Dockerfiles, entrypoints, and **`docker/component_entrypoint.sh`**.
> 
> **`test_component_image_serves_offline.py`** is gated on **`LITELLM_IMAGE`**, so default unit runs skip it. The **ci-coverage allowlist** no longer defers **`backend/Dockerfile`** and **`gateway/Dockerfile`** as unbuilt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11b5108778c40c5d5abbedbe462a42ea928e8a4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->