### PR TITLE
feat(ui): deployment affinity toggle for the auto-router

### DIFF
--- a/ui/litellm-dashboard/src/autorouter_presets.json
+++ b/ui/litellm-dashboard/src/autorouter_presets.json
@@ -11,7 +11,8 @@
       },
       "classifier_type": "heuristic",
       "escalation_keywords": ["LITELLM ESCALATE"],
-      "session_affinity": false
+      "session_affinity": false,
+      "deployment_affinity": true
     }
   },
   "openai_family": {
@@ -26,7 +27,8 @@
       },
       "classifier_type": "heuristic",
       "escalation_keywords": ["LITELLM ESCALATE"],
-      "session_affinity": false
+      "session_affinity": false,
+      "deployment_affinity": true
     }
   }
 }

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -602,3 +602,32 @@ describe("ComplexityRouterConfig tier labels", () => {
     expect(screen.getByTitle("Deep")).toBeInTheDocument();
   });
 });
+
+describe("ComplexityRouterConfig affinity panel", () => {
+  it("holds both affinity switches with their backend defaults", () => {
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} />);
+    fireEvent.click(screen.getByText("Advanced: Affinity"));
+
+    expect(screen.getByRole("switch", { name: "Pin a session to one deployment per model group" })).toBeChecked();
+    expect(screen.getByRole("switch", { name: "Pin a session to its first model" })).not.toBeChecked();
+  });
+
+  it("writes deployment_affinity through onChange without touching other keys", () => {
+    const onChange = vi.fn();
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} onChange={onChange} />);
+    fireEvent.click(screen.getByText("Advanced: Affinity"));
+
+    fireEvent.click(screen.getByRole("switch", { name: "Pin a session to one deployment per model group" }));
+
+    expect(onChange).toHaveBeenCalledWith({ ...defaultValue, deployment_affinity: false });
+  });
+
+  it("renders a stored deployment_affinity=false as off", () => {
+    renderWithProviders(
+      <ComplexityRouterConfig {...baseProps} value={{ ...defaultValue, deployment_affinity: false }} />,
+    );
+    fireEvent.click(screen.getByText("Advanced: Affinity"));
+
+    expect(screen.getByRole("switch", { name: "Pin a session to one deployment per model group" })).not.toBeChecked();
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -15,6 +15,7 @@ export const DEFAULT_TIER_DISTANCE_PENALTY = 0.5;
 export const DEFAULT_CLASSIFIER_CONTEXT_WINDOW_SIZE = 3;
 export const DEFAULT_CLASSIFIER_CONTEXT_PER_TURN_CHARS = 200;
 export const DEFAULT_SESSION_AFFINITY = false;
+export const DEFAULT_DEPLOYMENT_AFFINITY = true;
 
 export interface ComplexityTiers {
   SIMPLE: string[];
@@ -56,6 +57,7 @@ export interface ComplexityRouterConfigValue {
   classifier_context_include_assistant_turns?: boolean;
   classifier_fallback?: ClassifierFallback;
   session_affinity?: boolean;
+  deployment_affinity?: boolean;
   adaptive?: boolean;
   adaptive_weights?: AdaptiveRouterWeights;
   tier_distance_penalty?: number;
@@ -277,14 +279,26 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
             children: <AdaptiveRoutingConfig value={value} onChange={onChange} />,
           },
           {
-            key: "session-affinity",
+            key: "affinity",
             label: (
               <Text strong style={{ color: "#374151" }}>
-                Advanced: Session Affinity
+                Advanced: Affinity
               </Text>
             ),
             children: (
               <>
+                <div className="flex items-center gap-2 mb-2">
+                  <Switch
+                    checked={value.deployment_affinity ?? DEFAULT_DEPLOYMENT_AFFINITY}
+                    onChange={(deploymentAffinity) => onChange({ ...value, deployment_affinity: deploymentAffinity })}
+                    aria-label="Pin a session to one deployment per model group"
+                  />
+                  <Text strong>Pin a session to one deployment per model group</Text>
+                </div>
+                <Text type="secondary" style={{ display: "block", fontSize: 12, marginBottom: 12 }}>
+                  Keeps a session on the same deployment within a group, so provider prompt caches stay warm. Turn off
+                  to load-balance every turn.
+                </Text>
                 <div className="flex items-center gap-2 mb-2">
                   <Switch
                     checked={value.session_affinity ?? DEFAULT_SESSION_AFFINITY}
@@ -294,10 +308,8 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
                   <Text strong>Pin a session to its first model</Text>
                 </div>
                 <Text type="secondary" style={{ display: "block", fontSize: 12 }}>
-                  Off by default: every turn is classified on its own merits and routed to the cheapest adequate tier.
-                  Turn this on to reuse the model chosen on a session&apos;s first turn for every later turn, which
-                  preserves provider prompt caches and avoids cross-model conversation-history errors, at the cost of
-                  keeping the whole session on the first turn&apos;s tier.
+                  Keeps a session on its first turn&apos;s model instead of re-classifying each turn. Also pins the
+                  deployment.
                 </Text>
               </>
             ),

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -273,7 +273,7 @@ describe("AddAutoRouterTab", () => {
 
     await user.type(screen.getByPlaceholderText(/smart_router/i), "affinity-router");
     expandDetailedConfiguration();
-    await user.click(screen.getByText("Advanced: Session Affinity"));
+    await user.click(screen.getByText("Advanced: Affinity"));
     expect(await screen.findByRole("switch", { name: "Pin a session to its first model" })).not.toBeChecked();
 
     await user.click(screen.getByRole("button", { name: /add auto router/i }));
@@ -292,7 +292,7 @@ describe("AddAutoRouterTab", () => {
 
     await user.type(screen.getByPlaceholderText(/smart_router/i), "affinity-router");
     expandDetailedConfiguration();
-    await user.click(screen.getByText("Advanced: Session Affinity"));
+    await user.click(screen.getByText("Advanced: Affinity"));
     await user.click(await screen.findByRole("switch", { name: "Pin a session to its first model" }));
 
     await user.click(screen.getByRole("button", { name: /add auto router/i }));
@@ -300,6 +300,46 @@ describe("AddAutoRouterTab", () => {
     await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
     expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
       session_affinity: true,
+    });
+  });
+
+  it("defaults a new router to deployment affinity on, matching the backend field default", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(<Harness />);
+
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "affinity-router");
+    expandDetailedConfiguration();
+    await user.click(screen.getByText("Advanced: Affinity"));
+    expect(
+      await screen.findByRole("switch", { name: "Pin a session to one deployment per model group" }),
+    ).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+    expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
+      deployment_affinity: true,
+    });
+  });
+
+  it("carries deployment affinity turned off through to the create payload", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(<Harness />);
+
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "affinity-router");
+    expandDetailedConfiguration();
+    await user.click(screen.getByText("Advanced: Affinity"));
+    await user.click(await screen.findByRole("switch", { name: "Pin a session to one deployment per model group" }));
+
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+    expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
+      deployment_affinity: false,
     });
   });
 

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -15,6 +15,7 @@ import ComplexityRouterConfig, {
   ComplexityTiers,
   DEFAULT_ADAPTIVE_WEIGHTS,
   DEFAULT_SESSION_AFFINITY,
+  DEFAULT_DEPLOYMENT_AFFINITY,
   DEFAULT_TIER_DISTANCE_PENALTY,
 } from "./ComplexityRouterConfig";
 import { KeywordTierRule } from "./KeywordTierRules";
