### PR TITLE
fix(http): stop pooled clients persisting cookies on the aiohttp jar too

### DIFF
--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -13,7 +13,6 @@ import asyncio
 import datetime
 import uuid
 from collections.abc import AsyncIterator, Coroutine
-from http.cookiejar import DefaultCookiePolicy
 from typing import TYPE_CHECKING, Any, Final, Optional, cast
 
 import litellm
@@ -79,8 +78,6 @@ from litellm.a2a_protocol.exceptions import A2ALocalhostURLError
 
 # Use our custom resolver instead of the default A2A SDK resolver
 A2ACardResolver: Final = LiteLLMA2ACardResolver
-
-_BLOCK_ALL_COOKIES: Final = DefaultCookiePolicy(allowed_domains=())
 
 
 def _set_usage_on_logging_obj(
@@ -770,7 +767,6 @@ async def create_a2a_client(
         params={"timeout": timeout},
     )
     httpx_client: Final = _async_handler.client
-    httpx_client.cookies.jar.set_policy(_BLOCK_ALL_COOKIES)
     if extra_headers:
         verbose_proxy_logger.debug("A2A client created with extra_headers=%s", list(extra_headers.keys()))
 

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -8,11 +8,12 @@ import sys
 import threading
 import time
 from collections.abc import Callable, Mapping
+from http.cookiejar import CookieJar, DefaultCookiePolicy
 from typing import TYPE_CHECKING, Any, Final, Optional
 
 import certifi
 import httpx
-from aiohttp import ClientSession, TCPConnector
+from aiohttp import ClientSession, DummyCookieJar, TCPConnector
 from httpx import USE_CLIENT_DEFAULT, AsyncHTTPTransport, HTTPTransport
 from httpx._types import RequestFiles
 
@@ -142,6 +143,15 @@ def _handler_may_close_client(client_refcount: int, owns_client: bool) -> bool:
     refcount at the call site, since binding the client to a parameter would inflate it.
     """
     return owns_client and client_refcount <= _CLIENT_REFCOUNT_WHEN_HANDLER_IS_SOLE_REFERRER
+
+
+def blocked_cookie_jar() -> CookieJar:
+    """A jar that stores no response cookie and sends none, for httpx clients.
+
+    LiteLLM's outbound clients are pooled and shared by every caller, so a cookie one
+    upstream sets would be replayed to every other upstream on a matching domain.
+    """
+    return CookieJar(policy=DefaultCookiePolicy(allowed_domains=()))
 
 
 _STREAMING_ERROR_BODY_READ_TIMEOUT_SECONDS: Final = 5.0
@@ -587,6 +597,7 @@ class AsyncHTTPHandler:
             verify=ssl_config,
             cert=cert,
             headers=default_headers,
+            cookies=blocked_cookie_jar(),
             follow_redirects=True,
         )
 
@@ -1063,6 +1074,7 @@ class AsyncHTTPHandler:
         def session_factory() -> ClientSession:
             return ClientSession(
                 connector=TCPConnector(**transport_connector_kwargs),
+                cookie_jar=DummyCookieJar(),
                 trust_env=trust_env,
             )
 
@@ -1132,6 +1144,7 @@ class HTTPHandler:
             verify=ssl_config,
             cert=cert,
             headers=default_headers,
+            cookies=blocked_cookie_jar(),
             follow_redirects=True,
         )
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -868,7 +868,7 @@ async def proxy_shutdown_event():
 async def _initialize_shared_aiohttp_session():
     """Initialize shared aiohttp session for connection reuse with connection limits."""
     try:
-        from aiohttp import ClientSession, TCPConnector
+        from aiohttp import ClientSession, DummyCookieJar, TCPConnector
 
         from litellm.llms.custom_httpx.http_handler import (
             _build_aiohttp_keepalive_socket_factory,
@@ -889,7 +889,7 @@ async def _initialize_shared_aiohttp_session():
             connector_kwargs["socket_factory"] = socket_factory
 
         connector: Final = TCPConnector(**connector_kwargs)
-        session: Final = ClientSession(connector=connector)
+        session: Final = ClientSession(connector=connector, cookie_jar=DummyCookieJar())
 
         verbose_proxy_logger.info(
             "SESSION REUSE: Created shared aiohttp session for connection pooling (ID: %s, limit=%s, limit_per_host=%s)",

--- a/tests/test_litellm/a2a_protocol/test_main.py
+++ b/tests/test_litellm/a2a_protocol/test_main.py
@@ -174,21 +174,15 @@ _RPC_REPLY = {
 
 _AGENT_A_HEADERS = {"x-agent-token": "token-for-a", "x-tenant": "tenant-a"}
 _AGENT_B_HEADERS = {"x-agent-token": "token-for-b", "x-tenant": "tenant-b"}
-_UPSTREAM_SESSION_COOKIE = "a2a_session=only-agent-a-may-hold-this; Path=/"
 
 
 class _RequestRecorder:
-    """Records the headers httpx put on the wire, per outbound request.
+    """Records the headers httpx put on the wire, per outbound request."""
 
-    ``cookie_from_tenant`` makes that tenant's agent answer with a Set-Cookie, standing in
-    for an upstream that issues a session cookie.
-    """
-
-    def __init__(self, cookie_from_tenant: str | None = None):
+    def __init__(self):
         self.card_requests = []
         self.rpc_requests = []
         self.client = None
-        self.cookie_from_tenant = cookie_from_tenant
 
     def __call__(self, request: httpx.Request) -> httpx.Response:
         headers = {k.lower(): v for k, v in request.headers.items()}
@@ -196,8 +190,6 @@ class _RequestRecorder:
             self.card_requests.append(headers)
             return httpx.Response(200, json=_AGENT_CARD)
         self.rpc_requests.append(headers)
-        if self.cookie_from_tenant is not None and headers.get("x-tenant") == self.cookie_from_tenant:
-            return httpx.Response(200, json=_RPC_REPLY, headers={"set-cookie": _UPSTREAM_SESSION_COOKIE})
         return httpx.Response(200, json=_RPC_REPLY)
 
 
@@ -205,15 +197,14 @@ def _a2a_client_cache_key(timeout: float) -> str:
     return "async_httpx_client" + f"timeout_{timeout}" + httpxSpecialProvider.A2AProvider
 
 
-async def _seed_shared_a2a_client(cookie_from_tenant: str | None = None) -> _RequestRecorder:
+async def _seed_shared_a2a_client() -> _RequestRecorder:
     """Put the one A2A client the cache will hand out behind a mock transport.
 
     Seeding has to happen on the test's own event loop, because the client cache keys on
     it. The injected client is a real httpx.AsyncClient, so the merge of per-request
-    headers over client defaults, and httpx's own cookie handling, which is what these
-    tests are about, stay real.
+    headers over client defaults, which is what these tests are about, stays real.
     """
-    recorder = _RequestRecorder(cookie_from_tenant=cookie_from_tenant)
+    recorder = _RequestRecorder()
     handler = AsyncHTTPHandler(timeout=DEFAULT_A2A_AGENT_TIMEOUT)
     owned_client = handler.client
     handler.client = httpx.AsyncClient(transport=httpx.MockTransport(recorder))
@@ -333,17 +324,21 @@ async def test_agent_card_fetch_carries_the_callers_headers(isolated_client_cach
 
 
 @pytest.mark.asyncio
-async def test_one_agents_session_cookie_never_reaches_another_agent(isolated_client_cache):
-    """One pooled client is also one httpx cookie jar. httpx stores every Set-Cookie on the
-    client and replays it on any later request to a matching domain, so an agent's session
-    cookie would ride along on a different agent's call to the same host."""
-    recorder = await _seed_shared_a2a_client(cookie_from_tenant="tenant-a")
+async def test_the_pooled_a2a_client_arrives_with_cookie_persistence_disabled(isolated_client_cache):
+    """create_a2a_client takes its client from the shared builder rather than building one,
+    and the builder is what refuses to persist cookies. This pins the join between those
+    two facts, so the A2A path cannot quietly start acquiring a client that keeps a jar.
 
-    client_a = await create_a2a_client(base_url="http://127.0.0.1:9", extra_headers=_AGENT_A_HEADERS)
-    await _send_message(client_a, _send_request("a"))
-    client_b = await create_a2a_client(base_url="http://127.0.0.1:9", extra_headers=_AGENT_B_HEADERS)
-    await _send_message(client_b, _send_request("b"))
+    test_callers_with_different_headers_reuse_one_pooled_client pins the other half, that
+    create_a2a_client hands back exactly this cached client."""
+    handler = get_async_httpx_client(
+        llm_provider=httpxSpecialProvider.A2AProvider,
+        params={"timeout": DEFAULT_A2A_AGENT_TIMEOUT},
+    )
+    request = httpx.Request("GET", "https://agent-a.example.com/")
+    handler.client.cookies.extract_cookies(
+        httpx.Response(200, headers={"set-cookie": "SESSION=only-agent-a-may-hold-this"}, request=request)
+    )
 
-    assert dict(recorder.client.cookies) == {}, "the shared client kept an agent's session cookie"
-    assert "cookie" not in recorder.card_requests[-1]
-    assert "cookie" not in recorder.rpc_requests[-1]
+    assert dict(handler.client.cookies) == {}, "the pooled A2A client kept an upstream's cookie"
+    await handler.close()

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_cleanup_closed.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_cleanup_closed.py
@@ -13,7 +13,7 @@ def test_create_aiohttp_transport_sets_enable_cleanup_closed_when_needed(monkeyp
     ) as mock_tcp_connector:
         with patch.object(
             http_handler_module, "ClientSession", return_value=session_mock
-        ):
+        ), patch.object(http_handler_module, "DummyCookieJar", return_value=MagicMock(name="cookie_jar")):
             transport = http_handler_module.AsyncHTTPHandler._create_aiohttp_transport(
                 shared_session=None
             )
