### PR TITLE
fix(pricing): add missing deepseek-v4-flash-0731 entries for fireworks_ai

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -16490,6 +16490,22 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731": {
+        "cache_read_input_token_cost": 2.8e-08,
+        "input_cost_per_token": 1.4e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro": {
         "cache_read_input_token_cost": 1.45e-07,
         "input_cost_per_token": 1.74e-06,
@@ -16928,6 +16944,22 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/deepseek-v4-flash": {
+        "cache_read_input_token_cost": 2.8e-08,
+        "input_cost_per_token": 1.4e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
+    "fireworks_ai/deepseek-v4-flash-0731": {
         "cache_read_input_token_cost": 2.8e-08,
         "input_cost_per_token": 1.4e-07,
         "litellm_provider": "fireworks_ai",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -16490,6 +16490,22 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731": {
+        "cache_read_input_token_cost": 2.8e-08,
+        "input_cost_per_token": 1.4e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro": {
         "cache_read_input_token_cost": 1.45e-07,
         "input_cost_per_token": 1.74e-06,
@@ -16928,6 +16944,22 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/deepseek-v4-flash": {
+        "cache_read_input_token_cost": 2.8e-08,
+        "input_cost_per_token": 1.4e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
+    "fireworks_ai/deepseek-v4-flash-0731": {
         "cache_read_input_token_cost": 2.8e-08,
         "input_cost_per_token": 1.4e-07,
         "litellm_provider": "fireworks_ai",

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4515,6 +4515,16 @@ _FIREWORKS_MODELS = [
         False,
         True,
     ),
+    (
+        "accounts/fireworks/models/deepseek-v4-flash-0731",
+        1.4e-07,
+        2.8e-07,
+        2.8e-08,
+        1048576,
+        384000,
+        False,
+        True,
+    ),
 ]
 
 _FIREWORKS_SHORT_FORMS = [
@@ -4529,6 +4539,7 @@ _FIREWORKS_SHORT_FORMS = [
     "gpt-oss-20b",
     "deepseek-v4-pro",
     "deepseek-v4-flash",
+    "deepseek-v4-flash-0731",
 ]
 
 _FIREWORKS_ROUTER_SHORT_FORMS = [


### PR DESCRIPTION
## TLDR

Problem this solves:

- Missing pricing entries for Fireworks AI deepseek-v4-flash-0731
- Proxy cannot calculate request cost for deepseek-v4-flash-0731

How it solves it:

- Added deepseek-v4-flash-0731 entries to model cost maps
- Added unit tests for new Fireworks model pricing

## User Flow

Before: a developer sending requests to deepseek-v4-flash-0731 gets 0 cost calculated, so their dashboard logs $0 spend

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731"`
2. The completion response returns successfully, but token spend calculation evaluates to 0
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request calculates real token spend based on Fireworks serverless rates

1. They send the same POST https://litellm-domain/v1/chat/completions with `"model": "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731"`
2. The completion response returns successfully with calculated token spend using $0.14/1M input and $0.28/1M output rates
3. They open https://litellm-domain/ui/?page=logs and see the request logged with accurate non-zero spend

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Pricing source documentation links:
- Fireworks AI Serverless Pricing Docs: https://docs.fireworks.ai/serverless/pricing
- Fireworks AI Model Catalog Page: https://app.fireworks.ai/models/fireworks/deepseek-v4-flash-0731

Before (commit `1bafdb3c934fcfdb9a81501755e048a40c0ce81f`):

Command run:
```bash
python3 -c '
import os
os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
import litellm

response = litellm.ModelResponse(
    model="accounts/fireworks/models/deepseek-v4-flash-0731",
    usage=litellm.Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
)
cost = litellm.completion_cost(completion_response=response, model="fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731")
print(f"Model: {response.model}")
print(f"Usage: {response.usage}")
print(f"Calculated Cost: ${cost:.6f}")
'
```

Output:
```text
Model: accounts/fireworks/models/deepseek-v4-flash-0731
Usage: Usage(completion_tokens=500, prompt_tokens=1000, total_tokens=1500, completion_tokens_details=None, prompt_tokens_details=None)
Calculated Cost: $0.000000
```

After (commit `35e1820c7dcaeec818a02848f97b303f6fc54d70`):

Command run:
```bash
python3 -c '
import os
os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
import litellm

response = litellm.ModelResponse(
    model="accounts/fireworks/models/deepseek-v4-flash-0731",
    usage=litellm.Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
)
cost = litellm.completion_cost(completion_response=response, model="fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731")
print(f"Model: {response.model}")
print(f"Usage: {response.usage}")
print(f"Calculated Cost: ${cost:.6f}")
'
```

Output:
```text
Model: accounts/fireworks/models/deepseek-v4-flash-0731
Usage: Usage(completion_tokens=500, prompt_tokens=1000, total_tokens=1500, completion_tokens_details=None, prompt_tokens_details=None)
Calculated Cost: $0.000280
```

Command run with prompt caching:
```bash
python3 -c '
import os
os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
import litellm

response = litellm.ModelResponse(
    model="deepseek-v4-flash-0731",
    usage=litellm.Usage(
        prompt_tokens=1000,
        completion_tokens=500,
        total_tokens=1500,
        prompt_tokens_details={"cached_tokens": 800}
    )
)
cost = litellm.completion_cost(completion_response=response, model="fireworks_ai/deepseek-v4-flash-0731")
print(f"Model: {response.model}")
print(f"Usage: {response.usage}")
print(f"Calculated Cost with Prompt Caching: ${cost:.6f}")
'
```

Output:
```text
Model: deepseek-v4-flash-0731
Usage: Usage(completion_tokens=500, prompt_tokens=1000, total_tokens=1500, completion_tokens_details=None, prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=None, cached_tokens=800, text_tokens=None, image_tokens=None, video_tokens=None))
Calculated Cost with Prompt Caching: $0.000190
```

## Type

🐛 Bug Fix

## Changes

Added deepseek-v4-flash-0731 entries to model_prices_and_context_window.json, litellm/model_prices_and_context_window_backup.json, and tests/test_litellm/test_utils.py

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
