### PR TITLE
fix(proxy): preserve protocol-aware custom guardrail streams

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -103,6 +103,7 @@ class CustomGuardrail(CustomLogger):
     use_native_during_call_hook: ClassVar[bool] = False
 
     records_own_guardrail_information: ClassVar[bool] = False
+    supported_streaming_call_types: ClassVar[frozenset[CallTypes]] = frozenset()
 
     def __init__(
         self,
@@ -624,6 +625,9 @@ class CustomGuardrail(CustomLogger):
 
     def uses_apply_guardrail_interface(self) -> bool:
         return type(self).apply_guardrail is not CustomGuardrail.apply_guardrail
+
+    def supports_streaming_call_type(self, call_type: CallTypes) -> bool:
+        return call_type in self.supported_streaming_call_types
 
     def _deployment_pre_call_target(self) -> "CustomLogger":
         if not self.uses_apply_guardrail_interface():

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -626,9 +626,6 @@ class CustomGuardrail(CustomLogger):
     def uses_apply_guardrail_interface(self) -> bool:
         return type(self).apply_guardrail is not CustomGuardrail.apply_guardrail
 
-    def supports_streaming_call_type(self, call_type: CallTypes) -> bool:
-        return call_type in self.supported_streaming_call_types
-
     def _deployment_pre_call_target(self) -> "CustomLogger":
         if not self.uses_apply_guardrail_interface():
             return self

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1767,6 +1767,23 @@ class ProxyLogging:
         return call_types[0] in NON_OPENAI_STREAM_GUARDRAIL_TRANSLATION_CALL_TYPES
 
     @staticmethod
+    def _guardrail_supports_streaming_route(
+        guardrail: CustomGuardrail,
+        user_api_key_dict: UserAPIKeyAuth,
+    ) -> bool:
+        from litellm.litellm_core_utils.api_route_to_call_types import (
+            get_call_types_for_route,
+        )
+
+        route: Final = user_api_key_dict.request_route
+        if not route:
+            return False
+        call_types: Final = get_call_types_for_route(route)
+        if not call_types:
+            return False
+        return any(guardrail.supports_streaming_call_type(call_type) for call_type in call_types)
+
+    @staticmethod
     def has_post_call_response_headers_callbacks() -> bool:
         return ProxyLogging._callback_capabilities().has_post_call_response_headers
 
@@ -2744,6 +2761,10 @@ class ProxyLogging:
                     and isinstance(resolved_callback, CustomGuardrail)
                     and resolved_callback.uses_apply_guardrail_interface()
                     and not resolved_callback.mask_response_content
+                    and not ProxyLogging._guardrail_supports_streaming_route(
+                        resolved_callback,
+                        user_api_key_dict,
+                    )
                 )
                 else kind
             )

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1753,35 +1753,23 @@ class ProxyLogging:
         return caps
 
     @staticmethod
-    def _stream_requires_guardrail_translation(user_api_key_dict: UserAPIKeyAuth) -> bool:
-        from litellm.litellm_core_utils.api_route_to_call_types import (
-            get_call_types_for_route,
-        )
-
-        route: Final = user_api_key_dict.request_route
-        if not route:
-            return False
-        call_types: Final = get_call_types_for_route(route)
-        if not call_types:
-            return False
-        return call_types[0] in NON_OPENAI_STREAM_GUARDRAIL_TRANSLATION_CALL_TYPES
-
-    @staticmethod
-    def _guardrail_supports_streaming_route(
-        guardrail: CustomGuardrail,
+    def _stream_guardrail_translation_call_type(
         user_api_key_dict: UserAPIKeyAuth,
-    ) -> bool:
+    ) -> CallTypes | None:
         from litellm.litellm_core_utils.api_route_to_call_types import (
             get_call_types_for_route,
         )
 
         route: Final = user_api_key_dict.request_route
         if not route:
-            return False
+            return None
         call_types: Final = get_call_types_for_route(route)
         if not call_types:
-            return False
-        return any(guardrail.supports_streaming_call_type(call_type) for call_type in call_types)
+            return None
+        call_type: Final = call_types[0]
+        if call_type not in NON_OPENAI_STREAM_GUARDRAIL_TRANSLATION_CALL_TYPES:
+            return None
+        return call_type
 
     @staticmethod
     def has_post_call_response_headers_callbacks() -> bool:
@@ -2744,7 +2732,7 @@ class ProxyLogging:
         request_data = _check_and_merge_model_level_guardrails(data=request_data, llm_router=llm_router)
 
         current_response = response
-        stream_needs_translation: Final = ProxyLogging._stream_requires_guardrail_translation(user_api_key_dict)
+        stream_translation_call_type: Final = ProxyLogging._stream_guardrail_translation_call_type(user_api_key_dict)
 
         for resolved_callback, kind in caps.iterator_overrides:
             if isinstance(resolved_callback, CustomGuardrail):
@@ -2757,14 +2745,11 @@ class ProxyLogging:
                 "apply_guardrail"
                 if (
                     kind == "override"
-                    and stream_needs_translation
+                    and stream_translation_call_type is not None
                     and isinstance(resolved_callback, CustomGuardrail)
                     and resolved_callback.uses_apply_guardrail_interface()
                     and not resolved_callback.mask_response_content
-                    and not ProxyLogging._guardrail_supports_streaming_route(
-                        resolved_callback,
-                        user_api_key_dict,
-                    )
+                    and stream_translation_call_type not in resolved_callback.supported_streaming_call_types
                 )
                 else kind
             )

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1775,12 +1775,7 @@ class ProxyLogging:
             get_call_types_for_route,
         )
 
-        route: Final = user_api_key_dict.request_route
-        if not route:
-            return False
-        call_types: Final = get_call_types_for_route(route)
-        if not call_types:
-            return False
+        call_types: Final = get_call_types_for_route(user_api_key_dict.request_route)
         return any(guardrail.supports_streaming_call_type(call_type) for call_type in call_types)
 
     @staticmethod

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1775,7 +1775,12 @@ class ProxyLogging:
             get_call_types_for_route,
         )
 
-        call_types: Final = get_call_types_for_route(user_api_key_dict.request_route)
+        route: Final = user_api_key_dict.request_route
+        if not route:
+            return False
+        call_types: Final = get_call_types_for_route(route)
+        if not call_types:
+            return False
         return any(guardrail.supports_streaming_call_type(call_type) for call_type in call_types)
 
     @staticmethod

--- a/tests/test_litellm/proxy/test_proxy_logging_hook_detection.py
+++ b/tests/test_litellm/proxy/test_proxy_logging_hook_detection.py
@@ -51,6 +51,17 @@ def test_has_streaming_callbacks_detects_guardrails(monkeypatch):
     assert ProxyLogging.has_streaming_callbacks() is True
 
 
