### PR TITLE
fix(gemini): fail closed on off-origin Veo video.uri downloads

### DIFF
--- a/litellm/llms/gemini/common_utils.py
+++ b/litellm/llms/gemini/common_utils.py
@@ -4,11 +4,13 @@ import json
 import math
 from collections.abc import Sequence
 from typing import Any, Final
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
 import litellm
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
+from litellm.litellm_core_utils.url_utils import SSRFError, assert_same_origin
 from litellm.llms.base_llm.base_utils import BaseLLMModelInfo, BaseTokenCounter
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.secret_managers.main import get_secret_str
@@ -339,6 +341,36 @@ def _map_dimensions_to_gemini_image_size(width: int, height: int) -> str:
 
 class GeminiError(BaseLLMException):
     pass
+
+
+def assert_gemini_video_download_url(download_url: str, api_base: str) -> str:
+    """Validate Veo ``video.uri`` before credentialed download.
+
+    ``transform_video_content_request`` returns a provider-supplied URI that
+    ``llm_http_handler`` fetches with ``x-goog-api-key``. Relative file URIs
+    are resolved against ``api_base``; absolute URLs must share origin with
+    ``api_base`` so API keys are not forwarded off-origin (same class as
+    BFL polling URL / ``assert_same_origin``).
+    """
+    if not isinstance(download_url, str) or not download_url.strip():
+        raise GeminiError(
+            status_code=502,
+            message="Rejected video download URL: missing uri",
+        )
+
+    resolved: Final = (
+        download_url
+        if urlparse(download_url).scheme
+        else urljoin(api_base.rstrip("/") + "/", download_url.lstrip("/"))
+    )
+    try:
+        assert_same_origin(resolved, api_base)
+    except SSRFError as e:
+        raise GeminiError(
+            status_code=502,
+            message=f"Rejected video download URL: {e}",
+        ) from e
+    return resolved
 
 
 class GeminiModelInfo(BaseLLMModelInfo):

--- a/litellm/llms/gemini/common_utils.py
+++ b/litellm/llms/gemini/common_utils.py
@@ -359,9 +359,7 @@ def assert_gemini_video_download_url(download_url: str, api_base: str) -> str:
         )
 
     resolved: Final = (
-        download_url
-        if urlparse(download_url).scheme
-        else urljoin(api_base.rstrip("/") + "/", download_url.lstrip("/"))
+        download_url if urlparse(download_url).scheme else urljoin(api_base.rstrip("/") + "/", download_url.lstrip("/"))
     )
     try:
         assert_same_origin(resolved, api_base)

--- a/litellm/llms/gemini/videos/transformation.py
+++ b/litellm/llms/gemini/videos/transformation.py
@@ -8,6 +8,7 @@ import litellm
 from litellm.constants import DEFAULT_GOOGLE_VIDEO_DURATION_SECONDS
 from litellm.images.utils import ImageEditRequestUtils
 from litellm.llms.base_llm.videos.transformation import BaseVideoConfig
+from litellm.llms.gemini.common_utils import assert_gemini_video_download_url
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.gemini import (
     GeminiLongRunningOperationResponse,
@@ -456,7 +457,10 @@ class GeminiVideoConfig(BaseVideoConfig):
             raise ValueError("No response data in completed operation")
 
         generated_samples: Final = operation_response.response.generateVideoResponse.generatedSamples
-        download_url: Final = generated_samples[0].video.uri
+        download_url: Final = assert_gemini_video_download_url(
+            generated_samples[0].video.uri,
+            api_base,
+        )
 
         params: Final[dict[str, Any]] = {}
 

--- a/tests/test_litellm/llms/gemini/test_gemini_video_download_url.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_video_download_url.py
@@ -1,0 +1,38 @@
+"""Tests for assert_gemini_video_download_url (Veo video.uri credentialed fetch)."""
+
+import pytest
+
+from litellm.llms.gemini.common_utils import (
+    GeminiError,
+    assert_gemini_video_download_url,
+)
+
+API_BASE = "https://generativelanguage.googleapis.com"
+
+
+class TestAssertGeminiVideoDownloadUrl:
+    def test_accepts_same_origin_absolute_uri(self):
+        url = assert_gemini_video_download_url(
+            "https://generativelanguage.googleapis.com/v1beta/files/abc:download?alt=media",
+            API_BASE,
+        )
+        assert url.startswith("https://generativelanguage.googleapis.com/")
+
+    def test_resolves_relative_file_uri_against_api_base(self):
+        url = assert_gemini_video_download_url("files/abc123xyz", API_BASE)
+        assert url == "https://generativelanguage.googleapis.com/files/abc123xyz"
+
+    def test_rejects_off_origin_absolute_uri(self):
+        with pytest.raises(GeminiError, match="Rejected video download URL"):
+            assert_gemini_video_download_url("https://evil.com/steal-key", API_BASE)
+
+    def test_rejects_http_scheme(self):
+        with pytest.raises(GeminiError, match="Rejected video download URL"):
+            assert_gemini_video_download_url(
+                "http://generativelanguage.googleapis.com/v1beta/files/abc",
+                API_BASE,
+            )
+
+    def test_rejects_missing_uri(self):
+        with pytest.raises(GeminiError, match="missing uri"):
+            assert_gemini_video_download_url("", API_BASE)


### PR DESCRIPTION
## Summary
- Veo `transform_video_content_request` returns provider-supplied `video.uri`, which `llm_http_handler` fetches with `x-goog-api-key`.
- Relative file URIs are resolved against `api_base`; absolute URLs must share origin with `api_base` via `assert_same_origin` so credentials are not forwarded off-origin.
- Sibling of #36284 (Runway output URL `safe_get`) and #36339 (GigaChat `image_url`).

## Test plan
- [x] `pytest tests/test_litellm/llms/gemini/test_gemini_video_download_url.py` + existing `test_transform_video_content_request` (6 passed)
- [ ] CI


Made with [Cursor](https://cursor.com)