### PR TITLE
fix(e2e): per-call timeout so the deepseek reasoner test survives provider thinking latency

### DIFF
--- a/tests/e2e/llm_translation/test_deepseek_reasoning_e2e.py
+++ b/tests/e2e/llm_translation/test_deepseek_reasoning_e2e.py
@@ -29,6 +29,7 @@ pytestmark = pytest.mark.e2e
 
 REASONER = "deepseek/deepseek-v4-pro"
 PROMPT = "What is 17 + 26? Answer with just the number."
+REASONER_TIMEOUT_SECONDS = 240.0
 
 
 def _register_reasoner(client: PassthroughClient, resources: ResourceManager) -> str:
@@ -63,6 +64,7 @@ class TestDeepSeekReasoningDisable:
                     messages=[ChatMessage(role="user", content=PROMPT)],
                     max_tokens=64,
                 ),
+                timeout=REASONER_TIMEOUT_SECONDS,
             )
         )
         reasoning = _reasoning_content(response)
@@ -86,6 +88,7 @@ class TestDeepSeekReasoningDisable:
                     max_tokens=64,
                     reasoning_effort="none",
                 ),
+                timeout=REASONER_TIMEOUT_SECONDS,
             )
         )
         assert not _reasoning_content(response), (
@@ -108,6 +111,7 @@ class TestDeepSeekReasoningDisable:
                     max_tokens=64,
                     thinking=ThinkingParam(type="disabled"),
                 ),
