### PR TITLE
fix(lowest_cost): resolve provider-prefixed and zero custom-price model pricing

### DIFF
--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -257,10 +257,10 @@ class LowestCostLoggingHandler(CustomLogger):
             # check if user provided input_cost_per_token and output_cost_per_token in litellm_params
             item_input_cost = None
             item_output_cost = None
-            if _deployment.get("litellm_params", {}).get("input_cost_per_token", None):
+            if _deployment.get("litellm_params", {}).get("input_cost_per_token") is not None:
                 item_input_cost = _deployment.get("litellm_params", {}).get("input_cost_per_token")
 
-            if _deployment.get("litellm_params", {}).get("output_cost_per_token", None):
+            if _deployment.get("litellm_params", {}).get("output_cost_per_token") is not None:
                 item_output_cost = _deployment.get("litellm_params", {}).get("output_cost_per_token")
 
             if item_input_cost is None:

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -246,6 +246,13 @@ class LowestCostLoggingHandler(CustomLogger):
             )
             item_litellm_model_name = _deployment.get("litellm_params", {}).get("model")
             item_litellm_model_cost_map = litellm.model_cost.get(item_litellm_model_name, {})
+            if not item_litellm_model_cost_map and item_litellm_model_name:
+                try:
+                    item_litellm_model_cost_map = dict(
+                        litellm.get_model_info(model=item_litellm_model_name)
+                    )
+                except Exception:
+                    item_litellm_model_cost_map = {}
 
             # check if user provided input_cost_per_token and output_cost_per_token in litellm_params
             item_input_cost = None

--- a/tests/local_testing/test_lowest_cost_routing.py
+++ b/tests/local_testing/test_lowest_cost_routing.py
@@ -50,6 +50,36 @@ async def test_get_available_deployments():
 
 
 @pytest.mark.asyncio
+async def test_get_available_deployments_provider_prefixed_model_pricing():
+    test_cache = DualCache()
+    model_list = [
+        {
+            "model_name": "gpt-3.5-turbo",
+            "litellm_params": {"model": "openai/gpt-4o-mini"},
+            "model_info": {"id": "prefixed-openai"},
+        },
+        {
+            "model_name": "gpt-3.5-turbo",
+            "litellm_params": {
+                "model": "azure/some-custom-deployment",
+                "input_cost_per_token": 0.5,
+                "output_cost_per_token": 0.5,
+            },
+            "model_info": {"id": "custom-priced"},
+        },
+    ]
+    lowest_cost_logger = LowestCostLoggingHandler(
+        router_cache=test_cache,
+    )
+
+    selected_model = await lowest_cost_logger.async_get_available_deployments(
+        model_group="gpt-3.5-turbo", healthy_deployments=model_list
+    )
+
+    assert selected_model["model_info"]["id"] == "prefixed-openai"
+
+
+@pytest.mark.asyncio
 async def test_get_available_deployments_custom_price():
     from litellm._logging import verbose_router_logger
     import logging

--- a/tests/local_testing/test_lowest_cost_routing.py
+++ b/tests/local_testing/test_lowest_cost_routing.py
@@ -80,6 +80,40 @@ async def test_get_available_deployments_provider_prefixed_model_pricing():
 
 
 @pytest.mark.asyncio
+async def test_get_available_deployments_zero_custom_price_is_honored():
+    test_cache = DualCache()
+    model_list = [
+        {
+            "model_name": "gpt-3.5-turbo",
+            "litellm_params": {
+                "model": "anthropic/claude-3-5-haiku-latest",
+                "input_cost_per_token": 0,
+                "output_cost_per_token": 0,
+            },
+            "model_info": {"id": "byok-zero-cost"},
+        },
+        {
+            "model_name": "gpt-3.5-turbo",
+            "litellm_params": {
+                "model": "azure/some-custom-deployment",
+                "input_cost_per_token": 0.5,
+                "output_cost_per_token": 0.5,
+            },
+            "model_info": {"id": "custom-priced"},
+        },
+    ]
+    lowest_cost_logger = LowestCostLoggingHandler(
+        router_cache=test_cache,
+    )
+
+    selected_model = await lowest_cost_logger.async_get_available_deployments(
+        model_group="gpt-3.5-turbo", healthy_deployments=model_list
+    )
+
+    assert selected_model["model_info"]["id"] == "byok-zero-cost"
+
+
+@pytest.mark.asyncio
 async def test_get_available_deployments_custom_price():
     from litellm._logging import verbose_router_logger
     import logging


