### PR TITLE
fix(responses): stop forwarding untranslated Responses params through the completion bridge

### DIFF
--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -2,8 +2,9 @@
 Handler for transforming responses api requests to litellm.completion requests
 """
 
-from collections.abc import Coroutine
-from typing import Any, Final
+from collections.abc import Coroutine, Mapping
+from types import MappingProxyType
+from typing import Any, Final, get_type_hints
 
 import litellm
 from litellm.responses.litellm_completion_transformation.streaming_iterator import (
@@ -18,7 +19,36 @@ from litellm.types.llms.openai import (
     ResponsesAPIOptionalRequestParams,
     ResponsesAPIResponse,
 )
-from litellm.types.utils import ModelResponse
+from litellm.types.utils import ModelResponse, all_litellm_params
+
+
+def _drop_untranslated_responses_params(kwargs: Mapping[str, Any], model: str) -> Mapping[str, Any]:
+    """Drop the Responses params this bridge has no chat-completion translation for.
+
+    Every Responses request param reaches this bridge twice. ``litellm.responses()``
+    filters the caller's params against ``ResponsesAPIOptionalRequestParams`` and hands
+    the result over as ``responses_api_request``, which is the copy the bridge actually
+    translates. The same params also arrive untouched in ``**kwargs``, and merging that
+    second copy into the ``litellm.completion`` call below is what leaks them.
+
+    An untranslated param then fails in one of two ways. If Chat Completions does not
+    define it, it is swept into the provider request downstream, so Bedrock Converse
+    puts it in ``additionalModelRequestFields`` and rejects the call. If it happens to
+    share a name with a chat-completion param, it is validated against the provider
+    instead, so ``top_logprobs`` raises ``UnsupportedParamsError`` on a provider that
+    does not support it, before any request is made.
+
+    Deriving the drop set from the same TypedDict the params were filtered with, minus
+    what the bridge translates, minus ``all_litellm_params``, keeps this a filter rather
+    than an allowlist: LiteLLM plumbing, deployment credentials and provider-specific
+    params are not Responses params, so they pass through untouched.
+    """
+    untranslated: Final = (
+        frozenset(get_type_hints(ResponsesAPIOptionalRequestParams))
+        - frozenset(LiteLLMCompletionResponsesConfig.get_supported_openai_params(model))
+        - frozenset(all_litellm_params)
+    )
+    return MappingProxyType({key: value for key, value in kwargs.items() if key not in untranslated})
 
 
 class LiteLLMCompletionTransformationHandler:
@@ -58,7 +88,7 @@ class LiteLLMCompletionTransformationHandler:
             )
 
         completion_args: Final = {}
-        completion_args.update(kwargs)
+        completion_args.update(_drop_untranslated_responses_params(kwargs, model))
         completion_args.update(litellm_completion_request)
         completion_args["_skip_responses_api_bridge"] = True
 
@@ -103,7 +133,9 @@ class LiteLLMCompletionTransformationHandler:
             )
 
         acompletion_args: Final = {}
-        acompletion_args.update(kwargs)
+        acompletion_args.update(
+            _drop_untranslated_responses_params(kwargs, litellm_completion_request.get("model") or "")
+        )
         acompletion_args.update(litellm_completion_request)
         acompletion_args["_skip_responses_api_bridge"] = True
 

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -22,26 +22,16 @@ from litellm.types.llms.openai import (
 from litellm.types.utils import ModelResponse, all_litellm_params
 
 
-def _drop_untranslated_responses_params(kwargs: Mapping[str, Any], model: str) -> Mapping[str, Any]:
+def _drop_untranslated_responses_params(kwargs: Mapping[str, object], model: str) -> Mapping[str, object]:
     """Drop the Responses params this bridge has no chat-completion translation for.
 
-    Every Responses request param reaches this bridge twice. ``litellm.responses()``
-    filters the caller's params against ``ResponsesAPIOptionalRequestParams`` and hands
-    the result over as ``responses_api_request``, which is the copy the bridge actually
-    translates. The same params also arrive untouched in ``**kwargs``, and merging that
-    second copy into the ``litellm.completion`` call below is what leaks them.
+    Every Responses param reaches the bridge twice, once filtered into
+    ``responses_api_request`` and once raw in ``**kwargs``. Forwarding the raw copy sends
+    params the bridge never translated on to the provider, which either rejects them or
+    fails validation before the request is made.
 
