### PR TITLE
fix(ui): hide admin-only Logs tabs from roles that cannot call their endpoints

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/index.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.integration.test.tsx
@@ -1,0 +1,104 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SpendLogsTable from "./index";
+import { renderWithProviders, testQueryClient } from "../../../tests/test-utils";
+
+const { useAuthorizedMock } = vi.hoisted(() => ({ useAuthorizedMock: vi.fn() }));
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: useAuthorizedMock,
+}));
+
+vi.mock("./RequestLogsPanel", () => ({
+  default: function RequestLogsPanelMock() {
+    return <div data-testid="request-logs-panel" />;
+  },
+}));
+
+const fetchMock = vi.fn();
+
+const jsonResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  json: async () => body,
+});
+
+const requestedUrls = () => fetchMock.mock.calls.map(([url]) => String(url));
+
+const emptyAuditLogs = { audit_logs: [], total: 0, page: 1, page_size: 50, total_pages: 0 };
+
+const defaultProps = {
+  accessToken: "sk-test",
+  token: "jwt-test",
+  userRole: "Admin",
+  userID: "user-1",
+  premiumUser: true,
+};
+
+const renderAs = (sessionRole: string) => {
+  useAuthorizedMock.mockReturnValue({ accessToken: "sk-test", userRole: sessionRole, premiumUser: true });
+  return renderWithProviders(<SpendLogsTable {...defaultProps} userRole={sessionRole} />);
+};
+
+describe("SpendLogsTable network access by role", () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    fetchMock.mockImplementation(async (url: string) => {
+      if (String(url).includes("/audit")) {
+        return jsonResponse(emptyAuditLogs);
+      }
+      if (String(url).includes("/v2/team/list")) {
+        return jsonResponse({ teams: [] });
+      }
+      return jsonResponse({ keys: [], total_count: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("fires neither the audit nor the deleted-teams request for an internal user", async () => {
+    const user = userEvent.setup();
+    renderAs("Internal User");
+
+    // Liveness gate: the sibling Deleted Keys panel does reach the network, so a
+    // silent absence below means the gate worked, not that nothing rendered.
+    await waitFor(() => expect(requestedUrls().some((url) => url.includes("/key/list"))).toBe(true));
+
+    await user.click(screen.getByRole("tab", { name: "Deleted Keys" }));
+    await user.click(screen.getByRole("tab", { name: "Request Logs" }));
+
+    expect(requestedUrls().filter((url) => url.includes("/audit"))).toEqual([]);
+    expect(requestedUrls().filter((url) => url.includes("/v2/team/list"))).toEqual([]);
+  });
+
+  it("fetches deleted teams and audit logs for an admin", async () => {
+    const user = userEvent.setup();
+    renderAs("Admin");
+
+    await waitFor(() =>
+      expect(requestedUrls().some((url) => url.includes("/v2/team/list") && url.includes("status=deleted"))).toBe(true),
+    );
+
+    expect(requestedUrls().filter((url) => url.includes("/audit"))).toEqual([]);
+
+    await user.click(screen.getByRole("tab", { name: "Audit Logs" }));
+
+    await waitFor(() => expect(requestedUrls().some((url) => url.includes("/audit"))).toBe(true));
+  });
+
+  it("leaves the audit request unsent when an admin selects a tab after Audit Logs", async () => {
+    const user = userEvent.setup();
+    renderAs("Admin");
+
+    await user.click(screen.getByRole("tab", { name: "Deleted Teams" }));
+
+    expect(screen.getByRole("tab", { name: "Deleted Teams" })).toHaveAttribute("aria-selected", "true");
+    expect(requestedUrls().filter((url) => url.includes("/audit"))).toEqual([]);
+
+    await user.click(screen.getByRole("tab", { name: "Audit Logs" }));
+
+    await waitFor(() => expect(requestedUrls().some((url) => url.includes("/audit"))).toBe(true));
+  });
+});

--- a/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
@@ -1,8 +1,14 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import SpendLogsTable from "./index";
 import { renderWithProviders } from "../../../tests/test-utils";
+
+const { useAuthorizedMock } = vi.hoisted(() => ({ useAuthorizedMock: vi.fn() }));
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: useAuthorizedMock,
+}));
 
 vi.mock("./RequestLogsPanel", () => ({
   default: function RequestLogsPanelMock({ isActive }: { isActive: boolean }) {
@@ -36,9 +42,18 @@ const defaultProps = {
   premiumUser: false,
 };
 
+const renderAs = (sessionRole: string) => {
+  useAuthorizedMock.mockReturnValue({ userRole: sessionRole });
+  return renderWithProviders(<SpendLogsTable {...defaultProps} userRole={sessionRole} />);
+};
+
 describe("SpendLogsTable", () => {
+  beforeEach(() => {
+    useAuthorizedMock.mockReturnValue({ userRole: "Admin" });
+  });
+
   it("renders the four log tabs", () => {
-    renderWithProviders(<SpendLogsTable {...defaultProps} />);
+    renderAs("Admin");
 
     for (const label of ["Request Logs", "Audit Logs", "Deleted Keys", "Deleted Teams"]) {
       expect(screen.getByRole("tab", { name: label })).toBeInTheDocument();
@@ -47,7 +62,7 @@ describe("SpendLogsTable", () => {
 
   it("marks only the visible tab's panel active so background tabs do not query", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<SpendLogsTable {...defaultProps} />);
+    renderAs("Admin");
 
     expect(screen.getByTestId("request-logs-panel")).toHaveTextContent("active");
 
@@ -57,8 +72,64 @@ describe("SpendLogsTable", () => {
     expect(screen.getByTestId("request-logs-panel")).toHaveTextContent("inactive");
   });
 
+  describe("admin-only tabs", () => {
+    it.each(["Internal User", "Internal Viewer"])("hides Audit Logs and Deleted Teams from %s", (role) => {
+      renderAs(role);
+
+      expect(screen.getByRole("tab", { name: "Request Logs" })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Deleted Keys" })).toBeInTheDocument();
+      expect(screen.queryByRole("tab", { name: "Audit Logs" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("tab", { name: "Deleted Teams" })).not.toBeInTheDocument();
+    });
+
+    it("never mounts the panels that call the admin-only endpoints for an internal user", () => {
+      renderAs("Internal User");
+
+      expect(screen.queryByTestId("audit-logs-panel")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("deleted-teams-page")).not.toBeInTheDocument();
+      expect(screen.getByTestId("deleted-keys-page")).toBeInTheDocument();
+    });
+  });
+
+  describe("tab index mapping", () => {
+    it("activates the panel the admin selected, not the one at the old hardcoded index", async () => {
+      const user = userEvent.setup();
+      renderAs("Admin");
+
+      await user.click(screen.getByRole("tab", { name: "Deleted Keys" }));
+
+      expect(screen.getByTestId("audit-logs-panel")).toHaveTextContent("inactive");
+      expect(screen.getByTestId("request-logs-panel")).toHaveTextContent("inactive");
+    });
+
+    it("keeps the audit panel inert when an admin selects the last tab", async () => {
+      const user = userEvent.setup();
+      renderAs("Admin");
+
+      await user.click(screen.getByRole("tab", { name: "Deleted Teams" }));
+
+      expect(screen.getByTestId("audit-logs-panel")).toHaveTextContent("inactive");
+      expect(screen.getByTestId("deleted-teams-page")).toBeInTheDocument();
+    });
+
+    it("selects the last visible tab for an internal user and returns to Request Logs", async () => {
+      const user = userEvent.setup();
+      renderAs("Internal User");
+
+      await user.click(screen.getByRole("tab", { name: "Deleted Keys" }));
+
+      expect(screen.getByTestId("deleted-keys-page")).toBeInTheDocument();
+      expect(screen.getByTestId("request-logs-panel")).toHaveTextContent("inactive");
+
+      await user.click(screen.getByRole("tab", { name: "Request Logs" }));
+
+      expect(screen.getByTestId("request-logs-panel")).toHaveTextContent("active");
+    });
+  });
+
   describe("auth-not-ready guard", () => {
     it("shows a loading spinner when credentials are not yet resolved", () => {
+      useAuthorizedMock.mockReturnValue({ userRole: "Admin" });
       renderWithProviders(<SpendLogsTable {...defaultProps} accessToken={null} />);
 
       expect(document.querySelector(".ant-spin")).toBeInTheDocument();
@@ -66,7 +137,7 @@ describe("SpendLogsTable", () => {
     });
 
     it("renders the tabs (no spinner) once all credentials are present", () => {
-      renderWithProviders(<SpendLogsTable {...defaultProps} />);
+      renderAs("Admin");
 
       expect(document.querySelector(".ant-spin")).not.toBeInTheDocument();
       expect(screen.getByRole("tab", { name: "Request Logs" })).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@tremor/react";
+import useCan from "@/app/(dashboard)/hooks/useCan";
 import DeletedKeysPage from "../DeletedKeysPage/DeletedKeysPage";
 import DeletedTeamsPage from "../DeletedTeamsPage/DeletedTeamsPage";
 import AuditLogsPanel from "./AuditLogsPanel";
@@ -14,8 +15,22 @@ interface SpendLogsTableProps {
   premiumUser: boolean;
 }
 
+type LogsTabId = "request logs" | "audit logs" | "deleted keys" | "deleted teams";
+
+interface LogsTab {
+  id: LogsTabId;
+  label: string;
+}
+
+const REQUEST_LOGS_TAB: LogsTab = { id: "request logs", label: "Request Logs" };
+const AUDIT_LOGS_TAB: LogsTab = { id: "audit logs", label: "Audit Logs" };
+const DELETED_KEYS_TAB: LogsTab = { id: "deleted keys", label: "Deleted Keys" };
+const DELETED_TEAMS_TAB: LogsTab = { id: "deleted teams", label: "Deleted Teams" };
+
 export default function SpendLogsTable({ accessToken, token, userRole, userID, premiumUser }: SpendLogsTableProps) {
-  const [activeTab, setActiveTab] = useState("request logs");
+  const [activeTab, setActiveTab] = useState<LogsTabId>(REQUEST_LOGS_TAB.id);
+  const canViewAuditLogs = useCan("viewAuditLogs");
+  const canViewDeletedTeams = useCan("viewDeletedTeams");
 
   if (!accessToken || !token || !userRole || !userID) {
     return (
@@ -25,41 +40,55 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
     );
   }
 
+  const tabs: LogsTab[] = [
+    REQUEST_LOGS_TAB,
+    ...(canViewAuditLogs ? [AUDIT_LOGS_TAB] : []),
+    DELETED_KEYS_TAB,
+    ...(canViewDeletedTeams ? [DELETED_TEAMS_TAB] : []),
+  ];
+
+  const renderPanel = (tabId: LogsTabId) => {
+    switch (tabId) {
+      case "request logs":
+        return (
+          <RequestLogsPanel
+            accessToken={accessToken}
+            token={token}
+            userRole={userRole}
+            userID={userID}
+            isActive={activeTab === "request logs"}
+          />
+        );
+      case "audit logs":
+        return (
+          <AuditLogsPanel
+            userID={userID}
+            userRole={userRole}
+            token={token}
+            accessToken={accessToken}
+            isActive={activeTab === "audit logs"}
+            premiumUser={premiumUser}
+          />
+        );
+      case "deleted keys":
+        return <DeletedKeysPage />;
+      case "deleted teams":
+        return <DeletedTeamsPage />;
+    }
+  };
+
   return (
     <div className="w-full p-6 overflow-x-hidden box-border">
-      <TabGroup defaultIndex={0} onIndexChange={(index) => setActiveTab(index === 0 ? "request logs" : "audit logs")}>
+      <TabGroup defaultIndex={0} onIndexChange={(index) => setActiveTab(tabs[index].id)}>
         <TabList>
-          <Tab>Request Logs</Tab>
-          <Tab>Audit Logs</Tab>
-          <Tab>Deleted Keys</Tab>
-          <Tab>Deleted Teams</Tab>
+          {tabs.map((tab) => (
+            <Tab key={tab.id}>{tab.label}</Tab>
+          ))}
         </TabList>
         <TabPanels>
-          <TabPanel>
-            <RequestLogsPanel
-              accessToken={accessToken}
-              token={token}
-              userRole={userRole}
-              userID={userID}
-              isActive={activeTab === "request logs"}
-            />
-          </TabPanel>
-          <TabPanel>
-            <AuditLogsPanel
-              userID={userID}
-              userRole={userRole}
-              token={token}
-              accessToken={accessToken}
-              isActive={activeTab === "audit logs"}
-              premiumUser={premiumUser}
-            />
-          </TabPanel>
-          <TabPanel>
-            <DeletedKeysPage />
-          </TabPanel>
-          <TabPanel>
-            <DeletedTeamsPage />
-          </TabPanel>
+          {tabs.map((tab) => (
+            <TabPanel key={tab.id}>{renderPanel(tab.id)}</TabPanel>
+          ))}
         </TabPanels>
       </TabGroup>
     </div>

--- a/ui/litellm-dashboard/src/utils/capabilities.test.ts
+++ b/ui/litellm-dashboard/src/utils/capabilities.test.ts
@@ -18,6 +18,19 @@ describe("hasCapability", () => {
   );
 });
 
+describe.each(["viewAuditLogs", "viewDeletedTeams"] as const)("hasCapability - %s", (capability) => {
+  it.each(["Admin", "Admin Viewer", "proxy_admin", "proxy_admin_viewer"])("should grant it to %s", (role) => {
+    expect(hasCapability(role, capability)).toBe(true);
+  });
+
+  it.each(["Internal User", "Internal Viewer", "App User", "Org Admin", "Unknown Role", "", null, undefined])(
+    "should deny it to %s",
+    (role) => {
+      expect(hasCapability(role, capability)).toBe(false);
+    },
+  );
+});
+
 describe("rolesWithCapability", () => {
   it("should return a copy so callers cannot mutate the capability map", () => {
     const roles = rolesWithCapability("viewToolPolicies");

--- a/ui/litellm-dashboard/src/utils/capabilities.ts
+++ b/ui/litellm-dashboard/src/utils/capabilities.ts
@@ -2,6 +2,8 @@ import { all_admin_roles } from "./roles";
 
 const CAPABILITY_ROLES = {
   viewToolPolicies: all_admin_roles,
+  viewAuditLogs: all_admin_roles,
+  viewDeletedTeams: all_admin_roles,
 } as const satisfies Record<string, readonly string[]>;
 
 export type Capability = keyof typeof CAPABILITY_ROLES;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Logs page fires two admin-only calls for internal users
- Both come back 401, so the tabs render empty
- Opening Deleted Keys wrongly activated the Audit Logs panel

How it solves it:

- Audit Logs and Deleted Teams tabs now require an admin role
- Hidden tabs are never mounted, so no request goes out
- Active tab is derived from the visible tabs, not a fixed index

## User Flow

Before: an internal user opens the Logs page and two of its four tabs are dead ends that quietly get rejected by the gateway

1. They sign in at https://litellm-domain/ui/ with an account whose role is Internal User
2. They open https://litellm-domain/ui/?page=logs and see four tabs: Request Logs, Audit Logs, Deleted Keys, Deleted Teams
3. On load, the page issues GET https://litellm-domain/v2/team/list?page=1&page_size=100&status=deleted, which comes back 401 with "Only admin users can query all teams/other teams"
4. They click Deleted Keys, and the page issues GET https://litellm-domain/audit?page=1&page_size=50, which comes back 401 with "Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/audit"
5. They click Audit Logs and Deleted Teams and both show an empty table with no explanation of why

After: the same user sees only the two tabs their account can actually load, and the page makes no rejected calls

1. They sign in at https://litellm-domain/ui/ with an account whose role is Internal User
2. They open https://litellm-domain/ui/?page=logs and see two tabs: Request Logs and Deleted Keys
3. On load, the page issues GET https://litellm-domain/spend/logs/ui for their own requests and GET https://litellm-domain/key/list?status=deleted, both 200, and no call to /audit or /v2/team/list
4. They click Deleted Keys and the deleted keys table loads on its own, with no request to /audit
5. A Proxy Admin opening the same page still sees all four tabs, and Audit Logs and Deleted Teams load their data as before

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at 30c4898de9, against a live proxy on localhost:4000 and the dashboard dev server on localhost:3000

Proxy and dev server:

```bash
PYTHONPATH="$PWD:$PWD/enterprise" python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

```bash
cd ui/litellm-dashboard && npm run dev
```

Create the internal user the UI steps below use, then give it a password so it can sign in:

```bash
curl -s -X POST http://localhost:4000/user/new -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"user_email":"gating-demo@example.com","user_role":"internal_user","user_alias":"gating-demo"}'
```

```bash
curl -s -X POST http://localhost:4000/user/update -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"user_id":"<user_id from the call above>","password":"<pick one>"}'
```

Both endpoints reject that user's key and accept the master key. `INTERNAL_KEY` is the `key` field returned by `/user/new`:

```bash
for ep in "/audit?page=1&page_size=1" "/v2/team/list?status=deleted&page=1&page_size=100"; do for who in INTERNAL MASTER; do if [ "$who" = "INTERNAL" ]; then K="$INTERNAL_KEY"; else K="$LITELLM_MASTER_KEY"; fi; printf '=== GET %s [%s key] ===\n' "$ep" "$who"; curl -s -w '\nHTTP %{http_code}\n' -H "Authorization: Bearer $K" "http://localhost:4000$ep" | head -c 320; printf '\n\n'; done; done
```

```
=== GET /audit?page=1&page_size=1 [INTERNAL key] ===
{"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/audit. Your role=internal_user. Your user_id=edd610****************************62","type":"auth_error","param":"None","code":"401"}}
HTTP 401

=== GET /audit?page=1&page_size=1 [MASTER key] ===
{"audit_logs":[{"id":"16513a6c-ade0-40dc-8769-f9db39add14b","updated_at":"2026-08-01T16:52:02.514000Z","changed_by":"default_user_id","changed_by_api_key":"","action":"updated","table_name":"LiteLLM_UserTable","object_id":"default_user_id","before_value":{"spend":0.0,"teams":["a4e2ed0f-c5fc-45fc-9ba6-aba27b7d2261","3df
HTTP 200

=== GET /v2/team/list?status=deleted&page=1&page_size=100 [INTERNAL key] ===
{"detail":{"error":"Only admin users can query all teams/other teams. Your user role=internal_user"}}
HTTP 401

=== GET /v2/team/list?status=deleted&page=1&page_size=100 [MASTER key] ===
{"teams":[{"team_alias":"v-team","team_id":"9189c8aa-367f-4731-aefc-c6670724cb7c","organization_id":null,"admins":[],"members":[],"members_with_roles":[{"user_id":"default_user_id","user_email":null,"role":"admin"},{"user_id":"7807f6e8-32a3-4de4-827f-4a082e4c45be","user_email":"v-user@example.com","role":"user"}],"team
HTTP 200
```

Screenshots to take, as the internal user first:

1. Sign in at http://localhost:3000/ as gating-demo@example.com with the password set above, open the browser devtools Network tab, then go to http://localhost:3000/logs/
2. Screenshot the tab strip: only Request Logs and Deleted Keys are there
3. Filter the Network tab on `audit` and then on `team/list`, and screenshot both: no request to /audit, and no request to /v2/team/list
4. Click Deleted Keys and screenshot the deleted keys table loading, with the Network tab still showing no /audit request
5. Click back to Request Logs and screenshot the request log rows loading

Then as an admin:

6. Sign in at http://localhost:3000/ with the master key credentials and go to http://localhost:3000/logs/
7. Screenshot the tab strip: all four tabs are there
8. Click Audit Logs and screenshot the audit rows plus the 200 on GET /audit in the Network tab
9. Click Deleted Teams and screenshot the deleted teams table plus the 200 on GET /v2/team/list?status=deleted

## Type

🐛 Bug Fix

## Changes

Audit Logs and Deleted Teams are gated on two new capabilities in the shared capability map that PR #35812 introduced for Tool Policies, so a role that cannot call the endpoint never sees the tab and the panel behind it never mounts. Everything else on the page is untouched: Request Logs and Deleted Keys stay open to internal users

Tab selection previously treated index 0 as Request Logs and every other index as Audit Logs, so opening Deleted Keys or Deleted Teams activated the audit panel and sent its request. The active tab is now looked up in the visible tab list, which keeps working once tabs are filtered out by role

Tests cover the capability map for both new entries, the tab visibility for internal users and admins, and a network-level check that renders the real panels with the fetch boundary stubbed: an internal user reaches the network for deleted keys but never for /audit or /v2/team/list, while an admin gets both. Removing either gate fails four of them, and restoring the old index mapping fails three

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
