### PR TITLE
feat(ui): show models under each tier in routing benchmark chart

### DIFF
--- a/litellm/types/management_endpoints/auto_router_endpoints.py
+++ b/litellm/types/management_endpoints/auto_router_endpoints.py
@@ -126,8 +126,8 @@ class AutoRouterBenchmarkGroup(AutoRouterBenchmarkTotals):
         description="Turns per tier, keyed by the tier name the routing decision recorded at "
         "request time (never re-derived at read time, since the tier-to-model mapping is "
         "mutable config). Tier names are scoped to this group's router_type and are not "
-        "comparable across types: a complexity router reports 'simple'/'medium'/'complex'/"
-        "'reasoning', a quality router reports its numeric quality tier, and an adaptive router "
+        "comparable across types: a complexity router reports 'SIMPLE'/'MEDIUM'/'COMPLEX'/"
+        "'REASONING', a quality router reports its numeric quality tier, and an adaptive router "
         "records no tier at all. Turns no tier served (the classifier fell back to default_model) "
         "are absent rather than pooled under a sentinel key, so the values may sum to less than turns",
     )

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
@@ -124,13 +124,13 @@ describe("AutoRouterBenchmarksTab", () => {
     expect(screen.getByText("5.3M")).toBeInTheDocument();
   });
 
