### PR TITLE
Add deprecation_date to 62 models, each cited to the provider's own page

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -110,6 +110,7 @@
         "output_cost_per_token": 1.88e-05
     },
     "ai21.jamba-1-5-large-v1:0": {
+        "deprecation_date": "2026-11-26",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 256000,
@@ -119,6 +120,7 @@
         "output_cost_per_token": 8e-06
     },
     "ai21.jamba-1-5-mini-v1:0": {
+        "deprecation_date": "2026-11-26",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 256000,
@@ -287,6 +289,7 @@
         "supports_vision": true
     },
     "amazon.nova-canvas-v1:0": {
+        "deprecation_date": "2026-09-30",
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,
         "mode": "image_generation",
@@ -620,6 +623,7 @@
         "mode": "image_generation"
     },
     "twelvelabs.marengo-embed-2-7-v1:0": {
+        "deprecation_date": "2026-11-30",
         "input_cost_per_token": 7e-05,
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
@@ -776,6 +780,7 @@
         "prompt_cache_min_tokens": 4096
     },
     "anthropic.claude-3-5-sonnet-20240620-v1:0": {
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 1000000,
@@ -798,6 +803,7 @@
     "anthropic.claude-3-5-sonnet-20241022-v2:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 1000000,
@@ -841,6 +847,7 @@
     "anthropic.claude-3-7-sonnet-20250219-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
@@ -859,6 +866,7 @@
         "supports_vision": true
     },
     "anthropic.claude-3-haiku-20240307-v1:0": {
+        "deprecation_date": "2026-09-10",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -890,6 +898,7 @@
         "cache_creation_input_token_cost": 1.875e-05
     },
     "anthropic.claude-3-sonnet-20240229-v1:0": {
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -918,6 +927,7 @@
     "anthropic.claude-opus-4-1-20250805-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
+        "deprecation_date": "2027-01-08",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
@@ -2391,6 +2401,7 @@
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-10-14",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
@@ -9447,6 +9458,7 @@
         "supports_vision": true
     },
     "babbage-002": {
+        "deprecation_date": "2026-09-28",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "text-completion-openai",
         "max_input_tokens": 16384,
@@ -11396,6 +11408,7 @@
         "output_cost_per_token": 5e-07
     },
     "chatgpt-4o-latest": {
+        "deprecation_date": "2026-02-17",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -11499,6 +11512,7 @@
         "cache_creation_input_token_cost": 3e-07,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-08,
+        "deprecation_date": "2026-04-20",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
@@ -11754,6 +11768,7 @@
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_creation_input_token_cost_above_1hr": 3e-05,
         "cache_read_input_token_cost": 1.5e-06,
+        "deprecation_date": "2026-08-05",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
@@ -12546,6 +12561,7 @@
         "supports_tool_choice": true
     },
     "cohere.command-r-plus-v1:0": {
+        "deprecation_date": "2026-08-19",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -12556,6 +12572,7 @@
         "supports_tool_choice": true
     },
     "cohere.command-r-v1:0": {
+        "deprecation_date": "2026-08-19",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -12746,6 +12763,7 @@
         "supports_vision": true
     },
     "dall-e-2": {
+        "deprecation_date": "2026-05-12",
         "input_cost_per_image": 0.02,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -12756,6 +12774,7 @@
         ]
     },
     "dall-e-3": {
+        "deprecation_date": "2026-05-12",
         "input_cost_per_image": 0.04,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -14099,6 +14118,7 @@
         "mode": "search"
     },
     "davinci-002": {
+        "deprecation_date": "2026-09-28",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "text-completion-openai",
         "max_input_tokens": 16384,
@@ -15786,6 +15806,7 @@
         ]
     },
     "embed-english-light-v2.0": {
+        "deprecation_date": "2026-04-04",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 1024,
@@ -15802,6 +15823,7 @@
         "output_cost_per_token": 0.0
     },
     "embed-english-v2.0": {
+        "deprecation_date": "2026-04-04",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 4096,
@@ -15824,6 +15846,7 @@
         "supports_image_input": true
     },
     "embed-multilingual-v2.0": {
+        "deprecation_date": "2026-04-04",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 768,
@@ -21963,6 +21986,7 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-0125": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
@@ -22004,6 +22028,7 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-instruct": {
+        "deprecation_date": "2026-09-28",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "text-completion-openai",
         "max_input_tokens": 8192,
@@ -22091,6 +22116,7 @@
         "supports_tool_choice": true
     },
     "gpt-4-turbo": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -22381,6 +22407,7 @@
         "supports_vision": true
     },
     "gpt-4o-2024-05-13": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 5e-06,
         "input_cost_per_token_batches": 2.5e-06,
         "input_cost_per_token_priority": 8.75e-06,
