### PR TITLE
fix(responses): translate the reasoning object into a chat-completion reasoning effort

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -117,6 +117,14 @@ class ResponsesToolChatForm:
     web_search_options: OpenAIWebSearchOptions | None
 
 
+@dataclass(frozen=True, slots=True)
+class ResponsesReasoningChatForm:
+    """The Responses ``reasoning`` object as the two params Chat Completions takes."""
+
+    effort: str | None
+    summary: str | None
+
+
 if TYPE_CHECKING:
     from openai.types.responses.response_apply_patch_tool_call import (
         ResponseApplyPatchToolCall,
@@ -315,14 +323,15 @@ class LiteLLMCompletionResponsesConfig:
         custom_llm_provider: str | None,
         tools: Sequence[ChatCompletionToolParam | OpenAIMcpServerTool] | None,
         web_search_options: OpenAIWebSearchOptions | None,
-        reasoning_param: Reasoning,
+        reasoning_effort: str | None,
+        reasoning_summary: str | None,
         api_base: str | None,
     ) -> bool:
         """
         Whether ``litellm.completion`` will route this model back onto the Responses API.
 
-        Delegates to the same check ``litellm.completion`` itself runs, so the two cannot
-        disagree about which models take the Responses-shaped params.
+        Delegates to the same check ``litellm.completion`` itself runs, and is asked with the
+        params this transform is about to emit, so the two cannot reach different answers.
         """
         from litellm.main import responses_api_bridge_check
 
@@ -332,8 +341,8 @@ class LiteLLMCompletionResponsesConfig:
                 custom_llm_provider=custom_llm_provider or "",
                 web_search_options=web_search_options,
                 tools=tools,
-                reasoning_effort=reasoning_param,
-                reasoning_summary=reasoning_param.get("summary"),
+                reasoning_effort=reasoning_effort,
+                reasoning_summary=reasoning_summary,
                 api_base=api_base,
             )
         except Exception as e:  # noqa: BLE001  # a capability probe must never fail the request it probes for
@@ -342,37 +351,44 @@ class LiteLLMCompletionResponsesConfig:
         return model_info.get("mode") == "responses"
 
     @staticmethod
-    def _transform_reasoning_to_reasoning_effort(
+    def _transform_reasoning_for_chat_completion(
         reasoning_param: Reasoning | str | None,
         model: str,
         custom_llm_provider: str | None,
         tools: Sequence[ChatCompletionToolParam | OpenAIMcpServerTool] | None = None,
         web_search_options: OpenAIWebSearchOptions | None = None,
         api_base: str | None = None,
-    ) -> Reasoning | str | None:
+    ) -> ResponsesReasoningChatForm:
         """
-        Map the Responses ``reasoning`` param onto Chat Completions ``reasoning_effort``.
+        Split the Responses ``reasoning`` object into the params Chat Completions understands.
 
-        Chat Completions defines ``reasoning_effort`` as a string enum, and ``summary`` is a
-        Responses-only field with no Chat Completions equivalent. Sending the whole object to a
-        chat provider is rejected or silently discarded, which turns reasoning off. The object is
-        kept only when ``litellm.completion`` will bridge this model back onto the Responses API,
-        the one caller that can consume it.
+        ``reasoning_effort`` is a string enum there, so the object is never forwarded whole: a chat
+        provider either rejects it or silently drops it, and dropping it turns reasoning off while
+        still billing for the turn. ``summary`` has no chat equivalent, so it rides the
+        ``reasoning_summary`` alias, which ``litellm.completion`` reassembles into ``{effort,
+        summary}`` when it bridges the model back onto the Responses API, and is sent to nothing
+        else.
         """
         if not reasoning_param:
-            return None
+            return ResponsesReasoningChatForm(effort=None, summary=None)
         if isinstance(reasoning_param, str):
