### PR TITLE
fix(websearch): restore snippet text in native web_search_tool_result blocks (LIT-5315)

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -9,7 +9,7 @@ server-side using litellm router's search tools.
 import asyncio
 import math
 import uuid
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Final, cast
 
 import litellm
@@ -37,6 +37,8 @@ from litellm.types.integrations.custom_logger import (
     AgenticLoopRequestPatch,
 )
 from litellm.types.integrations.websearch_interception import (
+    AnthropicSearchQuery,
+    AnthropicServerToolUseBlock,
     WebSearchInterceptionConfig,
 )
 from litellm.types.llms.openai import AllMessageValues
@@ -833,22 +835,48 @@ class WebSearchInterceptionLogger(CustomLogger):
     def _build_native_result_blocks(
         tool_calls: list[dict],
         structured_results: list[SearchResponse | None],
-    ) -> list[dict[str, object]]:
-        """Build one ``web_search_tool_result`` block per tool_call."""
-        blocks: Final[list[dict[str, object]]] = []
-        for i, tool_call in enumerate(tool_calls):
-            tool_use_id = tool_call.get("id") or ""
-            structured = structured_results[i] if i < len(structured_results) else None
-            blocks.append(
-                WebSearchTransformation.build_web_search_tool_result_block(
-                    tool_use_id=tool_use_id,
-                    search_response=structured,
-                )
+    ) -> tuple[Mapping[str, object], ...]:
+        """
+        Build a ``server_tool_use`` + ``web_search_tool_result`` pair per tool_call.
+
+        The pair is what Anthropic's spec requires: a bare result block, or one
+        keyed by the model's ``toolu_...`` id instead of a ``srvtoolu_...`` one,
+        is rejected on replay ("String should match pattern '^srvtoolu_'") and
+        leaves native clients without a search to attach the sources to.
+        """
+        return tuple(
+            block
+            for i, tool_call in enumerate(tool_calls)
+            for block in WebSearchInterceptionLogger._native_result_pair(
+                query=WebSearchInterceptionLogger._tool_call_query(tool_call),
+                search_response=structured_results[i] if i < len(structured_results) else None,
             )
-        return blocks
+        )
 
     @staticmethod
-    def _inject_native_blocks(response: Any, native_blocks: list[dict[str, object]]) -> Any:
+    def _tool_call_query(tool_call: Mapping[str, object]) -> str:
+        tool_input: Final = tool_call.get("input")
+        if not isinstance(tool_input, Mapping):
+            return ""
+        query: Final = tool_input.get("query")
+        return query if isinstance(query, str) else ""
+
+    @staticmethod
+    def _native_result_pair(
+        query: str,
+        search_response: SearchResponse | None,
+    ) -> tuple[Mapping[str, object], Mapping[str, object]]:
+        tool_use_id: Final = f"srvtoolu_{uuid.uuid4().hex}"
+        return (
+            AnthropicServerToolUseBlock(id=tool_use_id, input=AnthropicSearchQuery(query=query)).model_dump(),
+            WebSearchTransformation.build_web_search_tool_result_block(
+                tool_use_id=tool_use_id,
+                search_response=search_response,
+            ),
+        )
+
+    @staticmethod
+    def _inject_native_blocks(response: Any, native_blocks: Sequence[Mapping[str, object]]) -> Any:
         """Prepend native blocks to response content, dict or object form."""
         if not native_blocks:
             return response

--- a/litellm/integrations/websearch_interception/transformation.py
+++ b/litellm/integrations/websearch_interception/transformation.py
@@ -412,6 +412,15 @@ class WebSearchTransformation:
         block that should accompany the model's text reply when the original
         request used a native ``web_search_*`` tool.
 
+        The spec'd shape carries page text only in ``encrypted_content``, an
+        opaque server-issued blob that we cannot mint. Emitting the four spec
+        fields alone would drop the snippet entirely, leaving the client (and
+        the model, on any replayed follow-up turn) with URLs and titles but no
+        evidence to answer from, forcing a fetch per result. So the snippet is
+        carried in an additive ``snippet`` key alongside the spec fields.
+        ``encrypted_content`` stays empty rather than holding plaintext, which
+        would assert encryption semantics that do not hold.
+
         Spec reference:
         https://docs.anthropic.com/en/api/web-search-tool
 
@@ -438,6 +447,7 @@ class WebSearchTransformation:
                         "title": title,
                         "page_age": page_age,
                         "encrypted_content": "",
