### PR TITLE
fix(router): bound fallback-walk work and error-log volume

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -7,6 +7,7 @@ from litellm.litellm_core_utils.env_utils import get_env_int, get_env_int_or_non
 DEFAULT_HEALTH_CHECK_PROMPT: Final = str(os.getenv("DEFAULT_HEALTH_CHECK_PROMPT", "test from litellm"))
 AZURE_DEFAULT_RESPONSES_API_VERSION: Final = str(os.getenv("AZURE_DEFAULT_RESPONSES_API_VERSION", "preview"))
 ROUTER_MAX_FALLBACKS: Final = int(os.getenv("ROUTER_MAX_FALLBACKS", 5))
+ROUTER_FALLBACK_ERROR_DETAIL_MAX_CHARS: Final = 2000
 DEFAULT_BATCH_SIZE: Final = int(os.getenv("DEFAULT_BATCH_SIZE", 512))
 DEFAULT_FLUSH_INTERVAL_SECONDS: Final = int(os.getenv("DEFAULT_FLUSH_INTERVAL_SECONDS", 5))
 DEFAULT_S3_FLUSH_INTERVAL_SECONDS: Final = int(os.getenv("DEFAULT_S3_FLUSH_INTERVAL_SECONDS", 10))

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -109,6 +109,7 @@ from litellm.router_utils.common_utils import (
     filter_team_based_models,
     filter_web_search_deployments,
     resolve_model_group_alias,
+    truncate_fallback_error_detail,
 )
 from litellm.router_utils.cooldown_cache import CooldownCache
 from litellm.router_utils.cooldown_handlers import (
@@ -340,6 +341,12 @@ def _replay_live_router_model_cost() -> None:
 
 
 set_live_deployment_replay(_replay_live_router_model_cost)
+
+
+# Kwargs that log_retry must not copy into a retry breadcrumb. The breadcrumbs reach spend
+# logs and logging callbacks, and these carry either the request payload or router-internal
+# walk state rather than anything that identifies the failed attempt.
+RETRY_BREADCRUMB_EXCLUDED_KWARGS: Final = frozenset(("messages", "original_function", "attempted_targets"))
 
 
 class Router:
@@ -6361,17 +6368,16 @@ class Router:
                 return response
         except Exception as new_exception:
             parent_otel_span: Final = _get_parent_otel_span_from_kwargs(kwargs)
-            fallback_failure_exception_str = redact_string(str(new_exception))
+            fallback_failure_exception_str = truncate_fallback_error_detail(redact_string(str(new_exception)))
             cooldown_info: Final = await _async_get_cooldown_deployments_with_debug_info(
                 litellm_router_instance=self,
                 parent_otel_span=parent_otel_span,
             )
             verbose_router_logger.error(
                 "litellm.router.py::async_function_with_fallbacks() - "
-                "Error occurred while trying to do fallbacks - %s\n%s\n"
+                "Error occurred while trying to do fallbacks - %s\n"
                 "Debug Information:\nCooldown Deployments=%s",
                 fallback_failure_exception_str,
-                redact_string(traceback.format_exc()),
                 cooldown_info,
             )
 
@@ -7162,7 +7168,7 @@ class Router:
                 k,
                 v,
             ) in kwargs.items():  # log everything in kwargs except the old previous_models value - prevent nesting
-                if k not in [_metadata_var, "messages", "original_function"]:
+                if k != _metadata_var and k not in RETRY_BREADCRUMB_EXCLUDED_KWARGS:
                     previous_model[k] = v
                 elif k == _metadata_var and isinstance(v, dict):
                     previous_model[_metadata_var] = {}

--- a/litellm/router_utils/common_utils.py
+++ b/litellm/router_utils/common_utils.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from litellm.types.llms.openai import OpenAIFileObject
 
 from litellm._logging import verbose_logger
+from litellm.constants import ROUTER_FALLBACK_ERROR_DETAIL_MAX_CHARS
 from litellm.exceptions import BadRequestError
 from litellm.types.router import CredentialLiteLLMParams
 
@@ -41,6 +42,22 @@ def resolve_model_group_alias(model_group_alias: object, model: str) -> str | No
     if not isinstance(target, str) or not target:
         return None
     return target