-            return reasoning_param
-        if LiteLLMCompletionResponsesConfig._completion_bridges_back_to_responses_api(
+            return ResponsesReasoningChatForm(effort=reasoning_param, summary=None)
+
+        effort: Final = reasoning_param.get("effort")
+        summary: Final = reasoning_param.get("summary")
+        if summary is None:
+            return ResponsesReasoningChatForm(effort=effort, summary=None)
+
+        bridges_back: Final = LiteLLMCompletionResponsesConfig._completion_bridges_back_to_responses_api(
             model=model,
             custom_llm_provider=custom_llm_provider,
             tools=tools,
             web_search_options=web_search_options,
-            reasoning_param=reasoning_param,
+            reasoning_effort=effort,
+            reasoning_summary=summary,
             api_base=api_base,
-        ):
-            return reasoning_param
-        return reasoning_param.get("effort")
+        )
+        return ResponsesReasoningChatForm(effort=effort, summary=summary if bridges_back else None)
 
     @staticmethod
     def transform_responses_api_request_to_chat_completion_request(
@@ -404,15 +420,13 @@ class LiteLLMCompletionResponsesConfig:
         if text_param:
             response_format = LiteLLMCompletionResponsesConfig._transform_text_format_to_response_format(text_param)
 
-        reasoning_effort: Final[Reasoning | str | None] = (
-            LiteLLMCompletionResponsesConfig._transform_reasoning_to_reasoning_effort(
-                reasoning_param=responses_api_request.get("reasoning"),
-                model=model,
-                custom_llm_provider=custom_llm_provider,
-                tools=tools,
-                web_search_options=web_search_options,
-                api_base=kwargs.get("api_base"),
-            )
+        reasoning: Final = LiteLLMCompletionResponsesConfig._transform_reasoning_for_chat_completion(
+            reasoning_param=responses_api_request.get("reasoning"),
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            tools=tools,
+            web_search_options=web_search_options,
+            api_base=kwargs.get("api_base"),
         )
 
         litellm_completion_request: dict = {
@@ -436,7 +450,8 @@ class LiteLLMCompletionResponsesConfig:
             "service_tier": kwargs.get("service_tier"),
             "web_search_options": web_search_options,
             "response_format": response_format,
-            "reasoning_effort": reasoning_effort,
+            "reasoning_effort": reasoning.effort,
+            "reasoning_summary": reasoning.summary,
             "context_management": responses_api_request.get("context_management"),
             # litellm specific params
             "custom_llm_provider": custom_llm_provider,

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -316,6 +316,7 @@ class LiteLLMCompletionResponsesConfig:
         tools: Sequence[ChatCompletionToolParam | OpenAIMcpServerTool] | None,
         web_search_options: OpenAIWebSearchOptions | None,
         reasoning_param: Reasoning,
+        api_base: str | None,
     ) -> bool:
         """
         Whether ``litellm.completion`` will route this model back onto the Responses API.
@@ -333,6 +334,7 @@ class LiteLLMCompletionResponsesConfig:
                 tools=tools,
                 reasoning_effort=reasoning_param,
                 reasoning_summary=reasoning_param.get("summary"),
+                api_base=api_base,
             )
         except Exception as e:  # noqa: BLE001  # a capability probe must never fail the request it probes for
             verbose_logger.debug(f"responses bridge: reasoning effort mode check failed: {e}")
@@ -346,6 +348,7 @@ class LiteLLMCompletionResponsesConfig:
         custom_llm_provider: str | None,
         tools: Sequence[ChatCompletionToolParam | OpenAIMcpServerTool] | None = None,
         web_search_options: OpenAIWebSearchOptions | None = None,
+        api_base: str | None = None,
     ) -> Reasoning | str | None:
         """
         Map the Responses ``reasoning`` param onto Chat Completions ``reasoning_effort``.
@@ -366,6 +369,7 @@ class LiteLLMCompletionResponsesConfig:
             tools=tools,
             web_search_options=web_search_options,
             reasoning_param=reasoning_param,
+            api_base=api_base,
         ):
             return reasoning_param
         return reasoning_param.get("effort")
@@ -407,6 +411,7 @@ class LiteLLMCompletionResponsesConfig:
                 custom_llm_provider=custom_llm_provider,
                 tools=tools,
                 web_search_options=web_search_options,
+                api_base=kwargs.get("api_base"),
             )
         )
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -310,6 +310,67 @@ class LiteLLMCompletionResponsesConfig:
         return supported_params is not None and "web_search_options" not in supported_params
 
     @staticmethod
