### PR TITLE
fix(azure_sentinel): respect AZURE_AUTHORITY_HOST and derive the Azure Monitor audience per cloud

### DIFF
--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -16,7 +16,10 @@ import asyncio
 import os
 import time
 import traceback
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Final
+from urllib.parse import urlparse
 
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
@@ -26,6 +29,16 @@ from litellm.llms.custom_httpx.http_handler import (
     httpxSpecialProvider,
 )
 from litellm.types.utils import StandardAuditLogPayload, StandardLoggingPayload
+
+DEFAULT_AZURE_AUTHORITY_HOST: Final = "https://login.microsoftonline.com"
+DEFAULT_AZURE_MONITOR_SCOPE: Final = "https://monitor.azure.com/.default"
+
+MONITOR_SCOPE_BY_AUTHORITY_HOST: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "login.microsoftonline.com": DEFAULT_AZURE_MONITOR_SCOPE,
+        "login.microsoftonline.us": "https://monitor.azure.us/.default",
+    }
+)
 
 
 class AzureSentinelLogger(CustomBatchLogger):
@@ -42,6 +55,7 @@ class AzureSentinelLogger(CustomBatchLogger):
         client_id: str | None = None,
         client_secret: str | None = None,
         audit_stream_name: str | None = None,
+        authority_host: str | None = None,
         **kwargs,
     ):
         """
@@ -62,6 +76,10 @@ class AzureSentinelLogger(CustomBatchLogger):
                 If not provided, will use AZURE_SENTINEL_CLIENT_SECRET or AZURE_CLIENT_SECRET env var.
             audit_stream_name (str, optional): Stream name from DCR for audit logs.
                 If not provided, will use AZURE_SENTINEL_AUDIT_STREAM_NAME env var or the standard stream name.
+            authority_host (str, optional): Microsoft Entra authority host that issues the OAuth2 token,
+                e.g. "https://login.microsoftonline.us" for Azure Government. If not provided, will use
+                AZURE_AUTHORITY_HOST env var or default to the Azure Public Cloud authority. The Azure
+                Monitor audience is derived from it.
         """
         self.async_httpx_client = get_async_httpx_client(llm_provider=httpxSpecialProvider.LoggingCallback)
 
@@ -75,6 +93,9 @@ class AzureSentinelLogger(CustomBatchLogger):
         resolved_client_id: Final = client_id or os.getenv("AZURE_SENTINEL_CLIENT_ID") or os.getenv("AZURE_CLIENT_ID")
         resolved_client_secret: Final = (
             client_secret or os.getenv("AZURE_SENTINEL_CLIENT_SECRET") or os.getenv("AZURE_CLIENT_SECRET")
+        )
+        resolved_authority_host: Final = self._normalize_authority_host(
+            authority_host or os.getenv("AZURE_AUTHORITY_HOST") or DEFAULT_AZURE_AUTHORITY_HOST
         )
 
         if not resolved_dcr_immutable_id:
@@ -119,7 +140,8 @@ class AzureSentinelLogger(CustomBatchLogger):
         )
 
         # OAuth2 scope for Azure Monitor
-        self.oauth_scope = "https://monitor.azure.com/.default"
+        self.authority_host = resolved_authority_host
+        self.oauth_scope = self._resolve_oauth_scope(authority_host=resolved_authority_host)
         self.oauth_token: str | None = None
         self.oauth_token_expires_at: float | None = None
 
@@ -128,6 +150,26 @@ class AzureSentinelLogger(CustomBatchLogger):
         asyncio.create_task(self.periodic_flush())
         self.log_queue: list[StandardLoggingPayload] = []
         self.audit_log_queue: list[StandardAuditLogPayload] = []
+
+    @staticmethod
+    def _normalize_authority_host(authority_host: str) -> str:
+        """
+        Normalize an authority host into an absolute URL with no trailing slash.
+
+        Accepts the scheme-qualified form litellm documents ("https://login.microsoftonline.us")
+        and the bare-host form the azure-identity AzureAuthorityHosts constants use.
+        """
+        stripped: Final = authority_host.strip().rstrip("/")
+        return stripped if "://" in stripped else f"https://{stripped}"
+
+    @staticmethod
+    def _resolve_oauth_scope(authority_host: str) -> str:
+        """
+        Map an authority host to the Azure Monitor Logs Ingestion audience for the same cloud,
+        falling back to the Azure Public Cloud audience for an unrecognized host.
+        """
+        host: Final = urlparse(authority_host).hostname or ""
+        return MONITOR_SCOPE_BY_AUTHORITY_HOST.get(host, DEFAULT_AZURE_MONITOR_SCOPE)
 
     @staticmethod
     def _build_api_endpoint(endpoint: str, dcr_immutable_id: str, stream_name: str) -> str:
