### PR TITLE
fix(proxy): treat SAML as configured in UI SSO detection

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -1159,8 +1159,8 @@ def _has_user_setup_sso() -> bool:
         microsoft_client_id is not None
         or google_client_id is not None
         or generic_client_id is not None
-        or saml_idp_metadata_url is not None
-        or saml_idp_metadata_xml is not None
+        or bool(saml_idp_metadata_url)
+        or bool(saml_idp_metadata_xml)
     )
 
 

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -1141,18 +1141,29 @@ def is_pass_through_provider_route(route: str) -> bool:
     return False
 
 
-def _has_user_setup_sso():
+def _has_user_setup_sso() -> bool:
     """
-    Check if the user has set up single sign-on (SSO) by verifying the presence of Microsoft client ID, Google client ID or generic client ID and UI username environment variables.
-    Returns a boolean indicating whether SSO has been set up.
+    Check if the user has set up single sign-on (SSO).
+
+    Covers OAuth providers (Microsoft, Google, generic) and SAML IdP metadata.
+    Used by UI discovery (``sso_configured``) so the login button enables when
+    any supported SSO path is configured — including SAML-only setups.
     """
     microsoft_client_id: Final = os.getenv("MICROSOFT_CLIENT_ID", None)
     google_client_id: Final = os.getenv("GOOGLE_CLIENT_ID", None)
     generic_client_id: Final = os.getenv("GENERIC_CLIENT_ID", None)
+    # SAML is configured via IdP metadata URL or inline XML (not OAuth client IDs).
+    # Keep this in sync with SAMLAuthHandler.is_saml_configured().
+    saml_idp_metadata_url: Final = os.getenv("SAML_IDP_METADATA_URL", None)
+    saml_idp_metadata_xml: Final = os.getenv("SAML_IDP_METADATA_XML", None)
 
-    sso_setup = (microsoft_client_id is not None) or (google_client_id is not None) or (generic_client_id is not None)
-
-    return sso_setup
+    return (
+        microsoft_client_id is not None
+        or google_client_id is not None
+        or generic_client_id is not None
+        or saml_idp_metadata_url is not None
+        or saml_idp_metadata_xml is not None
+    )
 
 
 def get_customer_user_header_from_mapping(user_id_mapping) -> list | None:

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -1152,8 +1152,6 @@ def _has_user_setup_sso() -> bool:
     microsoft_client_id: Final = os.getenv("MICROSOFT_CLIENT_ID", None)
     google_client_id: Final = os.getenv("GOOGLE_CLIENT_ID", None)
     generic_client_id: Final = os.getenv("GENERIC_CLIENT_ID", None)
-    # SAML is configured via IdP metadata URL or inline XML (not OAuth client IDs).
-    # Keep this in sync with SAMLAuthHandler.is_saml_configured().
     saml_idp_metadata_url: Final = os.getenv("SAML_IDP_METADATA_URL", None)
     saml_idp_metadata_xml: Final = os.getenv("SAML_IDP_METADATA_XML", None)
 

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -3087,3 +3087,47 @@ class TestIsRequestBodySafeChecksBracketNotationMetadata:
             )
             is True
         )
+
+
+class TestHasUserSetupSso:
+    """_has_user_setup_sso must treat SAML IdP metadata as SSO configured.
+
+    Regression: UI discovery used this helper for sso_configured, but it only
+    checked OAuth client IDs, so SAML-only setups left the login button gray.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_sso_env(self, monkeypatch):
+        for key in (
+            "MICROSOFT_CLIENT_ID",
+            "GOOGLE_CLIENT_ID",
+            "GENERIC_CLIENT_ID",
+            "SAML_IDP_METADATA_URL",
+            "SAML_IDP_METADATA_XML",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+    def test_false_when_no_sso_env(self):
+        from litellm.proxy.auth.auth_utils import _has_user_setup_sso
+
+        assert _has_user_setup_sso() is False
+
+    def test_true_for_oauth_client_ids(self, monkeypatch):
+        from litellm.proxy.auth.auth_utils import _has_user_setup_sso
+
+        monkeypatch.setenv("GOOGLE_CLIENT_ID", "google-client")
+        assert _has_user_setup_sso() is True
+
+    def test_true_for_saml_metadata_url(self, monkeypatch):
+        from litellm.proxy.auth.auth_utils import _has_user_setup_sso
+
+        monkeypatch.setenv(
+            "SAML_IDP_METADATA_URL", "https://idp.example.com/metadata.xml"
+        )
+        assert _has_user_setup_sso() is True
+
+    def test_true_for_saml_metadata_xml(self, monkeypatch):
+        from litellm.proxy.auth.auth_utils import _has_user_setup_sso
+
+        monkeypatch.setenv("SAML_IDP_METADATA_XML", "<EntityDescriptor/>")
+        assert _has_user_setup_sso() is True


### PR DESCRIPTION
IMPORTANT DISCLAIMER: this bug was found using Grok 4.5. AI was used to find the issue, as well as to fix it and create the tests. I validated the findings and output, but all code in this PR is generated by Grok 4.5!

_has_user_setup_sso only checked OAuth client IDs, so SAML-only setups left /.well-known/litellm-ui-config sso_configured=false and the login button gray even when SAML IdP metadata was set. Include SAML_IDP_METADATA_URL / SAML_IDP_METADATA_XML so UI discovery matches the login redirect path.

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- When SAML SSO is configured in the SSO Settings via the UI, the button for SSO login, remains gray. SSO does, work when tested via the direct path at https://<your-proxy>/sso/saml/login. 

How it solves it:

- By including to check for SAML SSO env variables that are set after configuration.

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

Before: 

<img width="817" height="1004" alt="image" src="https://github.com/user-attachments/assets/66d14b5c-bea6-4a6b-a27e-99525daa7063" />
<img width="1598" height="136" alt="image" src="https://github.com/user-attachments/assets/8f3fda26-b265-4596-abdb-d2242536e904" />

After:
<img width="800" height="1066" alt="image" src="https://github.com/user-attachments/assets/d928bb9e-b1d2-4715-9e62-b16223f95294" />
<img width="1252" height="83" alt="image" src="https://github.com/user-attachments/assets/a48e1f5c-1633-47ae-a4e6-b2c8944ac6c3" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
