### PR TITLE
fix(proxy): skip prisma-dependent hooks when no database is attached

### DIFF
--- a/litellm/proxy/openai_files_endpoints/storage_backend_service.py
+++ b/litellm/proxy/openai_files_endpoints/storage_backend_service.py
@@ -68,6 +68,16 @@ class StorageBackendFileService:
                 code=400,
             )
 
+        if target_model_names:
+            managed_files_hook: Final = proxy_logging_obj.get_proxy_hook("managed_files")
+            if not isinstance(managed_files_hook, BaseFileEndpoints):
+                raise ProxyException(
+                    message="Uploading with target_model_names requires a database-connected proxy, and this proxy has no database configured",
+                    type="invalid_request_error",
+                    param="target_model_names",
+                    code=400,
+                )
+
         # Extract file information
         file_content: Final = file_data["content"]
         filename: Final = file_data.get("filename", "file")

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -544,6 +544,11 @@ class ProxyLogging:
         for hook in PROXY_HOOKS:
             proxy_hook = get_proxy_hook(hook)
             expected_args = inspect.getfullargspec(proxy_hook).args
+            if "prisma_client" in expected_args and prisma_client is None:
+                verbose_proxy_logger.debug(
+                    "Skipping proxy hook %s: it requires a database and no prisma client is configured", hook
+                )
+                continue
             passed_in_args: dict[str, Any] = {}
             if "internal_usage_cache" in expected_args:
                 passed_in_args["internal_usage_cache"] = self.internal_usage_cache

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_storage_backend_service.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_storage_backend_service.py
@@ -1,0 +1,127 @@
+import pytest
+
+from litellm.llms.base_llm.files.transformation import BaseFileEndpoints
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+from litellm.proxy.openai_files_endpoints import storage_backend_service
+from litellm.proxy.openai_files_endpoints.storage_backend_service import (
+    StorageBackendFileService,
+)
+
+
+class _RecordingStorageBackend:
+    def __init__(self):
+        self.upload_calls = []
+
+    async def upload_file(self, **kwargs):
+        self.upload_calls.append(kwargs)
+        return "https://storage.example/blob-1"
+
+
+class _FakeManagedFilesHook(BaseFileEndpoints):
+    def __init__(self):
+        self.stored = []
+
+    async def acreate_file(
+        self, create_file_request, llm_router, target_model_names_list, litellm_parent_otel_span, user_api_key_dict
+    ):
+        raise NotImplementedError
+
+    async def afile_retrieve(self, file_id, litellm_parent_otel_span, llm_router=None):
+        raise NotImplementedError
+
+    async def afile_list(self, purpose, litellm_parent_otel_span, **data):
+        raise NotImplementedError
+
+    async def afile_delete(self, file_id, litellm_parent_otel_span, llm_router, **data):
+        raise NotImplementedError
+
+    async def afile_content(self, file_id, litellm_parent_otel_span, llm_router, **data):
+        raise NotImplementedError
+
+    async def store_unified_file_id(self, **kwargs):
+        self.stored.append(kwargs)
+
+
+class _FakeProxyLogging:
+    def __init__(self, hook):
+        self._hook = hook
+
+    def get_proxy_hook(self, hook_name):
+        return self._hook if hook_name == "managed_files" else None
+
+
+def _file_data():
+    return {"content": b"x", "filename": "input.jsonl", "content_type": "application/jsonl"}
+
+
+@pytest.mark.asyncio
+async def test_upload_with_target_model_names_but_no_hook_raises_before_uploading(monkeypatch):
+    backend = _RecordingStorageBackend()
+    monkeypatch.setattr(storage_backend_service, "get_storage_backend", lambda name: backend)
+
+    with pytest.raises(ProxyException) as exc_info:
+        await StorageBackendFileService.upload_file_to_storage_backend(
+            file_data=_file_data(),
+            target_storage="azure_storage",
+            target_model_names=["gpt-x"],
+            purpose="batch",
+            proxy_logging_obj=_FakeProxyLogging(hook=None),
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+        )
+
+    snapshot = {
+        "code": exc_info.value.code,
+        "message_names_requirement": "requires a database-connected proxy" in exc_info.value.message,
+        "upload_calls": backend.upload_calls,
+    }
+    assert snapshot == {"code": "400", "message_names_requirement": True, "upload_calls": []}
+
+
+@pytest.mark.asyncio
+async def test_upload_without_target_model_names_skips_hook_requirement(monkeypatch):
+    backend = _RecordingStorageBackend()
+    monkeypatch.setattr(storage_backend_service, "get_storage_backend", lambda name: backend)
+
+    file_object = await StorageBackendFileService.upload_file_to_storage_backend(
+        file_data=_file_data(),
+        target_storage="azure_storage",
+        target_model_names=[],
+        purpose="batch",
+        proxy_logging_obj=_FakeProxyLogging(hook=None),
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+    )
+
+    snapshot = {
+        "upload_count": len(backend.upload_calls),
+        "id_prefix": file_object.id.split("-")[0],
+    }
+    assert snapshot == {"upload_count": 1, "id_prefix": "file"}
+
+
+@pytest.mark.asyncio
+async def test_upload_with_target_model_names_and_hook_stores_unified_id(monkeypatch):
+    backend = _RecordingStorageBackend()
+    monkeypatch.setattr(storage_backend_service, "get_storage_backend", lambda name: backend)
+    hook = _FakeManagedFilesHook()
+
+    file_object = await StorageBackendFileService.upload_file_to_storage_backend(
+        file_data=_file_data(),
+        target_storage="azure_storage",
+        target_model_names=["gpt-x"],
+        purpose="batch",
+        proxy_logging_obj=_FakeProxyLogging(hook=hook),
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+    )
+
+    snapshot = {
+        "upload_count": len(backend.upload_calls),
+        "store_count": len(hook.stored),
+        "stored_id_matches_response": hook.stored[0]["file_id"] == file_object.id,
+        "model_mappings": hook.stored[0]["model_mappings"],
+    }
+    assert snapshot == {
+        "upload_count": 1,
+        "store_count": 1,
+        "stored_id_matches_response": True,
+        "model_mappings": {"gpt-x": "https://storage.example/blob-1"},
+    }

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_lifecycle.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_lifecycle.py
@@ -8,7 +8,6 @@ because they are direct dependents on the lifecycle state.
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -17,7 +16,6 @@ import pytest
 import litellm
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 from litellm.proxy.utils import (
-    InternalUsageCache,
     ProxyLogging,
 )
 