+                timeout=REASONER_TIMEOUT_SECONDS,
             )
         )
         assert not _reasoning_content(response), (

--- a/tests/e2e/proxy_client.py
+++ b/tests/e2e/proxy_client.py
@@ -269,12 +269,13 @@ class ProxyClient:
 
     # ---- LLM calls ------------------------------------------------------
 
-    def chat(self, key: str, body: ChatBody) -> Result[ChatResponse]:
+    def chat(self, key: str, body: ChatBody, timeout: float | None = None) -> Result[ChatResponse]:
         return self.transport.post(
             "/chat/completions",
             headers=self.transport.bearer(key),
             json=body,
             response_type=ChatResponse,
+            timeout=timeout,
         )
 
     def chat_stream(self, key: str, body: ChatBody) -> StreamingResponse:

--- a/tests/e2e/transport.py
+++ b/tests/e2e/transport.py
@@ -25,7 +25,13 @@ from e2e_http import (
 
 class Transport(Protocol):
     def post[R: BaseModel](
-        self, path: str, *, headers: BaseModel, json: BaseModel, response_type: type[R]
+        self,
+        path: str,
+        *,
+        headers: BaseModel,
+        json: BaseModel,
+        response_type: type[R],
+        timeout: float | None = None,
     ) -> Result[R]: ...
 
     def stream(
@@ -119,14 +125,20 @@ class HttpTransport:
         return self.bearer(self.master_key)
 
     def post[R: BaseModel](
-        self, path: str, *, headers: BaseModel, json: BaseModel, response_type: type[R]
+        self,
+        path: str,
+        *,
+        headers: BaseModel,
+        json: BaseModel,
+        response_type: type[R],
+        timeout: float | None = None,
     ) -> Result[R]:
         return e2e_http.post(
             self._url(path),
             headers=headers,
             json=json,
             response_type=response_type,
-            timeout=self.request_timeout,
+            timeout=timeout if timeout is not None else self.request_timeout,
         )
 
     def get[R: BaseModel](
@@ -323,10 +335,16 @@ class SplitTransport:
         return self.data.master
 
     def post[R: BaseModel](
-        self, path: str, *, headers: BaseModel, json: BaseModel, response_type: type[R]
+        self,
+        path: str,
+        *,
+        headers: BaseModel,
+        json: BaseModel,
+        response_type: type[R],
+        timeout: float | None = None,
     ) -> Result[R]:
         return self._route(path).post(
-            path, headers=headers, json=json, response_type=response_type
+            path, headers=headers, json=json, response_type=response_type, timeout=timeout
         )
 
     def get[R: BaseModel](


### PR DESCRIPTION
## TLDR

Problem this solves:

- Deepseek reasoner e2e test flakes on the harness 60s read timeout
- The reasoner legitimately thinks longer than 60s on slow days

How it solves it:

- Transport `post` and `ProxyClient.chat` accept an optional per-call timeout
- The three reasoner calls get a 240s budget; every other call is unchanged

## User Flow

Before: a developer running the e2e suite watches the deepseek reasoner test go red on a read timeout while the gateway and the provider are both healthy

1. They run `pytest tests/e2e/llm_translation/test_deepseek_reasoning_e2e.py` with `LITELLM_PROXY_URL` pointing at the staging gateway
2. The test registers its deployment via `POST http://gateway/model/new` and gets 200 with a model id
3. The test sends `POST http://gateway/v1/chat/completions` to `deepseek/deepseek-v4-pro`, which spends over a minute thinking before its first byte
4. At exactly 60s the run aborts with `NetworkError: ... Read timed out. (read timeout=60.0)` and the test fails even though the reply was still on its way

After: the same run rides out slow reasoner turns and goes green

1. They run `pytest tests/e2e/llm_translation/test_deepseek_reasoning_e2e.py` with `LITELLM_PROXY_URL` pointing at the staging gateway
2. The test registers its deployment via `POST http://gateway/model/new` and gets 200 with a model id
3. The test sends `POST http://gateway/v1/chat/completions` to `deepseek/deepseek-v4-pro`, which spends over a minute thinking before its first byte
4. The harness now waits up to 240s on the three reasoner calls, the reply lands with `reasoning_content`, and all three tests pass

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before: the failure this fixes is the CI flake from the 2-replica e2e run, where the reasoner's thinking latency crossed the transport's 60s default

```
llm_translation/test_deepseek_reasoning_e2e.py::TestDeepSeekReasoningDisable::test_reasoner_returns_reasoning_by_default
NetworkError: HTTPConnectionPool ... Read timed out. (read timeout=60.0)
```

After, harness at commit `910ac037ad`: the full file run against a live local proxy (model registered via `/model/new`, three real DeepSeek API calls costing real $)

```
$ LITELLM_PROXY_URL=http://127.0.0.1:53421 LITELLM_MASTER_KEY=... pytest -q llm_translation/test_deepseek_reasoning_e2e.py --durations=5
============================= slowest 5 durations ==============================
16.97s call     ...::TestDeepSeekReasoningDisable::test_reasoner_returns_reasoning_by_default
16.34s call     ...::TestDeepSeekReasoningDisable::test_reasoning_effort_none_disables_reasoning
15.96s call     ...::TestDeepSeekReasoningDisable::test_thinking_disabled_disables_reasoning
3 passed in 49.41s
```

DeepSeek answered in ~17s on this run; the point of the change is that a 3 minute thinking spike now stays inside the per-call budget instead of killing the run at 60s. The provider-latency spike itself cannot be forced without mocking, which this suite forbids

## Type

✅ Test

## Changes

`Transport.post`, `HttpTransport.post`, and `SplitTransport.post` accept an optional `timeout` that falls back to the transport-wide `request_timeout` when omitted, and `ProxyClient.chat` forwards it. The deepseek reasoner test passes a 240s `REASONER_TIMEOUT_SECONDS` on its three chat calls. No other call sites change behavior

## QA runbook

- tests/e2e/llm_translation/test_deepseek_reasoning_e2e.py::TestDeepSeekReasoningDisable (all three tests) - reasoner calls survive provider thinking latency past the 60s transport default
  - [ ] Boot a proxy backed by a DB with `DEEPSEEK_API_KEY` in its env, e.g. `litellm --config <config with store_model_in_db: true> --port 4000`
  - [ ] Run `LITELLM_PROXY_URL=http://localhost:4000 LITELLM_MASTER_KEY=<key> pytest tests/e2e/llm_translation/test_deepseek_reasoning_e2e.py`
  - [ ] Expect `3 passed`, with each `/chat/completions` call allowed to run for minutes without the harness aborting at 60s
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
