### PR TITLE
fix(ui): preserve usage counts after gateway metrics upgrade

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.test.tsx
@@ -676,6 +676,22 @@ describe("UsagePage", () => {
     expect(screen.queryByTestId("gateway-requests-by-endpoint")).not.toBeInTheDocument();
   });
 
+  it("should fall back to spend-derived counts while a new gateway table has no rows for the range", async () => {
+    mockGatewayDailyActivityCall.mockResolvedValue({
+      total_successful_requests: 0,
+      total_failed_requests: 0,
+      by_date: [],
+      by_route: [],
+    });
+
+    renderWithProviders(<UsagePage {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("1,450").length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText("50").length).toBeGreaterThan(0);
+  });
+
   it("should not request deployment-wide gateway counts for a non-admin", async () => {
     mockUseAuthorized.mockReturnValue(nonAdminSession);
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
@@ -56,6 +56,7 @@ import { DailyData, KeyMetricWithMetadata, MetricWithMetadata } from "@/componen
 import { valueFormatterSpend } from "@/components/UsagePage/utils/value_formatters";
 import {
   fetchedRangeKey,
+  hasGatewayCoverageForDates,
   selectForRange,
   selectGatewayActivity,
   topGatewayRoutes,
@@ -493,6 +494,10 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
     () => [...userSpendData.results].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()),
     [userSpendData.results],
   );
+  const gatewayCountsCoverSpend = hasGatewayCoverageForDates(
+    gatewayActivity,
+    userSpendData.results.map(({ date }) => date),
+  );
   const gatewayRequestsByRoute = useMemo(() => topGatewayRoutes(gatewayActivity), [gatewayActivity]);
   const modelMetrics = useMemo(
     () => processActivityData(userSpendData, modelViewType === "groups" ? "model_groups" : "models", teams),
@@ -687,7 +692,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                               */}
                               <Text className="text-2xl font-bold mt-2 text-green-600">
                                 {(
-                                  gatewayActivity?.total_successful_requests ??
+                                  (gatewayCountsCoverSpend ? gatewayActivity?.total_successful_requests : undefined) ??
                                   userSpendData.metadata?.total_successful_requests
                                 )?.toLocaleString() || 0}
                               </Text>
@@ -709,7 +714,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                                   tile disagrees with the endpoint breakdown chart below it. */}
                               <Text className="text-2xl font-bold mt-2 text-red-600">
                                 {(
-                                  gatewayActivity?.total_failed_requests ??
+                                  (gatewayCountsCoverSpend ? gatewayActivity?.total_failed_requests : undefined) ??
                                   userSpendData.metadata?.total_failed_requests
                                 )?.toLocaleString() || 0}
                               </Text>

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/gatewayActivity.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/gatewayActivity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   GATEWAY_TOP_ROUTES,
   fetchedRangeKey,
+  hasGatewayCoverageForDates,
   selectForRange,
   selectGatewayActivity,
   topGatewayRoutes,
@@ -70,6 +71,16 @@ describe("selectGatewayActivity", () => {
 
   it("returns null before anything has been fetched", () => {
     expect(selectGatewayActivity(true, null, JANUARY)).toBeNull();
+  });
+});
+
+describe("hasGatewayCoverageForDates", () => {
+  it("withholds a newly-created gateway table until it covers the existing spend dates", () => {
+    expect(hasGatewayCoverageForDates(activity(0), ["2024-12-31", "2025-01-01"])).toBe(false);
+  });
+
+  it("accepts gateway counts once every spend date is represented", () => {
+    expect(hasGatewayCoverageForDates(activity(7), ["2025-01-01"])).toBe(true);
   });
 });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/gatewayActivity.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/gatewayActivity.ts
@@ -64,6 +64,16 @@ export const selectGatewayActivity = (
   currentRangeKey: string,
 ): GatewayActivity | null => (isAdmin ? selectForRange(fetched, currentRangeKey) : null);
 
+export const hasGatewayCoverageForDates = (activity: GatewayActivity | null, dates: Iterable<string>): boolean => {
+  if (activity == null) return false;
+
+  const gatewayDates = new Set(activity.by_date.map(({ date }) => date));
+  for (const date of dates) {
+    if (!gatewayDates.has(date)) return false;
+  }
+  return true;
+};
+
 /**
  * Bars for the endpoint breakdown chart, capped so a deployment exercising many
  * endpoints does not render an unreadable axis. `by_route` arrives sorted by


### PR DESCRIPTION
## TLDR

Problem this solves:

- Upgrades can show zero successful and failed request counts
- Existing daily usage data remains available

How it solves it:

- Uses gateway counts only when they cover the selected spend dates
- Keeps daily usage counts visible while gateway metrics begin collecting

## User Flow

Before: an admin upgrades a PostgreSQL-backed proxy and sees zero request counts for existing usage

1. They open /ui/?page=usage and select a range that includes usage recorded before the upgrade
2. Project spend and total requests are present, but successful and failed request counts show 0

After: the same admin sees the existing usage counts until gateway metrics cover the range

1. They open /ui/?page=usage and select the same range
2. Project spend, total requests, successful requests, and failed requests remain visible from the daily usage data

## Relevant issues

Fixes #36337

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Commit: e155e87

Focused UI tests passed locally: 51 tests across the usage page and gateway activity helpers

## Type

🐛 Bug Fix

## Changes

Uses daily usage counters until the gateway metrics response covers every date with spend activity

### Final Attestation

- [x] The tests check the affected upgrade path and prevent zero gateway history from masking existing daily usage counts