@@ -36,7 +36,7 @@ def test_create_aiohttp_transport_omits_enable_cleanup_closed_when_not_needed(
     ) as mock_tcp_connector:
         with patch.object(
             http_handler_module, "ClientSession", return_value=session_mock
-        ):
+        ), patch.object(http_handler_module, "DummyCookieJar", return_value=MagicMock(name="cookie_jar")):
             transport = http_handler_module.AsyncHTTPHandler._create_aiohttp_transport(
                 shared_session=None
             )

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_so_keepalive.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_so_keepalive.py
@@ -34,7 +34,7 @@ def test_socket_factory_omitted_when_disabled(monkeypatch):
     ) as mock_tcp_connector:
         with patch.object(
             http_handler_module, "ClientSession", return_value=session_mock
-        ):
+        ), patch.object(http_handler_module, "DummyCookieJar", return_value=MagicMock(name="cookie_jar")):
             _invoke_connector_factory(http_handler_module)
 
     assert mock_tcp_connector.call_count >= 1
@@ -55,7 +55,7 @@ def test_socket_factory_attached_when_enabled(monkeypatch):
     ) as mock_tcp_connector:
         with patch.object(
             http_handler_module, "ClientSession", return_value=session_mock
-        ):
+        ), patch.object(http_handler_module, "DummyCookieJar", return_value=MagicMock(name="cookie_jar")):
             _invoke_connector_factory(http_handler_module)
 
     assert mock_tcp_connector.call_count >= 1
