### PR TITLE
fix(ui): allow clearing a key's budget reset from the Edit Key form

### DIFF
--- a/ui/litellm-dashboard/src/components/TeamSSOSettings.tsx
+++ b/ui/litellm-dashboard/src/components/TeamSSOSettings.tsx
@@ -236,7 +236,7 @@ const TeamSSOSettings: React.FC<TeamSSOSettingsProps> = ({ accessToken }) => {
               editContent={
                 <BudgetDurationDropdown
                   value={editedValues.budget_duration || null}
-                  onChange={(v) => update("budget_duration", v)}
+                  onChange={(v) => update("budget_duration", v ?? null)}
                   style={{ maxWidth: 320 }}
                 />
               }

--- a/ui/litellm-dashboard/src/components/common_components/budget_duration_dropdown.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/budget_duration_dropdown.tsx
@@ -5,7 +5,7 @@ const { Option } = Select;
 
 interface BudgetDurationDropdownProps {
   value?: string | null;
-  onChange?: (value: string) => void;
+  onChange?: (value: string | undefined) => void;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -22,7 +22,7 @@ const BudgetDurationDropdown: React.FC<BudgetDurationDropdownProps> = ({
       value={value || undefined}
       onChange={onChange}
       className={className}
-      placeholder="n/a"
+      placeholder="Never resets"
       allowClear
     >
       <Option value="1h">hourly</Option>

--- a/ui/litellm-dashboard/src/components/common_components/budget_duration_dropdown.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/budget_duration_dropdown.tsx
@@ -8,6 +8,7 @@ interface BudgetDurationDropdownProps {
   onChange?: (value: string | undefined) => void;
   className?: string;
   style?: React.CSSProperties;
+  placeholder?: string;
 }
 
 const BudgetDurationDropdown: React.FC<BudgetDurationDropdownProps> = ({
@@ -15,6 +16,7 @@ const BudgetDurationDropdown: React.FC<BudgetDurationDropdownProps> = ({
   onChange,
   className = "",
   style = {},
+  placeholder = "n/a",
 }) => {
   return (
     <Select
@@ -22,7 +24,7 @@ const BudgetDurationDropdown: React.FC<BudgetDurationDropdownProps> = ({
       value={value || undefined}
       onChange={onChange}
       className={className}
-      placeholder="Never resets"
+      placeholder={placeholder}
       allowClear
     >
       <Option value="1h">hourly</Option>

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -1060,7 +1060,10 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                     name="budget_duration"
                     help={`Team Reset Budget: ${team?.budget_duration !== null && team?.budget_duration !== undefined ? team?.budget_duration : "None"}`}
                   >
-                    <BudgetDurationDropdown onChange={(value) => form.setFieldValue("budget_duration", value)} />
+                    <BudgetDurationDropdown
+                      placeholder="Never resets"
+                      onChange={(value) => form.setFieldValue("budget_duration", value)}
+                    />
                   </Form.Item>
                   <Form.Item
                     className="mt-4"

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
@@ -507,6 +507,68 @@ describe("KeyInfoView handleKeyUpdate budget_duration", () => {
     const [, sentPayload] = keyUpdateCallMock.mock.calls[0];
     expect(sentPayload.budget_duration).toBe("30d");
   });
+
+  it("should forward a cleared budget_duration as an explicit null the JSON body keeps", async () => {
+    renderView(true);
+
+    fireEvent.click(screen.getByText("Settings"));
+    fireEvent.click(screen.getByText("Edit Settings"));
+    (globalThis as any).__TEST_FORM_VALUES = {
+      token: "tok_123",
+      budget_duration: null,
+    };
+
+    fireEvent.click(screen.getByText("Mock Submit"));
+
+    await waitFor(() => expect(keyUpdateCallMock).toHaveBeenCalled());
+
+    const [, sentPayload] = keyUpdateCallMock.mock.calls[0];
+    expect(sentPayload.budget_duration).toBeNull();
+    expect(JSON.parse(JSON.stringify(sentPayload))).toHaveProperty("budget_duration", null);
+  });
+
+  it("should render the cleared budget as never resetting instead of snapping back to the old interval", async () => {
+    keyUpdateCallMock.mockResolvedValueOnce({
+      ...baseKeyData,
+      budget_duration: null,
+      budget_reset_at: null,
+    });
+    mockUseAuthorized.mockReturnValue({
+      accessToken: "access_abc",
+      userId: "user_1",
+      userRole: "Admin",
+      premiumUser: true,
+      token: "token_123",
+      userEmail: "test@example.com",
+      disabledPersonalKeyCreation: false,
+      showSSOBanner: false,
+    });
+
+    render(
+      <KeyInfoView
+        keyId="tok_123"
+        onClose={() => {}}
+        keyData={{ ...baseKeyData, budget_duration: "30d", budget_reset_at: "2026-09-01T00:00:00Z" } as any}
+        onKeyDataUpdate={() => {}}
+        teams={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Settings"));
+    expect(screen.getByText("Budget Reset").parentElement?.textContent).toContain("Every 30d");
+
+    fireEvent.click(screen.getByText("Edit Settings"));
+    (globalThis as any).__TEST_FORM_VALUES = {
+      token: "tok_123",
+      budget_duration: null,
+    };
+
+    fireEvent.click(screen.getByText("Mock Submit"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Budget Reset").parentElement?.textContent).toBe("Budget ResetNever");
+    });
+  });
 });
 
 describe("KeyInfoView handleKeyUpdate empty strings", () => {

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
@@ -524,7 +524,7 @@ describe("KeyInfoView handleKeyUpdate budget_duration", () => {
 
     const [, sentPayload] = keyUpdateCallMock.mock.calls[0];
     expect(sentPayload.budget_duration).toBeNull();
-    expect(JSON.parse(JSON.stringify(sentPayload))).toHaveProperty("budget_duration", null);
+    expect(JSON.stringify({ ...sentPayload })).toContain('"budget_duration":null');
   });
 
   it("should render the cleared budget as never resetting instead of snapping back to the old interval", async () => {

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -777,6 +777,65 @@ describe("KeyEditView", () => {
     });
   });
 
+  it("should send an explicit null budget_duration when a previously-set Reset Budget is cleared", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(
+      <KeyEditView
+        keyData={MOCK_KEY_DATA}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"admin"}
+        premiumUser={false}
+      />,
+    );
+
+    const resetBudgetItem = (await screen.findByText("Reset Budget")).closest(".ant-form-item") as HTMLElement;
+    const clearIcon = resetBudgetItem.querySelector(".ant-select-clear");
+    expect(clearIcon).not.toBeNull();
+    fireEvent.mouseDown(clearIcon as Element);
+
+    await waitFor(() => {
+      expect(within(resetBudgetItem).getByText("Never resets")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+    });
+    const callArgs = onSubmitMock.mock.calls[0][0];
+    expect(callArgs.budget_duration).toBeNull();
+    expect(JSON.parse(JSON.stringify(callArgs))).toHaveProperty("budget_duration", null);
+  });
+
+  it("should send an explicit null budget_duration when a legacy word-form Reset Budget is cleared", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const legacyKeyData = { ...MOCK_KEY_DATA, budget_duration: "monthly" };
+    renderWithProviders(
+      <KeyEditView
+        keyData={legacyKeyData}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"admin"}
+        premiumUser={false}
+      />,
+    );
+
+    const resetBudgetItem = (await screen.findByText("Reset Budget")).closest(".ant-form-item") as HTMLElement;
+    fireEvent.mouseDown(resetBudgetItem.querySelector(".ant-select-clear") as Element);
+
+    await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+    });
+    expect(onSubmitMock.mock.calls[0][0].budget_duration).toBeNull();
+  });
+
   it("should omit budget_limits when existing windows are left untouched (issue #33246)", async () => {
     // The backend treats any budget_limits in the payload as an admin-only
     // budget change, so re-sending untouched windows 403s a non-admin owner.

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -807,7 +807,7 @@ describe("KeyEditView", () => {
     });
     const callArgs = onSubmitMock.mock.calls[0][0];
     expect(callArgs.budget_duration).toBeNull();
-    expect(JSON.parse(JSON.stringify(callArgs))).toHaveProperty("budget_duration", null);
+    expect(JSON.stringify({ ...callArgs })).toContain('"budget_duration":null');
   });
 
   it("should send an explicit null budget_duration when a legacy word-form Reset Budget is cleared", async () => {

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -294,6 +294,10 @@ export function KeyEditView({
         values.duration = null;
       }
 
+      if (keyData.budget_duration && !values.budget_duration) {
+        values.budget_duration = null;
+      }
+
       // Reconcile multi-window budget limits from the editor state, dropping
       // incomplete entries (no max_budget). The backend treats any budget_limits
       // in a /key/update request as an admin-only budget change, so re-sending

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -498,7 +498,7 @@ export function KeyEditView({
       </Form.Item>
 
       <Form.Item label="Reset Budget" name="budget_duration">
-        <BudgetDurationDropdown />
+        <BudgetDurationDropdown placeholder="Never resets" />
       </Form.Item>
 
       <Form.Item


### PR DESCRIPTION
## TLDR

Problem this solves:

- Clearing a key's Reset Budget silently reverts on save
- No UI way to stop a key budget resetting
- Dropdown's onChange type hid this class of bug

How it solves it:

- Send explicit null when a set interval is cleared
- Type onChange truthfully as `string | undefined`
- Label the empty state "Never resets" on the key forms

## Relevant issues

## Linear ticket

Resolves LIT-5129

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs hit a live proxy on localhost:4517 backed by a real Postgres, driving the real Admin UI dev server. The before run was captured with the three source files checked out at `f6587faef5` (this branch's base), the after run at `9c9905ee8d`, same proxy process and same key throughout

### Before (`f6587faef5`)

Key `lit5129-qa-a` starts on a monthly reset

![before edit form showing monthly](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5129_screenshots/before-02-edit-form-monthly.png)

Clicking the x empties the control, which looks like it worked

![before cleared control showing n/a](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5129_screenshots/before-03-cleared-shows-na.png)

Save Changes returns 200 and the success toast, but `budget_duration` is missing from the request body entirely, so `prepare_key_update_data` reads it as unset and keeps the old interval:

```json
{"key_alias":"lit5129-qa-a","models":[],"max_budget":10,"tpm_limit":null,"rpm_limit":null,"max_parallel_requests":null,"access_group_ids":[],"team_id":null,"metadata":{},"duration":null,"token":"b7d1072a...9104bc","auto_rotate":false,"tag_rpm_limit":{},"key":"b7d1072a...9104bc"}
```

The panel snaps straight back to the monthly reset

![before snapping back to Every 30d after save](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5129_screenshots/before-04-snaps-back-after-save.png)

### After (`9c9905ee8d`)

Same key, same x, and the empty state now says what it means

![after cleared control showing Never resets](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5129_screenshots/after-02-cleared-shows-never-resets.png)

The request body now carries the explicit null that the backend's clear branch is waiting for:

```json
{"key_alias":"lit5129-qa-a","models":[],"max_budget":10,"budget_duration":null,"tpm_limit":null,"rpm_limit":null,"max_parallel_requests":null,"access_group_ids":[],"team_id":null,"duration":null,"token":"b7d1072a...9104bc","auto_rotate":false,"tag_rpm_limit":{},"key":"b7d1072a...9104bc"}
```

![after key settings showing Budget Reset Never](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5129_screenshots/after-03-budget-reset-never.png)

The database agrees, and `budget_reset_at` is nulled alongside it so the reset job stops selecting the key:

```
$ curl -s -X GET 'http://localhost:4517/key/info?key=sk--LfG20GquUDVoDPsVpRgSg' -H 'Authorization: Bearer sk-1234' | jq '.info | {key_alias, max_budget, budget_duration, budget_reset_at}'
{
  "key_alias": "lit5129-qa-a",
  "max_budget": 10.0,
  "budget_duration": null,
  "budget_reset_at": null
}
```

Setting an interval still works from the cleared state, so this is not a one-way door. Picking weekly and saving:

![after re-setting to weekly](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5129_screenshots/after-04-reset-back-to-weekly.png)

```
$ curl -s -X GET 'http://localhost:4517/key/info?key=sk--LfG20GquUDVoDPsVpRgSg' -H 'Authorization: Bearer sk-1234' | jq '.info | {key_alias, budget_duration, budget_reset_at}'
{
  "key_alias": "lit5129-qa-a",
  "budget_duration": "7d",
  "budget_reset_at": "2026-08-10T00:00:00+00:00"
}
```

Re-run at `0b1438b9df` (branch head after the placeholder was scoped to the key forms) against a second key that was on a daily reset, to confirm the amendment left the key edit flow alone. Cleared the same way from the UI:

```
$ curl -s -X GET 'http://localhost:4517/key/info?key=sk-7gypYhds1OcP6l56W125zA' -H 'Authorization: Bearer sk-1234' | jq '.info | {key_alias, max_budget, budget_duration, budget_reset_at}'
{
  "key_alias": "lit5129-qa-b",
  "max_budget": 11.0,
  "budget_duration": null,
  "budget_reset_at": null
}
```

## Type

🐛 Bug Fix

## Changes

`/key/update` already honored an explicit `budget_duration: null` by nulling both `budget_duration` and `budget_reset_at`, and it reads the request with `exclude_unset`, so an absent field means "keep what you have". The UI could never reach that branch. antd's `allowClear` hands `onChange` a value of `undefined`, `JSON.stringify` drops undefined keys, and the field vanished from the body before it ever left the browser

`key_edit_view.tsx` now sends an explicit null when a key that had an interval is saved with the control empty, which is where the form's other clear-to-null coercions already live. The never-had-one path is untouched and still sends the same bytes as before

The dropdown's `onChange` was typed `(value: string) => void`, which is what let this ship: TypeScript could not have caught the undefined. It is now typed truthfully, and `TeamSSOSettings` picks up a `?? null` so its team-default state keeps matching its own declared type

The placeholder becomes a prop that still defaults to "n/a", and only key edit and key create pass "Never resets". Those are the two forms where an empty control is honest, since `/key/generate` and `/key/update` both read a missing or null duration as a one-time budget. The other five consumers stay on the default because the label would be a lie there. On user edit, `_update_internal_user_params` drops the cleared null and then applies `litellm.internal_user_budget_duration` with a fresh `budget_reset_at`, so the control would promise no resets while the save installs a recurring one. On tag info the cleared value is dropped client side and again by `model_dump(exclude_none=True)`, and on the team SSO defaults row the view half of the same row already renders "Not set"

Team and internal user forms have the same clearing gap. They are out of scope here and worth their own tickets, especially the user path described above

Four tests cover it. Two assert the cleared value leaves as `null` in the JSON body, from both a canonical and a legacy word-form starting value, and both fail with `expected undefined to be null` when the coercion is removed. Two more pin the surrounding behavior against regression, one on the field surviving `JSON.stringify` and one on the panel rendering the cleared budget instead of snapping back, and both were proven to fail against injected mutations of exactly those two hazards. The serialization assertions read the request body string, so a regression to `undefined` surfaces as a missing key rather than passing quietly

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