+def test_custom_guardrail_streaming_call_type_capability_is_opt_in():
+    from litellm.types.utils import CallTypes
+
+    class _ProtocolAwareGuardrail(CustomGuardrail):
+        supported_streaming_call_types = frozenset({CallTypes.anthropic_messages})
+
+    assert CustomGuardrail().supports_streaming_call_type(CallTypes.anthropic_messages) is False
+    assert _ProtocolAwareGuardrail().supports_streaming_call_type(CallTypes.anthropic_messages) is True
+    assert _ProtocolAwareGuardrail().supports_streaming_call_type(CallTypes.aresponses) is False
+
+
 @pytest.mark.asyncio
 async def test_post_call_response_headers_hook_returns_early_without_callbacks(
     monkeypatch,
@@ -425,6 +436,46 @@ async def test_post_call_stream_guardrail_reroutes_inherited_apply_guardrail(mon
 
     assert exc_info.value.detail["keyword"] == "zebra"
     assert delivered == []
+
+
+@pytest.mark.asyncio
+async def test_protocol_aware_guardrail_keeps_own_anthropic_streaming_iterator(monkeypatch):
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.types.utils import CallTypes
+
+    first_chunk = _sse_bytes("message_start", {"type": "message_start"})
+
+    class _ProtocolAwareGuardrail(CustomGuardrail):
+        supported_streaming_call_types = frozenset({CallTypes.anthropic_messages})
+
+        def __init__(self):
+            super().__init__(guardrail_name="protocol-aware", event_hook="post_call", default_on=True)
+            self.own_iterator_called = False
+
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
+            return inputs
+
+        async def async_post_call_streaming_iterator_hook(self, user_api_key_dict, response, request_data):
+            self.own_iterator_called = True
+            async for item in response:
+                yield item
+
+    async def response_stream():
+        yield first_chunk
+        raise AssertionError("upstream requested another chunk before the first chunk was emitted")
+
+    guardrail = _ProtocolAwareGuardrail()
+    monkeypatch.setattr(litellm, "callbacks", [guardrail])
+    guarded_stream = ProxyLogging(user_api_key_cache=DualCache()).async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test", request_route="/v1/messages"),
+        response=response_stream(),
+        request_data={"model": "claude-sonnet-5", "metadata": {}},
+    )
+
+    assert await anext(guarded_stream) == first_chunk
+    assert guardrail.own_iterator_called is True
+    await guarded_stream.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_proxy_logging_hook_detection.py
+++ b/tests/test_litellm/proxy/test_proxy_logging_hook_detection.py
@@ -51,17 +51,6 @@ def test_has_streaming_callbacks_detects_guardrails(monkeypatch):
     assert ProxyLogging.has_streaming_callbacks() is True
 
 
-def test_custom_guardrail_streaming_call_type_capability_is_opt_in():
-    from litellm.types.utils import CallTypes
-
-    class _ProtocolAwareGuardrail(CustomGuardrail):
-        supported_streaming_call_types = frozenset({CallTypes.anthropic_messages})
-
-    assert CustomGuardrail().supports_streaming_call_type(CallTypes.anthropic_messages) is False
-    assert _ProtocolAwareGuardrail().supports_streaming_call_type(CallTypes.anthropic_messages) is True
-    assert _ProtocolAwareGuardrail().supports_streaming_call_type(CallTypes.aresponses) is False
-
-
 @pytest.mark.asyncio
 async def test_post_call_response_headers_hook_returns_early_without_callbacks(
     monkeypatch,
@@ -244,27 +233,28 @@ def _streaming_logging_obj():
     )
 
 
-def test_stream_requires_guardrail_translation_route_detection():
+def test_stream_guardrail_translation_call_type_route_detection():
     from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.types.utils import CallTypes
 
     assert (
-        ProxyLogging._stream_requires_guardrail_translation(
+        ProxyLogging._stream_guardrail_translation_call_type(
             UserAPIKeyAuth(api_key="sk-1234", request_route="/v1/messages")
         )
-        is True
+        is CallTypes.anthropic_messages
     )
     assert (
-        ProxyLogging._stream_requires_guardrail_translation(
+        ProxyLogging._stream_guardrail_translation_call_type(
             UserAPIKeyAuth(api_key="sk-1234", request_route="/chat/completions")
         )
-        is False
+        is None
     )
-    assert ProxyLogging._stream_requires_guardrail_translation(UserAPIKeyAuth(api_key="sk-1234")) is False
+    assert ProxyLogging._stream_guardrail_translation_call_type(UserAPIKeyAuth(api_key="sk-1234")) is None
     assert (
-        ProxyLogging._stream_requires_guardrail_translation(
+        ProxyLogging._stream_guardrail_translation_call_type(
             UserAPIKeyAuth(api_key="sk-1234", request_route="/route/without/call/types")
         )
-        is False
+        is None
     )
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:
- Anthropic streams bypass protocol-aware custom guardrail iterators.
- The Unified fallback can retain the complete response before the first yield.

How it solves it:
- Adds an opt-in set of supported streaming `CallTypes` to `CustomGuardrail`.
- Resolves the active route once and keeps the native iterator when its call type is explicitly supported.
- Preserves the existing Unified fallback for all undeclared guardrails.

## Relevant issues

Fixes #36201

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks before requesting review
- [x] My PR's scope is limited to the issue described above
- [ ] Greptile has reviewed the PR with a score of 4/5 or higher

## Screenshots / Proof of Fix

Regression tests cover both compatibility paths:

- Default custom guardrails remain opt-in and continue using the Unified fallback.
- A guardrail declaring Anthropic streaming support keeps its own iterator and yields the first chunk without consuming the rest of the upstream stream.

Changed test module: 16 passed.  
Ruff checks and `git diff --check`: passed.

## Type

🐛 Bug Fix  
✅ Test

## Changes

- Add an explicit streaming protocol capability to custom guardrails.
- Make proxy hook selection respect that capability.
- Add regression coverage for opt-in behavior and Anthropic stream dispatch.

### Final Attestation

- [x] Tests verify both the new opt-in behavior and backward-compatible fallback.
- [x] No unrelated behavior is changed.