### PR TITLE
build(deps): bump h2 to 4.4.1 and js-yaml to 4.3.1

### DIFF
--- a/ui/litellm-dashboard/package-lock.json
+++ b/ui/litellm-dashboard/package-lock.json
@@ -8613,9 +8613,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -90,7 +90,7 @@
   },
   "overrides": {
     "prismjs": "1.30.0",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "brace-expansion": "5.0.9",
     "glob": "13.0.0",
     "minimatch": "10.2.4",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-04T00:00:57.623181Z"
+exclude-newer = "2026-08-04T01:43:29.894567Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3102,15 +3102,15 @@ wheels = [
 
 [[package]]
 name = "h2"
-version = "4.3.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
 ]
 
 [[package]]
@@ -3239,11 +3239,11 @@ wheels = [
 
 [[package]]
 name = "hpack"
-version = "4.1.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Clears both findings from the current osv-scan against `litellm_internal_staging`, bundled into one PR so the scan goes green on a single merge.

| Advisory | CVSS | Package | Bump | Lockfile |
| --- | --- | --- | --- | --- |
| `GHSA-6hr6-w5qg-qmwg` | 5.3 | h2 | 4.3.0 -> 4.4.1 | `uv.lock` |
| `GHSA-5p4m-2wfm-xmqj` | 7.5 | js-yaml (dev) | 4.3.0 -> 4.3.1 | `ui/litellm-dashboard/package-lock.json` |

### h2

Re-derived with `uv lock --upgrade-package h2`. Two packages move — h2, plus `hpack` 4.1.0 -> 4.2.0, which h2 4.4.1 requires. Diff is 14 lines.

This deliberately does not reuse the lockfile from the Dependabot PR for the same advisory, which came in at 388 changed lines because it also rewrote `exclude-newer` to the degenerate `0001-01-01T00:00:00Z` placeholder and stripped `python_full_version` markers from ~190 dependency entries. Re-locking with the repo's own uv keeps `exclude-newer` a real timestamp and leaves the markers alone.

### js-yaml

`js-yaml` is not a direct dependency — it arrives via `@eslint/eslintrc`, `knip` and `@redocly/openapi-core`, and is held at an exact version by an npm `overrides` entry. The override and the lock entry therefore move together; a lock-only bump would be reverted by the next resolve.

### Verification

- `osv-scanner scan source --config osv-scanner.toml -L uv.lock -L ui/litellm-dashboard/package-lock.json` on this branch, using v2.3.8 (the version the workflow pins): **No issues found**.
- `uv lock --check` passes.
- `npm ci` succeeds on the regenerated lock; installed tree resolves `js-yaml@4.3.1`, and the lock `integrity` matches the registry value for 4.3.1 exactly.
- `npm run lint` is unchanged from base — the single pre-existing error (`no-restricted-imports` on the `antd` import in `vertexCredentialsUpload.ts`) is present on `litellm_internal_staging` and untouched here.
- All three versions clear the repo's 3-day cooldown: h2 4.4.1 published 2026-08-03, hpack 4.2.0 on 2026-06-23, js-yaml 4.3.1 on 2026-07-31.

One finding stays suppressed rather than fixed: `GHSA-w8v5-vhqr-4h9v` (diskcache unsafe pickle deserialization) is filtered by `osv-scanner.toml` until 2026-09-09. Upstream still has no fixed release — diskcache 5.6.3 from 2023 is the latest and the advisory covers everything through it. That ignore will need extending or replacing before it expires.