@@ -290,6 +291,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     classifierContextIncludeAssistantTurns: complexityRouterConfig.classifier_context_include_assistant_turns,
     classifierFallback: complexityRouterConfig.classifier_fallback,
     sessionAffinity: complexityRouterConfig.session_affinity ?? DEFAULT_SESSION_AFFINITY,
+    deploymentAffinity: complexityRouterConfig.deployment_affinity ?? DEFAULT_DEPLOYMENT_AFFINITY,
     customTechnicalKeywords,
     keywordTierRules,
     semanticMatchingEnabled,

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
@@ -26,6 +26,7 @@ const baseParams: BuildComplexityRouterConfigParams = {
   classifierContextIncludeAssistantTurns: undefined,
   classifierFallback: undefined,
   sessionAffinity: false,
+  deploymentAffinity: true,
   customTechnicalKeywords: [],
   keywordTierRules: [],
   semanticMatchingEnabled: false,
@@ -46,6 +47,7 @@ describe("buildComplexityRouterConfig", () => {
       tiers,
       classifier_type: "heuristic",
       session_affinity: false,
+      deployment_affinity: true,
       escalation_keywords: ["LITELLM ESCALATE"],
     });
   });

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
@@ -30,6 +30,7 @@ export interface BuildComplexityRouterConfigParams {
   classifierContextIncludeAssistantTurns: boolean | undefined;
   classifierFallback: ClassifierFallback | undefined;
   sessionAffinity: boolean;
+  deploymentAffinity: boolean;
   customTechnicalKeywords: string[];
   keywordTierRules: KeywordTierRule[];
   semanticMatchingEnabled: boolean;
@@ -53,6 +54,7 @@ export interface ComplexityRouterConfigPayload {
   classifier_context_include_assistant_turns?: boolean;
   classifier_fallback?: ClassifierFallback;
   session_affinity: boolean;
+  deployment_affinity: boolean;
   custom_technical_keywords?: string[];
   keyword_tier_rules?: { keywords: string[]; tier: KeywordTierRule["tier"] }[];
   semantic_keyword_matching?: boolean;
@@ -137,6 +139,7 @@ export const buildComplexityRouterConfig = ({
   classifierContextIncludeAssistantTurns,
   classifierFallback,
   sessionAffinity,
+  deploymentAffinity,
   customTechnicalKeywords,
   keywordTierRules,
   semanticMatchingEnabled,
@@ -173,6 +176,7 @@ export const buildComplexityRouterConfig = ({
         classifier_context_include_assistant_turns: classifierContextIncludeAssistantTurns,
       }),
     session_affinity: sessionAffinity,
+    deployment_affinity: deploymentAffinity,
     ...(customTechnicalKeywords.length > 0 && { custom_technical_keywords: customTechnicalKeywords }),
     ...(cleanedKeywordTierRules.length > 0 && { keyword_tier_rules: cleanedKeywordTierRules }),
     escalation_keywords: cleanedEscalationKeywords,

--- a/ui/litellm-dashboard/src/components/edit_auto_router/build_updated_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/build_updated_complexity_router_config.test.ts
@@ -228,6 +228,31 @@ describe("buildUpdatedComplexityRouterConfig session affinity", () => {
   });
 });
 
+describe("buildUpdatedComplexityRouterConfig deployment affinity", () => {
+  it("writes deployment_affinity=false when the toggle is off", () => {
+    const result = buildUpdatedComplexityRouterConfig(STORED, { ...FORM_VALUE, deployment_affinity: false });
+    expect(result.deployment_affinity).toBe(false);
+  });
+
+  it("writes deployment_affinity=true when the toggle is on", () => {
+    const result = buildUpdatedComplexityRouterConfig(STORED, { ...FORM_VALUE, deployment_affinity: true });
+    expect(result.deployment_affinity).toBe(true);
+  });
+
+  it("re-asserts the backend's on-by-default when the form value is absent, rather than dropping the key", () => {
+    const result = buildUpdatedComplexityRouterConfig({ ...STORED, deployment_affinity: false }, FORM_VALUE);
+    expect(result.deployment_affinity).toBe(true);
+  });
+
+  it("stops a stored deployment_affinity=false from surviving a save that turned the toggle back on", () => {
+    const result = buildUpdatedComplexityRouterConfig(
+      { ...STORED, deployment_affinity: false },
+      { ...FORM_VALUE, deployment_affinity: true },
+    );
+    expect(result.deployment_affinity).toBe(true);
+  });
+});
+
 describe("buildUpdatedComplexityRouterConfig tier labels", () => {
   const RENAMED = { ...STORED, tier_labels: { SIMPLE: "Cheap", REASONING: "Deep" } };
 

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.ts
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.ts
@@ -48,6 +48,7 @@ const expectedClassifiedTierConfig = {
   embedding_model: "voyage-4-large",
   match_threshold: 0.65,
   session_affinity: false,
+  deployment_affinity: true,
   adaptive: true,
   adaptive_weights: { quality: 0.4, cost: 0.6 },
   adaptive_eligible: "classified_tier",
@@ -68,6 +69,7 @@ const expectedAdaptiveDisabledConfig = {
   embedding_model: "voyage-4-large",
   match_threshold: 0.65,
   session_affinity: false,
+  deployment_affinity: true,
 };
 
 describe("buildUpdatedComplexityRouterConfig", () => {

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
@@ -342,7 +342,7 @@ describe("EditAutoRouterModal session affinity", () => {
     const user = userEvent.setup();
     renderWithStoredConfig(STORED_CONFIG);
 
-    await user.click(await screen.findByText("Advanced: Session Affinity"));
+    await user.click(await screen.findByText("Advanced: Affinity"));
     expect(await screen.findByRole("switch", { name: "Pin a session to its first model" })).not.toBeChecked();
 
     await user.click(screen.getByRole("button", { name: /save changes/i }));
@@ -355,7 +355,7 @@ describe("EditAutoRouterModal session affinity", () => {
     const user = userEvent.setup();
     renderWithStoredConfig({ ...STORED_CONFIG, session_affinity: true });
 
-    await user.click(await screen.findByText("Advanced: Session Affinity"));
+    await user.click(await screen.findByText("Advanced: Affinity"));
     expect(await screen.findByRole("switch", { name: "Pin a session to its first model" })).toBeChecked();
 
     await user.click(screen.getByRole("button", { name: /save changes/i }));
@@ -368,7 +368,7 @@ describe("EditAutoRouterModal session affinity", () => {
     const user = userEvent.setup();
     renderWithStoredConfig(STORED_CONFIG);
 
-    await user.click(await screen.findByText("Advanced: Session Affinity"));
+    await user.click(await screen.findByText("Advanced: Affinity"));
     await user.click(await screen.findByRole("switch", { name: "Pin a session to its first model" }));
 
     await user.click(screen.getByRole("button", { name: /save changes/i }));
@@ -381,13 +381,74 @@ describe("EditAutoRouterModal session affinity", () => {
     const user = userEvent.setup();
     renderWithStoredConfig({ ...STORED_CONFIG, session_affinity: true });
 
-    await user.click(await screen.findByText("Advanced: Session Affinity"));
+    await user.click(await screen.findByText("Advanced: Affinity"));
     await user.click(await screen.findByRole("switch", { name: "Pin a session to its first model" }));
 
     await user.click(screen.getByRole("button", { name: /save changes/i }));
 
     await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
     expect(savedConfig().session_affinity).toBe(false);
+  });
+});
+
+describe("EditAutoRouterModal deployment affinity", () => {
+  beforeEach(() => {
+    modelPatchUpdateCall.mockClear();
+  });
+
+  const renderWithStoredConfig = (complexity_router_config: Record<string, unknown>) =>
+    renderWithProviders(
+      <EditAutoRouterModal
+        isVisible
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        modelData={{ ...MODEL_DATA, litellm_params: { ...MODEL_DATA.litellm_params, complexity_router_config } }}
+        accessToken="token"
+        userRole="Admin"
+      />,
+    );
+
+  it("shows a stored config with no deployment_affinity key as on, matching the backend default", async () => {
+    const user = userEvent.setup();
+    renderWithStoredConfig(STORED_CONFIG);
+
+    await user.click(await screen.findByText("Advanced: Affinity"));
+    expect(
+      await screen.findByRole("switch", { name: "Pin a session to one deployment per model group" }),
+    ).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().deployment_affinity).toBe(true);
+  });
+
+  it("shows a stored deployment_affinity=false as off and preserves it through an untouched save", async () => {
+    const user = userEvent.setup();
+    renderWithStoredConfig({ ...STORED_CONFIG, deployment_affinity: false });
+
+    await user.click(await screen.findByText("Advanced: Affinity"));
+    expect(
+      await screen.findByRole("switch", { name: "Pin a session to one deployment per model group" }),
+    ).not.toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().deployment_affinity).toBe(false);
+  });
+
+  it("persists turning deployment affinity off", async () => {
+    const user = userEvent.setup();
+    renderWithStoredConfig(STORED_CONFIG);
+
+    await user.click(await screen.findByText("Advanced: Affinity"));
+    await user.click(await screen.findByRole("switch", { name: "Pin a session to one deployment per model group" }));
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().deployment_affinity).toBe(false);
   });
 });
 

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -21,6 +21,7 @@ import ComplexityRouterConfig, {
   ComplexityRouterConfigValue,
   DEFAULT_ADAPTIVE_WEIGHTS,
   DEFAULT_SESSION_AFFINITY,
+  DEFAULT_DEPLOYMENT_AFFINITY,
   DEFAULT_TIER_DISTANCE_PENALTY,
 } from "../add_model/ComplexityRouterConfig";
 import NotificationsManager from "../molecules/notifications_manager";
@@ -47,6 +48,7 @@ const MANAGED_COMPLEXITY_ROUTER_KEYS = new Set([
   "classifier_context_include_assistant_turns",
   "classifier_fallback",
   "session_affinity",
+  "deployment_affinity",
   "adaptive",
   "adaptive_weights",
   "tier_distance_penalty",
@@ -119,6 +121,7 @@ export const buildUpdatedComplexityRouterConfig = (
         classifier_context_include_assistant_turns: value.classifier_context_include_assistant_turns,
       }),
     session_affinity: value.session_affinity ?? DEFAULT_SESSION_AFFINITY,
+    deployment_affinity: value.deployment_affinity ?? DEFAULT_DEPLOYMENT_AFFINITY,
     ...(customTechnicalKeywords &&
       customTechnicalKeywords.length > 0 && {
         custom_technical_keywords: customTechnicalKeywords,
@@ -255,6 +258,10 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
             typeof parsedConfig.session_affinity === "boolean"
               ? parsedConfig.session_affinity
               : DEFAULT_SESSION_AFFINITY,
+          deployment_affinity:
+            typeof parsedConfig.deployment_affinity === "boolean"
+              ? parsedConfig.deployment_affinity
+              : DEFAULT_DEPLOYMENT_AFFINITY,
           adaptive: parsedConfig.adaptive || false,
           adaptive_weights: parsedConfig.adaptive_weights,
           tier_distance_penalty: parsedConfig.tier_distance_penalty,

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -111,6 +111,7 @@ describe("autorouter_presets", () => {
         tiers: { SIMPLE: [presetModel], MEDIUM: [], COMPLEX: [], REASONING: [] },
         classifier_type: "heuristic" as const,
         session_affinity: false,
+        deployment_affinity: true,
       };
       expect(getMissingModels(config, availability)).toEqual([]);
       expect(buildPresetPrefill(config, availability).complexityRouterConfig.tiers.SIMPLE).toEqual([group]);
@@ -153,6 +154,7 @@ describe("autorouter_presets", () => {
         tiers: { SIMPLE: ["claude-opus-5"], MEDIUM: [], COMPLEX: [], REASONING: [] },
         classifier_type: "heuristic" as const,
         session_affinity: false,
+        deployment_affinity: true,
       };
       expect(buildPresetPrefill(config, availability).complexityRouterConfig.tiers.SIMPLE).toEqual(["a-group"]);
     });
@@ -166,6 +168,7 @@ describe("autorouter_presets", () => {
         tiers: { SIMPLE: ["claude-opus-5"], MEDIUM: [], COMPLEX: [], REASONING: [] },
         classifier_type: "heuristic" as const,
         session_affinity: false,
+        deployment_affinity: true,
       };
       expect(buildPresetPrefill(config, availability).complexityRouterConfig.tiers.SIMPLE).toEqual(["claude-opus-5"]);
     });
@@ -198,6 +201,7 @@ describe("autorouter_presets", () => {
       tiers: { SIMPLE: [presetModel], MEDIUM: [], COMPLEX: [], REASONING: [] },
       classifier_type: "heuristic" as const,
       session_affinity: false,
+      deployment_affinity: true,
     });
 
     it("resolves a preset model to a group expanded from a wildcard deployment", () => {
@@ -440,6 +444,7 @@ describe("autorouter_presets", () => {
         tiers: { SIMPLE: ["gpt-5-nano"], MEDIUM: [], COMPLEX: [], REASONING: [] },
         classifier_type: "heuristic" as const,
         session_affinity: false,
+        deployment_affinity: true,
         match_threshold: 0,
         escalation_keywords: [],
       };
@@ -454,6 +459,7 @@ describe("autorouter_presets", () => {
           tiers: { SIMPLE: ["gpt-5-nano"], MEDIUM: [], COMPLEX: [], REASONING: [] },
           classifier_type: "heuristic",
           session_affinity: false,
+          deployment_affinity: true,
         },
         groupsOnly(["gpt-5-nano"]),
       );
@@ -469,6 +475,7 @@ describe("autorouter_presets", () => {
         tiers: { SIMPLE: ["gpt-5-nano"], MEDIUM: [], COMPLEX: [], REASONING: [] },
         classifier_type: "heuristic" as const,
         session_affinity: false,
+        deployment_affinity: true,
       };
       const labeled = buildPresetPrefill(
         { ...base, tier_labels: { SIMPLE: "Cheap", REASONING: "Deep" } },
@@ -483,6 +490,7 @@ describe("autorouter_presets", () => {
         tiers: { SIMPLE: ["claude-sonnet-4-5"], MEDIUM: [], COMPLEX: [], REASONING: [] },
         classifier_type: "heuristic" as const,
         session_affinity: false,
+        deployment_affinity: true,
       };
       const prefill = buildPresetPrefill(config, groupsOnly(["claude-sonnet-4.5"]));
       expect(prefill.complexityRouterConfig.tiers.SIMPLE).toEqual(["claude-sonnet-4.5"]);

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.ts
@@ -8,6 +8,7 @@ import {
   ClassifierType,
   ClassifierLLMConfig,
   DEFAULT_SESSION_AFFINITY,
+  DEFAULT_DEPLOYMENT_AFFINITY,
 } from "@/components/add_model/ComplexityRouterConfig";
 import { KeywordTierRule } from "@/components/add_model/KeywordTierRules";
 import { hydrateKeywordTierRules } from "@/components/add_model/complexity_router_keywords";
@@ -260,6 +261,7 @@ export const buildPresetPrefill = (
       classifier_context_per_turn_chars: config.classifier_context_per_turn_chars,
       classifier_context_include_assistant_turns: config.classifier_context_include_assistant_turns,
       session_affinity: config.session_affinity ?? DEFAULT_SESSION_AFFINITY,
+      deployment_affinity: config.deployment_affinity ?? DEFAULT_DEPLOYMENT_AFFINITY,
       adaptive: config.adaptive,
       adaptive_weights: config.adaptive_weights,
       tier_distance_penalty: config.tier_distance_penalty,


### PR DESCRIPTION
## TLDR

Problem this solves:

- The auto-router's `deployment_affinity` flag shipped in #36146 default-on with no dashboard control, so opting a router out was config-file or raw API only
- Session affinity sat alone in its own Advanced panel while the two affinity knobs are one concept operators reason about together

How it solves it:

- Renames the panel to Advanced: Affinity and puts both switches in it, deployment affinity first (default on) with session affinity below it
- Both payload builders always write `deployment_affinity`, matching the `session_affinity` contract; the edit modal hydrates the stored value and manages the key, so a stored `false` survives an untouched save
- Presets and the routing-test modal flow through the same single builder, so they inherit the default with no per-preset edits

## User Flow

Before: an operator who wants one auto-router load-balanced across a group's deployments has no way to do it from the dashboard

1. They open http://localhost:4000/ui/?page=llm-playground, then Models & Endpoints, Add Model, Auto Router
2. They expand Detailed Configuration and every Advanced panel: no deployment affinity control exists anywhere
3. Their router pins sessions to deployments (the backend default) and the only opt-out is hand-editing `deployment_affinity: false` into the config YAML

After: the toggle is in the form, prefilled with what the router will actually do

1. They open the same Add Model, Auto Router flow and expand Detailed Configuration, then Advanced: Affinity
2. The panel shows "Pin a session to one deployment per model group" already on, and "Pin a session to its first model" off, mirroring both backend defaults
3. They switch deployment affinity off and create the router; the stored config carries `deployment_affinity: false`
4. Editing that router later shows the switch off, and saving without touching it keeps `false`

## Relevant issues

- Dashboard follow-up to #36146, which added the backend flag and its default
- One shared component serves both the add tab and the edit modal, so the section renders identically in both flows

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix
<img width="929" height="228" alt="image" src="https://github.com/user-attachments/assets/fbc18d7c-81ea-4feb-8dd7-94d045e396b0" />


UI change, so screenshots to follow this ordered list (proxy on :4000, dashboard dev server on :3000 via `npm run dev` in ui/litellm-dashboard)

1. Models & Endpoints, Add Model, select Auto Router, expand Detailed Configuration, open Advanced: Affinity: deployment switch on, session switch off
2. Toggle deployment affinity off, create the router, then confirm on the model's raw config that `complexity_router_config.deployment_affinity` is `false`
3. Open Edit Auto Router on that router: the deployment switch renders off; click Save Changes without touching anything, re-open, still off
4. Create a second router from the Claude Code preset without touching the panel and confirm its config carries `deployment_affinity: true`

## Type

🆕 New Feature

## Changes

- `ComplexityRouterConfig.tsx`: panel renamed Advanced: Affinity, deployment switch added above the session switch, `DEFAULT_DEPLOYMENT_AFFINITY = true` exported as the single default owner
- Both payload builders write the key unconditionally; the builder param is non-optional so the compiler forces every call site
- Edit modal: `deployment_affinity` added to the managed keys and hydrated in `initializeForm`, the pair that keeps a stored `false` from being silently rewritten to the default on an untouched save
- `buildPresetPrefill` hydrates the key so a future preset can express a non-default; the preset JSON is unchanged and inherits the default
- Tests: builder four-case matrices in both builders' suites, untouched-save regression in the modal, default-carry and toggle-off-carry in the add tab, and the shared component's first affinity panel tests. The hydration mutation is killed by the untouched-save test

## QA runbook

1. `npm run dev` in ui/litellm-dashboard against a proxy running the current staging build
2. Walk the four screenshot steps above
3. `npx vitest run src/components/add_model/ src/components/edit_auto_router/ src/lib/autorouter_presets.test.ts` inside ui/litellm-dashboard: 350 tests

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only wiring for an existing router flag; behavior changes only when an operator toggles the new control or saves configs through the updated builders.
> 
> **Overview**
> Adds dashboard control for **`deployment_affinity`** on complexity auto-routers (backend default **on**), which previously had no UI.
> 
> The **Advanced: Affinity** panel (renamed from Session Affinity) now has two switches: **pin a session to one deployment per model group** (default on) above **pin a session to its first model** (default off). Create and edit flows always persist `deployment_affinity` in `complexity_router_config`, with hydration and managed-key handling so stored `false` survives an untouched save.
> 
> Bundled **Anthropic/OpenAI** presets set `deployment_affinity: true` explicitly; preset prefill uses the same default when the key is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a29c6d1188d76e99a5476bc5a2b7faa7cd9d26cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->