### PR TITLE
fix(proxy): stop alerting on health probes that lose the planned engine-restart race

### DIFF
--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -486,6 +486,38 @@ class PrismaWrapper:
         os.environ[self._db_url_env_var] = _db_url
         return _db_url
 
+    @property
+    def engine_generation(self) -> int:
+        """How many query-engine replacements have completed on this wrapper.
+
+        Bumped under `_reconnection_lock` only after a replacement engine has
+        connected, so a change across an await proves a *successful* planned
+        replacement happened in between — a replacement that failed (a real
+        outage) leaves it untouched.
+        """
+        return self._engine_generation
+
+    async def _reconnection_settled(self) -> None:
+        async with self._reconnection_lock:
+            pass
+
+    async def wait_for_planned_engine_replacement(self, timeout_seconds: float) -> None:
+        """Wait, bounded, for an in-flight planned engine replacement to finish.
+
+        Both replacement paths (`recreate_prisma_client` and
+        `_safe_refresh_token`) hold `_reconnection_lock` across their whole
+        kill/connect window, so re-acquiring it means the replacement has
+        settled one way or the other. Gives up silently on timeout: a caller
+        that stopped waiting must treat the replacement as not completed and
+        consult `engine_generation` rather than assume success.
+        """
+        if timeout_seconds <= 0 or not self._reconnection_lock.locked():
+            return
+        try:
+            await asyncio.wait_for(self._reconnection_settled(), timeout=timeout_seconds)
+        except asyncio.TimeoutError:
+            return
+
     async def recreate_prisma_client(
         self,
         new_db_url: str,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3000,6 +3000,13 @@ class PrismaClient:
     ] = []  # mutable-ok: drained queue, mirrors tool_usage_transactions
     _autorouter_turn_transactions_lock = asyncio.Lock()
 
