### PR TITLE
feat: add HAI OpenAI-compatible provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -183,5 +183,11 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "hai": {
+    "base_url": "https://hai-api.hcloud.ltd/v1",
+    "api_key_env": "HAI_API_KEY",
+    "api_base_env": "HAI_API_BASE",
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   }
 }

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -46381,5 +46381,89 @@
                 }
             }
         ]
+    },
+    "hai/kimi-k3": {
+        "input_cost_per_token": 3e-06,
+        "output_cost_per_token": 1.5e-05,
+        "litellm_provider": "hai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "hai/kimi-k2.6": {
+        "input_cost_per_token": 8.2e-07,
+        "output_cost_per_token": 3.66e-06,
+        "litellm_provider": "hai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "hai/gemma-4-31b-it": {
+        "input_cost_per_token": 2.4e-07,
+        "output_cost_per_token": 5.8e-07,
+        "litellm_provider": "hai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_reasoning": false
+    },
+    "hai/qwen3.6-35b-a3b": {
+        "input_cost_per_token": 1.8e-07,
+        "output_cost_per_token": 1.24e-06,
+        "litellm_provider": "hai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "hai/qwen3.6-35b-a3b-uncensored": {
+        "input_cost_per_token": 2.4e-07,
+        "output_cost_per_token": 1.6000000000000001e-06,
+        "litellm_provider": "hai",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "hai/deepseek-v4-flash": {
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 2.8e-07,
+        "litellm_provider": "hai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false,
+        "supports_reasoning": true
     }
 }

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -46503,5 +46503,89 @@
                 }
             }
         ]
+    },
+    "hai/kimi-k3": {
+        "input_cost_per_token": 3e-06,
+        "output_cost_per_token": 1.5e-05,
+        "litellm_provider": "hai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "hai/kimi-k2.6": {
+        "input_cost_per_token": 8.2e-07,
+        "output_cost_per_token": 3.66e-06,
+        "litellm_provider": "hai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "hai/gemma-4-31b-it": {
+        "input_cost_per_token": 2.4e-07,
+        "output_cost_per_token": 5.8e-07,
+        "litellm_provider": "hai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_reasoning": false
+    },
+    "hai/qwen3.6-35b-a3b": {
+        "input_cost_per_token": 1.8e-07,
+        "output_cost_per_token": 1.24e-06,
+        "litellm_provider": "hai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "hai/qwen3.6-35b-a3b-uncensored": {
+        "input_cost_per_token": 2.4e-07,
+        "output_cost_per_token": 1.6000000000000001e-06,
+        "litellm_provider": "hai",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "hai/deepseek-v4-flash": {
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 2.8e-07,
+        "litellm_provider": "hai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false,
+        "supports_reasoning": true
     }
 }


### PR DESCRIPTION
## Summary

Add **HAI** (https://hai.hcloud.ltd) as an OpenAI-compatible provider via `providers.json`.

HAI is a Japan-based OpenAI-compatible LLM Inference API with JPY billing.

### Usage

```python
import litellm
import os
os.environ["HAI_API_KEY"] = "hai_..."
resp = litellm.completion(
    model="hai/kimi-k2.6",
    messages=[{"role": "user", "content": "hello"}],
)
```

### Models (pricing in model_prices_and_context_window.json)

- `hai/kimi-k3`
- `hai/kimi-k2.6`
- `hai/gemma-4-31b-it`
- `hai/qwen3.6-35b-a3b`
- `hai/qwen3.6-35b-a3b-uncensored`
- `hai/deepseek-v4-flash`

### Config

```json
"hai": {
  "base_url": "https://hai-api.hcloud.ltd/v1",
  "api_key_env": "HAI_API_KEY",
  "api_base_env": "HAI_API_BASE",
  "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
}
```

Docs: https://hai.hcloud.ltd/docs

## Type
🆕 New Feature

## Changes
- `litellm/llms/openai_like/providers.json`
- `model_prices_and_context_window.json` (+ backup)

## Test plan
- [ ] `litellm.completion(model="hai/kimi-k2.6", ...)` with valid `HAI_API_KEY`
- [ ] Responses API path works via supported_endpoints