@@ -22447,6 +22474,7 @@
         "supports_vision": true
     },
     "gpt-4o-audio-preview": {
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -22639,6 +22667,7 @@
         "supports_vision": false
     },
     "gpt-audio-mini-2025-10-06": {
+        "deprecation_date": "2026-07-23",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "openai",
@@ -22762,6 +22791,7 @@
         "supports_vision": true
     },
     "gpt-4o-mini-audio-preview": {
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "openai",
@@ -22798,6 +22828,7 @@
     "gpt-4o-mini-realtime-preview": {
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "openai",
@@ -22861,6 +22892,7 @@
     },
     "gpt-4o-mini-search-preview-2025-03-11": {
         "cache_read_input_token_cost": 7.5e-08,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.5e-07,
         "input_cost_per_token_batches": 7.5e-08,
         "litellm_provider": "openai",
@@ -22911,6 +22943,7 @@
     },
     "gpt-4o-realtime-preview": {
         "cache_read_input_token_cost": 2.5e-06,
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -22929,6 +22962,7 @@
     },
     "gpt-4o-realtime-preview-2024-12-17": {
         "cache_read_input_token_cost": 2.5e-06,
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -22947,6 +22981,7 @@
     },
     "gpt-4o-realtime-preview-2025-06-03": {
         "cache_read_input_token_cost": 2.5e-06,
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -22991,6 +23026,7 @@
     },
     "gpt-4o-search-preview-2025-03-11": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 2.5e-06,
         "input_cost_per_token_batches": 1.25e-06,
         "litellm_provider": "openai",
@@ -23023,6 +23059,7 @@
     },
     "gpt-image-1.5": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-12-01",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -23532,6 +23569,7 @@
     "gpt-5.1-chat-latest": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "openai",
@@ -23651,6 +23689,7 @@
     "gpt-5.2-chat-latest": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2026-08-10",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "openai",
@@ -23689,6 +23728,7 @@
     "gpt-5.3-chat-latest": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2026-08-10",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "openai",
@@ -24604,6 +24644,7 @@
         "supports_minimal_reasoning_effort": true
     },
     "gpt-5-pro-2025-10-06": {
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,
         "litellm_provider": "openai",
@@ -24643,6 +24684,7 @@
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_flex": 6.25e-08,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_flex": 6.25e-07,
         "input_cost_per_token_priority": 2.5e-06,
@@ -24718,6 +24760,7 @@
     },
     "gpt-5-chat-latest": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -24753,6 +24796,7 @@
     },
     "gpt-5-codex": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 272000,
@@ -24788,6 +24832,7 @@
     "gpt-5.1-codex": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "openai",
@@ -24824,6 +24869,7 @@
     },
     "gpt-5.1-codex-max": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 272000,
@@ -24859,6 +24905,7 @@
     "gpt-5.1-codex-mini": {
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_priority": 4.5e-08,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 2.5e-07,
         "input_cost_per_token_priority": 4.5e-07,
         "litellm_provider": "openai",
@@ -24896,6 +24943,7 @@
     "gpt-5.2-codex": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "openai",
@@ -25013,6 +25061,7 @@
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_flex": 1.25e-08,
         "cache_read_input_token_cost_priority": 4.5e-08,
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 2.5e-07,
         "input_cost_per_token_flex": 1.25e-07,
         "input_cost_per_token_priority": 4.5e-07,
@@ -25094,6 +25143,7 @@
     "gpt-5-nano-2025-08-07": {
         "cache_read_input_token_cost": 5e-09,
         "cache_read_input_token_cost_flex": 2.5e-09,
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 5e-08,
         "input_cost_per_token_priority": 2.5e-06,
         "input_cost_per_token_flex": 2.5e-08,
@@ -25133,6 +25183,7 @@
     },
     "gpt-image-1": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_image_token": 1e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -25145,6 +25196,7 @@
     },
     "gpt-image-1-mini": {
         "cache_read_input_token_cost": 2e-07,
+        "deprecation_date": "2026-12-01",
         "input_cost_per_image_token": 2.5e-06,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "openai",
@@ -29220,6 +29272,7 @@
         "supports_vision": true
     },
     "o1-pro": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 0.00015,
         "input_cost_per_token_batches": 7.5e-05,
         "litellm_provider": "openai",