+    def _completion_bridges_back_to_responses_api(
+        model: str,
+        custom_llm_provider: str | None,
+        tools: Sequence[ChatCompletionToolParam | OpenAIMcpServerTool] | None,
+        web_search_options: OpenAIWebSearchOptions | None,
+        reasoning_param: Reasoning,
+    ) -> bool:
+        """
+        Whether ``litellm.completion`` will route this model back onto the Responses API.
+
+        Delegates to the same check ``litellm.completion`` itself runs, so the two cannot
+        disagree about which models take the Responses-shaped params.
+        """
+        from litellm.main import responses_api_bridge_check
+
+        try:
+            model_info, _ = responses_api_bridge_check(
+                model=model,
+                custom_llm_provider=custom_llm_provider or "",
+                web_search_options=web_search_options,
+                tools=tools,
+                reasoning_effort=reasoning_param,
+                reasoning_summary=reasoning_param.get("summary"),
+            )
+        except Exception as e:  # noqa: BLE001  # a capability probe must never fail the request it probes for
+            verbose_logger.debug(f"responses bridge: reasoning effort mode check failed: {e}")
+            return False
+        return model_info.get("mode") == "responses"
+
+    @staticmethod
+    def _transform_reasoning_to_reasoning_effort(
+        reasoning_param: Reasoning | str | None,
+        model: str,
+        custom_llm_provider: str | None,
+        tools: Sequence[ChatCompletionToolParam | OpenAIMcpServerTool] | None = None,
+        web_search_options: OpenAIWebSearchOptions | None = None,
+    ) -> Reasoning | str | None:
+        """
+        Map the Responses ``reasoning`` param onto Chat Completions ``reasoning_effort``.
+
+        Chat Completions defines ``reasoning_effort`` as a string enum, and ``summary`` is a
+        Responses-only field with no Chat Completions equivalent. Sending the whole object to a
+        chat provider is rejected or silently discarded, which turns reasoning off. The object is
+        kept only when ``litellm.completion`` will bridge this model back onto the Responses API,
+        the one caller that can consume it.
+        """
+        if not reasoning_param:
+            return None
+        if isinstance(reasoning_param, str):
+            return reasoning_param
+        if LiteLLMCompletionResponsesConfig._completion_bridges_back_to_responses_api(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            tools=tools,
+            web_search_options=web_search_options,
+            reasoning_param=reasoning_param,
+        ):
+            return reasoning_param
+        return reasoning_param.get("effort")
+
+    @staticmethod
     def transform_responses_api_request_to_chat_completion_request(
         model: str,
         input: str | ResponseInputParam,
@@ -339,23 +400,15 @@ class LiteLLMCompletionResponsesConfig:
         if text_param:
             response_format = LiteLLMCompletionResponsesConfig._transform_text_format_to_response_format(text_param)
 
-        # Extract reasoning_effort from reasoning parameter
-        reasoning_effort: Reasoning | str | None = None
-        reasoning_param: Final = responses_api_request.get("reasoning")
-        if reasoning_param:
-            if isinstance(reasoning_param, dict):
-                # reasoning can be {"effort": "low|medium|high", "summary": "detailed"}
-                # Keep the full dict when summary is set so the responses API bridge can
-                # forward it; otherwise use the effort string for chat completion (e.g. Gemini).
-                if "summary" in reasoning_param:
-                    reasoning_effort = reasoning_param
-                elif "effort" in reasoning_param:
-                    reasoning_effort = reasoning_param.get("effort")
-                else:
-                    reasoning_effort = reasoning_param
-            elif isinstance(reasoning_param, str):
-                # reasoning could be a string directly
-                reasoning_effort = reasoning_param
+        reasoning_effort: Final[Reasoning | str | None] = (
+            LiteLLMCompletionResponsesConfig._transform_reasoning_to_reasoning_effort(
+                reasoning_param=responses_api_request.get("reasoning"),
+                model=model,
+                custom_llm_provider=custom_llm_provider,
+                tools=tools,
+                web_search_options=web_search_options,
+            )
+        )
 
         litellm_completion_request: dict = {
             "messages": LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -337,7 +337,7 @@ class LiteLLMCompletionResponsesConfig:
                 api_base=api_base,
             )
         except Exception as e:  # noqa: BLE001  # a capability probe must never fail the request it probes for
-            verbose_logger.debug(f"responses bridge: reasoning effort mode check failed: {e}")
+            verbose_logger.debug("responses bridge: reasoning effort mode check failed: %s", e)
             return False
         return model_info.get("mode") == "responses"
 

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2555,22 +2555,94 @@ class TestToolTransformation:
 
         assert result["reasoning_effort"] == "medium"
 
-    def test_responses_mode_model_keeps_the_whole_reasoning_object(self):
+    @pytest.mark.parametrize(
+        "model, custom_llm_provider",
+        [
+            ("gpt-5.4-pro", "azure_ai"),
+            ("gpt-5", "openai"),
+            ("gpt-5.1", "openai"),
+            ("gpt-5", "azure"),
+        ],
+    )
+    def test_bridged_model_carries_the_summary_as_an_alias(self, model, custom_llm_provider):
         """
-        The one consumer of the object form is ``litellm.completion`` bridging a ``mode: responses``
-        model back onto the Responses API, which has no native Responses config of its own. That
-        path reassembles ``{effort, summary}``, so the object must survive for it.
+        ``summary`` reaches a bridged model through the ``reasoning_summary`` alias, never smuggled
+        inside ``reasoning_effort``. ``litellm.completion`` reads that alias back with
+        ``peek_reasoning_summary_aliases`` and reassembles ``{effort, summary}``, so the far end
+        gets the same object it always did while no chat provider ever sees a non-string effort.
         """
-        responses_api_request = {"reasoning": {"effort": "medium", "summary": "auto"}}
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model=model,
+            input="hi",
+            responses_api_request={"reasoning": {"effort": "medium", "summary": "auto"}},
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        assert result["reasoning_effort"] == "medium"
+        assert result["reasoning_summary"] == "auto"
+
+    @pytest.mark.parametrize(
+        "model, custom_llm_provider",
+        [
+            ("gpt-5", "openai"),
+            ("gpt-5.1", "openai"),
+            ("gpt-5", "azure"),
+        ],
+    )
+    def test_gpt_5_summary_survives_the_bridge_it_claims_to_take(self, model, custom_llm_provider):
+        """
+        Regression for the probe disagreeing with the real decision. The transform asked
+        ``responses_api_bridge_check`` with ``reasoning_summary`` taken straight off the Responses
+        object, but ``litellm.completion`` reads it from ``optional_params`` via
+        ``peek_reasoning_summary_aliases``, which the bridged request never populated. So these
+        models answered "bridging" to the probe and "not bridging" for real, and the object landed
+        on Chat Completions, which only takes a string. Emitting the alias makes the two agree.
+        """
+        from litellm.main import responses_api_bridge_check
+        from litellm.utils import get_optional_params, peek_reasoning_summary_aliases
+
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model=model,
+            input="hi",
+            responses_api_request={"reasoning": {"effort": "medium", "summary": "auto"}},
+            custom_llm_provider=custom_llm_provider,
+        )
+        optional_params = get_optional_params(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            reasoning_effort=result["reasoning_effort"],
+            reasoning_summary=result["reasoning_summary"],
+        )
+        model_info, _ = responses_api_bridge_check(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            reasoning_effort=result["reasoning_effort"],
+            reasoning_summary=peek_reasoning_summary_aliases(optional_params),
+        )
+
+        assert model_info.get("mode") == "responses"
+
+    def test_a_failing_bridge_probe_falls_back_to_the_string_effort(self, monkeypatch):
+        """
+        The probe is a capability question, so a model-info lookup blowing up must not fail the
+        request. It degrades to the chat-safe form: a string effort and no alias.
+        """
+        import litellm.main
+
+        def _boom(**_kwargs):
+            raise RuntimeError("model info unavailable")
+
+        monkeypatch.setattr(litellm.main, "responses_api_bridge_check", _boom)
 
         result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
             model="gpt-5.4-pro",
             input="hi",
-            responses_api_request=responses_api_request,
+            responses_api_request={"reasoning": {"effort": "medium", "summary": "auto"}},
             custom_llm_provider="azure_ai",
         )
 
-        assert result["reasoning_effort"] == {"effort": "medium", "summary": "auto"}
+        assert result["reasoning_effort"] == "medium"
+        assert "reasoning_summary" not in result
 
     @pytest.mark.parametrize(
         "reasoning, expected",
@@ -2627,7 +2699,7 @@ class TestToolTransformation:
             {"reasoning_effort": bridged["reasoning_effort"]}, {}, model, True
         )
 
-        assert mapped["thinking"] == expected_thinking
+        assert expected_thinking.items() <= mapped["thinking"].items()
 
     def test_bedrock_anthropic_responses_tools_yield_only_function_toolspec(self):
         """

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2527,6 +2527,108 @@ class TestToolTransformation:
             "type": "object",
         }
 
+    @pytest.mark.parametrize(
+        "model, custom_llm_provider",
+        [
+            ("bedrock/converse/global.anthropic.claude-sonnet-5", "bedrock_converse"),
+            ("anthropic.claude-sonnet-4-5-20250929-v1:0", "bedrock"),
+            ("claude-sonnet-5", "vertex_ai"),
+            ("gemini-3.1-pro-preview", "vertex_ai"),
+            ("moonshotai.kimi-k2-thinking", "bedrock_mantle"),
+        ],
+    )
+    def test_reasoning_summary_still_yields_a_string_reasoning_effort(self, model, custom_llm_provider):
+        """
+        A Responses request carrying ``reasoning.summary`` must still reach a chat provider as a
+        plain ``reasoning_effort`` string. ``summary`` is Responses-only, and forwarding the whole
+        object turns reasoning off: Bedrock Converse and Vertex silently discard a non-string
+        ``reasoning_effort``, and Bedrock Mantle rejects the request outright.
+        """
+        responses_api_request = {"reasoning": {"effort": "medium", "summary": "auto"}}
+
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model=model,
+            input="hi",
+            responses_api_request=responses_api_request,
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        assert result["reasoning_effort"] == "medium"
+
+    def test_responses_mode_model_keeps_the_whole_reasoning_object(self):
+        """
+        The one consumer of the object form is ``litellm.completion`` bridging a ``mode: responses``
+        model back onto the Responses API, which has no native Responses config of its own. That
+        path reassembles ``{effort, summary}``, so the object must survive for it.
+        """
+        responses_api_request = {"reasoning": {"effort": "medium", "summary": "auto"}}
+
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="gpt-5.4-pro",
+            input="hi",
+            responses_api_request=responses_api_request,
+            custom_llm_provider="azure_ai",
+        )
+
+        assert result["reasoning_effort"] == {"effort": "medium", "summary": "auto"}
+
+    @pytest.mark.parametrize(
+        "reasoning, expected",
+        [
+            ({"effort": "high"}, "high"),
+            ("low", "low"),
+            ({"summary": "auto"}, None),
+            ({}, None),
+            (None, None),
+        ],
+    )
+    def test_reasoning_param_shapes_map_to_reasoning_effort(self, reasoning, expected):
+        """
+        An object without ``effort`` carries nothing Chat Completions can use, so no
+        ``reasoning_effort`` is sent at all (the bridge drops None-valued params).
+        """
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="anthropic.claude-sonnet-4-5-20250929-v1:0",
+            input="hi",
+            responses_api_request={"reasoning": reasoning},
+            custom_llm_provider="bedrock",
+        )
+
+        assert result.get("reasoning_effort") == expected
+        assert ("reasoning_effort" in result) is (expected is not None)
+
+    @pytest.mark.parametrize(
+        "model, expected_thinking",
+        [
+            ("global.anthropic.claude-sonnet-5", {"type": "adaptive"}),
+            (
+                "anthropic.claude-sonnet-4-5-20250929-v1:0",
+                {"type": "enabled", "budget_tokens": 2048},
+            ),
+        ],
+    )
+    def test_reasoning_summary_still_enables_thinking_on_bedrock(self, model, expected_thinking):
+        """
+        End to end through Bedrock Converse's own param mapping: the effort a Responses request asks
+        for must survive into ``thinking``, whether the model takes an adaptive effort or a legacy
+        token budget. Forwarding the object instead leaves ``thinking`` unset and the model never
+        reasons, which is the failure this guards.
+        """
+        from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+
+        bridged = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model=model,
+            input="hi",
+            responses_api_request={"reasoning": {"effort": "medium", "summary": "auto"}},
+            custom_llm_provider="bedrock",
+        )
+
+        mapped = AmazonConverseConfig().map_openai_params(
+            {"reasoning_effort": bridged["reasoning_effort"]}, {}, model, True
+        )
+
+        assert mapped["thinking"] == expected_thinking
+
     def test_bedrock_anthropic_responses_tools_yield_only_function_toolspec(self):
         """
         End-to-end (no network) of the LIT-3858 acceptance criterion: the mixed tools array


### PR DESCRIPTION
## TLDR

Problem this solves:

- The Responses `reasoning` object is forwarded whole to chat providers
- Bedrock Converse ignores anything that is not a string
- Thinking is never enabled, and nothing reports it

How it solves it:

- Always flatten the object to its `effort` string
- Send `summary` as its own param, which the bridge reassembles
- Ask the bridge check with the exact params we emit

## User Flow

Before: a developer asking for reasoning on a Bedrock model gets a normal answer with no thinking, pays for it, and has nothing to tell them why

1. They send POST https://litellm-domain/v1/responses with `"model": "claude-4-5-sonnet"` and `"reasoning": {"effort": "high", "summary": "auto"}`, the object shape the Responses API defines
2. HTTP 200 comes back with an answer, no `reasoning` item, and no warning
3. They check usage and see they were billed for the turn, so the request was accepted and simply did not think
4. They try the same request on a Vertex Claude model and reasoning works there, so the behaviour differs by provider for an identical request
5. They have no way to tell from the response which providers honour the field

After: the same request thinks, on both providers

1. They send the same POST with `"reasoning": {"effort": "high", "summary": "auto"}`
2. HTTP 200 comes back carrying a `reasoning` item with a real summary
3. The Vertex Claude model still works exactly as before
4. A request that sends `reasoning` with no `effort` sets no `reasoning_effort` at all, instead of forwarding an object the provider cannot read
5. The same request against a `gpt-5` model routed over chat completions now keeps its summary too, where before the request was built in a shape that endpoint does not accept

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Driven with Codex CLI 0.154.0, the agentic client that sends `reasoning` as an object on every request, pointed at a local proxy over a virtual key. Two proxies built from source on the same box, one per side. Shared setup:

