### PR TITLE
fix(streaming): preserve hidden usage in chunk builder

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -739,12 +739,12 @@ class ChunkProcessor:
         usage_chunk: Usage | None = None
         if hasattr(chunk, "usage") and chunk.usage is not None:
             usage_chunk = chunk.usage
-        elif "usage" in chunk:
-            usage_chunk = chunk["usage"]
         elif (isinstance(chunk, ModelResponse) or isinstance(chunk, ModelResponseStream)) and hasattr(
             chunk, "_hidden_params"
         ):
             usage_chunk = chunk._hidden_params.get("usage", None)
+        elif "usage" in chunk:
+            usage_chunk = chunk["usage"]
 
         if isinstance(usage_chunk, dict):
             return Usage(**usage_chunk)

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -1,4 +1,3 @@
-import json
 import os
 import sys
 
@@ -9,13 +8,13 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 from litellm import ChatCompletionUsageBlock, stream_chunk_builder
-from litellm.types.utils import GenericStreamingChunk
 from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProcessor
 from litellm.types.utils import (
     ChatCompletionDeltaToolCall,
     ChatCompletionMessageToolCall,
     Delta,
     Function,
+    GenericStreamingChunk,
     ModelResponseStream,
     PromptTokensDetails,
     ServerToolUse,
@@ -595,6 +594,38 @@ def test_stream_chunk_builder_litellm_usage_chunks():
     assert usage.prompt_tokens == 50
     assert usage.completion_tokens == 27
     assert usage.total_tokens == 77
+
+
+def test_calculate_usage_falls_back_to_hidden_usage():
+    hidden_usage = Usage(
+        prompt_tokens=2852,
+        completion_tokens=85,
+        total_tokens=2937,
+    )
+    chunk = ModelResponseStream(
+        id="chatcmpl-hidden-usage",
+        created=1745513206,
+        model="openai/test",
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content="done"),
+            )
+        ],
+        usage=None,
+    )
+    setattr(chunk, "_hidden_params", {"usage": hidden_usage})
+
+    usage = ChunkProcessor(chunks=[chunk]).calculate_usage(
+        chunks=[chunk],
+        model="openai/test",
+        completion_output="done",
+    )
+
+    assert usage.prompt_tokens == 2852
+    assert usage.completion_tokens == 85
+    assert usage.total_tokens == 2937
 
 
 def test_get_model_from_chunks_azure_model_router():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming aggregation discards preserved provider usage
- Recomputed token counts severely undercount usage

How it solves it:

- Use preserved usage when public usage is null
- Add focused regression coverage for streaming aggregation

## User Flow

Before: a developer streaming through chained proxies receives severely undercounted token usage

1. They POST `https://<front-proxy>/v1/chat/completions` with `"stream": true` and `"include_usage": true`
2. The upstream proxy returns 2,852 prompt and 85 completion tokens
3. The front proxy reports 22 prompt and 169 completion tokens

After: the same streaming request preserves the provider-reported usage

1. They POST `https://<front-proxy>/v1/chat/completions` with `"stream": true` and `"include_usage": true`
2. The upstream proxy returns 2,852 prompt and 85 completion tokens
3. The front proxy reports 2,852 prompt and 85 completion tokens

## Relevant issues

Fixes #36114

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Pending before-and-after `curl` output from the chained-proxy environment described in #36114

Before revision: `ecba48dd7c`

Fixed revision: `7d15f8e7f4`

## Type

🐛 Bug Fix  
✅ Test

## Changes

- Correct usage-selection precedence during streaming aggregation
- Preserve provider usage when the public usage field is null
- Add regression coverage for the reported fallback path

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR