### PR TITLE
fix(proxy): preserve repeated multipart form fields in get_form_data

### DIFF
--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -274,9 +274,8 @@ async def get_form_data(request: Request) -> dict[str, Any]:
     Handles when OpenAI SDKs pass form keys as `timestamp_granularities[]="word"` instead of `timestamp_granularities=["word", "sentence"]`
     """
     form: Final = await request.form()
-    form_data: Final = dict(form)
     parsed_form_data: Final[dict[str, Any]] = {}
-    for key, value in form_data.items():
+    for key, value in form.multi_items():
         # OpenAI SDKs pass form keys as `timestamp_granularities[]="word"` instead of `timestamp_granularities=["word", "sentence"]`
         if key.endswith("[]"):
             clean_key = key[:-2]

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -503,22 +503,30 @@ async def test_get_form_data():
     Test that get_form_data correctly handles form data with array notation.
     Tests audio transcription parameters as a specific example.
     """
+    from starlette.datastructures import FormData
+
     # Create a mock request with transcription form data
     mock_request = MagicMock()
 
-    # Create mock form data with array notation for timestamp_granularities
-    mock_form_data = {
-        "file": "file_object",  # In a real request this would be an UploadFile
-        "model": "gpt-4o-transcribe",
-        "include[]": "logprobs",  # Array notation
-        "language": "en",
-        "prompt": "Transcribe this audio file",
-        "response_format": "json",
-        "stream": "false",
-        "temperature": "0.2",
-        "timestamp_granularities[]": "word",  # First array item
-        "timestamp_granularities[]": "segment",  # Second array item (would overwrite in dict, but handled by the function)
-    }
+    # Real multipart/form-data requests can repeat the same field name (e.g. the
+    # OpenAI SDK sends `timestamp_granularities[]=word` and
+    # `timestamp_granularities[]=segment` as two separate parts). Starlette
+    # represents this as a FormData multidict, not a plain dict, so the mock must
+    # preserve repeated keys the way a real request.form() would.
+    mock_form_data = FormData(
+        [
+            ("file", "file_object"),  # In a real request this would be an UploadFile
+            ("model", "gpt-4o-transcribe"),
+            ("include[]", "logprobs"),  # Array notation
+            ("language", "en"),
+            ("prompt", "Transcribe this audio file"),
+            ("response_format", "json"),
+            ("stream", "false"),
+            ("temperature", "0.2"),
+            ("timestamp_granularities[]", "word"),  # First array item
+            ("timestamp_granularities[]", "segment"),  # Second array item
+        ]
+    )
 
     # Mock the form method to return the test data
     mock_request.form = AsyncMock(return_value=mock_form_data)
@@ -540,11 +548,12 @@ async def test_get_form_data():
     assert isinstance(result["include"], list)
     assert "logprobs" in result["include"]
 
+    # Regression test for https://github.com/BerriAI/litellm/issues/35937:
+    # both repeated timestamp_granularities[] values must be preserved, not just
+    # the last one.
     assert "timestamp_granularities" in result
     assert isinstance(result["timestamp_granularities"], list)
-    # Note: In a real MultiDict, both values would be present
-    # But in our mock dictionary the second value overwrites the first
-    assert "segment" in result["timestamp_granularities"]
+    assert result["timestamp_granularities"] == ["word", "segment"]
 
 
 def test_get_tags_from_request_body_with_metadata_tags():
@@ -1022,10 +1031,12 @@ class TestGetRequestBody:
 
     @pytest.mark.asyncio
     async def test_form_post_routes_to_form_data(self):
+        from starlette.datastructures import FormData
+
         mock_request = MagicMock()
         mock_request.method = "POST"
         mock_request.headers = {"content-type": "multipart/form-data; boundary=x"}
-        mock_request.form = AsyncMock(return_value={"k": "v"})
+        mock_request.form = AsyncMock(return_value=FormData([("k", "v")]))
         mock_request.scope = {}
 
         result = await get_request_body(mock_request)

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -508,11 +508,6 @@ async def test_get_form_data():
     # Create a mock request with transcription form data
     mock_request = MagicMock()
 
-    # Real multipart/form-data requests can repeat the same field name (e.g. the
-    # OpenAI SDK sends `timestamp_granularities[]=word` and
-    # `timestamp_granularities[]=segment` as two separate parts). Starlette
-    # represents this as a FormData multidict, not a plain dict, so the mock must
-    # preserve repeated keys the way a real request.form() would.
     mock_form_data = FormData(
         [
             ("file", "file_object"),  # In a real request this would be an UploadFile
@@ -548,9 +543,6 @@ async def test_get_form_data():
     assert isinstance(result["include"], list)
     assert "logprobs" in result["include"]
 
-    # Regression test for https://github.com/BerriAI/litellm/issues/35937:
-    # both repeated timestamp_granularities[] values must be preserved, not just
-    # the last one.
     assert "timestamp_granularities" in result
     assert isinstance(result["timestamp_granularities"], list)
     assert result["timestamp_granularities"] == ["word", "segment"]

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -510,16 +510,16 @@ async def test_get_form_data():
 
     mock_form_data = FormData(
         [
-            ("file", "file_object"),  # In a real request this would be an UploadFile
+            ("file", "file_object"),
             ("model", "gpt-4o-transcribe"),
-            ("include[]", "logprobs"),  # Array notation
+            ("include[]", "logprobs"),
             ("language", "en"),
             ("prompt", "Transcribe this audio file"),
             ("response_format", "json"),
             ("stream", "false"),
             ("temperature", "0.2"),
-            ("timestamp_granularities[]", "word"),  # First array item
-            ("timestamp_granularities[]", "segment"),  # Second array item
+            ("timestamp_granularities[]", "word"),
+            ("timestamp_granularities[]", "segment"),
         ]
     )
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -1260,10 +1260,12 @@ async def test_is_streaming_request_fn():
         is_streaming_request_fn,
     )
 
+    from starlette.datastructures import FormData
+
     mock_request = Mock()
     mock_request.method = "POST"
     mock_request.headers = {"content-type": "multipart/form-data"}
-    mock_request.form = AsyncMock(return_value={"stream": "true"})
+    mock_request.form = AsyncMock(return_value=FormData({"stream": "true"}))
     assert await is_streaming_request_fn(mock_request) is True
 
 


### PR DESCRIPTION
Fixes #35937

## Problem
`get_form_data()` in `litellm/proxy/common_utils/http_parsing_utils.py` (used by `/v1/audio/transcriptions`) called `dict(form)` on Starlette's `FormData` object before iterating it. `FormData` is a multidict that can hold multiple values under the same key, but `dict()` collapses repeated keys and silently keeps only the last one. The OpenAI SDK encodes `timestamp_granularities=["word", "segment"]` as two separate `timestamp_granularities[]=...` multipart fields, so the collapse meant only the second value ever reached litellm — matching the exact "last one wins" behavior reported.

## Fix
Replaced `dict(form).items()` with `form.multi_items()` in `get_form_data()`, which preserves every repeated key/value pair from the original multidict.

## Testing
Updated `tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py::test_get_form_data` to use a real `starlette.datastructures.FormData` (the previous mock was a plain dict literal, which can't represent a duplicate key and never actually exercised the bug) and assert both `"word"` and `"segment"` survive. Also fixed `TestGetRequestBody::test_form_post_routes_to_form_data`, whose mock likewise needed a real `FormData` object to support `.multi_items()`.

Verified as a genuine regression guard: reverting the fix makes `test_get_form_data` fail with `AssertionError: assert ['segment'] == ['word', 'segment']`; restoring the fix passes it again.

```
============================= 57 passed in 8.24s ==============================
```