@@ -77,7 +77,7 @@ def test_socket_factory_skipped_on_old_aiohttp(monkeypatch):
     ) as mock_tcp_connector:
         with patch.object(
             http_handler_module, "ClientSession", return_value=session_mock
-        ):
+        ), patch.object(http_handler_module, "DummyCookieJar", return_value=MagicMock(name="cookie_jar")):
             _invoke_connector_factory(http_handler_module)
 
     assert mock_tcp_connector.call_count >= 1

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -1171,3 +1171,77 @@ async def test_client_handed_out_by_async_cache_survives_eviction_and_collection
     assert not consumer_client.is_closed
 
     await consumer_client.aclose()
+
+
+_SET_COOKIE = "SESSION=upstream-a-secret; Path=/"
+
+
+def _cookie_recorder():
+    """A transport that hands out a Set-Cookie once, and records what comes back."""
+    seen = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("cookie"))
+        if request.url.path == "/set":
+            return httpx.Response(200, headers={"set-cookie": _SET_COOKIE})
+        return httpx.Response(200)
+
+    return handler, seen
+
+
+@pytest.mark.asyncio
+async def test_async_client_never_replays_one_upstreams_cookie_to_another():
+    """LiteLLM's async clients are pooled and shared by every caller, so a cookie one
+    upstream sets would be attached to every later request on a matching domain, reaching
+    a different tenant's upstream. The client must persist no response cookie."""
+    handler, seen = _cookie_recorder()
+    http_handler = AsyncHTTPHandler()
+    client = http_handler.client
+    client._transport = httpx.MockTransport(handler)
+
+    await client.get("https://upstream-a.example.com/set")
+    await client.get("https://upstream-b.example.com/rpc")
+    await client.aclose()
+
+    assert dict(client.cookies) == {}, "the shared client stored an upstream's cookie"
+    assert seen == [None, None]
+
+
+def test_sync_client_never_replays_one_upstreams_cookie_to_another():
+    """Same invariant on the sync client, which is pooled the same way."""
+    handler, seen = _cookie_recorder()
+    http_handler = HTTPHandler()
+    client = http_handler.client
+    client._transport = httpx.MockTransport(handler)
+
+    client.get("https://upstream-a.example.com/set")
+    client.get("https://upstream-b.example.com/rpc")
+    client.close()
+
+    assert dict(client.cookies) == {}
+    assert seen == [None, None]
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_session_never_replays_one_upstreams_cookie_to_another():
+    """The httpx jar is not the only one. AiohttpTransport is litellm's default transport
+    and the aiohttp ClientSession keeps its own cookie jar, which httpx-level assertions
+    cannot see, so blocking only the httpx jar leaves the leak intact on the real path.
+
+    aiohttp's default jar refuses cookies for IP hosts, so this drives a hostname. An
+    IP-addressed check passes whether or not the session jar is blocked."""
+    from aiohttp import DummyCookieJar
+    from yarl import URL
+
+    http_handler = AsyncHTTPHandler(timeout=61.0)
+    transport = http_handler.client._transport
+    assert isinstance(transport, LiteLLMAiohttpTransport), "aiohttp is no longer the default transport"
+
+    session = transport.client() if callable(transport.client) else transport.client
+    jar = session.cookie_jar
+    assert isinstance(jar, DummyCookieJar)
+
+    jar.update_cookies({"SESSION": "upstream-a-secret"}, URL("https://upstream-a.example.com"))
+    assert len(jar) == 0
+    assert dict(jar.filter_cookies(URL("https://upstream-a.example.com"))) == {}
+    await session.close()


