### PR TITLE
fix(proxy): keep counters reserved when reservation cleanup fails

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2637,8 +2637,11 @@ async def _reconcile_budget_reservation_for_counter_update(
             await invalidate_budget_reservation_counters(budget_reservation=budget_reservation)
         except Exception:
             verbose_proxy_logger.exception(
-                "Failed to invalidate reserved counters after reservation reconciliation failed"
+                "Failed to invalidate reserved counters after reservation reconciliation failed; "
+                "treating them as still reserved so the caller does not add actual cost on top of "
+                "a reservation that is still on the counter"
             )
+            return reserved_counter_keys
         return set()
     return reserved_counter_keys
 

--- a/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
+++ b/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
@@ -672,6 +672,80 @@ async def test_reconcile_budget_reservation_for_counter_update_failure_invalidat
     assert fake_invalidate.called is True
 
 
+@pytest.mark.asyncio
+async def test_reconcile_budget_reservation_keeps_keys_reserved_when_invalidation_fails(
+    monkeypatch,
+):
+    """When invalidation also raises, the reservation is still on the counter. Returning
+    an empty set would tell the caller to add the full actual cost on top of it, leaving
+    previous_spend + reserved_cost + actual_cost and a counter that can 429 forever."""
+    import litellm.proxy.spend_tracking.budget_reservation as br
+
+    monkeypatch.setattr(
+        br, "get_reserved_counter_keys", MagicMock(return_value={"spend:key:abc"})
+    )
+    monkeypatch.setattr(
+        br, "reconcile_budget_reservation", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+    monkeypatch.setattr(
+        br,
+        "invalidate_budget_reservation_counters",
+        AsyncMock(side_effect=RuntimeError("delete failed")),
+    )
+
+    result = await ps._reconcile_budget_reservation_for_counter_update(
+        budget_reservation={"foo": "bar"}, response_cost=1.0
+    )
+
+    assert result == {"spend:key:abc"}
+
+
+@pytest.mark.asyncio
+async def test_increment_spend_counters_does_not_double_count_when_cleanup_fails(
+    monkeypatch,
+):
+    """End-to-end guard: with both reconcile and invalidation failing, the key counter
+    still holds its reservation, so increment_spend_counters must not increment it a
+    second time with the actual cost."""
+    import litellm.proxy.spend_tracking.budget_reservation as br
+
+    fake_cache = _make_spend_counter_cache(redis_get_value=None, redis_increment_value=5.0)
+    fake_user_cache = _make_user_api_key_cache(get_value=None)
+    monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
+    monkeypatch.setattr(ps, "user_api_key_cache", fake_user_cache)
+    monkeypatch.setattr(ps, "prisma_client", None)
+    monkeypatch.setattr(ps.SpendCounterReseed, "coalesced", AsyncMock(return_value=None))
+
+    key_counter = "spend:key:hashed-tok"
+    monkeypatch.setattr(
+        br, "get_reserved_counter_keys", MagicMock(return_value={key_counter})
+    )
+    monkeypatch.setattr(
+        br, "reconcile_budget_reservation", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+    monkeypatch.setattr(
+        br,
+        "invalidate_budget_reservation_counters",
+        AsyncMock(side_effect=RuntimeError("delete failed")),
+    )
+
+    await ps.increment_spend_counters(
+        token="hashed-tok",
+        team_id="t1",
+        user_id="u1",
+        response_cost=5.0,
+        budget_reservation={"entries": [{"counter_key": key_counter}]},
+    )
+
+    incremented = [
+        call.kwargs.get("key", call.args[0] if call.args else None)
+        for call in fake_cache.redis_cache.async_increment.call_args_list
+    ]
+    assert key_counter not in incremented, (
+        f"reserved counter was incremented on top of its reservation: {incremented}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # _increment_end_user_and_tag_spend_counters
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
+++ b/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
@@ -714,7 +714,6 @@ async def test_increment_spend_counters_does_not_double_count_when_cleanup_fails
     monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
     monkeypatch.setattr(ps, "user_api_key_cache", fake_user_cache)
     monkeypatch.setattr(ps, "prisma_client", None)
-    monkeypatch.setattr(ps.SpendCounterReseed, "coalesced", AsyncMock(return_value=None))
 
     key_counter = "spend:key:hashed-tok"
     monkeypatch.setattr(


### PR DESCRIPTION
## TLDR

Problem this solves:

- A failed reservation cleanup still reports "nothing reserved" to the caller
- The counter then gets actual cost on top of a live reservation, over-counting

How it solves it:

- Return the reserved keys when invalidation raises, so the caller skips the increment
- The reservation already on the counter stands in for the cost

## Relevant issues

Fixes #35569

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This path needs both a reconcile failure and an invalidation failure against a live counter, which no provider call reproduces on its own, so the proof is the control flow rather than a curl. On the parent commit:

```
reconcile fails + invalidation FAILS -> set()
reconcile fails + invalidation OK    -> set()
```

Both cases return the same value, so `increment_spend_counters` cannot tell them apart and runs the direct increment in both. On this branch:

```
reconcile fails + invalidation FAILS -> {'spend:key:demo'}   caller skips the increment
reconcile fails + invalidation OK    -> set()                caller increments, unchanged
```

The reproduction harness is the one from the issue, and the two new tests pin both halves. To watch it against a running proxy: give a key a budget, force `reconcile_budget_reservation` and `invalidate_budget_reservation_counters` to raise, send one request, then read the key's counter through `/key/info`. Before the fix it advances by reserved + actual; after, by the reservation alone

## Type

🐛 Bug Fix

## Changes

`_reconcile_budget_reservation_for_counter_update` returns the set of counter keys that still hold a reservation. The caller treats anything in that set as already accounted for and skips its direct increment. When reconciliation raises, the fallback invalidates the reserved counters and returns an empty set so the full actual cost gets applied directly, which is correct only when the invalidation worked

The inner handler logged its exception and fell through to the same `return set()`, so "invalidation failed" looked exactly like "invalidation succeeded". The counter kept its reservation and then also took the actual cost, ending at previous_spend + reserved_cost + actual_cost. The direction of the error matters: it over-counts rather than losing billing, so it surfaces as premature budget exhaustion and 429s that stick until a durable reseed repairs the counter

Returning the reserved keys from that handler makes the two outcomes distinguishable. The reservation still sitting on the counter is then what accounts for the request, which is what it was placed there to do

One limitation worth stating, since the issue raises it and this change does not fully solve it. `invalidate_budget_reservation_counters` walks its keys sequentially with no per-key result, so a failure partway leaves some keys deleted and some reserved, and the caller only learns that the call raised. Treating them all as reserved is the safer half of that trade: the keys that really were deleted lose this request's cost, while none are counted twice. Resolving it exactly means having the helper report which keys it actually removed, which changes a signature that three call sites and several tests depend on. That felt like a separate change rather than something to fold in here, but happy to take it further if you would rather fix it properly in one go

Two tests, both failing on the parent commit. One pins the return value directly, the other drives `increment_spend_counters` end to end with both calls failing and asserts the reserved counter is never incremented, which is the regression test the issue asks for

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