@@ -29325,6 +29378,7 @@
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_flex": 2.5e-07,
         "cache_read_input_token_cost_priority": 8.75e-07,
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_flex": 1e-06,
         "input_cost_per_token_priority": 3.5e-06,
@@ -29493,6 +29547,7 @@
         "supports_web_search": true
     },
     "o3-pro-2025-06-10": {
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 2e-05,
         "input_cost_per_token_batches": 1e-05,
         "litellm_provider": "openai",
@@ -33367,6 +33422,7 @@
         "supports_system_messages": true
     },
     "rerank-english-v2.0": {
+        "deprecation_date": "2025-04-30",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "cohere",
@@ -33387,6 +33443,7 @@
         "output_cost_per_token": 0.0
     },
     "rerank-multilingual-v2.0": {
+        "deprecation_date": "2025-04-30",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "cohere",
@@ -34391,6 +34448,7 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "text-moderation-007": {
+        "deprecation_date": "2025-10-27",
         "input_cost_per_token": 0.0,
         "litellm_provider": "openai",
         "max_input_tokens": 32768,
@@ -44374,6 +44432,7 @@
         ]
     },
     "gpt-4o-mini-transcribe-2025-03-20": {
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
@@ -44444,6 +44503,7 @@
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_audio_token_cost": 3e-07,
         "cache_read_input_token_cost": 6e-08,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_image": 8e-07,
         "input_cost_per_token": 6e-07,
@@ -44524,6 +44584,7 @@
         "supports_audio_input": true
     },
     "sora-2": {
+        "deprecation_date": "2026-09-24",
         "litellm_provider": "openai",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.1,
@@ -44537,6 +44598,7 @@
         ]
     },
     "sora-2-pro": {
+        "deprecation_date": "2026-09-24",
         "litellm_provider": "openai",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.3,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -110,6 +110,7 @@
         "output_cost_per_token": 1.88e-05
     },
     "ai21.jamba-1-5-large-v1:0": {
+        "deprecation_date": "2026-11-26",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 256000,
@@ -119,6 +120,7 @@
         "output_cost_per_token": 8e-06
     },
     "ai21.jamba-1-5-mini-v1:0": {
+        "deprecation_date": "2026-11-26",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 256000,
@@ -287,6 +289,7 @@
         "supports_vision": true
     },
     "amazon.nova-canvas-v1:0": {
+        "deprecation_date": "2026-09-30",
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,
         "mode": "image_generation",
@@ -620,6 +623,7 @@
         "mode": "image_generation"
     },
     "twelvelabs.marengo-embed-2-7-v1:0": {
+        "deprecation_date": "2026-11-30",
         "input_cost_per_token": 7e-05,
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
@@ -776,6 +780,7 @@
         "prompt_cache_min_tokens": 4096
     },
     "anthropic.claude-3-5-sonnet-20240620-v1:0": {
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 1000000,
@@ -798,6 +803,7 @@
     "anthropic.claude-3-5-sonnet-20241022-v2:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 1000000,
@@ -841,6 +847,7 @@
     "anthropic.claude-3-7-sonnet-20250219-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
@@ -859,6 +866,7 @@
         "supports_vision": true
     },
     "anthropic.claude-3-haiku-20240307-v1:0": {
+        "deprecation_date": "2026-09-10",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -890,6 +898,7 @@
         "cache_creation_input_token_cost": 1.875e-05
     },
     "anthropic.claude-3-sonnet-20240229-v1:0": {
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -918,6 +927,7 @@
     "anthropic.claude-opus-4-1-20250805-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
+        "deprecation_date": "2027-01-08",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
@@ -2391,6 +2401,7 @@
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-10-14",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
@@ -9447,6 +9458,7 @@
         "supports_vision": true
     },
     "babbage-002": {
+        "deprecation_date": "2026-09-28",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "text-completion-openai",
         "max_input_tokens": 16384,
@@ -11396,6 +11408,7 @@
         "output_cost_per_token": 5e-07
     },
     "chatgpt-4o-latest": {
+        "deprecation_date": "2026-02-17",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -11499,6 +11512,7 @@
         "cache_creation_input_token_cost": 3e-07,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-08,
+        "deprecation_date": "2026-04-20",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
@@ -11754,6 +11768,7 @@
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_creation_input_token_cost_above_1hr": 3e-05,
         "cache_read_input_token_cost": 1.5e-06,
+        "deprecation_date": "2026-08-05",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
@@ -12546,6 +12561,7 @@
         "supports_tool_choice": true
     },
     "cohere.command-r-plus-v1:0": {
+        "deprecation_date": "2026-08-19",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -12556,6 +12572,7 @@
         "supports_tool_choice": true
     },
     "cohere.command-r-v1:0": {
+        "deprecation_date": "2026-08-19",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -12746,6 +12763,7 @@
         "supports_vision": true
     },
     "dall-e-2": {
+        "deprecation_date": "2026-05-12",
         "input_cost_per_image": 0.02,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -12756,6 +12774,7 @@
         ]
     },
     "dall-e-3": {
+        "deprecation_date": "2026-05-12",
         "input_cost_per_image": 0.04,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -14099,6 +14118,7 @@
         "mode": "search"
     },
     "davinci-002": {
+        "deprecation_date": "2026-09-28",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "text-completion-openai",
         "max_input_tokens": 16384,
@@ -15786,6 +15806,7 @@
         ]
     },
     "embed-english-light-v2.0": {
+        "deprecation_date": "2026-04-04",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 1024,
@@ -15802,6 +15823,7 @@
         "output_cost_per_token": 0.0
     },
     "embed-english-v2.0": {
+        "deprecation_date": "2026-04-04",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 4096,
@@ -15824,6 +15846,7 @@
         "supports_image_input": true
     },
     "embed-multilingual-v2.0": {
+        "deprecation_date": "2026-04-04",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 768,
@@ -22038,6 +22061,7 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-0125": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
@@ -22079,6 +22103,7 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-instruct": {
+        "deprecation_date": "2026-09-28",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "text-completion-openai",
         "max_input_tokens": 8192,
@@ -22166,6 +22191,7 @@
         "supports_tool_choice": true
     },
     "gpt-4-turbo": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -22456,6 +22482,7 @@
         "supports_vision": true
     },
     "gpt-4o-2024-05-13": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 5e-06,
         "input_cost_per_token_batches": 2.5e-06,
         "input_cost_per_token_priority": 8.75e-06,
