### PR TITLE
feat(ui): show user email or alias in usage data export

### DIFF
--- a/ui/litellm-dashboard/src/components/EntityUsageExport/utils.test.ts
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/utils.test.ts
@@ -2197,4 +2197,176 @@ describe("EntityUsageExport utils", () => {
       });
     });
   });
+
+  describe("display name resolution from entity metadata", () => {
+    const entityMetrics = {
+      spend: 12.25,
+      api_requests: 40,
+      successful_requests: 39,
+      failed_requests: 1,
+      total_tokens: 900,
+      prompt_tokens: 500,
+      completion_tokens: 400,
+      cache_read_input_tokens: 20,
+      cache_creation_input_tokens: 10,
+    };
+
+    const makeSpendData = (entity: string, metadata?: Record<string, any>): EntitySpendData => ({
+      results: [
+        {
+          date: "2025-04-01",
+          breakdown: {
+            entities: {
+              [entity]: {
+                metrics: entityMetrics,
+                metadata,
+                api_key_breakdown: {
+                  key1: {
+                    metrics: entityMetrics,
+                    metadata: { key_alias: "prod-key" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+      metadata: mockSpendData.metadata,
+    });
+
+    it("should export the user email as the entity label and keep the raw user id in the id column", () => {
+      const result = generateDailyData(
+        makeSpendData("user-123", { user_email: "ada@example.com", user_alias: "Ada" }),
+        "User",
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]["User"]).toBe("ada@example.com");
+      expect(result[0]["User ID"]).toBe("user-123");
+    });
+
+    it("should fall back to the user alias when the user has no email", () => {
+      const nullEmail = generateDailyData(
+        makeSpendData("user-123", { user_email: null, user_alias: "Ada Lovelace" }),
+        "User",
+      );
+      const missingEmail = generateDailyData(makeSpendData("user-123", { user_alias: "Ada Lovelace" }), "User");
+
+      expect(nullEmail[0]["User"]).toBe("Ada Lovelace");
+      expect(missingEmail[0]["User"]).toBe("Ada Lovelace");
+    });
+
+    it("should fall back to the raw entity key when the entity carries no metadata", () => {
+      const noMetadata = generateDailyData(makeSpendData("my-tag"), "Tag");
+      const emptyMetadata = generateDailyData(makeSpendData("customer-9", {}), "Customer");
+      const blankNames = generateDailyData(makeSpendData("user-123", { user_email: null, user_alias: null }), "User");
+
+      expect(noMetadata[0]["Tag"]).toBe("my-tag");
+      expect(emptyMetadata[0]["Customer"]).toBe("customer-9");
+      expect(blankNames[0]["User"]).toBe("user-123");
+    });
+
+    it("should prefer the team alias map over any alias in entity metadata", () => {
+      const result = generateDailyData(
+        makeSpendData("team-1", { team_alias: "Stale Alias", user_email: "ada@example.com" }),
+        "Team",
+        mockTeamAliasMap,
+      );
+
+      expect(result[0]["Team"]).toBe("Team One");
+    });
+
+    it("should use the team alias from entity metadata when the alias map has no entry for the team", () => {
+      const result = generateDailyData(
+        makeSpendData("team-9", { team_alias: "Team Nine", user_email: "ada@example.com" }),
+        "Team",
+        mockTeamAliasMap,
+      );
+
+      expect(result[0]["Team"]).toBe("Team Nine");
+    });
+
+    it("should resolve metadata.alias to the user email in getEntityBreakdown", () => {
+      const withEmail = getEntityBreakdown(
+        makeSpendData("user-123", { user_email: "ada@example.com", user_alias: "Ada" }),
+      );
+      const withoutEmail = getEntityBreakdown(makeSpendData("user-123", { user_alias: "Ada" }));
+
+      expect(withEmail[0].metadata.alias).toBe("ada@example.com");
+      expect(withEmail[0].metadata.id).toBe("user-123");
+      expect(withoutEmail[0].metadata.alias).toBe("Ada");
+    });
+
+    it("should resolve the user email on every key row of the keys scope", () => {
+      const spendData: EntitySpendData = {
+        results: [
+          {
+            date: "2025-04-01",
+            breakdown: {
+              entities: {
+                "user-123": {
+                  metrics: entityMetrics,
+                  metadata: { user_email: "ada@example.com", user_alias: "Ada" },
+                  api_key_breakdown: {
+                    key1: { metrics: entityMetrics, metadata: { key_alias: "prod-key" } },
+                    key2: { metrics: entityMetrics, metadata: { key_alias: "dev-key" } },
+                  },
+                },
+              },
+            },
+          },
+        ],
+        metadata: mockSpendData.metadata,
+      };
+
+      const result = generateDailyWithKeysData(spendData, "User");
+
+      expect(result).toHaveLength(2);
+      expect(result.map((r) => r["User"])).toEqual(["ada@example.com", "ada@example.com"]);
+      expect(result.map((r) => r["User ID"])).toEqual(["user-123", "user-123"]);
+      expect(result.find((r) => r["Key ID"] === "key1")?.["Key Alias"]).toBe("prod-key");
+      expect(result.find((r) => r["Key ID"] === "key2")?.["Key Alias"]).toBe("dev-key");
+    });
+
+    it("should resolve each entity's own email in the models scope", () => {
+      const spendData: EntitySpendData = {
+        results: [
+          {
+            date: "2025-04-01",
+            breakdown: {
+              entities: {
+                "user-a": {
+                  metrics: entityMetrics,
+                  metadata: { user_email: "ada@example.com", user_alias: "Ada" },
+                  api_key_breakdown: { key1: { metrics: entityMetrics, metadata: {} } },
+                },
+                "user-b": {
+                  metrics: entityMetrics,
+                  metadata: { user_email: null, user_alias: "Grace" },
+                  api_key_breakdown: { key2: { metrics: entityMetrics, metadata: {} } },
+                },
+              },
+              models: {
+                "claude-sonnet-4-5": {
+                  metrics: entityMetrics,
+                  api_key_breakdown: {
+                    key1: { metrics: entityMetrics, metadata: {} },
+                    key2: { metrics: entityMetrics, metadata: {} },
+                  },
+                },
+              },
+            },
+          },
+        ],
+        metadata: mockSpendData.metadata,
+      };
+
+      const result = generateDailyWithModelsData(spendData, "User");
+
+      expect(result).toHaveLength(2);
+      expect(result.every((r) => r.Model === "claude-sonnet-4-5")).toBe(true);
+      expect(result.find((r) => r["User ID"] === "user-a")?.["User"]).toBe("ada@example.com");
+      expect(result.find((r) => r["User ID"] === "user-b")?.["User"]).toBe("Grace");
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts
@@ -3,10 +3,6 @@ import type { DateRangePickerValue } from "@tremor/react";
 import Papa from "papaparse";
 import type { EntityBreakdown, EntitySpendData, EntityType, ExportMetadata, ExportScope } from "./types";
 
-// Resolve display name for an entity, mirroring the precedence the usage
-// charts use (getEntityLabel in EntityUsage.tsx): team alias, then the
-// user email/alias the backend joins into entity metadata, then the raw
-// entity key (tag name, org id, customer id, …) which is already the label.
 const resolveEntityDisplay = (
   entity: string,
   teamAliasMap: Record<string, string>,

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts
@@ -3,12 +3,22 @@ import type { DateRangePickerValue } from "@tremor/react";
 import Papa from "papaparse";
 import type { EntityBreakdown, EntitySpendData, EntityType, ExportMetadata, ExportScope } from "./types";
 
-// Resolve display name for an entity. For teams the teamAliasMap provides
-// a human-readable alias; for every other entity type the entity key itself
-// (tag name, org id, customer id, …) is already the correct label.
-const resolveEntityDisplay = (entity: string, teamAliasMap: Record<string, string>): { id: string; alias: string } => ({
+// Resolve display name for an entity, mirroring the precedence the usage
+// charts use (getEntityLabel in EntityUsage.tsx): team alias, then the
+// user email/alias the backend joins into entity metadata, then the raw
+// entity key (tag name, org id, customer id, …) which is already the label.
+const resolveEntityDisplay = (
+  entity: string,
+  teamAliasMap: Record<string, string>,
+  entityMetadata?: Record<string, any>,
+): { id: string; alias: string } => ({
   id: entity,
-  alias: teamAliasMap[entity] || entity,
+  alias:
+    teamAliasMap[entity] ||
+    entityMetadata?.team_alias ||
+    entityMetadata?.user_email ||
+    entityMetadata?.user_alias ||
+    entity,
 });
 
 // Mirrors backend SpendMetrics fields (litellm/types/activity_tracking.py).
@@ -68,7 +78,7 @@ export const getEntityBreakdown = (
 
   spendData.results.forEach((day) => {
     Object.entries(resolveEntities(day.breakdown)).forEach(([entity, data]: [string, any]) => {
-      const { id, alias } = resolveEntityDisplay(entity, teamAliasMap);
+      const { id, alias } = resolveEntityDisplay(entity, teamAliasMap, data.metadata);
 
       if (!entitySpend[entity]) {
         entitySpend[entity] = {
@@ -113,7 +123,7 @@ export const generateDailyData = (
 
   spendData.results.forEach((day) => {
     Object.entries(resolveEntities(day.breakdown)).forEach(([entity, data]: [string, any]) => {
-      const { id, alias } = resolveEntityDisplay(entity, teamAliasMap);
+      const { id, alias } = resolveEntityDisplay(entity, teamAliasMap, data.metadata);
 
       dailyBreakdown.push({
         Date: day.date,
@@ -164,7 +174,7 @@ export const generateDailyWithKeysData = (
 
   spendData.results.forEach((day) => {
     Object.entries(resolveEntities(day.breakdown)).forEach(([entity, data]: [string, any]) => {
-      const { id: entityId, alias: entityAlias } = resolveEntityDisplay(entity, teamAliasMap);
+      const { id: entityId, alias: entityAlias } = resolveEntityDisplay(entity, teamAliasMap, data.metadata);
       const apiKeyBreakdown = data.api_key_breakdown || {};
 
       // Iterate through each API key in the breakdown
@@ -241,11 +251,13 @@ export const generateDailyWithModelsData = (
 
   spendData.results.forEach((day) => {
     const dailyEntityModels: { [key: string]: { [key: string]: any } } = {};
+    const dailyEntityMetadata: { [key: string]: Record<string, any> | undefined } = {};
 
     Object.entries(resolveEntities(day.breakdown)).forEach(([entity, entityData]: [string, any]) => {
       if (!dailyEntityModels[entity]) {
         dailyEntityModels[entity] = {};
       }
+      dailyEntityMetadata[entity] = entityData.metadata;
 
       Object.entries(day.breakdown.models || {}).forEach(([model, modelData]: [string, any]) => {
         const entityApiKeys = entityData.api_key_breakdown || {};
@@ -282,7 +294,7 @@ export const generateDailyWithModelsData = (
     });
 
     Object.entries(dailyEntityModels).forEach(([entity, models]) => {
-      const { id, alias } = resolveEntityDisplay(entity, teamAliasMap);
+      const { id, alias } = resolveEntityDisplay(entity, teamAliasMap, dailyEntityMetadata[entity]);
 
       Object.entries(models).forEach(([model, metrics]: [string, any]) => {
         dailyModelBreakdown.push({


### PR DESCRIPTION
## TLDR

Problem this solves:

- Usage exports carried only raw user IDs
- Admins could not tell who spent what without a manual lookup

How it solves it:

- The User column now shows the user's email or alias
- The User ID column keeps the raw ID; unknown users stay unchanged

## User Flow

Before: an admin exporting per-user usage gets a file where every user is a UUID

1. They open https://litellm-domain/ui/?page=new_usage and switch the Usage View selector to User Usage
2. They click Export Data, keep "Day-by-day breakdown by user" with CSV, and click Export CSV
3. In the downloaded file the User and User ID columns both read `1425a2fc-1744-4853-af23-08e9f793908d`, so they must join against their user list by hand to know who that is

After: the same export names each user in clear text

1. They open https://litellm-domain/ui/?page=new_usage and switch the Usage View selector to User Usage
2. They click Export Data, keep "Day-by-day breakdown by user" with CSV, and click Export CSV
3. In the downloaded file the User column reads `jane.doe@example.com` while User ID still carries `1425a2fc-1744-4853-af23-08e9f793908d`

## Relevant issues

## Linear ticket

Resolves LIT-5148

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Captured at da9690ca96 against a live proxy built from this branch (running on port 4148), with real Groq API calls costing real money

Seed two users with emails and generate spend:

```bash
curl -s http://localhost:4148/user/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"user_email":"jane.doe@example.com","user_alias":"Jane Doe"}'
curl -s http://localhost:4148/user/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"user_email":"mark.smith@example.com"}'
for k in $JANE_KEY $JANE_KEY $MARK_KEY; do
  curl -s http://localhost:4148/v1/chat/completions -H "Authorization: Bearer $k" -H 'Content-Type: application/json' \
    -d '{"model":"groq-gpt-oss-120b","messages":[{"role":"user","content":"Say ping"}],"max_tokens":10}'
done
```

Then in the Admin UI: Usage, switch the view to User Usage, Export Data, Export CSV. The seeded rows of the downloaded `user_usage_daily_2026-08-07.csv`:

```csv
Date,User,User ID,Spend ($),Requests,Successful Requests,Failed Requests,Total Tokens,Prompt Tokens,Completion Tokens,Cache Read Input Tokens,Cache Creation Input Tokens
2026-08-07,mark.smith@example.com,93225f27-79b6-4bb6-8e3d-c47cfea50011,0.0000,4,3,1,188,158,30,0,0
2026-08-07,jane.doe@example.com,1425a2fc-1744-4853-af23-08e9f793908d,0.0001,8,5,3,354,304,50,0,0
```

The "by user and key" scope resolves the same way (`user_usage_daily_with_keys_2026-08-07.csv`):

```csv
Date,User,User ID,Key Alias,Key ID,Spend ($),Requests,Successful Requests,Failed Requests,Total Tokens,Prompt Tokens,Completion Tokens,Cache Read Input Tokens,Cache Creation Input Tokens
2026-08-07,mark.smith@example.com,93225f27-79b6-4bb6-8e3d-c47cfea50011,-,549b7bcf6c4b8f8d38372306493e6f71841b4709776d9dca98de5aa6083058da,0.0000,4,3,1,188,158,30,0,0
2026-08-07,jane.doe@example.com,1425a2fc-1744-4853-af23-08e9f793908d,-,1240dd60f3bd4b9caa5aa53bcff4859752b2751bc454a7463eb6efbb1fc7c84d,0.0001,8,5,3,354,304,50,0,0
```

Rows with no matching user record keep the old behavior, e.g. `default_user_id` and `Unassigned` still export as the raw key in both columns

User Usage view whose table shows the same labels the export now uses:

![User Usage spend per user](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5148_screenshots/02_spend_per_user.png)

Export modal used for the download:

![Export modal](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5148_screenshots/03_export_modal.png)

## Type

🆕 New Feature

## Changes

`resolveEntityDisplay` in `ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts` resolved display labels only through the client-side team alias map, so user exports duplicated the raw user id into the User column even though `/user/daily/activity` already joins `user_email` and `user_alias` into each entity's metadata. It now also reads that metadata with the same precedence the usage chart uses (`team_alias`, then `user_email`, then `user_alias`, then the raw key), and all three export scopes plus `getEntityBreakdown` pass the metadata through. The models scope carries a per-entity metadata map across its two aggregation loops so each row resolves its own user

Added regression tests for every scope and fallback; the six new assertions fail against the previous implementation and pass with this one (76/76 total)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
