### PR TITLE
test(proxy): guard management_v1 against fastapi names removed in supported releases

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/management_v1/test_common.py
+++ b/tests/test_litellm/proxy/management_endpoints/management_v1/test_common.py
@@ -1,11 +1,18 @@
+import ast
+import importlib.util
+from pathlib import Path
+from types import ModuleType
 from typing import Annotated
 
+import fastapi.dependencies.utils as fastapi_dependency_utils
+import pytest
 from fastapi import Depends, FastAPI, Header, Query, Request
 from fastapi.testclient import TestClient
 
+import litellm.proxy.management_endpoints.management_v1.common as common_module
 from litellm.proxy.management_endpoints.management_v1.common import (
-    ManagementProblem,
     PROBLEM_CONTENT_TYPE,
+    ManagementProblem,
     _declared_query_params,
     problem_response,
     reject_unknown_query_params,
@@ -93,3 +100,57 @@ def test_declared_query_params_is_empty_when_the_route_has_no_dependant():
         }
     )
     assert _declared_query_params(request) == frozenset()
+
+
+# fastapi removed these in 0.140.7, which `pyproject.toml` still allows via
+# `fastapi>=0.136.3,<1.0`. Add a name here whenever a supported release drops one.
+FASTAPI_NAMES_REMOVED_IN_0_140_7 = frozenset({"get_flat_dependant"})
+
+MANAGEMENT_V1_PACKAGE = Path(str(common_module.__file__)).parent
+
+
+def _public_names(module: ModuleType) -> frozenset[str]:
+    return frozenset(name for name in vars(module) if not name.startswith("_"))
+
+
+def _fastapi_names_imported_by(source_file: Path) -> frozenset[str]:
+    tree = ast.parse(source_file.read_text())
+    return frozenset(
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("fastapi")
+        for alias in node.names
+    )
+
+
+@pytest.mark.parametrize(
+    "source_file", sorted(MANAGEMENT_V1_PACKAGE.glob("*.py")), ids=lambda path: path.name
+)
+def test_no_module_imports_a_fastapi_name_removed_in_a_supported_release(source_file: Path):
+    """`pyproject.toml` allows fastapi up to <1.0, but CI only ever resolves 0.136.3.
+
+    Every other test here passes just as well against a module importing a name
+    fastapi has since deleted, because the pinned fastapi still has it. On a user's
+    fastapi>=0.140.7 that import is an ImportError, and `proxy_server` imports this
+    package unguarded at module level, so it takes the whole proxy down rather than
+    just these routes. Globbing the package means a new module is covered on sight.
+    """
+    assert not _fastapi_names_imported_by(source_file) & FASTAPI_NAMES_REMOVED_IN_0_140_7
+
+
+def test_common_still_imports_when_fastapi_has_dropped_those_names(monkeypatch: pytest.MonkeyPatch):
+    """The static check above cannot prove the module actually loads; this does.
+
+    Behaviour cannot be asserted under the same simulation: on 0.136.3
+    `get_flat_params` calls `get_flat_dependant` internally, so it raises NameError
+    once the name is gone. Loading is the part this pins.
+    """
+    for name in FASTAPI_NAMES_REMOVED_IN_0_140_7:
+        monkeypatch.delattr(fastapi_dependency_utils, name, raising=False)
+    spec = importlib.util.spec_from_file_location(
+        "management_v1_common__simulated_fastapi", Path(str(common_module.__file__))
+    )
+    assert spec is not None and spec.loader is not None
+    reimported = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(reimported)
+    assert _public_names(reimported) == _public_names(common_module)


### PR DESCRIPTION
## TLDR

Problem this solves:

- #35773 fixed a real boot failure but shipped no test that can fail
- CI only ever resolves fastapi 0.136.3, where the removed name still exists
- its 6 tests pass identically against the broken and the fixed module
- so nothing stops the same import coming back tomorrow

How it solves it:

- scan every module in the package for fastapi names removed in supported releases
- load `common.py` against a fastapi that no longer has them
- both go red on the pre-#35773 module, green after