-  it("pairs the savings with the session and turn counts it was earned over", () => {
+  it("pairs the savings with the session count it was earned over", () => {
     mockHook({ data: response([group(), group({ router_name: "gpt-auto" })]) });
     renderTab();
 
     expect(screen.getByText("Avg saved per session")).toBeInTheDocument();
     expect(screen.getByText("$23.13")).toBeInTheDocument();
-    expect(screen.getByText("across 94 sessions and 3,073 turns")).toBeInTheDocument();
+    expect(screen.getByText("across 94 sessions")).toBeInTheDocument();
   });
 
   it("shows a cost increase as a positive delta rather than a saving", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
@@ -1,10 +1,15 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { AutoRouterDeployment } from "@/app/(dashboard)/hooks/models/useModels";
 import { ApiError } from "@/lib/http/client";
 
 vi.mock("./useAutoRouterBenchmarks", () => ({ useAutoRouterBenchmarks: vi.fn() }));
+vi.mock("@/app/(dashboard)/hooks/models/useModels", () => ({ useAutoRouters: vi.fn() }));
+
+import { useAutoRouters } from "@/app/(dashboard)/hooks/models/useModels";
 
 import AutoRouterBenchmarksTab from "./AutoRouterBenchmarksTab";
 import type {
@@ -15,6 +20,10 @@ import type {
 import { useAutoRouterBenchmarks } from "./useAutoRouterBenchmarks";
 
 type HookResult = ReturnType<typeof useAutoRouterBenchmarks>;
+
+const mockAutoRouters = (deployments: AutoRouterDeployment[] = []) => {
+  vi.mocked(useAutoRouters).mockReturnValue({ data: deployments } as unknown as ReturnType<typeof useAutoRouters>);
+};
 
 const mockHook = (result: { data?: AutoRouterBenchmarksResponse; isPending?: boolean; error?: Error }) => {
   vi.mocked(useAutoRouterBenchmarks).mockReturnValue({
@@ -71,9 +80,20 @@ const response = (groups: AutoRouterBenchmarkGroup[], shared: Totals = totals())
   groups,
 });
 
-const renderTab = () => render(<AutoRouterBenchmarksTab accessToken="sk-test" />);
+const renderTab = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AutoRouterBenchmarksTab accessToken="sk-test" />
+    </QueryClientProvider>,
+  );
+};
 
 describe("AutoRouterBenchmarksTab", () => {
+  beforeEach(() => {
+    mockAutoRouters();
+  });
+
   it("leads with total estimated savings, before the three session-shape metrics", () => {
     mockHook({ data: response([group(), group({ router_name: "gpt-auto" })]) });
     renderTab();
@@ -97,23 +117,20 @@ describe("AutoRouterBenchmarksTab", () => {
     expect(screen.getByText("-86%")).toBeInTheDocument();
     expect(screen.getByText("Actual auto-router spend")).toBeInTheDocument();
     expect(screen.getByText("$359.86")).toBeInTheDocument();
-    expect(screen.getByText("Estimated spend at highest-cost model")).toBeInTheDocument();
+    expect(screen.getByText("Estimated spend at highest-tier model")).toBeInTheDocument();
     expect(screen.getByText("$2,534.45")).toBeInTheDocument();
     expect(screen.getByText("32.7")).toBeInTheDocument();
     expect(screen.getByText("2.1h")).toBeInTheDocument();
     expect(screen.getByText("5.3M")).toBeInTheDocument();
   });
 
-  it("pairs the savings with the session count it was earned over", () => {
+  it("pairs the savings with the session and turn counts it was earned over", () => {
     mockHook({ data: response([group(), group({ router_name: "gpt-auto" })]) });
     renderTab();
 
-    expect(screen.getByText("Total sessions")).toBeInTheDocument();
-    expect(screen.getByText("94")).toBeInTheDocument();
-    expect(screen.getByText("Total turns")).toBeInTheDocument();
-    expect(screen.getByText("3,073")).toBeInTheDocument();
     expect(screen.getByText("Avg saved per session")).toBeInTheDocument();
     expect(screen.getByText("$23.13")).toBeInTheDocument();
+    expect(screen.getByText("across 94 sessions and 3,073 turns")).toBeInTheDocument();
   });
 
   it("shows a cost increase as a positive delta rather than a saving", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
@@ -82,9 +82,7 @@ const HeroCard: React.FC<{ view: BenchmarkView }> = ({ view }) => {
         <div className="flex flex-col items-center justify-center gap-2 border-t p-6 md:border-t-0 md:border-l">
           <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Avg saved per session</p>
           <p className="text-5xl font-semibold tracking-tight text-foreground">{usd(stats.saved_per_session)}</p>
-          <p className="text-sm text-muted-foreground">
-            across {stats.sessions.toLocaleString()} sessions and {stats.turns.toLocaleString()} turns
-          </p>
+          <p className="text-sm text-muted-foreground">across {stats.sessions.toLocaleString()} sessions</p>
         </div>
       </div>
     </Card>

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState } from "react";
 
+import type { AutoRouterDeployment } from "@/app/(dashboard)/hooks/models/useModels";
+import { useAutoRouters } from "@/app/(dashboard)/hooks/models/useModels";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -29,6 +31,7 @@ import {
   type BucketRow,
 } from "./autoRouterBenchmarks";
 import { usd } from "./costOptimizationUtils";
+import TierTurnsChart from "./TierTurnsChart";
 import { useAutoRouterBenchmarks } from "./useAutoRouterBenchmarks";
 
 const Message: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -51,7 +54,7 @@ const HeroCard: React.FC<{ view: BenchmarkView }> = ({ view }) => {
   const cheaper = stats.saved_spend >= 0;
   return (
     <Card className="overflow-hidden py-0">
-      <div className="grid md:grid-cols-[4fr_3fr_5fr]">
+      <div className="grid md:grid-cols-[1fr_1fr]">
         <div className="flex flex-col justify-center gap-3 p-6">
           <p className="text-sm text-muted-foreground">Total estimated savings</p>
           <div className="flex flex-wrap items-center gap-3">
@@ -64,38 +67,24 @@ const HeroCard: React.FC<{ view: BenchmarkView }> = ({ view }) => {
               {Math.abs(stats.saved_pct).toFixed(0)}%
             </Badge>
           </div>
-        </div>
-
-        <div className="flex flex-col justify-center px-6 pb-6 md:py-6">
           <dl className="divide-y text-sm">
             <div className="flex items-baseline justify-between gap-6 py-3">
               <dt className="text-muted-foreground">Actual auto-router spend</dt>
               <dd className="font-medium tabular-nums text-foreground">{usd(stats.spend)}</dd>
             </div>
             <div className="flex items-baseline justify-between gap-6 py-3">
-              <dt className="text-muted-foreground">Estimated spend at highest-cost model</dt>
+              <dt className="text-muted-foreground">Estimated spend at highest-tier model</dt>
               <dd className="font-medium tabular-nums text-foreground">{usd(stats.baseline_spend)}</dd>
             </div>
           </dl>
         </div>
 
-        <div className="flex flex-col border-t md:border-t-0 md:border-l">
-          <div className="grid flex-1 grid-cols-2 divide-x">
-            <div className="flex flex-col justify-center gap-1 px-6 py-4">
-              <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Total sessions</p>
-              <p className="text-3xl font-semibold text-foreground">{stats.sessions.toLocaleString()}</p>
-            </div>
-            <div className="flex flex-col justify-center gap-1 px-6 py-4">
-              <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Total turns</p>
-              <p className="text-3xl font-semibold text-foreground">{stats.turns.toLocaleString()}</p>
-            </div>
-          </div>
-          <dl className="flex flex-col divide-y border-t text-sm">
-            <div className="flex items-center justify-between gap-2 px-6 py-3">
-              <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">Avg saved per session</dt>
-              <dd className="text-lg font-semibold tabular-nums text-foreground">{usd(stats.saved_per_session)}</dd>
-            </div>
-          </dl>
+        <div className="flex flex-col items-center justify-center gap-2 border-t p-6 md:border-t-0 md:border-l">
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Avg saved per session</p>
+          <p className="text-5xl font-semibold tracking-tight text-foreground">{usd(stats.saved_per_session)}</p>
+          <p className="text-sm text-muted-foreground">
+            across {stats.sessions.toLocaleString()} sessions and {stats.turns.toLocaleString()} turns
+          </p>
         </div>
       </div>
     </Card>
@@ -233,9 +222,10 @@ interface BenchmarksBodyProps {
   error: unknown;
   data: AutoRouterBenchmarksResponse | undefined;
   selectedKey: string;
+  autoRouters: readonly AutoRouterDeployment[];
 }
 
-const BenchmarksBody: React.FC<BenchmarksBodyProps> = ({ isPending, error, data, selectedKey }) => {
+const BenchmarksBody: React.FC<BenchmarksBodyProps> = ({ isPending, error, data, selectedKey, autoRouters }) => {
   if (isPending) return <Message>Loading auto-router usage...</Message>;
   if (error instanceof ApiError && error.status === 403) {
     return <Message>Auto-router usage is visible to proxy admin roles only</Message>;
@@ -248,6 +238,8 @@ const BenchmarksBody: React.FC<BenchmarksBodyProps> = ({ isPending, error, data,
   return (
     <>
       <HeroCard view={view} />
+
+      <TierTurnsChart view={view} autoRouters={autoRouters} />
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <Metric label="Avg turns per session" value={stats.avg_turns_per_session.toFixed(1)} />
@@ -282,6 +274,7 @@ const AutoRouterBenchmarksTab: React.FC<AutoRouterBenchmarksTabProps> = ({ acces
   const [range, setRange] = useState<BenchmarkWindow>("30d");
   const { data, isPending, error } = useAutoRouterBenchmarks(accessToken, range);
   const [selectedKey, setSelectedKey] = useState<string>(ALL_ROUTERS);
+  const { data: autoRouters } = useAutoRouters();
 
   const groups = data?.groups ?? [];
   const selectedLabel = data ? viewFor(data, selectedKey).label : "All auto-routers";
@@ -319,7 +312,13 @@ const AutoRouterBenchmarksTab: React.FC<AutoRouterBenchmarksTabProps> = ({ acces
         </div>
       </div>
 
-      <BenchmarksBody isPending={isPending} error={error} data={data} selectedKey={selectedKey} />
+      <BenchmarksBody
+        isPending={isPending}
+        error={error}
+        data={data}
+        selectedKey={selectedKey}
+        autoRouters={autoRouters ?? []}
+      />
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.activity.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.activity.test.tsx
@@ -4,9 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const mockUserDailyActivityCall = vi.fn();
-const { useAuthorizedMock } = vi.hoisted(() => ({ useAuthorizedMock: vi.fn() }));
-
-const mockToolSpendResponse = { by_tool: [], daily: [], start_date: null, end_date: null };
+const { useAuthorizedMock, mockToolSpendResponse } = vi.hoisted(() => ({
+  useAuthorizedMock: vi.fn(),
+  mockToolSpendResponse: { by_tool: [], daily: [], start_date: null, end_date: null },
+}));
 
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: useAuthorizedMock,

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.activity.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.activity.test.tsx
@@ -1,12 +1,20 @@
+import React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const mockUserDailyActivityCall = vi.fn();
+const { useAuthorizedMock } = vi.hoisted(() => ({ useAuthorizedMock: vi.fn() }));
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: useAuthorizedMock,
+}));
 
 vi.mock("@/components/networking", () => ({
   userDailyActivityCall: (...args: unknown[]) => mockUserDailyActivityCall(...args),
   getToolSpend: vi.fn().mockResolvedValue({ by_tool: [], daily: [], start_date: null, end_date: null }),
   getGeneralSettingsCall: vi.fn().mockResolvedValue([]),
+  organizationListCall: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/components/shared/advanced_date_picker", () => ({
@@ -38,9 +46,13 @@ const singlePage = {
 describe("CostOptimizationView daily activity", () => {
   it("fetches daily activity once for the page and shares it with every tab that needs it", async () => {
     mockUserDailyActivityCall.mockResolvedValue(singlePage);
+    useAuthorizedMock.mockReturnValue({ accessToken: "test-token", userId: "u1", userRole: "proxy_admin" });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
     const { getByRole, getByTestId } = render(
-      <CostOptimizationView accessToken="test-token" userId="u1" userRole="proxy_admin" />,
+      <QueryClientProvider client={queryClient}>
+        <CostOptimizationView accessToken="test-token" userId="u1" userRole="proxy_admin" />
+      </QueryClientProvider>,
     );
 
     await waitFor(() => expect(mockUserDailyActivityCall).toHaveBeenCalledTimes(1));

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.activity.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.activity.test.tsx
@@ -6,13 +6,15 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 const mockUserDailyActivityCall = vi.fn();
 const { useAuthorizedMock } = vi.hoisted(() => ({ useAuthorizedMock: vi.fn() }));
 
+const mockToolSpendResponse = { by_tool: [], daily: [], start_date: null, end_date: null };
+
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: useAuthorizedMock,
 }));
 
 vi.mock("@/components/networking", () => ({
   userDailyActivityCall: (...args: unknown[]) => mockUserDailyActivityCall(...args),
-  getToolSpend: vi.fn().mockResolvedValue({ by_tool: [], daily: [], start_date: null, end_date: null }),
+  getToolSpend: vi.fn().mockResolvedValue(mockToolSpendResponse),
   getGeneralSettingsCall: vi.fn().mockResolvedValue([]),
   organizationListCall: vi.fn().mockResolvedValue([]),
 }));

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.test.tsx
@@ -1,10 +1,17 @@
+import React from "react";
 import { fireEvent, render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const { useAuthorizedMock } = vi.hoisted(() => ({ useAuthorizedMock: vi.fn() }));
 
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: useAuthorizedMock,
+}));
+
+vi.mock("@/components/networking", () => ({
+  organizationListCall: vi.fn().mockResolvedValue([]),
+  userDailyActivityCall: vi.fn().mockResolvedValue({ results: [], metadata: { total_pages: 1, has_more: false, page: 1 } }),
 }));
 
 vi.mock("./UsageTab", () => ({ __esModule: true, default: () => <div data-testid="usage-tab" /> }));
@@ -19,7 +26,12 @@ import CostOptimizationView from "./CostOptimizationView";
 
 const renderView = (userRole = "Admin") => {
   useAuthorizedMock.mockReturnValue({ accessToken: "test-token", userId: "u1", userRole });
-  return render(<CostOptimizationView accessToken="test-token" userId="u1" userRole={userRole} />);
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CostOptimizationView accessToken="test-token" userId="u1" userRole={userRole} />
+    </QueryClientProvider>
+  );
 };
 
 describe("CostOptimizationView", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.test.tsx
@@ -11,7 +11,9 @@ vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
 
 vi.mock("@/components/networking", () => ({
   organizationListCall: vi.fn().mockResolvedValue([]),
-  userDailyActivityCall: vi.fn().mockResolvedValue({ results: [], metadata: { total_pages: 1, has_more: false, page: 1 } }),
+  userDailyActivityCall: vi
+    .fn()
+    .mockResolvedValue({ results: [], metadata: { total_pages: 1, has_more: false, page: 1 } }),
 }));
 
 vi.mock("./UsageTab", () => ({ __esModule: true, default: () => <div data-testid="usage-tab" /> }));
@@ -30,7 +32,7 @@ const renderView = (userRole = "Admin") => {
   return render(
     <QueryClientProvider client={queryClient}>
       <CostOptimizationView accessToken="test-token" userId="u1" userRole={userRole} />
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
 };
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/TierTurnsChart.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/TierTurnsChart.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AutoRouterDeployment } from "@/app/(dashboard)/hooks/models/useModels";
+
+vi.mock("@/components/shared/charts", () => ({
+  DonutChart: ({ label }: { label: string }) => <div data-testid="donut">{label}</div>,
+  SEQUENTIAL_COLOR_RAMP: ["indigo", "blue"],
+  chartColorValue: (color: string) => color,
+}));
+
+import TierTurnsChart, { tierDisplayLabel } from "./TierTurnsChart";
+import type { AutoRouterBenchmarkGroup, BenchmarkView } from "./autoRouterBenchmarks";
+
+const totalsOnly = {
+  sessions: 3,
+  turns: 9,
+  avg_turns_per_session: 3,
+  avg_session_seconds: 60,
+  avg_tokens_per_session: 100,
+  spend: 1,
+  saved_spend: 1,
+  baseline_spend: 2,
+  saved_pct: 50,
+  saved_per_session: 0.33,
+  cache: {
+    coverage_pct: 0,
+    hit_rate_pct: 0,
+    same_model: { turns: 0, hits: 0, hit_rate_pct: 0 },
+    first_visit: { turns: 0, hits: 0, hit_rate_pct: 0 },
+    return_to_tier: { turns: 0, hits: 0, hit_rate_pct: 0 },
+    unordered_turns: 0,
+    return_misses_expired: 0,
+    return_misses_within_ttl: 0,
+    return_misses_unknown: 0,
+    ttl_5m_turns: 0,
+    ttl_1h_turns: 0,
+  },
+};
+
+const groupView = (overrides: Partial<AutoRouterBenchmarkGroup> = {}): BenchmarkView => ({
+  label: "claude-auto",
+  stats: {
+    ...totalsOnly,
+    router_name: "claude-auto",
+    router_type: "complexity",
+    tier_turns: { SIMPLE: 3, COMPLEX: 1 },
+    ...overrides,
+  } as AutoRouterBenchmarkGroup,
+});
+
+const deployment = (config: unknown): AutoRouterDeployment => ({
+  model_name: "claude-auto",
+  litellm_params: { model: "auto_router/claude-auto", complexity_router_config: config },
+});
+
+describe("tierDisplayLabel", () => {
+  it("prefers the admin's custom label for a canonical complexity tier", () => {
+    expect(tierDisplayLabel("SIMPLE", { SIMPLE: "Cheap" })).toBe("Cheap");
+  });
+
+  it("falls back to the canonical name when that tier has no custom label", () => {
+    expect(tierDisplayLabel("COMPLEX", { SIMPLE: "Cheap" })).toBe("Complex");
+    expect(tierDisplayLabel("REASONING", undefined)).toBe("Reasoning");
+  });
+
+  it("shows a non-complexity tier verbatim, since no label map covers a quality router's tier", () => {
+    expect(tierDisplayLabel("3", { SIMPLE: "Cheap" })).toBe("3");
+  });
+});
+
+describe("TierTurnsChart", () => {
+  it("labels each slice with its tier and share of the tiered turns", () => {
+    render(<TierTurnsChart view={groupView()} autoRouters={[deployment({ tier_labels: { SIMPLE: "Cheap" } })]} />);
+
+    expect(screen.getByText("Cheap 75%")).toBeInTheDocument();
+    expect(screen.getByText("Complex 25%")).toBeInTheDocument();
+    expect(screen.getByTestId("donut")).toHaveTextContent("4 total turns");
+  });
+
+  it("reads tier_labels out of a config stored as a JSON string", () => {
+    const stored = JSON.stringify({ tier_labels: { SIMPLE: "Cheap" } });
+    render(<TierTurnsChart view={groupView()} autoRouters={[deployment(stored)]} />);
+
+    expect(screen.getByText("Cheap 75%")).toBeInTheDocument();
+  });
+
+  it("uses canonical names when the router is not in the deployment list", () => {
+    render(<TierTurnsChart view={groupView()} autoRouters={[]} />);
+
+    expect(screen.getByText("Simple 75%")).toBeInTheDocument();
+    expect(screen.getByText("Complex 25%")).toBeInTheDocument();
+  });
+
+  it("lists each tier's assigned models below its name and share", () => {
+    render(
+      <TierTurnsChart
+        view={groupView()}
+        autoRouters={[deployment({ tiers: { SIMPLE: ["gpt-4o-mini"], COMPLEX: ["gpt-4o", "claude-3-opus"] } })]}
+      />,
+    );
+
+    expect(screen.getByText("gpt-4o-mini")).toBeInTheDocument();
+    expect(screen.getByText("gpt-4o, claude-3-opus")).toBeInTheDocument();
+  });
+
+  it("widens a bare string tier (pinned single model) into its one-model list", () => {
+    render(<TierTurnsChart view={groupView()} autoRouters={[deployment({ tiers: { SIMPLE: "gpt-4o-mini" } })]} />);
+
+    expect(screen.getByText("gpt-4o-mini")).toBeInTheDocument();
+  });
+
+  it("omits the model line for a tier with no configured models", () => {
+    render(<TierTurnsChart view={groupView()} autoRouters={[deployment({ tiers: { SIMPLE: [] } })]} />);
+
+    expect(screen.getByText("Simple 75%")).toBeInTheDocument();
+  });
+
+  it("shows no models for a quality router's numeric tier, which has no per-tier model list", () => {
+    render(
+      <TierTurnsChart
+        view={groupView({ router_type: "quality", tier_turns: { "3": 3, "1": 1 } })}
+        autoRouters={[deployment({ quality_router_config: { available_models: ["gpt-4o"] } })]}
+      />,
+    );
+
+    expect(screen.getByText("3 75%")).toBeInTheDocument();
+    expect(screen.getByText("1 25%")).toBeInTheDocument();
+    expect(screen.queryByText("gpt-4o")).not.toBeInTheDocument();
+  });
+
+  it("ignores a same-named deployment of a different router type", () => {
+    const qualityDeployment = {
+      model_name: "claude-auto",
+      litellm_params: { model: "auto_router/claude-auto", quality_router_config: { available_models: ["gpt-4o"] } },
+    };
+
+    render(
+      <TierTurnsChart
+        view={groupView()} // complexity router
+        autoRouters={[qualityDeployment] as AutoRouterDeployment[]}
+      />,
+    );
+
+    // No complexity_router_config on the quality deployment, so no tier labels are read,
+    // falling back to canonical names. No models are shown (quality config doesn't have tiers).
+    expect(screen.getByText("Simple 75%")).toBeInTheDocument();
+    expect(screen.queryByText("gpt-4o")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for the all-routers view, which carries no router identity", () => {
+    const { container } = render(
+      <TierTurnsChart view={{ label: "All auto-routers", stats: totalsOnly }} autoRouters={[]} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the router recorded no tiers", () => {
+    const { container } = render(<TierTurnsChart view={groupView({ tier_turns: {} })} autoRouters={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/TierTurnsChart.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/TierTurnsChart.test.tsx
@@ -143,8 +143,6 @@ describe("TierTurnsChart", () => {
       />,
     );
 
-    // No complexity_router_config on the quality deployment, so no tier labels are read,
-    // falling back to canonical names. No models are shown (quality config doesn't have tiers).
     expect(screen.getByText("Simple 75%")).toBeInTheDocument();
     expect(screen.queryByText("gpt-4o")).not.toBeInTheDocument();
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/TierTurnsChart.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/TierTurnsChart.tsx
@@ -126,7 +126,7 @@ const TierTurnsChart: React.FC<TierTurnsChartProps> = ({ view, autoRouters }) =>
               <li key={slice.tier} className="flex items-start gap-2">
                 <span
                   className="mt-1.5 h-2 w-2 shrink-0 rounded-full ring-4 ring-white"
-                  style={{ backgroundColor: chartColorValue(colors[idx % colors.length]) }}
+                  style={{ backgroundColor: chartColorValue(colors[idx]) }}
                 />
                 <div className="min-w-0">
                   <p className="text-sm text-muted-foreground">

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/TierTurnsChart.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/TierTurnsChart.tsx
@@ -11,7 +11,7 @@ import {
   type ComplexityTiers,
 } from "@/components/add_model/ComplexityRouterConfig";
 import { normalizeTierModels } from "@/components/add_model/complexity_router_tiers";
-import { chartColorValue, DonutChart, SEQUENTIAL_COLOR_RAMP } from "@/components/shared/charts";
+import { chartColorValue, DonutChart, type ChartColor } from "@/components/shared/charts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 import { viewGroup, type BenchmarkView } from "./autoRouterBenchmarks";
@@ -84,6 +84,8 @@ interface TierTurnsChartProps {
   autoRouters: readonly AutoRouterDeployment[];
 }
 
+const TIER_DONUT_COLORS: readonly ChartColor[] = ["#c7d2fe", "#1e293b", "#d4b483", "#87a878"];
+
 const TierTurnsChart: React.FC<TierTurnsChartProps> = ({ view, autoRouters }) => {
   const group = viewGroup(view);
   const entries = Object.entries(group?.tier_turns ?? {}).filter(([, turns]) => turns > 0);
@@ -96,7 +98,7 @@ const TierTurnsChart: React.FC<TierTurnsChartProps> = ({ view, autoRouters }) =>
     turns,
     models: tierModelsFor(tier, group.router_name, group.router_type, autoRouters),
   }));
-  const colors = SEQUENTIAL_COLOR_RAMP.slice(0, slices.length);
+  const colors = slices.map((_, idx) => TIER_DONUT_COLORS[idx % TIER_DONUT_COLORS.length]);
 
   return (
     <Card>
@@ -119,7 +121,7 @@ const TierTurnsChart: React.FC<TierTurnsChartProps> = ({ view, autoRouters }) =>
             showLabel
             label={`${total.toLocaleString()} total turns`}
           />
-          <ul className="flex flex-col gap-3">
+          <ul className="flex flex-col gap-6">
             {slices.map((slice, idx) => (
               <li key={slice.tier} className="flex items-start gap-2">
                 <span

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/TierTurnsChart.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/TierTurnsChart.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import React from "react";
+
+import type { AutoRouterDeployment } from "@/app/(dashboard)/hooks/models/useModels";
+import { hydrateTierLabels } from "@/components/add_model/build_complexity_router_config";
+import {
+  TIER_KEYS,
+  effectiveTierLabel,
+  type ComplexityTierLabels,
+  type ComplexityTiers,
+} from "@/components/add_model/ComplexityRouterConfig";
+import { normalizeTierModels } from "@/components/add_model/complexity_router_tiers";
+import { chartColorValue, DonutChart, SEQUENTIAL_COLOR_RAMP } from "@/components/shared/charts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import { viewGroup, type BenchmarkView } from "./autoRouterBenchmarks";
+
+const safeParse = (value: string): unknown => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+};
+
+const asRecord = (value: unknown): Record<string, unknown> => {
+  const parsed: unknown = typeof value === "string" ? safeParse(value) : value;
+  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : {};
+};
+
+const isComplexityTier = (tier: string): tier is keyof ComplexityTiers =>
+  (TIER_KEYS as readonly string[]).includes(tier);
+
+export const tierDisplayLabel = (tier: string, tierLabels: ComplexityTierLabels | undefined): string =>
+  isComplexityTier(tier) ? effectiveTierLabel(tier, tierLabels) : tier;
+
+const CONFIG_KEY_BY_ROUTER_TYPE: Record<string, keyof NonNullable<AutoRouterDeployment["litellm_params"]>> = {
+  complexity: "complexity_router_config",
+  quality: "quality_router_config",
+  auto_router: "auto_router_config",
+  adaptive: "adaptive_router_config",
+};
+
+const deploymentFor = (
+  routerName: string,
+  routerType: string,
+  autoRouters: readonly AutoRouterDeployment[],
+): AutoRouterDeployment | undefined => {
+  const configKey = CONFIG_KEY_BY_ROUTER_TYPE[routerType];
+  if (!configKey) return undefined;
+  return autoRouters.find((d) => d.model_name === routerName && d.litellm_params?.[configKey]);
+};
+
+const tierLabelsFor = (
+  routerName: string,
+  routerType: string,
+  autoRouters: readonly AutoRouterDeployment[],
+): ComplexityTierLabels | undefined => {
+  const deployment = deploymentFor(routerName, routerType, autoRouters);
+  if (!deployment) return undefined;
+  const config = asRecord(deployment.litellm_params?.complexity_router_config);
+  return hydrateTierLabels(config.tier_labels);
+};
+
+const tierModelsFor = (
+  tier: string,
+  routerName: string,
+  routerType: string,
+  autoRouters: readonly AutoRouterDeployment[],
+): string[] => {
+  if (!isComplexityTier(tier)) return [];
+  const deployment = deploymentFor(routerName, routerType, autoRouters);
+  if (!deployment) return [];
+  const config = asRecord(deployment.litellm_params?.complexity_router_config);
+  const tiers = asRecord(config.tiers);
+  return normalizeTierModels(tiers[tier]);
+};
+
+interface TierTurnsChartProps {
+  view: BenchmarkView;
+  autoRouters: readonly AutoRouterDeployment[];
+}
+
+const TierTurnsChart: React.FC<TierTurnsChartProps> = ({ view, autoRouters }) => {
+  const group = viewGroup(view);
+  const entries = Object.entries(group?.tier_turns ?? {}).filter(([, turns]) => turns > 0);
+  if (!group || entries.length === 0) return null;
+
+  const tierLabels = tierLabelsFor(group.router_name, group.router_type, autoRouters);
+  const total = entries.reduce((sum, [, turns]) => sum + turns, 0);
+  const slices = entries.map(([tier, turns]) => ({
+    tier: tierDisplayLabel(tier, tierLabels),
+    turns,
+    models: tierModelsFor(tier, group.router_name, group.router_type, autoRouters),
+  }));
+  const colors = SEQUENTIAL_COLOR_RAMP.slice(0, slices.length);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Routing by tier</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Turns each tier served. Turns the classifier sent to the default model belong to no tier and are not counted
+          here, so this can total less than the router&apos;s turns.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 items-center gap-6 lg:grid-cols-2">
+          <DonutChart
+            className="h-80"
+            data={slices}
+            index="tier"
+            category="turns"
+            colors={colors}
+            valueFormatter={(value) => value.toLocaleString()}
+            showLabel
+            label={`${total.toLocaleString()} total turns`}
+          />
+          <ul className="flex flex-col gap-3">
+            {slices.map((slice, idx) => (
+              <li key={slice.tier} className="flex items-start gap-2">
+                <span
+                  className="mt-1.5 h-2 w-2 shrink-0 rounded-full ring-4 ring-white"
+                  style={{ backgroundColor: chartColorValue(colors[idx % colors.length]) }}
+                />
+                <div className="min-w-0">
+                  <p className="text-sm text-muted-foreground">
+                    {slice.tier} {Math.round((100 * slice.turns) / total).toLocaleString()}%
+                  </p>
+                  {slice.models.length > 0 && (
+                    <p className="text-xs break-words text-muted-foreground/70">{slice.models.join(", ")}</p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TierTurnsChart;

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/autoRouterBenchmarks.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/autoRouterBenchmarks.ts
@@ -24,8 +24,11 @@ export const windowFor = (range: BenchmarkWindow, now: Date): { start_date: stri
 
 export interface BenchmarkView {
   label: string;
-  stats: AutoRouterBenchmarkTotals;
+  stats: AutoRouterBenchmarkTotals | AutoRouterBenchmarkGroup;
 }
+
+export const viewGroup = (view: BenchmarkView): AutoRouterBenchmarkGroup | null =>
+  "router_name" in view.stats ? view.stats : null;
 
 export const groupKey = (group: AutoRouterBenchmarkGroup): string => `${group.router_name} ${group.router_type}`;
 

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -21403,7 +21403,7 @@ export interface components {
             spend: number;
             /**
              * Tier Turns
-             * @description Turns per tier, keyed by the tier name the routing decision recorded at request time (never re-derived at read time, since the tier-to-model mapping is mutable config). Tier names are scoped to this group's router_type and are not comparable across types: a complexity router reports 'simple'/'medium'/'complex'/'reasoning', a quality router reports its numeric quality tier, and an adaptive router records no tier at all. Turns no tier served (the classifier fell back to default_model) are absent rather than pooled under a sentinel key, so the values may sum to less than turns
+             * @description Turns per tier, keyed by the tier name the routing decision recorded at request time (never re-derived at read time, since the tier-to-model mapping is mutable config). Tier names are scoped to this group's router_type and are not comparable across types: a complexity router reports 'SIMPLE'/'MEDIUM'/'COMPLEX'/'REASONING', a quality router reports its numeric quality tier, and an adaptive router records no tier at all. Turns no tier served (the classifier fell back to default_model) are absent rather than pooled under a sentinel key, so the values may sum to less than turns
              */
             tier_turns?: {
                 [key: string]: number;


### PR DESCRIPTION
## Summary
Shows each complexity tier's configured model(s) in the "Routing by tier" chart legend, labels the donut's center number, and clarifies the baseline spend wording.

## Changes

### TierTurnsChart.tsx (new)
- Donut chart showing turns distributed across complexity tiers, only rendered when a single auto-router is selected
- Center label reads "N total turns" instead of a bare number
- Custom legend lists each tier's assigned models below the tier name and percentage
- Quality routers show tier name and percentage only, since they share one model pool instead of pinning models per tier
- Deployment lookup matches on both router name and router type, so two routers sharing a name but different types never borrow each other's config

### AutoRouterBenchmarks helpers
- Added `viewGroup()` to narrow a view to the single-router case, the only one with tier identity
- Widened `BenchmarkView.stats` to explicitly include `AutoRouterBenchmarkGroup`

### AutoRouterBenchmarksTab.tsx
- Changed the label "Estimated spend at highest-cost model" to "highest-tier model", since the baseline compares against the most capable tier rather than a single highest-priced model

## User Flow

Before: an admin on the Auto-Router usage tab, with a specific router selected, sees only tier names and turn percentages, with no indication of which models each tier routes to, and the donut's center just shows a bare number

1. They open http://localhost:4000/ui/cost-optimization/, click the Auto-Router tab, and pick a router from the dropdown
2. The "Routing by tier" legend lists each tier and its share of turns, but nothing about which models that tier uses
3. The donut's center shows a plain number like "6,916" with no unit

After: the same admin sees the models behind each tier and a labeled total

1. Same navigation as above
2. Each legend entry now shows the tier's assigned model(s) beneath its name, e.g. "Fast & Cheap 57%" followed by "claude-3-haiku-fake"
3. The donut's center reads "6,916 total turns"

## Relevant issues

## Linear ticket

Resolves LIT-5302

## Screenshots / Proof of Fix

Backend data, live proxy on localhost:4000, seeded with 340 complexity-router sessions and 180 quality-router sessions, commit 7224c68ca3:

```
curl -s "http://localhost:4000/auto_router/benchmarks?start_date=2026-07-09&end_date=2026-08-08" \
  -H "Authorization: Bearer sk-1234" | python3 -m json.tool
```

```json
{
  "totals": { "sessions": 520, "turns": 9616, "saved_spend": 1036.17, "baseline_spend": 1258.24 },
  "groups": [
    { "router_name": "claude-auto", "router_type": "complexity", "sessions": 340, "turns": 6916 }
  ]
}
```

UI: http://localhost:4000/ui/cost-optimization/, Auto-Router tab, claude-auto selected. The legend shows Fast & Cheap 57% / claude-3-haiku-fake, Balanced 30% / claude-3-sonnet-fake, High Quality 12% / claude-3-opus-fake, Deep Reasoning 2% / claude-3-opus-fake, claude-3-5-sonnet-fake, and the donut center reads "6,916 total turns". The hero card reads "Estimated spend at highest-tier model".

## Type

New Feature

## Changes

Covered above.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only analytics and copy changes; deployment config is read for display with type-safe matching and no auth or billing logic changes.
> 
> **Overview**
> Adds a **Routing by tier** donut on the Auto-Router usage tab when a single router is selected. Slices use admin **tier labels** and benchmark `tier_turns` keys (`SIMPLE`/`MEDIUM`/…); the legend lists **configured models** for complexity tiers, with deployment lookup matched on **router name and type**. Quality routers show tier share only; aggregate “all routers” and empty tier data hide the chart. The donut center is labeled **“N total turns”**.
> 
> The savings **hero card** is simplified to two columns: spend breakdown moves under total savings, **avg saved per session** is emphasized with **“across N sessions”**, and baseline copy changes from **highest-cost** to **highest-tier model**. Benchmark helpers add **`viewGroup()`** and widen **`BenchmarkView.stats`** for per-router tier data.
> 
> API/schema docs for `tier_turns` now document uppercase complexity tier keys. Tests wrap cost-optimization views in **`QueryClientProvider`** and mock **`useAutoRouters`** for the new chart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef0aaae6f7afd94410a09ea2f15a7b1238ad7f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->