### PR TITLE
fix(proxy): keep the in-memory credential in step with the row it was written from

### DIFF
--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -274,10 +274,7 @@ def update_db_credential(
 
     # update model info
     if encrypted_credential.credential_info:
-        """Update credential info"""
-        if "credential_info" not in merged_credential.credential_info:
-            merged_credential.credential_info = {}
-        merged_credential.credential_info.update(encrypted_credential.credential_info)
+        merged_credential.credential_info = encrypted_credential.credential_info
 
     return merged_credential
 
@@ -331,9 +328,11 @@ async def update_credential(
             in_memory_values: Final = dict(existing_in_memory.credential_values or {})
             if credential.credential_values:
                 in_memory_values.update(credential.credential_values)
-            in_memory_info: Final = dict(existing_in_memory.credential_info or {})
-            if credential.credential_info:
-                in_memory_info.update(credential.credential_info)
+            in_memory_info: Final = (
+                dict(credential.credential_info)
+                if credential.credential_info
+                else dict(existing_in_memory.credential_info or {})
+            )
             updated_in_memory: Final = CredentialItem(
                 credential_name=new_name,
                 credential_values=in_memory_values,

--- a/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
@@ -1,0 +1,121 @@
+"""Tests for the credential management endpoints."""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.credential_endpoints.endpoints import update_db_credential
+from litellm.proxy.proxy_server import app
+from litellm.types.utils import CredentialItem
+
+client = TestClient(app)
+
+
+def _as_admin():
+    return UserAPIKeyAuth(api_key="test-key", user_role="proxy_admin")
+
+
+def test_update_db_credential_replaces_credential_info_wholesale():
+    """The stored row has always been replaced, not merged: the old guard asked whether
+    the stored info contained a key literally named ``credential_info``, which nothing
+    stores, so it emptied the dict and repopulated it from the patch every time. This
+    pins that behaviour so the simplification cannot drift into a real merge."""
+    stored = CredentialItem(
+        credential_name="c1",
+        credential_values={"api_key": "sk-old"},
+        credential_info={"custom_llm_provider": "openai", "description": "keep me"},
+    )
+    patch_item = CredentialItem(
+        credential_name="c1",
+        credential_values={},
+        credential_info={"description": "patched"},
+    )
+
+    merged = update_db_credential(stored, patch_item)
+
+    assert merged.credential_info == {"description": "patched"}
+    assert "custom_llm_provider" not in merged.credential_info
+
+
+def test_update_db_credential_keeps_credential_info_when_the_patch_carries_none():
+    """An empty ``credential_info`` on the patch must leave the stored one alone; the
+    master-key rotation path relies on the untouched branch."""
+    stored = CredentialItem(
+        credential_name="c1",
+        credential_values={"api_key": "sk-old"},
+        credential_info={"custom_llm_provider": "openai"},
+    )
+    patch_item = CredentialItem(credential_name="c1", credential_values={"api_key": "sk-new"}, credential_info={})
+
+    with patch("litellm.proxy.proxy_server.master_key", "sk-test-master"):
+        merged = update_db_credential(stored, patch_item)
+
+    assert merged.credential_info == {"custom_llm_provider": "openai"}
+
+
+def test_update_db_credential_is_unchanged_for_a_full_patch():
+    """Master-key rotation passes the whole decrypted row as the patch
+    (``key_management_endpoints.py`` rotate loop), so replace and merge agree there."""
+    info = {"custom_llm_provider": "openai", "description": "prod"}
+    stored = CredentialItem(credential_name="c1", credential_values={"api_key": "sk-old"}, credential_info=dict(info))
+    full_patch = CredentialItem(
+        credential_name="c1", credential_values={"api_key": "sk-old"}, credential_info=dict(info)
+    )
+
+    with patch("litellm.proxy.proxy_server.master_key", "sk-test-master"):
+        merged = update_db_credential(stored, full_patch)
+
+    assert merged.credential_info == info
+
+
+def test_partial_patch_leaves_no_stale_fields_in_the_in_memory_credential():
+    """Regression: the in-memory copy merged ``credential_info`` while the DB row replaced
+    it, so after a partial patch ``litellm.credential_list`` still advertised fields the
+    row no longer had. The dashboard refetches from that list, so it showed values that
+    were already gone, until the next config reload (30s) silently dropped them."""
+    stored = CredentialItem(
+        credential_name="c1",
+        credential_values={"api_key": "sk-old"},
+        credential_info={"custom_llm_provider": "openai", "description": "keep me"},
+    )
+    original_list = litellm.credential_list
+    litellm.credential_list = [
+        CredentialItem(
+            credential_name="c1",
+            credential_values={"api_key": "sk-old"},
+            credential_info={"custom_llm_provider": "openai", "description": "keep me"},
+        )
+    ]
+    app.dependency_overrides[user_api_key_auth] = _as_admin
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), patch(
+            "litellm.proxy.proxy_server.master_key", "sk-test-master"
+        ), patch("litellm.proxy.credential_endpoints.endpoints.CredentialsRepository") as repository:
+            repository.return_value.find_by_name = AsyncMock(return_value=stored)
+            repository.return_value.update_by_name = AsyncMock(return_value=None)
+
+            response = client.patch(
+                "/credentials/c1",
+                json={
+                    "credential_name": "c1",
+                    "credential_values": {"api_key": "sk-new"},
+                    "credential_info": {"description": "patched"},
+                },
+                headers={"Authorization": "Bearer test-key"},
+            )
+
+        assert response.status_code == 200, response.text
+        in_memory = next(c for c in litellm.credential_list if c.credential_name == "c1")
+        assert in_memory.credential_info == {"description": "patched"}
+        assert "custom_llm_provider" not in in_memory.credential_info
+    finally:
+        app.dependency_overrides.clear()
+        litellm.credential_list = original_list


### PR DESCRIPTION
## TLDR

Problem this solves:

- A partial credential patch leaves the in-memory copy disagreeing with the row
- The dashboard refetches that copy, so it shows fields already deleted
- The next config reload drops them silently, 30 seconds later

How it solves it:

- The in-memory sync replaces `credential_info`, matching what the row does
- Removes a dead guard that made the DB write look like a merge

## Relevant issues

## Linear ticket

<!-- Linear was unreachable when this PR was opened; ticket to be linked -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy, real Postgres, no mocks. A credential is created with three `credential_info` keys, then patched with only `custom_llm_provider`, exactly as the dashboard's credential editor does.

Before, staging `4b7adab548`:

```
API reports: {'custom_llm_provider': 'openai', 'description': 'keep me', 'owner_team': 'platform'}
stored row : {"custom_llm_provider": "openai"}
```

After, this branch `6867aecb73`:

```
API reports: {'custom_llm_provider': 'openai'}
stored row : {"custom_llm_provider": "openai"}
```

`GET /credentials/by_name` reads `litellm.credential_list`, so before this change it advertised two fields the database had already dropped. The window closes on its own at the next config reload (`PROXY_CONFIG_RELOAD_INTERVAL_SECONDS`, default 30), which is what makes it easy to miss: the credential keeps working, then quietly stops after a reload nobody triggered.

The same run confirms this PR changes nothing else: patching a name that does not exist still answers 200 on both legs. That is a separate defect with its own PR.

## Type

🐛 Bug Fix

## Changes

Two edits in `litellm/proxy/credential_endpoints/endpoints.py`.

`update_credential` builds the in-memory `credential_info` by replacing when the patch carries one, instead of merging it over the existing copy. That is what the stored row has always done, so the routing-live copy can no longer disagree with it.

`update_db_credential` drops a dead guard. It read `if "credential_info" not in merged_credential.credential_info: merged_credential.credential_info = {}` before updating, which tests whether the stored info dict contains a key literally named `credential_info`. Nothing stores such a key, so the branch always fired, emptied the dict and repopulated it from the patch. Running both spellings over the same input gives identical output, and the mutation check agrees: reverting this line alone leaves every test green, which is the evidence that it is behaviour-preserving.

Four tests in a new `tests/test_litellm/proxy/credential_endpoints/test_endpoints.py` covering the replace semantics, the untouched branch when a patch carries no `credential_info`, the full-patch case that master-key rotation uses, and the route-level regression asserting the in-memory copy no longer keeps stale fields. The last one fails against the unfixed sync.

## Behavior changes

The field loss itself is unchanged and pre-existing: a partial `credential_info` patch has always replaced the stored row. What changes is when a caller can observe it. `GET /credentials` and `GET /credentials/by_name` now report the row's contents immediately rather than up to 30 seconds later, so a client that read the merged copy in that window sees fewer fields than before.

The only input where replace and merge genuinely differ is a stored `credential_info` that itself contains a key named `credential_info`, which nothing in the product writes.

Second caller checked: `key_management_endpoints.py` calls `update_db_credential` in the master-key rotation loop, passing the whole decrypted row as the patch. `decrypt_credentials` rebuilds the item from the full row and rewrites only `credential_values`, so `credential_info` arrives complete and replace equals merge there. A test pins that case.

Merge-order note: this PR and the credential-update status-code PR both create `tests/test_litellm/proxy/credential_endpoints/test_endpoints.py`. Whichever merges second needs a trivial rebase that concatenates the two test sets.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/36167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->