### PR TITLE
fix(proxy): attribute managed batch spend to the creating API key

### DIFF
--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -497,8 +497,6 @@ class CheckBatchCost:
                     }
                 },
                 "metadata": {
-                    # Hashed creating key (when present) so key spend / max_budget
-                    # see batch workloads, not only user/team (#36071).
                     "user_api_key": getattr(job, "created_by_api_key", None) or "",
                     "user_api_key_user_id": creator_user_id,
                     "user_api_key_team_id": getattr(job, "team_id", None),

--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -497,6 +497,9 @@ class CheckBatchCost:
                     }
                 },
                 "metadata": {
+                    # Hashed creating key (when present) so key spend / max_budget
+                    # see batch workloads, not only user/team (#36071).
+                    "user_api_key": getattr(job, "created_by_api_key", None) or "",
                     "user_api_key_user_id": creator_user_id,
                     "user_api_key_team_id": getattr(job, "team_id", None),
                     **user_info,

--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -212,6 +212,8 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                     "model_object_id": model_object_id,
                     "file_purpose": file_purpose,
                     "created_by": user_api_key_dict.user_id,
+                    # Hashed virtual key — CheckBatchCost attributes spend to this key.
+                    "created_by_api_key": user_api_key_dict.api_key,
                     "team_id": user_api_key_dict.team_id,
                     "updated_by": user_api_key_dict.user_id,
                     "status": file_object.status,

--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -212,7 +212,6 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                     "model_object_id": model_object_id,
                     "file_purpose": file_purpose,
                     "created_by": user_api_key_dict.user_id,
-                    # Hashed virtual key — CheckBatchCost attributes spend to this key.
                     "created_by_api_key": user_api_key_dict.api_key,
                     "team_id": user_api_key_dict.team_id,
                     "updated_by": user_api_key_dict.user_id,

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260807000000_add_created_by_api_key_to_managed_object_table/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260807000000_add_created_by_api_key_to_managed_object_table/migration.sql
@@ -1,0 +1,4 @@
+-- Persist the hashed creating API key on managed batch/fine-tune objects so
+-- CheckBatchCost can attribute completed-batch spend to the key (key spend /
+-- max_budget), not only to user_id / team_id.
+ALTER TABLE "LiteLLM_ManagedObjectTable" ADD COLUMN IF NOT EXISTS "created_by_api_key" TEXT;

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -984,7 +984,7 @@ model LiteLLM_ManagedObjectTable { // for batches or finetuning jobs which use t
   batch_processed Boolean @default(false) // set to true by CheckBatchCost after cost is computed
   created_at DateTime @default(now())
   created_by String?
-  created_by_api_key String? // Hashed API key that created this object; used for spend attribution
+  created_by_api_key String?
   team_id String?
   updated_at DateTime @updatedAt
   updated_by String?

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -984,6 +984,7 @@ model LiteLLM_ManagedObjectTable { // for batches or finetuning jobs which use t
   batch_processed Boolean @default(false) // set to true by CheckBatchCost after cost is computed
   created_at DateTime @default(now())
   created_by String?
+  created_by_api_key String? // Hashed API key that created this object; used for spend attribution
   team_id String?
   updated_at DateTime @updatedAt
   updated_by String?

--- a/litellm/models/managed_files.py
+++ b/litellm/models/managed_files.py
@@ -31,6 +31,7 @@ class LiteLLM_ManagedObjectTable(LiteLLMPydanticObjectBase):
     file_purpose: Literal["batch", "fine-tune", "response", "container"]
     file_object: LiteLLMBatch | LiteLLMFineTuningJob | ResponsesAPIResponse
     created_by: str | None = None
+    created_by_api_key: str | None = None
     team_id: str | None = None
 
 

--- a/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
+++ b/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
@@ -675,6 +675,7 @@ async def _mint_or_reuse_object(
                     "model_object_id": namespaced_model_object_id,
                     "file_purpose": file_purpose,
                     "created_by": user_api_key_dict.user_id,
+                    "created_by_api_key": user_api_key_dict.api_key,
                     "team_id": user_api_key_dict.team_id,
                     "updated_by": user_api_key_dict.user_id,
                 },

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -984,7 +984,7 @@ model LiteLLM_ManagedObjectTable { // for batches or finetuning jobs which use t
   batch_processed Boolean @default(false) // set to true by CheckBatchCost after cost is computed
   created_at DateTime @default(now())
   created_by String?
-  created_by_api_key String? // Hashed API key that created this object; used for spend attribution
+  created_by_api_key String?
   team_id String?
   updated_at DateTime @updatedAt
   updated_by String?

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -984,6 +984,7 @@ model LiteLLM_ManagedObjectTable { // for batches or finetuning jobs which use t
   batch_processed Boolean @default(false) // set to true by CheckBatchCost after cost is computed
   created_at DateTime @default(now())
   created_by String?
+  created_by_api_key String? // Hashed API key that created this object; used for spend attribution
   team_id String?
   updated_at DateTime @updatedAt
   updated_by String?

--- a/schema.prisma
+++ b/schema.prisma
@@ -984,7 +984,7 @@ model LiteLLM_ManagedObjectTable { // for batches or finetuning jobs which use t
   batch_processed Boolean @default(false) // set to true by CheckBatchCost after cost is computed
   created_at DateTime @default(now())
   created_by String?
-  created_by_api_key String? // Hashed API key that created this object; used for spend attribution
+  created_by_api_key String?
   team_id String?
   updated_at DateTime @updatedAt
   updated_by String?

--- a/schema.prisma
+++ b/schema.prisma
@@ -984,6 +984,7 @@ model LiteLLM_ManagedObjectTable { // for batches or finetuning jobs which use t
   batch_processed Boolean @default(false) // set to true by CheckBatchCost after cost is computed
   created_at DateTime @default(now())
   created_by String?
+  created_by_api_key String? // Hashed API key that created this object; used for spend attribution
   team_id String?
   updated_at DateTime @updatedAt
   updated_by String?


### PR DESCRIPTION
## Summary
- Persist the hashed creating API key on `LiteLLM_ManagedObjectTable` (`created_by_api_key`) when storing managed batches.
- `CheckBatchCost` now sets `metadata.user_api_key` from that field so completed-batch spend attributes to the creating key (key spend / `max_budget`), not only user/team.

## Test plan
- [ ] Create a capped key, run a managed batch without polling, wait for `CheckBatchCost`, confirm `GET /key/info` spend increases and spend log `api_key` is set
- [ ] Confirm create path still writes `created_by` / `team_id` as before

Fixes #36071

Base: `litellm_internal_staging`
