### PR TITLE
feat(key_management): let any authenticated user resolve a raw key via /key/info

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -6351,6 +6351,12 @@ async def _can_user_query_key_info(
 ) -> bool:
     """
     Helper to check if the user has access to the key's info
+
+    Any authenticated caller who presents the raw key value (i.e. a preimage of the
+    stored token hash) is allowed: possession of the raw key already grants the
+    ability to call /key/info with that key as the bearer token, so resolving
+    raw key -> key info discloses nothing new. Lookups by hashed token remain
+    restricted to admins, the key's owner, and the key's teammates.
     """
     if (
         (
@@ -6359,6 +6365,7 @@ async def _can_user_query_key_info(
         )
         or user_api_key_dict.api_key == key
         or key_info.user_id == user_api_key_dict.user_id
+        or (key is not None and hash_token(token=key) == key_info.token)
         or await TeamMemberPermissionChecks.user_belongs_to_keys_team(
             user_api_key_dict=user_api_key_dict,
             existing_key_row=key_info,

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -15323,3 +15323,149 @@ async def test_rotate_master_key_rotates_sso_identity_assertions(
         prisma_client=mock_prisma_client,
         new_master_key="sk-new-master-key",
     )
+
+
+@pytest.mark.asyncio
+async def test_can_user_query_key_info_raw_key_possession_allows_any_user():
+    """
+    Any authenticated user who presents the raw sk- key value can query that
+    key's info: possessing the raw key already lets them call /key/info with
+    the key itself as the bearer token, so this discloses nothing new.
+    """
+    from litellm.proxy._types import hash_token
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _can_user_query_key_info,
+    )
+
+    raw_key = "sk-raw-key-owned-by-someone-else"
+    key_info = LiteLLM_VerificationToken(
+        token=hash_token(raw_key),
+        user_id="key-owner",
+        team_id=None,
+        key_alias="prod-batch-alias",
+    )
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="unrelated-user",
+        api_key="hashed-caller-token",
+    )
+
+    assert (
+        await _can_user_query_key_info(
+            user_api_key_dict=caller,
+            key=raw_key,
+            key_info=key_info,
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_can_user_query_key_info_hashed_token_still_forbidden():
+    """
+    Querying by hashed token (e.g. copied from spend logs) must stay
+    restricted to admins, the key's owner, and teammates.
+    """
+    from litellm.proxy._types import hash_token
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _can_user_query_key_info,
+    )
+
+    raw_key = "sk-raw-key-owned-by-someone-else"
+    key_info = LiteLLM_VerificationToken(
+        token=hash_token(raw_key),
+        user_id="key-owner",
+        team_id=None,
+        key_alias="prod-batch-alias",
+    )
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="unrelated-user",
+        api_key="hashed-caller-token",
+    )
+
+    assert (
+        await _can_user_query_key_info(
+            user_api_key_dict=caller,
+            key=hash_token(raw_key),
+            key_info=key_info,
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_info_key_fn_resolves_alias_from_raw_key_for_any_user(monkeypatch):
+    """
+    End-to-end through /key/info: a non-admin user unrelated to the key can
+    resolve raw sk- key -> key_alias.
+    """
+    from litellm.proxy._types import hash_token
+    from litellm.proxy.management_endpoints.key_management_endpoints import info_key_fn
+
+    raw_key = "sk-raw-key-owned-by-someone-else"
+    key_row = LiteLLM_VerificationToken(
+        token=hash_token(raw_key),
+        user_id="key-owner",
+        team_id=None,
+        key_alias="prod-batch-alias",
+    )
+
+    mock_prisma_client = AsyncMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    monkeypatch.setattr("litellm.proxy.proxy_server.user_api_key_cache", AsyncMock())
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=key_row
+    )
+
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="unrelated-user",
+        api_key="hashed-caller-token",
+    )
+
+    result = await info_key_fn(key=raw_key, user_api_key_dict=caller)
+
+    assert result["info"]["key_alias"] == "prod-batch-alias"
+    assert "token" not in result["info"]
+
+    find_unique_kwargs = (
+        mock_prisma_client.db.litellm_verificationtoken.find_unique.call_args.kwargs
+    )
+    assert find_unique_kwargs["where"] == {"token": hash_token(raw_key)}
+
+
+@pytest.mark.asyncio
+async def test_info_key_fn_hashed_lookup_still_403_for_unrelated_user(monkeypatch):
+    """
+    End-to-end through /key/info: the same unrelated user querying by hashed
+    token still gets a 403.
+    """
+    from litellm.proxy._types import hash_token
+    from litellm.proxy.management_endpoints.key_management_endpoints import info_key_fn
+
+    raw_key = "sk-raw-key-owned-by-someone-else"
+    key_row = LiteLLM_VerificationToken(
+        token=hash_token(raw_key),
+        user_id="key-owner",
+        team_id=None,
+        key_alias="prod-batch-alias",
+    )
+
+    mock_prisma_client = AsyncMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    monkeypatch.setattr("litellm.proxy.proxy_server.user_api_key_cache", AsyncMock())
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=key_row
+    )
+
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="unrelated-user",
+        api_key="hashed-caller-token",
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await info_key_fn(key=hash_token(raw_key), user_api_key_dict=caller)
+
+    assert int(exc_info.value.code) == 403


