### PR TITLE
fix(proxy): include model group in daily usage aggregation

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260806000000_add_model_group_to_daily_usage_unique_keys/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260806000000_add_model_group_to_daily_usage_unique_keys/migration.sql
@@ -1,53 +1,35 @@
--- DropIndex
 DROP INDEX IF EXISTS "LiteLLM_DailyAgentSpend_agent_id_date_api_key_model_custom__key";
 
--- DropIndex
 DROP INDEX IF EXISTS "LiteLLM_DailyEndUserSpend_end_user_id_date_api_key_model_cu_key";
 
--- DropIndex
 DROP INDEX IF EXISTS "LiteLLM_DailyOrganizationSpend_organization_id_date_api_key_key";
 
--- DropIndex
 DROP INDEX IF EXISTS "LiteLLM_DailyTagSpend_tag_date_api_key_model_custom_llm_pro_key";
 
--- DropIndex
 DROP INDEX IF EXISTS "LiteLLM_DailyTeamSpend_team_id_date_api_key_model_custom_ll_key";
 
--- DropIndex
 DROP INDEX IF EXISTS "LiteLLM_DailyUserSpend_user_id_date_api_key_model_custom_ll_key";
 
--- Backfill
 UPDATE "LiteLLM_DailyAgentSpend" SET "model_group" = '' WHERE "model_group" IS NULL;
 
--- Backfill
 UPDATE "LiteLLM_DailyEndUserSpend" SET "model_group" = '' WHERE "model_group" IS NULL;
 
--- Backfill
 UPDATE "LiteLLM_DailyOrganizationSpend" SET "model_group" = '' WHERE "model_group" IS NULL;
 
--- Backfill
 UPDATE "LiteLLM_DailyTagSpend" SET "model_group" = '' WHERE "model_group" IS NULL;
 
--- Backfill
 UPDATE "LiteLLM_DailyTeamSpend" SET "model_group" = '' WHERE "model_group" IS NULL;
 
--- Backfill
 UPDATE "LiteLLM_DailyUserSpend" SET "model_group" = '' WHERE "model_group" IS NULL;
 
--- CreateIndex
 CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_DailyAgentSpend_agent_id_date_api_key_model_custom__key" ON "LiteLLM_DailyAgentSpend"("agent_id", "date", "api_key", "model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint");
 
--- CreateIndex
 CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_DailyEndUserSpend_end_user_id_date_api_key_model_cu_key" ON "LiteLLM_DailyEndUserSpend"("end_user_id", "date", "api_key", "model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint");
 
--- CreateIndex
 CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_DailyOrganizationSpend_organization_id_date_api_key_key" ON "LiteLLM_DailyOrganizationSpend"("organization_id", "date", "api_key", "model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint");
 
--- CreateIndex
 CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_DailyTagSpend_tag_date_api_key_model_custom_llm_pro_key" ON "LiteLLM_DailyTagSpend"("tag", "date", "api_key", "model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint");
 
--- CreateIndex
 CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_DailyTeamSpend_team_id_date_api_key_model_custom_ll_key" ON "LiteLLM_DailyTeamSpend"("team_id", "date", "api_key", "model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint");
 