+    # How long a health probe failure waits for an in-flight planned engine
+    # replacement to settle before deciding whether to report itself. Generous
+    # against a replacement that takes well under a second, and far short of the
+    # reconnect budget an outage-hung `connect()` runs under, so a real outage
+    # is never waited out.
+    PLANNED_ENGINE_REPLACEMENT_SETTLE_SECONDS: ClassVar[float] = 5.0
+
     def __init__(
         self,
         database_url: str,
@@ -4970,6 +4977,101 @@ class PrismaClient:
                 else:
                     verbose_proxy_logger.debug("Prisma DB health watchdog observed non-DB error: %s", e)
 
+    def _probe_target_wrapper(self) -> PrismaWrapper:
+        """The Prisma wrapper a `SELECT 1` health probe actually reaches.
+
+        `health_check()` issues `query_raw`, which `RoutingPrismaWrapper` sends
+        to the reader unless the reader is degraded. The writer's engine state
+        therefore says nothing about a probe that failed against the reader, so
+        the gate has to follow the same routing rule the probe did.
+        """
+        if isinstance(self.db, RoutingPrismaWrapper):
+            return self.db.writer if self.db.reader_unavailable else self.db.reader
+        return self.db
+
+    async def _run_health_probe(self, wrapper: PrismaWrapper) -> object:
+        """Issue the `SELECT 1` a health check is made of, against `wrapper`.
+
+        Takes the wrapper rather than re-reading `self.db`, because routing is
+        re-resolved on every attribute access: a reader that recovers between
+        the caller picking its target and the query going out would send the
+        probe to a different engine than the one whose generation the caller is
+        about to check, and attribute the failure to the wrong replacement.
+        """
+        sql_query: Final = "SELECT 1"
+        response: Final = await wrapper.query_raw(sql_query)
+        return response
+
+    async def _probe_answers_now(self, wrapper: PrismaWrapper) -> bool:
+        try:
+            await self._run_health_probe(wrapper)
+        except Exception as probe_error:  # noqa: BLE001  # any failure means the database is not answering
+            verbose_proxy_logger.debug("Prisma health_check() confirmation probe failed: %s", probe_error)
+            return False
+        return True
+
+    async def _planned_engine_replacement_absorbed(
+        self,
+        e: Exception,
+        wrapper: PrismaWrapper,
+        generation_before: int,
+    ) -> bool:
+        """True iff `e` is a connection-class probe failure that a completed
+        planned query-engine replacement explains.
+
+        Planned replacements (RDS IAM token refresh, guarded reconnect) kill the
+        running query engine and spawn a new one. A `SELECT 1` probe that races
+        that sub-second window fails with a transport error against the engine's
+        local HTTP port even though nothing is wrong with the database, and
+        reporting it drives a false-positive `db_exceptions` alert on every
+        replacement.
+
+        Two things must both hold, because neither is sufficient alone. The
+        engine generation must have moved, which says a replacement completed
+        rather than merely being attempted: reconnect attempts during a real
+        outage hold the same lock for tens of seconds, so gating on an in-flight
+        replacement would swallow most of an outage's alerts. And a fresh probe
+        must succeed, because `Prisma.connect()` polls the query engine's own
+        `/status` endpoint rather than round-tripping to the database, so a
+        future engine that binds before it validates its connection pool would
+        let the generation advance with the database still unreachable.
+
+        Waiting for an in-flight replacement to settle is what makes the
+        generation check meaningful, since the generation has not moved yet at
+        the instant the probe fails. The wait is generous against a replacement
+        that takes well under a second and short enough that an outage-hung
+        reconnect is not waited out; a replacement that has not settled by then
+        reports rather than stays silent.
+        """
+        if not PrismaDBExceptionHandler.is_database_connection_error(e):
+            return False
+        await wrapper.wait_for_planned_engine_replacement(self.PLANNED_ENGINE_REPLACEMENT_SETTLE_SECONDS)
+        if wrapper.engine_generation == generation_before:
+            return False
+        return await self._probe_answers_now(wrapper)
+
+    async def _report_health_check_failure(
+        self,
+        e: Exception,
+        duration: float,
+        traceback_str: str,
+        wrapper: PrismaWrapper,
+        generation_before: int,
+    ) -> None:
+        if await self._planned_engine_replacement_absorbed(e, wrapper, generation_before):
+            verbose_proxy_logger.info(
+                "Prisma health_check() connection error raced a planned query-engine replacement; "
+                "not reporting it as a DB exception: %s",
+                e,
+            )
+            return
+        await self.proxy_logging_obj.failure_handler(
+            original_exception=e,
+            duration=duration,
+            call_type="health_check",
+            traceback_str=traceback_str,
+        )
+
     @backoff.on_exception(
         backoff.expo,
         Exception,
@@ -4982,13 +5084,10 @@ class PrismaClient:
         Health check endpoint for the prisma client
         """
         start_time: Final = time.time()
+        probe_wrapper: Final = self._probe_target_wrapper()
+        generation_before: Final = probe_wrapper.engine_generation
         try:
-            sql_query: Final = "SELECT 1"
-
-            # Execute the raw query
-            # The asterisk before `user_id_list` unpacks the list into separate arguments
-            response: Final = await self.db.query_raw(sql_query)
-            return response
+            return await self._run_health_probe(probe_wrapper)
         except Exception as e:
             import traceback
 
@@ -4998,11 +5097,12 @@ class PrismaClient:
             end_time: Final = time.time()
             _duration: Final = end_time - start_time
             asyncio.create_task(
-                self.proxy_logging_obj.failure_handler(
-                    original_exception=e,
+                self._report_health_check_failure(
+                    e=e,
                     duration=_duration,
-                    call_type="health_check",
                     traceback_str=error_traceback,
+                    wrapper=probe_wrapper,
+                    generation_before=generation_before,
                 )
             )
             raise e

--- a/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
+++ b/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
@@ -6,13 +6,24 @@ subprocess), and the engine-death watcher / in-flight transport-error
 retries must not treat that planned restart as a crash and recreate the
 client a second time.
 
+A planned restart is also invisible to the database itself, so a ``SELECT 1``
+health probe that races the kill/connect window fails with a transport error
+against the engine's local HTTP port. That failure must not be reported as a
+``db_exceptions`` DB failure, or every IAM refresh cycle raises a false alarm.
+
 Symbols pinned here:
   - ``PrismaWrapper._expected_engine_deaths``
   - ``PrismaWrapper._engine_generation``
+  - ``PrismaWrapper.engine_generation``
+  - ``PrismaWrapper.wait_for_planned_engine_replacement``
   - ``PrismaWrapper.on_engine_replaced``
   - ``PrismaWrapper.recreate_prisma_client`` (expected_generation guard)
   - ``PrismaWrapper._safe_refresh_token`` (refresh coalescing)
   - ``RoutingPrismaWrapper.recreate_prisma_client`` (guard forwarding)
+  - ``PrismaClient.health_check`` (planned-replacement alert suppression)
+  - ``PrismaClient._probe_target_wrapper``
+  - ``PrismaClient._probe_answers_now``
+  - ``PrismaClient._planned_engine_replacement_absorbed``
 """
 
 import asyncio
@@ -21,22 +32,29 @@ import signal
 import sys
 import urllib.parse
 from datetime import datetime, timedelta
+from typing import Any, List
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import httpx
 import pytest
 from prisma import Prisma as GeneratedPrisma
+from prisma.engine.errors import EngineConnectionError
 
 sys.path.insert(
     0, os.path.abspath("../../../..")
 )  # Adds the parent directory to the system path
 
 from litellm.proxy.db.prisma_client import PrismaWrapper
+from litellm.proxy.utils import PrismaClient
 
 
 @pytest.fixture(autouse=True)
 def mock_prisma_binary():
     """Mock prisma.Prisma to avoid requiring generated Prisma binaries for unit tests."""
     mock_module = MagicMock()
+    # Production code isinstance-checks against this, which a bare MagicMock
+    # attribute cannot satisfy.
+    mock_module.engine.errors.EngineConnectionError = EngineConnectionError
     with patch.dict(sys.modules, {"prisma": mock_module}):
         yield mock_module
 
@@ -47,6 +65,87 @@ def _make_wrapper(engine_pid: int = 111, iam: bool = False) -> PrismaWrapper:
     engine.process.pid = engine_pid
     setattr(prisma, "_Prisma__engine", engine)
     return PrismaWrapper(original_prisma=prisma, iam_token_db_auth=iam)
+
+
+def _make_prisma_client(db: Any) -> PrismaClient:
+    """A ``PrismaClient`` whose ``db`` is a real wrapper and whose alerting
+    hook is observable."""
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.failure_handler = AsyncMock()
+    client = PrismaClient(
+        database_url="postgresql://user:pass@localhost:5432/db",
+        proxy_logging_obj=proxy_logging_obj,
+    )
+    client.db = db
+    client._db_watchdog_reconnect_timeout_seconds = 5.0
+    return client
+
+
+_real_asyncio_sleep = asyncio.sleep
+
+
+async def _yield_to_loop(times: int = 10) -> None:
+    """Let already-scheduled tasks make progress.
+
+    Bound to the real ``asyncio.sleep`` at import time: the tests below patch
+    ``asyncio.sleep`` to skip the SIGTERM/SIGKILL grace, and an ``AsyncMock``
+    stand-in never yields to the event loop, which would silently leave every
+    background task un-started and the assertions vacuous.
+    """
+    for _ in range(times):
+        await _real_asyncio_sleep(0)
+
+
+async def _await_health_check_reports() -> None:
+    """Await the fire-and-forget reporting tasks ``health_check()`` scheduled.
+
+    Selected by coroutine qualname rather than by draining every pending task,
+    so an unrelated background task can never make these assertions pass by
+    accident.
+    """
+    reports = [
+        task
+        for task in asyncio.all_tasks()
+        if getattr(task.get_coro(), "__qualname__", "")
+        == "PrismaClient._report_health_check_failure"
+    ]
+    if reports:
+        await asyncio.gather(*reports, return_exceptions=True)
+
+
+def _fails_then_answers(error: Exception, failures: int = 3) -> Any:
+    """Raise ``error`` for the first ``failures`` probes, then answer.
+
+    ``health_check`` retries up to three times, so this exhausts the retries and
+    still lets the confirmation probe that decides suppression succeed. Without
+    that, a test would report for the wrong reason: the confirmation probe would
+    fail too, masking whether the error type was classified at all.
+    """
+    seen: List[int] = []
+
+    async def _query_raw(_sql: str) -> Any:
+        seen.append(1)
+        if len(seen) <= failures:
+            raise error
+        return [{"?column?": 1}]
+
+    return _query_raw
+
+
+def _blocking_replacement(gate: asyncio.Event, fail: bool = False) -> MagicMock:
+    """A replacement Prisma whose ``connect()`` parks until ``gate`` is set.
+
+    Holds ``_reconnection_lock`` open for as long as the test needs, which is
+    how a health probe is made to fail *while* a planned replacement is in
+    flight rather than after it.
+    """
+
+    async def _connect(*_: Any, **__: Any) -> None:
+        await gate.wait()
+        if fail:
+            raise ConnectionRefusedError("database is down")
+
+    return MagicMock(connect=AsyncMock(side_effect=_connect))
 
 
 def _token_db_url(created: datetime, expires_in: int = 900) -> str:
@@ -603,3 +702,348 @@ async def test_recreate_caps_expected_engine_deaths_set(mock_prisma_binary):
         await wrapper.recreate_prisma_client("postgresql://new")
 
     assert wrapper._expected_engine_deaths == {111}
+
+
+@pytest.mark.asyncio
+async def test_wait_for_planned_engine_replacement_returns_once_recreate_settles(
+    mock_prisma_binary,
+):
+    wrapper = _make_wrapper(engine_pid=111)
+    gate = asyncio.Event()
+    mock_prisma_binary.Prisma.return_value = _blocking_replacement(gate)
+
+    with patch("os.kill"), patch("asyncio.sleep", new_callable=AsyncMock):
+        recreate = asyncio.create_task(
+            wrapper.recreate_prisma_client("postgresql://new")
+        )
+        await _yield_to_loop()
+        assert wrapper._reconnection_lock.locked() is True
+
+        waiter = asyncio.create_task(wrapper.wait_for_planned_engine_replacement(5.0))
+        await _yield_to_loop()
+        blocked_while_in_flight = not waiter.done()
+
+        gate.set()
+        await recreate
+        await waiter
+
+    assert {
+        "blocked_while_in_flight": blocked_while_in_flight,
+        "generation": wrapper.engine_generation,
+    } == {"blocked_while_in_flight": True, "generation": 1}
+
+
+@pytest.mark.asyncio
+async def test_wait_for_planned_engine_replacement_gives_up_at_timeout(
+    mock_prisma_binary,
+):
+    """A replacement that never settles must not stall the caller forever; the
+    caller then sees an unchanged generation and reports the failure."""
+    wrapper = _make_wrapper(engine_pid=111)
+    gate = asyncio.Event()
+    mock_prisma_binary.Prisma.return_value = _blocking_replacement(gate)
+
+    with patch("os.kill"), patch("asyncio.sleep", new_callable=AsyncMock):
+        recreate = asyncio.create_task(
+            wrapper.recreate_prisma_client("postgresql://new")
+        )
+        await _yield_to_loop()
+        assert wrapper._reconnection_lock.locked() is True
+
+        await asyncio.wait_for(
+            wrapper.wait_for_planned_engine_replacement(0.05), timeout=5.0
+        )
+        gave_up_with_replacement_still_in_flight = not recreate.done()
+
+        gate.set()
+        await recreate
+
+    assert gave_up_with_replacement_still_in_flight is True
+
+
+@pytest.mark.asyncio
+async def test_health_check_does_not_alert_when_probe_races_a_completed_replacement(
+    mock_prisma_binary,
+):
+    """The reported bug: an IAM-refresh engine recreate makes a concurrent
+    readiness probe fail transiently, and that failure was alerting as a DB
+    exception on every refresh cycle.
+
+    The reporting task is drained while the replacement is still in flight,
+    which is when it runs in production; a decision taken at that instant sees
+    an engine generation that has not moved yet.
+    """
+    wrapper = _make_wrapper(engine_pid=111)
+    client = _make_prisma_client(wrapper)
+    wrapper.query_raw = AsyncMock(
+        side_effect=[
+            httpx.ConnectError("All connection attempts failed"),
+            [{"?column?": 1}],
+            [{"?column?": 1}],
+        ]
+    )
+    gate = asyncio.Event()
+    mock_prisma_binary.Prisma.return_value = _blocking_replacement(gate)
+
+    with patch("os.kill"), patch("asyncio.sleep", new_callable=AsyncMock):
+        recreate = asyncio.create_task(
+            wrapper.recreate_prisma_client("postgresql://new")
+        )
+        await _yield_to_loop()
+        assert wrapper._reconnection_lock.locked() is True
+
+        probe_result = await client.health_check()
+
+        drain = asyncio.create_task(_await_health_check_reports())
+        await _yield_to_loop()
+        alerts_while_replacement_in_flight = (
+            client.proxy_logging_obj.failure_handler.await_count
+        )
+
+        gate.set()
+        await recreate
+        await drain
+
+    assert {
+        "probe_result": probe_result,
+        "probe_attempts": wrapper.query_raw.await_count,
+        "alerts_while_in_flight": alerts_while_replacement_in_flight,
+        "alerts": client.proxy_logging_obj.failure_handler.await_count,
+    } == {
+        "probe_result": [{"?column?": 1}],
+        "probe_attempts": 3,
+        "alerts_while_in_flight": 0,
+        "alerts": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_health_check_alerts_when_a_completed_replacement_still_cannot_reach_the_database(
+    mock_prisma_binary,
+):
+    """``Prisma.connect()`` polls the query engine's own ``/status`` endpoint
+    rather than round-tripping to the database, so a replacement can complete
+    against a database that is still unreachable. The engine generation alone
+    must not be enough to stay silent."""
+    wrapper = _make_wrapper(engine_pid=111)
+    client = _make_prisma_client(wrapper)
+    wrapper.query_raw = AsyncMock(
+        side_effect=httpx.ConnectError("All connection attempts failed")
+    )
+    gate = asyncio.Event()
+    mock_prisma_binary.Prisma.return_value = _blocking_replacement(gate)
+
+    with patch("os.kill"), patch("asyncio.sleep", new_callable=AsyncMock):
+        recreate = asyncio.create_task(
+            wrapper.recreate_prisma_client("postgresql://new")
+        )
+        await _yield_to_loop()
+        assert wrapper._reconnection_lock.locked() is True
+
+        with pytest.raises(httpx.ConnectError):
+            await client.health_check()
+
+        gate.set()
+        await recreate
+        await _await_health_check_reports()
+
+    assert {
+        "replacement_completed": wrapper.engine_generation,
+        "alerted": client.proxy_logging_obj.failure_handler.await_count > 0,
+    } == {"replacement_completed": 1, "alerted": True}
+
+
+@pytest.mark.asyncio
+async def test_health_check_alerts_when_the_replacement_never_completes(
+    mock_prisma_binary,
+):
+    """A real outage also has a replacement in flight, but it fails, so the
+    engine generation never advances and the probe failure must still alert."""
+    wrapper = _make_wrapper(engine_pid=111)
+    client = _make_prisma_client(wrapper)
+    wrapper.query_raw = AsyncMock(
+        side_effect=httpx.ConnectError("All connection attempts failed")
+    )
+    gate = asyncio.Event()
+    mock_prisma_binary.Prisma.return_value = _blocking_replacement(gate, fail=True)
+
+    with patch("os.kill"), patch("asyncio.sleep", new_callable=AsyncMock):
+        recreate = asyncio.create_task(
+            wrapper.recreate_prisma_client("postgresql://new")
+        )
+        await _yield_to_loop()
+        assert wrapper._reconnection_lock.locked() is True
+
+        with pytest.raises(httpx.ConnectError):
+            await client.health_check()
+
+        gate.set()
+        with pytest.raises(ConnectionRefusedError):
+            await recreate
+        await _await_health_check_reports()
+
+    call_types: List[str] = [
+        c.kwargs["call_type"]
+        for c in client.proxy_logging_obj.failure_handler.await_args_list
+    ]
+    assert {
+        "generation": wrapper.engine_generation,
+        "alerted": len(call_types) > 0,
+        "call_types": set(call_types),
+    } == {"generation": 0, "alerted": True, "call_types": {"health_check"}}
+
+
+@pytest.mark.asyncio
+async def test_health_check_alerts_for_non_connection_errors_during_a_replacement(
+    mock_prisma_binary,
+):
+    """Suppression is scoped to transport failures. A query the database itself
+    rejected is a real defect and must alert even mid-replacement, and even
+    though the database is plainly reachable a moment later."""
+    wrapper = _make_wrapper(engine_pid=111)
+    client = _make_prisma_client(wrapper)
+    wrapper.query_raw = AsyncMock(side_effect=_fails_then_answers(ValueError("malformed SELECT")))
+    gate = asyncio.Event()
+    mock_prisma_binary.Prisma.return_value = _blocking_replacement(gate)
+
+    with patch("os.kill"), patch("asyncio.sleep", new_callable=AsyncMock):
+        recreate = asyncio.create_task(
+            wrapper.recreate_prisma_client("postgresql://new")
+        )
+        await _yield_to_loop()
+        assert wrapper._reconnection_lock.locked() is True
+
+        with pytest.raises(ValueError):
+            await client.health_check()
+
+        gate.set()
+        await recreate
+        await _await_health_check_reports()
+
+    assert {
+        "generation": wrapper.engine_generation,
+        "alerted": client.proxy_logging_obj.failure_handler.await_count > 0,
+    } == {"generation": 1, "alerted": True}
+
+
+@pytest.mark.asyncio
+async def test_health_check_alerts_for_a_transient_failure_with_no_engine_replacement(
+    mock_prisma_binary,
+):
+    """Suppression is scoped to failures a planned replacement explains. A
+    transport blip that self-heals with no engine replacement at all still
+    alerts, so the gate cannot be widened into silencing every failure whose
+    database happens to answer a moment later."""
+    wrapper = _make_wrapper(engine_pid=111)
+    client = _make_prisma_client(wrapper)
+    wrapper.query_raw = AsyncMock(
+        side_effect=[
+            httpx.ConnectError("All connection attempts failed"),
+            [{"?column?": 1}],
+            [{"?column?": 1}],
+        ]
+    )
+
+    probe_result = await client.health_check()
+    await _await_health_check_reports()
+
+    assert {
+        "probe_result": probe_result,
+        "generation": wrapper.engine_generation,
+        "alerted": client.proxy_logging_obj.failure_handler.await_count > 0,
+    } == {"probe_result": [{"?column?": 1}], "generation": 0, "alerted": True}
+
+
+@pytest.mark.asyncio
+async def test_health_probe_stays_on_its_target_when_reader_availability_flips(
+    mock_prisma_binary, monkeypatch
+):
+    """Routing is re-resolved on every attribute access, so a reader that
+    recovers mid-call would otherwise send the probe to a different engine than
+    the one whose generation is being checked, and blame the wrong replacement.
+    The probe follows the wrapper it was handed."""
+    from litellm.proxy.db.routing_prisma_wrapper import RoutingPrismaWrapper
+
+    monkeypatch.setenv("DATABASE_URL_READ_REPLICA", "postgresql://reader")
+    writer = _make_wrapper(engine_pid=111)
+    reader = _make_wrapper(engine_pid=222)
+    routing = RoutingPrismaWrapper(writer=writer, reader=reader)
+    client = _make_prisma_client(routing)
+    writer.query_raw = AsyncMock(return_value=[{"writer": 1}])
+    reader.query_raw = AsyncMock(return_value=[{"reader": 1}])
+
+    routing._reader_unavailable = False
+    target = client._probe_target_wrapper()
+    routing._reader_unavailable = True
+    result = await client._run_health_probe(target)
+
+    assert {
+        "target_is_reader": target is reader,
+        "result": result,
+        "reader_probes": reader.query_raw.await_count,
+        "writer_probes": writer.query_raw.await_count,
+    } == {
+        "target_is_reader": True,
+        "result": [{"reader": 1}],
+        "reader_probes": 1,
+        "writer_probes": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_health_check_consults_the_reader_wrapper_under_read_replica_routing(
+    mock_prisma_binary, monkeypatch
+):
+    """``query_raw`` is routed to the reader, so a reader-side planned
+    replacement is the one that explains a probe failure."""
+    from litellm.proxy.db.routing_prisma_wrapper import RoutingPrismaWrapper
+
+    monkeypatch.setenv("DATABASE_URL_READ_REPLICA", "postgresql://reader")
+    writer = _make_wrapper(engine_pid=111)
+    reader = _make_wrapper(engine_pid=222)
+    routing = RoutingPrismaWrapper(writer=writer, reader=reader)
+    client = _make_prisma_client(routing)
+    reader.query_raw = AsyncMock(
+        side_effect=[
+            httpx.ConnectError("All connection attempts failed"),
+            [{"?column?": 1}],
+            [{"?column?": 1}],
+        ]
+    )
+    gate = asyncio.Event()
+    mock_prisma_binary.Prisma.return_value = _blocking_replacement(gate)
+
+    with patch("os.kill"), patch("asyncio.sleep", new_callable=AsyncMock):
+        recreate = asyncio.create_task(
+            reader.recreate_prisma_client("postgresql://new-reader")
+        )
+        await _yield_to_loop()
+        assert reader._reconnection_lock.locked() is True
+
+        probe_result = await client.health_check()
+
+        drain = asyncio.create_task(_await_health_check_reports())
+        await _yield_to_loop()
+        alerts_while_replacement_in_flight = (
+            client.proxy_logging_obj.failure_handler.await_count
+        )
+
+        gate.set()
+        await recreate
+        await drain
+
+    assert {
+        "probe_target_is_the_reader": client._probe_target_wrapper() is reader,
+        "writer_generation": writer.engine_generation,
+        "reader_generation": reader.engine_generation,
+        "probe_result": probe_result,
+        "alerts_while_in_flight": alerts_while_replacement_in_flight,
+        "alerts": client.proxy_logging_obj.failure_handler.await_count,
+    } == {
+        "probe_target_is_the_reader": True,
+        "writer_generation": 0,
+        "reader_generation": 1,
+        "probe_result": [{"?column?": 1}],
+        "alerts_while_in_flight": 0,
+        "alerts": 0,
+    }

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -1096,6 +1096,7 @@ async def test_prisma_health_check_failure_names_itself_at_operator_visible_leve
     function and reads as "the check never ran", and reporting it only at debug
     level hides a database fault behind a flag nobody enables in production."""
     import logging
+    from functools import partial
     from unittest.mock import AsyncMock
 
     from litellm.proxy.utils import PrismaClient
@@ -1103,6 +1104,9 @@ async def test_prisma_health_check_failure_names_itself_at_operator_visible_leve
     client = MagicMock()
     client.db.query_raw = AsyncMock(side_effect=Exception("connection refused"))
     client.proxy_logging_obj.failure_handler = AsyncMock()
+    client._probe_target_wrapper = MagicMock(return_value=client.db)
+    client._run_health_probe = partial(PrismaClient._run_health_probe, client)
+    client._report_health_check_failure = AsyncMock()
 
     with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
         with pytest.raises(Exception, match="connection refused"):
@@ -1142,6 +1146,7 @@ async def test_prisma_health_check_failure_redacts_database_credentials(caplog):
     text can carry a full connection string, so the credential has to be gone
     from the emitted record."""
     import logging
+    from functools import partial
     from unittest.mock import AsyncMock
 
     from litellm.proxy.utils import PrismaClient
@@ -1151,6 +1156,9 @@ async def test_prisma_health_check_failure_redacts_database_credentials(caplog):
         side_effect=Exception("could not connect to postgresql://admin:hunter2@db.internal:5432/litellm")
     )
     client.proxy_logging_obj.failure_handler = AsyncMock()
+    client._probe_target_wrapper = MagicMock(return_value=client.db)
+    client._run_health_probe = partial(PrismaClient._run_health_probe, client)
+    client._report_health_check_failure = AsyncMock()
 
     with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
         with pytest.raises(Exception):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Planned Prisma engine restarts raise false `db_exceptions` alerts
- A readiness probe that retries and succeeds still pages someone
- Alert says the DB failed while the DB is healthy

How it solves it:

- Suppress only when a replacement completed and the DB answers
- Engine generation advances only after a replacement engine connects
- A confirmation probe keeps real outages alerting either way

## Relevant issues

Fixes #33276

## Linear ticket

Resolves LIT-4924

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on port 4062, real Postgres 16 in Docker on port 5462, `alerting: ["slack"]` pointed at a local webhook sink so every delivered `db_exceptions` alert is captured verbatim. No mocks anywhere in the rig

The trigger is a real writer query-engine replacement on a healthy database. `/health/readiness` caches a healthy result for 15 seconds, so each cycle waits the cache out and then replaces the engine, which is the race a Kubernetes readiness probe loses on every planned restart

```bash
docker run -d --name lit4924-pg -e POSTGRES_PASSWORD=litellm -e POSTGRES_USER=litellm \
  -e POSTGRES_DB=litellm -p 5462:5432 postgres:16
DATABASE_URL=postgresql://litellm:litellm@127.0.0.1:5462/litellm \
  python -m prisma db push --schema litellm-proxy-extras/litellm_proxy_extras/schema.prisma --accept-data-loss

# webhook sink that records every alert litellm actually delivers
python sink.py alerts.jsonl 4063 &

export DATABASE_URL=postgresql://litellm:litellm@127.0.0.1:5462/litellm
export SLACK_WEBHOOK_URL=http://127.0.0.1:4063/hook
export PRISMA_HEALTH_WATCHDOG_INTERVAL_SECONDS=5 PRISMA_RECONNECT_COOLDOWN_SECONDS=1
python litellm/proxy/proxy_cli.py --config config.yaml --port 4062 --detailed_debug &

# one cycle, repeated three times
curl -s -o /dev/null http://127.0.0.1:4062/health/readiness   # arms the 15s readiness cache
sleep 15
kill -9 "$(pgrep -P "$PROXY_PID" -f query-engine | head -1)"  # writer engine replacement
for i in $(seq 1 50); do
  curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4062/health/readiness; sleep 0.2
done
```

`config.yaml`

```yaml
model_list:
  - model_name: fake-model
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: sk-not-used
      mock_response: "hello"

general_settings:
  master_key: sk-lit4924
  alerting: ["slack"]
  alert_types: ["db_exceptions"]
  alerting_threshold: 1
```

Four legs, same rig, same probe schedule. Legs A and B run three engine replacements against a healthy database; legs C and D take the database away with `docker stop lit4924-pg` for 75 seconds

| leg | build | scenario | `health_check()` failures | `db_exceptions` alerts delivered | readiness responses |
| --- | --- | --- | --- | --- | --- |
| A | `f6587faef5` (base) | 3 planned engine replacements | 3 | **3** | 121x 200 |
| B | `2065dc1e1d` (this PR) | 3 planned engine replacements | 3 | **0** | 119x 200 |
| C | `2065dc1e1d` (this PR) | genuine database outage | 69 | **13** | 000 / 503 |
| D | `f6587faef5` (base) | genuine database outage | 27 | **6** | 000 / 503 |

A is the bug: every readiness probe answered 200 the whole time, and the proxy still paged three times

```
===== A-base-replace =====
fix present in the running tree: 0
cycle 1: writer query-engine 59736 -> 59774
cycle 2: writer query-engine 59774 -> 59972
cycle 3: writer query-engine 59972 -> 60136
readiness status codes    :  121 200
health_check failures     : 3
db_exceptions ALERTS sent : 3
suppressed as planned     : 0
```

The alert an operator receives on base, unchanged from the sink:

```
Alert type: `db_exceptions`
Level: `High`
Timestamp: `16:46:30`

Message: DB read/write call failed: All connection attempts failed
LiteLLM Prisma Client Exception health_check(): All connection attempts failed
Traceback (most recent call last):
  File ".../httpx/_transports/default.py", line 101, in map_httpcore_exceptions
```

B is the same scenario on this PR. Same three engine replacements, same three transport failures, zero alerts:

```
===== B3-fixed-replace =====
fix present in the running tree: 2
cycle 1: writer query-engine 71133 -> 71148
cycle 2: writer query-engine 71148 -> 71314
cycle 3: writer query-engine 71314 -> 71449
readiness status codes    :  119 200
health_check failures     : 3
db_exceptions ALERTS sent : 0
suppressed as planned     : 3
```

C is the control that matters. On the fixed build, with the database genuinely stopped, the replacement attempts fail, the engine generation never advances, and the alerts still go out:

```
===== C3-fixed-outage =====
fix present in the running tree: 2
stopping postgres
restarting postgres
readiness status codes    :   11 000    1 503
health_check failures     : 69
db_exceptions ALERTS sent : 13
suppressed as planned     : 0
```

D is the same outage on base, for symmetry: 27 failures, 6 alerts, nothing suppressed. Both builds page during a real outage, only the fixed one stays quiet during a planned restart

## Type

🐛 Bug Fix

## Changes

`PrismaWrapper` gains `engine_generation`, a read of the counter that already exists, and `wait_for_planned_engine_replacement`, a bounded wait on the reconnection lock that both replacement paths already hold across their whole kill and connect window

`PrismaClient.health_check()` snapshots the engine generation of the wrapper its probe will actually reach, and moves the `failure_handler` call into `_report_health_check_failure`. That helper reports as before unless the failure is connection-class and two things both hold

First, the engine generation must have moved, which says a replacement completed rather than merely being attempted. Reconnect attempts during a real outage hold the same lock for up to `PRISMA_WATCHDOG_RECONNECT_TIMEOUT_SECONDS`, so gating on an in-flight replacement alone would swallow most of an outage's alerts

Second, a fresh `SELECT 1` must succeed. `Prisma.connect()` polls the query engine's own `/status` endpoint rather than round-tripping to the database, so "a replacement completed" is only as strong as whatever the engine binary chooses to validate before it binds. On the pinned engine a stopped database does make `connect()` raise `EngineConnectionError`, which leg C shows, but the confirmation probe means the gate stays correct without depending on that

The gate follows the same routing rule the probe did, and the probe is issued against the wrapper the gate resolved rather than through `self.db`. `query_raw` goes to the reader on a read-replica deployment, and routing is re-resolved on every attribute access, so a reader that recovers mid-call would otherwise send the probe to a different engine than the one whose generation is being checked

Worth flagging two things a reviewer will want to know. Suppression silences the whole `failure_handler` fan-out, so the Prometheus/Datadog `litellm_postgres_failed_requests_total` counter and the Sentry capture go quiet alongside the Slack alert. That is deliberate: all three say the database failed, and it did not. And the routine IAM token refresh no longer kills before it constructs, since `_replace_prisma_client_for_token_refresh_locked` connects the replacement first and retires the old engine after it drains. The window this fixes is the one the reconnect cycle and the reader recreate still have, which is what the proof reproduces

Tests extend `tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py`, which already pins the planned-restart coordination this builds on. Eight mutants were run one at a time and each was killed by a different test: removing the gate, dropping the connection-class scope, treating an in-flight replacement as sufficient, watching the writer when the probe was routed to the reader, skipping the settle wait, dropping the wait's timeout bound, trusting a completed replacement without confirming, and treating a failed confirmation as success

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes health-check failure reporting and alert/metrics behavior during engine replacements; logic is gated on generation + confirmation probe but misclassification could hide or duplicate real DB faults.
> 
> **Overview**
> Stops **`db_exceptions`** (and the rest of the health-check **`failure_handler`** fan-out) from firing when a **`SELECT 1`** readiness probe hits a transient transport error during a **planned** Prisma query-engine kill/reconnect (e.g. RDS IAM refresh), while real outages still alert.
> 
> **`PrismaWrapper`** exposes **`engine_generation`** and **`wait_for_planned_engine_replacement`**, which waits up to a bounded time on **`_reconnection_lock`** so callers can tell when an in-flight replacement has settled.
> 
> **`PrismaClient.health_check()`** now probes the same wrapper routing would use (reader vs writer on read-replica setups), snapshots that wrapper’s generation before the probe, and routes failures through **`_report_health_check_failure`**. It skips reporting only for **connection-class** errors where the generation advanced **and** a follow-up probe succeeds—so failed replacements and non-transport errors are not silenced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2065dc1e1d2015724856dcd4e89b2ee0378122fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->