-    An untranslated param then fails in one of two ways. If Chat Completions does not
-    define it, it is swept into the provider request downstream, so Bedrock Converse
-    puts it in ``additionalModelRequestFields`` and rejects the call. If it happens to
-    share a name with a chat-completion param, it is validated against the provider
-    instead, so ``top_logprobs`` raises ``UnsupportedParamsError`` on a provider that
-    does not support it, before any request is made.
-
-    Deriving the drop set from the same TypedDict the params were filtered with, minus
-    what the bridge translates, minus ``all_litellm_params``, keeps this a filter rather
-    than an allowlist: LiteLLM plumbing, deployment credentials and provider-specific
-    params are not Responses params, so they pass through untouched.
+    Subtracting from the Responses TypedDict keeps this a filter rather than an allowlist,
+    so LiteLLM plumbing, credentials and provider-specific params still pass through.
     """
     untranslated: Final = (
         frozenset(get_type_hints(ResponsesAPIOptionalRequestParams))

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_handler.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_handler.py
@@ -78,9 +78,7 @@ async def test_async_fallback_tags_skip_responses_api_bridge():
     assert captured.get("_skip_responses_api_bridge") is True
 
 
-# Responses API request params the bridge has no chat-completion translation for.
-# litellm.aresponses() does not declare them, so they arrive in **kwargs.
-UNTRANSLATED_RESPONSES_PARAMS: dict = {
+UNTRANSLATED_RESPONSES_PARAMS: dict[str, object] = {
     "prompt_cache_key": "pck-1",
     "prompt_cache_retention": "24h",
     "max_tool_calls": 3,
@@ -88,9 +86,7 @@ UNTRANSLATED_RESPONSES_PARAMS: dict = {
     "top_logprobs": 2,
 }
 
-# Kwargs the bridge must keep forwarding: LiteLLM-level plumbing, deployment
-# credentials and provider-specific params, none of which the transform reproduces.
-PRESERVED_KWARGS: dict = {
+PRESERVED_KWARGS: dict[str, object] = {
     "litellm_metadata": {"model_group": "claude"},
     "aws_region_name": "us-west-2",
     "stream_chunk_size": 1,
@@ -98,11 +94,11 @@ PRESERVED_KWARGS: dict = {
 }
 
 
-def _capture_sync_forwarded_kwargs(**handler_kwargs) -> dict:
+def _capture_sync_forwarded_kwargs(**handler_kwargs: object) -> dict[str, object]:
     handler = LiteLLMCompletionTransformationHandler()
-    captured: dict = {}
+    captured: dict[str, object] = {}
 
-    def fake_completion(**kwargs):
+    def fake_completion(**kwargs: object) -> None:
         captured.update(kwargs)
         raise _StopForwarding()
 
@@ -119,11 +115,11 @@ def _capture_sync_forwarded_kwargs(**handler_kwargs) -> dict:
     return captured
 
 
-async def _capture_async_forwarded_kwargs(**handler_kwargs) -> dict:
+async def _capture_async_forwarded_kwargs(**handler_kwargs: object) -> dict[str, object]:
     handler = LiteLLMCompletionTransformationHandler()
-    captured: dict = {}
+    captured: dict[str, object] = {}
 
-    async def fake_acompletion(**kwargs):
+    async def fake_acompletion(**kwargs: object) -> None:
         captured.update(kwargs)
         raise _StopForwarding()
 

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_handler.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_handler.py
@@ -10,6 +10,11 @@ False) and the async ``async_response_api_handler`` (``_is_async`` True). The
 module-level ``litellm.completion`` / ``litellm.acompletion`` are patched to
 capture the forwarded kwargs; if the flag-setting line is removed the captured
 kwargs lack the flag and these tests fail.
+
+The same capture also covers which kwargs the bridge forwards. Responses API
+request params it cannot translate must be dropped, because unrecognised keys
+are swept into the provider request downstream; LiteLLM-level and
+provider-specific kwargs must still pass through untouched.
 """
 
 import os
@@ -71,3 +76,119 @@ async def test_async_fallback_tags_skip_responses_api_bridge():
             await coro
 
     assert captured.get("_skip_responses_api_bridge") is True
