### PR TITLE
fix(vertex_ai): honor Anthropic-shaped input_schema on Gemini tools

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -6,6 +6,7 @@ import time
 from collections.abc import Callable, Mapping
 from copy import deepcopy
 from functools import partial
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, Union, cast
 
 import httpx
@@ -606,7 +607,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             elif "name" in tool:  # functions list
                 _input_schema = tool.get("input_schema") if tool.get("parameters") is None else None
                 _named_tool = (
-                    {**tool, "parameters": _build_vertex_schema(_input_schema)}
+                    MappingProxyType({**tool, "parameters": _build_vertex_schema(_input_schema)})
                     if isinstance(_input_schema, dict)
                     else tool
                 )

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -604,7 +604,14 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 openai_function_object = _openai_function_object
 
             elif "name" in tool:  # functions list
-                openai_function_object = ChatCompletionToolParamFunctionChunk(**tool)
+                _named_function_object = ChatCompletionToolParamFunctionChunk(**tool)
+
+                if _named_function_object.get("parameters") is None:
+                    _input_schema = tool.get("input_schema")
+                    if isinstance(_input_schema, dict):
+                        _named_function_object["parameters"] = _build_vertex_schema(_input_schema)
+
+                openai_function_object = _named_function_object
 
             if "type" in tool and tool["type"] == "computer_use":
                 computer_use_config = {k: v for k, v in tool.items() if k != "type"}

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -604,14 +604,13 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 openai_function_object = _openai_function_object
 
             elif "name" in tool:  # functions list
-                _named_function_object = ChatCompletionToolParamFunctionChunk(**tool)
-
-                if _named_function_object.get("parameters") is None:
-                    _input_schema = tool.get("input_schema")
-                    if isinstance(_input_schema, dict):
-                        _named_function_object["parameters"] = _build_vertex_schema(_input_schema)
-
-                openai_function_object = _named_function_object
+                _input_schema = tool.get("input_schema") if tool.get("parameters") is None else None
+                _named_tool = (
+                    {**tool, "parameters": _build_vertex_schema(_input_schema)}
+                    if isinstance(_input_schema, dict)
+                    else tool
+                )
+                openai_function_object = ChatCompletionToolParamFunctionChunk(**_named_tool)
 
             if "type" in tool and tool["type"] == "computer_use":
                 computer_use_config = {k: v for k, v in tool.items() if k != "type"}

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -1182,6 +1182,94 @@ def test_vertex_ai_map_tool_with_anyof():
     }, f"Expected only anyOf field and its contents to be kept, but got {new_tools[0]['function_declarations'][0]['parameters']['properties']['base_branch']}"
 
 
+def _anthropic_shaped_tool(input_schema: dict) -> dict:
+    return {
+        "name": "get_weather",
+        "description": "Get the current weather for a location.",
+        "input_schema": input_schema,
+    }
+
+
+def _declaration_for(tool: dict) -> dict:
+    """Map a single tool through the public entry point and return its FunctionDeclaration."""
+    transformed = VertexGeminiConfig().map_openai_params(
+        non_default_params={"tools": [deepcopy(tool)]},
+        optional_params={},
+        model="gemini-2.5-flash",
+        drop_params=False,
+    )
+    return transformed["tools"][0]["function_declarations"][0]
+
+
+def test_vertex_ai_map_tool_with_anthropic_input_schema():
+    """
+    Related issue: https://github.com/BerriAI/litellm/issues/35685
+
+    A tool that carries its schema under Anthropic's `input_schema` key instead of
+    OpenAI's `parameters` must still reach Gemini with its parameters. Dropping them
+    produces an HTTP 200 and a tool call with empty arguments, so the failure is
+    silent and the model never sees the schema it needed.
+    """
+    declaration = _declaration_for(
+        _anthropic_shaped_tool(
+            {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"],
+            }
+        )
+    )
+
+    assert declaration["name"] == "get_weather"
+    assert declaration.get("parameters") == {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+    }, f"input_schema was dropped from the Gemini FunctionDeclaration: {declaration}"
+
+
+def test_vertex_ai_map_tool_input_schema_gets_vertex_schema_conversion():
+    """
+    `input_schema` is JSON Schema just like `parameters`, so it needs the same
+    OpenAPI conversion. Passing it through raw leaves `$defs`/`$ref` in place, which
+    Vertex rejects.
+    """
+    declaration = _declaration_for(
+        _anthropic_shaped_tool(
+            {
+                "type": "object",
+                "properties": {"loc": {"$ref": "#/$defs/Loc"}},
+                "$defs": {"Loc": {"type": "object", "properties": {"city": {"type": "string"}}}},
+            }
+        )
+    )
+
+    parameters = declaration["parameters"]
+    assert "$defs" not in parameters
+    assert parameters["properties"]["loc"] == {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+    }, f"$ref was not unwound: {parameters}"
+
+
+def test_vertex_ai_map_tool_explicit_parameters_wins_over_input_schema():
+    """A tool carrying both keys must keep `parameters` — `input_schema` is only a fallback."""
+    tool = _anthropic_shaped_tool({"type": "object", "properties": {"ignored": {"type": "string"}}})
+    tool["parameters"] = {"type": "object", "properties": {"location": {"type": "string"}}}
+
+    declaration = _declaration_for(tool)
+
+    assert declaration["parameters"]["properties"] == {"location": {"type": "string"}}
+
+
+def test_vertex_ai_map_tool_without_any_schema_is_unchanged():
+    """A named tool with no schema at all must still map, without inventing parameters."""
+    declaration = _declaration_for({"name": "ping", "description": "no args"})
+
+    assert declaration["name"] == "ping"
+    assert "parameters" not in declaration
+
+
 def test_vertex_ai_streaming_usage_calculation():
     """
     Ensure streaming usage calculation uses same function as non-streaming usage calculation

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -1254,12 +1254,30 @@ def test_vertex_ai_map_tool_input_schema_gets_vertex_schema_conversion():
 
 def test_vertex_ai_map_tool_explicit_parameters_wins_over_input_schema():
     """A tool carrying both keys must keep `parameters` — `input_schema` is only a fallback."""
-    tool = _anthropic_shaped_tool({"type": "object", "properties": {"ignored": {"type": "string"}}})
-    tool["parameters"] = {"type": "object", "properties": {"location": {"type": "string"}}}
+    tool = {
+        **_anthropic_shaped_tool({"type": "object", "properties": {"ignored": {"type": "string"}}}),
+        "parameters": {"type": "object", "properties": {"location": {"type": "string"}}},
+    }
 
     declaration = _declaration_for(tool)
 
     assert declaration["parameters"]["properties"] == {"location": {"type": "string"}}
+
+
+def test_vertex_ai_map_tool_null_parameters_falls_back_to_input_schema():
+    """A JSON `"parameters": null` alongside `input_schema` must take the fallback, not
+    send a null schema upstream."""
+    tool = {
+        **_anthropic_shaped_tool({"type": "object", "properties": {"location": {"type": "string"}}}),
+        "parameters": None,
+    }
+
+    declaration = _declaration_for(tool)
+
+    assert declaration["parameters"] == {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+    }
 
 
 def test_vertex_ai_map_tool_without_any_schema_is_unchanged():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini silently drops tool schemas given under Anthropic's `input_schema`
- Model then calls the function with empty arguments, no error raised

How it solves it:

- Fall back to `input_schema` when `parameters` is absent
- Run it through `_build_vertex_schema`, same as the OpenAI path

## Relevant issues

Fixes #35685

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

There are no Vertex credentials in this environment, so the live run below is the exact command list rather than captured output. `dev_config.yaml` has no Vertex Gemini entry, so add one first:

```yaml
  - model_name: vertex-gemini-flash
    litellm_params:
      model: vertex_ai/gemini-2.5-flash
      vertex_project: os.environ/VERTEX_PROJECT
      vertex_location: us-central1
```

1. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload 2>&1 | tee litellm.log`
2. Send a tool whose schema uses the Anthropic key, forcing a call:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "vertex-gemini-flash",
    "messages": [{"role": "user", "content": "What is the weather in Paris?"}],
    "tool_choice": "required",
    "tools": [{
      "name": "get_weather",
      "description": "Get the current weather for a location.",
      "input_schema": {
        "type": "object",
        "properties": {"location": {"type": "string"}},
        "required": ["location"]
      }
    }]
  }' | jq '.choices[0].message.tool_calls[0].function.arguments'
```

Before the fix that prints `"{}"`. After it prints `"{\"location\": \"Paris\"}"`. Grepping litellm.log for `functionDeclarations` shows the same story on the request side: no `parameters` key before, the full schema after

Same call with the schema under `parameters` instead of `input_schema` is unchanged by this PR, which is the regression worth spot-checking

## Type

🐛 Bug Fix

## Changes

`_map_function` builds a Gemini `FunctionDeclaration` from each tool, but the functions-list branch only ever read `parameters`. `ChatCompletionToolParamFunctionChunk` is a TypedDict, so `ChatCompletionToolParamFunctionChunk(**tool)` keeps an `input_schema` key without validating anything, and nothing downstream ever looked at it. The declaration went upstream with a name and description and no parameters, which Vertex accepts, so the caller got HTTP 200 and a tool call with `{}` for arguments

The fix reads `input_schema` only when `parameters` is absent, so an explicit `parameters` still wins and the existing empty-string handling below is untouched. It runs the result through `_build_vertex_schema` because `input_schema` is JSON Schema exactly like `parameters`, and skipping that would leave `$defs` and `$ref` in place for Vertex to reject. That is a half-fix worth avoiding: one of the tests covers it

Worth noting for reviewers that Gemini was the odd one out here, not the norm. Bedrock and Databricks already read either key, and the Anthropic adapters rewrite `input_schema` to `parameters` before a provider config sees it, which is why the managed `/v1/messages` path never hit this. What remains exposed is a caller passing Anthropic-shaped tools straight into `completion(model="vertex_ai/gemini-*", ...)`, including router fallbacks that reuse one tool list across providers

I did not take the issue's alternative suggestion of raising when no schema resolves. That would turn today's silent success into a hard failure for anyone relying on schema-less tools, which is a behavior change well beyond the report

Four tests in the existing Gemini test file, driven through `map_openai_params` rather than `_map_function` so they exercise the real entry point. Two fail without the fix, the other two are guards: explicit `parameters` still wins, and a tool with no schema at all still maps without inventing one

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