@@ -102,9 +100,7 @@ def test_update_values_with_no_args_is_noop(proxy_logging):
 
 
 def test_update_values_invalid_type_for_alerting_raises(proxy_logging):
-    proxy_logging.slack_alerting_instance = MagicMock(
-        update_values=MagicMock(side_effect=TypeError("bad type"))
-    )
+    proxy_logging.slack_alerting_instance = MagicMock(update_values=MagicMock(side_effect=TypeError("bad type")))
     with pytest.raises(TypeError):
         proxy_logging.update_values(alerting={"not": "a list"})  # type: ignore[arg-type]
 
@@ -190,6 +186,90 @@ def test_add_proxy_hooks_registers_callbacks(proxy_logging, monkeypatch):
     }
 
 
+def _stub_hook_classes():
+    class _PrismaFreeHook:
+        def __init__(self, internal_usage_cache):
+            self.internal_usage_cache = internal_usage_cache
+
+    class _PrismaRequiringHook:
+        def __init__(self, internal_usage_cache, prisma_client):
+            self.internal_usage_cache = internal_usage_cache
+            self.prisma_client = prisma_client
+
+    class _PrismaOnlyHook:
+        def __init__(self, prisma_client):
+            self.prisma_client = prisma_client
+
+    return {
+        "cache_control_check": _PrismaFreeHook,
+        "needs_db_hook": _PrismaRequiringHook,
+        "db_only_hook": _PrismaOnlyHook,
+    }
+
+
+def test_add_proxy_hooks_skips_prisma_requiring_hook_when_no_db(proxy_logging, monkeypatch):
+    hook_classes = _stub_hook_classes()
+    registered: List[Any] = []
+
+    from litellm.proxy import utils as utils_mod
+
+    monkeypatch.setattr(utils_mod, "PROXY_HOOKS", list(hook_classes.keys()))
+    monkeypatch.setattr(utils_mod, "get_proxy_hook", hook_classes.__getitem__)
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "add_litellm_callback",
+        lambda cb: registered.append(cb),
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client", None):
+        proxy_logging._add_proxy_hooks(llm_router=None)
+
+    snapshot = {
+        "mapping_keys": list(proxy_logging.proxy_hook_mapping.keys()),
+        "registered_types": [type(r).__name__ for r in registered],
+        "needs_db_hook_lookup": proxy_logging.get_proxy_hook("needs_db_hook"),
+        "db_only_hook_lookup": proxy_logging.get_proxy_hook("db_only_hook"),
+    }
+    assert snapshot == {
+        "mapping_keys": ["cache_control_check"],
+        "registered_types": ["_PrismaFreeHook"],
+        "needs_db_hook_lookup": None,
+        "db_only_hook_lookup": None,
+    }
+
+
+def test_add_proxy_hooks_registers_prisma_requiring_hook_with_db(proxy_logging, monkeypatch):
+    hook_classes = _stub_hook_classes()
+    registered: List[Any] = []
+    fake_prisma = MagicMock()
+
+    from litellm.proxy import utils as utils_mod
+
+    monkeypatch.setattr(utils_mod, "PROXY_HOOKS", list(hook_classes.keys()))
+    monkeypatch.setattr(utils_mod, "get_proxy_hook", hook_classes.__getitem__)
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "add_litellm_callback",
+        lambda cb: registered.append(cb),
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client", fake_prisma):
+        proxy_logging._add_proxy_hooks(llm_router=None)
+
+    snapshot = {
+        "mapping_keys": list(proxy_logging.proxy_hook_mapping.keys()),
+        "registered_count": len(registered),
+        "needs_db_hook_got_prisma": proxy_logging.proxy_hook_mapping["needs_db_hook"].prisma_client is fake_prisma,
+        "db_only_hook_got_prisma": proxy_logging.proxy_hook_mapping["db_only_hook"].prisma_client is fake_prisma,
+    }
+    assert snapshot == {
+        "mapping_keys": ["cache_control_check", "needs_db_hook", "db_only_hook"],
+        "registered_count": 3,
+        "needs_db_hook_got_prisma": True,
+        "db_only_hook_got_prisma": True,
+    }
+
+
 def test_add_proxy_hooks_unknown_hook_raises(proxy_logging, monkeypatch):
     from litellm.proxy import utils as utils_mod
 