### PR DESCRIPTION
## TLDR

Problem this solves:

- Users holding a raw sk- key cannot learn its key alias
- /key/info 403s unless caller is admin, owner, or teammate

How it solves it:

- Any authenticated user presenting the raw key value may query it
- Possession of the raw key already grants /key/info via self-auth
- Hashed token lookups stay restricted to admin, owner, teammates

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup, run against a live proxy with a real Postgres DB. As the admin, create a key owned by one user and a caller key for a completely unrelated user:

```bash
KEY_B=$(curl -s http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"key_alias": "prod-batch-alias", "user_id": "qa-key-owner"}' | jq -r .key)
KEY_A=$(curl -s http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"user_id": "qa-unrelated-user"}' | jq -r .key)
```

Before, at 0659738b3e, the unrelated user cannot resolve the raw key:

```bash
curl -s -w "\nHTTP %{http_code}\n" "http://localhost:4000/key/info?key=$KEY_B" -H "Authorization: Bearer $KEY_A"
```

```
{"error":{"message":"You are not allowed to access this key's info. Your role=internal_user","type":"internal_server_error","param":"None","code":"403"}}
HTTP 403
```

After, at d0c1d2be8a, the same request resolves the raw key to its alias (full key info returned, trimmed here to the relevant fields):

```
{"key":"sk-pg0...9spw","info":{"key_name":"sk-...9spw","key_alias":"prod-batch-alias","user_id":"qa-key-owner", ...}}
HTTP 200
```

Still at d0c1d2be8a, looking the key up by its hashed token instead of the raw value stays forbidden for that same unrelated user:

```bash
HASH_B=$(python3 -c "import hashlib;print(hashlib.sha256('$KEY_B'.encode()).hexdigest())")
curl -s -w "\nHTTP %{http_code}\n" "http://localhost:4000/key/info?key=$HASH_B" -H "Authorization: Bearer $KEY_A"
```

```
{"error":{"message":"You are not allowed to access this key's info. Your role=internal_user","type":"internal_server_error","param":"None","code":"403"}}
HTTP 403
```

## Type

🆕 New Feature

## Changes

`_can_user_query_key_info` gains one clause: if the caller supplied a value whose sha256 equals the stored token hash, they hold the raw key, so they may read its info. This is not a widening of the security boundary: anyone with the raw key can already call /key/info with that key as the bearer token and read the same info. What was missing was doing the lookup while authenticated as yourself, which is what users need to map an sk- key found in some app config back to its alias

Lookups by hashed token are unchanged and remain limited to proxy admins, the key's owner, and members of the key's team. The other two call sites of the helper (/v2/key/info and the key_hash filter on /key/list) pass the stored hash itself as the queried value, and sha256(hash) never equals the hash, so their behavior is untouched

Tests: two unit tests on the helper (raw key allowed, hashed token denied) and two endpoint tests through info_key_fn (alias resolution for an unrelated user, 403 preserved for hashed lookup). The two feature tests fail without the source change

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
