### PR TITLE
fix(cost): use transcription usage seconds

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1404,11 +1404,26 @@ def completion_cost(  # noqa: PLR0915
                     # Check _hidden_params first (duration stored there to
                     # avoid polluting the response body), then fall back to
                     # the response attribute (for verbose_json responses that
-                    # naturally include duration from the provider).
+                    # naturally include duration from the provider), then to
+                    # duration-based usage returned by newer transcription APIs.
                     _hidden = getattr(completion_response, "_hidden_params", {}) or {}
-                    audio_transcription_file_duration = _hidden.get(
-                        "audio_transcription_duration",
-                        getattr(completion_response, "duration", 0.0),
+                    _transcription_usage = getattr(completion_response, "usage", None)
+                    _usage_duration = (
+                        _transcription_usage.get("seconds")
+                        if isinstance(_transcription_usage, dict)
+                        else getattr(_transcription_usage, "seconds", None)
+                    )
+                    audio_transcription_file_duration = next(
+                        (
+                            duration
+                            for duration in (
+                                _hidden.get("audio_transcription_duration"),
+                                getattr(completion_response, "duration", None),
+                                _usage_duration,
+                            )
+                            if duration is not None
+                        ),
+                        0.0,
                     )
                 elif call_type in _RERANK_CALL_TYPES:
                     if completion_response is not None and isinstance(

--- a/tests/test_litellm/llms/openai/transcriptions/test_transcription_duration_hidden.py
+++ b/tests/test_litellm/llms/openai/transcriptions/test_transcription_duration_hidden.py
@@ -132,6 +132,36 @@ class TestCostCalculatorReadsDurationFromHiddenParams:
         assert kwargs["duration"] == 42.7
 
     @patch("litellm.cost_calculator.openai_cost_per_second")
+    def test_completion_cost_falls_back_to_usage_seconds(self, mock_cost_fn):
+        """Duration-based transcription usage should be used for cost calculation."""
+        mock_cost_fn.return_value = (0.0027, 0.0)
+        response = convert_to_model_response_object(
+            response_object={
+                "text": "test",
+                "usage": {"type": "duration", "seconds": 27},
+            },
+            model_response_object=TranscriptionResponse(),
+            hidden_params={
+                "model": "whisper-1",
+                "custom_llm_provider": "openai",
+            },
+            response_type="audio_transcription",
+        )
+        response_body = response.model_dump()
+
+        completion_cost(
+            completion_response=response,
+            model="whisper-1",
+            call_type="atranscription",
+        )
+
+        mock_cost_fn.assert_called_once()
+        _, kwargs = mock_cost_fn.call_args
+        assert kwargs["duration"] == 27
+        assert response.model_dump() == response_body
+        assert "duration" not in response_body
+
+    @patch("litellm.cost_calculator.openai_cost_per_second")
     def test_completion_cost_defaults_to_zero_duration(self, mock_cost_fn):
         """When neither hidden params nor response has duration, use 0.0."""
         mock_cost_fn.return_value = (0.0, 0.0)


### PR DESCRIPTION
## What

- Use duration-based transcription `usage.seconds` as a cost-calculation fallback.
- Add a regression test for a transcription response containing 27 usage seconds.

## Why

Some transcription APIs report audio duration only as `usage: {"type": "duration", "seconds": ...}`. `completion_cost()` currently checks only the internal hidden duration and `response.duration`, so these otherwise valid responses reach `openai_cost_per_second()` with `duration=0.0` and are recorded at zero cost.

## Impact

This only changes transcription cost calculation. Duration precedence remains:

1. Internal `_hidden_params.audio_transcription_duration`
2. Provider `response.duration`
3. Provider `usage.seconds`
4. `0.0`

The transcription response body is not modified.

## Root cause

Duration-based transcription usage is preserved on the response object, but the transcription branch of `completion_cost()` did not read it.

## Tests

- `pytest -q tests/test_litellm/llms/openai/transcriptions/` — 18 passed
- `ruff check litellm/cost_calculator.py tests/test_litellm/llms/openai/transcriptions/test_transcription_duration_hidden.py`
- `git diff --check`