@@ -22522,6 +22549,7 @@
         "supports_vision": true
     },
     "gpt-4o-audio-preview": {
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -22714,6 +22742,7 @@
         "supports_vision": false
     },
     "gpt-audio-mini-2025-10-06": {
+        "deprecation_date": "2026-07-23",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "openai",
@@ -22837,6 +22866,7 @@
         "supports_vision": true
     },
     "gpt-4o-mini-audio-preview": {
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "openai",
@@ -22873,6 +22903,7 @@
     "gpt-4o-mini-realtime-preview": {
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "openai",
@@ -22936,6 +22967,7 @@
     },
     "gpt-4o-mini-search-preview-2025-03-11": {
         "cache_read_input_token_cost": 7.5e-08,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.5e-07,
         "input_cost_per_token_batches": 7.5e-08,
         "litellm_provider": "openai",
@@ -22986,6 +23018,7 @@
     },
     "gpt-4o-realtime-preview": {
         "cache_read_input_token_cost": 2.5e-06,
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -23004,6 +23037,7 @@
     },
     "gpt-4o-realtime-preview-2024-12-17": {
         "cache_read_input_token_cost": 2.5e-06,
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -23022,6 +23056,7 @@
     },
     "gpt-4o-realtime-preview-2025-06-03": {
         "cache_read_input_token_cost": 2.5e-06,
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -23066,6 +23101,7 @@
     },
     "gpt-4o-search-preview-2025-03-11": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 2.5e-06,
         "input_cost_per_token_batches": 1.25e-06,
         "litellm_provider": "openai",
@@ -23098,6 +23134,7 @@
     },
     "gpt-image-1.5": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-12-01",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -23607,6 +23644,7 @@
     "gpt-5.1-chat-latest": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "openai",