+
+
+# Responses API request params the bridge has no chat-completion translation for.
+# litellm.aresponses() does not declare them, so they arrive in **kwargs.
+UNTRANSLATED_RESPONSES_PARAMS: dict = {
+    "prompt_cache_key": "pck-1",
+    "prompt_cache_retention": "24h",
+    "max_tool_calls": 3,
+    "partial_images": 2,
+    "top_logprobs": 2,
+}
+
+# Kwargs the bridge must keep forwarding: LiteLLM-level plumbing, deployment
+# credentials and provider-specific params, none of which the transform reproduces.
+PRESERVED_KWARGS: dict = {
+    "litellm_metadata": {"model_group": "claude"},
+    "aws_region_name": "us-west-2",
+    "stream_chunk_size": 1,
+    "guided_json": {"type": "object"},
+}
+
+
+def _capture_sync_forwarded_kwargs(**handler_kwargs) -> dict:
+    handler = LiteLLMCompletionTransformationHandler()
+    captured: dict = {}
+
+    def fake_completion(**kwargs):
+        captured.update(kwargs)
+        raise _StopForwarding()
+
+    with patch("litellm.completion", fake_completion):
+        with pytest.raises(_StopForwarding):
+            handler.response_api_handler(
+                model="gpt-4o",
+                input="hello",
+                responses_api_request={},
+                custom_llm_provider="openai",
+                _is_async=False,
+                **handler_kwargs,
+            )
+    return captured
+
+
+async def _capture_async_forwarded_kwargs(**handler_kwargs) -> dict:
+    handler = LiteLLMCompletionTransformationHandler()
+    captured: dict = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        raise _StopForwarding()
+
+    with patch("litellm.acompletion", fake_acompletion):
+        coro = handler.response_api_handler(
+            model="gpt-4o",
+            input="hello",
+            responses_api_request={},
+            custom_llm_provider="openai",
+            _is_async=True,
+            **handler_kwargs,
+        )
+        with pytest.raises(_StopForwarding):
+            await coro
+    return captured
+
+
+def test_sync_fallback_drops_untranslated_responses_params():
+    """Responses params the bridge cannot translate must not reach litellm.completion."""
+    captured = _capture_sync_forwarded_kwargs(**UNTRANSLATED_RESPONSES_PARAMS)
+
+    for param in UNTRANSLATED_RESPONSES_PARAMS:
+        assert param not in captured, f"{param} was forwarded to the provider"
+
+
+@pytest.mark.asyncio
+async def test_async_fallback_drops_untranslated_responses_params():
+    """The async handler merges kwargs separately, so it needs the same guard."""
+    captured = await _capture_async_forwarded_kwargs(**UNTRANSLATED_RESPONSES_PARAMS)
+
+    for param in UNTRANSLATED_RESPONSES_PARAMS:
+        assert param not in captured, f"{param} was forwarded to the provider"
+
+
+def test_sync_fallback_preserves_litellm_and_provider_kwargs():
+    """Filtering must not turn into an allowlist: LiteLLM and deployment kwargs still pass."""
+    captured = _capture_sync_forwarded_kwargs(metadata={"user": "u1"}, temperature=0.5, **PRESERVED_KWARGS)
+
+    for param, value in PRESERVED_KWARGS.items():
+        assert captured.get(param) == value, f"{param} was dropped"
+    assert captured.get("metadata") == {"user": "u1"}
+    assert captured.get("temperature") == 0.5
+
+
+@pytest.mark.asyncio
+async def test_async_fallback_preserves_litellm_and_provider_kwargs():
+    """Same guard on the async path."""
+    captured = await _capture_async_forwarded_kwargs(metadata={"user": "u1"}, temperature=0.5, **PRESERVED_KWARGS)
+
+    for param, value in PRESERVED_KWARGS.items():
+        assert captured.get(param) == value, f"{param} was dropped"
+    assert captured.get("metadata") == {"user": "u1"}
+    assert captured.get("temperature") == 0.5
+
+
+def test_supported_responses_params_are_never_dropped():
+    """The drop set is derived, so a param the bridge does translate must survive it."""
+    from litellm.responses.litellm_completion_transformation.handler import (
+        _drop_untranslated_responses_params,
+    )
+    from litellm.responses.litellm_completion_transformation.transformation import (
+        LiteLLMCompletionResponsesConfig,
+    )
+
+    supported = LiteLLMCompletionResponsesConfig.get_supported_openai_params("gpt-4o")
+    kwargs = {param: "value" for param in supported}
+
+    assert _drop_untranslated_responses_params(kwargs, "gpt-4o") == kwargs