### PR DESCRIPTION
## TLDR

Problem this solves:

- cost-based routing prices provider-prefixed models like `openai/gpt-4o-mini` at the $10 fallback
- and it drops an explicit `input_cost_per_token: 0` / `output_cost_per_token: 0` (BYOK) as if unset
- so the strategy skips genuinely cheaper, or free, deployments and picks a costlier one

How it solves it:

- fall back to `get_model_info` (the resolver the cost calculator already uses) on a raw cost-map miss
- treat custom per-token costs as set when they are not None, so a deliberate 0 is honored
- the deployment's real rates drive the routing decision

## User Flow

Before: a developer using `routing_strategy="cost-based-routing"` sees a cheaper or free deployment lose to a pricier one

1. They register an `openai/gpt-4o-mini` deployment, or a BYOK deployment with `input_cost_per_token: 0`, next to a costlier one
2. They send a chat completion to that model group expecting the cheap or free deployment
3. The router prices the prefixed model at 10.0 (missing-model fallback) and the zero-cost one at the fallback too, then routes to the costlier deployment

After: the same request routes to the cheapest deployment

1. They register the same deployments
2. They send the same chat completion
3. The router resolves the prefixed model to its published rates, honors the explicit 0, and routes to the lowest-cost option

## Relevant issues

Fixes #35787
Partially addresses the zero custom-price handling noted in #30081 for the cost-based routing path

## Linear ticket

## Type

🐛 Bug Fix

## Changes

`LowestCostLoggingHandler.async_get_available_deployments` had two cost-resolution misses in the same block. It looked up pricing with `litellm.model_cost.get(item_litellm_model_name, {})`, so provider-prefixed names such as `openai/gpt-4o-mini` (only the bare `gpt-4o-mini` is a key) missed and fell back to 5.0 each, a 10.0 routing cost; the fix resolves those through `get_model_info`, the same provider-prefix resolution the regular cost calculator uses. It also gated the deployment's custom `input_cost_per_token` / `output_cost_per_token` behind a truthiness check, so an explicit `0` (BYOK deployments that must bill at zero) was treated as unset and overwritten by the model-cost fallback; the fix checks `is not None`. Custom non-zero prices still take precedence and unknown models still fall back to the existing default.

## Screenshots / Proof of Fix

Captured against the current `model_cost` map (no mocks, real map data). A live-proxy run with cost-based routing is welcome; this shows the exact resolution the router now performs.

Raw lookup for a prefixed name misses today:

```
$ python -c "import litellm; m=litellm.model_cost.get('openai/gpt-4o-mini', {}); print(m.get('input_cost_per_token'), m.get('output_cost_per_token'))"
None None      # -> both default to 5.0, routing cost 10.0
$ python -c "import litellm; i=litellm.get_model_info(model='openai/gpt-4o-mini'); print(i['input_cost_per_token'], i['output_cost_per_token'])"
1.5e-07 6e-07  # resolved after the fix
```

Handler-level checks (two deployments per group):

```
prefixed openai vs 1.0 custom-priced   -> selected: prefixed-openai   (was custom-priced at the 10.0 fallback)
zero-cost BYOK vs 1.0 custom-priced    -> selected: byok-zero-cost    (was custom-priced; the 0 was dropped)
```

Regression tests added in `tests/local_testing/test_lowest_cost_routing.py`: `test_get_available_deployments_provider_prefixed_model_pricing` and `test_get_available_deployments_zero_custom_price_is_honored`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
