### PR TITLE
fix(ui): invalidate keys list after key update so table reflects changes

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
@@ -2,11 +2,12 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---- Hoisted shared mocks (safe to use inside vi.mock factories) ----
-const { keyUpdateCallMock, keyDeleteCallMock, mockUseAuthorized } = vi.hoisted(() => {
+const { keyUpdateCallMock, keyDeleteCallMock, mockUseAuthorized, invalidateQueriesMock } = vi.hoisted(() => {
   return {
     keyUpdateCallMock: vi.fn().mockResolvedValue({}),
     keyDeleteCallMock: vi.fn().mockResolvedValue({}),
     mockUseAuthorized: vi.fn(),
+    invalidateQueriesMock: vi.fn(),
   };
 });
 
@@ -160,12 +161,11 @@ vi.mock("@/app/(dashboard)/hooks/keys/useSetKeyBlockedState", () => ({
   }),
 }));
 
-// useQueryClient also needs a provider; the delete-path invalidation is covered in key_info_view.test.tsx
 vi.mock("@tanstack/react-query", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tanstack/react-query")>();
   return {
     ...actual,
-    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+    useQueryClient: () => ({ invalidateQueries: invalidateQueriesMock }),
   };
 });
 
@@ -191,6 +191,7 @@ vi.mock("./key_edit_view", async () => {
 
 // ---- SUT import AFTER mocks ----
 import KeyInfoView from "./key_info_view";
+import { keyKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
 
 // ---- Test data helpers ----
 const baseKeyData = {
@@ -480,6 +481,27 @@ describe("KeyInfoView handleKeyUpdate empty strings", () => {
       const [sentAccessToken, sentPayload] = keyUpdateCallMock.mock.calls[0];
       expect(sentAccessToken).toBe("access_abc");
       expect(sentPayload[limit]).toBeNull();
+    });
+  });
+});
+
+describe("KeyInfoView handleKeyUpdate keys-list invalidation", () => {
+  it("invalidates the keys list query after a successful update so the table reflects the change", async () => {
+    renderView(true);
+
+    fireEvent.click(screen.getByText("Settings"));
+    fireEvent.click(screen.getByText("Edit Settings"));
+    (globalThis as any).__TEST_FORM_VALUES = {
+      token: "tok_123",
+      max_budget: 60,
+      budget_duration: "24h",
+    };
+
+    fireEvent.click(screen.getByText("Mock Submit"));
+
+    await waitFor(() => expect(keyUpdateCallMock).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(invalidateQueriesMock).toHaveBeenCalledWith({ queryKey: keyKeys.lists() });
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
@@ -2,11 +2,12 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---- Hoisted shared mocks (safe to use inside vi.mock factories) ----
-const { keyUpdateCallMock, keyDeleteCallMock, mockUseAuthorized } = vi.hoisted(() => {
+const { keyUpdateCallMock, keyDeleteCallMock, mockUseAuthorized, invalidateQueriesMock } = vi.hoisted(() => {
   return {
     keyUpdateCallMock: vi.fn().mockResolvedValue({}),
     keyDeleteCallMock: vi.fn().mockResolvedValue({}),
     mockUseAuthorized: vi.fn(),
+    invalidateQueriesMock: vi.fn(),
   };
 });
 
@@ -270,12 +271,13 @@ vi.mock("@/app/(dashboard)/hooks/keys/useSetKeyBlockedState", () => ({
   }),
 }));
 
-// useQueryClient also needs a provider; the delete-path invalidation is covered in key_info_view.test.tsx
+// useQueryClient also needs a provider; return a hoisted spy so we can assert the
+// update path invalidates the keys list (mirrors the delete-path test in key_info_view.test.tsx)
 vi.mock("@tanstack/react-query", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tanstack/react-query")>();
   return {
     ...actual,
-    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+    useQueryClient: () => ({ invalidateQueries: invalidateQueriesMock }),
   };
 });
 
@@ -301,6 +303,7 @@ vi.mock("./key_edit_view", async () => {
 
 // ---- SUT import AFTER mocks ----
 import KeyInfoView from "./key_info_view";
+import { keyKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
 
 // ---- Test data helpers ----
 const baseKeyData = {
@@ -590,6 +593,29 @@ describe("KeyInfoView handleKeyUpdate empty strings", () => {
       const [sentAccessToken, sentPayload] = keyUpdateCallMock.mock.calls[0];
       expect(sentAccessToken).toBe("access_abc");
       expect(sentPayload[limit]).toBeNull();
+    });
+  });
+});
+
+describe("KeyInfoView handleKeyUpdate keys-list invalidation", () => {
+  it("invalidates the keys list query after a successful update so the table reflects the change", async () => {
+    renderView(true);
+
+    fireEvent.click(screen.getByText("Settings"));
+    fireEvent.click(screen.getByText("Edit Settings"));
+    (globalThis as any).__TEST_FORM_VALUES = {
+      token: "tok_123",
+      max_budget: 60,
+      budget_duration: "24h",
+    };
+
+    fireEvent.click(screen.getByText("Mock Submit"));
+
+    await waitFor(() => expect(keyUpdateCallMock).toHaveBeenCalled());
+    // The keys list must be invalidated, otherwise returning to the table shows
+    // stale (cached) values — the original bug behind "budget save looks invalid".
+    await waitFor(() => {
+      expect(invalidateQueriesMock).toHaveBeenCalledWith({ queryKey: keyKeys.lists() });
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -327,7 +327,7 @@ export default function KeyInfoView({
       }
       toast.success("Key updated successfully");
       setIsEditing(false);
-      // Refresh key data here if needed
+      await queryClient.invalidateQueries({ queryKey: keyKeys.lists() });
     } catch (error) {
       toast.fromError(parseErrorMessage(error));
       console.error("Error updating key:", error);

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -314,7 +314,8 @@ export default function KeyInfoView({
       }
       NotificationManager.success("Key updated successfully");
       setIsEditing(false);
-      // Refresh key data here if needed
+      // Invalidate the keys list so the table reflects the update (mirrors handleDelete)
+      await queryClient.invalidateQueries({ queryKey: keyKeys.lists() });
     } catch (error) {
       NotificationManager.fromBackend(parseErrorMessage(error));
       console.error("Error updating key:", error);


### PR DESCRIPTION
## Problem

Editing a key from the **Key Info** view (e.g. daily budget, budget reset, rate limits) and clicking **Save** looks like it "didn't work": returning to the **Keys** table still shows the **old** values. The change *was* persisted to the backend — a hard refresh / re-fetch reveals the new values — so the appearance of failure is a stale-cache display bug.

## Root cause

`handleKeyUpdate` in [`key_info_view.tsx`](https://github.com/BerriAI/litellm/blob/main/ui/litellm-dashboard/src/components/templates/key_info_view.tsx) updates local component state and calls `onKeyDataUpdate(...)` after a successful `keyUpdateCall`, but it never invalidates the React Query **keys list** query. The Keys table reads from that cached query, so it keeps rendering stale data until something else happens to invalidate it.

Notably, `handleDelete` in the **same file** already does the right thing:

```ts
await queryClient.invalidateQueries({ queryKey: keyKeys.lists() });
```

…and `handleKeyUpdate` even carried a leftover `// Refresh key data here if needed` TODO where the call belongs.

## Fix

Mirror the delete path — invalidate `keyKeys.lists()` after a successful update:

```ts
NotificationManager.success("Key updated successfully");
setIsEditing(false);
// Invalidate the keys list so the table reflects the update (mirrors handleDelete)
await queryClient.invalidateQueries({ queryKey: keyKeys.lists() });
```

This is the same pattern already used by `handleDelete`, and `queryClient` / `keyKeys` are already imported in the file.

## Testing

Adds a focused regression test in `KeyInfoView.handleKeyUpdate.test.tsx`:

- The existing test file mocked `useQueryClient` with a throwaway `vi.fn()`, which couldn't be asserted against. This PR promotes it to a hoisted, shared spy (`invalidateQueriesMock`).
- New test `invalidates the keys list query after a successful update so the table reflects the change` submits a budget edit via the (already-mocked) edit form and asserts `invalidateQueries` was called with `{ queryKey: keyKeys.lists() }`.

The test **fails before the fix** (`expected "spy" to be called with arguments: [ { queryKey: [ 'keys', 'list' ] } ]`) and **passes after**.

Full local validation:
- `vitest run` for both affected files: **39/39 pass**.
- `tsc --noEmit`: no new errors in the touched files.
- `next build`: `✓ Compiled successfully`.

## Notes

- Backend is unaffected and already correct: `/key/update` persists `max_budget` / `budget_duration` and refreshes the runtime key cache, so this is purely a dashboard display issue.
- Diff is intentionally minimal (1 functional line + the regression test).