### PR DESCRIPTION
## TLDR

Problem this solves:

- #35978 blocked the pooled client's cookie jar, but there are two jars on the request path
- AiohttpTransport is the default, and its ClientSession keeps a second jar no httpx assertion can see
- So one upstream's session cookie still reaches another tenant's upstream on the same domain, live on current staging
- The reason it read as fixed: aiohttp's default jar refuses cookies for IP hosts, so a proof against 127.0.0.1 passes either way

How it solves it:

- Both httpx clients, async and sync, get a jar whose policy rejects every domain
- Both ClientSession constructions litellm owns get a DummyCookieJar
- The blocking moves to where the clients are built, so the A2A-scoped policy is removed as dead
- Regression tests live with the fix and cover both jars, the aiohttp one addressed by hostname

## Relevant issues

Completes #35978

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before is current staging, `2b38991df9`, with #35978's fix in place and nothing reverted. After is `e463984e94`. Two agents on one host so both land on the same cookie domain, a proxy on 15230 and a recording upstream on 25230 that answers `agent-alpha`'s JSON-RPC call with `Set-Cookie: a2a_session=only-alpha-may-hold-this` and reports the `Cookie` header on everything it receives, agent card fetches included

The upstream is reached by hostname rather than by `127.0.0.1`, and that is the detail that makes this measurable at all. aiohttp's default `CookieJar` is constructed with `unsafe=False` and will not store a cookie for an IP host, so an IP-addressed run reads clean whether the aiohttp jar is blocked or not. That is what made the aiohttp half invisible in #35978, whose cookie proof was addressed to `127.0.0.1`

