### PR TITLE
feat(auto-router): track turns per complexity tier (LIT-5302)

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260807000000_add_autorouter_session_tier_turns/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260807000000_add_autorouter_session_tier_turns/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "LiteLLM_AutoRouterSession" ADD COLUMN IF NOT EXISTS "tier_turns" JSONB NOT NULL DEFAULT '{}';

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -1439,6 +1439,7 @@ model LiteLLM_AutoRouterSession {
   total_tokens          BigInt   @default(0)
   spend                 Float    @default(0)
   saved_spend           Float    @default(0)
+  tier_turns            Json     @default("{}")
 
   @@id([api_key, session_id, router_name])
   @@index([last_turn_at], map: "idx_autorouter_session_last_turn")

--- a/litellm/proxy/db/autorouter_session_rollup.py
+++ b/litellm/proxy/db/autorouter_session_rollup.py
@@ -49,6 +49,11 @@ class AutoRouterTurnTransaction:
     cache_hit: bool
     cache_ttl_seconds: int | None
     cache_touched: bool
+    # The complexity tier the router decided (or resolved a pinned model to) for this
+    # turn, exactly as the routing_decision recorded it. None when no tier served the
+    # turn (classifier fell back to default_model, or a non-complexity router), and
+    # such turns increment no tier counter rather than a synthetic "unknown" bucket.
+    tier: str | None = None
 
 
 class TurnCacheFacts(NamedTuple):
@@ -152,11 +157,13 @@ def build_autorouter_turn_transaction(
         return None
     usage_object_raw: Final = metadata.get("usage_object")
     cache: Final = turn_cache_facts(usage_object_raw if isinstance(usage_object_raw, Mapping) else None)
+    tier_raw: Final = routing_decision.get("tier")
     return AutoRouterTurnTransaction(
         api_key=api_key,
         session_id=_bounded_session_id(session_id),
         router_name=router_name,
         router_type=str(routing_decision.get("router_type") or "unknown"),
+        tier=tier_raw if isinstance(tier_raw, str) and tier_raw else None,
         model=model,
         turn_at=turn_at,
         total_tokens=int(payload.get("prompt_tokens") or 0) + int(payload.get("completion_tokens") or 0),
@@ -184,6 +191,14 @@ _COVERED: Final = _p("covered")
 _CACHE_HIT: Final = _p("cache_hit")
 _CACHE_TTL: Final = _p("cache_ttl_seconds")
 _TOUCHED: Final = _p("cache_touched")
+_TIER: Final = _p("tier")
+
+# One key per tier that served a turn, incremented per turn. A NULL tier increments
+# nothing: '{}' both on insert and on update, so untiered turns are simply absent
+# rather than pooled under a sentinel key the dashboard would have to special-case.
+_TIER_TURNS_DELTA: Final = (
+    f"(CASE WHEN {_TIER} IS NOT NULL THEN jsonb_build_object({_TIER}, 1) ELSE '{{}}'::jsonb END)"
+)
 
 _IN_ORDER: Final = f"{_TURN_AT}::timestamp >= t.last_turn_at"
 _SAME: Final = f"{_IN_ORDER} AND t.last_model = {_MODEL}"
@@ -201,7 +216,7 @@ INSERT INTO "LiteLLM_AutoRouterSession" AS t (
     last_model, models, turns, unordered_turns, covered_turns, cache_hits,
     same_model_turns, same_model_hits, first_visit_turns, first_visit_hits,
     return_turns, return_hits, return_expired_misses, return_within_ttl_misses,
-    ttl_5m_turns, ttl_1h_turns, total_tokens, spend, saved_spend
+    ttl_5m_turns, ttl_1h_turns, total_tokens, spend, saved_spend, tier_turns
 )
 VALUES (
     {_p("api_key")}, {_p("session_id")}, {_p("router_name")}, {_p("router_type")}, {_TURN_AT}::timestamp, {_TURN_AT}::timestamp,
@@ -211,7 +226,8 @@ VALUES (
     0, 0, 0, 0,
     (CASE WHEN {_CACHE_TTL}::int = {CACHE_TTL_5M_SECONDS} THEN 1 ELSE 0 END),
     (CASE WHEN {_CACHE_TTL}::int = {CACHE_TTL_1H_SECONDS} THEN 1 ELSE 0 END),
-    {_p("total_tokens")}::bigint, {_p("spend")}::float8, {_p("saved_spend")}::float8
+    {_p("total_tokens")}::bigint, {_p("spend")}::float8, {_p("saved_spend")}::float8,
+    {_TIER_TURNS_DELTA}
 )
 ON CONFLICT (api_key, session_id, router_name) DO UPDATE SET
     turns = t.turns + 1,
@@ -242,6 +258,9 @@ ON CONFLICT (api_key, session_id, router_name) DO UPDATE SET
                 ELSE COALESCE((t.models -> {_MODEL} ->> 'ttl')::int, {_CACHE_TTL}::int) END)
     )),
     last_model = (CASE WHEN {_IN_ORDER} THEN {_MODEL} ELSE t.last_model END),
+    tier_turns = (CASE WHEN {_TIER} IS NOT NULL
+        THEN t.tier_turns || jsonb_build_object({_TIER}, COALESCE((t.tier_turns ->> {_TIER})::int, 0) + 1)
+        ELSE t.tier_turns END),
     first_turn_at = LEAST(t.first_turn_at, EXCLUDED.first_turn_at),
     last_turn_at = GREATEST(t.last_turn_at, EXCLUDED.last_turn_at)
 """

--- a/litellm/proxy/management_endpoints/auto_router_endpoints.py
+++ b/litellm/proxy/management_endpoints/auto_router_endpoints.py
@@ -4,11 +4,12 @@ AUTO ROUTER MANAGEMENT ENDPOINTS
 POST /auto_router/test_routing - Route one prompt through an unsaved complexity-router config
 """
 
+import json
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Annotated, Final
 
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, Field, TypeAdapter, field_validator
 
 from litellm._logging import verbose_proxy_logger
 from litellm.exceptions import BudgetExceededError
@@ -284,6 +285,23 @@ class _SessionAggRow(BaseModel):
 _SESSION_AGG_ROWS: Final = TypeAdapter(list[_SessionAggRow])
 
 _BENCHMARKS_SQL: Final = """
+WITH windowed AS (
+    SELECT * FROM "LiteLLM_AutoRouterSession"
+    WHERE last_turn_at >= $1::timestamp AND first_turn_at < $2::timestamp
+),
+tier_maps AS (
+    SELECT router_name, router_type, jsonb_object_agg(tier, tier_turns) AS tier_turns
+    FROM (
+        SELECT router_name, router_type, kv.key AS tier, SUM((kv.value)::int)::int AS tier_turns
+        FROM windowed, LATERAL jsonb_each_text(tier_turns) AS kv
+        GROUP BY router_name, router_type, kv.key
+    ) per_tier
+    GROUP BY router_name, router_type
+)
+SELECT
+    agg.*,
+    COALESCE(tier_maps.tier_turns, '{}'::jsonb)::text AS tier_turns
+FROM (
 SELECT
     router_name,
     router_type,
@@ -306,10 +324,11 @@ SELECT
     COALESCE(SUM(spend), 0)::float8 AS spend,
     COALESCE(SUM(saved_spend), 0)::float8 AS saved_spend,
     COALESCE(SUM(EXTRACT(EPOCH FROM (last_turn_at - first_turn_at))), 0)::float8 AS session_seconds
-FROM "LiteLLM_AutoRouterSession"
-WHERE last_turn_at >= $1::timestamp AND first_turn_at < $2::timestamp
+FROM windowed
 GROUP BY router_name, router_type
-ORDER BY SUM(spend) DESC
+) agg
+LEFT JOIN tier_maps USING (router_name, router_type)
+ORDER BY agg.spend DESC
 """
 
 
@@ -443,6 +462,7 @@ async def get_auto_router_benchmarks(
         AutoRouterBenchmarkGroup(
             router_name=row.router_name,
             router_type=row.router_type,
+            tier_turns=row.tier_turns,
             **_benchmark_totals(row).model_dump(),
         )
         for row in rows

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -1439,6 +1439,7 @@ model LiteLLM_AutoRouterSession {
   total_tokens          BigInt   @default(0)
   spend                 Float    @default(0)
   saved_spend           Float    @default(0)
+  tier_turns            Json     @default("{}")
 
   @@id([api_key, session_id, router_name])
   @@index([last_turn_at], map: "idx_autorouter_session_last_turn")

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -1730,6 +1730,13 @@ class ComplexityRouter(CustomLogger):
                         routing_decision=self._build_routing_decision(
                             routed_model=routed_model,
                             cause=cause,
+                            # No classification ran, but the model this session is pinned to still
+                            # belongs to a tier, and that tier is what actually served the turn. It
+                            # is resolved against the config live at this turn (not the one that set
+                            # the pin) so the record matches the pools the request was served from.
+                            # None when the pin no longer maps to any configured tier, i.e. the
+                            # operator removed the model from every pool while the session was live.
+                            tier=self._tier_for_model(routed_model),
                             escalation_keyword=pin_escalation_keyword,
                             escalated=escalated,
                             conversation_continuing=conversation_continuing,
@@ -1797,6 +1804,7 @@ class ComplexityRouter(CustomLogger):
 
         if user_message is None:
             verbose_router_logger.debug("ComplexityRouter: No user message found, routing to default model")
+            fallback_tier: ComplexityTier | None = None
             if not self.config.plugins and self.config.default_model:
                 # No plugins configured: preserve the pre-existing default_model-first
                 # priority exactly (changing it would be a silent behavior change for
@@ -1809,12 +1817,22 @@ class ComplexityRouter(CustomLogger):
                 routed_model = await self._pick_model_for_tier(
                     ComplexityTier.MEDIUM, messages, resolved_messages, request_kwargs
                 )
+                # This branch asked the MEDIUM pool for the model, so MEDIUM is the tier that
+                # served the turn -- but only when a MEDIUM pool is actually configured.
+                # get_model_for_tier's own branch order (tier pool, then default_model) falls
+                # back to default_model when MEDIUM has no pool, and that fallback is not a
+                # MEDIUM-tier serve; mirroring the same condition here (rather than resolving
+                # the returned model back through _tier_for_model) avoids miscounting a
+                # default_model that happens to also sit in some other tier's pool.
+                if ComplexityTier.MEDIUM.value in self.config.tiers:
+                    fallback_tier = ComplexityTier.MEDIUM
             return PreRoutingHookResponse(
                 model=routed_model,
                 messages=messages if has_original_messages else None,
                 routing_decision=self._build_routing_decision(
                     routed_model=routed_model,
                     cause="default_fallback",
+                    tier=fallback_tier,
                     conversation_continuing=conversation_continuing,
                 ),
             )

--- a/litellm/types/management_endpoints/auto_router_endpoints.py
+++ b/litellm/types/management_endpoints/auto_router_endpoints.py
@@ -120,6 +120,14 @@ class AutoRouterBenchmarkGroup(AutoRouterBenchmarkTotals):
 
     router_name: str = Field(description="The auto-router alias requests were sent to")
     router_type: str = Field(description="complexity, adaptive or quality")
+    tier_turns: dict[str, int] = Field(
+        default_factory=dict,
+        description="Turns per complexity tier, keyed by the tier name the routing decision "
+        "recorded at request time (never re-derived from the routed model). Only complexity "
+        "routers produce tiers; turns that no tier served (classifier fell back to "
+        "default_model) are absent, so the values may sum to less than turns. Per-group only: "
+        "tier names are router-scoped, so a cross-router union would mix taxonomies",
+    )
 
 
 class AutoRouterBenchmarksResponse(BaseModel):

--- a/schema.prisma
+++ b/schema.prisma
@@ -1439,6 +1439,7 @@ model LiteLLM_AutoRouterSession {
   total_tokens          BigInt   @default(0)
   spend                 Float    @default(0)
   saved_spend           Float    @default(0)
+  tier_turns            Json     @default("{}")
 
   @@id([api_key, session_id, router_name])
   @@index([last_turn_at], map: "idx_autorouter_session_last_turn")


### PR DESCRIPTION
## What this does

Adds per-tier turn tracking to the auto-router benchmarks, backend only —
frontend dashboard is a separate follow-up PR.

- Stamps `tier` onto the routing_decision at call sites that previously lacked it (session-affinity pin/escalation, default_fallback-via-MEDIUM), resolved against the router's live config at that turn.
- Rolls a per-tier turn counter into `LiteLLM_AutoRouterSession.tier_turns` (jsonb, keyed by tier name), via the same conditional UPSERT that already maintains `same_model_turns`/`cache_hits`/etc.
- `GET /auto_router/benchmarks` aggregates `tier_turns` per router (`jsonb_object_agg`) and returns it on `AutoRouterBenchmarkGroup.tier_turns: dict[str, int]`.

## Why record at decision time, not derive at read time

The tier→model mapping is mutable config. Re-deriving tier from the routed model at read time would make a 30-day window report *today's* config against turns actually routed under yesterday's. Tier is decided once, at the point the routing decision is made, and the dashboard only sums what was recorded — same reasoning that put `tier_boundaries` on the decision record so a historical spend log row stays explainable after the router config changes.

## Why jsonb, not fixed columns

PR #35915 (open) makes the tier set operator-defined via `tier_definitions`. A fixed column set (`simple_turns`, `medium_turns`, ...) would need a migration per operator taxonomy; jsonb keyed by tier name absorbs that with no schema change.

## Scope

- No new endpoint — extends the existing, already admin-gated `GET /auto_router/benchmarks`.
- Turns not served by any tier (classifier fell back to `default_model`) are simply absent from the map, not pooled under a synthetic key — so per-tier values may sum to less than `turns`.
- Spend-per-tier is intentionally **not** included here (out of scope for this PR); only turns + tier_turns, which is what the frontend dashboard needs for turns/share.

## Testing

- [ ] Migration applies cleanly
- [ ] `tier_turns` populated for complexity-router sessions across the call sites listed above
- [ ] `GET /auto_router/benchmarks` returns `tier_turns` per group, absent key for untiered turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches spend-time session rollup SQL and complexity-router decision metadata; behavior is additive with a safe DB default, but incorrect tier stamping would skew dashboard metrics without affecting routing.
> 
> **Overview**
> Adds **per-tier turn counts** for auto-router benchmarks by recording the complexity tier on each routing decision at request time and rolling it into session analytics.
> 
> **Persistence:** New `tier_turns` JSONB column on `LiteLLM_AutoRouterSession` (migration + Prisma). The session rollup reads `routing_decision.tier`, extends `AutoRouterTurnTransaction` with optional `tier`, and increments per-tier counters in the existing upsert (null tier leaves the map unchanged—no synthetic “unknown” bucket).
> 
> **Routing:** `ComplexityRouter` now sets `tier` on paths that previously omitted it: session-affinity pin serves use `_tier_for_model` against live config; no-user-message fallback sets `MEDIUM` only when a MEDIUM pool exists (avoids mis-labeling `default_model` fallbacks).
> 
> **API:** `GET /auto_router/benchmarks` aggregates session `tier_turns` per router via `jsonb_each` / `jsonb_object_agg` and exposes `tier_turns: dict[str, int]` on each `AutoRouterBenchmarkGroup` (per-router only; untiered turns are absent so sums may be below `turns`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit effae98e59eb443fe32820d1af786c235ab37147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->