### PR TITLE
fix(images): preserve explicit provider for async generation

### DIFF
--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -101,7 +101,11 @@ async def aimage_generation(*args, **kwargs) -> ImageResponse:
         ctx: Final = contextvars.copy_context()
         func_with_context: Final = partial(ctx.run, func)
 
-        _, custom_llm_provider, _, _ = get_llm_provider(model=model, api_base=kwargs.get("api_base", None))
+        _, custom_llm_provider, _, _ = get_llm_provider(
+            model=model,
+            custom_llm_provider=kwargs.get("custom_llm_provider"),
+            api_base=kwargs.get("api_base", None),
+        )
 
         # Await normally
         init_response: Final = await loop.run_in_executor(None, func_with_context)

--- a/tests/test_litellm/images/test_image_generation_extra_headers.py
+++ b/tests/test_litellm/images/test_image_generation_extra_headers.py
@@ -8,7 +8,7 @@ code paths.
 
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -81,8 +81,8 @@ class TestImageGenerationExtraHeaders:
     @patch("litellm.images.main.image_generation")
     @patch("litellm.images.main.get_llm_provider")
     async def test_aimage_generation_forwards_explicit_provider_to_resolution(
-        self, mock_get_llm_provider, mock_image_generation
-    ):
+        self, mock_get_llm_provider: Mock, mock_image_generation: Mock
+    ) -> None:
         mock_get_llm_provider.return_value = ("Qwen-Image", "openai", None, None)
         mock_image_generation.return_value = litellm.utils.ImageResponse(
             created=1234567890,

--- a/tests/test_litellm/images/test_image_generation_extra_headers.py
+++ b/tests/test_litellm/images/test_image_generation_extra_headers.py
@@ -8,14 +8,14 @@ code paths.
 
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 sys.path.insert(0, os.path.abspath("../../.."))
 
 import litellm
-from litellm.images.main import image_generation
+from litellm.images.main import aimage_generation, image_generation
 
 
 class TestImageGenerationExtraHeaders:
@@ -76,3 +76,27 @@ class TestImageGenerationExtraHeaders:
         )
 
         assert "extra_headers" not in optional_params
+
+    @pytest.mark.asyncio
+    @patch("litellm.images.main.image_generation")
+    @patch("litellm.images.main.get_llm_provider")
+    async def test_aimage_generation_forwards_explicit_provider_to_resolution(
+        self, mock_get_llm_provider, mock_image_generation
+    ):
+        mock_get_llm_provider.return_value = ("Qwen-Image", "openai", None, None)
+        mock_image_generation.return_value = litellm.utils.ImageResponse(
+            created=1234567890,
+            data=[{"url": "https://example.com/image.png"}],
+        )
+
+        await aimage_generation(
+            model="Qwen-Image",
+            prompt="A red circle",
+            custom_llm_provider="openai",
+        )
+
+        mock_get_llm_provider.assert_called_once_with(
+            model="Qwen-Image",
+            custom_llm_provider="openai",
+            api_base=None,
+        )


### PR DESCRIPTION
## TLDR

### What does this PR do?

Fix async image generation dropping an explicitly supplied `custom_llm_provider` before provider resolution

### Problem

`aimage_generation()` resolved the provider using only `model` and `api_base`

For a custom OpenAI-compatible image model with a bare model name, the explicit provider was ignored and LiteLLM raised `LLM Provider NOT provided` before making a provider request

### How it solves the problem

Forward `custom_llm_provider` into `get_llm_provider()` from `aimage_generation()`

Add a regression test covering a bare custom image model with an explicit provider

---

## User Flow

### Before

1. A Proxy admin configures a custom image model with a bare model name
2. The configuration supplies an explicit `custom_llm_provider`
3. The admin triggers image generation or tests the deployment
4. Provider resolution can fail before LiteLLM reaches the configured provider

### After

1. A Proxy admin configures the same custom image model
2. The configuration supplies an explicit `custom_llm_provider`
3. The admin triggers image generation or tests the deployment
4. LiteLLM preserves the explicit provider and continues to the configured provider request

---

## Relevant issues

Fixes #29280

---

## Checklist

- [x] I added a focused regression test
- [x] I ran the focused test locally
- [x] I ran Ruff on the changed files
- [x] My changes are isolated to async image-generation provider resolution
- [x] All CI checks are passing
- [x] Greptile review score is 4 or higher

---

## Screenshots / Proof of Fix

Verified through a local LiteLLM Proxy using a custom DashScope image deployment with a bare model name and an explicit `custom_llm_provider`

A request to `POST /v1/images/generations` completed successfully and returned an image response

The screenshot below is sanitized and does not include API credentials

<img width="1091" height="1036" alt="Successful local Proxy image-generation response" src="https://github.com/user-attachments/assets/035df44d-d40c-44ee-b9b1-f007c42ae0a5" />

---

## Type

- Bug Fix

---

## Changes

- Preserve `custom_llm_provider` during async image-generation provider resolution
- Add regression coverage for custom image deployments with bare model names
- Add type annotations to the new mock parameters

---

## Final Attestation

- [x] I verified the change locally and through a real Proxy image-generation request
- [x] All remote CI checks have completed successfully