```yaml
model_list: []

general_settings:
  master_key: sk-lit5229-cookie

agents:
  - agent_name: agent-alpha-5230
    agent_card_params:
      url: http://localhost:25230
      name: agent-alpha-5230
    static_headers:
      X-Agent-Tag: alpha
  - agent_name: agent-beta-5230
    agent_card_params:
      url: http://localhost:25230
      name: agent-beta-5230
    static_headers:
      X-Agent-Tag: beta
```

```bash
python litellm/proxy/proxy_cli.py --config config_5230.yaml --port 15230

KEY=sk-lit5229-cookie
ALPHA=$(curl -s -H "Authorization: Bearer $KEY" http://127.0.0.1:15230/v1/agents \
  | python -c "import sys,json; print([a['agent_id'] for a in json.load(sys.stdin) if a['agent_name']=='agent-alpha-5230'][0])")
BETA=$(curl -s -H "Authorization: Bearer $KEY" http://127.0.0.1:15230/v1/agents \
  | python -c "import sys,json; print([a['agent_id'] for a in json.load(sys.stdin) if a['agent_name']=='agent-beta-5230'][0])")

for pair in "$ALPHA:m-alpha" "$BETA:m-beta"; do
  AID=${pair%%:*}; MID=${pair##*:}
  curl -s -o /dev/null -w "%{http_code}\n" -X POST "http://127.0.0.1:15230/a2a/$AID/message/send" \
    -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
    -d "{\"jsonrpc\":\"2.0\",\"id\":\"$MID\",\"method\":\"message/send\",\"params\":{\"message\":{\"role\":\"user\",\"parts\":[{\"kind\":\"text\",\"text\":\"hello\"}],\"messageId\":\"$MID\"}}}"
done

curl -s http://localhost:25230/_dump
```

Before, on current staging:

```
### agent-alpha calls its agent (this upstream answers with Set-Cookie)
  http status: 200
### agent-beta calls its agent, a different agent on the same host
  http status: 200
### what the upstream received
  card  from agent-tag alpha  Cookie: None
  rpc   from agent-tag alpha  Cookie: None
  card  from agent-tag beta   Cookie: a2a_session=only-alpha-may-hold-this
  rpc   from agent-tag beta   Cookie: a2a_session=only-alpha-may-hold-this
```

After:

```
### agent-alpha calls its agent (this upstream answers with Set-Cookie)
  http status: 200
### agent-beta calls its agent, a different agent on the same host
  http status: 200
### what the upstream received
  card  from agent-tag alpha  Cookie: None
  rpc   from agent-tag alpha  Cookie: None
  card  from agent-tag beta   Cookie: None
  rpc   from agent-tag beta   Cookie: None
```

Connection pooling, which is what #35978 was mainly about, is untouched. 20 further alternating calls on the same proxy, after the two above:

```
  established proxy -> upstream connections: 2
  upstream requests recorded:               44
  of those, requests carrying any Cookie:   0
```

## Type

🐛 Bug Fix

## Changes

`httpx.AsyncClient._send_single_request` calls `self.cookies.extract_cookies(response)` on every response and `_merge_cookies` replays the jar onto every outgoing request, so pooling one client across callers pools its cookie jar with it. #35978 pooled the A2A client and blocked that jar, and that part holds

It is not the only jar. `AsyncHTTPHandler._should_use_aiohttp_transport()` returns True unless `litellm.disable_aiohttp_transport` or `DISABLE_AIOHTTP_TRANSPORT` says otherwise, and the aiohttp `ClientSession` behind that transport keeps a cookie jar of its own, read on every request and written from every response, which nothing at the httpx layer can observe. Blocking only the httpx jar therefore leaves the leak intact on the default path, which the before leg above shows on current staging

What hid it is worth stating plainly, because it is the same trap for anyone testing this next. aiohttp's default `CookieJar` takes `unsafe=False` and declines to store a cookie whose host is an IP address, so a proof addressed to `127.0.0.1` comes back clean against the broken code. #35978's cookie proof was addressed that way. Driving the same rig through `localhost` separates the two builds immediately