@@ -267,9 +347,7 @@ def test_init_litellm_callbacks_replaces_string_with_instance(proxy_logging, mon
     snapshot = {
         "replaced_first_item": litellm.callbacks[0] is sentinel_instance,
         "callbacks_grew_with_service": len(litellm.callbacks) >= 2,
-        "service_logging_appended": any(
-            "ServiceLogging" in type(c).__name__ for c in litellm.callbacks
-        ),
+        "service_logging_appended": any("ServiceLogging" in type(c).__name__ for c in litellm.callbacks),
     }
     assert snapshot == {
         "replaced_first_item": True,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Batch create on a DB-less proxy 500s with `'NoneType' object has no attribute 'db'`
- The provider job has already started by then, so it bills
- The caller never gets the batch id, so no poll or cancel
- Every retry starts another paid provider job

How it solves it:

- Hooks that require a database are not registered when none is attached
- Batch and fine-tuning creates then respond normally on DB-less proxies
- Uploads asking for `target_model_names` without a database fail fast with a 400

## User Flow

Before: a batch create through a proxy running without a database spends real money and then reports failure

1. The proxy admin boots the gateway with a Vertex AI model in the config and no `DATABASE_URL`
2. A user uploads their batch input with POST http://litellm-domain/v1/files (`purpose=batch`, `custom_llm_provider=vertex_ai`) and gets back an id like `gs://<bucket>/litellm-vertex-files/publishers/google/models/gemini-3.6-flash/<uuid>`
3. They send POST http://litellm-domain/v1/batches with that id and `"custom_llm_provider": "vertex_ai"`, and get HTTP 500 with `{"error":{"message":"'NoneType' object has no attribute 'db'", ...}}`
4. The batch job actually started on Vertex before the 500 and runs to completion billed, but the user never saw its id, so they cannot poll it, cancel it, or fetch its output, and retrying the create starts another paid job

After: the same walk returns the batch object and the batch lifecycle completes without a database

1. The proxy admin boots the gateway the same way
2. The user uploads the same input with POST http://litellm-domain/v1/files and gets the same style of id back
3. The same POST http://litellm-domain/v1/batches now returns 200 with the batch object, a numeric id and `"status": "validating"`
4. GET http://litellm-domain/v1/batches/{id}?provider=vertex_ai reaches `"status": "completed"` and the output sits at the returned output file path

## Relevant issues

Resolves #36265

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live e2e proof, no mocks, real Vertex AI spend. Both legs boot a DB-less proxy from its own clean worktree: no `DATABASE_URL` anywhere (the leg `.env` carries only GCS settings, `grep -c DATABASE_URL .env` prints 0, and the boot log prints `prisma_client: None`), same config (`gemini-3.6-flash`, project `vertex-check-481318`, location `global`), same flow. Only the commit the proxy boots from differs

### Before leg, merge base b6e3ff639c: 500 after the provider job already started

The upload succeeds:

```
curl -sS -X POST http://localhost:41783/v1/files -H "Authorization: Bearer sk-1234" \
  -F purpose=batch -F custom_llm_provider=vertex_ai -F file=@batch-input.jsonl

{"id":"gs://litellm_bucket-16/litellm-vertex-files/publishers/google/models/gemini-3.6-flash/c8f46fbd-f175-402f-8df7-ce2b6cfc24e7","bytes":447,...,"purpose":"batch","status":"uploaded",...}
```

then the batch create 500s and the client never sees the batch id:

```
curl -sS -i -X POST http://localhost:41783/v1/batches -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"input_file_id": "gs://litellm_bucket-16/litellm-vertex-files/publishers/google/models/gemini-3.6-flash/c8f46fbd-f175-402f-8df7-ce2b6cfc24e7", "endpoint": "/v1/chat/completions", "completion_window": "24h", "custom_llm_provider": "vertex_ai"}'

HTTP/1.1 500 Internal Server Error
{"error":{"message":"'NoneType' object has no attribute 'db'","type":"internal_server_error","param":"None","code":"500"}}
```

The proxy log shows the provider call had already succeeded, `LiteLLMBatch(id='1667570736853680128', ..., status='validating')`, before the hook crashed:

```
File ".../enterprise/litellm_enterprise/proxy/hooks/managed_files.py", line 231, in store_unified_object_id
    await self.prisma_client.db.litellm_managedobjecttable.upsert(
AttributeError: 'NoneType' object has no attribute 'db'
INFO: 127.0.0.1:59270 - "POST /v1/batches HTTP/1.1" 500 Internal Server Error
```

and querying Vertex directly confirms the orphaned job exists and bills:

```
GET https://aiplatform.googleapis.com/v1/projects/vertex-check-481318/locations/global/batchPredictionJobs/1667570736853680128

"state": "JOB_STATE_QUEUED",
"model": "publishers/google/models/gemini-3.6-flash",
"createTime": "2026-08-08T08:50:21.257594Z"
```

### After leg, PR head 855c49d0ef: 200 and pollable to completed

The startup log shows the fix at work, and the pre-fix error string appears zero times in the whole log:

```
Skipping proxy hook managed_files: it requires a database and no prisma client is configured
Skipping proxy hook managed_vector_stores: it requires a database and no prisma client is configured
```

Same upload, then the same batch create now returns the batch object:

```
curl -sS -i -X POST http://localhost:41217/v1/batches -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"input_file_id": "gs://litellm_bucket-16/litellm-vertex-files/publishers/google/models/gemini-3.6-flash/2d937a6b-3daa-4b7e-b460-3d79527495b5", "endpoint": "/v1/chat/completions", "completion_window": "24h", "custom_llm_provider": "vertex_ai"}'

HTTP/1.1 200 OK
{"id":"5186007945736880128","completion_window":"24h","created_at":1786204125,"endpoint":"","input_file_id":"gs://litellm_bucket-16/...","object":"batch","status":"validating",...}
```

and polling reaches a terminal state in about 3.5 minutes (validating -> in_progress -> completed):

```
curl -sS "http://localhost:41217/v1/batches/5186007945736880128?provider=vertex_ai" -H "Authorization: Bearer sk-1234"

{"id":"5186007945736880128",...,"status":"completed","output_file_id":"gs://litellm_bucket-16/litellm-vertex-files/publishers/google/models/gemini-3.6-flash/prediction-model-2026-08-08T08:48:45.356899Z/predictions.jsonl",...}
```

## Type

🐛 Bug Fix

## Changes

`_add_proxy_hooks` (`litellm/proxy/utils.py`) instantiated every registered hook, passing the module-global `prisma_client` into any constructor that asks for it, and registered the result even when that global was `None`. Two enterprise hooks have such constructors, `managed_files` and `managed_vector_stores`, and the managed-files post-success handler writes every batch and fine-tuning create to the database unconditionally, so on DB-less proxies the write raised `AttributeError` after the provider had already accepted the job. The fix skips construction and registration of a hook whose constructor requires `prisma_client` while none is configured, with a debug log naming the skipped hook

Startup ordering makes the skip safe for DB-backed deployments: the lifespan sets the prisma client (`proxy_server.py:1002`) before hook registration runs (`_initialize_startup_logging` at `proxy_server.py:1068` -> `startup_event` -> `_init_litellm_callbacks`, the only path into `_add_proxy_hooks`), and the function re-imports the global at call time. Every consumer of `get_proxy_hook("managed_files")` and of `get_proxy_hook("managed_vector_stores")` already handles `None`, since that is what non-enterprise installs return today

One consumer needed an explicit decision: `POST /v1/files` with `target_model_names` plus a storage backend previously crashed the same way on DB-less proxies after uploading the file. With the hook absent it would have silently returned a file that cannot do target-model routing, so `upload_file_to_storage_backend` now rejects `target_model_names` with a 400 naming the database requirement before uploading anything. That also turns the pre-existing silent skip on enterprise-absent deployments into the same explicit 400

Tests: `test_lifecycle.py` gains regression tests that a `prisma_client`-requiring hook is skipped (mapping and callbacks) without a database and registered with one, and the skip test fails on the unfixed code. A new `test_storage_backend_service.py` pins the 400 firing before upload, the no-`target_model_names` path staying hook-free, and the with-hook path storing the unified id

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