@@ -150,7 +192,7 @@ class AzureSentinelLogger(CustomBatchLogger):
         assert self.client_id is not None, "client_id is required"
         assert self.client_secret is not None, "client_secret is required"
 
-        token_url: Final = f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/v2.0/token"
+        token_url: Final = f"{self.authority_host}/{self.tenant_id}/oauth2/v2.0/token"
 
         token_data: Final = {
             "client_id": self.client_id,

--- a/tests/test_litellm/integrations/test_azure_sentinel.py
+++ b/tests/test_litellm/integrations/test_azure_sentinel.py
@@ -296,3 +296,96 @@ async def test_azure_sentinel_audit_stream_name_from_env_var(monkeypatch):
         )
 
     assert explicit_logger.audit_stream_name == "Custom-LiteLLM-Explicit"
+
+
+def _build_logger(**overrides):
+    kwargs = {
+        "dcr_immutable_id": "dcr-test123456789",
+        "endpoint": "https://test-dce.eastus-1.ingest.monitor.azure.com",
+        "tenant_id": "test-tenant-id",
+        "client_id": "test-client-id",
+        "client_secret": "test-client-secret",
+        **overrides,
+    }
+    with patch("asyncio.create_task", side_effect=_close_periodic_flush_task):
+        return AzureSentinelLogger(**kwargs)
+
+
+@pytest.fixture
+def _no_authority_host_env(monkeypatch):
+    monkeypatch.delenv("AZURE_AUTHORITY_HOST", raising=False)
+
+
+@pytest.mark.parametrize(
+    "authority_host, expected_authority, expected_scope",
+    [
+        (None, "https://login.microsoftonline.com", "https://monitor.azure.com/.default"),
+        ("https://login.microsoftonline.us", "https://login.microsoftonline.us", "https://monitor.azure.us/.default"),
+        ("https://login.microsoftonline.us/", "https://login.microsoftonline.us", "https://monitor.azure.us/.default"),
+        ("login.microsoftonline.us", "https://login.microsoftonline.us", "https://monitor.azure.us/.default"),
+        ("https://adfs.contoso.example", "https://adfs.contoso.example", "https://monitor.azure.com/.default"),
+    ],
+)
+def test_azure_sentinel_resolves_authority_host_and_audience_together(
+    _no_authority_host_env, authority_host, expected_authority, expected_scope
+):
+    """Both the Entra authority and the Azure Monitor audience must follow the configured cloud.
+
+    Moving only the authority leaves a sovereign deployment asking sovereign Entra for the
+    commercial audience, which the sovereign ingestion endpoint rejects.
+    """
+    logger = _build_logger(**({} if authority_host is None else {"authority_host": authority_host}))
+
+    assert logger.authority_host == expected_authority
+    assert logger.oauth_scope == expected_scope
+
+
+def test_azure_sentinel_authority_host_from_env_var(_no_authority_host_env, monkeypatch):
+    """AZURE_AUTHORITY_HOST is the documented setting and the string callback constructs the logger
+    with no arguments, so the env var alone has to move both values."""
+    monkeypatch.setenv("AZURE_AUTHORITY_HOST", "https://login.microsoftonline.us")
+
+    logger = _build_logger()
+
+    assert logger.authority_host == "https://login.microsoftonline.us"
+    assert logger.oauth_scope == "https://monitor.azure.us/.default"
+
+
+@pytest.mark.asyncio
+async def test_azure_sentinel_token_request_uses_sovereign_authority_and_audience(_no_authority_host_env):
+    """The resolved values must reach the wire, not just the instance attributes."""
+    logger = _build_logger(authority_host="https://login.microsoftonline.us")
+    logger.log_queue.append(
+        StandardLoggingPayload(
+            id="test_id",
+            call_type="completion",
+            model="gpt-3.5-turbo",
+            status="success",
+            messages=[{"role": "user", "content": "Hello"}],
+            response={"choices": [{"message": {"content": "Hi"}}]},
+        )
+    )
+
+    mock_token_response = MagicMock()
+    mock_token_response.status_code = 200
+    mock_token_response.json = MagicMock(return_value={"access_token": "test-bearer-token", "expires_in": 3600})
+    mock_token_response.text = "Success"
+    mock_api_response = MagicMock()
+    mock_api_response.status_code = 204
+    mock_api_response.text = "Success"
+
+    async def mock_post(*args, **kwargs):
+        if "oauth2/v2.0/token" in kwargs.get("url", ""):
+            return mock_token_response
+        return mock_api_response
+
+    logger.async_httpx_client.post = AsyncMock(side_effect=mock_post)
+
+    await logger.async_send_batch()
+
+    token_calls = [
+        call for call in logger.async_httpx_client.post.call_args_list if "oauth2/v2.0/token" in call.kwargs["url"]
+    ]
+    assert len(token_calls) == 1
+    assert token_calls[0].kwargs["url"] == "https://login.microsoftonline.us/test-tenant-id/oauth2/v2.0/token"
+    assert token_calls[0].kwargs["data"]["scope"] == "https://monitor.azure.us/.default"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `azure_sentinel` hardcoded the commercial Entra authority (`https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token`) and the commercial Azure Monitor audience (`https://monitor.azure.com/.default`), so Log Analytics ingestion could not work in Azure Government even with `AZURE_SENTINEL_ENDPOINT` pointed at a sovereign Data Collection Endpoint
- A customer hit exactly this and asked whether the codepath could respect `AZURE_AUTHORITY_HOST`