The blocking now lives where the clients are built. `blocked_cookie_jar()` returns a `CookieJar(policy=DefaultCookiePolicy(allowed_domains=()))`, which rejects every domain on the way in through `set_ok_domain` and on the way out through `domain_return_ok`, and both `httpx.AsyncClient` and `httpx.Client` are constructed with one. Both `ClientSession` constructions litellm owns, the transport's `session_factory` and `_initialize_shared_aiohttp_session` on the proxy, get a `DummyCookieJar`. The A2A-scoped policy #35978 added is deleted, since the client it was reaching for now arrives already blocked, and leaving it would be a second mechanism for one invariant

Doing it gateway-wide rather than per-caller is the point. `get_async_httpx_client` hands one cached client to every caller of a given provider, so the jar was shared across tenants everywhere, not just for A2A, and litellm reads a response cookie nowhere: the A2A surface has no `cookie` reference at all, and the a2a SDK's own auth interceptor skips API keys declared `in: cookie` and says so. Explicitly supplied cookies keep working, because blocking a jar stops persistence rather than a header a caller passes, so the passthrough routes that forward `cookies=` per request are unaffected, as is listing `cookie` in an agent's `extra_headers`. Two sibling aiohttp sessions are deliberately left alone, the presidio guardrail's and `BaseLLMAIOHTTPHandler`'s, and the reason is narrower than "they only talk to one upstream". A single upstream removes the cross-agent leak but not the cross-caller one, since two callers reaching the same host through one jar is exactly the case that leaks here. What makes those two safe is that every caller of them is the proxy itself, using the proxy's own credentials, so there is no privilege boundary between one call and the next. The residual is a routing or sticky-session cookie from a load balancer in front of that upstream, which would pin every tenant to one backend: a correctness oddity rather than a leak, and not worth the five unrelated tests that blocking those two jars breaks. Worth stating as a known limitation rather than leaving it to look like an oversight

On tests, the three regression tests move to `tests/test_litellm/llms/custom_httpx/test_http_handler.py`, the file mapped to where the fix now lives. The async and sync clients each collect a `Set-Cookie` from one upstream through `httpx.MockTransport` and must send no `Cookie` to the next. The aiohttp one asserts the session the transport factory builds carries a `DummyCookieJar` and then drives that jar's real `update_cookies` and `filter_cookies` to show it discards, and it uses a hostname for the reason above, which its docstring records so nobody quietly changes it to an IP

The A2A boundary keeps an explicit test, `test_the_pooled_a2a_client_arrives_with_cookie_persistence_disabled`, which drives the real acquisition path and asserts the client the A2A cache key hands out discards a `Set-Cookie`. Together with `test_callers_with_different_headers_reuse_one_pooled_client`, which pins that `create_a2a_client` returns exactly that cached client, the two halves compose into the end-to-end invariant without a test that has to lie about which transport it is measuring

`test_one_agents_session_cookie_never_reaches_another_agent`, added by #35978, is removed rather than moved. It asserts on a hand-built `httpx.AsyncClient` seeded into the client cache, which `create_client` never produced, so with the blocking at the builder it would be testing its own fixture, and being `MockTransport`-based it is structurally blind to the aiohttp jar that this PR is about. The A2A path keeps its coverage through the builder-level tests and through the live proof above

`test_aiohttp_so_keepalive.py` and `test_aiohttp_cleanup_closed.py` drive the session factory synchronously with `ClientSession` patched, which is only possible because a real `ClientSession` needs a running event loop. `DummyCookieJar` has that same requirement, so those tests patch it for exactly the reason they already patch `ClientSession`

Mutation check over the four blocking sites, each mutated and run on its own so none can hide behind another, with each edit asserting it changed the file and each run asserting pytest reported a test count:

```
KILLED   c1 async httpx client keeps its cookie jar   ->  1 failed, 2 passed
KILLED   c2 sync httpx client keeps its cookie jar    ->  1 failed, 2 passed
KILLED   c3 aiohttp session keeps its cookie jar      ->  1 failed, 2 passed
KILLED   c4 blocked jar allows every domain           ->  2 failed, 1 passed
```

525 tests pass across the affected suites: `tests/test_litellm/llms/custom_httpx/`, `tests/test_litellm/a2a_protocol/`, `tests/test_litellm/proxy/agent_endpoints/`, and the three proxy suites that exercise the shared aiohttp session

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
