### PR TITLE
fix: parse duplicate issue response without line splitting

### DIFF
--- a/.github/scripts/close_duplicate_issues.py
+++ b/.github/scripts/close_duplicate_issues.py
@@ -50,17 +50,7 @@ def fetch_open_issues(repo: str | None) -> list[dict]:
     cmd = ["api", "--paginate", endpoint]
 
     raw = gh(*cmd)
-    # gh --paginate concatenates JSON arrays, so we may get multiple arrays
-    issues = []
-    for line in raw.strip().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        parsed = json.loads(line)
-        if isinstance(parsed, list):
-            issues.extend(parsed)
-        else:
-            issues.append(parsed)
+    issues = json.loads(raw)
 
     # Filter out pull requests (they also appear in the issues endpoint)
     return [i for i in issues if "pull_request" not in i]

--- a/tests/test_litellm/test_close_duplicate_issues.py
+++ b/tests/test_litellm/test_close_duplicate_issues.py
@@ -1,0 +1,27 @@
+"""Unit tests for `.github/scripts/close_duplicate_issues.py`."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "close_duplicate_issues.py"
+
+
+@pytest.fixture(scope="module")
+def duplicate_issues_module():
+    spec = importlib.util.spec_from_file_location("close_duplicate_issues", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fetch_open_issues_preserves_unicode_line_separators(duplicate_issues_module, monkeypatch):
+    raw = '[{"number": 1, "body": "line\u2028separator"}, {"number": 2, "body": "paragraph\u2029separator"}]'
+    monkeypatch.setattr(duplicate_issues_module, "gh", lambda *args: raw)
+
+    assert duplicate_issues_module.fetch_open_issues("BerriAI/litellm") == [
+        {"number": 1, "body": "line\u2028separator"},
+        {"number": 2, "body": "paragraph\u2029separator"},
+    ]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Unicode line separators break duplicate-issue JSON parsing.

How it solves it:

- Parse the complete paginated response as one JSON array.
- Add regression coverage for U+2028 and U+2029.

## Relevant issues

Fixes #35696

## Linear ticket

N/A — external contribution.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (local focused checks pass; CI is pending)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (pending automated review)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (`e24a9146e32437f33603a768133535c017e59b60`), the issue's U+2028 reproduction returned:

```text
old splitlines parser: JSONDecodeError
```

After (`c472b0667bd14f1fa53c685015bdf3bf63d59320`), the same response parses intact:

```text
new whole-response parser: 1 issue
```

Focused regression test:

```text
python3 -m pytest tests/test_litellm/test_close_duplicate_issues.py -q
1 passed in 0.08s
```

## Type

🐛 Bug Fix

✅ Test

## Changes

- Replace unsafe `splitlines()` parsing with `json.loads(raw)`.
- Cover raw Unicode line and paragraph separators in issue bodies.

## QA runbook

N/A — this PR does not edit end-to-end tests.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