How it solves it:

- The Entra authority now resolves from the existing `AZURE_AUTHORITY_HOST`, defaulting to the Azure Public Cloud authority when unset
- The Logs Ingestion audience is derived from that authority. Moving only the token URL is not enough: sovereign Entra would then be asked for a token scoped to the commercial audience, which the sovereign endpoint rejects. The audience values come from the Azure SDK's `KnownMonitorAudience` enum in `Azure/azure-sdk-for-js`, `sdk/monitor/monitor-ingestion/src/models/models.ts`
- No new environment variables. One file changed, plus its tests
- **THIS IS A BREAKING CHANGE FOR DEPLOYMENTS THAT ALREADY SET `AZURE_AUTHORITY_HOST` AND KEEP THEIR SENTINEL WORKSPACE IN THE COMMERCIAL CLOUD. SEE BEHAVIOR CHANGES BELOW.**

## Relevant issues

## Linear ticket

Resolves LIT-5293

## Behavior changes

> ### BREAKING CHANGE FOR ONE CONFIGURATION
>
> **IF YOU SET `AZURE_AUTHORITY_HOST` TO A SOVEREIGN AUTHORITY AND YOUR AZURE SENTINEL WORKSPACE IS IN THE COMMERCIAL CLOUD, THIS PR WILL STOP YOUR SENTINEL LOGS FROM BEING DELIVERED.**
>
> **SENTINEL PREVIOUSLY IGNORED THAT VARIABLE AND ALWAYS USED THE COMMERCIAL CLOUD. IT NOW FOLLOWS IT. THERE IS CURRENTLY NO PER INTEGRATION OPT OUT, BECAUSE THE PROXY CONSTRUCTS THE LOGGER WITH NO ARGUMENTS, SO THE `authority_host` CONSTRUCTOR PARAMETER IS REACHABLE ONLY FROM THE SDK.**
>
> **REQUESTS, BILLING AND ALL OTHER CALLBACKS ARE UNAFFECTED. DEPLOYMENTS THAT DO NOT SET `AZURE_AUTHORITY_HOST` SEE NO CHANGE AT ALL.**

Azure Sentinel was the only subsystem minting an Entra token for an **Azure resource** that did not follow `AZURE_AUTHORITY_HOST`. Azure OpenAI, the `azure_storage` logger, Redis AAD auth, Key Vault and the Azure Blob backend all construct azure-identity credentials without an explicit `authority=`, so they inherit it already, and the Azure OpenAI OIDC path reads it directly at `litellm/llms/azure/common_utils.py:174`. The Graph-facing callers, the Purview guardrail and Microsoft SSO, still hardcode `login.microsoftonline.com` and are out of scope here.

The audience has to move with the authority because Azure Monitor publishes a different one per cloud, `monitor.azure.us` in Government. Azure Storage is the instructive contrast: Microsoft documents its `https://storage.azure.com/.default` audience as identical in every cloud, which is why `azure_storage` needs only an endpoint-suffix setting and no audience mapping. The two axes move independently, since storage hostnames do change per cloud even though the audience does not.

**Who this breaks, stated plainly, because it is narrower than it sounds but genuinely reachable.** The sibling integrations mostly default to non-Entra auth: `azure_storage` branches to account-key auth and never touches Entra, Redis AAD is opt-in behind `REDIS_AZURE_AD_TOKEN`, Key Vault loads only when enabled, and `enable_azure_ad_token_refresh` defaults to false. So a deployment can be perfectly healthy today with a sovereign `AZURE_AUTHORITY_HOST` used only for Azure OpenAI, alongside a commercial Sentinel workspace. That configuration works now, stops working after this PR, and the operator has no way to opt out. Measured base-vs-head against a real Azure Monitor endpoint: base delivered and stored the row, head did not attempt ingestion, and requests and spend logging were identical on both sides.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review. 5/5, anchored to the current head `c593445c`

