### PR TITLE
feat(router): add disable_mid_stream_continuation option

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -427,6 +427,7 @@ class Router:
         health_check_staleness_threshold: int | None = None,
         health_check_ignore_transient_errors: bool = False,
         enable_weighted_failover: bool = False,
+        disable_mid_stream_continuation: bool = False,
     ) -> None:
         """
         Initialize the Router class with the given parameters for caching, reliability, and routing strategy.
@@ -678,6 +679,7 @@ class Router:
         _content_policy_fallbacks: Final = content_policy_fallbacks or litellm.content_policy_fallbacks
         self.validate_fallbacks(fallback_param=_content_policy_fallbacks)
         self.content_policy_fallbacks = _content_policy_fallbacks
+        self.disable_mid_stream_continuation = disable_mid_stream_continuation
         self.total_calls: defaultdict = defaultdict(int)  # dict to store total calls made to each model
         self.fail_calls: defaultdict = defaultdict(int)  # dict to store fail_calls made to each model
         self.success_calls: defaultdict = defaultdict(int)  # dict to store success_calls  made to each model
@@ -2145,8 +2147,13 @@ class Router:
                 async for item in model_response:
                     yield item
             except MidStreamFallbackError as e:
-                if not e.is_pre_first_chunk and (
-                    e.generated_content or _stream_chunks_have_generated_content(model_response.chunks)
+                if (
+                    not self.disable_mid_stream_continuation
+                    and not e.is_pre_first_chunk
+                    and (
+                        e.generated_content
+                        or _stream_chunks_have_generated_content(model_response.chunks)
+                    )
                 ):
                     if e.original_exception is not None:
                         raise e.original_exception from e
@@ -2579,7 +2586,11 @@ class Router:
                     # original_generic_function is preserved by the caller so
                     # the helper knows what underlying API to invoke per attempt.
                     initial_kwargs["original_function"] = self._ageneric_api_call_with_fallbacks_helper
-                    if e.is_pre_first_chunk or not e.generated_content:
+                    if (
+                        e.is_pre_first_chunk
+                        or not e.generated_content
+                        or self.disable_mid_stream_continuation
+                    ):
                         # No content generated before the error — retry with the
                         # original input. Adding a continuation prompt would
                         # waste tokens and confuse the model.
@@ -2690,8 +2701,13 @@ class Router:
                 for item in model_response:
                     yield item
             except MidStreamFallbackError as e:
-                if not e.is_pre_first_chunk and (
-                    e.generated_content or _stream_chunks_have_generated_content(model_response.chunks)
+                if (
+                    not router_self.disable_mid_stream_continuation
+                    and not e.is_pre_first_chunk
+                    and (
+                        e.generated_content
+                        or _stream_chunks_have_generated_content(model_response.chunks)
+                    )
                 ):
                     if e.original_exception is not None:
                         raise e.original_exception from e
@@ -10070,6 +10086,7 @@ class Router:
             "model_group_alias",
             "enable_weighted_failover",
             "enable_tag_filtering",
+            "disable_mid_stream_continuation",
         ]
 
         for var in vars_to_include:
@@ -10107,6 +10124,7 @@ class Router:
             "model_group_alias",
             "enable_weighted_failover",
             "enable_tag_filtering",
+            "disable_mid_stream_continuation",
         ]
 
         _int_settings: Final = [

--- a/tests/router_unit_tests/test_router_aresponses_streaming_fallback.py
+++ b/tests/router_unit_tests/test_router_aresponses_streaming_fallback.py
@@ -28,7 +28,7 @@ from litellm.types.llms.openai import (
 )
 
 
-def _make_router() -> Router:
+def _make_router(**router_kwargs: Any) -> Router:
     return Router(
         model_list=[
             {
@@ -45,7 +45,8 @@ def _make_router() -> Router:
                     "api_key": "sk-test",
                 },
             },
-        ]
+        ],
+        **router_kwargs,
     )
 
 
@@ -443,6 +444,97 @@ async def test_aresponses_fallback_uses_continuation_input_after_partial_content
     assert continuation[-2]["role"] == "developer"
     assert continuation[-1]["role"] == "assistant"
     assert continuation[-1]["content"][0]["text"] == "partial answer"
+
+
+@pytest.mark.asyncio
+async def test_aresponses_fallback_keeps_original_input_when_continuation_disabled():
+    """With disable_mid_stream_continuation=True, the fallback re-entry after a
+    partial-content error must keep the original input instead of appending the
+    developer/assistant continuation block."""
+    import json
+    from unittest.mock import Mock
+
+    from litellm.exceptions import MidStreamFallbackError
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+    from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
+    from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
+    from litellm.types.llms.openai import ErrorEvent, ErrorEventError
+
+    router = _make_router(disable_mid_stream_continuation=True)
+    assert router.disable_mid_stream_continuation is True
+
+    events = [
+        {"type": "response.output_text.delta", "delta": "partial answer"},
+        {"type": "error", "error": {"type": "server_error", "code": "internal_error", "message": "boom"}},
+    ]
+    sse_payload = b"".join(f"data: {json.dumps(event)}\n\n".encode() for event in events)
+
+    async def mock_aiter_bytes():
+        yield sse_payload
+
+    mock_response = Mock()
+    mock_response.headers = {}
+    mock_response.aiter_bytes = mock_aiter_bytes
+    mock_logging_obj = MagicMock(spec=LiteLLMLoggingObj)
+    mock_logging_obj.model_call_details = {"litellm_params": {}}
+    mock_logging_obj.completion_start_time = None
+    mock_config = Mock(spec=BaseResponsesAPIConfig)
+
+    def transform(model, parsed_chunk, logging_obj):
+        if parsed_chunk.get("type") == "error":
+            return ErrorEvent(
+                type=ResponsesAPIStreamEvents.ERROR,
+                sequence_number=0,
+                error=ErrorEventError(**parsed_chunk["error"]),
+            )
+        delta_event = Mock()
+        delta_event.type = ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA
+        delta_event.delta = parsed_chunk["delta"]
+        return delta_event
+
+    mock_config.transform_streaming_response.side_effect = transform
+
+    source = ResponsesAPIStreamingIterator(
+        response=mock_response,
+        model="gpt-5",
+        responses_api_provider_config=mock_config,
+        logging_obj=mock_logging_obj,
+        custom_llm_provider="openai",
+    )
+
+    fallback_event = _make_completed_event(1, 1, 2)
+
+    class _FallbackStream:
+        def __init__(self) -> None:
+            self._done = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._done:
+                raise StopAsyncIteration
+            self._done = True
+            return fallback_event
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        new=AsyncMock(return_value=_FallbackStream()),
+    ) as mock_fallback:
+        wrapped = await router._aresponses_streaming_iterator(
+            response=source,
+            initial_kwargs={"model": "primary", "input": "original question"},
+        )
+        collected = [ev async for ev in wrapped]
+
+    assert collected[-1] == fallback_event
+    raised = mock_fallback.await_args.kwargs["e"]
+    assert isinstance(raised, MidStreamFallbackError)
+    assert raised.is_pre_first_chunk is False
+    assert raised.generated_content == "partial answer"
+    fallback_input = mock_fallback.await_args.kwargs["kwargs"]["input"]
+    assert fallback_input == "original question"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -2001,6 +2001,103 @@ async def test_acompletion_streaming_iterator_edge_cases():
 
 
 @pytest.mark.asyncio
+async def test_acompletion_streaming_iterator_disable_mid_stream_continuation_uses_original_messages():
+    """With disable_mid_stream_continuation=True, a mid-stream failure after
+    partial content is NOT re-raised: the fallback re-entry must retry with the
+    original conversation messages (no assistant prefill/continuation block)."""
+    from unittest.mock import MagicMock
+
+    from litellm.exceptions import MidStreamFallbackError
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            }
+        ],
+        disable_mid_stream_continuation=True,
+        set_verbose=True,
+    )
+    assert router.disable_mid_stream_continuation is True
+
+    messages = [{"role": "user", "content": "Test"}]
+    initial_kwargs = {"model": "gpt-4", "stream": True}
+
+    error = MidStreamFallbackError(
+        message="Connection lost",
+        model="gpt-4",
+        llm_provider="openai",
+        generated_content="Hello",
+    )
+
+    class AsyncIteratorWithError:
+        def __init__(self, items, error_after_index):
+            self.items = items
+            self.index = 0
+            self.error_after_index = error_after_index
+            self.model = "gpt-4"
+            self.custom_llm_provider = "openai"
+            self.logging_obj = MagicMock()
+            self.chunks = []
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self.index >= len(self.items):
+                raise StopAsyncIteration
+            if self.index == self.error_after_index:
+                raise error
+            item = self.items[self.index]
+            self.index += 1
+            return item
+
+    mock_chunks = [
+        MagicMock(choices=[MagicMock(delta=MagicMock(content="Hello"))]),
+        MagicMock(choices=[MagicMock(delta=MagicMock(content=" there"))]),
+    ]
+    mock_error_response = AsyncIteratorWithError(mock_chunks, 1)
+
+    # Mock empty fallback response using AsyncIterator
+    class EmptyAsyncIterator:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        return_value=EmptyAsyncIterator(),
+    ) as mock_fallback_utils:
+        collected_chunks = []
+        iterator = await router._acompletion_streaming_iterator(
+            model_response=mock_error_response,
+            messages=messages,
+            initial_kwargs=initial_kwargs,
+        )
+
+        async for chunk in iterator:
+            collected_chunks.append(chunk)
+
+        # Fallback must be attempted (not re-raised) even though content was
+        # generated mid-stream, because continuation is disabled.
+        assert mock_fallback_utils.called
+        fallback_kwargs = mock_fallback_utils.call_args.kwargs["kwargs"]
+        fallback_messages = fallback_kwargs["messages"]
+
+        # Original messages only — no assistant prefill / continuation block.
+        assert fallback_messages == messages
+        assert all(
+            msg.get("role") != "assistant" or "prefix" not in msg
+            for msg in fallback_messages
+        )
+    print("✓ disable_mid_stream_continuation retries fallback with original messages")
+
+
+@pytest.mark.asyncio
 async def test_acompletion_streaming_iterator_preserves_hidden_params():
     """
     Regression test: FallbackStreamWrapper must copy _hidden_params from the


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mid-stream fallbacks append an assistant prefill / continuation block to the fallback request, which some models (Claude Sonnet 4.6 / Opus 4.7 on both Anthropic and Vertex) reject with a 400 about assistant message prefill (#27967)
- Users who hit this have no supported way to opt out without monkey-patching internal classes

How it solves it:

- Adds a `router_settings.disable_mid_stream_continuation` flag (default `false`)
- When enabled, streaming fallbacks retry with the original conversation messages instead of appending the continuation block

## User Flow

Before: an admin whose fallback target rejects assistant prefill sees a confusing 400 instead of the real upstream error

1. They configure a model group `claude-primary` with `fallbacks: [claude-fallback]` in `config.yaml`
2. A streaming request to `claude-primary` times out mid-stream (e.g. via `stream_timeout`)
3. The router builds a fallback request that carries an assistant message with `"prefix": true`
4. `claude-fallback` returns HTTP 400 "This model does not support assistant message prefill", and the original timeout is swallowed

After: the same admin can opt out and the fallback simply replays the original conversation

1. They set `router_settings: { disable_mid_stream_continuation: true }` in `config.yaml`
2. The same streaming request to `claude-primary` times out mid-stream
3. The router retries the fallback with the original `messages` — no prefill / continuation block
4. `claude-fallback` answers normally, or the real upstream error surfaces if it also fails

## Relevant issues

Fixes #27967

## Linear ticket

<!-- external contributor, no Linear ticket -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- `litellm/router.py`: new `Router.__init__` param `disable_mid_stream_continuation` (default `false`), stored on the instance
- Async/sync chat streaming fallbacks now skip re-raising the original exception and retry with the original `messages` when the flag is set
- Responses-API streaming fallback keeps the original `input` and skips the developer/assistant continuation block when the flag is set
- Wired into `get_settings()` / `update_settings()`; accepted automatically in proxy `router_settings` via `get_valid_args()`
- New tests:
  - `tests/router_unit_tests/test_router_aresponses_streaming_fallback.py::test_aresponses_fallback_keeps_original_input_when_continuation_disabled`
  - `tests/test_litellm/test_router.py::test_acompletion_streaming_iterator_disable_mid_stream_continuation_uses_original_messages`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