+
+
+def truncate_fallback_error_detail(detail: str) -> str:
+    """
+    Bound a fallback failure detail before it is logged or appended to an exception message.
+
+    Each level of the fallback walk records the failure of the level below it, so an
+    untruncated detail carries every nested failure with it and grows superlinearly with
+    the number of attempted model groups. One deterministic pre-network failure walked
+    through a small fallback graph is enough to turn that into hundreds of megabytes of
+    output on the event-loop thread, which starves the process that produced it.
+    """
+    if len(detail) <= ROUTER_FALLBACK_ERROR_DETAIL_MAX_CHARS:
+        return detail
+    dropped: Final = len(detail) - ROUTER_FALLBACK_ERROR_DETAIL_MAX_CHARS
+    return f"{detail[:ROUTER_FALLBACK_ERROR_DETAIL_MAX_CHARS]}... [truncated {dropped} characters]"
 
 
 def get_litellm_params_sensitive_credential_hash(litellm_params: dict) -> str:

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -1,3 +1,6 @@
+import hashlib
+import json
+from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final
 
@@ -17,6 +20,52 @@ if TYPE_CHECKING:
     LitellmRouter = _Router
 else:
     LitellmRouter = Any
+
+
+def fallback_attempt_key(fallback_target: object) -> str | None:
+    """
+    Identity of one fallback attempt, so the same attempt is never made twice per request.
+
+    A bare model group name and a `{"model": name}` entry describe the same attempt. An
+    entry carrying anything else describes a different one and keeps its own identity: a
+    client-side fallback list overrides request params such as `messages`, and the router
+    re-targets the group that just failed by attaching `_target_order` or
+    `_excluded_deployment_ids` to select a different set of deployments inside it. The
+    payload is hashed rather than kept, so a large `messages` override does not make the
+    request hold a second copy of itself.
+
+    Returns None for a shape with no usable identity, which is never skipped.
+    """
+    if isinstance(fallback_target, str):
+        return fallback_target
+    if not isinstance(fallback_target, dict):
+        return None
+    model: Final = fallback_target.get("model")
+    if tuple(fallback_target) == ("model",) and isinstance(model, str):
+        return model
+    serialized: Final = json.dumps(fallback_target, sort_keys=True, default=str)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+@dataclass(slots=True)
+class AttemptedFallbackTargets:
+    """
+    The fallback attempts a single request has already made.
+
+    One instance is created on the first fallback hop and shared by reference for the rest
+    of the walk, so an attempt made in one branch is not repeated in a sibling branch.
+    Without it the walk enumerates paths rather than attempts: a fallback graph containing
+    a cycle retries one deterministic failure once per path through the cycle, and a
+    client-side fallback list is re-walked at every level of the recursion.
+    """
+
+    keys: frozenset[str] = frozenset()
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.keys
+
+    def record(self, key: str) -> None:
+        self.keys = self.keys | frozenset((key,))
 
 
 def _check_stripped_model_group(model_group: str, fallback_key: str) -> bool:
