### PR TITLE
fix(responses): emit streamed output_item.done events in output_index order

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -689,15 +689,14 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         if not self.litellm_model_response or isinstance(self.litellm_model_response, TextCompletionResponse):
             self.litellm_model_response = self.create_litellm_model_response()
         if self.litellm_model_response:
-            # If tool calls exist, emit tool events before finishing/response.completed.
+            done_event: Final = self.return_default_done_events(self.litellm_model_response)
+            if done_event:
+                return done_event
+
             if isinstance(self.litellm_model_response, ModelResponse):
                 self._queue_final_tool_call_done_events(self.litellm_model_response)
             if self._pending_tool_events:
                 return self._pending_tool_events.pop(0)
-
-            done_event: Final = self.return_default_done_events(self.litellm_model_response)
-            if done_event:
-                return done_event
         else:
             if sync_mode:
                 raise StopIteration

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
@@ -8,6 +8,7 @@ Also ensures that tool calls that only appear in the final built response still 
 before response.completed.
 """
 
+from itertools import islice, takewhile
 from unittest.mock import AsyncMock
 
 from litellm.responses.litellm_completion_transformation.streaming_iterator import (
@@ -107,18 +108,15 @@ def test_tool_calls_present_only_in_final_response_are_emitted_before_completed(
     iterator.litellm_model_response = response
 
     # The message item holds output_index 0, so it finishes before the tool item at index 1.
-    message_done = []
-    while True:
-        evt1 = iterator.common_done_event_logic(sync_mode=True)
-        if evt1.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED:
-            break
-        message_done.append(evt1)
-    assert [evt.type for evt in message_done] == [
+    prelude = tuple(iterator.common_done_event_logic(sync_mode=True) for _ in range(4))
+    message_done, evt1 = prelude[:-1], prelude[-1]
+    assert tuple(evt.type for evt in message_done) == (
         ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE,
         ResponsesAPIStreamEvents.CONTENT_PART_DONE,
         ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
-    ]
+    )
     assert all(evt.output_index == 0 for evt in message_done)
+    assert evt1.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
     assert evt1.output_index == 1
 
     # Now delta events are emitted (arguments split into chunks)
@@ -442,13 +440,11 @@ def test_output_item_done_events_arrive_in_output_index_order():
         ],
     )
 
-    done_indexes = []
-    for _ in range(40):
-        evt = iterator.common_done_event_logic(sync_mode=True)
-        if evt.type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED:
-            break
-        if evt.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
-            done_indexes.append(evt.output_index)
+    events = islice(iter(lambda: iterator.common_done_event_logic(sync_mode=True), None), 40)
+    turn = takewhile(lambda evt: evt.type != ResponsesAPIStreamEvents.RESPONSE_COMPLETED, events)
+    done_indexes = tuple(
+        evt.output_index for evt in turn if evt.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE
+    )
 
-    assert done_indexes == sorted(done_indexes)
-    assert done_indexes == [0, 1]
+    assert done_indexes == tuple(sorted(done_indexes))
+    assert done_indexes == (0, 1)

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
@@ -416,7 +416,7 @@ def test_output_item_done_events_arrive_in_output_index_order():
         responses_api_request={},
     )
     iterator.litellm_model_response = ModelResponse(
-        id="resp-1",
+        id="resp-done-order",
         created=123,
         model="test-model",
         object="chat.completion",
@@ -429,7 +429,7 @@ def test_output_item_done_events_arrive_in_output_index_order():
                     "content": "calling a tool",
                     "tool_calls": [
                         {
-                            "id": "call_1",
+                            "id": "call_done_order",
                             "type": "function",
                             "function": {"name": "do_thing", "arguments": '{"y":2}'},
                             "index": 0,

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
@@ -106,9 +106,19 @@ def test_tool_calls_present_only_in_final_response_are_emitted_before_completed(
     )
     iterator.litellm_model_response = response
 
-    # First common_done_event_logic call should yield tool events, not response.completed.
-    evt1 = iterator.common_done_event_logic(sync_mode=True)
-    assert evt1.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
+    # The message item holds output_index 0, so it finishes before the tool item at index 1.
+    message_done = []
+    while True:
+        evt1 = iterator.common_done_event_logic(sync_mode=True)
+        if evt1.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED:
+            break
+        message_done.append(evt1)
+    assert [evt.type for evt in message_done] == [
+        ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE,
+        ResponsesAPIStreamEvents.CONTENT_PART_DONE,
+        ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
+    ]
+    assert all(evt.output_index == 0 for evt in message_done)
     assert evt1.output_index == 1
 
     # Now delta events are emitted (arguments split into chunks)
@@ -397,3 +407,48 @@ def test_reused_index_with_new_call_id_marks_fallback_ambiguous():
     assert arguments_by_call_id["call_b"] == '{"b":'
     assert arguments_by_call_id["call_a"] != '{"a":1}'
     assert arguments_by_call_id["call_b"] != '{"b":1}'
+
+def test_output_item_done_events_arrive_in_output_index_order():
+    """Regression: the tool item's done event was emitted before the message item's, inverting
+    arrival order relative to output_index and to the non-streaming response."""
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=AsyncMock(),
+        request_input="Test input",
+        responses_api_request={},
+    )
+    iterator.litellm_model_response = ModelResponse(
+        id="resp-1",
+        created=123,
+        model="test-model",
+        object="chat.completion",
+        choices=[
+            {
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": "calling a tool",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "do_thing", "arguments": '{"y":2}'},
+                            "index": 0,
+                        }
+                    ],
+                },
+            }
+        ],
+    )
+
+    done_indexes = []
+    for _ in range(40):
+        evt = iterator.common_done_event_logic(sync_mode=True)
+        if evt.type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED:
+            break
+        if evt.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
+            done_indexes.append(evt.output_index)
+
+    assert done_indexes == sorted(done_indexes)
+    assert done_indexes == [0, 1]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed `output_item.done` events arrive out of index order
- The tool item finishes before the message item
- Clients rebuild the turn with the tool call first

How it solves it:

- Emit the message item's done events before the queued tool events
- Arrival order now matches `output_index` and the non-streaming path

## User Flow

Before: a developer streaming a Responses turn that both says something and calls a tool gets the items back in the wrong order, and the damage only shows up on the next turn

1. They send POST https://litellm-domain/v1/responses with `"stream": true`, a tool defined, and input that makes the model answer and then call the tool
2. They read the SSE stream and append each item as its `response.output_item.done` arrives
3. The function call item at `output_index` 1 arrives first, then the message item at `output_index` 0, so their assembled turn has the tool call ahead of the text
4. The same response's `output` array, and the same request sent without `"stream": true`, both put the message first, so streaming and non-streaming disagree
5. On the next turn they replay that transcript and the provider rejects it, because an assistant message may not follow a tool call in the same turn. The error names the turn they just sent, not the one that was assembled wrongly

After: the items arrive in the order their indexes claim

1. They send the same streaming request
2. The message item at `output_index` 0 finishes first, then the function call at `output_index` 1
3. Arrival order matches `output_index`, matches the completed response's `output` array, and matches the non-streaming response
4. Replaying the assembled transcript on the next turn is accepted

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Two proxies built from source, identical but for this commit, fronting live Bedrock Converse and Vertex Anthropic models. Before is `litellm_internal_staging` at `ecba48dd7c`, after is that commit plus this change at `b35baed2fc`. Each run streams a request that makes the model speak and then call a tool, and prints the `output_index` of every `response.output_item.done` in the order it arrived

```bash
for m in claude-4-5-haiku claude-5-opus vertex-claude-5-opus; do
  curl -sN http://localhost:PORT/v1/responses \
    -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d "{\"model\":\"$m\",\"stream\":true,
         \"input\":\"Say the words checking now, then call get_weather for Paris.\",
         \"tools\":[{\"type\":\"function\",\"name\":\"get_weather\",
           \"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},
           \"required\":[\"city\"]}}]}" \
  | grep '"type": "response.output_item.done"'
done
```

Before, at `ecba48dd7c`, the tool item finishes first on every model:

```
MODEL                    output_item.done indexes in arrival order
claude-4-5-haiku         1 0
claude-5-opus            1 0
vertex-claude-5-opus     1 0
```

After, at `b35baed2fc`, they arrive in index order:

```
MODEL                    output_item.done indexes in arrival order
claude-4-5-haiku         0 1
claude-5-opus            0 1
vertex-claude-5-opus     0 1
```

## Type

🐛 Bug Fix

## Changes

At the end of a stream `common_done_event_logic` drained the queued tool-call events before the message item's own done events. The message holds `output_index` 0 and the tool calls follow it, so `response.output_item.done` arrived in the opposite order to the indexes it carried, and in the opposite order to both the completed response's `output` array and the non-streaming transformation

A client that appends items as their done events arrive therefore rebuilds the assistant turn with the tool call ahead of the text. Replaying that transcript is rejected by providers that do not accept an assistant message following a tool call in the same turn, and the error surfaces on the turn after the one that was actually assembled wrongly, which makes it awkward to trace back

The fix returns the message item's done events first, then falls through to the queued tool events, so arrival order agrees with `output_index`, with the response's `output` array, and with the non-streaming path

Two tests cover it. A new regression test drives a response carrying both text and a tool call and asserts the `output_item.done` indexes arrive sorted. The existing `test_tool_calls_present_only_in_final_response_are_emitted_before_completed` asserted the old ordering, that the first event out is the tool item's `output_item.added`, so it now asserts the message item's three done events arrive first at `output_index` 0. Reverting the source change while keeping both tests fails exactly those two

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
