### PR TITLE
refactor(lint): graduate zero-violation strict rules and guard the budget ratchet

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -17,7 +17,7 @@ import json
 import traceback
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from typing import Any, Final, cast
+from typing import Any, Final, Literal, cast
 
 import fastapi
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status

--- a/ruff-strict-budget.json
+++ b/ruff-strict-budget.json
@@ -56,9 +56,6 @@
   "B026": {
     "limit": 3
   },
-  "B033": {
-    "limit": 0
-  },
   "BLE001": {
     "limit": 2924
   },
@@ -113,18 +110,6 @@
   "F401": {
     "limit": 17
   },
-  "FURB136": {
-    "limit": 0
-  },
-  "FURB168": {
-    "limit": 0
-  },
-  "FURB188": {
-    "limit": 0
-  },
-  "I001": {
-    "limit": 0
-  },
   "LOG015": {
     "limit": 5
   },
@@ -137,17 +122,8 @@
   "PERF401": {
     "limit": 12
   },
-  "PERF402": {
-    "limit": 0
-  },
   "PERF403": {
     "limit": 34
-  },
-  "PIE790": {
-    "limit": 0
-  },
-  "PIE800": {
-    "limit": 0
   },
   "PIE804": {
     "limit": 18
@@ -158,9 +134,6 @@
   "PLC0206": {
     "limit": 26
   },
-  "PLC0208": {
-    "limit": 0
-  },
   "PLC0414": {
     "limit": 46
   },
@@ -170,23 +143,11 @@
   "PLR0206": {
     "limit": 1
   },
-  "PLR0402": {
-    "limit": 0
-  },
   "PLR1704": {
     "limit": 3
   },
-  "PLR1711": {
-    "limit": 0
-  },
   "PLR1714": {
     "limit": 257
-  },
-  "PLR1730": {
-    "limit": 0
-  },
-  "PLR2044": {
-    "limit": 0
   },
   "PLW0127": {
     "limit": 57
@@ -206,26 +167,11 @@
   "PLW1510": {
     "limit": 2
   },
-  "PYI030": {
-    "limit": 0
-  },
   "PYI036": {
     "limit": 3
   },
-  "PYI041": {
-    "limit": 0
-  },
-  "PYI064": {
-    "limit": 0
-  },
-  "RET501": {
-    "limit": 0
-  },
   "RET504": {
     "limit": 177
-  },
-  "RUF010": {
-    "limit": 0
   },
   "RUF012": {
     "limit": 241
@@ -236,17 +182,8 @@
   "RUF019": {
     "limit": 38
   },
-  "RUF022": {
-    "limit": 0
-  },
-  "RUF023": {
-    "limit": 0
-  },
   "RUF046": {
     "limit": 4
-  },
-  "RUF051": {
-    "limit": 0
   },
   "RUF059": {
     "limit": 67
@@ -272,17 +209,11 @@
   "SIM113": {
     "limit": 3
   },
-  "SIM114": {
-    "limit": 0
-  },
   "SIM115": {
     "limit": 2
   },
   "SIM117": {
     "limit": 7
-  },
-  "SIM118": {
-    "limit": 0
   },
   "SIM201": {
     "limit": 1
@@ -302,9 +233,6 @@
   "TC004": {
     "limit": 5
   },
-  "TC005": {
-    "limit": 0
-  },
   "TID251": {
     "limit": 1240
   },
@@ -323,46 +251,13 @@
   "TRY300": {
     "limit": 860
   },
-  "UP006": {
-    "limit": 0
-  },
-  "UP007": {
-    "limit": 0
-  },
-  "UP008": {
-    "limit": 0
-  },
-  "UP012": {
-    "limit": 0
-  },
-  "UP018": {
-    "limit": 0
-  },
-  "UP024": {
-    "limit": 0
-  },
   "UP028": {
     "limit": 2
   },
   "UP031": {
     "limit": 2
   },
-  "UP032": {
-    "limit": 0
-  },
-  "UP034": {
-    "limit": 0
-  },
-  "UP035": {
-    "limit": 0
-  },
   "UP036": {
     "limit": 1
-  },
-  "UP037": {
-    "limit": 0
-  },
-  "UP045": {
-    "limit": 0
   }
 }

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,14 +1,26 @@
 lint.ignore = ["F405", "E402", "F403"]
-lint.extend-select = ["T20", "PGH004", "RUF008", "RUF009", "RUF100"]
+# The second group is the strict gate's graduates: rules the codebase already has zero
+# violations of, so they hard-fail here instead of being ratcheted in ruff-strict-budget.json.
+# That gives editors and `ruff check --fix` the diagnostic, which the gate script cannot.
+lint.extend-select = [
+    "T20", "PGH004", "RUF008", "RUF009", "RUF100",
+    "B033", "FURB136", "FURB168", "FURB188", "I001", "PERF402", "PIE790", "PIE800", "PLC0208",
+    "PLR0402", "PLR1711", "PLR1730", "PLR2044", "PYI030", "PYI041", "PYI064", "RET501", "RUF010",
+    "RUF022", "RUF023", "RUF051", "SIM114", "SIM118", "TC005", "UP006", "UP007", "UP008", "UP012",
+    "UP018", "UP024", "UP032", "UP034", "UP035", "UP037", "UP045",
+]
 # RUF100 (unused-noqa) only knows the rules enabled in THIS config, so it would strip
 # `# noqa` directives that protect rules enforced elsewhere. List those codes as external
 # so RUF100 leaves their directives alone: the strict gate (ruff-strict.toml) and upstream
 # litellm's own ruff config both rely on suppressions this config can't see.
 lint.external = [
-    # Enforced by the strict-rule gate (scripts/ruff_strict_gate.py + ruff-strict.toml)
-    "ANN", "ASYNC230", "B", "C", "D419", "DTZ", "EXE", "FURB", "I001", "LOG015", "N999", "PERF",
-    "PIE", "PL", "PYI", "RET", "RUF010", "RUF012", "RUF015", "RUF019", "RUF022", "RUF023",
-    "RUF046", "RUF051", "RUF059", "S110", "S112", "SIM", "TC", "TID251", "TRY", "UP",
+    # Enforced by the strict-rule gate (scripts/ruff_strict_gate.py + ruff-strict.toml).
+    # Family entries whose every strict rule graduated into extend-select above (FURB), and
+    # standalone graduated codes (I001, RUF010, RUF022, RUF023, RUF051), are dropped so this
+    # config's RUF100 polices their directives itself.
+    "ANN", "ASYNC230", "B", "C", "D419", "DTZ", "EXE", "LOG015", "N999", "PERF",
+    "PIE", "PL", "PYI", "RET", "RUF012", "RUF015", "RUF019",
+    "RUF046", "RUF059", "S110", "S112", "SIM", "TC", "TID251", "TRY", "UP",
     # Enforced by upstream litellm's ruff config, but not run in this repo's CI
     "PLC0415", "E402", "BLE001", "ARG002", "S102", "S324", "S606", "D401", "F403", "F405",
 ]

--- a/scripts/budget_ratchet_check.py
+++ b/scripts/budget_ratchet_check.py
@@ -10,7 +10,10 @@ content at the merge-base with the target branch and fails (exits 1, red) if:
   * a rule was dropped from a budget (its ceiling effectively became infinite), or
   * an entire budget file was deleted.
 
-New rules and lowered/equal limits are fine.
+New rules and lowered/equal limits are fine. So is a rule that graduated: once a
+paired config (ruff.toml for the ruff-strict budget) selects the rule outright it
+hard-fails at the first violation, which is stricter than any ceiling the budget
+could hold, so dropping its entry tightens the guard rather than removing it.
 
 This is deliberately NOT a gating check. It should turn the run red so that a
 loosening is impossible to miss in review, but it must stay OUT of the
@@ -30,7 +33,9 @@ import argparse
 import json
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
+from types import MappingProxyType
 from typing import NamedTuple
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -40,6 +45,7 @@ DEFAULT_BUDGETS: tuple[str, ...] = (
     "type-discipline-budget.json",
     "basedpyright-code-budget.json",
 )
+GRADUATION_CONFIGS = MappingProxyType({"ruff-strict-budget.json": "ruff.toml"})
 
 
 class Regression(NamedTuple):
@@ -106,24 +112,57 @@ def _limits(budget: dict) -> dict[str, int]:
     }
 
 
+def selectors_hard_failed_by(lint: dict) -> tuple[str, ...]:
+    """A ruff `[lint]` table's selected codes, minus anything `ignore` turns back off.
+
+    `lint.ignore` wins over `lint.extend-select` in ruff, so an ignored code is not
+    actually enforced and must not count as a graduation.
+    """
+    ignored = tuple(lint.get("ignore", ()))
+    return tuple(
+        selector
+        for selector in lint.get("extend-select", ())
+        if not (ignored and selector.startswith(ignored))
+    )
+
+
+def graduated_selectors(rel: str) -> tuple[str, ...]:
+    """Selectors the budget's paired ruff config hard-fails, so its ceiling is moot."""
+    config = GRADUATION_CONFIGS.get(rel)
+    if config is None or not (REPO_ROOT / config).exists():
+        return ()
+    return selectors_hard_failed_by(
+        tomllib.loads((REPO_ROOT / config).read_text()).get("lint", {})
+    )
+
+
 def _regression_detail(
     rule: str,
     base_limits: dict[str, int],
     head_limits: dict[str, int],
+    graduated: tuple[str, ...],
 ) -> str | None:
-    """Why `rule` regressed vs base, or None when it held flat or fell.
+    """Why `rule` regressed vs base, or None when it held flat, fell, or graduated.
 
-    A dropped rule is terminal; otherwise the only loosening left is a raised limit.
+    A dropped rule is terminal unless it graduated; otherwise the only loosening
+    left is a raised limit.
     """
     base_limit = base_limits[rule]
     if rule not in head_limits:
+        if graduated and rule.startswith(graduated):
+            return None
         return f"rule dropped (limit {base_limit} -> removed)"
     if head_limits[rule] > base_limit:
         return f"limit raised {base_limit} -> {head_limits[rule]}"
     return None
 
 
-def regressions_for(rel: str, base: dict | None, head: dict | None) -> list[Regression]:
+def regressions_for(
+    rel: str,
+    base: dict | None,
+    head: dict | None,
+    graduated: tuple[str, ...] = (),
+) -> list[Regression]:
     if base is None:
         return []  # new budget file: nothing to ratchet against yet
     if head is None:
@@ -133,7 +172,7 @@ def regressions_for(rel: str, base: dict | None, head: dict | None) -> list[Regr
     return [
         Regression(rel, rule, detail)
         for rule in sorted(base_limits)
-        if (detail := _regression_detail(rule, base_limits, head_limits)) is not None
+        if (detail := _regression_detail(rule, base_limits, head_limits, graduated)) is not None
     ]
 
 
@@ -164,7 +203,7 @@ def main() -> int:
             print(f"skip {rel}: new file (no base at {args.base} to ratchet against)")
             continue
         checked.append(rel)
-        regressions.extend(regressions_for(rel, base, head))
+        regressions.extend(regressions_for(rel, base, head, graduated_selectors(rel)))
 
     if regressions:
         print(

--- a/tests/test_litellm/test_budget_ratchet_check.py
+++ b/tests/test_litellm/test_budget_ratchet_check.py
@@ -68,6 +68,50 @@ def test_new_rule_in_head_is_clean():
     assert ratchet.regressions_for("b.json", {}, {"new-rule": _spec_of(5)}) == []
 
 
+def test_dropped_rule_that_graduated_to_a_hard_failing_config_is_clean():
+    base = {"UP006": _spec_of(0)}
+    assert ratchet.regressions_for("b.json", base, {}, graduated=("UP006",)) == []
+
+
+def test_graduation_matches_by_prefix_like_ruff_selectors_do():
+    base = {"ANN202": _spec_of(865)}
+    assert ratchet.regressions_for("b.json", base, {}, graduated=("ANN",)) == []
+
+
+def test_an_unrelated_graduation_does_not_excuse_a_dropped_rule():
+    base = {"C901": _spec_of(3)}
+    regs = ratchet.regressions_for("b.json", base, {}, graduated=("UP006", "SIM118"))
+    assert [r.rule for r in regs] == ["C901"]
+    assert "dropped" in regs[0].detail
+
+
+def test_graduation_never_excuses_a_raised_limit():
+    base = {"UP006": _spec_of(0)}
+    regs = ratchet.regressions_for("b.json", base, {"UP006": _spec_of(7)}, graduated=("UP006",))
+    assert [r.rule for r in regs] == ["UP006"]
+    assert "0 -> 7" in regs[0].detail
+
+
+def test_graduated_selectors_come_from_the_paired_ruff_config():
+    selectors = ratchet.graduated_selectors("ruff-strict-budget.json")
+    assert "UP006" in selectors
+    assert "ANN" not in selectors
+
+
+def test_budgets_without_a_paired_config_can_never_graduate():
+    assert ratchet.graduated_selectors("type-discipline-budget.json") == ()
+    assert ratchet.graduated_selectors("basedpyright-code-budget.json") == ()
+
+
+def test_a_selector_the_config_also_ignores_does_not_count_as_graduated():
+    lint = {"ignore": ["UP006"], "extend-select": ["UP006", "SIM118"]}
+    assert ratchet.selectors_hard_failed_by(lint) == ("SIM118",)
+
+
+def test_selectors_hard_failed_by_reads_a_config_with_no_ignore_list():
+    assert ratchet.selectors_hard_failed_by({"extend-select": ["UP006"]}) == ("UP006",)
+
+
 def test_deleted_budget_file_is_a_regression():
     regs = ratchet.regressions_for("b.json", {"LIT006": _spec_of(1)}, None)
     assert [r.rule for r in regs] == ["*"]

--- a/tests/test_litellm/test_ruff_strict_gate.py
+++ b/tests/test_litellm/test_ruff_strict_gate.py
@@ -1,15 +1,23 @@
 import importlib.util
+import json
+import re
+import shutil
 import subprocess
+import sys
+import tomllib
 from pathlib import Path
 
 import pytest
 
-_MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ruff_strict_gate.py"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = _REPO_ROOT / "scripts" / "ruff_strict_gate.py"
 _spec = importlib.util.spec_from_file_location("ruff_strict_gate", _MODULE_PATH)
 gate = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(gate)
 
 Violation = gate.Violation
+
+_ENABLED_BY_RUFF_DEFAULTS = frozenset({"F401"})
 
 
 def rule(name, limit):
@@ -151,3 +159,213 @@ def test_base_point_mid_merge_advances_to_the_merged_in_base_tip(tmp_path):
     repo, _, base_tip = _branched_repo(tmp_path)
     _git(repo, "merge", "--no-commit", "--no-ff", "main")
     assert gate.resolve_base_point("main", cwd=repo) == base_tip
+
+
+def _lint_section(config_name: str) -> dict:
+    return tomllib.loads((_REPO_ROOT / config_name).read_text())["lint"]
+
+
+def _base_external() -> tuple[str, ...]:
+    return tuple(_lint_section("ruff.toml")["external"])
+
+
+def _strict_external() -> tuple[str, ...]:
+    return tuple(_lint_section("ruff-strict.toml")["external"])
+
+
+def _strict_selected() -> frozenset:
+    return frozenset(_lint_section("ruff-strict.toml")["select"])
+
+
+def _prefix_covered(code: str, prefixes: tuple[str, ...]) -> bool:
+    return any(code.startswith(prefix) for prefix in prefixes)
+
+
+def _selected_by_the_normal_config() -> frozenset:
+    return frozenset(_lint_section("ruff.toml")["extend-select"]) | _ENABLED_BY_RUFF_DEFAULTS
+
+
+def _budgeted_rules() -> frozenset:
+    return frozenset(json.loads((_REPO_ROOT / "ruff-strict-budget.json").read_text()))
+
+
+def _ruff_binary() -> str | None:
+    beside_interpreter = Path(sys.executable).with_name("ruff")
+    return str(beside_interpreter) if beside_interpreter.exists() else shutil.which("ruff")
+
+
+_RUFF = _ruff_binary()
+_needs_ruff = pytest.mark.skipif(_RUFF is None, reason="ruff is not installed in this environment")
+
+
+def _ruff_output_for_noqa(code: str, *extra_args: str) -> str:
+    proc = subprocess.run(
+        [
+            _RUFF,
+            "check",
+            "--no-cache",
+            "--stdin-filename",
+            "litellm/types/_external_probe.py",
+            *extra_args,
+            "-",
+        ],
+        cwd=_REPO_ROOT,
+        input=f"def _probe(x: int):  # noqa: {code}\n    return x\n",
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout
+
+
+def test_every_strict_gate_rule_is_protected_from_base_ruf100():
+    unprotected = frozenset(
+        selector
+        for selector in _strict_selected()
+        if not _prefix_covered(selector, _base_external())
+        and selector not in _selected_by_the_normal_config()
+    )
+    assert unprotected == frozenset(), (
+        f"`ruff check` deletes any `# noqa` naming {sorted(unprotected)} as unused, so suppressing "
+        "one of those strict-gate rules breaks lint. Cover them in ruff.toml's lint.external or "
+        "enable them in its lint.extend-select."
+    )
+
+
+def test_every_selected_rule_keeps_stale_noqa_detection_somewhere():
+    policed_by_strict = frozenset(
+        selector
+        for selector in _strict_selected()
+        if not _prefix_covered(selector, _strict_external())
+    )
+    policed_by_base = frozenset(
+        selector
+        for selector in _selected_by_the_normal_config()
+        if not _prefix_covered(selector, _base_external())
+    )
+    shadowed = (
+        _strict_selected() | _selected_by_the_normal_config()
+    ) - policed_by_strict - policed_by_base
+    assert shadowed == frozenset(), (
+        f"no config's RUF100 can ever report a stale `# noqa` for {sorted(shadowed)}: every config "
+        "that selects each of them also shadows it with an external entry. Narrow the external "
+        "entry in ruff.toml or ruff-strict.toml."
+    )
+
+
+_BASE_OWNED_FAMILY = re.compile(r"E[479]\d+|F\d+|T20\d+")
+_BASE_OWNED_SINGLES = frozenset({"PGH004", "RUF008", "RUF009", "RUF100"})
+
+
+@pytest.fixture(scope="module")
+def all_ruff_rule_codes() -> frozenset:
+    listing = subprocess.run(
+        [_RUFF, "rule", "--all", "--output-format", "json"],
+        capture_output=True,
+        text=True,
+    )
+    assert listing.returncode == 0, listing.stderr
+    return frozenset(
+        entry["code"] for entry in json.loads(listing.stdout) if "Removed" not in entry["status"]
+    )
+
+
+@_needs_ruff
+def test_every_base_owned_rule_is_external_or_selected_in_the_strict_config(all_ruff_rule_codes):
+    base_owned = frozenset(
+        code
+        for code in all_ruff_rule_codes
+        if _BASE_OWNED_FAMILY.fullmatch(code) or code in _BASE_OWNED_SINGLES
+    )
+    stranded = frozenset(
+        code
+        for code in base_owned
+        if code not in _strict_selected() and not _prefix_covered(code, _strict_external())
+    )
+    assert stranded == frozenset(), (
+        f"the strict gate's RUF100 reads a valid `# noqa` for {sorted(stranded)} as unused, the "
+        "spurious-breach trap ruff-strict.toml's external override exists to prevent. Cover them "
+        "there."
+    )
+    double_booked = frozenset(
+        code
+        for code in base_owned
+        if code in _strict_selected() and _prefix_covered(code, _strict_external())
+    )
+    assert double_booked == frozenset(), (
+        f"{sorted(double_booked)} are selected by the strict config yet shadowed by its external "
+        "list, so their stale suppressions can never be reported. Narrow the external entry in "
+        "ruff-strict.toml."
+    )
+
+
+def test_every_budgeted_rule_is_one_the_gate_actually_measures():
+    selectors = tuple(_lint_section("ruff-strict.toml")["select"])
+    unmeasured = frozenset(code for code in _budgeted_rules() if not code.startswith(selectors))
+    assert unmeasured == frozenset(), (
+        f"the gate never counts {sorted(unmeasured)}, so their ceilings are dead config that reads "
+        "as coverage. Either select them in ruff-strict.toml or drop them from the budget."
+    )
+
+
+@_needs_ruff
+def test_every_strict_selected_rule_is_budgeted_or_hard_failed_by_the_base_config(all_ruff_rule_codes):
+    strict_enabled = frozenset(
+        code
+        for code in all_ruff_rule_codes
+        if code.startswith(tuple(_lint_section("ruff-strict.toml")["select"]))
+    )
+    base_hard_failed = tuple(_lint_section("ruff.toml")["extend-select"])
+    unpoliced = frozenset(
+        code
+        for code in strict_enabled
+        if code not in _budgeted_rules()
+        and not code.startswith(base_hard_failed)
+        and code not in _ENABLED_BY_RUFF_DEFAULTS
+    )
+    assert unpoliced == frozenset(), (
+        f"nothing enforces {sorted(unpoliced)}: the gate skips rules missing from the budget, and "
+        "the base config does not hard-fail them. Re-add a budget ceiling or graduate them into "
+        "ruff.toml's lint.extend-select."
+    )
+
+
+@_needs_ruff
+def test_a_noqa_for_a_strict_gate_rule_survives_the_normal_ruff_run():
+    assert "RUF100" not in _ruff_output_for_noqa("ANN202")
+
+
+@_needs_ruff
+def test_the_external_list_is_what_saves_that_noqa():
+    assert "RUF100" in _ruff_output_for_noqa("ANN202", "--config", "lint.external=[]")
+
+
+@_needs_ruff
+def test_a_stale_noqa_for_a_locally_enabled_rule_is_still_reported():
+    assert "RUF100" in _ruff_output_for_noqa("F401")
+
+
+def _ruff_output_for_source(source: str) -> str:
+    proc = subprocess.run(
+        [_RUFF, "check", "--no-cache", "--stdin-filename", "litellm/types/_graduate_probe.py", "-"],
+        cwd=_REPO_ROOT,
+        input=source,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout
+
+
+_DEPRECATED_TYPING_ALIAS = "from typing import List  # noqa: UP035\n\n\ndef _probe(x: List[int]) -> None: ...\n"
+
+
+@_needs_ruff
+def test_a_graduated_rule_now_fails_the_normal_ruff_run_instead_of_waiting_for_the_gate():
+    assert "UP006" in _ruff_output_for_source(_DEPRECATED_TYPING_ALIAS)
+
+
+@_needs_ruff
+def test_a_graduated_rule_can_still_be_suppressed_without_tripping_unused_noqa():
+    suppressed = _DEPRECATED_TYPING_ALIAS.replace("...\n", "...  # noqa: UP006\n")
+    output = _ruff_output_for_source(suppressed)
+    assert "UP006" not in output
+    assert "RUF100" not in output


### PR DESCRIPTION
## TLDR

Problem this solves:

- 35 strict-gate rules already sit at a zero-violation ceiling
- their diagnostics only surface in the strict CI job, never locally
- deleting a rule from a budget file silently removed its ceiling
- two UP037 violations hid behind a star-imported Literal

How it solves it:

- graduates those 35 rules into ruff.toml lint.extend-select
- ruff check and editors now flag them instantly, with fixes
- the ratchet guard excuses a dropped budget rule only if graduated
- imports Literal explicitly so UP037 graduates clean
- drift tests pin every rule to exactly one enforcer

## User Flow

Before: a contributor who writes a pattern like `str("value")` sees every local check pass and only learns of the violation when the strict-rules CI job fails after push

1. They add `x = str("value")` to a module under `litellm/`
2. They run `ruff check litellm` and get "All checks passed!", and their editor shows no diagnostic either
3. They push, and the strict-rules CI job fails with "UP018: total 1 over limit 0 (this change added 1)"
4. They rewrite the line by hand, since no local tool names the rule or offers the fix

After: the same mistake fails `ruff check` immediately, names the rule, and auto-fixes

1. They add `x = str("value")` to a module under `litellm/`
2. `ruff check litellm` fails on the spot with "UP018 [*] Unnecessary `str` call (rewrite as a literal)", and their editor shows the same diagnostic
3. `ruff check --fix litellm` rewrites the line to `x = "value"`
4. They push and the lint jobs pass first try

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before, at staging tip dee667edb7: a fresh UP018 violation passes `ruff check` untouched and only the strict-gate script catches it

```console
$ echo 'x = str("value")' > litellm/_up018_probe.py
$ ruff check litellm/_up018_probe.py
All checks passed!
$ python scripts/ruff_strict_gate.py --base origin/litellm_internal_staging
FAIL: strict-rule totals exceed their limit (base origin/litellm_internal_staging):
  UP018: total 1 over limit 0 (this change added 1)
```

After, at PR head 5cd027cbbc: the same probe fails `ruff check` directly and is auto-fixable, and the tree-wide runs stay green

```console
$ echo 'x = str("value")' > litellm/_up018_probe.py
$ ruff check litellm/_up018_probe.py
UP018 [*] Unnecessary `str` call (rewrite as a literal)
 --> litellm/_up018_probe.py:1:5
help: Replace with string literal
Found 1 error.
$ ruff check --fix litellm/_up018_probe.py && cat litellm/_up018_probe.py
x = "value"
$ rm litellm/_up018_probe.py && ruff check litellm && python scripts/ruff_strict_gate.py --base origin/litellm_internal_staging
All checks passed!
OK: every strict rule is within its codebase ceiling (base origin/litellm_internal_staging)
```

The ratchet guard, at 5cd027cbbc: the 35 graduated drops are excused, while dropping a rule without graduating it still fails

```console
$ python scripts/budget_ratchet_check.py --base origin/litellm_internal_staging
OK: no budget limit increased vs base origin/litellm_internal_staging (ruff-strict-budget.json, type-discipline-budget.json, basedpyright-code-budget.json)
$ python - <<'EOF'  # delete UP028 from ruff-strict-budget.json without graduating it, rerun, restore
...
EOF
FAIL: budget limit(s) loosened vs base origin/litellm_internal_staging (merge-base c3536c29a0eb):
  ruff-strict-budget.json  UP028: rule dropped (limit 2 -> removed)
```

UP037: at dee667edb7 `ruff check --select UP037 litellm` finds 2 fixable errors in `litellm/proxy/management_endpoints/internal_user_endpoints.py`; at 5cd027cbbc it prints "All checks passed!"

## Type

🧹 Refactoring
✅ Test

## Changes

ruff.toml's lint.extend-select gains the 35 strict-gate rules whose ceiling in ruff-strict-budget.json was already 0, so the normal `ruff check` run and editors hard-fail them, and the budget file shrinks from 122 rules to the 87 that still carry real debt. The graduates stay selected in ruff-strict.toml, so the strict config's RUF100 pass keeps flagging their stale noqa directives, and the base external entries they made redundant (FURB, I001, RUF010, RUF022, RUF023, RUF051) are dropped so the base RUF100 pass polices those directives itself

scripts/budget_ratchet_check.py previously read any rule disappearing from a budget file as fine, which would have let a ceiling vanish silently. It now knows the pairing between ruff-strict-budget.json and ruff.toml: a dropped rule is excused only when the paired config's lint.extend-select, minus lint.ignore, hard-fails that rule

UP037 could not graduate because `internal_user_endpoints.py` had two violations ruff could not see past a star-imported `Literal`; importing it explicitly fixes both

Tests: drift tests assert every strict-selected rule is budgeted or hard-failed by the base config, every base-owned rule stays visible to exactly one RUF100 pass, and every strict rule's noqa survives the normal run, plus subprocess probes that a graduated rule now fails `ruff check` directly and that suppressing one does not trip unused-noqa. The ratchet guard's graduation logic is covered by its own unit tests. A five-way config mutation sweep (dropping an external family, re-adding a shadowing entry, un-covering a base-owned rule, double-booking F401, un-graduating UP018) kills every mutation, each caught by the test written for it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
