### PR TITLE
ci: set up frog friction logging

### DIFF
--- a/.agents/friction-log/README.md
+++ b/.agents/friction-log/README.md
@@ -1,0 +1,39 @@
+# Friction log
+
+Friction hit while working in this repository, one directory per item:
+
+```
+<id>/
+  friction.md   the write-up
+  artifacts/    optional, whatever reproduces it
+```
+
+Reporting an entry gives it an owner. The write-up then carries an `issue:` link and mirrors what happens
+to it. The whole directory is deleted once the friction is resolved. Every entry left here is still
+outstanding, including friction in dependencies.
+
+Do not maintain an index here. This directory is the index.
+
+## Logging Friction
+
+```sh
+frog list    # what is already known
+frog log     # add one
+```
+
+`frog log` writes the sections to fill in. Each id is when the friction was hit plus its title, so
+the directory reads oldest-first.
+
+Put anything that reproduces the friction in that entry's `artifacts/` and reference it from the
+write-up. The next reader runs the reproduction instead of rebuilding it.
+
+## For Agents
+
+Add these rules near the top of `AGENTS.md`, under the appropriate section. Create the file if missing; otherwise amend it in place, preserve all existing content, and never replace the file.
+
+- If `frog` is not installed, install the binary: `curl -fsSL https://frog.fm/install | sh`.
+- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `frog log`.
+- Do not add global, system, or internal friction.
+- Run `frog list` first to see what is already known.
+
+Managed by [Frog](https://github.com/wevm/frog).

--- a/.agents/friction-log/README.md
+++ b/.agents/friction-log/README.md
@@ -29,11 +29,6 @@ write-up. The next reader runs the reproduction instead of rebuilding it.
 
 ## For Agents
 
-Add these rules near the top of `AGENTS.md`, under the appropriate section. Create the file if missing; otherwise amend it in place, preserve all existing content, and never replace the file.
-
-- If `frog` is not installed, install the binary: `curl -fsSL https://frog.fm/install | sh`.
-- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `frog log`.
-- Do not add global, system, or internal friction.
-- Run `frog list` first to see what is already known.
+These rules live in `CLAUDE.md`, which `AGENTS.md` points at, so amend them there rather than duplicating them into `AGENTS.md`.
 
 Managed by [Frog](https://github.com/wevm/frog).

--- a/.agents/friction-log/config.json
+++ b/.agents/friction-log/config.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://unpkg.com/frog/schema.json",
+  "inbound": {
+    "enabled": true
+  }
+}

--- a/.github/ISSUE_TEMPLATE/friction.yml
+++ b/.github/ISSUE_TEMPLATE/friction.yml
@@ -1,0 +1,34 @@
+name: Friction
+description: Something about this project cost you time.
+labels: [friction]
+body:
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: Describe what should happen.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: Describe what happens instead.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Possible Solution
+      description: Optional. Suggest a fix or a reason for the friction.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Minimal Reproducible Example
+      description: Add a minimal reproducible example under `artifacts/`, or an unambiguous set of steps to reproduce this. Include code where relevant.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Context
+      description: Describe how this affected you, and what you were trying to accomplish.
+    validations:
+      required: false

--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -1,0 +1,39 @@
+name: Friction Log
+on:
+  push:
+    branches: [litellm_internal_staging]
+  issues:
+    types: [closed, reopened]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+concurrency:
+  group: friction-log
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  friction-log:
+    name: Friction Log
+    if: github.event_name != 'issues' || github.event.issue.user.login == 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Report and reconcile frictions
+        uses: wevm/frog/action@702c4eadefe175a208290a99c36e7f4ac1390e53 # frog@1.1.0
+        with:
+          issue-author: github-actions[bot]
+          branch: frog-sync
+          version: 1.1.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,8 @@
 Read @CLAUDE.md for coding guidelines
+
+## Friction log
+
+- If `frog` is not installed, install the binary: `curl -fsSL https://frog.fm/install | sh`
+- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `frog log`
+- Do not add global, system, or internal friction
+- Run `frog list` first to see what is already known

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,1 @@
 Read @CLAUDE.md for coding guidelines
-
-## Friction log
-
-- If `frog` is not installed, install the binary: `curl -fsSL https://frog.fm/install | sh`
-- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `frog log`
-- Do not add global, system, or internal friction
-- Run `frog list` first to see what is already known

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,16 @@ Follow these coding conventions for new/updated code (a three-line fix in a lega
 
 Follow conventional commits for commit names and PR titles
 
+Log papercuts and friction you hit in this repository (tooling, docs, APIs, tests, conventions) with `frog log`, and run `frog list` first so you don't re-report something already known. Only repo-level friction belongs in `.agents/friction-log/`, not global, system, or agent-harness friction. If `frog` is missing, install the pinned release instead of piping the installer into a shell (pick the asset matching your platform from https://github.com/wevm/frog/releases/tag/frog@1.1.0):
+
+```sh
+ver=1.1.0
+asset=frog-linux-x64-glibc-baseline.gz
+curl -fsSLO "https://github.com/wevm/frog/releases/download/frog@$ver/$asset"
+curl -fsSL "https://github.com/wevm/frog/releases/download/frog@$ver/SHA256SUMS" | grep "$asset" | sha256sum -c -
+gunzip -c "$asset" > ~/.local/bin/frog && chmod +x ~/.local/bin/frog
+```
+
 ## Think Before Coding
 
 **Don't assume. Don't hide confusion. Surface tradeoffs**


### PR DESCRIPTION
## TLDR

Problem this solves:

- Agents hit friction constantly and nothing records it
- Workarounds die with the session, so the next agent repeats them
- Nobody who could fix the papercut ever hears about it

How it solves it:

- Sets up [Frog](https://github.com/wevm/frog), automated friction logging for agents
- Agents commit friction entries to `.agents/friction-log/` via `frog log`
- A workflow files each entry as a GitHub issue
- Closing the issue removes the entry through a `frog-sync` PR

## User Flow

Before: an agent that hits a papercut in this repo has nowhere durable to put it, so the friction dies with the session

1. An agent working on a litellm change hits a papercut (a misleading make target failure, a stale doc, a confusing test convention), builds a workaround, and moves on
2. It looks for a friction log to check or update, and the repo has none; CLAUDE.md says nothing about recording friction
3. The workaround exists only in that session's transcript, and nothing lands in the repo or on https://github.com/BerriAI/litellm/issues
4. The next agent hits the identical papercut and rebuilds the same workaround from nothing
5. A maintainer browsing https://github.com/BerriAI/litellm/issues never sees the papercut, so nobody ever fixes it

After: the same papercut becomes a committed log entry, then a tracked issue, and the log empties itself once the issue closes

1. An agent working on a litellm change hits the same papercut and builds the same workaround
2. CLAUDE.md now tells it to run `frog list`, which prints what is already known, and `frog log`, which writes the entry under `.agents/friction-log/`
3. The entry commits alongside the code change and merges to `litellm_internal_staging`
4. That merge push runs the Friction Log workflow on https://github.com/BerriAI/litellm/actions, which files a `friction`-labeled issue on https://github.com/BerriAI/litellm/issues using the new friction issue form and links it back into the entry
5. The next agent runs `frog list` before guessing and reuses the recorded workaround
6. A maintainer fixes the papercut and closes the issue, the workflow's next run updates a `frog-sync` PR deleting the resolved entry, and merging that PR leaves the log holding only what is still unresolved

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at `f3dfacf93e`. The install steps CLAUDE.md now documents are the pinned 1.1.0 release checked against the release's own SHA256SUMS, no installer piped into a shell:

```
$ ver=1.1.0
$ asset=frog-linux-x64-glibc-baseline.gz
$ curl -fsSLO "https://github.com/wevm/frog/releases/download/frog@$ver/$asset"
$ curl -fsSL "https://github.com/wevm/frog/releases/download/frog@$ver/SHA256SUMS" | grep "$asset" | sha256sum -c -
frog-linux-x64-glibc-baseline.gz: OK
$ gunzip -c "$asset" > ~/.local/bin/frog && chmod +x ~/.local/bin/frog
$ frog --version
1.1.0
```

`frog init` generated the files in this PR and `frog list` parses the log cleanly (it exits 1 on a malformed entry, so it doubles as a CI check):

```
$ frog init --format json
{"ok": true, "data": {"created": [".agents/friction-log/README.md", ".agents/friction-log/config.json", ".github/ISSUE_TEMPLATE/friction.yml"], "existing": []}}
$ frog list
entries: []
linked: 0
pending: 0
```

The workflow itself only runs from the default branch, so it cannot execute before merge. Post-merge verification: trigger Friction Log from the Actions tab via workflow_dispatch and expect a green no-op run (zero entries to publish), then run `frog log` in a working tree, merge the entry to `litellm_internal_staging`, and expect a `friction`-labeled issue plus a `frog-sync` PR. The repository setting Frog needs (Allow GitHub Actions to create and approve pull requests) is already enabled, verified via the Actions permissions API

## Type

🚄 Infrastructure

## Changes

`frog init` (v1.1.0) generated `.agents/friction-log/README.md`, `.agents/friction-log/config.json` (inbound reports enabled, the init default), and `.github/ISSUE_TEMPLATE/friction.yml`, the issue form friction reports are filed with

`.github/workflows/friction-log.yml` is Frog's documented Action-only workflow: it uses the repository's own `GITHUB_TOKEN` rather than granting the Frog GitHub App third-party access. Three deliberate deviations from the upstream template: the push trigger is filtered to `litellm_internal_staging` (the repository's default branch) so the busy branch traffic here does not spawn a skipped run per push, the sync branch is `frog-sync` instead of the upstream default `frog/sync` to keep slashes out of branch names, and both actions are pinned to full commit SHAs with the exact Frog version (1.1.0) passed as the `version` input, per this repo's CI supply-chain rules and Frog's own pinning guidance

The agent rules `frog init` asks for go in `CLAUDE.md`, next to the rest of the repo's conventions, rather than in `AGENTS.md`, which exists only to point at `CLAUDE.md`: check `frog list` first, log friction with `frog log` as it is hit, keep global or harness friction out, and install the CLI by downloading the pinned release and verifying its checksum instead of the `curl | sh` one-liner the generated README suggests, which this repo's own supply-chain rule bans. The generated README's "For Agents" section now points at `CLAUDE.md` so a later `frog init` or a future reader doesn't re-add the rules to `AGENTS.md`

No tests: the change is config, docs, and a workflow, with no Python or dashboard surface. The unchecked tests box above reflects that

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/7f6ee3f9fc624ac692d3eda018737e2a
Requested by: @mateo-berri