## Screenshots / Proof of Fix

No stubs. Real proxy, real Postgres, real Gemini call driving the callback, real Microsoft Entra, and a real Azure Monitor Data Collection Endpoint backed by a real Log Analytics workspace, built for this run in a commercial subscription. Tenant id redacted.

```bash
export AZURE_SENTINEL_DCR_IMMUTABLE_ID="dcr-e3a8a133f5004c89b6ab2d76b50a1b68"
export AZURE_SENTINEL_ENDPOINT="https://litellm-lit5293-dce-yv7r.eastus-1.ingest.monitor.azure.com"
export AZURE_SENTINEL_TENANT_ID=...  AZURE_SENTINEL_CLIENT_ID=...  AZURE_SENTINEL_CLIENT_SECRET=...

python -m litellm.proxy.proxy_cli --config config.yaml --port 20297 --use_prisma_db_push --detailed_debug

curl -sS http://127.0.0.1:20297/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"Reply with exactly: <marker>"}]}'
```

| leg | tree | `AZURE_AUTHORITY_HOST` | Entra token | Azure ingestion | row in Log Analytics |
|---|---|---|---|---|---|
| 1 | head | unset | 200 | **204** | **stored** |
| 2 | base | unset | 200 | **204** | **stored** |
| 3 | base | gov | 200, setting ignored | **204** | **stored** |
| 4 | head | gov | **400** at `login.microsoftonline.us` | not attempted | **absent** |

Leg 1 against leg 2 is the backward-compatibility result: with no authority host configured, head behaves exactly like base and the log still lands.

Leg 3 against leg 4 is the fix, confirmed at the destination rather than inferred from a status code. Base ignores the sovereign authority and quietly ships to the commercial cloud; head routes where it was told and, because this service principal lives in a commercial tenant, gets `AADSTS90038: Tenant ... request is being redirected to the National Cloud 'MicrosoftOnline.COM'`. A genuine Azure Government tenant would get a token.

```bash
az monitor log-analytics query -w <workspace-id> --analytics-query \
  "Custom_LiteLLM_CL | project TimeGenerated, Model, Status, TotalTokens, Msg=tostring(Messages) | order by TimeGenerated asc"
```

```
2026-08-07T01:15:00  model=gemini/gemini-3.5-flash status=success tokens=173  leg=2 (base, default)
2026-08-07T01:15:31  model=gemini/gemini-3.5-flash status=success tokens=149  leg=3 (base, gov)
2026-08-07T02:42:41  model=gemini/gemini-3.5-flash status=success tokens=119  leg=1 (head, default)

leg 4 present: False
```

Both head legs were re-run against the exact code in this PR after it was cut back; the two base legs are unchanged upstream code and were not affected by that. Leg 4 is absent by design, which is the whole point of the differential.

### What this evidence does not cover

Only commercial (`AzureCloud`) subscriptions were available, so nothing here demonstrates a sovereign Data Collection Endpoint *accepting* a token minted with a sovereign audience; that needs an Azure Government tenant. What is proven is that the authority and the audience follow the configured cloud, that the commercial path is unchanged, and that the audience values match the Azure SDK's own enum. Requesting the gov audience from commercial Entra returns `AADSTS500011: The resource principal named https://monitor.azure.us was not found in the tenant`, which echoes the requested scope back and confirms it reaches the wire.

## Type

🐛 Bug Fix

## Changes

`litellm/integrations/azure_sentinel/azure_sentinel.py` gains a two-entry authority-to-audience table, two pure static helpers, and an optional `authority_host` constructor parameter mirroring the existing settings. The token URL is built from the resolved authority instead of a literal.

Azure China is not mapped. Its audience is known and the entry would be one line, but no one has asked for it, so it is left out rather than shipped untested.

## QA runbook

1. Set `AZURE_SENTINEL_*` for a real workspace, add `azure_sentinel` to `success_callback`, leave `AZURE_AUTHORITY_HOST` unset, send a chat completion, confirm the record lands in Log Analytics exactly as before
2. Set `AZURE_AUTHORITY_HOST=https://login.microsoftonline.us` and confirm the proxy's token request goes to `login.microsoftonline.us` with the `https://monitor.azure.us/.default` audience

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
