### PR TITLE
fix(mcp): forward dcr_bridge-injected credential instead of discarding it for oauth_delegate

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3193,12 +3193,25 @@ class MCPServerManager:
         # arbitrary bearer upstream, so we keep the v2 spec and ignore the override for these; the
         # REST tools preview supplies its not-yet-persisted token through the resolver
         # (cred_provider), never this path.
+        #
+        # dcr_bridge is a different origin, not a caller override: for a client-forwarded-token
+        # server admitted through the gateway-DCR bridge, `_admit_dcr_bridge_delegate` has already
+        # opened the caller's signed envelope and injected the real upstream credential it sealed —
+        # `mcp_auth_header` here IS that unsealed credential, not an arbitrary bearer the caller
+        # attached. Keeping `spec` for PassthroughConfig in this case discards that credential and
+        # falls through to the v2 resolver's own passthrough headers, which the DCR caller has no
+        # way to populate (it only ever presents the one envelope bearer, which admission already
+        # strips before egress). So a dcr_bridge server always takes the v1 path here regardless of
+        # spec.config, same as the non-exempted modes above.
         if (
             spec is not None
             and mcp_auth_header
-            and not isinstance(
-                spec.config,
-                (AuthorizationCodeConfig, IdJagConfig, PassthroughConfig, TokenExchangeConfig),
+            and (
+                server.is_dcr_bridge
+                or not isinstance(
+                    spec.config,
+                    (AuthorizationCodeConfig, IdJagConfig, PassthroughConfig, TokenExchangeConfig),
+                )
             )
         ):
             spec = None

--- a/tests/mcp_tests/test_mcp_auth_priority.py
+++ b/tests/mcp_tests/test_mcp_auth_priority.py
@@ -76,3 +76,35 @@ async def test_mcp_server_config_auth_value_header_used(token_key):
     emitted = next(client._resolved_auth.auth_flow(httpx.Request("POST", server.url)))
     assert emitted.headers["Authorization"] == "Bearer example_token"
     assert client.auth_type == MCPAuth.bearer_token
+
+
+@pytest.mark.asyncio
+async def test_dcr_bridge_oauth_delegate_uses_admission_injected_credential():
+    """A dcr_bridge + oauth_delegate server's mcp_auth_header must not be discarded.
+
+    ``_admit_dcr_bridge_delegate`` opens the caller's signed envelope during admission and
+    injects the real upstream credential it sealed as ``mcp_auth_header`` here -- it is not an
+    arbitrary caller-supplied override. oauth_delegate maps to PassthroughConfig in the v2
+    resolver (see outbound_credentials/adapter.py), which used to be exempted from the v1
+    override path regardless of origin, silently discarding this credential and leaving the
+    upstream MCP server with no Authorization header at all (regression: BerriAI/litellm#36358).
+    """
+    server = MCPServer(
+        server_id="test-dcr-bridge-server",
+        name="Test DCR Bridge Server",
+        server_name="test_dcr_bridge_server",
+        alias="test_dcr_bridge",
+        url="https://internal-mcp-server.example.com/mcp",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth_delegate,
+        dcr_bridge=True,
+    )
+
+    manager = MCPServerManager()
+
+    client = await manager._create_mcp_client(
+        server=server,
+        mcp_auth_header="Bearer unsealed_upstream_token",
+    )
+
+    assert client._mcp_auth_value == "Bearer unsealed_upstream_token"


### PR DESCRIPTION
## Summary

Fixes #36358.

For a `dcr_bridge` + `oauth_delegate` MCP server (the gateway-DCR bridge mode that lets an external OAuth client like claude.ai's custom connector UI authenticate against an MCP server LiteLLM otherwise reaches with a static credential), the OAuth handshake completes successfully end-to-end, but the upstream MCP server never receives a valid `Authorization` header, so no tools are ever returned.

`_admit_dcr_bridge_delegate` correctly opens the caller's signed envelope during admission and injects the real, unsealed upstream credential as `mcp_auth_header`. But `_create_mcp_client`'s v1-override exemption unconditionally kept the v2 resolver's `spec` for any `PassthroughConfig`-mapped server (which is what `oauth_delegate` maps to in `outbound_credentials/adapter.py`) — discarding that correctly-injected credential and falling through to the v2 resolver's own passthrough-header resolution instead. An external DCR client has no way to populate those headers itself; it only ever presents the one envelope bearer, and that gets stripped separately by `_should_strip_caller_authorization` since it lacks the LiteLLM-specific `x-litellm-api-key` disambiguation header. Net result: the upstream server gets no `Authorization` header at all.

This PR makes `dcr_bridge` servers always take the v1 override path in `_create_mcp_client`, regardless of `spec.config`, since their `mcp_auth_header` is a cryptographically verified credential recovered during admission — not an arbitrary caller-supplied bearer. The security concern the `PassthroughConfig` exemption exists for (a caller substituting another user's resolved credential) doesn't apply to this origin.

## Root cause

Traced end-to-end against a live reproduction: OAuth flow (`register` → `authorize` → SSO login → `callback` → `token`) all return `200`, the external client shows "Connected," but the upstream MCP server's own session count stays at `0` for the entire session — it never receives a request with a matching `Authorization` header. Full trace is in #36358.

## Test plan

- [x] Added `test_dcr_bridge_oauth_delegate_uses_admission_injected_credential` to `tests/mcp_tests/test_mcp_auth_priority.py`, asserting `_create_mcp_client` forwards the injected `mcp_auth_header` for a `dcr_bridge=True, auth_type=oauth_delegate` server.
- [x] Confirmed the new test fails against the pre-fix code (`AssertionError: assert None == 'Bearer unsealed_upstream_token'`) and passes with the fix.
- [x] `ruff format` / `ruff check` pass on both changed files (pre-existing unrelated lint findings in the test file's import block were left untouched).
- [x] Ran the full `tests/mcp_tests/test_mcp_auth_priority.py` suite — all 4 tests pass.