@@ -23726,6 +23764,7 @@
     "gpt-5.2-chat-latest": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2026-08-10",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "openai",
@@ -23764,6 +23803,7 @@
     "gpt-5.3-chat-latest": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2026-08-10",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "openai",
@@ -24679,6 +24719,7 @@
         "supports_minimal_reasoning_effort": true
     },
     "gpt-5-pro-2025-10-06": {
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,
         "litellm_provider": "openai",
@@ -24718,6 +24759,7 @@
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_flex": 6.25e-08,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_flex": 6.25e-07,
         "input_cost_per_token_priority": 2.5e-06,
@@ -24793,6 +24835,7 @@
     },
     "gpt-5-chat-latest": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -24828,6 +24871,7 @@
     },
     "gpt-5-codex": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 272000,
@@ -24863,6 +24907,7 @@
     "gpt-5.1-codex": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "openai",
@@ -24899,6 +24944,7 @@
     },
     "gpt-5.1-codex-max": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 272000,
@@ -24934,6 +24980,7 @@
     "gpt-5.1-codex-mini": {
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_priority": 4.5e-08,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 2.5e-07,
         "input_cost_per_token_priority": 4.5e-07,
         "litellm_provider": "openai",
@@ -24971,6 +25018,7 @@
     "gpt-5.2-codex": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "openai",
@@ -25088,6 +25136,7 @@
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_flex": 1.25e-08,
         "cache_read_input_token_cost_priority": 4.5e-08,
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 2.5e-07,
         "input_cost_per_token_flex": 1.25e-07,
         "input_cost_per_token_priority": 4.5e-07,
@@ -25169,6 +25218,7 @@
     "gpt-5-nano-2025-08-07": {
         "cache_read_input_token_cost": 5e-09,
         "cache_read_input_token_cost_flex": 2.5e-09,
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 5e-08,
         "input_cost_per_token_priority": 2.5e-06,
         "input_cost_per_token_flex": 2.5e-08,
@@ -25208,6 +25258,7 @@
     },
     "gpt-image-1": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_image_token": 1e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -25220,6 +25271,7 @@
     },
     "gpt-image-1-mini": {
         "cache_read_input_token_cost": 2e-07,
+        "deprecation_date": "2026-12-01",
         "input_cost_per_image_token": 2.5e-06,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "openai",
@@ -29295,6 +29347,7 @@
         "supports_vision": true
     },
     "o1-pro": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 0.00015,
         "input_cost_per_token_batches": 7.5e-05,
         "litellm_provider": "openai",
@@ -29400,6 +29453,7 @@
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_flex": 2.5e-07,
         "cache_read_input_token_cost_priority": 8.75e-07,
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_flex": 1e-06,
         "input_cost_per_token_priority": 3.5e-06,