@@ -106,7 +155,14 @@ async def run_async_fallback(
         fallback_model_group: List[str] of fallback model groups. example: ["gpt-4", "gpt-3.5-turbo"]
         original_model_group: The original model group. example: "gpt-3.5-turbo"
         original_exception: The original exception.
-        **kwargs: Keyword arguments.
+        **kwargs: Keyword arguments. `attempted_targets` carries the fallback attempts
+            already made for this request, created on the first hop and shared by reference
+            for the rest of the walk. A target already in it is skipped, so neither a
+            fallback graph that loops back on itself nor a client-side fallback list
+            re-walked at each level can repeat an attempt that has already failed. Identity
+            comes from `fallback_attempt_key`, so an entry that overrides request params or
+            re-targets the failed group with a different deployment selection stays distinct
+            from a bare name.
 
     Returns:
         The response from the successful fallback model group.
@@ -120,10 +176,27 @@ async def run_async_fallback(
 
     error_from_fallbacks = original_exception
     fallback_errors = (get_fallback_error_info(original_exception),)
+    # Read out of kwargs and narrowed here rather than declared as a parameter: every caller
+    # reaches this function by spreading a loosely-typed kwargs dict, so a declared parameter
+    # would carry an annotation that no call site can actually be checked against.
+    carried_targets: Final = kwargs.get("attempted_targets")
+    attempted: Final = (
+        carried_targets if isinstance(carried_targets, AttemptedFallbackTargets) else AttemptedFallbackTargets()
+    )
+    attempted.record(original_model_group)
 
     for mg in fallback_model_group:
         if mg == original_model_group:
             continue
+        attempt_key = fallback_attempt_key(mg)
+        if attempt_key is not None:
+            if attempt_key in attempted:
+                verbose_router_logger.info(
+                    "Skipping fallback to model_group = %s, already attempted for this request",
+                    mask_sensitive_structure(mg),
+                )
+                continue
+            attempted.record(attempt_key)
         try:
             # LOGGING
             kwargs = litellm_router.log_retry(kwargs=kwargs, e=original_exception)
@@ -138,6 +211,7 @@ async def run_async_fallback(
             fallback_depth = fallback_depth + 1
             kwargs["fallback_depth"] = fallback_depth
             kwargs["max_fallbacks"] = max_fallbacks
+            kwargs["attempted_targets"] = attempted
             if include_fallback_errors:
                 kwargs["include_fallback_errors"] = include_fallback_errors
             response = await litellm_router.async_function_with_fallbacks(*args, **kwargs)

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3479,6 +3479,7 @@ all_litellm_params = (
         "user_continue_message",
         "fallback_depth",
         "max_fallbacks",
+        "attempted_targets",
         "max_budget",
         "budget_duration",
         "use_in_pass_through",

--- a/tests/test_litellm/router_utils/test_fallback_event_handlers.py
+++ b/tests/test_litellm/router_utils/test_fallback_event_handlers.py
@@ -3,6 +3,8 @@ import json
 import pytest
 
 from litellm.router_utils.fallback_event_handlers import (
+    AttemptedFallbackTargets,
+    fallback_attempt_key,
     get_fallback_model_group,
     run_async_fallback,
 )
@@ -140,6 +142,208 @@ async def test_run_async_fallback_skips_original_model_group():
     )
 
     assert response._hidden_params["additional_headers"]["x-litellm-attempted-fallbacks"] == 1
+
+
+class RecordingFailRouter:
+    def __init__(self):
+        self.attempted_models = []
+
+    def log_retry(self, kwargs, e):
+        return kwargs
+
+    async def async_function_with_fallbacks(self, *args, **kwargs):
+        self.attempted_models.append(kwargs.get("model"))
+        raise RuntimeError("fallback model also failed")
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_skips_model_group_already_attempted():
+    """A fallback graph that loops back on itself must not re-attempt a model group that
+    already failed for this request. Every group in a cycle fails identically, so
+    revisiting one multiplies the work and the error output without any chance of
+    succeeding."""
+    router = RecordingFailRouter()
+
+    with pytest.raises(RuntimeError, match="original failed"):
+        await run_async_fallback(
+            litellm_router=router,
+            fallback_model_group=["already-attempted"],
+            original_model_group="primary-model",
+            original_exception=RuntimeError("original failed"),
+            max_fallbacks=3,
+            fallback_depth=0,
+            attempted_targets=AttemptedFallbackTargets(frozenset({"already-attempted"})),
+        )
+
+    assert router.attempted_models == []
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_attempts_a_repeated_target_once():
+    router = RecordingFailRouter()
+
+    with pytest.raises(RuntimeError, match="fallback model also failed"):
+        await run_async_fallback(
+            litellm_router=router,
+            fallback_model_group=["fallback-model", "fallback-model", "other-model"],
+            original_model_group="primary-model",
+            original_exception=RuntimeError("original failed"),
+            max_fallbacks=5,
+            fallback_depth=0,
+        )
+
+    assert router.attempted_models == ["fallback-model", "other-model"]
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_forwards_attempted_model_groups_to_nested_call():
+    """The nested call is where the next hop of the walk decides what to skip, so the
+    accumulated set has to reach it, carrying both the group that just failed and the
+    target being attempted."""
+    router = RecordingRouter()
+
+    await run_async_fallback(
+        litellm_router=router,
+        fallback_model_group=["fallback-model"],
+        original_model_group="primary-model",
+        original_exception=RuntimeError("original failed"),
+        max_fallbacks=3,
+        fallback_depth=0,
+        attempted_targets=AttemptedFallbackTargets(frozenset({"earlier-model"})),
+    )
+
+    assert router.received_kwargs["attempted_targets"].keys == frozenset(
+        {"earlier-model", "primary-model", "fallback-model"}
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"model": "primary-model", "_target_order": 2},
+        {"model": "primary-model", "_excluded_deployment_ids": ["dep-1"]},
+    ],
+)
+async def test_run_async_fallback_still_retargets_the_same_group_via_dict_entry(entry):
+    """Order-based fallback and weighted intra-group failover both re-target the group that
+    just failed, selecting a different set of deployments inside it. Those entries are dicts
+    rather than plain names and must survive a guard that skips already-attempted names."""
+    router = RecordingRouter()
+
+    await run_async_fallback(
+        litellm_router=router,
+        fallback_model_group=[entry],
+        original_model_group="primary-model",
+        original_exception=RuntimeError("original failed"),
+        max_fallbacks=3,
+        fallback_depth=0,
+        attempted_targets=AttemptedFallbackTargets(frozenset({"primary-model"})),
+    )
+
+    assert router.received_kwargs["model"] == "primary-model"
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_skips_a_repeated_dict_target():
+    """A client-side fallback list names its targets with dicts, and that list is re-walked
+    at every level of the recursion, so an entry that carries no request override has to be
+    recognised as the same attempt as the bare name."""
+    router = RecordingFailRouter()
+
+    with pytest.raises(RuntimeError, match="original failed"):
+        await run_async_fallback(
+            litellm_router=router,
+            fallback_model_group=[{"model": "already-attempted"}],
+            original_model_group="primary-model",
+            original_exception=RuntimeError("original failed"),
+            max_fallbacks=3,
+            fallback_depth=0,
+            attempted_targets=AttemptedFallbackTargets(frozenset({"already-attempted"})),
+        )
+
+    assert router.attempted_models == []
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_attempts_a_repeated_dict_target_once():
+    router = RecordingFailRouter()
+    entry = {"model": "fallback-model", "messages": [{"role": "user", "content": "shorter"}]}
+
+    with pytest.raises(RuntimeError, match="fallback model also failed"):
+        await run_async_fallback(
+            litellm_router=router,
+            fallback_model_group=[entry, entry, {"model": "other-model"}],
+            original_model_group="primary-model",
+            original_exception=RuntimeError("original failed"),
+            max_fallbacks=5,
+            fallback_depth=0,
+        )
+
+    assert router.attempted_models == ["fallback-model", "other-model"]
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_keeps_a_request_override_distinct_from_the_bare_name():
+    """The documented use of the client-side form is to retry a group with different request
+    params, so an entry carrying an override must survive even when the bare name of that
+    same group has already been attempted."""
+    router = RecordingFailRouter()
+
+    with pytest.raises(RuntimeError, match="fallback model also failed"):
+        await run_async_fallback(
+            litellm_router=router,
+            fallback_model_group=[
+                {"model": "already-attempted", "messages": [{"role": "user", "content": "shorter"}]}
+            ],
+            original_model_group="primary-model",
+            original_exception=RuntimeError("original failed"),
+            max_fallbacks=3,
+            fallback_depth=0,
+            attempted_targets=AttemptedFallbackTargets(frozenset({"already-attempted"})),
+        )
+
+    assert router.attempted_models == ["already-attempted"]
+
+
+@pytest.mark.parametrize(
+    "target, expected",
+    [
+        ("group-a", "group-a"),
+        ({"model": "group-a"}, "group-a"),
+        (None, None),
+        (["group-a"], None),
+    ],
+)
+def test_fallback_attempt_key_identity(target, expected):
+    """A bare name and a `{"model": name}` entry are the same attempt. A shape with no
+    usable identity returns None and is never skipped, so an unrecognised entry keeps
+    today's behaviour rather than being silently dropped."""
+    assert fallback_attempt_key(target) == expected
+
+
+def test_fallback_attempt_key_gives_a_param_only_entry_its_own_identity():
+    """An entry with no `model` re-targets the group currently being attempted with
+    different request params, so it is a distinct attempt and still needs an identity."""
+    key = fallback_attempt_key({"messages": [{"role": "user", "content": "shorter"}]})
+
+    assert key is not None
+    assert key != fallback_attempt_key({"messages": [{"role": "user", "content": "other"}]})
+
+
+def test_fallback_attempt_key_separates_overrides_from_the_bare_name():
+    bare = fallback_attempt_key("group-a")
+    override = fallback_attempt_key({"model": "group-a", "messages": [{"role": "user", "content": "x"}]})
+    other_override = fallback_attempt_key({"model": "group-a", "messages": [{"role": "user", "content": "y"}]})
+    order_retarget = fallback_attempt_key({"model": "group-a", "_target_order": 2})
+
+    assert len({bare, override, other_override, order_retarget}) == 4
+
+
+def test_fallback_attempt_key_is_stable_across_key_order():
+    assert fallback_attempt_key({"model": "group-a", "_target_order": 2}) == fallback_attempt_key(
+        {"_target_order": 2, "model": "group-a"}
+    )
 
 
 def test_get_fallback_model_group_does_not_mutate_fallbacks():

--- a/tests/test_litellm/router_utils/test_router_utils_common_utils.py
+++ b/tests/test_litellm/router_utils/test_router_utils_common_utils.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 from litellm import Router
+from litellm.constants import ROUTER_FALLBACK_ERROR_DETAIL_MAX_CHARS
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.router_utils.common_utils import (
     _deployment_supports_web_search,
@@ -11,6 +12,7 @@ from litellm.router_utils.common_utils import (
     filter_team_based_models,
     filter_web_search_deployments,
     resolve_model_group_alias,
+    truncate_fallback_error_detail,
 )
 
 
@@ -558,3 +560,27 @@ class TestResolveModelGroupAlias:
         assert router._get_model_from_alias("group-a") == "group-b"
         assert router._get_model_from_alias("group-item") == "group-b"
         assert router._get_model_from_alias("group-b") is None
+
+
+class TestTruncateFallbackErrorDetail:
+    def test_short_detail_is_returned_unchanged(self):
+        assert truncate_fallback_error_detail("boom") == "boom"
+
+    def test_detail_at_the_limit_is_returned_unchanged(self):
+        detail = "x" * ROUTER_FALLBACK_ERROR_DETAIL_MAX_CHARS
+        assert truncate_fallback_error_detail(detail) == detail
+
+    def test_long_detail_is_bounded_and_reports_what_was_dropped(self):
+        detail = "x" * (ROUTER_FALLBACK_ERROR_DETAIL_MAX_CHARS + 500)
+
+        truncated = truncate_fallback_error_detail(detail)
+
+        assert truncated.startswith("x" * ROUTER_FALLBACK_ERROR_DETAIL_MAX_CHARS)
+        assert truncated.endswith("... [truncated 500 characters]")
+        assert len(truncated) < len(detail)
+
+    def test_a_megabyte_of_detail_comes_back_small(self):
+        """The detail is what a fallback level records about the level below it, so it has
+        to stay small enough that a walk over many model groups cannot compound it into an
+        output volume that starves the process."""
+        assert len(truncate_fallback_error_detail("x" * 1_000_000)) < 3_000

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import json
+import logging
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,6 +15,7 @@ sys.path.insert(
 
 import litellm
 from litellm.exceptions import MidStreamFallbackError
+from litellm.integrations.custom_logger import CustomLogger
 
 
 def test_update_kwargs_does_not_mutate_defaults_and_merges_metadata():
@@ -7415,3 +7417,136 @@ class TestAutoRouterMaxInputCharsWiring:
         router = self._router()
 
         assert self._registered_auto_router(router).max_input_chars == DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS
+
+
+class _LogCapture(logging.Handler):
+    def __init__(self, level):
+        super().__init__(level=level)
+        self._level = level
+        self.messages = []
+
+    def emit(self, record):
+        if record.levelno == self._level:
+            self.messages.append(record.getMessage())
+
+
+class _FallbackAttemptRecorder(CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.failed_targets = []
+
+    async def log_failure_fallback_event(self, original_model_group, kwargs, original_exception):
+        self.failed_targets.append(kwargs.get("model"))
+
+
+def _cyclic_fallback_router(num_retries=0):
+    groups = ["group-a", "group-b", "group-c", "group-d"]
+    return litellm.Router(
+        model_list=[
+            {
+                "model_name": group,
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "sk-fake",
+                    "mock_response": "litellm.InternalServerError",
+                },
+            }
+            for group in groups
+        ],
+        fallbacks=[
+            {"group-a": ["group-b", "group-c"]},
+            {"group-b": ["group-a", "group-c"]},
+            {"group-c": ["group-d"]},
+            {"group-d": ["group-b", "group-a"]},
+        ],
+        num_retries=num_retries,
+    )
+
+
+async def _drive_cyclic_fallback(router, capture, recorder=None, **request_kwargs):
+    router_logger = logging.getLogger("LiteLLM Router")
+    previous_level = router_logger.level
+    router_logger.setLevel(capture.level)
+    router_logger.addHandler(capture)
+    if recorder is not None:
+        litellm.callbacks.append(recorder)
+    try:
+        with pytest.raises(litellm.InternalServerError):
+            await router.acompletion(
+                model="group-a", messages=[{"role": "user", "content": "hi"}], **request_kwargs
+            )
+    finally:
+        router_logger.removeHandler(capture)
+        router_logger.setLevel(previous_level)
+        if recorder is not None:
+            litellm.callbacks.remove(recorder)
+
+
+@pytest.mark.asyncio
+async def test_cyclic_fallback_graph_does_not_amplify_one_request():
+    """A fallback graph whose entries loop back on each other is easy to build by accident,
+    and every group in the loop fails identically on a deterministic error, so the walk must
+    not revisit a group and must not re-emit a growing chained traceback at each level. Left
+    unbounded, one request blocks the event loop long enough for health probes to fail."""
+    recorder = _FallbackAttemptRecorder()
+    capture = _LogCapture(logging.ERROR)
+
+    await _drive_cyclic_fallback(_cyclic_fallback_router(), capture, recorder)
+
+    assert sorted(set(recorder.failed_targets)) == ["group-b", "group-c", "group-d"]
+    assert len(recorder.failed_targets) == len(set(recorder.failed_targets))
+    assert not any("Traceback (most recent call last)" in message for message in capture.messages)
+    assert sum(len(message) for message in capture.messages) < 5_000
+
+
+@pytest.mark.asyncio
+async def test_retry_breadcrumbs_do_not_carry_the_walk_state():
+    """log_retry copies every kwarg into previous_models, which reaches spend logs and
+    logging callbacks. The set of already-attempted groups is router-internal walk state
+    with no diagnostic value there, and it is the one entry that is not a plain scalar.
+    A retry has to be configured for the walk state to reach log_retry at all."""
+    router = _cyclic_fallback_router(num_retries=1)
+    capture = _LogCapture(logging.ERROR)
+
+    await _drive_cyclic_fallback(router, capture)
+
+    assert router.previous_models, "no retry breadcrumbs were recorded"
+    assert any(
+        "fallback_depth" in breadcrumb for breadcrumb in router.previous_models
+    ), "no breadcrumb carried router walk state, so this test cannot see the leak"
+    for breadcrumb in router.previous_models:
+        assert "attempted_targets" not in breadcrumb
+
+
+@pytest.mark.asyncio
+async def test_fallback_traceback_stays_available_at_debug_level():
+    """Dropping the stack from the ERROR line is only safe because the fallback path still
+    emits it once per level at DEBUG, which is what an operator needs to diagnose why every
+    fallback failed. This pins that remaining debug traceback."""
+    capture = _LogCapture(logging.DEBUG)
+
+    await _drive_cyclic_fallback(_cyclic_fallback_router(), capture)
+
+    assert any("Traceback (most recent call last)" in message for message in capture.messages)
+
+
+@pytest.mark.asyncio
+async def test_fallback_failure_detail_from_upstream_is_bounded():
+    """The detail each level records about the level below it is attacker-influenced, since
+    it carries whatever the upstream error said. It has to be bounded on its own, so a walk
+    over several groups cannot compound one large message into the log or into the message
+    handed back to the caller."""
+    huge_message = "z" * 50_000
+    capture = _LogCapture(logging.ERROR)
+
+    await _drive_cyclic_fallback(
+        _cyclic_fallback_router(),
+        capture,
+        mock_response=litellm.InternalServerError(
+            message=huge_message, llm_provider="openai", model="group-a"
+        ),
+    )
+
+    assert capture.messages, "the fallback failure path did not log at ERROR"
+    assert huge_message not in "".join(capture.messages)
+    assert max(len(message) for message in capture.messages) < 5_000


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cyclic `fallbacks` make one request retry the same groups repeatedly
- Every fallback level re-logs the whole chained traceback at ERROR
- One malformed request produced 456 MB of logs in 9 minutes
- Event loop starved, so `/health/liveliness` stopped answering

How it solves it:

- Never attempt a model group twice for the same request
- Bound the failure detail each level records about the level below
- Drop the traceback from ERROR, it is already emitted at DEBUG
- Same request now takes 34s, 86 KB, zero probe failures

## Relevant issues

Relates to #35303

The transformation half of that report (Bedrock Converse raising a bare `Exception` on malformed `tool_calls[].function.arguments`, which `exception_type()` maps to a retryable `APIConnectionError`) is already covered by #35311 and #35374 and is untouched here. This PR fixes the router behaviour that turns any such deterministic pre-network failure into an outage, which is provider independent and which neither of those PRs addresses.

## Linear ticket

Resolves LIT-5269

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy, no mocks. Four Bedrock Converse model groups wired into the cyclic `fallbacks` graph from #35303, `num_retries: 2`, `retry_after: 2.0`, `modify_params: true`. Credentials are deliberately bogus because the failure happens during request transformation, before any socket is opened, so nothing ever reaches Bedrock. One request, the truncated `tool_calls[].function.arguments` from the report.

Before was captured at `f6587faef5` (the merge base), after at `430063db77` (current head).

<details>
<summary>config.yaml and the request</summary>

```yaml
model_list:
  - model_name: claude-sonnet-5
    litellm_params: {model: bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0, aws_region_name: ap-southeast-1, aws_access_key_id: fake-key, aws_secret_access_key: fake-secret}
  - model_name: claude-sonnet-4-6
    litellm_params: {model: bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0, aws_region_name: ap-southeast-1, aws_access_key_id: fake-key, aws_secret_access_key: fake-secret}
  - model_name: claude-haiku-4-5
    litellm_params: {model: bedrock/anthropic.claude-3-5-haiku-20241022-v1:0, aws_region_name: ap-southeast-1, aws_access_key_id: fake-key, aws_secret_access_key: fake-secret}
  - model_name: GLM-5.2
    litellm_params: {model: bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0, aws_region_name: ap-southeast-1, aws_access_key_id: fake-key, aws_secret_access_key: fake-secret}

router_settings:
  num_retries: 2
  retry_after: 2.0
  allowed_fails: 3
  cooldown_time: 60.0
  routing_strategy: simple-shuffle
  fallbacks:
    - claude-sonnet-5: [claude-sonnet-4-6, claude-haiku-4-5]
    - claude-sonnet-4-6: [claude-sonnet-5, claude-haiku-4-5]
    - claude-haiku-4-5: [GLM-5.2]
    - GLM-5.2: [claude-sonnet-4-6, claude-sonnet-5]

litellm_settings:
  num_retries: 2
  drop_params: true
  modify_params: true
```

```bash
curl -s -o /dev/null -w 'HTTP %{http_code} in %{time_total}s\n' \
  -X POST http://127.0.0.1:4269/v1/chat/completions \
  -H 'Authorization: Bearer sk-lit5269' -H 'Content-Type: application/json' \
  -d '{"model":"claude-sonnet-5","stream":true,"messages":[
        {"role":"user","content":"rename that note"},
        {"role":"assistant","content":null,"tool_calls":[{"id":"tooluse_MAh2QLVjBRkvi5QJkLQ08V","type":"function",
          "function":{"name":"replace_note_content",
                      "arguments":"{\"note_id\": \"999af35c-4061-4ece-8581-7d43fc988ba4\", \"title\": \"WG-example\""}}]},
        {"role":"tool","tool_call_id":"tooluse_MAh2QLVjBRkvi5QJkLQ08V","content":"ok"}]}'
```
</details>

### One request, before

```
$ curl ... -w 'HTTP %{http_code} in %{time_total}s\n'
HTTP 500 in 551.972622s

$ wc -c proxy-before.log
478333097
$ wc -l proxy-before.log
5522931
$ grep -c 'Unable to convert openai tool calls' proxy-before.log
215668
```

Nine minutes of blocked event loop and 456 MB of stdout for one request. While it was in flight, `/health/liveliness` was polled every 5s with the reporter's 10s probe timeout:

```
$ grep -c 'rc=28' health-before.txt
15
23:46:11Z liveness FAILED (curl rc=28, waited 10s, probe timeout 10s)
23:46:26Z liveness FAILED (curl rc=28, waited 10s, probe timeout 10s)
23:46:53Z liveness FAILED (curl rc=28, waited 10s, probe timeout 10s)
...
23:53:54Z liveness FAILED (curl rc=28, waited 10s, probe timeout 10s)
```

Fifteen liveness probes exceeding their 10s timeout is what a kubelet turns into a restart. Every one is `rc=28`, a timeout against a listening socket, not a refused connection.

### One request, after

```
$ curl ... -w 'HTTP %{http_code} in %{time_total}s\n'
HTTP 500 in 34.580271s

$ wc -c proxy-after.log
84268
$ wc -l proxy-after.log
786
$ grep -c 'Unable to convert openai tool calls' proxy-after.log
28

$ grep -c 'rc=28' health-after.txt
0
```

The remaining 34s is the configured `retry_after: 2.0` backoff doing its job, and the slowest liveness probe in that window answered in 1s.

### The walk itself, same request re-run with `LITELLM_LOG=INFO`

Before, the four groups are attempted 19 times between them, and the group the request started on is re-entered five times:

```
$ grep -o 'Falling back to model_group = [A-Za-z0-9.-]*' proxy-before-info.log | sort | uniq -c
   6 Falling back to model_group = claude-haiku-4-5
   5 Falling back to model_group = claude-sonnet-4-6
   5 Falling back to model_group = claude-sonnet-5
   3 Falling back to model_group = GLM-5.2
HTTP 500 in 602.307490s
```

After, each group is attempted exactly once, the origin group is never re-entered, and the four cycle edges are named as they are skipped:

```
$ grep -o 'Falling back to model_group = [A-Za-z0-9.-]*' proxy-after-info.log | sort | uniq -c
   1 Falling back to model_group = claude-haiku-4-5
   1 Falling back to model_group = claude-sonnet-4-6
   1 Falling back to model_group = GLM-5.2

$ grep -o 'Skipping fallback to model_group = [A-Za-z0-9.-]*' proxy-after-info.log | sort | uniq -c
   1 Skipping fallback to model_group = claude-haiku-4-5
   1 Skipping fallback to model_group = claude-sonnet-4-6
   2 Skipping fallback to model_group = claude-sonnet-5
HTTP 500 in 35.134640s
```

### Summary

| one request, cyclic graph | before `f6587faef5` | after `430063db77` |
|---|---|---|
| status returned to the client | 500 | 500 |
| wall clock, event loop blocked | 552 s | 34 s |
| fallback attempts across 4 groups | 19 | 3 |
| origin group re-attempted | 5 times | never |
| proxy log written | 456 MB | 86 KB |
| log lines | 5,522,931 | 793 |
| liveness probes timing out at 10s | 15 | 0 |

## Type

🐛 Bug Fix

## Changes

`run_async_fallback` walks the fallback graph by recursing through `async_function_with_fallbacks`, and the only bound was `max_fallbacks` on the depth. A graph where entries point back at each other is easy to build by accident, each entry looks locally reasonable, and nothing rejects or warns about it. Under such a graph the walk enumerates paths rather than groups, so the same model group is attempted once per path that reaches it, and every one of those attempts fails identically when the underlying error is deterministic.

`AttemptedFallbackTargets` records the attempts a request has already made. It is created on the first fallback hop and shared by reference for the rest of the walk, so an attempt made in one branch is not repeated in a sibling branch.

Identity comes from the target itself rather than from its Python type. A bare model group name and a `{"model": name}` entry describe the same attempt and share an identity. An entry carrying anything else describes a different attempt and keeps its own: a client-side fallback list overrides request params such as `messages`, and the router re-targets the group that just failed by attaching `_target_order` or `_excluded_deployment_ids` to pick a different set of deployments inside it. That distinction matters in both directions. Keying on the name alone would break the documented client-side form, which exists precisely to retry a group with different params. Keying on the Python type instead, so every dict is exempt, leaves the larger hole: a client-side fallback list is re-walked at every level of the recursion. On the base, a request-level `fallbacks=[{"model": "g"}, {"model": "g"}]` measured 24 attempts against that one group, where the string form of the same list measured 2. Both are 1 here.

The second half is the output volume. `async_function_with_fallbacks_common_utils` logged `traceback.format_exc()` at ERROR once per level, and that traceback carries the whole `__context__` chain of every level below it, so its size grows with the number of attempts rather than staying constant. It also appends the nested failure to `original_exception.message`, which grows the same way and is what the caller receives. The traceback is now left to the DEBUG line the same function already emits on entry, and the appended detail is bounded by `ROUTER_FALLBACK_ERROR_DETAIL_MAX_CHARS`

Two behaviour notes worth stating rather than leaving a reviewer to find them. An attempt that failed transiently is not repeated later in the same walk; `num_retries` already covers transient failure inside a group, since every visit runs `1 + num_retries` attempts against it, so a repeat buys little and is what makes the blowup possible. And the set spans the whole request, so it also covers the `context_window_fallbacks` and `content_policy_fallbacks` lists, which means a group that already failed for one reason is not re-attempted as a typed fallback for another. Both are deliberate.

The sync entry point needs nothing: `function_with_fallbacks` wraps `async_function_with_fallbacks`, so it walks through the same code.

Measured on the fallback graph from the report, one request:

| | before | after |
|---|---|---|
| wall clock, event loop blocked | 552 s | 34 s |
| proxy log written | 456 MB | 86 KB |
| log lines | 5,522,931 | 793 |
| liveness probes timing out at 10s | 15 | 0 |

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core router fallback traversal and error surfacing; behavior shifts for cyclic graphs and for groups that might have succeeded on a second visit in the same walk, but scope is router reliability with broad test coverage.
> 
> **Overview**
> **Stops cyclic or repeated router fallbacks from amplifying one failed request** into huge log volume and long event-loop blocking (the production case: ~552s / 456 MB logs vs ~34s / 86 KB).
> 
> **Per-request deduplication:** `run_async_fallback` now keeps shared `AttemptedFallbackTargets` (via `attempted_targets` in kwargs) and uses `fallback_attempt_key` so each model group / distinct dict override (params, `_target_order`, deployment exclusions) is tried at most once per request—not once per path through a cyclic `fallbacks` graph or duplicate client-side list entries.
> 
> **Bounded failure text:** Nested fallback errors are truncated with `truncate_fallback_error_detail` (`ROUTER_FALLBACK_ERROR_DETAIL_MAX_CHARS` = 2000) before ERROR logs and before appending to the raised exception message. The full chained traceback is no longer logged at ERROR (still available at DEBUG).
> 
> **Cleaner retry breadcrumbs:** `log_retry` excludes `attempted_targets` (and related walk state) from `previous_models` via `RETRY_BREADCRUMB_EXCLUDED_KWARGS`, so spend logs and callbacks do not carry router-internal state or duplicate `messages`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 430063db77cdcb5dd19fbe073785f3be29d89d19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->