### PR TITLE
docs(pr-template): add a User Flow section with authoring instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,33 @@ How it solves it:
 - <blah>
 - ...
 
+## User Flow
+
+<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
+     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
+     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
+     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
+     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
+     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
+     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
+     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision
+
+Example:
+
+Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero
+
+1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
+2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
+3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend
+
+After: the same request comes back with real token counts, so the dashboard shows real spend
+
+1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
+2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
+3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
+4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
+-->
+
 ## Relevant issues
 
 <!-- e.g., "Fixes #000" -->


### PR DESCRIPTION
## TLDR

Problem this solves:

- PR bodies describe code changes, not what users see
- Reviewers can't tell what actually broke for someone
- Only some authors write a before/after user walkthrough

How it solves it:

- Adds a User Flow section right below the TLDR
- Comment instructions spell out the rules and forbid internals
- Ships a worked before/after example to copy

## User Flow

Before: a contributor opening a LiteLLM PR has no place to say what the user actually experienced, so reviewers read a diff with no symptom attached to it

1. They open https://github.com/BerriAI/litellm/compare and pick their branch
2. GitHub prefills the body from `.github/pull_request_template.md`, which jumps straight from TLDR to Relevant issues
3. They describe the change in code terms because nothing asks them for the user's side of it
4. A reviewer lands on the PR and can see what the diff does, but not what a user hitting `/v1/chat/completions` saw go wrong or what they will see now

After: the same contributor gets a User Flow section with rules and an example, so the PR opens with the user-visible symptom and fix

1. They open https://github.com/BerriAI/litellm/compare and pick their branch
2. GitHub prefills the body from the template, which now has a User Flow section directly under TLDR
3. The section's comment tells them exactly what to write: two ordered lists, Before and After, each led by one plain sentence, every step an HTTP method plus full URL or a UI page the user visits, no function names or file paths, the two lists identical until the step that changed
4. A worked example in the same comment shows the shape, so they fill it in without needing any local tooling or a maintainer to explain the format
5. A reviewer lands on the PR and reads the failing user journey and the fixed one before reading a single line of the diff

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (not applicable: this PR only edits a markdown template, so there is nothing executable to test)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR only edits `.github/pull_request_template.md`, so the proof is the rendered form GitHub serves to the next contributor rather than a proxy call. The section renders in place under TLDR, and the instructions ship as an HTML comment, so they guide the author and disappear from the published body.

Before, at `281e52ac49`:

```
$ git show 281e52ac49:.github/pull_request_template.md | grep -n '^## '
1:## TLDR
16:## Relevant issues
20:## Linear ticket
24:## Pre-Submission checklist
33:## Delays in PR merge?
37:## Screenshots / Proof of Fix
47:## Type
59:## Changes
61:## QA runbook
```

After, at `cb22477b79`:

```
$ git show cb22477b79:.github/pull_request_template.md | grep -n '^## '
1:## TLDR
16:## User Flow
43:## Relevant issues
47:## Linear ticket
51:## Pre-Submission checklist
60:## Delays in PR merge?
64:## Screenshots / Proof of Fix
74:## Type
86:## Changes
88:## QA runbook
```

This PR's own body is the end-user proof: it was written by following only the new comment, with no local skill or tooling, and its User Flow section above is the result.

## Type

📖 Documentation

## Changes

The template gains one section, `## User Flow`, between TLDR and Relevant issues. Its HTML comment carries the rules a contributor needs: read the linked issue or thread first so the flow tracks a real application, lead each list with one plain sentence, make every step an observable action with the method and full URL or the UI page, keep internals out, keep the two lists step-for-step identical until they diverge, call out any authorization consequence, and regenerate the section when later commits change behavior. A full before/after example follows so nobody has to guess the shape.

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR (not applicable: no code changes, so no regression surface)