@@ -29568,6 +29622,7 @@
         "supports_web_search": true
     },
     "o3-pro-2025-06-10": {
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 2e-05,
         "input_cost_per_token_batches": 1e-05,
         "litellm_provider": "openai",
@@ -33458,6 +33513,7 @@
         "supports_system_messages": true
     },
     "rerank-english-v2.0": {
+        "deprecation_date": "2025-04-30",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "cohere",
@@ -33478,6 +33534,7 @@
         "output_cost_per_token": 0.0
     },
     "rerank-multilingual-v2.0": {
+        "deprecation_date": "2025-04-30",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "cohere",
@@ -34482,6 +34539,7 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "text-moderation-007": {
+        "deprecation_date": "2025-10-27",
         "input_cost_per_token": 0.0,
         "litellm_provider": "openai",
         "max_input_tokens": 32768,
@@ -44495,6 +44553,7 @@
         ]
     },
     "gpt-4o-mini-transcribe-2025-03-20": {
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
@@ -44565,6 +44624,7 @@
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_audio_token_cost": 3e-07,
         "cache_read_input_token_cost": 6e-08,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_image": 8e-07,
         "input_cost_per_token": 6e-07,
@@ -44645,6 +44705,7 @@
         "supports_audio_input": true
     },
     "sora-2": {
+        "deprecation_date": "2026-09-24",
         "litellm_provider": "openai",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.1,
@@ -44658,6 +44719,7 @@
         ]
     },
     "sora-2-pro": {
+        "deprecation_date": "2026-09-24",
         "litellm_provider": "openai",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.3,


### PR DESCRIPTION
`deprecation_date` is currently set on 93 of 2,988 entries (3.1%). This fills 62 of the gaps.

Every value is transcribed from the provider's own published retirement table, and I verified each one against the **raw page** rather than a summarizer — 62 of 62 confirmed. No existing value is changed, nothing is removed, and no other field is touched: the diff is 62 added lines in each file.

### On the convention

The schema describes the field as "Date the provider deprecates the model." I checked what the existing data actually encodes before adding anything: of the 14 models where a `deprecation_date` was already present and I had an independent provider-cited date, **9 matched the shutdown/retirement date exactly** (`claude-3-7-sonnet-20250219` → 2026-02-19, `gpt-3.5-turbo-1106` → 2026-09-28, the four `gemini-2.0-flash*` → 2026-06-01, `gpt-4-0314` → 2026-03-26, `text-embedding-004` → 2026-01-14). So these 62 use the same convention: **the date the model stops serving requests.** Happy to switch them to announcement dates if that was the intent — say the word and I will regenerate.

### The values


<details>
<summary><b>42 models</b> — source: https://developers.openai.com/api/docs/deprecations</summary>

| model | `deprecation_date` |
|:--|:--|
| `babbage-002` | 2026-09-28 |
| `chatgpt-4o-latest` | 2026-02-17 |
| `dall-e-2` | 2026-05-12 |
| `dall-e-3` | 2026-05-12 |
| `davinci-002` | 2026-09-28 |
| `gpt-3.5-turbo-0125` | 2026-10-23 |
| `gpt-3.5-turbo-instruct` | 2026-09-28 |
| `gpt-4-turbo` | 2026-10-23 |
| `gpt-4o-2024-05-13` | 2026-10-23 |
| `gpt-4o-audio-preview` | 2026-05-07 |
| `gpt-4o-mini-audio-preview` | 2026-05-07 |
| `gpt-4o-mini-realtime-preview` | 2026-05-07 |
| `gpt-4o-mini-search-preview-2025-03-11` | 2026-07-23 |
| `gpt-4o-mini-transcribe-2025-03-20` | 2027-01-20 |
| `gpt-4o-realtime-preview` | 2026-05-07 |
| `gpt-4o-realtime-preview-2024-12-17` | 2026-05-07 |
| `gpt-4o-realtime-preview-2025-06-03` | 2026-05-07 |
| `gpt-4o-search-preview-2025-03-11` | 2026-07-23 |
| `gpt-5-2025-08-07` | 2026-12-11 |
| `gpt-5-chat-latest` | 2026-07-23 |
| `gpt-5-codex` | 2026-07-23 |
| `gpt-5-mini-2025-08-07` | 2026-12-11 |
| `gpt-5-nano-2025-08-07` | 2026-12-11 |
| `gpt-5-pro-2025-10-06` | 2026-12-11 |
| `gpt-5.1-chat-latest` | 2026-07-23 |
| `gpt-5.1-codex` | 2026-07-23 |
| `gpt-5.1-codex-max` | 2026-07-23 |
| `gpt-5.1-codex-mini` | 2026-07-23 |
| `gpt-5.2-chat-latest` | 2026-08-10 |
| `gpt-5.2-codex` | 2026-07-23 |
| `gpt-5.3-chat-latest` | 2026-08-10 |
| `gpt-audio-mini-2025-10-06` | 2026-07-23 |
| `gpt-image-1` | 2026-10-23 |
| `gpt-image-1-mini` | 2026-12-01 |
| `gpt-image-1.5` | 2026-12-01 |
| `gpt-realtime-mini-2025-10-06` | 2026-07-23 |
| `o1-pro` | 2026-10-23 |
| `o3-2025-04-16` | 2026-12-11 |
| `o3-pro-2025-06-10` | 2026-12-11 |
| `sora-2` | 2026-09-24 |
| `sora-2-pro` | 2026-09-24 |
| `text-moderation-007` | 2025-10-27 |

</details>

<details>
<summary><b>13 models</b> — source: https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html</summary>

| model | `deprecation_date` |
|:--|:--|
| `ai21.jamba-1-5-large-v1:0` | 2026-11-26 |
| `ai21.jamba-1-5-mini-v1:0` | 2026-11-26 |
| `amazon.nova-canvas-v1:0` | 2026-09-30 |
| `anthropic.claude-3-5-sonnet-20240620-v1:0` | 2026-07-30 |
| `anthropic.claude-3-5-sonnet-20241022-v2:0` | 2026-07-30 |
| `anthropic.claude-3-7-sonnet-20250219-v1:0` | 2026-07-30 |
| `anthropic.claude-3-haiku-20240307-v1:0` | 2026-09-10 |
| `anthropic.claude-3-sonnet-20240229-v1:0` | 2026-07-30 |
| `anthropic.claude-opus-4-1-20250805-v1:0` | 2027-01-08 |
| `anthropic.claude-sonnet-4-20250514-v1:0` | 2026-10-14 |
| `cohere.command-r-plus-v1:0` | 2026-08-19 |
| `cohere.command-r-v1:0` | 2026-08-19 |
| `twelvelabs.marengo-embed-2-7-v1:0` | 2026-11-30 |

</details>

<details>
<summary><b>5 models</b> — source: https://docs.cohere.com/docs/deprecations</summary>

| model | `deprecation_date` |
|:--|:--|
| `embed-english-light-v2.0` | 2026-04-04 |
| `embed-english-v2.0` | 2026-04-04 |
| `embed-multilingual-v2.0` | 2026-04-04 |
| `rerank-english-v2.0` | 2025-04-30 |
| `rerank-multilingual-v2.0` | 2025-04-30 |

</details>

<details>
<summary><b>2 models</b> — source: https://platform.claude.com/docs/en/about-claude/model-deprecations</summary>

| model | `deprecation_date` |
|:--|:--|
| `claude-3-haiku-20240307` | 2026-04-20 |
| `claude-opus-4-1` | 2026-08-05 |

</details>
### Five existing values that appear to disagree with the provider

Not touched in this PR — flagging them rather than changing them, since they may be deliberate:

| model | current | provider's page says |
|:--|:--|:--|
| `claude-3-opus-20240229` | 2026-05-01 | 2026-01-05 |
| `claude-opus-4-20250514` | 2026-05-14 | 2026-06-15 |
| `claude-sonnet-4-20250514` | 2026-05-14 | 2026-06-15 |
| `gpt-4-0613` | 2025-06-06 | 2026-10-23 |
| `gpt-4-1106-preview` | 2026-03-26 | 2026-10-23 |

The two `20250514` rows are worth a look: both currently read exactly one year after the model's own date stamp, which is the signature of a heuristic rather than a published date. Anthropic's deprecation table gives 2026-06-15 for both. I can send a follow-up PR for these if you want them corrected.

### Notes

- Both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json` were already out of sync at `main` before this change (`ci_cd/check_files_match.py` fails on `main` today). Rather than copy one over the other and drag ~280 unrelated lines into this PR, I applied the same 62 additions to each file independently. Both now carry identical additions.
- Validated against `model_prices_and_context_window.schema.json` with `jsonschema` — passes.
- These dates come from [driftcite](https://github.com/nilaypatell/driftcite), which tracks provider deprecation pages daily. The model-lifecycle rows are CC BY 4.0, so you are free to take them. **Standing offer: I'm happy to keep this field current via a recurring automated PR** rather than have it drift again — just tell me the cadence and shape you'd want.