+                        "snippet": getattr(r, "snippet", "") or "",
                     }
                 )
         return {

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -4,9 +4,12 @@ This file contains common utils for anthropic calls.
 
 import copy
 import re
-from typing import Any, Final
+from collections.abc import Mapping, Sequence
+from types import MappingProxyType
+from typing import Any, Final, Literal
 
 import httpx
+from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
 
 import litellm
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
@@ -1055,6 +1058,145 @@ def sanitize_tool_use_ids_in_anthropic_messages(messages: list[Any]) -> list[Any
         else:
             out.append({**m, "content": new_content})
     return out
+
+
+class _ReplayedSearchQuery(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    query: str = ""
+
+
+class _ReplayedWebSearchResult(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["web_search_result"]
+    url: str = ""
+    title: str = ""
+    snippet: str = ""
+    encrypted_content: str = ""
+
+
+class _ReplayedWebSearchToolResult(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["web_search_tool_result"]
+    tool_use_id: str
+    content: tuple[_ReplayedWebSearchResult, ...]
+
+
+class _ReplayedServerToolUse(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["server_tool_use"]
+    id: str
+    input: _ReplayedSearchQuery = _ReplayedSearchQuery()
+
+
+class _TextBlock(BaseModel):
+    type: Literal["text"] = "text"
+    text: str
+
+
+_WEB_SEARCH_TOOL_RESULT_ADAPTER: Final = TypeAdapter(_ReplayedWebSearchToolResult)
+_SERVER_TOOL_USE_ADAPTER: Final = TypeAdapter(_ReplayedServerToolUse)
+
+
+def _flattenable_web_search_tool_result(block: object) -> _ReplayedWebSearchToolResult | None:
+    """
+    The parsed block when it is a ``web_search_tool_result`` carrying results with
+    no ``encrypted_content``, else None for anything Anthropic itself issued.
+    """
+    try:
+        parsed: Final = _WEB_SEARCH_TOOL_RESULT_ADAPTER.validate_python(block)
+    except ValidationError:
+        return None
+    if not parsed.content or any(result.encrypted_content for result in parsed.content):
+        return None
+    return parsed
+
+
+def _replayed_server_tool_use(block: object) -> _ReplayedServerToolUse | None:
+    try:
+        return _SERVER_TOOL_USE_ADAPTER.validate_python(block)
+    except ValidationError:
+        return None
+
+
+def _render_web_search_results(query: str, results: tuple[_ReplayedWebSearchResult, ...]) -> str:
+    header: Final = f"Web search results for '{query}':" if query else "Web search results:"
+    body: Final = "\n\n".join(
+        "\n".join(
+            line
+            for line in (
+                f"Title: {result.title}" if result.title else "",
+                f"URL: {result.url}" if result.url else "",
+                f"Snippet: {result.snippet}" if result.snippet else "",
+            )
+            if line
+        )
+        for result in results
+    )
+    return f"{header}\n\n{body}" if body else header
+
+
+def _rewrite_replayed_web_search_block(
+    block: object,
+    flattenable: Mapping[str, _ReplayedWebSearchToolResult],
+    queries: Mapping[str, str],
+) -> object | None:
+    parsed_result: Final = _flattenable_web_search_tool_result(block)
+    if parsed_result is not None:
+        return _TextBlock(
+            text=_render_web_search_results(queries.get(parsed_result.tool_use_id, ""), parsed_result.content)
+        ).model_dump()
+    parsed_use: Final = _replayed_server_tool_use(block)
+    if parsed_use is not None and parsed_use.id in flattenable:
+        return None
+    return block
+
+
+def _flatten_web_search_results_in_message(message: object) -> object:
+    if not isinstance(message, Mapping) or not isinstance(message.get("content"), Sequence):
+        return message
+    content: Final = message["content"]
+    if isinstance(content, str):
+        return message
+    flattenable: Final = MappingProxyType(
+        {
+            parsed.tool_use_id: parsed
+            for parsed in (_flattenable_web_search_tool_result(block) for block in content)
+            if parsed is not None
+        }
+    )
+    if not flattenable:
+        return message
+    queries: Final = MappingProxyType(
+        {
+            parsed.id: parsed.input.query
+            for parsed in (_replayed_server_tool_use(block) for block in content)
+            if parsed is not None
+        }
+    )
+    rewritten: Final = tuple(_rewrite_replayed_web_search_block(block, flattenable, queries) for block in content)
+    return {**message, "content": [b for b in rewritten if b is not None]}  # mutable-ok: JSON wire format
+
+
+def flatten_unencrypted_web_search_results_in_anthropic_messages(  # mutable-ok: as sibling sanitizers
+    messages: list[Any],
+) -> list[Any]:
+    """
+    Return a new message list with replayed ``web_search_tool_result`` blocks that
+    carry no ``encrypted_content`` rewritten into plain ``text`` blocks holding the
+    same title / url / snippet evidence.
+
+    ``encrypted_content`` is an opaque blob only Anthropic's own search backend can
+    mint, so blocks synthesized by LiteLLM (websearch interception against a search
+    provider) are rejected with ``Invalid encrypted_content in search_result block``
+    when a native client loops them back as history. Flattening them keeps the
+    evidence in the conversation instead of 400ing the follow-up turn, and leaves
+    genuine Anthropic-issued blocks untouched.
+    """
+    return [_flatten_web_search_results_in_message(m) for m in messages]  # mutable-ok: JSON wire format
 
 
 def process_anthropic_headers(headers: httpx.Headers | dict) -> dict:

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -1103,14 +1103,19 @@ _SERVER_TOOL_USE_ADAPTER: Final = TypeAdapter(_ReplayedServerToolUse)
 
 def _flattenable_web_search_tool_result(block: object) -> _ReplayedWebSearchToolResult | None:
     """
-    The parsed block when it is a ``web_search_tool_result`` carrying results with
-    no ``encrypted_content``, else None for anything Anthropic itself issued.
+    The parsed block when it is a ``web_search_tool_result`` carrying no
+    ``encrypted_content``, else None for anything Anthropic itself issued.
+
+    An empty ``content`` list is flattenable too. It is what the interceptor emits
+    when a search legitimately returns nothing and when a search raises, and it
+    carries neither evidence to preserve nor an ``encrypted_content`` to respect,
+    so leaving it in place only buys the 400 this whole function exists to avoid.
     """
     try:
         parsed: Final = _WEB_SEARCH_TOOL_RESULT_ADAPTER.validate_python(block)
     except ValidationError:
         return None
-    if not parsed.content or any(result.encrypted_content for result in parsed.content):
+    if any(result.encrypted_content for result in parsed.content):
         return None
     return parsed
 
@@ -1124,6 +1129,8 @@ def _replayed_server_tool_use(block: object) -> _ReplayedServerToolUse | None:
 
 def _render_web_search_results(query: str, results: tuple[_ReplayedWebSearchResult, ...]) -> str:
     header: Final = f"Web search results for '{query}':" if query else "Web search results:"
+    if not results:
+        return f"{header}\n\nNo results were returned."
     body: Final = "\n\n".join(
         "\n".join(
             line

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -14,6 +14,7 @@ from typing import Any, Final, cast
 import litellm
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.anthropic.common_utils import (
+    flatten_unencrypted_web_search_results_in_anthropic_messages,
     sanitize_tool_use_ids_in_anthropic_messages,
     strip_empty_text_blocks_from_anthropic_messages,
 )
@@ -222,6 +223,7 @@ async def anthropic_messages(
     # Replay of cross-provider tool history (e.g. kimi -> Anthropic) may carry
     # ids like ``functions.Bash:0`` that violate Anthropic's id pattern.
     messages = sanitize_tool_use_ids_in_anthropic_messages(messages)
+    messages = flatten_unencrypted_web_search_results_in_anthropic_messages(messages)
 
     from litellm.integrations.anthropic_cache_control_hook import (
         AnthropicCacheControlHook,
@@ -413,6 +415,7 @@ def anthropic_messages_handler(
     if not kwargs.pop("_litellm_messages_presanitized", False):
         messages = strip_empty_text_blocks_from_anthropic_messages(messages)
         messages = sanitize_tool_use_ids_in_anthropic_messages(messages)
+        messages = flatten_unencrypted_web_search_results_in_anthropic_messages(messages)
 
     from litellm.integrations.anthropic_cache_control_hook import (
         AnthropicCacheControlHook,

--- a/litellm/types/integrations/websearch_interception.py
+++ b/litellm/types/integrations/websearch_interception.py
@@ -2,7 +2,28 @@
 Type definitions for WebSearch Interception integration.
 """
 
-from typing import TypedDict
+from typing import Literal, TypedDict
+
+from pydantic import BaseModel
+
+
+class AnthropicSearchQuery(BaseModel):
+    """``input`` of an Anthropic ``server_tool_use`` block for a web search."""
+
+    query: str
+
+
+class AnthropicServerToolUseBlock(BaseModel):
+    """
+    The ``server_tool_use`` block that must accompany a ``web_search_tool_result``.
+
+    Anthropic requires the pair, with a ``srvtoolu_``-prefixed id shared by both.
+    """
+
+    type: Literal["server_tool_use"] = "server_tool_use"
+    id: str
+    name: Literal["web_search"] = "web_search"
+    input: AnthropicSearchQuery
 
 
 class WebSearchInterceptionConfig(TypedDict, total=False):

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_native_blocks.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_native_blocks.py
@@ -247,11 +247,15 @@ class TestBuildPlanAttachesBlocks:
             )
 
         blocks = plan.metadata.get(WEBSEARCH_NATIVE_BLOCKS_METADATA_KEY)
-        assert isinstance(blocks, list)
-        assert len(blocks) == 1
-        assert blocks[0]["type"] == "web_search_tool_result"
-        assert blocks[0]["tool_use_id"] == "toolu_one"
-        assert blocks[0]["content"][0]["url"] == "https://docs.litellm.ai/"
+        assert isinstance(blocks, tuple)
+        assert [b["type"] for b in blocks] == [
+            "server_tool_use",
+            "web_search_tool_result",
+        ]
+        assert blocks[0]["id"].startswith("srvtoolu_")
+        assert blocks[0]["input"] == {"query": "what is litellm"}
+        assert blocks[1]["tool_use_id"] == blocks[0]["id"]
+        assert blocks[1]["content"][0]["url"] == "https://docs.litellm.ai/"
 
     @pytest.mark.asyncio
     async def test_metadata_does_not_carry_blocks_when_flag_absent(self):
@@ -503,6 +507,9 @@ class TestLegacyPathMatchesNewPath:
                 kwargs={WEBSEARCH_EMIT_NATIVE_BLOCKS_KEY: True},
             )
 
-        assert out["content"][0]["type"] == "web_search_tool_result"
-        assert out["content"][0]["tool_use_id"] == "toolu_legacy"
-        assert out["content"][1]["type"] == "text"
+        assert [b["type"] for b in out["content"]] == [
+            "server_tool_use",
+            "web_search_tool_result",
+            "text",
+        ]
+        assert out["content"][1]["tool_use_id"] == out["content"][0]["id"]

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_native_blocks.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_native_blocks.py
@@ -134,6 +134,30 @@ class TestBuildWebSearchToolResultBlock:
         assert first["title"] == "LiteLLM Docs"
         assert first["page_age"] == "2025-01-15"
         assert first["encrypted_content"] == ""
+        assert first["snippet"] == "Unified interface for LLMs."
+
+    def test_snippet_carried_for_every_result(self):
+        # The snippet is the only field carrying page text. Losing it leaves the
+        # client and the model with nothing to answer from, forcing a fetch per
+        # result.
+        block = WebSearchTransformation.build_web_search_tool_result_block(
+            tool_use_id="toolu_abc",
+            search_response=_make_search_response(),
+        )
+        assert [r["snippet"] for r in block["content"]] == [
+            "Unified interface for LLMs.",
+            "Pay-per-use pricing model.",
+        ]
+
+    def test_missing_snippet_degrades_to_empty_string(self):
+        response = SearchResponse(
+            results=[SearchResult(title="T", url="https://x/", snippet="")]
+        )
+        block = WebSearchTransformation.build_web_search_tool_result_block(
+            tool_use_id="toolu_abc",
+            search_response=response,
+        )
+        assert block["content"][0]["snippet"] == ""
 
     def test_handles_none_search_response(self):
         block = WebSearchTransformation.build_web_search_tool_result_block(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -732,6 +732,61 @@ def test_handler_skips_strip_when_presanitized():
     assert result is not None
 
 
+def test_handler_flattens_replayed_unencrypted_web_search_results():
+    """Synthesized search blocks replayed as history must reach the provider as text."""
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    captured = {}
+
+    def fake_base_handler(*args, **kwargs):
+        captured.update(kwargs)
+        return "stub"
+
+    with patch.object(
+        handler.base_llm_http_handler,
+        "anthropic_messages_handler",
+        side_effect=fake_base_handler,
+    ):
+        handler.anthropic_messages_handler(
+            max_tokens=10,
+            messages=[
+                {"role": "user", "content": "latest litellm version?"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "server_tool_use",
+                            "id": "srvtoolu_1",
+                            "name": "web_search",
+                            "input": {"query": "latest litellm version"},
+                        },
+                        {
+                            "type": "web_search_tool_result",
+                            "tool_use_id": "srvtoolu_1",
+                            "content": [
+                                {
+                                    "type": "web_search_result",
+                                    "url": "https://github.com/BerriAI/litellm/releases",
+                                    "title": "Releases",
+                                    "page_age": None,
+                                    "encrypted_content": "",
+                                    "snippet": "Latest release v1.95.0",
+                                }
+                            ],
+                        },
+                    ],
+                },
+                {"role": "user", "content": "which version?"},
+            ],
+            model="anthropic/claude-3-5-sonnet-20241022",
+            custom_llm_provider="anthropic",
+        )
+
+    replayed = captured["messages"][1]["content"]
+    assert [b["type"] for b in replayed] == ["text"]
+    assert "Snippet: Latest release v1.95.0" in replayed[0]["text"]
+
+
 def test_presanitized_flag_not_leaked_to_provider_params():
     """The private sentinel must be popped, never forwarded as a request param."""
     from litellm.llms.anthropic.experimental_pass_through.messages import handler

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -12,6 +12,7 @@ Verifies that:
 
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -1501,6 +1502,48 @@ class TestAnthropicThinkingSignatureSelfHeal:
         assert "URL: https://github.com/BerriAI/litellm/releases" in flattened
         assert "Snippet: Latest release v1.95.0" in flattened
         assert msgs[1]["content"][0]["type"] == "server_tool_use"
+
+    @pytest.mark.parametrize("results", [[], None], ids=["empty_list", "search_raised"])
+    def test_flatten_unencrypted_web_search_results_flattens_a_resultless_search(self, results):
+        """A search that found nothing, or that raised, still has to be flattened.
+
+        Both cases reach the client as ``content: []``, and leaving that block in
+        place ships an unsupported tag to Bedrock on the next turn just as surely
+        as a populated one does.
+        """
+        from litellm.integrations.websearch_interception.transformation import (
+            WebSearchTransformation,
+        )
+        from litellm.llms.anthropic.common_utils import (
+            flatten_unencrypted_web_search_results_in_anthropic_messages,
+        )
+
+        block = WebSearchTransformation.build_web_search_tool_result_block(
+            tool_use_id="srvtoolu_1",
+            search_response=None if results is None else SimpleNamespace(results=results),
+        )
+        assert block["content"] == [], "fixture drifted from what the interceptor emits"
+
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "server_tool_use",
+                        "id": "srvtoolu_1",
+                        "name": "web_search",
+                        "input": {"query": "who won"},
+                    },
+                    block,
+                    {"type": "text", "text": "I could not find that."},
+                ],
+            }
+        ]
+
+        out = flatten_unencrypted_web_search_results_in_anthropic_messages(msgs)
+
+        assert [b["type"] for b in out[0]["content"]] == ["text", "text"]
+        assert out[0]["content"][0]["text"] == ("Web search results for 'who won':\n\nNo results were returned.")
 
     def test_flatten_unencrypted_web_search_results_preserves_real_anthropic_blocks(self):
         from litellm.llms.anthropic.common_utils import (

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1457,6 +1457,112 @@ class TestAnthropicThinkingSignatureSelfHeal:
         out = strip_empty_text_blocks_from_anthropic_messages(msgs)
         assert [b["type"] for b in out[0]["content"]] == ["tool_result"]
 
+    def test_flatten_unencrypted_web_search_results_keeps_snippet_evidence(self):
+        from litellm.llms.anthropic.common_utils import (
+            flatten_unencrypted_web_search_results_in_anthropic_messages,
+        )
+
+        msgs = [
+            {"role": "user", "content": "latest litellm version?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "server_tool_use",
+                        "id": "srvtoolu_1",
+                        "name": "web_search",
+                        "input": {"query": "latest litellm version"},
+                    },
+                    {
+                        "type": "web_search_tool_result",
+                        "tool_use_id": "srvtoolu_1",
+                        "content": [
+                            {
+                                "type": "web_search_result",
+                                "url": "https://github.com/BerriAI/litellm/releases",
+                                "title": "Releases",
+                                "page_age": None,
+                                "encrypted_content": "",
+                                "snippet": "Latest release v1.95.0",
+                            }
+                        ],
+                    },
+                    {"type": "text", "text": "v1.95.0"},
+                ],
+            },
+        ]
+
+        out = flatten_unencrypted_web_search_results_in_anthropic_messages(msgs)
+
+        assert out[0] is msgs[0]
+        assert [b["type"] for b in out[1]["content"]] == ["text", "text"]
+        flattened = out[1]["content"][0]["text"]
+        assert "Web search results for 'latest litellm version':" in flattened
+        assert "URL: https://github.com/BerriAI/litellm/releases" in flattened
+        assert "Snippet: Latest release v1.95.0" in flattened
+        assert msgs[1]["content"][0]["type"] == "server_tool_use"
+
+    def test_flatten_unencrypted_web_search_results_preserves_real_anthropic_blocks(self):
+        from litellm.llms.anthropic.common_utils import (
+            flatten_unencrypted_web_search_results_in_anthropic_messages,
+        )
+
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "server_tool_use",
+                        "id": "srvtoolu_1",
+                        "name": "web_search",
+                        "input": {"query": "q"},
+                    },
+                    {
+                        "type": "web_search_tool_result",
+                        "tool_use_id": "srvtoolu_1",
+                        "content": [
+                            {
+                                "type": "web_search_result",
+                                "url": "https://example.com",
+                                "title": "Example",
+                                "page_age": None,
+                                "encrypted_content": "EqgfCioIARgBIiQ4",
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+
+        out = flatten_unencrypted_web_search_results_in_anthropic_messages(msgs)
+
+        assert out[0] is msgs[0]
+
+    def test_flatten_unencrypted_web_search_results_leaves_error_blocks_alone(self):
+        from litellm.llms.anthropic.common_utils import (
+            flatten_unencrypted_web_search_results_in_anthropic_messages,
+        )
+
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "web_search_tool_result",
+                        "tool_use_id": "srvtoolu_1",
+                        "content": {
+                            "type": "web_search_tool_result_error",
+                            "error_code": "max_uses_exceeded",
+                        },
+                    }
+                ],
+            }
+        ]
+
+        out = flatten_unencrypted_web_search_results_in_anthropic_messages(msgs)
+
+        assert out[0] is msgs[0]
+
     def test_sanitize_tool_use_ids_in_anthropic_messages(self):
         from litellm.llms.anthropic.common_utils import (
             sanitize_tool_use_ids_in_anthropic_messages,

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -10,6 +10,7 @@ Verifies that:
 - ANTHROPIC_API_KEY / ANTHROPIC_API_BASE take precedence over their aliases.
 """
 
+import json
 import os
 import sys
 from types import SimpleNamespace
@@ -1544,6 +1545,42 @@ class TestAnthropicThinkingSignatureSelfHeal:
 
         assert [b["type"] for b in out[0]["content"]] == ["text", "text"]
         assert out[0]["content"][0]["text"] == ("Web search results for 'who won':\n\nNo results were returned.")
+
+    @pytest.mark.parametrize("results", [[SimpleNamespace(title="Rome", url="u", snippet="s", date=None)], []])
+    def test_flatten_unencrypted_web_search_results_is_idempotent(self, results):
+        """Flattening twice must equal flattening once.
+
+        The agentic loop re-enters the same entry point for its follow-up call and
+        hands it the original history, so this runs again on already-flattened
+        messages once per iteration. A pass that appended instead of replacing
+        would duplicate the evidence on every loop.
+        """
+        from litellm.integrations.websearch_interception.transformation import (
+            WebSearchTransformation,
+        )
+        from litellm.llms.anthropic.common_utils import (
+            flatten_unencrypted_web_search_results_in_anthropic_messages,
+        )
+
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "server_tool_use", "id": "srvtoolu_1", "name": "web_search", "input": {"query": "when"}},
+                    WebSearchTransformation.build_web_search_tool_result_block(
+                        tool_use_id="srvtoolu_1",
+                        search_response=SimpleNamespace(results=results),
+                    ),
+                    {"type": "text", "text": "753 BC."},
+                ],
+            }
+        ]
+
+        once = flatten_unencrypted_web_search_results_in_anthropic_messages(msgs)
+        twice = flatten_unencrypted_web_search_results_in_anthropic_messages(once)
+
+        assert [b["type"] for b in once[0]["content"]] == ["text", "text"]
+        assert json.dumps(twice) == json.dumps(once)
 
     def test_flatten_unencrypted_web_search_results_preserves_real_anthropic_blocks(self):
         from litellm.llms.anthropic.common_utils import (

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -2515,3 +2516,67 @@ def test_bedrock_messages_thinking_shape_follows_exact_bedrock_entry_flag(
     assert thinking.get("type") == "enabled"
     assert isinstance(thinking.get("budget_tokens"), int)
     assert "output_config" not in flipped
+
+
+@pytest.mark.parametrize(
+    "search_results, expected_evidence",
+    [
+        pytest.param(
+            [SimpleNamespace(title="Rome", url="https://ex.com/rome", snippet="Founded 753 BC.", date=None)],
+            "Snippet: Founded 753 BC.",
+            id="search_returned_results",
+        ),
+        pytest.param([], "No results were returned.", id="search_returned_nothing"),
+    ],
+)
+def test_replayed_intercepted_search_turn_leaves_no_unsupported_block_for_bedrock(search_results, expected_evidence):
+    """A native client replaying an intercepted search turn must not 400 on Bedrock.
+
+    ``websearch_interception`` hands Claude Desktop an Anthropic-native
+    ``server_tool_use`` + ``web_search_tool_result`` pair, and Anthropic's protocol
+    obliges the client to replay that assistant turn verbatim on every later turn.
+    Bedrock's Anthropic schema defines neither tag, so both have to be gone from the
+    outbound body by the time it is signed, with the search evidence carried forward
+    as text instead. Built from the real builder rather than a hand-written fixture
+    so the two cannot drift apart.
+    """
+    from litellm.integrations.websearch_interception.transformation import (
+        WebSearchTransformation,
+    )
+    from litellm.llms.anthropic.common_utils import (
+        flatten_unencrypted_web_search_results_in_anthropic_messages,
+    )
+    from litellm.types.router import GenericLiteLLMParams
+
+    replayed_turn = [
+        {
+            "type": "server_tool_use",
+            "id": "srvtoolu_1",
+            "name": "web_search",
+            "input": {"query": "when was Rome founded"},
+        },
+        WebSearchTransformation.build_web_search_tool_result_block(
+            tool_use_id="srvtoolu_1",
+            search_response=SimpleNamespace(results=search_results),
+        ),
+        {"type": "text", "text": "Rome was founded in 753 BC."},
+    ]
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "When was Rome founded?"}]},
+        {"role": "assistant", "content": replayed_turn},
+        {"role": "user", "content": [{"type": "text", "text": "Repeat the year."}]},
+    ]
+
+    body = AmazonAnthropicClaudeMessagesConfig().transform_anthropic_messages_request(
+        model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        messages=flatten_unencrypted_web_search_results_in_anthropic_messages(messages),
+        anthropic_messages_optional_request_params={"max_tokens": 64},
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    serialized = json.dumps(body)
+    assert "web_search_tool_result" not in serialized
+    assert "server_tool_use" not in serialized
+    assert expected_evidence in serialized
+    assert "Rome was founded in 753 BC." in serialized


### PR DESCRIPTION
## TLDR

Problem this solves:

- Replayed intercepted web search turns 400 on Bedrock
- Snippet text never reached the client, forcing a fetch per URL
- A resultless or failed search still 400s the next turn
- No test anywhere replayed an intercepted search turn

How it solves it:

- Carry the snippet on each `web_search_result`
- Pair each result block with its own `srvtoolu_` `server_tool_use`
- Rewrite replayed unencrypted blocks to text before dispatch
- Flatten an empty result list too, not only a populated one
- Assert the outbound Bedrock body over both cases

## User Flow

Before: someone using a native Anthropic client against a Bedrock-backed gateway with web search interception on loses the conversation on the turn after any search

1. They ask a question needing current information, and the gateway runs the search and answers correctly
2. Their client stores the assistant turn it was handed, which lists each source as a url and a title with no page text
3. They send a follow-up message, and the client replays that stored assistant turn as the protocol requires
4. The gateway returns `400` with `Input tag 'server_tool_use' found using 'type' does not match any of the expected tags: 'document', 'image', 'redacted_thinking', 'search_result', 'text', 'thinking', 'tool_result', 'tool_use'`
5. Every later message in that conversation fails the same way, because the client keeps replaying the same turn
6. Deleting the search turn from the history by hand makes the request succeed, at the cost of the sources

After: the same follow-up succeeds, and the model can still answer from the search evidence

1. They ask the same question and get the same answer
2. Their client stores an assistant turn whose sources now carry the snippet text alongside the url and title
3. They send a follow-up message, and the client replays that stored assistant turn unchanged
4. The gateway returns `200` and the model answers from the replayed evidence rather than fetching each url again
5. This holds when the search found nothing and when the search failed, where the turn previously still returned `400`

## Relevant issues

## Linear ticket

Resolves LIT-5315
Resolves LIT-5320

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Three live proxies against real Bedrock, `bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0` in `us-east-1`, billed to a real account. Config is the one this feature ships for:

```yaml
model_list:
  - model_name: claude-sonnet-bedrock
    litellm_params:
      model: bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0
      aws_region_name: us-east-1

litellm_settings:
  callbacks: ["websearch_interception"]
  websearch_interception_params:
    enabled_providers: ["bedrock"]
```

The replayed assistant turn is generated by `WebSearchTransformation.build_web_search_tool_result_block` itself rather than written by hand, so it is byte-for-byte what a native client would be handed:

```bash
$ curl -s -X POST http://127.0.0.1:$PORT/v1/messages \
    -H "x-api-key: $KEY" -H 'anthropic-version: 2023-06-01' \
    -H 'content-type: application/json' -d @messages_replay_with_results.json
```

Each request replays one assistant turn holding `server_tool_use` + `web_search_tool_result` and then asks `Reply with only the year you just gave me.`

**Before, at `1e7b39d15c` (`litellm_internal_staging`), port 4071**

```
REPLAY, search returned results              HTTP 400
{"message":"messages.1.content.0: Input tag 'server_tool_use' found using 'type' does not match
 any of the expected tags: 'document', 'image', 'redacted_thinking', 'search_result', 'text',
 'thinking', 'tool_result', 'tool_use'"}

REPLAY, search returned nothing              HTTP 400
{"message":"messages.1.content.0: Input tag 'server_tool_use' found using 'type' does not match ..."}

CONTROL, same turn minus the search blocks   HTTP 200
{"content":[{"type":"text","text":"753 BC"}],"usage":{"input_tokens":620,"output_tokens":7}}
```

The control answers correctly on the unfixed build, so the `400` is attributable to the replayed block and to nothing else in the request.

**Intermediate, at `878c1278e2`, port 4072**

```
REPLAY, search returned results              HTTP 200   {"text":"753 BC"}
REPLAY, search returned nothing              HTTP 400   Input tag 'server_tool_use' ...
CONTROL                                      HTTP 200   {"text":"753 BC"}
```

The resultless case was still dead here, which is what `b9c0eee88b` fixes.

**After, at `b9c0eee88b`, port 4073**

```
REPLAY, search returned results              HTTP 200
{"id":"msg_bdrk_01MYUypwKX64svUGJFX6h7JS","content":[{"type":"text","text":"753 BC"}],
 "usage":{"input_tokens":651,"output_tokens":7}}

REPLAY, search returned nothing              HTTP 200
{"id":"msg_bdrk_01NxXE35hjenKFMw3fxnEk6w","content":[{"type":"text","text":"753 BC"}],
 "usage":{"input_tokens":637,"output_tokens":7}}

CONTROL, same turn minus the search blocks   HTTP 200
{"id":"msg_bdrk_018g4Ym49QcnAT5hFnF9UmpS","content":[{"type":"text","text":"753 BC"}],
 "usage":{"input_tokens":620,"output_tokens":7}}
```

The 651 vs 620 input-token gap on the results-present run is the flattened search evidence still being carried into the prompt, so the model is answering from the sources rather than from a stripped history.

## Type

🐛 Bug Fix

## Changes

`build_web_search_tool_result_block` carries `snippet` on each result, and emits its own `srvtoolu_` `server_tool_use` paired with each result block, since a bare result block is rejected on replay.

`flatten_unencrypted_web_search_results_in_anthropic_messages` rewrites a replayed block that carries no `encrypted_content` into a text block holding the same title, url and snippet, and drops the paired `server_tool_use` with it. Blocks Anthropic itself issued keep a real `encrypted_content` and are left untouched, so native Anthropic behaviour is unchanged.

An empty `content` list flattens on the same path. That is what the interceptor emits both when a search legitimately returns nothing and when a search raises, and it holds neither evidence to preserve nor an `encrypted_content` to respect, so leaving it in place only bought back the `400` the flatten exists to avoid. The rendered text says `No results were returned.` rather than emitting a bare header.

Tests: the outbound Bedrock invoke body is asserted free of both block types, parametrized over the results-present and resultless cases, built from the interceptor's own builder so the fixture cannot drift from what it emits. Mutation checked per site: restoring the empty-content bail fails 3, dropping the resultless rendering fails 3, restored 7 pass. Affected suites 916 passed, 2 skipped.

Scope note: the `/chat/completions` surfaces mishandle a replayed search turn too, and are deliberately left alone. Interception never mints `srvtoolu_` ids or `web_search_tool_result` blocks there, so reaching them needs a cross-provider replay where a client runs an Anthropic-native search and later replays that history against Bedrock. Confirmed live for completeness: `/chat/completions` returns `400` "tool_use ids were found without tool_result blocks immediately after", and Bedrock Converse silently drops the search turn instead. Both want their own tickets

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conversation shaping on every `/v1/messages` request with replayed search history; incorrect flattening could drop citations or alter multi-turn behavior, though real Anthropic encrypted blocks are explicitly preserved.
> 
> **Overview**
> Fixes **multi-turn failures** when native Anthropic clients replay intercepted web-search assistant turns against Bedrock-backed `/v1/messages`.
> 
> **Websearch interception** now emits a spec-correct **`server_tool_use` + `web_search_tool_result` pair** per search (shared `srvtoolu_` id) instead of a lone result block tied to the model’s `toolu_` id. Each **`web_search_result`** also carries an additive **`snippet`** field so clients and follow-ups have page text without relying on `encrypted_content`.
> 
> **Before dispatch**, `flatten_unencrypted_web_search_results_in_anthropic_messages` rewrites LiteLLM-synthesized blocks (no real `encrypted_content`) into **plain text** with title/URL/snippet, drops the paired `server_tool_use`, and handles **empty result lists** the same way—so Bedrock no longer 400s on unsupported `server_tool_use` / `web_search_tool_result` tags while preserving evidence. Genuine Anthropic blocks with `encrypted_content` are left unchanged.
> 
> Wired into the Anthropic messages handler (async + sync paths) alongside existing message sanitizers; tests cover snippets, native block pairs, flattening edge cases, and Bedrock outbound bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3958abe8d36b740585d6bb8820c92f9e6ee09f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->