## User Flow

This PR adds tests only and changes no runtime behaviour, so there is no before and after for an end user. The flow below is the one that broke, and the one these tests keep broken code from reaching again

Before, on the module #35773 replaced, for anyone whose install resolved fastapi 0.140.7 or newer:

1. They `pip install 'litellm[proxy]'`, which allows `fastapi>=0.136.3,<1.0` and so resolves 0.141.1
2. They start the proxy
3. It never serves anything: startup ends in `ImportError: cannot import name 'get_flat_dependant' from 'fastapi.dependencies.utils'`
4. Every route is gone, not just `/management/v1/*`, because `proxy_server` imports the package unguarded at module level

After #35773, on the same install:

1. They `pip install 'litellm[proxy]'` and get the same fastapi 0.141.1
2. They start the proxy
3. It boots, and `GET /management/v1/spend_logs/end_users?bogus=1` answers 400 with the problem body as it does on 0.136.3

## Relevant issues

Follow-up to #35773

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR is tests only, so the proof is that the new tests fail on the module #35773 replaced and pass on the one it merged. No LLM is reachable from this code path, so there is no inference call to show

Red, at `00600c1af7` with `common.py` reverted to its content at `e9d1ea59fb` (the staging tip immediately before #35773 merged):

```
$ git show e9d1ea59fb:litellm/proxy/management_endpoints/management_v1/common.py | sed -n '7p'
from fastapi.dependencies.utils import get_flat_dependant

$ python -m pytest tests/test_litellm/proxy/management_endpoints/management_v1/test_common.py -q -p no:randomly
FAILED ...test_common.py::test_common_still_imports_when_fastapi_has_dropped_those_names
FAILED ...test_common.py::test_no_module_imports_a_fastapi_name_removed_in_a_supported_release[common.py]
2 failed, 10 passed, 1 warning in 1.32s
```

The 10 that pass there include all 6 tests from #35773, which is the gap this PR closes

Green, at `00600c1af7` on merged staging (`ecba48dd7c`):

```
$ python -m pytest tests/test_litellm/proxy/management_endpoints/management_v1/ -q -p no:randomly
174 passed, 1 warning in 55.58s
```

The behaviour the tests stand in for, driven through `TestClient` against the real `proxy_server.app` on an install pinned to fastapi 0.141.1, at `ecba48dd7c`:

```
$ python -c "import fastapi; print(fastapi.__version__)"
0.141.1

503  /management/v1/budgets
503  /management/v1/spend_logs/end_users?filter[startTime][gte]=...&filter[startTime][lte]=...
400  /management/v1/spend_logs/end_users?bogus=1
200  /health/liveliness
```

The 503s are the absent database, not the routing. On the same interpreter at `e9d1ea59fb` the process never gets that far, since `import litellm.proxy.proxy_server` itself raises

## Type

✅ Test

## Changes

`test_no_module_imports_a_fastapi_name_removed_in_a_supported_release` parses every `.py` in `management_v1/` and fails if it imports a fastapi name a supported release has deleted. It globs the directory, so a module added later is covered without anyone remembering to list it

`test_common_still_imports_when_fastapi_has_dropped_those_names` deletes the name from `fastapi.dependencies.utils` and loads `common.py` from source, which is the closest a run on 0.136.3 gets to the failure a user on 0.141.1 sees. Behaviour cannot be asserted under that simulation, because 0.136.3's `get_flat_params` calls `get_flat_dependant` internally and raises `NameError` once it is gone. The same reason is why the check stops at `common.py`: `budgets.py` and `spend_logs.py` register routes at import, and registration reaches the deleted name on 0.136.3 no matter how the module is written

Known limitation, stated rather than buried: `FASTAPI_NAMES_REMOVED_IN_0_140_7` is hand-maintained, so this catches the removal we know about and not the next one. The durable version is a CI job that resolves the newest fastapi our range allows and runs this suite against it. That is a separate change and I would rather verify it on a real run than bundle it here

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
