### PR TITLE
docs: require re-running live QA proof at each new PR head

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ Do not add `Co-Authored-By: Claude` or any Claude attribution to commit messages
 
 When working on a PR, keep the PR description in sync with new commits being made
 
+Every new commit pushed to a PR requires re-running the live QA proof at that new head and de-staling the description in the same pass. Proof blocks, commit hashes, labels like "this PR's head", expected test counts, env vars, and thresholds silently stop matching HEAD once you push, and a reviewer following the runbook then verifies the wrong thing. Don't just append the new run next to the old ones: replace the superseded sections so the body shows a single proof captured at the current head. Broad unit-test sweeps are the exception since CI covers those at the head, so label old pytest numbers with the commit they were captured at instead of re-running them locally. Local re-capture is for live-proxy proofs, lint/type gate outputs, and the targeted tests for whatever the commit touched
+
 All GitHub comments must be human-readable and 15-25 words max
 
 Monkeypatching attributes of a class to do testing is an anti-pattern. Prefer dependency-injecting things into classes. That way, at unit test time, you can pass a mocked dependency in


### PR DESCRIPTION
## TLDR

Problem this solves:

- Proof blocks go stale after a new commit
- Reviewers follow a runbook pinned to an old head
- Only "keep the description in sync" was written down

How it solves it:

- CLAUDE.md now requires re-running live QA per commit
- Says replace superseded proof, don't append it
- Exempts broad unit sweeps, CI covers the head

## User Flow

Before

1. No end-user-observable step changes: this PR only edits CLAUDE.md, the agent instruction file, so no route, response, or UI behavior differs

After

1. Same as before, unchanged

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Tests are left unchecked on purpose: the change is one paragraph of agent instructions in CLAUDE.md, with no code path to assert against

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

No live proof applies here. CLAUDE.md is instruction text read by coding agents, not code the proxy executes, so there is nothing to reproduce against a running proxy and no before/after behavior to capture. The full diff is the one paragraph below

```
$ git show --stat 7d7ea1504b
 CLAUDE.md | 2 ++
 1 file changed, 2 insertions(+)
```

## Type

📖 Documentation

## Changes

Adds a rule directly under the existing "keep the PR description in sync with new commits" line. It states that every new commit pushed to a PR requires re-running the live QA proof at that new head and de-staling the description in the same pass, calls out what silently stops matching HEAD (proof blocks, commit hashes, "this PR's head" labels, expected test counts, env vars, thresholds), and says to replace the superseded sections rather than appending a second run beside them

It also carves out the exception so the rule stays practical: broad unit-test sweeps don't need a local re-run since CI runs them at the head, so label old pytest numbers with the commit they were captured at. Local re-capture is for live-proxy proofs, lint and type gate outputs, and the targeted tests for whatever the commit touched

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
