### PR TITLE
fix(proxy): return the real status code when a credential update is rejected

### DIFF
--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -346,4 +346,4 @@ async def update_credential(
 
         return {"success": True, "message": "Credential updated successfully"}
     except Exception as e:
-        return handle_exception_on_proxy(e)
+        raise handle_exception_on_proxy(e)

--- a/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
@@ -1,0 +1,86 @@
+"""Tests for the credential management endpoints."""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.proxy_server import app
+from litellm.types.utils import CredentialItem
+
+client = TestClient(app)
+
+
+def _as_admin():
+    return UserAPIKeyAuth(api_key="test-key", user_role="proxy_admin")
+
+
+def _patch_credential(name: str, body: dict):
+    app.dependency_overrides[user_api_key_auth] = _as_admin
+    try:
+        return client.patch(
+            f"/credentials/{name}",
+            json=body,
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_update_credential_answers_404_when_the_credential_does_not_exist():
+    """Regression: the handler used to ``return handle_exception_on_proxy(e)``, which makes
+    the exception the response body and lets FastAPI answer 200, so a write the handler
+    rejected read as a success to every caller that checks the status. The dashboard's API
+    client branches on the status, so it reported a failed edit as applied."""
+    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), patch(
+        "litellm.proxy.credential_endpoints.endpoints.CredentialsRepository"
+    ) as repository:
+        repository.return_value.find_by_name = AsyncMock(return_value=None)
+
+        response = _patch_credential(
+            "definitely-not-there",
+            {"credential_name": "definitely-not-there", "credential_values": {"api_key": "sk-x"}, "credential_info": {}},
+        )
+
+    assert response.status_code == 404, f"rejected write answered {response.status_code}: {response.text}"
+    assert "error" in response.json()
+
+
+def test_update_credential_answers_500_when_the_database_is_not_connected():
+    """The other rejection this handler raises must carry its own status too."""
+    with patch("litellm.proxy.proxy_server.prisma_client", None):
+        response = _patch_credential(
+            "any-name",
+            {"credential_name": "any-name", "credential_values": {"api_key": "sk-x"}, "credential_info": {}},
+        )
+
+    assert response.status_code == 500, f"rejected write answered {response.status_code}: {response.text}"
+
+
+def test_update_credential_still_answers_200_on_a_successful_write():
+    """The fix must not turn a legitimate update into an error; the dashboard and the
+    Playwright credentials spec both assert the success path."""
+    stored = CredentialItem(
+        credential_name="existing",
+        credential_values={"api_key": "sk-old"},
+        credential_info={"custom_llm_provider": "openai"},
+    )
+    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), patch(
+        "litellm.proxy.proxy_server.master_key", "sk-test-master"
+    ), patch("litellm.proxy.credential_endpoints.endpoints.CredentialsRepository") as repository:
+        repository.return_value.find_by_name = AsyncMock(return_value=stored)
+        repository.return_value.update_by_name = AsyncMock(return_value=None)
+
+        response = _patch_credential(
+            "existing",
+            {"credential_name": "existing", "credential_values": {"api_key": "sk-new"}, "credential_info": {}},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["success"] is True

--- a/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
@@ -22,6 +22,8 @@ def _as_admin():
 
 
 def _patch_credential(name: str, body: dict):
+    missing = object()
+    previous_override = app.dependency_overrides.get(user_api_key_auth, missing)
     app.dependency_overrides[user_api_key_auth] = _as_admin
     try:
         return client.patch(
@@ -30,7 +32,10 @@ def _patch_credential(name: str, body: dict):
             headers={"Authorization": "Bearer test-key"},
         )
     finally:
-        app.dependency_overrides.clear()
+        if previous_override is missing:
+            app.dependency_overrides.pop(user_api_key_auth, None)
+        else:
+            app.dependency_overrides[user_api_key_auth] = previous_override
 
 
 def test_update_credential_answers_404_when_the_credential_does_not_exist():


### PR DESCRIPTION
## TLDR

Problem this solves:

- `PATCH /credentials/{name}` answers 200 for writes it rejected
- Callers that check the status treat a failed edit as applied
- The route has no test coverage today

How it solves it:

- Raise the proxy exception instead of returning it as the body
- Add the first tests for this route, including the success path

## Relevant issues

## Linear ticket

<!-- Linear was unreachable when this PR was opened; ticket to be linked -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy, real Postgres, no mocks. Both legs patch a credential name that does not exist.

Before, staging `4b7adab548`:

```
PATCH /credentials/definitely-not-there -> HTTP 200
{"message":"Credential not found in DB.","type":"internal_server_error","param":"None","code":"404"}
```

After, this branch `493edfde4f`:

```
PATCH /credentials/definitely-not-there -> HTTP 404
{"error":{"message":"Credential not found in DB.","type":"internal_server_error","param":"None","code":"404"}}
```

The real status was always computed; returning the exception object made it the response body and let FastAPI answer 200, so it survived only as a string inside a success-shaped payload.

The same run confirms this PR changes nothing else: after a partial `credential_info` patch, both legs still report the same divergence between the API read and the stored row. That is a separate defect, fixed in its own PR (see Behavior changes).

## Type

🐛 Bug Fix

## Changes

`update_credential` in `litellm/proxy/credential_endpoints/endpoints.py` now ends its except clause with `raise handle_exception_on_proxy(e)`. `create_credential`, `get_credential_by_name` and `get_credential_by_model` in the same file already raise; this brings the update route in line with them.

Three tests in a new `tests/test_litellm/proxy/credential_endpoints/test_endpoints.py`, driving the real route through `TestClient`: a missing credential answers 404, a disconnected database answers 500, and a legitimate update still answers 200. The first two fail against the unfixed handler.

Deliberately not included: `get_credentials` (list) and `delete_credential` in the same file still return their exception the same way. They are the only other occurrences of the pattern in the repository and each deserves its own change, since fixing delete would alter the long-standing behaviour where deleting a missing credential answers 200.

## Behavior changes

Backward incompatible for a caller that parses the flat, success-shaped error body from this route. The same fields are still present, nested under `error`. Callers that branch on the status code begin to see failures they previously missed, which is the point.

Checked consumers: the dashboard's API client throws on any non-2xx (`ui/litellm-dashboard/src/lib/http/client.ts`), and both call sites already wrap the call in try/catch and discard the response body, so a real 4xx surfaces the existing error toast instead of a false success. `litellm/proxy/client/` has no update method, and the Playwright spec at `tests/e2e/ui/tests/modelsPage/credentials.spec.ts` sends a valid payload, so it keeps its 200. No documentation states a status contract for this route, and the generated OpenAPI type declares no error responses, so `schema.d.ts` does not change.

Merge-order note: this PR and the in-memory credential sync PR both create `tests/test_litellm/proxy/credential_endpoints/test_endpoints.py`. Whichever merges second needs a trivial rebase that concatenates the two test sets.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/36166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral fix in one handler plus tests; low scope, but clients that parsed the old flat error body on HTTP 200 need to handle real status codes and nested error JSON.
> 
> **Overview**
> **`PATCH /credentials/{name}`** no longer answers **HTTP 200** when the handler rejects the write. The `update_credential` except block now **`raise`s** `handle_exception_on_proxy(e)` instead of **returning** it, matching **`create_credential`** and the credential GET routes so FastAPI applies the intended status (e.g. **404** for missing credentials, **500** when the DB is disconnected).
> 
> Adds **`tests/test_litellm/proxy/credential_endpoints/test_endpoints.py`** with **`TestClient`** coverage for those failure paths and a regression test that a successful update still returns **200** with `success: true`.
> 
> Callers that only checked status codes will now see failures they previously treated as success; error bodies follow the nested **`error`** shape from raised proxy exceptions rather than a flat success-shaped payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32a3db96a1729d2358847a0b5cd8c62b09b67562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->