### PR TITLE
fix(arize): trace MCP tool calls instead of crashing on CallToolResult

### DIFF
--- a/litellm/integrations/arize/_utils.py
+++ b/litellm/integrations/arize/_utils.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Final
 
 from typing_extensions import override
@@ -1072,7 +1073,7 @@ def _parse_passthrough_response(raw_response_obj, coerced_response_obj, kwargs):
 
 def _maybe_set_mcp_tool_attrs(
     span: "Span",
-    kwargs: dict,
+    kwargs: Mapping[str, object],
     standard_logging_payload: StandardLoggingPayload | None,
     coerced_response_obj: object,
 ) -> None:
@@ -1083,24 +1084,24 @@ def _maybe_set_mcp_tool_attrs(
     in `metadata.mcp_tool_call_metadata`; the result is an MCP `CallToolResult`
     whose `content` is a list of typed parts.
     """
-    if not isinstance(standard_logging_payload, dict):
+    if standard_logging_payload is None:
         return
     if standard_logging_payload.get("call_type") != CallTypes.call_mcp_tool.value:
         return
 
     metadata: Final = standard_logging_payload.get("metadata")
-    mcp_meta: Final = metadata.get("mcp_tool_call_metadata") if isinstance(metadata, dict) else None
-    if not isinstance(mcp_meta, dict):
+    mcp_meta: Final = metadata.get("mcp_tool_call_metadata") if metadata else None
+    if mcp_meta is None:
         return
 
     tool_name: Final = mcp_meta.get("name") or mcp_meta.get("namespaced_tool_name")
     if tool_name:
         safe_set_attribute(span, SpanAttributes.TOOL_NAME, tool_name)
 
-    if should_redact_message_logging(kwargs):
+    if should_redact_message_logging(kwargs):  # pyright: ignore[reportArgumentType]  # reads the mapping, never mutates it
         return
 
-    arguments: Final = mcp_meta.get("arguments")
+    arguments: Final[object] = mcp_meta.get("arguments")
     if arguments:
         safe_set_attribute(span, SpanAttributes.INPUT_VALUE, safe_dumps(arguments))
         safe_set_attribute(span, SpanAttributes.INPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value)
@@ -1109,11 +1110,11 @@ def _maybe_set_mcp_tool_attrs(
 
 
 def _set_mcp_tool_output(span: "Span", coerced_response_obj: object) -> None:
-    if not isinstance(coerced_response_obj, dict):
+    if not isinstance(coerced_response_obj, Mapping):
         return
 
-    content: Final = coerced_response_obj.get("content")
-    text: Final = _coerce_text(content)
+    content: Final[object] = coerced_response_obj.get("content")
+    text: Final[str | None] = _coerce_text(content)
     if text:
         safe_set_attribute(span, SpanAttributes.OUTPUT_VALUE, text)
         safe_set_attribute(span, SpanAttributes.OUTPUT_MIME_TYPE, OpenInferenceMimeTypeValues.TEXT.value)

--- a/litellm/integrations/arize/_utils.py
+++ b/litellm/integrations/arize/_utils.py
@@ -1073,8 +1073,8 @@ def _parse_passthrough_response(raw_response_obj, coerced_response_obj, kwargs):
 def _maybe_set_mcp_tool_attrs(
     span: "Span",
     kwargs: dict,
-    standard_logging_payload,
-    coerced_response_obj,
+    standard_logging_payload: StandardLoggingPayload | None,
+    coerced_response_obj: object,
 ) -> None:
     """Render `call_mcp_tool` spans as OpenInference TOOL spans.
 
@@ -1108,7 +1108,7 @@ def _maybe_set_mcp_tool_attrs(
     _set_mcp_tool_output(span, coerced_response_obj)
 
 
-def _set_mcp_tool_output(span: "Span", coerced_response_obj) -> None:
+def _set_mcp_tool_output(span: "Span", coerced_response_obj: object) -> None:
     if not isinstance(coerced_response_obj, dict):
         return
 

--- a/litellm/integrations/arize/_utils.py
+++ b/litellm/integrations/arize/_utils.py
@@ -1,6 +1,7 @@
 import json
 from typing import TYPE_CHECKING, Any, Final
 
+from pydantic import BaseModel
 from typing_extensions import override
 
 from litellm._logging import verbose_logger
@@ -538,9 +539,12 @@ def _set_request_attributes(
     if optional_params.get("user"):
         safe_set_attribute(span, "llm.user", optional_params.get("user"))
 
-    if response_obj and response_obj.get("id"):
+    if not hasattr(response_obj, "get"):
+        return
+
+    if response_obj.get("id"):
         safe_set_attribute(span, "llm.response.id", response_obj.get("id"))
-    if response_obj and response_obj.get("model"):
+    if response_obj.get("model"):
         safe_set_attribute(span, "llm.response.model", response_obj.get("model"))
 
 
@@ -588,6 +592,8 @@ def _coerce_response_obj_for_attrs(response_obj):
     - dicts and Pydantic models that already expose `.get` are returned
       unchanged (preserves all current behavior, including the Responses API
       flow which relies on Pydantic attribute access).
+    - Pydantic models without `.get` (e.g. the MCP SDK's `CallToolResult`,
+      logged for `call_mcp_tool` spans) are dumped to a dict.
     - `httpx.Response` and other text-only responses (passthrough routes)
       are JSON-decoded so the standard extraction paths can read fields like
       `id`, `model`, and `usage`. On failure the original object is returned
@@ -595,6 +601,11 @@ def _coerce_response_obj_for_attrs(response_obj):
     """
     if response_obj is None or hasattr(response_obj, "get"):
         return response_obj
+    if isinstance(response_obj, BaseModel):
+        try:
+            return response_obj.model_dump()
+        except Exception:
+            return response_obj
     text: Final = getattr(response_obj, "text", None)
     if isinstance(text, str) and text:
         try:

--- a/litellm/integrations/arize/_utils.py
+++ b/litellm/integrations/arize/_utils.py
@@ -1,7 +1,6 @@
 import json
 from typing import TYPE_CHECKING, Any, Final
 
-from pydantic import BaseModel
 from typing_extensions import override
 
 from litellm._logging import verbose_logger
@@ -13,7 +12,7 @@ from litellm.litellm_core_utils.redact_messages import (
     should_redact_message_logging,
 )
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
-from litellm.types.utils import StandardLoggingPayload
+from litellm.types.utils import CallTypes, StandardLoggingPayload
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
@@ -23,6 +22,7 @@ from litellm.integrations._types.open_inference import (
     ImageAttributes,
     MessageAttributes,
     MessageContentAttributes,
+    OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
     ToolCallAttributes,
@@ -481,6 +481,7 @@ def set_attributes(span: "Span", kwargs, response_obj, attributes: type[BaseLLMO
         response_obj_for_attrs,
         slp,
     )
+    _safe_emit("mcp tool attrs", _maybe_set_mcp_tool_attrs, span, kwargs, slp, response_obj_for_attrs)
 
 
 def _sanitize_optional_params(optional_params: dict | None) -> dict:
@@ -601,11 +602,9 @@ def _coerce_response_obj_for_attrs(response_obj):
     """
     if response_obj is None or hasattr(response_obj, "get"):
         return response_obj
-    if isinstance(response_obj, BaseModel):
-        try:
-            return response_obj.model_dump()
-        except Exception:
-            return response_obj
+    dumped: Final = _to_plain_dict(response_obj)
+    if isinstance(dumped, dict):
+        return dumped
     text: Final = getattr(response_obj, "text", None)
     if isinstance(text, str) and text:
         try:
@@ -1069,3 +1068,57 @@ def _parse_passthrough_response(raw_response_obj, coerced_response_obj, kwargs):
         except Exception:
             return None
     return None
+
+
+def _maybe_set_mcp_tool_attrs(
+    span: "Span",
+    kwargs: dict,
+    standard_logging_payload,
+    coerced_response_obj,
+) -> None:
+    """Render `call_mcp_tool` spans as OpenInference TOOL spans.
+
+    MCP tool calls carry neither `messages` nor `choices`, so the generic
+    extraction paths leave Input/Output blank. The tool name and arguments live
+    in `metadata.mcp_tool_call_metadata`; the result is an MCP `CallToolResult`
+    whose `content` is a list of typed parts.
+    """
+    if not isinstance(standard_logging_payload, dict):
+        return
+    if standard_logging_payload.get("call_type") != CallTypes.call_mcp_tool.value:
+        return
+
+    metadata: Final = standard_logging_payload.get("metadata")
+    mcp_meta: Final = metadata.get("mcp_tool_call_metadata") if isinstance(metadata, dict) else None
+    if not isinstance(mcp_meta, dict):
+        return
+
+    tool_name: Final = mcp_meta.get("name") or mcp_meta.get("namespaced_tool_name")
+    if tool_name:
+        safe_set_attribute(span, SpanAttributes.TOOL_NAME, tool_name)
+
+    if should_redact_message_logging(kwargs):
+        return
+
+    arguments: Final = mcp_meta.get("arguments")
+    if arguments:
+        safe_set_attribute(span, SpanAttributes.INPUT_VALUE, safe_dumps(arguments))
+        safe_set_attribute(span, SpanAttributes.INPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value)
+
+    _set_mcp_tool_output(span, coerced_response_obj)
+
+
+def _set_mcp_tool_output(span: "Span", coerced_response_obj) -> None:
+    if not isinstance(coerced_response_obj, dict):
+        return
+
+    content: Final = coerced_response_obj.get("content")
+    text: Final = _coerce_text(content)
+    if text:
+        safe_set_attribute(span, SpanAttributes.OUTPUT_VALUE, text)
+        safe_set_attribute(span, SpanAttributes.OUTPUT_MIME_TYPE, OpenInferenceMimeTypeValues.TEXT.value)
+        return
+
+    if content:
+        safe_set_attribute(span, SpanAttributes.OUTPUT_VALUE, safe_dumps(content))
+        safe_set_attribute(span, SpanAttributes.OUTPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value)

--- a/tests/test_litellm/integrations/arize/test_arize_utils.py
+++ b/tests/test_litellm/integrations/arize/test_arize_utils.py
@@ -1193,3 +1193,77 @@ def test_arize_coerce_response_obj_returns_original_on_bad_json():
 
     obj = BadJson()
     assert _coerce_response_obj_for_attrs(obj) is obj
+
+
+def test_arize_mcp_call_tool_result_does_not_break_attribute_setting():
+    """`call_mcp_tool` logs the MCP SDK's `CallToolResult`, a Pydantic model
+    with no `.get`. It used to raise inside `_set_request_attributes`, aborting
+    the whole attribute block (input messages, invocation params, outputs)."""
+    from unittest.mock import MagicMock
+
+    from mcp.types import CallToolResult, TextContent
+
+    span = MagicMock()
+    kwargs = {
+        "model": "MCP: get_weather",
+        "standard_logging_object": {
+            "model_parameters": {"user": "u-1"},
+            "metadata": {},
+            "call_type": "call_mcp_tool",
+        },
+        "optional_params": {},
+        "litellm_params": {"custom_llm_provider": "mcp"},
+    }
+    response_obj = CallToolResult(
+        content=[TextContent(type="text", text="sunny, 21C")], isError=False
+    )
+
+    ArizeLogger.set_arize_attributes(span, kwargs, response_obj)
+
+    span.record_exception.assert_not_called()
+    written = {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list}
+    assert written[SpanAttributes.OPENINFERENCE_SPAN_KIND] == "TOOL"
+    assert written["llm.request.type"] == "call_mcp_tool"
+    # Emitted after the old crash point, so absent before the fix.
+    assert written[SpanAttributes.LLM_INVOCATION_PARAMETERS] == '{"user": "u-1"}'
+    assert written[SpanAttributes.USER_ID] == "u-1"
+
+
+def test_arize_coerce_response_obj_dumps_pydantic_without_get():
+    from mcp.types import CallToolResult, TextContent
+
+    from litellm.integrations.arize._utils import _coerce_response_obj_for_attrs
+
+    result = CallToolResult(content=[TextContent(type="text", text="hi")], isError=False)
+    coerced = _coerce_response_obj_for_attrs(result)
+
+    assert isinstance(coerced, dict)
+    assert coerced["isError"] is False
+    assert coerced["content"][0]["text"] == "hi"
+
+
+def test_arize_request_attributes_survive_uncoercible_response_obj():
+    """A response object that is neither dict-like nor coercible (binary
+    passthrough body, SDK object) must not abort attribute setting."""
+    from unittest.mock import MagicMock
+
+    span = MagicMock()
+    kwargs = {
+        "model": "gpt-4o",
+        "standard_logging_object": {
+            "model_parameters": {},
+            "metadata": {},
+            "call_type": "completion",
+        },
+        "optional_params": {},
+        "litellm_params": {"custom_llm_provider": "openai"},
+    }
+
+    class Opaque:
+        pass
+
+    ArizeLogger.set_arize_attributes(span, kwargs, Opaque())
+
+    span.record_exception.assert_not_called()
+    written = {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list}
+    assert written["llm.provider"] == "openai"

--- a/tests/test_litellm/integrations/arize/test_arize_utils.py
+++ b/tests/test_litellm/integrations/arize/test_arize_utils.py
@@ -1267,3 +1267,120 @@ def test_arize_request_attributes_survive_uncoercible_response_obj():
     span.record_exception.assert_not_called()
     written = {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list}
     assert written["llm.provider"] == "openai"
+
+
+def _mcp_kwargs(**overrides):
+    kwargs = {
+        "model": "MCP: get_weather",
+        "standard_logging_object": {
+            "model_parameters": {},
+            "metadata": {
+                "mcp_tool_call_metadata": {
+                    "name": "get_weather",
+                    "arguments": {"city": "Seoul"},
+                    "namespaced_tool_name": "weather-mcp/get_weather",
+                }
+            },
+            "call_type": "call_mcp_tool",
+        },
+        "optional_params": {},
+        "litellm_params": {"custom_llm_provider": "mcp"},
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_arize_mcp_tool_span_renders_name_input_and_output():
+    """`call_mcp_tool` spans have no messages/choices, so Input and Output came
+    out blank. Render them from mcp_tool_call_metadata + CallToolResult."""
+    from unittest.mock import MagicMock
+
+    from mcp.types import CallToolResult, TextContent
+
+    span = MagicMock()
+    response_obj = CallToolResult(
+        content=[TextContent(type="text", text="sunny, 21C")], isError=False
+    )
+
+    ArizeLogger.set_arize_attributes(span, _mcp_kwargs(), response_obj)
+
+    written = {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list}
+    assert written[SpanAttributes.TOOL_NAME] == "get_weather"
+    assert written[SpanAttributes.INPUT_VALUE] == '{"city": "Seoul"}'
+    assert written[SpanAttributes.INPUT_MIME_TYPE] == "application/json"
+    assert written[SpanAttributes.OUTPUT_VALUE] == "sunny, 21C"
+    assert written[SpanAttributes.OUTPUT_MIME_TYPE] == "text/plain"
+
+
+def test_arize_mcp_tool_span_serializes_non_text_content():
+    """Image/resource results have no text part, so fall back to JSON."""
+    from unittest.mock import MagicMock
+
+    from mcp.types import CallToolResult, ImageContent
+
+    span = MagicMock()
+    response_obj = CallToolResult(
+        content=[ImageContent(type="image", data="Zm9v", mimeType="image/png")],
+        isError=False,
+    )
+
+    ArizeLogger.set_arize_attributes(span, _mcp_kwargs(), response_obj)
+
+    written = {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list}
+    assert written[SpanAttributes.OUTPUT_MIME_TYPE] == "application/json"
+    assert "image/png" in written[SpanAttributes.OUTPUT_VALUE]
+
+
+def test_arize_mcp_tool_span_respects_message_redaction():
+    """Tool arguments and results are user content. With redaction on, only the
+    tool name may reach the span."""
+    from unittest.mock import MagicMock
+
+    from mcp.types import CallToolResult, TextContent
+
+    span = MagicMock()
+    response_obj = CallToolResult(
+        content=[TextContent(type="text", text="SSN 123-45-6789")], isError=False
+    )
+
+    ArizeLogger.set_arize_attributes(
+        span,
+        _mcp_kwargs(standard_callback_dynamic_params={"turn_off_message_logging": True}),
+        response_obj,
+    )
+
+    written = {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list}
+    assert written[SpanAttributes.TOOL_NAME] == "get_weather"
+    assert SpanAttributes.INPUT_VALUE not in written
+    assert SpanAttributes.OUTPUT_VALUE not in written
+
+
+def test_arize_non_mcp_span_gets_no_tool_name():
+    """The MCP emitter must not fire on ordinary completions."""
+    from unittest.mock import MagicMock
+
+    from litellm.types.utils import Choices, ModelResponse
+
+    span = MagicMock()
+    kwargs = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+        "standard_logging_object": {
+            "model_parameters": {},
+            "metadata": {"mcp_tool_call_metadata": {"name": "get_weather"}},
+            "call_type": "completion",
+        },
+        "optional_params": {},
+        "litellm_params": {"custom_llm_provider": "openai"},
+    }
+    response_obj = ModelResponse(
+        choices=[Choices(message={"role": "assistant", "content": "hello"})],
+        model="gpt-4o",
+        id="r-1",
+    )
+
+    ArizeLogger.set_arize_attributes(span, kwargs, response_obj)
+
+    written = {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list}
+    assert SpanAttributes.TOOL_NAME not in written
+    assert written[SpanAttributes.OUTPUT_VALUE] == "hello"


### PR DESCRIPTION
## TLDR

Problem this solves:

- MCP tool calls crash Arize span attribute setting
- Crash also blanks the span's remaining attributes
- MCP tool spans show empty Input and Output

How it solves it:

- Coerce Pydantic responses without `.get` to dicts
- Guard the response id/model reads like the sibling helper
- Emit tool name, arguments, and result on MCP spans

## User Flow

Before: a developer tracing MCP tool calls through the proxy in Arize gets an error in the proxy logs and a span with nothing in it

1. The proxy admin adds `callbacks: ["arize"]` plus an MCP server to the config and restarts the proxy
2. The developer sends POST http://localhost:4000/mcp with a `tools/call` for `get_weather` and `{"city": "Seoul"}`
3. The tool result comes back fine, but the proxy log prints `AttributeError: 'CallToolResult' object has no attribute 'get'`
4. They open the trace in https://app.arize.com and the span shows only the model and provider, with the Input and Output panes blank and no tool name

After: the same call traces cleanly, and the span shows which tool ran with what arguments and what it returned

1. The proxy admin adds `callbacks: ["arize"]` plus an MCP server to the config and restarts the proxy
2. The developer sends POST http://localhost:4000/mcp with a `tools/call` for `get_weather` and `{"city": "Seoul"}`
3. The tool result comes back fine and the proxy log prints no `AttributeError`
4. https://app.arize.com shows the span as a TOOL span named `get_weather`, with Input `{"city": "Seoul"}` and Output carrying the tool's text result

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Pending, being captured against a live proxy with a real Arize project

## Type

🐛 Bug Fix

🆕 New Feature

## Changes

`call_mcp_tool` is wrapped by the `@client` decorator, so the value handed to the success handler is the MCP SDK's `CallToolResult`. That is a Pydantic model with no `.get`, and `_coerce_response_obj_for_attrs` only knew how to convert dicts and `.text`-bearing objects, so it passed the model straight through. `_set_request_attributes` then called `response_obj.get("id")` and raised, which aborted the whole attribute block. Everything sequenced after that point was lost: tool attributes, input messages, invocation parameters, and every response attribute.

The coercion now falls back to the existing `_to_plain_dict` helper, which dumps any Pydantic model to a dict. `_set_request_attributes` also gained the same `hasattr(response_obj, "get")` guard that `_set_response_attributes` has always had, so a response object that genuinely cannot be converted degrades instead of taking the span down with it.

Fixing the crash alone still left MCP spans empty, because these calls carry neither `messages` nor `choices` for the generic extraction paths to read. A new additive emitter reads the tool name and arguments from `metadata.mcp_tool_call_metadata` and the result from the coerced `CallToolResult`, writing `tool.name`, `input.value`, and `output.value`. Text content parts render as `text/plain`; anything else, such as image or resource parts, is serialized as JSON. Arguments and results are user content, so that emitter is gated on the same `should_redact_message_logging` check the passthrough normalizer already uses, leaving only the tool name on the span when redaction is on.

Seven tests cover this. Three pin the crash: the MCP payload no longer records an exception on the span and keeps emitting the attributes that follow the old failure point, Pydantic models without `.get` coerce to dicts, and an object that cannot be coerced at all no longer aborts the request attributes. Four cover the rendering: the tool name and input and output land on the span, non-text content falls back to JSON, redaction strips input and output while keeping the tool name, and an ordinary completion is left untouched.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Arize OTEL attribute emission and observability; behavior changes are additive with guards and broad test coverage, with no auth or request-path changes.
> 
> **Overview**
> Fixes Arize/Phoenix tracing for **`call_mcp_tool`** when the success callback receives the MCP SDK’s **`CallToolResult`** (a Pydantic model without `.get`).
> 
> **Crash fix:** `_coerce_response_obj_for_attrs` now dumps such models via `_to_plain_dict` before attribute extraction. `_set_request_attributes` bails early when the response object has no `.get`, matching `_set_response_attributes`, so uncoercible responses no longer abort the whole span attribute pipeline.
> 
> **MCP span rendering:** A new `_safe_emit` path (`_maybe_set_mcp_tool_attrs`) fills OpenInference **TOOL** spans from `metadata.mcp_tool_call_metadata` (tool name, JSON arguments) and from the coerced result (`content` as text/plain or JSON). Input/output are skipped when message redaction is enabled; regular completions are unchanged.
> 
> Tests cover the crash regression, coercion, MCP I/O, redaction, and non-MCP guardrails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12f9bc9252d761abad08707fd592969893ab8ce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->