### PR TITLE
fix(azure_sentinel): add AZURE_SENTINEL_AUTHORITY_HOST as a Sentinel scoped override

### DIFF
--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -78,8 +78,8 @@ class AzureSentinelLogger(CustomBatchLogger):
                 If not provided, will use AZURE_SENTINEL_AUDIT_STREAM_NAME env var or the standard stream name.
             authority_host (str, optional): Microsoft Entra authority host that issues the OAuth2 token,
                 e.g. "https://login.microsoftonline.us" for Azure Government. If not provided, will use
-                AZURE_AUTHORITY_HOST env var or default to the Azure Public Cloud authority. The Azure
-                Monitor audience is derived from it.
+                AZURE_SENTINEL_AUTHORITY_HOST or AZURE_AUTHORITY_HOST env vars, or default to the Azure
+                Public Cloud authority. The Azure Monitor audience is derived from it.
         """
         self.async_httpx_client = get_async_httpx_client(llm_provider=httpxSpecialProvider.LoggingCallback)
 
@@ -95,7 +95,10 @@ class AzureSentinelLogger(CustomBatchLogger):
             client_secret or os.getenv("AZURE_SENTINEL_CLIENT_SECRET") or os.getenv("AZURE_CLIENT_SECRET")
         )
         resolved_authority_host: Final = self._normalize_authority_host(
-            authority_host or os.getenv("AZURE_AUTHORITY_HOST") or DEFAULT_AZURE_AUTHORITY_HOST
+            authority_host
+            or os.getenv("AZURE_SENTINEL_AUTHORITY_HOST")
+            or os.getenv("AZURE_AUTHORITY_HOST")
+            or DEFAULT_AZURE_AUTHORITY_HOST
         )
 
         if not resolved_dcr_immutable_id:

--- a/tests/test_litellm/integrations/test_azure_sentinel.py
+++ b/tests/test_litellm/integrations/test_azure_sentinel.py
@@ -313,6 +313,7 @@ def _build_logger(**overrides):
 
 @pytest.fixture
 def _no_authority_host_env(monkeypatch):
+    monkeypatch.delenv("AZURE_SENTINEL_AUTHORITY_HOST", raising=False)
     monkeypatch.delenv("AZURE_AUTHORITY_HOST", raising=False)
 
 
@@ -389,3 +390,38 @@ async def test_azure_sentinel_token_request_uses_sovereign_authority_and_audienc
     assert len(token_calls) == 1
     assert token_calls[0].kwargs["url"] == "https://login.microsoftonline.us/test-tenant-id/oauth2/v2.0/token"
     assert token_calls[0].kwargs["data"]["scope"] == "https://monitor.azure.us/.default"
+
+
+def test_azure_sentinel_authority_host_prefers_the_sentinel_scoped_env_var(_no_authority_host_env, monkeypatch):
+    """AZURE_AUTHORITY_HOST is shared with Azure OpenAI and the azure_storage callback, so a deployment
+    whose Sentinel workspace lives in a different cloud than the rest of its Azure resources needs a
+    Sentinel-scoped override. This mirrors how tenant, client id and secret already resolve."""
+    monkeypatch.setenv("AZURE_AUTHORITY_HOST", "https://login.microsoftonline.com")
+    monkeypatch.setenv("AZURE_SENTINEL_AUTHORITY_HOST", "https://login.microsoftonline.us")
+
+    logger = _build_logger()
+
+    assert logger.authority_host == "https://login.microsoftonline.us"
+    assert logger.oauth_scope == "https://monitor.azure.us/.default"
+
+
+def test_azure_sentinel_falls_back_to_the_shared_authority_host(_no_authority_host_env, monkeypatch):
+    """With no Sentinel-scoped override the shared variable still applies, which is the behavior
+    shipped in the original fix."""
+    monkeypatch.setenv("AZURE_AUTHORITY_HOST", "https://login.microsoftonline.us")
+
+    logger = _build_logger()
+
+    assert logger.authority_host == "https://login.microsoftonline.us"
+    assert logger.oauth_scope == "https://monitor.azure.us/.default"
+
+
+def test_azure_sentinel_authority_host_argument_outranks_the_scoped_env_var(_no_authority_host_env, monkeypatch):
+    """An explicit constructor argument is the most specific source and has to win, otherwise a
+    deployment that exports the scoped variable silently overrides an SDK caller."""
+    monkeypatch.setenv("AZURE_SENTINEL_AUTHORITY_HOST", "https://login.microsoftonline.us")
+
+    logger = _build_logger(authority_host="https://login.microsoftonline.com")
+
+    assert logger.authority_host == "https://login.microsoftonline.com"
+    assert logger.oauth_scope == "https://monitor.azure.com/.default"


### PR DESCRIPTION
## TLDR

Problem this solves:

- BerriAI/litellm#36137 made Azure Sentinel follow `AZURE_AUTHORITY_HOST`, which is shared with Azure OpenAI and the `azure_storage` callback. That is a breaking change for a deployment that sets the shared variable for one of those while keeping a commercial Sentinel workspace
- Such a deployment currently has no opt-out. The proxy constructs `AzureSentinelLogger()` with no arguments at `litellm/litellm_core_utils/litellm_logging.py:3692`, so the `authority_host` constructor parameter is reachable only from the SDK

How it solves it:

- The authority now resolves from `AZURE_SENTINEL_AUTHORITY_HOST` before `AZURE_AUTHORITY_HOST`, matching how `tenant_id`, `client_id` and `client_secret` already resolve three lines above in the same constructor
- Set `AZURE_SENTINEL_AUTHORITY_HOST=https://login.microsoftonline.com` to keep Sentinel on the commercial cloud while the rest of your Azure resources use a sovereign authority
- No behavior change for anyone who does not set the new variable

## Relevant issues

Follow-up to #36137

## Linear ticket

## Merge order

BerriAI/litellm-docs#813 must merge first. `tests/documentation_tests/test_env_keys.py` checks out litellm-docs at its default branch and fails any env var read under `litellm/` that is not documented there, so `documentation` and `code-quality` stay red until it lands.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks. `documentation` and `code-quality` are red until BerriAI/litellm-docs#813 merges, for the reason above
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Real proxy, real Postgres, real Gemini call driving the callback, real Microsoft Entra, and the same real Azure Monitor Data Collection Endpoint used to verify #36137. Tenant id redacted.

```bash
export AZURE_SENTINEL_ENDPOINT="https://litellm-lit5293-dce-yv7r.eastus-1.ingest.monitor.azure.com"
export AZURE_SENTINEL_DCR_IMMUTABLE_ID=...  AZURE_SENTINEL_TENANT_ID=...  AZURE_SENTINEL_CLIENT_ID=...  AZURE_SENTINEL_CLIENT_SECRET=...
export AZURE_AUTHORITY_HOST="https://login.microsoftonline.us"          # sovereign, for the other Azure integrations
export AZURE_SENTINEL_AUTHORITY_HOST="https://login.microsoftonline.com" # commercial, for Sentinel only

python -m litellm.proxy.proxy_cli --config config.yaml --port 20310 --use_prisma_db_push --detailed_debug
curl -sS http://127.0.0.1:20310/v1/chat/completions -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d '{"model":"gemini-flash","messages":[{"role":"user","content":"hi"}]}'
```

| leg | tree | `AZURE_AUTHORITY_HOST` | `AZURE_SENTINEL_AUTHORITY_HOST` | token request | Azure ingestion |
|---|---|---|---|---|---|
| 1 | base | gov | commercial | override ignored, goes to `login.microsoftonline.us`, **400** | none |
| 2 | head | gov | commercial | override honored, token issued | **204** |
| 3 | head | gov | unset | follows the shared variable, `login.microsoftonline.us`, 400 | none |

Leg 1 against leg 2 is the fix: the breaking change from #36137 becomes remediable, confirmed by a real 204 from Azure Monitor. Leg 3 is the guard: with no override, the behavior shipped in #36137 is untouched.

## Type

🐛 Bug Fix

## Changes

`litellm/integrations/azure_sentinel/azure_sentinel.py` reads one additional environment variable in the authority resolution chain. No other file changes.

### On the Azure Government authority alias

`azure-identity` groups `login.usgovcloudapi.net` with `AZURE_GOVERNMENT` in its token-cache alias set, so mapping it looked worthwhile. It was implemented and then removed. That host resolves to genuine Azure Government identity infrastructure and answers as Entra with `AADSTS90038` when certificate validation is disabled, but it presents no TLS certificate covering its own name, so a normal client cannot connect at all. Mapping it would advertise a configuration that cannot work, behind a unit test that would pass regardless.

## QA runbook

1. With `AZURE_AUTHORITY_HOST` unset, confirm Sentinel logging still reaches a commercial workspace exactly as before
2. Set `AZURE_AUTHORITY_HOST` to the Azure Government authority and confirm the token request moves to `login.microsoftonline.us`
3. Add `AZURE_SENTINEL_AUTHORITY_HOST=https://login.microsoftonline.com` and confirm Sentinel returns to the commercial authority while the shared variable stays sovereign

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/36165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow logging-integration config change with backward-compatible fallback order and targeted unit tests; no auth or data-path changes outside Sentinel OAuth token acquisition.
> 
> **Overview**
> Adds **`AZURE_SENTINEL_AUTHORITY_HOST`** to the Entra authority resolution chain in `AzureSentinelLogger`, checked **after** the `authority_host` constructor argument and **before** the shared **`AZURE_AUTHORITY_HOST`**. Deployments can point Sentinel at a different cloud (e.g. commercial Sentinel while other Azure integrations use a sovereign authority) without changing behavior when the new variable is unset.
> 
> Tests cover precedence: Sentinel-scoped env beats shared env, shared env still applies when the Sentinel var is missing, and an explicit constructor `authority_host` beats the scoped env. The authority-host test fixture now clears **`AZURE_SENTINEL_AUTHORITY_HOST`** so cases stay isolated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66c00a8130152c77497b4e445117251146b02165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->