### PR TITLE
fix(batches): route filtered list_batches through provider fallback

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -344,16 +344,18 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         # This is because the encoded object ids stored in the managed objects table do not contain the provider information
         # To support provider filtering, we would need to store the provider information in the encoded object ids
         if provider:
-            raise Exception(
-                "Filtering by 'provider' is not supported when using managed batches."
+            raise HTTPException(
+                status_code=400,
+                detail="Filtering by 'provider' is not supported when using managed batches.",
             )
 
         # Model name filtering is not supported for managed batches
         # This is because the encoded object ids stored in the managed objects table do not contain the model name
         # A hash of the model name + litellm_params for the model name is encoded as the model id. This is not sufficient to reliably map the target model names to the model ids.
         if target_model_names:
-            raise Exception(
-                "Filtering by 'target_model_names' is not supported when using managed batches."
+            raise HTTPException(
+                status_code=400,
+                detail="Filtering by 'target_model_names' is not supported when using managed batches.",
             )
 
         owner_filter = build_owner_filter(user_api_key_dict)

--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -420,13 +420,19 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         # This is because the encoded object ids stored in the managed objects table do not contain the provider information
         # To support provider filtering, we would need to store the provider information in the encoded object ids
         if provider:
-            raise Exception("Filtering by 'provider' is not supported when using managed batches.")
+            raise HTTPException(
+                status_code=400,
+                detail="Filtering by 'provider' is not supported when using managed batches.",
+            )
 
         # Model name filtering is not supported for managed batches
         # This is because the encoded object ids stored in the managed objects table do not contain the model name
         # A hash of the model name + litellm_params for the model name is encoded as the model id. This is not sufficient to reliably map the target model names to the model ids.
         if target_model_names:
-            raise Exception("Filtering by 'target_model_names' is not supported when using managed batches.")
+            raise HTTPException(
+                status_code=400,
+                detail="Filtering by 'target_model_names' is not supported when using managed batches.",
+            )
 
         owner_filter = build_owner_filter(user_api_key_dict)
         if owner_filter is None:

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -682,7 +682,12 @@ async def list_batches(
 
         # Try to use managed objects table for listing batches (returns encoded IDs).
         managed_files_obj: Final = proxy_logging_obj.get_proxy_hook("managed_files")
-        if managed_files_obj is not None and hasattr(managed_files_obj, "list_user_batches"):
+        if (
+            managed_files_obj is not None
+            and hasattr(managed_files_obj, "list_user_batches")
+            and not provider
+            and not target_model_names
+        ):
             verbose_proxy_logger.debug("Using managed objects table for batch listing")
             response = await cast(Any, managed_files_obj).list_user_batches(
                 user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -695,7 +695,12 @@ async def list_batches(
 
         # Try to use managed objects table for listing batches (returns encoded IDs).
         managed_files_obj: Final = proxy_logging_obj.get_proxy_hook("managed_files")
-        if managed_files_obj is not None and hasattr(managed_files_obj, "list_user_batches"):
+        if (
+            managed_files_obj is not None
+            and hasattr(managed_files_obj, "list_user_batches")
+            and not provider
+            and not target_model_names
+        ):
             verbose_proxy_logger.debug("Using managed objects table for batch listing")
             response = await cast(Any, managed_files_obj).list_user_batches(
                 user_api_key_dict=user_api_key_dict,

--- a/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
+++ b/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
@@ -2007,15 +2007,16 @@ async def test_list_batches_from_managed_objects_table_provider_filter_raises_ex
         DualCache(), prisma_client=prisma_client
     )
 
-    # Filtering by provider should raise Exception
-    with pytest.raises(Exception) as exc_info:
+    # Filtering by provider should raise HTTPException with 400
+    with pytest.raises(HTTPException) as exc_info:
         await proxy_managed_files.list_user_batches(
             user_api_key_dict=UserAPIKeyAuth(user_id="test-user"),
             limit=10,
             provider="openai",
         )
 
-    assert str(exc_info.value) == (
+    assert exc_info.value.status_code == 400
+    assert str(exc_info.value.detail) == (
         "Filtering by 'provider' is not supported when using managed batches."
     )
 
@@ -2033,15 +2034,16 @@ async def test_list_batches_from_managed_objects_table_target_model_name_filter_
         DualCache(), prisma_client=prisma_client
     )
 
-    # Filtering by provider should raise Exception
-    with pytest.raises(Exception) as exc_info:
+    # Filtering by target_model_names should raise HTTPException with 400
+    with pytest.raises(HTTPException) as exc_info:
         await proxy_managed_files.list_user_batches(
             user_api_key_dict=UserAPIKeyAuth(user_id="test-user"),
             limit=10,
             target_model_names="gpt-5.5,gpt-3.5",
         )
 
-    assert str(exc_info.value) == (
+    assert exc_info.value.status_code == 400
+    assert str(exc_info.value.detail) == (
         "Filtering by 'target_model_names' is not supported when using managed batches."
     )
 

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -1485,13 +1485,35 @@ async def test_list__managed_files_path(list_harness):
         user_api_key_dict=user,
         limit=7,
         after="batch-cursor",
-        provider="openai",
-        target_model_names="m1,m2",
         llm_router=list_harness.router,
     )
     list_harness.litellm_alist.assert_not_called()
     list_harness.router_alist.assert_not_called()
     assert resp is page
+
+
+@pytest.mark.asyncio
+async def test_list__managed_files_rejects_provider_filter(list_harness):
+    """Provider/target_model filters must not enter the managed-files path;
+    they must fall through to provider/model routing instead.
+    """
+    page = FakeListPage([make_batch(id="batch-1")])
+    list_harness.set_managed_files(page)
+
+    user = UserAPIKeyAuth(api_key="sk-test")
+    resp = await call_list(
+        list_harness,
+        user=user,
+        limit=7,
+        after="batch-cursor",
+        provider="openai",
+        target_model_names="m1,m2",
+    )
+
+    # Filtered requests bypass managed-files and use provider fallback.
+    list_harness.litellm_alist.assert_called_once()
+    list_harness.router_alist.assert_not_called()
+    assert list_harness.alist_kwargs()["custom_llm_provider"] == "openai"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -1483,6 +1483,8 @@ async def test_list__managed_files_path(list_harness):
         user_api_key_dict=user,
         limit=7,
         after="batch-cursor",
+        provider=None,
+        target_model_names=None,
         llm_router=list_harness.router,
     )
     list_harness.litellm_alist.assert_not_called()
@@ -1505,7 +1507,6 @@ async def test_list__managed_files_rejects_provider_filter(list_harness):
         limit=7,
         after="batch-cursor",
         provider="openai",
-        target_model_names="m1,m2",
     )
 
     # Filtered requests bypass managed-files and use provider fallback.

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -1476,11 +1476,9 @@ async def test_list__managed_files_path(list_harness):
         user=user,
         limit=7,
         after="batch-cursor",
-        provider="openai",
-        target_model_names="m1,m2",
     )
 
-    # DISPATCH - managed-files seam fired, neither provider seam did.
+    # DISPATCH - managed-files seam fired, no provider/model filters present.
     list_user_batches.assert_called_once_with(
         user_api_key_dict=user,
         limit=7,


### PR DESCRIPTION
## What
DB proxies with managed files route all `GET /v1/batches` through the managed-files hook. Filtered requests (`provider` or `target_model_names`) should fall through to provider routing instead of hitting a bare `Exception`.

## Root Cause
`list_batches` unconditionally calls `managed_files.list_user_batches()` when the hook is present, even for filtered requests the hook cannot satisfy. The hook raised `Exception`, which became an opaque HTTP 500.

## Fix
- Gate the managed-files path in `list_batches` on unfiltered requests only (`not provider and not target_model_names`)
- Change bare `Exception` → `HTTPException(status_code=400)` in the enterprise hook

## Test Plan
- Updated `tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py` to expect `HTTPException(400)` for provider and target_model_names filters
- Verified with: `pytest tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py -k provider_filter_raises_exception -v`

Closes #36242