### PR TITLE
test: roll back live router replay membership between tests

### DIFF
--- a/tests/test_litellm/conftest.py
+++ b/tests/test_litellm/conftest.py
@@ -19,6 +19,7 @@ sys.path.insert(
 import asyncio
 
 import litellm
+from litellm import router as litellm_router_module
 from litellm import utils as litellm_utils_module
 from litellm._logging import ALL_LOGGERS
 from litellm.litellm_core_utils.prompt_templates import (
@@ -244,6 +245,8 @@ def isolate_litellm_state():
         for model_key, model_value in litellm_utils_module._runtime_registered_model_cost.items()
     }
 
+    original_live_routers = set(litellm_router_module._live_routers)
+
     # Store LiteLLM logger state. Some tests reconfigure handlers/propagation for
     # JSON logging and do not restore them, which breaks later caplog-based tests.
     logger_state = {}
@@ -312,6 +315,11 @@ def isolate_litellm_state():
 
     litellm_utils_module._runtime_registered_model_cost.clear()
     litellm_utils_module._runtime_registered_model_cost.update(original_runtime_registered_model_cost)
+
+    for _router in tuple(litellm_router_module._live_routers):
+        litellm_router_module._live_routers.discard(_router)
+    for _router in original_live_routers:
+        litellm_router_module._live_routers.add(_router)
 
     # Restore logger configuration mutated by logging-focused tests.
     for logger in ALL_LOGGERS:

--- a/tests/test_litellm/test_conftest_isolation.py
+++ b/tests/test_litellm/test_conftest_isolation.py
@@ -1,7 +1,13 @@
 import litellm
+from litellm import Router
+from litellm import router as litellm_router_module
 from litellm import utils as litellm_utils_module
 
 CANARY_MODEL = "conftest-isolation-canary-model"
+
+
+class _CanaryRouterHolder:
+    router: Router | None = None
 
 
 def test_register_model_ledger_entry_is_scoped_to_this_test():
@@ -11,3 +17,20 @@ def test_register_model_ledger_entry_is_scoped_to_this_test():
 
 def test_register_model_ledger_entry_was_rolled_back():
     assert CANARY_MODEL not in litellm_utils_module._runtime_registered_model_cost
+
+
+def test_live_router_membership_is_scoped_to_this_test():
+    _CanaryRouterHolder.router = Router(
+        model_list=[
+            {
+                "model_name": "conftest-isolation-canary-router",
+                "litellm_params": {"model": "openai/conftest-isolation-canary-backend", "api_key": "sk-canary"},
+            }
+        ]
+    )
+    assert _CanaryRouterHolder.router in litellm_router_module._live_routers
+
+
+def test_live_router_membership_was_rolled_back():
+    assert _CanaryRouterHolder.router is not None
+    assert _CanaryRouterHolder.router not in litellm_router_module._live_routers


### PR DESCRIPTION
## TLDR

Problem this solves:

- proxy-infra check still flakes on `test_distributed_reload_check_function` after #36039
- #35491 added two replay mechanisms; #36039 isolated only the ledger one
- cost map swaps also replay deployments of every still-alive `Router`
- a leftover router from any earlier same-worker test balloons the test's sparse mock
- reruns can't save the run because the router survives in the worker process

How it solves it:

- the autouse isolation fixture now also rolls back `_live_routers` membership
- a second canary pair proves router membership no longer outlives its test

## User Flow

Before: a contributor's PR touching nothing near pricing fails the proxy-infra required check on an unrelated test, and the automatic reruns fail the same way

1. A contributor pushes a branch and opens a PR, e.g. #36276 changing only pre-commit tooling
2. On the PR's Checks tab, the required check "Unit Tests: Proxy Infrastructure / proxy-infra / Run tests" turns red after ~11 minutes
3. Opening the job log at `https://github.com/BerriAI/litellm/actions/runs/31251929962/job/93089535345`, they see `TestPriceDataReloadIntegration::test_distributed_reload_check_function` failing on an assert that expected the two-field pricing entry `{'input_cost_per_token': 0.001}` and got a ~106-field dump of mostly `None` values, in a file their PR never touched
4. The summary line shows `2 rerun`, so both automatic retries hit the identical assert and the red is sticky for this run
5. They click "Re-run failed jobs" and wait ~10 minutes; whether the fresh run goes green depends on which tests share a worker and on garbage collection timing, so they may burn several reruns before merging

After: the same PR's proxy-infra check passes, and the test no longer depends on which tests ran before it

1. A contributor pushes a branch and opens a PR changing only pre-commit tooling
2. On the PR's Checks tab, "Unit Tests: Proxy Infrastructure / proxy-infra / Run tests" turns green
3. `test_distributed_reload_check_function` passes regardless of which other tests ran earlier in the same worker, so no reruns are needed for this failure

## Relevant issues

Observed on PR #36276 (run 31251929962), whose head already contained #36039, so this is the second, previously unfixed half of the same #35491 replay pollution

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR changes only test isolation, no proxy runtime code, so there is no end-user request to curl: the observable behavior is the CI shard itself. The proof is a deterministic reproduction of the exact CI failure and its disappearance at the exact commits

| Leg | Commit | Run | Result |
| --- | --- | --- | --- |
| staging, polluted | e24a9146e3 | polluter then flaky test | FAIL |
| this PR, polluted | 38c8e8dab4 | polluter then flaky test | PASS |
| staging, regression pair | e24a9146e3 | new canary pair | FAIL |
| this PR, regression pair | 38c8e8dab4 | new canary pair | PASS |

The reproduction plants a minimal polluter that does what many router tests already do, construct a `Router` with a `gpt-3.5-turbo` deployment, and holds it alive the way any module-level fixture or uncollected reference cycle would. `PYTEST_XDIST_WORKER=gw0` mimics a CI xdist worker, and the polluter's function name sorts first because the conftest orders tests by bare name

```bash
cat > tests/test_litellm/proxy/test_aaa_repro_polluter.py <<'EOF'
from litellm import Router

_held_routers = []


def test_aaa_repro_polluter_creates_router():
    _held_routers.append(
        Router(
            model_list=[
                {
                    "model_name": "gpt-3.5-turbo",
                    "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "sk-test"},
                }
            ]
        )
    )
EOF
PYTEST_XDIST_WORKER=gw0 .venv/bin/pytest tests/test_litellm/proxy/test_aaa_repro_polluter.py \
  "tests/test_litellm/proxy/test_proxy_server.py::TestPriceDataReloadIntegration::test_distributed_reload_check_function" \
  -q -p no:randomly
```

On staging (e24a9146e3) this fails with the same assert diff as the CI logs, the sparse `{"input_cost_per_token": 0.001}` mock ballooned into a ~106-field mostly-`None` `ModelInfo` dict, and the captured log even shows the router's deployment re-registration firing inside the flaky test's reload call:

```text
FAILED tests/test_litellm/proxy/test_proxy_server.py::TestPriceDataReloadIntegration::test_distributed_reload_check_function
1 failed, 1 passed, 1 warning in 1.75s
```

On this branch (38c8e8dab4) the identical sequence passes:

```text
2 passed, 1 warning in 1.39s
```

The new canary pair in `tests/test_litellm/test_conftest_isolation.py` fails on staging at the rollback assert (`1 failed, 3 passed`) and passes here (`4 passed`). The full proxy-infra shard command from `.github/workflows/test-unit-proxy-infra.yml` (`-n 2 --dist=loadscope --reruns 2`) was also run on this branch: 6296 passed with the only failures being the 21 tests of `test_semantic_tool_filter.py` hitting a missing optional `semantic_router` package in the local venv, which fail identically on clean staging (e24a9146e3) without this change

## Type

✅ Test

## Changes

`tests/test_litellm/conftest.py`: the autouse `isolate_litellm_state` fixture snapshots `litellm.router._live_routers` membership before each test and restores it on teardown. Since #35491 every `Router` joins that weak set at construction, and every cost map swap walks it to re-register each member's deployments on top of the freshly adopted map, so a router constructed by one test kept rewriting the model entries a later test swapped in for as long as the object stayed referenced or uncollected. Restoring membership rather than dropping the routers keeps fixture-provided routers working within their own test while stopping them from contributing to later tests' cost map rebuilds

`tests/test_litellm/test_conftest_isolation.py`: a second canary pair; the first test constructs a router, holds it in a module-level slot so it deliberately stays alive, and asserts it joined `_live_routers`, the second asserts the fixture removed it despite the object still being alive. On current staging the second test fails, with this PR both pass

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
