### PR TITLE
feat(proxy): let USE_V2_MIGRATION_RESOLVER select the v2 migration resolver

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -916,6 +916,7 @@ class ProxyInitializationHelpers:
         "path that can cause schema thrashing during rolling deploys where two "
         "LiteLLM versions contend for the same DB. Default is the v1 resolver."
     ),
+    envvar="USE_V2_MIGRATION_RESOLVER",
 )
 @click.option(
     "--reload",

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -1925,6 +1925,64 @@ class TestRunServerDbSetup:
             assert exc_info.value.code == 1
             mock_setup_database.assert_not_called()
 
+    @patch("subprocess.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch("litellm.proxy.db.check_migration.check_prisma_schema_diff")
+    @patch("litellm.proxy.db.prisma_client.should_update_prisma_schema")
+    def test_v2_migration_resolver_opts_in_via_env_var(
+        self,
+        mock_should_update_schema,
+        mock_check_schema_diff,
+        mock_setup_database,
+        mock_atexit_register,
+        mock_subprocess_run,
+    ):
+        """USE_V2_MIGRATION_RESOLVER must select the v2 resolver.
+
+        The Helm migrations Job runs `python litellm/proxy/prisma_migration.py`,
+        which calls run_server with a fixed argv, so a deployment has no way to
+        pass --use_v2_migration_resolver and an env var is the only route in.
+        """
+        from litellm.proxy.proxy_cli import run_server
+
+        mock_subprocess_run.return_value = MagicMock(returncode=0)
+        mock_should_update_schema.return_value = True
+        mock_setup_database.return_value = True
+
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "DIRECT_URL")
+        }
+        clean_env["DATABASE_URL"] = "postgresql://test:test@localhost:5432/test"
+        clean_env["USE_V2_MIGRATION_RESOLVER"] = "true"
+
+        with (
+            patch.dict(os.environ, clean_env, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "proxy_server": mock_proxy_module,
+                    "litellm.proxy.proxy_server": mock_proxy_module,
+                },
+            ),
+        ):
+            run_server.main(
+                ["--local", "--skip_server_startup"], standalone_mode=False
+            )
+
+        mock_setup_database.assert_called_once_with(
+            use_migrate=True, use_v2_resolver=True
+        )
+
 
 # --- Module-level helpers for worker startup hook tests ---
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Helm deployments cannot reach the v2 migration resolver

How it solves it:

- Add `USE_V2_MIGRATION_RESOLVER` env var to the existing flag

## User Flow

Before: an operator wants the v2 resolver on a Helm install and has no way to turn it on

1. They read that `--use_v2_migration_resolver` avoids schema thrashing during rolling deploys and decide to adopt it
2. They add `USE_V2_MIGRATION_RESOLVER: "true"` under `envVars` in their values file and run `helm upgrade`
3. `kubectl logs job/litellm-migrations` still shows the default resolver warning, so nothing changed
4. They try passing the flag instead, and find the migration job's command takes no arguments, so there is nowhere to put it
5. Their only remaining option is a custom image or a patched chart

After: the env var turns it on

1. They add `USE_V2_MIGRATION_RESOLVER: "true"` under `envVars` and run `helm upgrade`
2. `kubectl logs job/litellm-migrations` shows `Using v2 migration resolver (--use_v2_migration_resolver)`
3. The default resolver warning is gone
4. Removing the env var, or setting it to `"false"`, returns them to the v1 resolver

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

🆕 New Feature

## Changes

`--use_v2_migration_resolver` gains `envvar="USE_V2_MIGRATION_RESOLVER"`. Nothing else changes: the flag, its default, and both resolvers are untouched, so a deployment that sets nothing keeps the v1 resolver exactly as before.

The gap this closes is that the flag was unreachable from a deployment. The Helm migrations job's container command is `python litellm/proxy/prisma_migration.py`, and that script calls `run_server` with a fixed argv, so there is no place to append a CLI flag. Every other migration-related knob on that path is already an env var, and this one was not.

Worth knowing before adopting it: the v2 resolver raises on unrecoverable migration failures, where v1 returns a bool that startup ignores unless `ENFORCE_PRISMA_MIGRATION_CHECK` is set. Turning this on therefore makes a failing migration fail the job instead of passing quietly, which is the intended behavior but will be visible as new job failures wherever a migration was already failing unnoticed.

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