--- CreateIndex
 CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_DailyUserSpend_user_id_date_api_key_model_custom_ll_key" ON "LiteLLM_DailyUserSpend"("user_id", "date", "api_key", "model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint");

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260806000000_add_model_group_to_daily_usage_unique_keys/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260806000000_add_model_group_to_daily_usage_unique_keys/migration.sql
@@ -1,0 +1,53 @@
+-- DropIndex
+DROP INDEX IF EXISTS "LiteLLM_DailyAgentSpend_agent_id_date_api_key_model_custom__key";
+
+-- DropIndex
+DROP INDEX IF EXISTS "LiteLLM_DailyEndUserSpend_end_user_id_date_api_key_model_cu_key";
+
+-- DropIndex
+DROP INDEX IF EXISTS "LiteLLM_DailyOrganizationSpend_organization_id_date_api_key_key";
+
+-- DropIndex
+DROP INDEX IF EXISTS "LiteLLM_DailyTagSpend_tag_date_api_key_model_custom_llm_pro_key";
+
+-- DropIndex
+DROP INDEX IF EXISTS "LiteLLM_DailyTeamSpend_team_id_date_api_key_model_custom_ll_key";
+
+-- DropIndex
+DROP INDEX IF EXISTS "LiteLLM_DailyUserSpend_user_id_date_api_key_model_custom_ll_key";
+
+-- Backfill
+UPDATE "LiteLLM_DailyAgentSpend" SET "model_group" = '' WHERE "model_group" IS NULL;
+
+-- Backfill
+UPDATE "LiteLLM_DailyEndUserSpend" SET "model_group" = '' WHERE "model_group" IS NULL;
+
+-- Backfill
+UPDATE "LiteLLM_DailyOrganizationSpend" SET "model_group" = '' WHERE "model_group" IS NULL;
+
+-- Backfill
+UPDATE "LiteLLM_DailyTagSpend" SET "model_group" = '' WHERE "model_group" IS NULL;
+
+-- Backfill
+UPDATE "LiteLLM_DailyTeamSpend" SET "model_group" = '' WHERE "model_group" IS NULL;
+
+-- Backfill
+UPDATE "LiteLLM_DailyUserSpend" SET "model_group" = '' WHERE "model_group" IS NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_DailyAgentSpend_agent_id_date_api_key_model_custom__key" ON "LiteLLM_DailyAgentSpend"("agent_id", "date", "api_key", "model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_DailyEndUserSpend_end_user_id_date_api_key_model_cu_key" ON "LiteLLM_DailyEndUserSpend"("end_user_id", "date", "api_key", "model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_DailyOrganizationSpend_organization_id_date_api_key_key" ON "LiteLLM_DailyOrganizationSpend"("organization_id", "date", "api_key", "model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_DailyTagSpend_tag_date_api_key_model_custom_llm_pro_key" ON "LiteLLM_DailyTagSpend"("tag", "date", "api_key", "model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_DailyTeamSpend_team_id_date_api_key_model_custom_ll_key" ON "LiteLLM_DailyTeamSpend"("team_id", "date", "api_key", "model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_DailyUserSpend_user_id_date_api_key_model_custom_ll_key" ON "LiteLLM_DailyUserSpend"("user_id", "date", "api_key", "model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint");

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -758,7 +758,7 @@ model LiteLLM_DailyUserSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([user_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([user_id, date])
   @@index([api_key])
@@ -793,7 +793,7 @@ model LiteLLM_DailyOrganizationSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([organization_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([organization_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([organization_id, date])
   @@index([api_key])
@@ -827,7 +827,7 @@ model LiteLLM_DailyEndUserSpend {
   failed_requests     BigInt      @default(0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
-  @@unique([end_user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([end_user_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([end_user_id, date])
   @@index([api_key])
@@ -861,7 +861,7 @@ model LiteLLM_DailyAgentSpend {
   failed_requests     BigInt      @default(0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
-  @@unique([agent_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([agent_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([agent_id, date])
   @@index([api_key])
@@ -896,7 +896,7 @@ model LiteLLM_DailyTeamSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([team_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([team_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([team_id, date])
   @@index([api_key])
@@ -932,7 +932,7 @@ model LiteLLM_DailyTagSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([tag, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([tag, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([tag, date])
   @@index([api_key])

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -758,7 +758,7 @@ model LiteLLM_DailyUserSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([user_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([user_id, date])
   @@index([api_key])
@@ -793,7 +793,7 @@ model LiteLLM_DailyOrganizationSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([organization_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([organization_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([organization_id, date])
   @@index([api_key])
@@ -827,7 +827,7 @@ model LiteLLM_DailyEndUserSpend {
   failed_requests     BigInt      @default(0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
-  @@unique([end_user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([end_user_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([end_user_id, date])
   @@index([api_key])
@@ -861,7 +861,7 @@ model LiteLLM_DailyAgentSpend {
   failed_requests     BigInt      @default(0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
-  @@unique([agent_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([agent_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([agent_id, date])
   @@index([api_key])
@@ -897,7 +897,7 @@ model LiteLLM_DailyTeamSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([team_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([team_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([team_id, date])
   @@index([api_key])
@@ -933,7 +933,7 @@ model LiteLLM_DailyTagSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([tag, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([tag, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([tag, date])
   @@index([api_key])

--- a/litellm/proxy/db/daily_spend_bulk_upsert.py
+++ b/litellm/proxy/db/daily_spend_bulk_upsert.py
@@ -46,7 +46,15 @@ DAILY_SPEND_TABLES: Final[Mapping[DailySpendEntity, DailySpendTable]] = MappingP
 # The unique constraint's columns after the entity id, in constraint order. A NULL can
 # never match itself in a unique index, so every one of these is normalized to '': the
 # conflict target has to be NULL-free or the row is re-inserted on every single flush.
-_KEY_COLUMNS: Final = ("date", "api_key", "model", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint")
+_KEY_COLUMNS: Final = (
+    "date",
+    "api_key",
+    "model",
+    "model_group",
+    "custom_llm_provider",
+    "mcp_namespaced_tool_name",
+    "endpoint",
+)
 
 _COUNTER_COLUMNS: Final = (
     "prompt_tokens",
@@ -129,7 +137,6 @@ def _row_params(
     return (
         str(uuid.uuid4()),
         *key,
-        None if transaction.get("model_group") is None else _as_text(transaction.get("model_group")),
         *(_as_int(transaction.get(column)) for column in _COUNTER_COLUMNS),
         *(_as_float(transaction.get(column)) for column in _SPEND_COLUMNS),
         *((None if request_id is None else _as_text(request_id),) if table.carries_request_id else ()),
@@ -141,7 +148,6 @@ def _insert_columns(table: DailySpendTable) -> tuple[str, ...]:
         "id",
         table.entity_id_column,
         *_KEY_COLUMNS,
-        "model_group",
         *_COUNTER_COLUMNS,
         *_SPEND_COLUMNS,
         *(("request_id",) if table.carries_request_id else ()),

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -1423,6 +1423,10 @@ class DBSpendUpdateWriter:
                         e=e, start_time=start_time, proxy_logging_obj=proxy_logging_obj
                     )
 
+    @staticmethod
+    def _daily_transaction_key(*parts: object | None) -> str:
+        return json.dumps(tuple(str(part or "") for part in parts), separators=(",", ":"))
+
     # fmt: off
 
     @overload
@@ -1855,7 +1859,16 @@ class DBSpendUpdateWriter:
             return
 
         endpoint_str: Final = base_daily_transaction.get("endpoint") or ""
-        daily_transaction_key = f"{payload['user']}_{base_daily_transaction['date']}_{payload['api_key']}_{payload['model']}_{payload['custom_llm_provider']}_{endpoint_str}"
+        daily_transaction_key: Final = self._daily_transaction_key(
+            payload["user"],
+            base_daily_transaction["date"],
+            payload["api_key"],
+            payload["model"],
+            base_daily_transaction.get("model_group"),
+            payload["custom_llm_provider"],
+            base_daily_transaction.get("mcp_namespaced_tool_name"),
+            endpoint_str,
+        )
         daily_transaction: Final = DailyUserSpendTransaction(user_id=payload["user"], **base_daily_transaction)
         await self.daily_spend_update_queue.add_update(update={daily_transaction_key: daily_transaction})
 
@@ -1878,7 +1891,16 @@ class DBSpendUpdateWriter:
             return
 
         endpoint_str: Final = base_daily_transaction.get("endpoint") or ""
-        daily_transaction_key = f"{payload['team_id']}_{base_daily_transaction['date']}_{payload['api_key']}_{payload['model']}_{payload['custom_llm_provider']}_{endpoint_str}"
+        daily_transaction_key: Final = self._daily_transaction_key(
+            payload["team_id"],
+            base_daily_transaction["date"],
+            payload["api_key"],
+            payload["model"],
+            base_daily_transaction.get("model_group"),
+            payload["custom_llm_provider"],
+            base_daily_transaction.get("mcp_namespaced_tool_name"),
+            endpoint_str,
+        )
         daily_transaction: Final = DailyTeamSpendTransaction(team_id=payload["team_id"], **base_daily_transaction)
         await self.daily_team_spend_update_queue.add_update(update={daily_transaction_key: daily_transaction})
 
@@ -1911,7 +1933,16 @@ class DBSpendUpdateWriter:
             return
 
         endpoint_str: Final = base_daily_transaction.get("endpoint") or ""
-        daily_transaction_key = f"{org_id}_{base_daily_transaction['date']}_{payload_with_org['api_key']}_{payload_with_org['model']}_{payload_with_org['custom_llm_provider']}_{endpoint_str}"
+        daily_transaction_key: Final = self._daily_transaction_key(
+            org_id,
+            base_daily_transaction["date"],
+            payload_with_org["api_key"],
+            payload_with_org["model"],
+            base_daily_transaction.get("model_group"),
+            payload_with_org["custom_llm_provider"],
+            base_daily_transaction.get("mcp_namespaced_tool_name"),
+            endpoint_str,
+        )
         daily_transaction: Final = DailyOrganizationSpendTransaction(organization_id=org_id, **base_daily_transaction)
         await self.daily_org_spend_update_queue.add_update(update={daily_transaction_key: daily_transaction})
 
@@ -1944,7 +1975,16 @@ class DBSpendUpdateWriter:
             return
 
         endpoint_str: Final = base_daily_transaction.get("endpoint") or ""
-        daily_transaction_key = f"{end_user_id}_{base_daily_transaction['date']}_{payload_with_end_user_id['api_key']}_{payload_with_end_user_id['model']}_{payload_with_end_user_id['custom_llm_provider']}_{endpoint_str}"
+        daily_transaction_key: Final = self._daily_transaction_key(
+            end_user_id,
+            base_daily_transaction["date"],
+            payload_with_end_user_id["api_key"],
+            payload_with_end_user_id["model"],
+            base_daily_transaction.get("model_group"),
+            payload_with_end_user_id["custom_llm_provider"],
+            base_daily_transaction.get("mcp_namespaced_tool_name"),
+            endpoint_str,
+        )
         daily_transaction: Final = DailyEndUserSpendTransaction(end_user_id=end_user_id, **base_daily_transaction)
         await self.daily_end_user_spend_update_queue.add_update(update={daily_transaction_key: daily_transaction})
 
@@ -1971,7 +2011,16 @@ class DBSpendUpdateWriter:
         if base_daily_transaction is None:
             return
         endpoint_str: Final = base_daily_transaction.get("endpoint") or ""
-        daily_transaction_key = f"{payload['agent_id']}_{base_daily_transaction['date']}_{payload_with_agent_id['api_key']}_{payload_with_agent_id['model']}_{payload_with_agent_id['custom_llm_provider']}_{endpoint_str}"
+        daily_transaction_key: Final = self._daily_transaction_key(
+            payload["agent_id"],
+            base_daily_transaction["date"],
+            payload_with_agent_id["api_key"],
+            payload_with_agent_id["model"],
+            base_daily_transaction.get("model_group"),
+            payload_with_agent_id["custom_llm_provider"],
+            base_daily_transaction.get("mcp_namespaced_tool_name"),
+            endpoint_str,
+        )
         daily_transaction: Final = DailyAgentSpendTransaction(agent_id=payload["agent_id"], **base_daily_transaction)
         await self.daily_agent_spend_update_queue.add_update(update={daily_transaction_key: daily_transaction})
 
@@ -2002,7 +2051,16 @@ class DBSpendUpdateWriter:
             raise ValueError(f"Invalid request_tags: {payload['request_tags']}")
         for tag in request_tags:
             endpoint_str = base_daily_transaction.get("endpoint") or ""
-            daily_transaction_key = f"{tag}_{base_daily_transaction['date']}_{payload['api_key']}_{payload['model']}_{payload['custom_llm_provider']}_{endpoint_str}"
+            daily_transaction_key = self._daily_transaction_key(
+                tag,
+                base_daily_transaction["date"],
+                payload["api_key"],
+                payload["model"],
+                base_daily_transaction.get("model_group"),
+                payload["custom_llm_provider"],
+                base_daily_transaction.get("mcp_namespaced_tool_name"),
+                endpoint_str,
+            )
             daily_transaction = DailyTagSpendTransaction(
                 tag=tag, **base_daily_transaction, request_id=payload["request_id"]
             )

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -1426,6 +1426,10 @@ class DBSpendUpdateWriter:
                         e=e, start_time=start_time, proxy_logging_obj=proxy_logging_obj
                     )
 
+    @staticmethod
+    def _daily_transaction_key(*parts: object | None) -> str:
+        return "_".join(str(part or "") for part in parts)
+
     # fmt: off
 
     @overload
@@ -1562,6 +1566,7 @@ class DBSpendUpdateWriter:
                                     x[1].get(entity_id_field) or "",
                                     x[1].get("api_key") or "",
                                     x[1].get("model") or "",
+                                    x[1].get("model_group") or "",
                                     x[1].get("custom_llm_provider") or "",
                                 ),
                             )[:BATCH_SIZE]
@@ -1585,6 +1590,7 @@ class DBSpendUpdateWriter:
                                             "date": transaction["date"],
                                             "api_key": transaction["api_key"],
                                             "model": transaction["model"],
+                                            "model_group": transaction.get("model_group") or "",
                                             "custom_llm_provider": transaction.get("custom_llm_provider") or "",
                                             "mcp_namespaced_tool_name": transaction.get("mcp_namespaced_tool_name")
                                             or "",
@@ -1635,7 +1641,7 @@ class DBSpendUpdateWriter:
                                         "date": transaction["date"],
                                         "api_key": transaction["api_key"],
                                         "model": transaction.get("model"),
-                                        "model_group": transaction.get("model_group"),
+                                        "model_group": transaction.get("model_group") or "",
                                         "mcp_namespaced_tool_name": transaction.get("mcp_namespaced_tool_name") or "",
                                         "custom_llm_provider": transaction.get("custom_llm_provider"),
                                         "endpoint": transaction.get("endpoint") or "",
@@ -1734,7 +1740,7 @@ class DBSpendUpdateWriter:
             entity_type="user",
             entity_id_field="user_id",
             table_name="litellm_dailyuserspend",
-            unique_constraint_name="user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+            unique_constraint_name="user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
         )
 
     @staticmethod
@@ -1755,7 +1761,7 @@ class DBSpendUpdateWriter:
             entity_type="team",
             entity_id_field="team_id",
             table_name="litellm_dailyteamspend",
-            unique_constraint_name="team_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+            unique_constraint_name="team_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
         )
 
     @staticmethod
@@ -1776,7 +1782,7 @@ class DBSpendUpdateWriter:
             entity_type="org",
             entity_id_field="organization_id",
             table_name="litellm_dailyorganizationspend",
-            unique_constraint_name="organization_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+            unique_constraint_name="organization_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
         )
 
     @staticmethod
@@ -1797,7 +1803,7 @@ class DBSpendUpdateWriter:
             entity_type="end_user",
             entity_id_field="end_user_id",
             table_name="litellm_dailyenduserspend",
-            unique_constraint_name="end_user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+            unique_constraint_name="end_user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
         )
 
     @staticmethod
@@ -1818,7 +1824,7 @@ class DBSpendUpdateWriter:
             entity_type="agent",
             entity_id_field="agent_id",
             table_name="litellm_dailyagentspend",
-            unique_constraint_name="agent_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+            unique_constraint_name="agent_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
         )
 
     @staticmethod
@@ -1839,7 +1845,7 @@ class DBSpendUpdateWriter:
             entity_type="tag",
             entity_id_field="tag",
             table_name="litellm_dailytagspend",
-            unique_constraint_name="tag_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+            unique_constraint_name="tag_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
         )
 
     async def _common_add_spend_log_transaction_to_daily_transaction(
@@ -1972,7 +1978,15 @@ class DBSpendUpdateWriter:
             return
 
         endpoint_str: Final = base_daily_transaction.get("endpoint") or ""
-        daily_transaction_key = f"{payload['user']}_{base_daily_transaction['date']}_{payload['api_key']}_{payload['model']}_{payload['custom_llm_provider']}_{endpoint_str}"
+        daily_transaction_key: Final = self._daily_transaction_key(
+            payload["user"],
+            base_daily_transaction["date"],
+            payload["api_key"],
+            payload["model"],
+            base_daily_transaction.get("model_group"),
+            payload["custom_llm_provider"],
+            endpoint_str,
+        )
         daily_transaction: Final = DailyUserSpendTransaction(user_id=payload["user"], **base_daily_transaction)
         await self.daily_spend_update_queue.add_update(update={daily_transaction_key: daily_transaction})
 
@@ -1995,7 +2009,15 @@ class DBSpendUpdateWriter:
             return
 
         endpoint_str: Final = base_daily_transaction.get("endpoint") or ""
-        daily_transaction_key = f"{payload['team_id']}_{base_daily_transaction['date']}_{payload['api_key']}_{payload['model']}_{payload['custom_llm_provider']}_{endpoint_str}"
+        daily_transaction_key: Final = self._daily_transaction_key(
+            payload["team_id"],
+            base_daily_transaction["date"],
+            payload["api_key"],
+            payload["model"],
+            base_daily_transaction.get("model_group"),
+            payload["custom_llm_provider"],
+            endpoint_str,
+        )
         daily_transaction: Final = DailyTeamSpendTransaction(team_id=payload["team_id"], **base_daily_transaction)
         await self.daily_team_spend_update_queue.add_update(update={daily_transaction_key: daily_transaction})
 
@@ -2028,7 +2050,15 @@ class DBSpendUpdateWriter:
             return
 
         endpoint_str: Final = base_daily_transaction.get("endpoint") or ""
-        daily_transaction_key = f"{org_id}_{base_daily_transaction['date']}_{payload_with_org['api_key']}_{payload_with_org['model']}_{payload_with_org['custom_llm_provider']}_{endpoint_str}"
+        daily_transaction_key: Final = self._daily_transaction_key(
+            org_id,
+            base_daily_transaction["date"],
+            payload_with_org["api_key"],
+            payload_with_org["model"],
+            base_daily_transaction.get("model_group"),
+            payload_with_org["custom_llm_provider"],
+            endpoint_str,
+        )
         daily_transaction: Final = DailyOrganizationSpendTransaction(organization_id=org_id, **base_daily_transaction)
         await self.daily_org_spend_update_queue.add_update(update={daily_transaction_key: daily_transaction})
 
@@ -2061,7 +2091,15 @@ class DBSpendUpdateWriter:
             return
 
         endpoint_str: Final = base_daily_transaction.get("endpoint") or ""
-        daily_transaction_key = f"{end_user_id}_{base_daily_transaction['date']}_{payload_with_end_user_id['api_key']}_{payload_with_end_user_id['model']}_{payload_with_end_user_id['custom_llm_provider']}_{endpoint_str}"
+        daily_transaction_key: Final = self._daily_transaction_key(
+            end_user_id,
+            base_daily_transaction["date"],
+            payload_with_end_user_id["api_key"],
+            payload_with_end_user_id["model"],
+            base_daily_transaction.get("model_group"),
+            payload_with_end_user_id["custom_llm_provider"],
+            endpoint_str,
+        )
         daily_transaction: Final = DailyEndUserSpendTransaction(end_user_id=end_user_id, **base_daily_transaction)
         await self.daily_end_user_spend_update_queue.add_update(update={daily_transaction_key: daily_transaction})
 
@@ -2088,7 +2126,15 @@ class DBSpendUpdateWriter:
         if base_daily_transaction is None:
             return
         endpoint_str: Final = base_daily_transaction.get("endpoint") or ""
-        daily_transaction_key = f"{payload['agent_id']}_{base_daily_transaction['date']}_{payload_with_agent_id['api_key']}_{payload_with_agent_id['model']}_{payload_with_agent_id['custom_llm_provider']}_{endpoint_str}"
+        daily_transaction_key: Final = self._daily_transaction_key(
+            payload["agent_id"],
+            base_daily_transaction["date"],
+            payload_with_agent_id["api_key"],
+            payload_with_agent_id["model"],
+            base_daily_transaction.get("model_group"),
+            payload_with_agent_id["custom_llm_provider"],
+            endpoint_str,
+        )
         daily_transaction: Final = DailyAgentSpendTransaction(agent_id=payload["agent_id"], **base_daily_transaction)
         await self.daily_agent_spend_update_queue.add_update(update={daily_transaction_key: daily_transaction})
 
@@ -2119,7 +2165,15 @@ class DBSpendUpdateWriter:
             raise ValueError(f"Invalid request_tags: {payload['request_tags']}")
         for tag in request_tags:
             endpoint_str = base_daily_transaction.get("endpoint") or ""
-            daily_transaction_key = f"{tag}_{base_daily_transaction['date']}_{payload['api_key']}_{payload['model']}_{payload['custom_llm_provider']}_{endpoint_str}"
+            daily_transaction_key = self._daily_transaction_key(
+                tag,
+                base_daily_transaction["date"],
+                payload["api_key"],
+                payload["model"],
+                base_daily_transaction.get("model_group"),
+                payload["custom_llm_provider"],
+                endpoint_str,
+            )
             daily_transaction = DailyTagSpendTransaction(
                 tag=tag, **base_daily_transaction, request_id=payload["request_id"]
             )

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -1428,7 +1428,7 @@ class DBSpendUpdateWriter:
 
     @staticmethod
     def _daily_transaction_key(*parts: object | None) -> str:
-        return "_".join(str(part or "") for part in parts)
+        return json.dumps(tuple(str(part or "") for part in parts), separators=(",", ":"))
 
     # fmt: off
 

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -758,7 +758,7 @@ model LiteLLM_DailyUserSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([user_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([user_id, date])
   @@index([api_key])
@@ -793,7 +793,7 @@ model LiteLLM_DailyOrganizationSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([organization_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([organization_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([organization_id, date])
   @@index([api_key])
@@ -827,7 +827,7 @@ model LiteLLM_DailyEndUserSpend {
   failed_requests     BigInt      @default(0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
-  @@unique([end_user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([end_user_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([end_user_id, date])
   @@index([api_key])
@@ -861,7 +861,7 @@ model LiteLLM_DailyAgentSpend {
   failed_requests     BigInt      @default(0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
-  @@unique([agent_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([agent_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([agent_id, date])
   @@index([api_key])
@@ -896,7 +896,7 @@ model LiteLLM_DailyTeamSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([team_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([team_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([team_id, date])
   @@index([api_key])
@@ -932,7 +932,7 @@ model LiteLLM_DailyTagSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([tag, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([tag, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([tag, date])
   @@index([api_key])

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -758,7 +758,7 @@ model LiteLLM_DailyUserSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([user_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([user_id, date])
   @@index([api_key])
@@ -793,7 +793,7 @@ model LiteLLM_DailyOrganizationSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([organization_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([organization_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([organization_id, date])
   @@index([api_key])
@@ -827,7 +827,7 @@ model LiteLLM_DailyEndUserSpend {
   failed_requests     BigInt      @default(0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
-  @@unique([end_user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([end_user_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([end_user_id, date])
   @@index([api_key])
@@ -861,7 +861,7 @@ model LiteLLM_DailyAgentSpend {
   failed_requests     BigInt      @default(0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
-  @@unique([agent_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([agent_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([agent_id, date])
   @@index([api_key])
@@ -897,7 +897,7 @@ model LiteLLM_DailyTeamSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([team_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([team_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([team_id, date])
   @@index([api_key])
@@ -933,7 +933,7 @@ model LiteLLM_DailyTagSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([tag, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([tag, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([tag, date])
   @@index([api_key])

--- a/schema.prisma
+++ b/schema.prisma
@@ -758,7 +758,7 @@ model LiteLLM_DailyUserSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([user_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([user_id, date])
   @@index([api_key])
@@ -793,7 +793,7 @@ model LiteLLM_DailyOrganizationSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([organization_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([organization_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([organization_id, date])
   @@index([api_key])
@@ -827,7 +827,7 @@ model LiteLLM_DailyEndUserSpend {
   failed_requests     BigInt      @default(0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
-  @@unique([end_user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([end_user_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([end_user_id, date])
   @@index([api_key])
@@ -861,7 +861,7 @@ model LiteLLM_DailyAgentSpend {
   failed_requests     BigInt      @default(0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
-  @@unique([agent_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([agent_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([agent_id, date])
   @@index([api_key])
@@ -896,7 +896,7 @@ model LiteLLM_DailyTeamSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([team_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([team_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([team_id, date])
   @@index([api_key])
@@ -932,7 +932,7 @@ model LiteLLM_DailyTagSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([tag, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([tag, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([tag, date])
   @@index([api_key])

--- a/schema.prisma
+++ b/schema.prisma
@@ -758,7 +758,7 @@ model LiteLLM_DailyUserSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([user_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([user_id, date])
   @@index([api_key])
@@ -793,7 +793,7 @@ model LiteLLM_DailyOrganizationSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([organization_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([organization_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([organization_id, date])
   @@index([api_key])
@@ -827,7 +827,7 @@ model LiteLLM_DailyEndUserSpend {
   failed_requests     BigInt      @default(0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
-  @@unique([end_user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([end_user_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([end_user_id, date])
   @@index([api_key])
@@ -861,7 +861,7 @@ model LiteLLM_DailyAgentSpend {
   failed_requests     BigInt      @default(0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
-  @@unique([agent_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([agent_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([agent_id, date])
   @@index([api_key])
@@ -897,7 +897,7 @@ model LiteLLM_DailyTeamSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([team_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([team_id, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([team_id, date])
   @@index([api_key])
@@ -933,7 +933,7 @@ model LiteLLM_DailyTagSpend {
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
-  @@unique([tag, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
+  @@unique([tag, date, api_key, model, model_group, custom_llm_provider, mcp_namespaced_tool_name, endpoint])
   @@index([date])
   @@index([tag, date])
   @@index([api_key])

--- a/tests/test_litellm/proxy/db/test_daily_spend_bulk_upsert.py
+++ b/tests/test_litellm/proxy/db/test_daily_spend_bulk_upsert.py
@@ -17,7 +17,7 @@ USER_TABLE = DAILY_SPEND_TABLES["user"]
 
 # Every nullable member of the unique constraint, so a test that only varied the provider
 # cannot pass while a sibling column still leaks a NULL into the conflict target.
-NULLABLE_KEY_COLUMNS = ("model", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint")
+NULLABLE_KEY_COLUMNS = ("model", "model_group", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint")
 
 
 def tag_txn(**overrides):
@@ -78,6 +78,15 @@ def test_distinct_keys_are_not_merged_and_are_ordered_deterministically():
     assert merged == merge_by_conflict_key(TAG_TABLE, tuple(reversed(unordered)))
 
 
+def test_distinct_model_groups_are_not_merged():
+    merged = merge_by_conflict_key(
+        TAG_TABLE,
+        (tag_txn(model_group="public-a"), tag_txn(model_group="public-b")),
+    )
+
+    assert len(merged) == 2
+
+
 def test_one_statement_carries_every_row_in_the_batch():
     batch = merge_by_conflict_key(TAG_TABLE, tuple(tag_txn(tag=f"team-{i}") for i in range(100)))
 
@@ -98,7 +107,8 @@ def test_conflict_target_is_the_full_unique_constraint():
     conflict_target = re.search(r"ON CONFLICT \(([^)]*)\)", sql)
     assert conflict_target is not None
     assert conflict_target.group(1) == (
-        '"tag", "date", "api_key", "model", "custom_llm_provider", "mcp_namespaced_tool_name", "endpoint"'
+        '"tag", "date", "api_key", "model", "model_group", "custom_llm_provider", '
+        '"mcp_namespaced_tool_name", "endpoint"'
     )
 
 

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -308,6 +308,7 @@ async def test_update_daily_spend_with_null_entity_id():
     assert _row_values(statement, "date") == ["2024-01-01"]
     assert _row_values(statement, "api_key") == ["test-api-key"]
     assert _row_values(statement, "model") == ["gpt-4"]
+    assert _row_values(statement, "model_group") == [""]
     assert _row_values(statement, "custom_llm_provider") == ["openai"]
     assert _row_values(statement, "mcp_namespaced_tool_name") == [""]
     assert _row_values(statement, "endpoint") == [""]

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -4,9 +4,7 @@ import json
 import os
 import sys
 
-sys.path.insert(
-    0, os.path.abspath("../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../.."))  # Adds the parent directory to the system path
 
 
 from datetime import datetime, timezone
@@ -67,9 +65,7 @@ async def test_daily_spend_tracking_with_disabled_spend_logs():
         assert db_writer.add_spend_log_transaction_to_daily_user_transaction.called
 
         # Verify the payload passed to add_spend_log_transaction_to_daily_user_transaction
-        call_args = (
-            db_writer.add_spend_log_transaction_to_daily_user_transaction.call_args[1]
-        )
+        call_args = db_writer.add_spend_log_transaction_to_daily_user_transaction.call_args[1]
         assert "payload" in call_args
         assert call_args["payload"]["spend"] == 0.1
         assert call_args["payload"]["model"] == "gpt-4"
@@ -359,9 +355,15 @@ async def test_daily_user_transaction_key_includes_model_group():
     ]
 
     assert queued_keys == [
-        "test-user_2024-01-01_test-key_openai/gpt-4o-mini_a_openai_",
-        "test-user_2024-01-01_test-key_openai/gpt-4o-mini_b_openai_",
+        '["test-user","2024-01-01","test-key","openai/gpt-4o-mini","a","openai",""]',
+        '["test-user","2024-01-01","test-key","openai/gpt-4o-mini","b","openai",""]',
     ]
+
+
+def test_daily_transaction_key_is_not_delimiter_ambiguous():
+    assert DBSpendUpdateWriter._daily_transaction_key(
+        "user", "model_a", "group"
+    ) != DBSpendUpdateWriter._daily_transaction_key("user", "model", "a_group")
 
 
 @pytest.mark.asyncio
@@ -446,7 +448,7 @@ async def test_update_daily_spend_sorting():
     upsert_calls = []
     for i in range(50):
         daily_spend_transactions[f"test_key_{i}"] = {
-            "user_id": f"user{60-i}",  # user60 ... user11, reverse order
+            "user_id": f"user{60 - i}",  # user60 ... user11, reverse order
             "date": "2024-01-01",
             "api_key": "test-api-key",
             "model": "gpt-4",
@@ -462,7 +464,7 @@ async def test_update_daily_spend_sorting():
             call(
                 where={
                     "user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint": {
-                        "user_id": f"user{i+11}",  # user11 ... user60, sorted order
+                        "user_id": f"user{i + 11}",  # user11 ... user60, sorted order
                         "date": "2024-01-01",
                         "api_key": "test-api-key",
                         "model": "gpt-4",
@@ -474,7 +476,7 @@ async def test_update_daily_spend_sorting():
                 },
                 data={
                     "create": {
-                        "user_id": f"user{i+11}",
+                        "user_id": f"user{i + 11}",
                         "date": "2024-01-01",
                         "api_key": "test-api-key",
                         "model": "gpt-4",
@@ -1085,9 +1087,9 @@ async def test_add_spend_log_transaction_to_daily_tag_transaction_with_request_i
         transaction_dict = update_call[1]["update"]
         # Each transaction should have one key with the format tag_date_api_key_model_provider
         for key, transaction in transaction_dict.items():
-            assert (
-                transaction["request_id"] == request_id
-            ), f"request_id should be {request_id} but got {transaction.get('request_id')}"
+            assert transaction["request_id"] == request_id, (
+                f"request_id should be {request_id} but got {transaction.get('request_id')}"
+            )
 
 
 @pytest.mark.asyncio
@@ -1130,7 +1132,7 @@ async def test_add_spend_log_transaction_to_daily_org_transaction_injects_org_id
     update_dict = call_args["update"]
     assert len(update_dict) == 1
     for key, transaction in update_dict.items():
-        assert key == f"{org_id}_2024-01-01_test-key_gpt-4_gpt-4-group_openai_"
+        assert key == f'["{org_id}","2024-01-01","test-key","gpt-4","gpt-4-group","openai",""]'
         assert transaction["organization_id"] == org_id
         assert transaction["date"] == "2024-01-01"
         assert transaction["api_key"] == "test-key"
@@ -1207,7 +1209,7 @@ async def test_add_spend_log_transaction_to_daily_end_user_transaction_injects_e
     update_dict = call_args["update"]
     assert len(update_dict) == 1
     for key, transaction in update_dict.items():
-        assert key == f"{end_user_id}_2024-01-01_test-key_gpt-4_gpt-4-group_openai_"
+        assert key == f'["{end_user_id}","2024-01-01","test-key","gpt-4","gpt-4-group","openai",""]'
         assert transaction["end_user_id"] == end_user_id
         assert transaction["date"] == "2024-01-01"
         assert transaction["api_key"] == "test-key"
@@ -1283,7 +1285,7 @@ async def test_add_spend_log_transaction_to_daily_agent_transaction_injects_agen
     update_dict = call_args["update"]
     assert len(update_dict) == 1
     for key, transaction in update_dict.items():
-        assert key == f"{agent_id}_2024-01-01_test-key_gpt-4_gpt-4-group_openai_"
+        assert key == f'["{agent_id}","2024-01-01","test-key","gpt-4","gpt-4-group","openai",""]'
         assert transaction["agent_id"] == agent_id
         assert transaction["date"] == "2024-01-01"
         assert transaction["api_key"] == "test-key"
@@ -1313,21 +1315,15 @@ async def test_add_spend_log_transaction_to_daily_agent_transaction_calls_common
     }
 
     writer.daily_agent_spend_update_queue.add_update = AsyncMock()
-    original_common_helper = (
-        writer._common_add_spend_log_transaction_to_daily_transaction
-    )
-    writer._common_add_spend_log_transaction_to_daily_transaction = AsyncMock(
-        wraps=original_common_helper
-    )
+    original_common_helper = writer._common_add_spend_log_transaction_to_daily_transaction
+    writer._common_add_spend_log_transaction_to_daily_transaction = AsyncMock(wraps=original_common_helper)
 
     await writer.add_spend_log_transaction_to_daily_agent_transaction(
         payload=payload,
         prisma_client=mock_prisma,
     )
 
-    assert (
-        writer._common_add_spend_log_transaction_to_daily_transaction.await_count == 1
-    )
+    assert writer._common_add_spend_log_transaction_to_daily_transaction.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -1404,7 +1400,7 @@ async def test_endpoint_field_is_correctly_mapped_from_call_type():
 
     for key, transaction in update_dict.items():
         # Verify endpoint is included in the key
-        assert key == "test-user_2024-01-01_test-key_gpt-4_gpt-4-group_openai_/chat/completions"
+        assert key == '["test-user","2024-01-01","test-key","gpt-4","gpt-4-group","openai","/chat/completions"]'
 
         # Verify endpoint is set in the transaction
         assert transaction["endpoint"] == "/chat/completions"
@@ -1641,9 +1637,7 @@ async def test_update_database_creates_single_task():
         patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
         patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
         patch("litellm.proxy.proxy_server.litellm_proxy_budget_name", "test-budget"),
-        patch(
-            "litellm.proxy.db.db_spend_update_writer.asyncio.create_task"
-        ) as mock_create_task,
+        patch("litellm.proxy.db.db_spend_update_writer.asyncio.create_task") as mock_create_task,
     ):
         await db_writer.update_database(
             token="test-token",
@@ -1742,9 +1736,7 @@ async def test_daily_agent_receives_deepcopied_payload():
     db_writer._update_agent_db = AsyncMock()
     db_writer.add_spend_log_transaction_to_daily_user_transaction = AsyncMock()
     db_writer.add_spend_log_transaction_to_daily_end_user_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_agent_transaction = AsyncMock(
-        side_effect=capture_agent_payload
-    )
+    db_writer.add_spend_log_transaction_to_daily_agent_transaction = AsyncMock(side_effect=capture_agent_payload)
     db_writer.add_spend_log_transaction_to_daily_team_transaction = AsyncMock()
     db_writer.add_spend_log_transaction_to_daily_org_transaction = AsyncMock()
     db_writer.add_spend_log_transaction_to_daily_tag_transaction = AsyncMock()
@@ -1806,8 +1798,8 @@ async def test_commit_spend_updates_uses_pipeline():
     mock_redis_update_buffer = AsyncMock()
     mock_redis_update_buffer.store_in_memory_spend_updates_in_redis = AsyncMock()
     # Return all-None tuple (no data to commit)
-    mock_redis_update_buffer.get_all_transactions_from_redis_buffer_pipeline = (
-        AsyncMock(return_value=(None, None, None, None, None, None, None))
+    mock_redis_update_buffer.get_all_transactions_from_redis_buffer_pipeline = AsyncMock(
+        return_value=(None, None, None, None, None, None, None)
     )
     db_writer.redis_update_buffer = mock_redis_update_buffer
 
@@ -2016,9 +2008,7 @@ async def test_update_database_does_not_deepcopy_on_request_path():
     db_writer._update_org_db = AsyncMock()
     db_writer._update_tag_db = AsyncMock()
     db_writer._update_agent_db = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_user_transaction = AsyncMock(
-        side_effect=capture_batch_payload
-    )
+    db_writer.add_spend_log_transaction_to_daily_user_transaction = AsyncMock(side_effect=capture_batch_payload)
     db_writer.add_spend_log_transaction_to_daily_end_user_transaction = AsyncMock()
     db_writer.add_spend_log_transaction_to_daily_agent_transaction = AsyncMock()
     db_writer.add_spend_log_transaction_to_daily_team_transaction = AsyncMock()
@@ -2110,9 +2100,7 @@ async def test_spend_update_path_never_queries_user_cache_with_none_user_id():
     db_writer = DBSpendUpdateWriter()
 
     strict_redis_backed_cache = MagicMock()
-    strict_redis_backed_cache.async_get_cache = AsyncMock(
-        side_effect=DataError("Invalid input of type: 'NoneType'")
-    )
+    strict_redis_backed_cache.async_get_cache = AsyncMock(side_effect=DataError("Invalid input of type: 'NoneType'"))
 
     with (
         patch.object(litellm, "max_budget", 0),
@@ -2236,9 +2224,7 @@ async def test_daily_transaction_carries_compression_saved_tokens():
     input_cost = model_info["input_cost_per_token"] or 0.0
     cache_read_cost = model_info.get("cache_read_input_token_cost") or input_cost
     assert transaction["compression_savings_spend"] == pytest.approx(7600 * input_cost)
-    assert transaction["prompt_caching_savings_spend"] == pytest.approx(
-        40 * max(input_cost - cache_read_cost, 0.0)
-    )
+    assert transaction["prompt_caching_savings_spend"] == pytest.approx(40 * max(input_cost - cache_read_cost, 0.0))
     assert transaction["compression_savings_spend"] > 0
     assert transaction["prompt_caching_savings_spend"] > 0
 

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -337,6 +337,51 @@ def _daily_txn(user_id: str = "user1") -> dict:
 
 
 @pytest.mark.asyncio
+async def test_daily_user_transaction_key_includes_model_group():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+    mock_prisma.get_request_status = MagicMock(return_value="success")
+    writer.daily_spend_update_queue.add_update = AsyncMock()
+    base_payload = {
+        "request_id": "req-model-group-key",
+        "user": "test-user",
+        "startTime": "2024-01-01T12:00:00",
+        "api_key": "test-key",
+        "model": "openai/gpt-4o-mini",
+        "custom_llm_provider": "openai",
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "spend": 0.2,
+        "metadata": '{"usage_object": {}}',
+    }
+
+    await writer.add_spend_log_transaction_to_daily_user_transaction(
+        payload={**base_payload, "model_group": "a"},
+        prisma_client=mock_prisma,
+    )
+    await writer.add_spend_log_transaction_to_daily_user_transaction(
+        payload={**base_payload, "model_group": "b"},
+        prisma_client=mock_prisma,
+    )
+
+    queued_keys = [
+        next(iter(call_kwargs.kwargs["update"].keys()))
+        for call_kwargs in writer.daily_spend_update_queue.add_update.call_args_list
+    ]
+
+    assert queued_keys == [
+        '["test-user","2024-01-01","test-key","openai/gpt-4o-mini","a","openai","",""]',
+        '["test-user","2024-01-01","test-key","openai/gpt-4o-mini","b","openai","",""]',
+    ]
+
+
+def test_daily_transaction_key_is_not_delimiter_ambiguous():
+    assert DBSpendUpdateWriter._daily_transaction_key(
+        "user", "model_a", "group"
+    ) != DBSpendUpdateWriter._daily_transaction_key("user", "model", "a_group")
+
+
+@pytest.mark.asyncio
 async def test_update_daily_spend_does_not_retry_post_send_ambiguous_errors():
     # Regression for the double-apply hazard: a ReadTimeout means the batch was
     # sent and its outcome is unknown; the engine can leave the transaction open
@@ -1036,7 +1081,7 @@ async def test_add_spend_log_transaction_to_daily_org_transaction_injects_org_id
     update_dict = call_args["update"]
     assert len(update_dict) == 1
     for key, transaction in update_dict.items():
-        assert key == f"{org_id}_2024-01-01_test-key_gpt-4_openai_"
+        assert key == f'["{org_id}","2024-01-01","test-key","gpt-4","gpt-4-group","openai","",""]'
         assert transaction["organization_id"] == org_id
         assert transaction["date"] == "2024-01-01"
         assert transaction["api_key"] == "test-key"
@@ -1113,7 +1158,7 @@ async def test_add_spend_log_transaction_to_daily_end_user_transaction_injects_e
     update_dict = call_args["update"]
     assert len(update_dict) == 1
     for key, transaction in update_dict.items():
-        assert key == f"{end_user_id}_2024-01-01_test-key_gpt-4_openai_"
+        assert key == f'["{end_user_id}","2024-01-01","test-key","gpt-4","gpt-4-group","openai","",""]'
         assert transaction["end_user_id"] == end_user_id
         assert transaction["date"] == "2024-01-01"
         assert transaction["api_key"] == "test-key"
@@ -1189,7 +1234,7 @@ async def test_add_spend_log_transaction_to_daily_agent_transaction_injects_agen
     update_dict = call_args["update"]
     assert len(update_dict) == 1
     for key, transaction in update_dict.items():
-        assert key == f"{agent_id}_2024-01-01_test-key_gpt-4_openai_"
+        assert key == f'["{agent_id}","2024-01-01","test-key","gpt-4","gpt-4-group","openai","",""]'
         assert transaction["agent_id"] == agent_id
         assert transaction["date"] == "2024-01-01"
         assert transaction["api_key"] == "test-key"
@@ -1310,7 +1355,7 @@ async def test_endpoint_field_is_correctly_mapped_from_call_type():
 
     for key, transaction in update_dict.items():
         # Verify endpoint is included in the key
-        assert key == f"test-user_2024-01-01_test-key_gpt-4_openai_/chat/completions"
+        assert key == '["test-user","2024-01-01","test-key","gpt-4","gpt-4-group","openai","","/chat/completions"]'
 
         # Verify endpoint is set in the transaction
         assert transaction["endpoint"] == "/chat/completions"

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -12,7 +12,7 @@ sys.path.insert(
 
 from collections.abc import Callable
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from redis.exceptions import DataError
@@ -375,6 +375,47 @@ async def test_daily_user_transaction_key_includes_model_group():
     ]
 
 
+@pytest.mark.asyncio
+async def test_daily_user_transaction_key_includes_mcp_tool_name():
+    writer = DBSpendUpdateWriter()
+    writer.daily_spend_update_queue = MagicMock()
+    writer.daily_spend_update_queue.add_update = AsyncMock()
+    mock_prisma = MagicMock()
+
+    base_payload = {
+        "request_id": "req-mcp-tool-key",
+        "user": "test-user",
+        "startTime": "2024-01-01T12:00:00",
+        "api_key": "test-key",
+        "model": "openai/gpt-4o-mini",
+        "model_group": "a",
+        "custom_llm_provider": "openai",
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "spend": 0.2,
+        "metadata": '{"usage_object": {}}',
+    }
+
+    await writer.add_spend_log_transaction_to_daily_user_transaction(
+        payload={**base_payload, "mcp_namespaced_tool_name": "server_a.tool"},
+        prisma_client=mock_prisma,
+    )
+    await writer.add_spend_log_transaction_to_daily_user_transaction(
+        payload={**base_payload, "mcp_namespaced_tool_name": "server_b.tool"},
+        prisma_client=mock_prisma,
+    )
+
+    queued_keys = [
+        next(iter(call_kwargs.kwargs["update"].keys()))
+        for call_kwargs in writer.daily_spend_update_queue.add_update.call_args_list
+    ]
+
+    assert queued_keys == [
+        '["test-user","2024-01-01","test-key","openai/gpt-4o-mini","a","openai","server_a.tool",""]',
+        '["test-user","2024-01-01","test-key","openai/gpt-4o-mini","a","openai","server_b.tool",""]',
+    ]
+
+
 def test_daily_transaction_key_is_not_delimiter_ambiguous():
     assert DBSpendUpdateWriter._daily_transaction_key(
         "user", "model_a", "group"
@@ -677,7 +718,7 @@ async def test_update_tag_db_with_valid_tags():
     """
     Test that _update_tag_db correctly processes valid tags and adds them to the spend update queue.
     """
-    from litellm.proxy._types import Litellm_EntityType, SpendUpdateQueueItem
+    from litellm.proxy._types import Litellm_EntityType
 
     writer = DBSpendUpdateWriter()
     mock_prisma = MagicMock()
@@ -1019,8 +1060,6 @@ async def test_add_spend_log_transaction_to_daily_tag_transaction_with_request_i
         "metadata": '{"usage_object": {}}',
     }
 
-    # Mock the add_update method to capture what's being added
-    original_add_update = writer.daily_tag_spend_update_queue.add_update
     writer.daily_tag_spend_update_queue.add_update = AsyncMock()
 
     await writer.add_spend_log_transaction_to_daily_tag_transaction(
@@ -1032,8 +1071,8 @@ async def test_add_spend_log_transaction_to_daily_tag_transaction_with_request_i
     assert writer.daily_tag_spend_update_queue.add_update.call_count == 2
 
     # Check that request_id is included in both transactions
-    for call in writer.daily_tag_spend_update_queue.add_update.call_args_list:
-        transaction_dict = call[1]["update"]
+    for update_call in writer.daily_tag_spend_update_queue.add_update.call_args_list:
+        transaction_dict = update_call[1]["update"]
         # Each transaction should have one key with the format tag_date_api_key_model_provider
         for key, transaction in transaction_dict.items():
             assert (

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -272,7 +272,7 @@ async def test_update_daily_spend_with_null_entity_id():
         entity_type="user",
         entity_id_field="user_id",
         table_name="litellm_dailyuserspend",
-        unique_constraint_name="user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+        unique_constraint_name="user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
     )
 
     # Verify that table.upsert was called
@@ -281,12 +281,13 @@ async def test_update_daily_spend_with_null_entity_id():
     # Verify the where clause contains null entity_id
     call_args = mock_table.upsert.call_args[1]
     where_clause = call_args["where"][
-        "user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint"
+        "user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint"
     ]
     assert where_clause["user_id"] is None
     assert where_clause["date"] == "2024-01-01"
     assert where_clause["api_key"] == "test-api-key"
     assert where_clause["model"] == "gpt-4"
+    assert where_clause["model_group"] == ""
     assert where_clause["custom_llm_provider"] == "openai"
     assert where_clause["mcp_namespaced_tool_name"] == ""
     assert where_clause["endpoint"] == ""
@@ -325,6 +326,45 @@ def _daily_txn(user_id: str = "user1") -> dict:
 
 
 @pytest.mark.asyncio
+async def test_daily_user_transaction_key_includes_model_group():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+    mock_prisma.get_request_status = MagicMock(return_value="success")
+    writer.daily_spend_update_queue.add_update = AsyncMock()
+    base_payload = {
+        "request_id": "req-model-group-key",
+        "user": "test-user",
+        "startTime": "2024-01-01T12:00:00",
+        "api_key": "test-key",
+        "model": "openai/gpt-4o-mini",
+        "custom_llm_provider": "openai",
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "spend": 0.2,
+        "metadata": '{"usage_object": {}}',
+    }
+
+    await writer.add_spend_log_transaction_to_daily_user_transaction(
+        payload={**base_payload, "model_group": "a"},
+        prisma_client=mock_prisma,
+    )
+    await writer.add_spend_log_transaction_to_daily_user_transaction(
+        payload={**base_payload, "model_group": "b"},
+        prisma_client=mock_prisma,
+    )
+
+    queued_keys = [
+        next(iter(call_kwargs.kwargs["update"].keys()))
+        for call_kwargs in writer.daily_spend_update_queue.add_update.call_args_list
+    ]
+
+    assert queued_keys == [
+        "test-user_2024-01-01_test-key_openai/gpt-4o-mini_a_openai_",
+        "test-user_2024-01-01_test-key_openai/gpt-4o-mini_b_openai_",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_update_daily_spend_does_not_retry_post_send_ambiguous_errors():
     # Regression for the double-apply hazard: a ReadTimeout means the batch was
     # sent and its outcome is unknown; the engine can leave the transaction open
@@ -347,7 +387,7 @@ async def test_update_daily_spend_does_not_retry_post_send_ambiguous_errors():
             entity_type="user",
             entity_id_field="user_id",
             table_name="litellm_dailyuserspend",
-            unique_constraint_name="user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+            unique_constraint_name="user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
         )
 
     mock_prisma_client.db.batch_.assert_called_once()
@@ -380,7 +420,7 @@ async def test_update_daily_spend_retries_connect_errors(monkeypatch):
         entity_type="user",
         entity_id_field="user_id",
         table_name="litellm_dailyuserspend",
-        unique_constraint_name="user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+        unique_constraint_name="user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
     )
 
     assert mock_prisma_client.db.batch_.call_count == 2
@@ -421,11 +461,12 @@ async def test_update_daily_spend_sorting():
         upsert_calls.append(
             call(
                 where={
-                    "user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint": {
+                    "user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint": {
                         "user_id": f"user{i+11}",  # user11 ... user60, sorted order
                         "date": "2024-01-01",
                         "api_key": "test-api-key",
                         "model": "gpt-4",
+                        "model_group": "",
                         "custom_llm_provider": "openai",
                         "mcp_namespaced_tool_name": "",
                         "endpoint": "",
@@ -437,7 +478,7 @@ async def test_update_daily_spend_sorting():
                         "date": "2024-01-01",
                         "api_key": "test-api-key",
                         "model": "gpt-4",
-                        "model_group": None,
+                        "model_group": "",
                         "mcp_namespaced_tool_name": "",
                         "custom_llm_provider": "openai",
                         "endpoint": "",
@@ -470,7 +511,7 @@ async def test_update_daily_spend_sorting():
         entity_type="user",
         entity_id_field="user_id",
         table_name="litellm_dailyuserspend",
-        unique_constraint_name="user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+        unique_constraint_name="user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
     )
 
     # Verify that table.upsert was called
@@ -517,7 +558,7 @@ async def test_update_daily_spend_drains_all_batches_over_batch_size():
         entity_type="user",
         entity_id_field="user_id",
         table_name="litellm_dailyuserspend",
-        unique_constraint_name="user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+        unique_constraint_name="user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
     )
 
     assert mock_table.upsert.call_count == num_entities
@@ -565,7 +606,7 @@ async def test_update_daily_spend_tag_with_request_id():
         entity_type="tag",
         entity_id_field="tag",
         table_name="litellm_dailytagspend",
-        unique_constraint_name="tag_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name",
+        unique_constraint_name="tag_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
     )
 
     # Verify that table.upsert was called
@@ -672,7 +713,7 @@ async def test_update_daily_spend_with_none_values_in_sorting_fields():
         entity_type="user",
         entity_id_field="user_id",
         table_name="litellm_dailyuserspend",
-        unique_constraint_name="user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+        unique_constraint_name="user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
     )
 
     # Verify that table.upsert was called (should be called 5 times, once for each transaction)
@@ -687,7 +728,7 @@ async def test_update_tag_db_with_valid_tags():
     """
     Test that _update_tag_db correctly processes valid tags and adds them to the spend update queue.
     """
-    from litellm.proxy._types import Litellm_EntityType, SpendUpdateQueueItem
+    from litellm.proxy._types import Litellm_EntityType
 
     writer = DBSpendUpdateWriter()
     mock_prisma = MagicMock()
@@ -1029,8 +1070,6 @@ async def test_add_spend_log_transaction_to_daily_tag_transaction_with_request_i
         "metadata": '{"usage_object": {}}',
     }
 
-    # Mock the add_update method to capture what's being added
-    original_add_update = writer.daily_tag_spend_update_queue.add_update
     writer.daily_tag_spend_update_queue.add_update = AsyncMock()
 
     await writer.add_spend_log_transaction_to_daily_tag_transaction(
@@ -1042,8 +1081,8 @@ async def test_add_spend_log_transaction_to_daily_tag_transaction_with_request_i
     assert writer.daily_tag_spend_update_queue.add_update.call_count == 2
 
     # Check that request_id is included in both transactions
-    for call in writer.daily_tag_spend_update_queue.add_update.call_args_list:
-        transaction_dict = call[1]["update"]
+    for update_call in writer.daily_tag_spend_update_queue.add_update.call_args_list:
+        transaction_dict = update_call[1]["update"]
         # Each transaction should have one key with the format tag_date_api_key_model_provider
         for key, transaction in transaction_dict.items():
             assert (
@@ -1091,7 +1130,7 @@ async def test_add_spend_log_transaction_to_daily_org_transaction_injects_org_id
     update_dict = call_args["update"]
     assert len(update_dict) == 1
     for key, transaction in update_dict.items():
-        assert key == f"{org_id}_2024-01-01_test-key_gpt-4_openai_"
+        assert key == f"{org_id}_2024-01-01_test-key_gpt-4_gpt-4-group_openai_"
         assert transaction["organization_id"] == org_id
         assert transaction["date"] == "2024-01-01"
         assert transaction["api_key"] == "test-key"
@@ -1168,7 +1207,7 @@ async def test_add_spend_log_transaction_to_daily_end_user_transaction_injects_e
     update_dict = call_args["update"]
     assert len(update_dict) == 1
     for key, transaction in update_dict.items():
-        assert key == f"{end_user_id}_2024-01-01_test-key_gpt-4_openai_"
+        assert key == f"{end_user_id}_2024-01-01_test-key_gpt-4_gpt-4-group_openai_"
         assert transaction["end_user_id"] == end_user_id
         assert transaction["date"] == "2024-01-01"
         assert transaction["api_key"] == "test-key"
@@ -1244,7 +1283,7 @@ async def test_add_spend_log_transaction_to_daily_agent_transaction_injects_agen
     update_dict = call_args["update"]
     assert len(update_dict) == 1
     for key, transaction in update_dict.items():
-        assert key == f"{agent_id}_2024-01-01_test-key_gpt-4_openai_"
+        assert key == f"{agent_id}_2024-01-01_test-key_gpt-4_gpt-4-group_openai_"
         assert transaction["agent_id"] == agent_id
         assert transaction["date"] == "2024-01-01"
         assert transaction["api_key"] == "test-key"
@@ -1365,7 +1404,7 @@ async def test_endpoint_field_is_correctly_mapped_from_call_type():
 
     for key, transaction in update_dict.items():
         # Verify endpoint is included in the key
-        assert key == f"test-user_2024-01-01_test-key_gpt-4_openai_/chat/completions"
+        assert key == "test-user_2024-01-01_test-key_gpt-4_gpt-4-group_openai_/chat/completions"
 
         # Verify endpoint is set in the transaction
         assert transaction["endpoint"] == "/chat/completions"
@@ -1433,7 +1472,7 @@ async def test_update_daily_spend_logs_detailed_error_on_batch_upsert_failure():
                 entity_type="user",
                 entity_id_field="user_id",
                 table_name="litellm_dailyuserspend",
-                unique_constraint_name="user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+                unique_constraint_name="user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
             )
 
         # Verify that the error was logged with detailed information.
@@ -1445,7 +1484,7 @@ async def test_update_daily_spend_logs_detailed_error_on_batch_upsert_failure():
         assert "Daily user spend batch upsert failed" in formatted
         assert "Table: litellm_dailyuserspend" in formatted
         assert (
-            "Constraint: user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint"
+            "Constraint: user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint"
             in formatted
         )
         assert "Batch size: 1" in formatted
@@ -1502,7 +1541,7 @@ async def test_update_daily_spend_re_raises_exception_after_logging():
             entity_type="user",
             entity_id_field="user_id",
             table_name="litellm_dailyuserspend",
-            unique_constraint_name="user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
+            unique_constraint_name="user_id_date_api_key_model_model_group_custom_llm_provider_mcp_namespaced_tool_name_endpoint",
         )
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Usage tab merges public model groups
- Shared backend models collapse daily usage rows
- Raw logs differ from Usage tab totals

How it solves it:

- Adds `model_group` to daily unique keys
- Includes `model_group` in daily upserts
- Adds regression coverage for public model groups

## Relevant issues

Fixes #36172

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduced with public model names `a`, `b`, and `c` all routing to `openai/gpt-4o-mini`.

Before fix, raw spend logs preserved separate `model_group` values, but daily usage aggregates used a unique key without `model_group`, so Usage tab data could merge or miss public model names.

After fix, `LiteLLM_DailyUserSpend` keeps separate rows for each public model group.

Proof captured on commit `2428db08b7`:

```sql
SELECT date, user_id, model, model_group, custom_llm_provider, api_requests, spend
FROM "LiteLLM_DailyUserSpend"
ORDER BY date DESC, model_group
LIMIT 20;
```

<img width="801" height="307" alt="image" src="https://github.com/user-attachments/assets/8f80a4be-10a4-4dc8-860d-54216dc21919" />

Expected result includes separate rows:
```
model                model_group
openai/gpt-4o-mini  a
openai/gpt-4o-mini  b
openai/gpt-4o-mini  c
```

Validation run:
```bash
./.venv/bin/python -m pytest tests/test_litellm/proxy/db/test_db_spend_update_writer.py -v
make pre-commit
```

## Type
🐛 Bug Fix
✅ Test

## Changes

- Added model_group to daily spend unique constraints.
- Updated daily spend upsert selectors to include model_group.
- Added migration to rebuild daily spend unique indexes.
- Updated proxy-extras schema to match main Prisma schemas.
- Added regression test for public model groups sharing a backend model.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR