### PR TITLE
fix(proxy): deterministically close upstream streams for /v1/responses and /v1/messages

### DIFF
--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -117,6 +117,10 @@ class PassThroughStreamingHandler:
                     )
                 except Exception as e:
                     verbose_proxy_logger.error("Error scheduling chunk_processor logging: %s", e)
+            try:
+                await response.aclose()
+            except Exception as e:
+                verbose_proxy_logger.debug("Error closing passthrough upstream response: %s", e)
 
     @staticmethod
     async def _route_streaming_logging_to_handler(

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -119,7 +119,7 @@ class PassThroughStreamingHandler:
                     verbose_proxy_logger.error("Error scheduling chunk_processor logging: %s", e)
             try:
                 await response.aclose()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001  # closing a possibly-broken transport must not mask stream teardown
                 verbose_proxy_logger.debug("Error closing passthrough upstream response: %s", e)
 
     @staticmethod

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -106,6 +106,9 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._accumulated_provider_specific_fields: dict[str, Any] = {}
         self._custom_tool_names: set[str] = extract_custom_tool_names(self.responses_api_request.get("tools"))
 
+    async def aclose(self) -> None:
+        await self.litellm_custom_stream_wrapper.aclose()
+
     def _get_or_assign_tool_output_index(self, call_id: str) -> int:
         existing: Final = self._tool_output_index_by_call_id.get(call_id)
         if existing is not None:

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -326,6 +326,11 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         self._error_event_emitted = False
         self._last_sequence_number = 0
 
+    async def aclose(self) -> None:
+        base_aclose: Final = getattr(self.base_iterator, "aclose", None)
+        if base_aclose is not None:
+            await base_aclose()
+
     def _extract_mcp_headers_from_params(self) -> None:
         """Extract MCP headers from original request params to pass to tool calls"""
 

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -147,6 +147,12 @@ class BaseResponsesAPIStreamingIterator:
     This class contains shared logic for both synchronous and asynchronous iterators.
     """
 
+    response: httpx.Response | None = None
+
+    async def aclose(self) -> None:
+        if self.response is not None:
+            await self.response.aclose()
+
     def __init__(
         self,
         response: httpx.Response,

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler.py
@@ -3,7 +3,7 @@ when the stream ends, including on client disconnect (generator aclose), so
 the provider connection is released and backends like vLLM stop generating.
 """
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Coroutine
 from datetime import datetime, timezone
 from typing import Final
 from unittest.mock import MagicMock, patch
@@ -51,7 +51,7 @@ def _logging_obj_stub() -> MagicMock:
     return logging_obj
 
 
-def _chunk_processor(response: httpx.Response):
+def _chunk_processor(response: httpx.Response) -> AsyncIterator[bytes]:
     return PassThroughStreamingHandler.chunk_processor(
         response=response,
         request_body={"model": "claude-sonnet-4-5"},
@@ -63,7 +63,7 @@ def _chunk_processor(response: httpx.Response):
     )
 
 
-def _drop_scheduled_coroutine(async_coroutine) -> None:
+def _drop_scheduled_coroutine(async_coroutine: Coroutine[object, object, object]) -> None:
     async_coroutine.close()
 
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler.py
@@ -1,0 +1,114 @@
+"""Regression tests: chunk_processor must close the upstream httpx.Response
+when the stream ends, including on client disconnect (generator aclose), so
+the provider connection is released and backends like vLLM stop generating.
+"""
+
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+from typing import Final
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterator import (
+    AnthropicMessagesStreamHiddenParams,
+    AnthropicMessagesStreamingResponse,
+)
+from litellm.proxy.pass_through_endpoints.streaming_handler import (
+    PassThroughStreamingHandler,
+)
+from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointType
+
+
+class _TrackingStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = chunks
+        self.aclose_called = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.aclose_called = True
+
+
+def _streaming_response(chunks: list[bytes]) -> tuple[httpx.Response, _TrackingStream]:
+    stream: Final = _TrackingStream(chunks)
+    response: Final = httpx.Response(
+        200,
+        stream=stream,
+        request=httpx.Request("POST", "http://upstream.test/v1/messages"),
+    )
+    return response, stream
+
+
+def _logging_obj_stub() -> MagicMock:
+    logging_obj: Final = MagicMock()
+    logging_obj.completion_start_time = None
+    logging_obj.model_call_details = {}
+    return logging_obj
+
+
+def _chunk_processor(response: httpx.Response):
+    return PassThroughStreamingHandler.chunk_processor(
+        response=response,
+        request_body={"model": "claude-sonnet-4-5"},
+        litellm_logging_obj=_logging_obj_stub(),
+        endpoint_type=EndpointType.ANTHROPIC,
+        start_time=datetime.now(timezone.utc),
+        passthrough_success_handler_obj=MagicMock(),
+        url_route="/v1/messages",
+    )
+
+
+def _drop_scheduled_coroutine(async_coroutine) -> None:
+    async_coroutine.close()
+
+
+@pytest.mark.asyncio
+async def test_chunk_processor_closes_response_on_client_disconnect():
+    response, stream = _streaming_response([b"event: message_start\n\n", b"event: message_stop\n\n"])
+    generator: Final = _chunk_processor(response)
+
+    with patch("litellm.proxy.pass_through_endpoints.streaming_handler.GLOBAL_LOGGING_WORKER") as worker:
+        worker.ensure_initialized_and_enqueue.side_effect = _drop_scheduled_coroutine
+        first_chunk: Final = await generator.__anext__()
+        assert first_chunk == b"event: message_start\n\n"
+        await generator.aclose()
+
+    assert stream.aclose_called
+    assert response.is_closed
+
+
+@pytest.mark.asyncio
+async def test_chunk_processor_closes_response_on_natural_completion():
+    response, stream = _streaming_response([b"event: message_start\n\n", b"event: message_stop\n\n"])
+    generator: Final = _chunk_processor(response)
+
+    with patch("litellm.proxy.pass_through_endpoints.streaming_handler.GLOBAL_LOGGING_WORKER") as worker:
+        worker.ensure_initialized_and_enqueue.side_effect = _drop_scheduled_coroutine
+        collected: Final = [chunk async for chunk in generator]
+
+    assert collected == [b"event: message_start\n\n", b"event: message_stop\n\n"]
+    assert stream.aclose_called
+    assert response.is_closed
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_streaming_response_aclose_closes_upstream_response():
+    response, stream = _streaming_response([b"event: message_start\n\n"])
+    wrapped: Final = AnthropicMessagesStreamingResponse(
+        completion_stream=_chunk_processor(response),
+        hidden_params=AnthropicMessagesStreamHiddenParams(additional_headers={}),
+    )
+
+    with patch("litellm.proxy.pass_through_endpoints.streaming_handler.GLOBAL_LOGGING_WORKER") as worker:
+        worker.ensure_initialized_and_enqueue.side_effect = _drop_scheduled_coroutine
+        first_chunk: Final = await wrapped.__anext__()
+        assert first_chunk == b"event: message_start\n\n"
+        await wrapped.aclose()
+
+    assert stream.aclose_called
+    assert response.is_closed

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_streaming_iterator.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_streaming_iterator.py
@@ -1,0 +1,44 @@
+"""Regression test: the /v1/responses bridge iterator must expose aclose()
+so the proxy's streaming cleanup can release the upstream provider
+connection on client disconnect.
+"""
+
+from typing import Final
+from unittest.mock import MagicMock
+
+import pytest
+
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+    LiteLLMCompletionStreamingIterator,
+)
+
+
+class _TrackingCompletionStream:
+    def __init__(self):
+        self.aclose_called = False
+
+    async def aclose(self) -> None:
+        self.aclose_called = True
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_wrapped_completion_stream():
+    completion_stream: Final = _TrackingCompletionStream()
+    wrapper: Final = CustomStreamWrapper(
+        completion_stream=completion_stream,
+        model="gpt-4o-mini",
+        logging_obj=MagicMock(),
+        custom_llm_provider="openai",
+    )
+    iterator: Final = LiteLLMCompletionStreamingIterator(
+        model="gpt-4o-mini",
+        litellm_custom_stream_wrapper=wrapper,
+        request_input="hello",
+        responses_api_request={},
+    )
+
+    await iterator.aclose()
+
+    assert completion_stream.aclose_called
+    assert wrapper.completion_stream is None

--- a/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
+++ b/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
@@ -257,3 +257,29 @@ async def test_initial_call_failure_is_stashed_for_eager_reraise(monkeypatch):
 
     assert iterator._initial_creation_error is not None
     assert "initial boom" in str(iterator._initial_creation_error)
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_base_iterator():
+    class _ClosableStream:
+        def __init__(self):
+            self.aclose_called = False
+
+        async def aclose(self) -> None:
+            self.aclose_called = True
+
+    iterator = _make_iterator([])
+    closable = _ClosableStream()
+    iterator.base_iterator = closable
+
+    await iterator.aclose()
+
+    assert closable.aclose_called
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_a_noop_without_base_iterator():
+    iterator = _make_iterator([])
+    iterator.base_iterator = None
+
+    await iterator.aclose()

--- a/tests/test_litellm/responses/test_streaming_iterator.py
+++ b/tests/test_litellm/responses/test_streaming_iterator.py
@@ -235,3 +235,50 @@ def test_sync_transport_error_before_completed_event_raises():
     with pytest.raises(httpx.ReadError):
         for _ in iterator:
             pass
+
+
+class _TrackingByteStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = chunks
+        self.aclose_called = False
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.aclose_called = True
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_underlying_httpx_response():
+    stream = _TrackingByteStream([_sse_event({"type": "response.output_text.delta", "delta": "hi"})])
+    response = httpx.Response(
+        200,
+        stream=stream,
+        request=httpx.Request("POST", "http://upstream.test/v1/responses"),
+    )
+
+    iterator = ResponsesAPIStreamingIterator(
+        response=response,
+        model="gpt-4o-mini",
+        responses_api_provider_config=_mock_config(),
+        logging_obj=_logging_obj_stub(),
+        litellm_metadata={},
+        custom_llm_provider="openai",
+    )
+
+    await iterator.__anext__()
+    await iterator.aclose()
+
+    assert stream.aclose_called
+    assert response.is_closed
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_a_noop_for_iterators_without_a_response():
+    from litellm.responses.streaming_iterator import BaseResponsesAPIStreamingIterator
+
+    iterator = BaseResponsesAPIStreamingIterator.__new__(BaseResponsesAPIStreamingIterator)
+
+    await iterator.aclose()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cancelled /v1/responses and /v1/messages streams leave the upstream connection open
- Backends like vLLM keep generating into a dead socket
- Whether the connection closes depends on garbage collection timing

How it solves it:

- Both routes' stream objects now expose an explicit close
- The /v1/messages passthrough closes its upstream response on stream end
- Same contract the chat completions route received in #30245

## User Flow

Before: a developer streaming against a self-hosted backend cancels a request, but the backend keeps generating until the response is complete

1. They send POST http://localhost:4000/v1/messages with `"stream": true` for a model served by their vLLM box
2. A few seconds in, they cancel (Ctrl-C in curl, or their app navigates away and drops the connection)
3. Watching the backend, the request keeps decoding to the very end; GPU stays busy and the serving slot stays occupied for the full response length

After: cancelling frees the backend within about a second

1. They send the same POST http://localhost:4000/v1/messages with `"stream": true`
2. A few seconds in, they cancel the same way
3. The backend sees its connection close right away, aborts the request, and the slot frees

The same before and after applies to POST http://localhost:4000/v1/responses with `"stream": true`. Chat completions was already covered by #30245 and is unchanged here

## Relevant issues

Fixes #36123

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: live proxy (`python litellm/proxy/proxy_cli.py --config <config> --port 4000`) in front of a local SSE upstream that emits one chunk per second for 60 seconds and logs the moment its client socket dies. The upstream stands in for a self-hosted backend because this run had no provider credentials to spend; the observed signal, the upstream socket closing, is exactly what #36123 reports vLLM never seeing. No LiteLLM code is mocked, the requests below are what a customer sends

After the fix (commit a4ce0f2ced), both endpoints, curl killed 3 seconds in:

```
curl -sN --max-time 3 http://localhost:4000/v1/responses \
  -H "Authorization: Bearer sk-litellm-test-1234" -H "Content-Type: application/json" \
  -d '{"model": "mock-openai", "input": "count forever", "stream": true}'

curl -sN --max-time 3 http://localhost:4000/v1/messages \
  -H "Authorization: Bearer sk-litellm-test-1234" -H "Content-Type: application/json" \
  -d '{"model": "mock-anthropic", "max_tokens": 500, "messages": [{"role": "user", "content": "count forever"}], "stream": true}'
```

Upstream log, close arrives about one second after each curl dies instead of 60 chunks later:

```
[08:12:17.189] STREAM START /v1/responses
[08:12:21.199] STREAM ABORTED /v1/responses after 4 chunks (ConnectionResetError) -- upstream connection was closed
[08:12:38.611] STREAM START /v1/messages
[08:12:41.618] STREAM ABORTED /v1/messages after 3 chunks (ConnectionResetError) -- upstream connection was closed
```

Honest caveat on the before run (commit e24a9146e3): in this small local repro the connection also closed within about a second, because with nothing else holding references CPython immediately collects the abandoned stream objects and the transport closes on finalization. The leak in #36123 shows up when that collection does not happen promptly, for example when the response object is retained for the request's lifetime under load. What this PR changes is that the close no longer depends on collection timing at all: cleanup now invokes an explicit close on both routes, which is the same guarantee #30245 gave chat completions. With the fix reverted, the new regression tests fail with `AttributeError: 'LiteLLMCompletionStreamingIterator' object has no attribute 'aclose'` and with the upstream response left open in the passthrough generator

For an operator with a vLLM or sglang backend, the two curl commands above (pointed at a real model, cancelled mid-stream) plus the backend's abort log or nvidia-smi are the full verification

## Type

🐛 Bug Fix

## Changes

`BaseResponsesAPIStreamingIterator` gains a null-safe `aclose` that closes the httpx response it holds; null-safe because two subclasses bypass its constructor and carry no response. The bridge iterator used when /v1/responses is served by a chat-completions model overrides it to close its stream wrapper, which releases the provider connection through the #30245 machinery. The /v1/messages passthrough generator now closes its upstream response in its `finally`, after spend logging is scheduled, so partial-usage billing on disconnect is untouched. The MCP-enhanced wrapper keeps its upstream-owning iterator in a separate field, so it overrides the shared close to delegate there (flagged by Greptile). The proxy's existing streaming cleanup and the router's fallback cleanup both already probe for `aclose`; they now find one on these routes

Tests: regression coverage in `tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler.py` (new, mirrors its module), `tests/test_litellm/responses/test_streaming_iterator.py` (extended), and `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_streaming_iterator.py` (new; descriptive name because the directory is not a package and the mirrored name collides with an existing file). Disconnect and natural-completion paths are both pinned, plus the no-response subclass case and the MCP wrapper delegation in `tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