```bash
# virtual key, scoped to the models under test
curl -s -X POST http://localhost:4137/key/generate -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{"key_alias":"codex-qa","models":["bedrock-converse-sonnet-4-6","gpt-5.5"],"max_budget":5}'

# ~/.codex/config.toml equivalent (CODEX_HOME pointed at a scratch dir)
model = "bedrock-converse-sonnet-4-6"
model_provider = "litellm"
model_reasoning_effort = "high"
model_reasoning_summary = "auto"
[model_providers.litellm]
base_url = "http://localhost:4137/v1"
env_key = "LITELLM_API_KEY"
wire_api = "responses"
```

The prompt is a word problem whose numbers do not divide evenly, so a thinking model has something to work through:

```bash
codex exec "A farmer has 17 sheep. All but 9 run away. He then buys twice as many sheep as he
has left, sells 4, and splits the rest evenly among 3 pens. How many sheep are in each pen?
Show your working."
```

### Before (`d4a72e7372`)

#### Case 1: Codex against a Bedrock Converse model

1. Run the `codex exec` above. The header confirms Codex asked for reasoning:

   ```
   model: bedrock-converse-sonnet-4-6
   reasoning effort: high
   reasoning summaries: auto
   ```

2. The answer comes back with no thinking at all, straight to the response:

   ```
   codex
   Here's the working:

   1. **Start:** 17 sheep
   2. **"All but 9 run away"** -> 9 sheep remain
   ...
   tokens used
   10,055
   ```

3. The proxy log shows why. The object was handed to Bedrock as `reasoning_effort`, and `thinking` stayed unset:

   ```
   'reasoning_effort': {'effort': 'high', 'summary': 'auto'}, ... 'thinking': None
   "additionalModelRequestFields": {"tool_choice": {"disable_parallel_tool_use": false}}
   ```

#### Case 2: the same request as raw SSE

1. Send it with the object shape and count the reasoning summary events:

   ```bash
   curl -sN http://localhost:4137/v1/responses -H "Authorization: Bearer $KEY" \
     -H 'Content-Type: application/json' \
     -d '{"model":"bedrock-converse-sonnet-4-6","stream":true,
          "reasoning":{"effort":"high","summary":"auto"},
          "input":"In two sentences, explain why 23 does not divide evenly by 3."}' \
   | grep -c 'reasoning_summary_text.delta'
   ```

2. Output: `0`. The event stream goes `response.created`, `response.in_progress`, `response.output_item.added` (a `message`), and never opens a `reasoning` item

3. The same request with `"reasoning":{"effort":"high"}`, the string path that already worked, returns `5`. So the object is the only difference

#### Case 3: a GPT-5 model over the chat-completions bridge

1. Force the bridge and look at what the transform emitted:

   ```bash
   curl -s http://localhost:4137/v1/responses -H "Authorization: Bearer $KEY" \
     -H 'Content-Type: application/json' \
     -d '{"model":"gpt-5.5","use_chat_completions_api":true,
          "reasoning":{"effort":"high","summary":"auto"},
          "input":"In one sentence, why does 23 not divide evenly by 3?"}'
   ```

2. The proxy log carries the object in `reasoning_effort`, the shape Chat Completions has no enum member for:

   ```
   reasoning_effort={'effort': 'high', 'summary': 'auto'}
   ```

3. Counting every object-shaped `reasoning_effort` across the whole run: `8`

### After (`0c83e831db`)

#### Case 1: Codex against a Bedrock Converse model

1. Same `codex exec`, same header. The model now thinks out loud before answering:

   ```
   codex
   This is a math problem, no need for tools.

   Let me work through it:
   ...
   Hmm, that doesn't divide evenly.
   Let me reconsider the wording. "Buys twice as many sheep as he has left" ...
   I keep running into the same issue, no matter how I interpret ...
   I'm wondering if there's a typo in the problem, maybe it should be "sells 3" instead of "sells 4"
   ```

2. Then the answer, as before:

   ```
   tokens used
   11,362
   ```

#### Case 2: the same request as raw SSE

1. Same curl, same count command

2. Output: `5`. The stream now opens a `reasoning` item and emits `response.reasoning_summary_text.delta`, matching what the string path already produced

#### Case 3: a GPT-5 model over the chat-completions bridge

1. Same curl. The transform now emits the two params separately:

   ```
   reasoning_effort='high'   reasoning_summary='auto'
   ```

2. The request that leaves for OpenAI is reassembled correctly:

   ```
   "reasoning": {"effort": "high", "summary": "auto"}
   ```

3. Counting every object-shaped `reasoning_effort` across the whole run: `0`. No chat provider receives a non-string effort on any path

### Pre-existing bug this uncovers, not caused by this PR

Once Codex actually receives reasoning items, it logs `ERROR codex_core::util: OutputTextDelta without active item` 107 times per run. The bridge emits `response.output_item.added` for the reasoning item, closes it, then streams the message's `response.output_text.delta` without ever opening a `message` item

This predates the PR. The identical event order reproduces at `d4a72e7372` with `"reasoning":{"effort":"high"}`, the string form that already enabled thinking there:

```
response.created -> response.in_progress -> response.output_item.added (reasoning)
 -> reasoning_summary deltas -> response.output_item.done
 -> response.output_text.delta        <- no output_item.added for the message
```

The run still completes and the answer renders. This PR only makes reasoning items reachable on Bedrock Converse, which is what exposes it. Worth its own issue

## Type

🐛 Bug Fix

## Changes

The Responses API takes `reasoning` as an object, `{effort, summary}`. Chat Completions takes `reasoning_effort` as a string enum and has no equivalent of `summary`, but the bridge forwarded the whole object whenever `summary` was set, which agentic clients set on every request

`BedrockConverseConfig` maps the parameter under `elif param == "reasoning_effort" and isinstance(value, str)` with no `else`, so the object fell through and thinking was never enabled. The request still succeeded and was still billed, which is why this is invisible without comparing responses side by side

`_transform_reasoning_for_chat_completion` now always flattens the object to its `effort` string, so no chat provider ever receives a non-string `reasoning_effort`. The `summary` travels separately as `reasoning_summary`, the alias `litellm.completion` already reads with `peek_reasoning_summary_aliases` and reassembles into `{effort, summary}` on the bridged path, and it is emitted only for a model that bridges, so nothing else sees it. An object carrying no `effort` yields no `reasoning_effort` at all, rather than an object the provider cannot read

Splitting the two params also closes a gap in the earlier revision. It asked `responses_api_bridge_check` with the summary read straight off the Responses object, while `litellm.completion` reads that argument out of `optional_params`, which the bridged request never populated. `gpt-5`, `gpt-5.1` and `azure/gpt-5` therefore answered "bridging" to the probe and "not bridging" for real, and the object still reached Chat Completions. The probe is now asked with the exact params the transform emits, so the two cannot reach different answers

Six tests, twenty cases once parameterised, cover it across Bedrock, Bedrock Converse, Vertex Anthropic, Gemini, a Mantle model and the GPT-5 family: a summary-carrying request yields a string effort, a bridged model carries the summary as an alias, the GPT-5 models really do bridge with what the transform emits, the shape variants map as expected, a failing probe degrades to the chat-safe form, and thinking is still enabled on Bedrock

## Caveats (if any)

### Medium

- Streaming sends text deltas before opening a message item; pre-existing, now visible

### Low

- A `reasoning` object carrying only the deprecated `generate_summary` is still dropped
- GPT-5 case proves the wire shape; the model returned no summary either way

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