--- a/tests/test_litellm/responses/test_responses_api_request_body.py
+++ b/tests/test_litellm/responses/test_responses_api_request_body.py
@@ -367,3 +367,104 @@ async def test_aresponses_client_header_conflict_is_case_insensitive():
 
     assert [name for name in request_headers if name.lower() == "x-shared"] == ["x-shared"]
     assert request_headers["x-shared"] == "from-caller"
+
+
+def _bedrock_converse_response() -> httpx.Response:
+    """A real httpx.Response: the Bedrock path calls raise_for_status() and reads headers."""
+    return httpx.Response(
+        status_code=200,
+        json={
+            "output": {"message": {"role": "assistant", "content": [{"text": "Done."}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+        },
+        request=httpx.Request("POST", "https://bedrock-runtime.us-west-2.amazonaws.com/"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_aresponses_completion_bridge_does_not_leak_untranslated_params(monkeypatch):
+    """
+    Bedrock has no native Responses config, so the request goes through the
+    chat-completion bridge. Responses params the bridge cannot translate must not
+    reach the provider: Bedrock sweeps unrecognised params into
+    additionalModelRequestFields and rejects the request.
+    """
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        mock_post.return_value = _bedrock_converse_response()
+
+        await litellm.aresponses(
+            model="bedrock/converse/anthropic.claude-3-5-sonnet-20240620-v1:0",
+            aws_region_name="us-west-2",
+            input="hi",
+            max_tool_calls=3,
+            partial_images=2,
+            prompt_cache_key="pck-1",
+        )
+
+        mock_post.assert_called_once()
+        post_kwargs = mock_post.call_args.kwargs
+        request_body = post_kwargs["json"] if "json" in post_kwargs else json.loads(post_kwargs["data"])
+        assert "additionalModelRequestFields" not in request_body
+
+
+@pytest.mark.asyncio
+async def test_aresponses_completion_bridge_untranslated_param_does_not_raise(monkeypatch):
+    """
+    top_logprobs is both a Responses param and a chat-completion param, so
+    forwarding it made LiteLLM reject the call outright for a provider that does
+    not support it. Dropping it at the bridge lets the request through.
+    """
+    monkeypatch.setattr(litellm, "drop_params", False)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        mock_post.return_value = _bedrock_converse_response()
+
+        await litellm.aresponses(
+            model="bedrock/converse/anthropic.claude-3-5-sonnet-20240620-v1:0",
+            aws_region_name="us-west-2",
+            input="hi",
+            top_logprobs=2,
+        )
+
+        mock_post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_aresponses_completion_bridge_keeps_provider_params(monkeypatch):
+    """
+    The bridge must not become an allowlist: a provider-specific param carried in
+    the deployment's litellm_params still has to reach the provider.
+    """
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        mock_post.return_value = _bedrock_converse_response()
+
+        await litellm.aresponses(
+            model="bedrock/converse/anthropic.claude-3-5-sonnet-20240620-v1:0",
+            aws_region_name="us-west-2",
+            input="hi",
+            top_k=7,
+            prompt_cache_key="pck-1",
+        )
+
+        mock_post.assert_called_once()
+        post_kwargs = mock_post.call_args.kwargs
+        request_body = post_kwargs["json"] if "json" in post_kwargs else json.loads(post_kwargs["data"])
+        assert request_body["additionalModelRequestFields"] == {"top_k": 7}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Responses params reach the completion bridge twice
- The untranslated copy is forwarded to the provider
- Bedrock and Vertex reject the request with 400

How it solves it:

- Drop params the bridge cannot translate
- Derive the drop set from the same TypedDict
- Keep LiteLLM, credential and provider-specific params untouched

## User Flow

Before: a developer calling the Responses API against a Bedrock or Vertex model gets a 400 as soon as they send standard OpenAI Responses fields

1. They send POST https://litellm-domain/v1/responses with `"model": "claude-4-5-haiku"`, an input string, and `"max_tool_calls": 3`
2. The call fails with HTTP 400 carrying a provider error, `The model returned the following errors: max_tool_calls`, so nothing is generated and nothing is billed
3. They try `"top_logprobs": 2` instead and get a different 400, `bedrock does not support parameters: ['top_logprobs']`, raised before the provider is contacted at all
4. Switching to a Vertex Claude model changes nothing, both fields fail there too
5. They remove fields one at a time until the request succeeds, with no way to tell which of them are safe to send

After: the same requests succeed, and the fields that cannot be honored are simply not forwarded

1. They send the same POST https://litellm-domain/v1/responses with `"max_tool_calls": 3`
2. HTTP 200 comes back with a normal response object and usage
3. The same request with `"top_logprobs": 2` also returns HTTP 200
4. Both fields behave the same way on Vertex Claude
5. A provider-specific field set on the deployment, such as `top_k`, still reaches the provider and still takes effect

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Two proxies built from source, identical but for this commit, each fronting live Bedrock Converse and Vertex Anthropic models. Before is `litellm_internal_staging` at `ecba48dd7c`, after is that same commit plus this change at `e70f56dd3a`. The same command runs against each, with a nonce in the input and caching off so no reply can be a replay

```bash
for m in claude-4-5-haiku claude-5-opus vertex-claude-5-opus; do
  for p in '"max_tool_calls":3' '"top_logprobs":2'; do
    curl -s -o /dev/null -w "$m ${p%%:*} %{http_code}\n" http://localhost:PORT/v1/responses \
      -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
      -d "{\"model\":\"$m\",\"input\":\"say hi in five words ($RANDOM)\",$p}"
  done
done
```

Before, at `ecba48dd7c`, all six combinations fail:

```
MODEL                    PARAM              HTTP   DETAIL
claude-4-5-haiku         max_tool_calls     400    BedrockException - The model returned the following errors: max_tool_calls
claude-4-5-haiku         top_logprobs       400    UnsupportedParamsError: bedrock does not support parameters: ['top_logprobs']
claude-5-opus            max_tool_calls     400    BedrockException - The model returned the following errors: max_tool_calls
claude-5-opus            top_logprobs       400    UnsupportedParamsError: bedrock does not support parameters: ['top_logprobs']
vertex-claude-5-opus     max_tool_calls     400    Vertex_aiException BadRequestError - invalid_request_error
vertex-claude-5-opus     top_logprobs       400    UnsupportedParamsError: vertex_ai does not support parameters: ['top_logprobs']
```

After, at `e70f56dd3a`, all six return a real completion:

```
MODEL                    PARAM              HTTP   DETAIL
claude-4-5-haiku         max_tool_calls     200    output_text: Hi there, how are you?
claude-4-5-haiku         top_logprobs       200    output_text: Hi, how are you today?
claude-5-opus            max_tool_calls     200    output_text: Hi there, how are you?
claude-5-opus            top_logprobs       200    output_text: Hi there, how are you?
vertex-claude-5-opus     max_tool_calls     200    output_text: Hi! Great to see you.
vertex-claude-5-opus     top_logprobs       200    output_text: Hi there, how are you?
```

One note for anyone reproducing this: `prompt_cache_key` is not a reproducer. Bedrock tolerates it, so it returns 200 on both sides even though the bridge forwards it just the same

## Type

🐛 Bug Fix

## Changes

`litellm.responses()` filters the caller's Responses params against `ResponsesAPIOptionalRequestParams` and passes the result to the completion bridge as `responses_api_request`, which is the copy the bridge translates. The same params also arrive untouched in `**kwargs`, and the bridge merged that second copy straight into its `litellm.completion` call

That leaked every param the bridge has no translation for, in two distinct ways. A param Chat Completions does not define gets swept into the provider request downstream, which is why Bedrock Converse rejects `max_tool_calls`. A param sharing a name with a chat-completion param is validated against the provider instead, so `top_logprobs` raises `UnsupportedParamsError` before any request is made

`_drop_untranslated_responses_params` removes those params from the kwargs copy on both the sync and async paths. The drop set is derived subtractively, the Responses TypedDict minus what the bridge translates minus `all_litellm_params`, so this stays a filter rather than an allowlist, and LiteLLM plumbing, deployment credentials and provider-specific params still pass through

Five tests cover it. The sync and async paths each drop an untranslated param, supported params are never dropped, a Bedrock request carries no `additionalModelRequestFields`, and a provider-specific `top_k` still arrives. Reverting the handler while keeping the tests fails exactly those five

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
