### PR TITLE
fix(streaming): preserve OpenAI SDK usage details in stream chunk builder

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -748,6 +748,8 @@ class ChunkProcessor:
 
         if isinstance(usage_chunk, dict):
             return Usage(**usage_chunk)
+        if hasattr(usage_chunk, "model_dump"):
+            return Usage(**usage_chunk.model_dump())
         return usage_chunk
 
     def _calculate_usage_per_chunk(

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -1267,25 +1267,27 @@ def test_get_combined_tool_content_joins_many_custom_tool_input_fragments_in_ord
 def test_stream_chunk_builder_preserves_details_from_openai_sdk_usage():
     from openai.types.completion_usage import CompletionUsage
 
-    chunk = ModelResponseStream(
-        id="chatcmpl-1",
-        created=1745513206,
-        model="openai/deepseek-v4-flash",
-        choices=[
-            StreamingChoices(
-                finish_reason="stop",
-                index=0,
-                delta=Delta(content="Hi"),
-            )
-        ],
-    ).model_dump()
-    chunk["usage"] = CompletionUsage(
-        prompt_tokens=1714,
-        completion_tokens=14,
-        total_tokens=1728,
-        prompt_tokens_details={"cached_tokens": 1664},
-        completion_tokens_details={"reasoning_tokens": 12},
-    )
+    chunk = {
+        **ModelResponseStream(
+            id="chatcmpl-1",
+            created=1745513206,
+            model="openai/deepseek-v4-flash",
+            choices=[
+                StreamingChoices(
+                    finish_reason="stop",
+                    index=0,
+                    delta=Delta(content="Hi"),
+                )
+            ],
+        ).model_dump(),
+        "usage": CompletionUsage(
+            prompt_tokens=1714,
+            completion_tokens=14,
+            total_tokens=1728,
+            prompt_tokens_details={"cached_tokens": 1664},
+            completion_tokens_details={"reasoning_tokens": 12},
+        ),
+    }
 
     processor = ChunkProcessor(chunks=[chunk])
     usage = processor.calculate_usage(

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -1262,3 +1262,41 @@ def test_get_combined_tool_content_joins_many_custom_tool_input_fragments_in_ord
     assert isinstance(combined[1], ChatCompletionMessageCustomToolCall)
     assert combined[1].custom.name == "run_script"
     assert combined[1].custom.input == "".join(object_fragments)
+
+
+def test_stream_chunk_builder_preserves_details_from_openai_sdk_usage():
+    from openai.types.completion_usage import CompletionUsage
+
+    chunk = ModelResponseStream(
+        id="chatcmpl-1",
+        created=1745513206,
+        model="openai/deepseek-v4-flash",
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content="Hi"),
+            )
+        ],
+    ).model_dump()
+    chunk["usage"] = CompletionUsage(
+        prompt_tokens=1714,
+        completion_tokens=14,
+        total_tokens=1728,
+        prompt_tokens_details={"cached_tokens": 1664},
+        completion_tokens_details={"reasoning_tokens": 12},
+    )
+
+    processor = ChunkProcessor(chunks=[chunk])
+    usage = processor.calculate_usage(
+        chunks=[chunk],
+        model="openai/deepseek-v4-flash",
+        completion_output="Hi",
+    )
+
+    assert usage.prompt_tokens == 1714
+    assert usage.completion_tokens == 14
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cached_tokens == 1664
+    assert usage.completion_tokens_details is not None
+    assert usage.completion_tokens_details.reasoning_tokens == 12


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed usage chunks built from raw OpenAI SDK `CompletionUsage` objects silently lose `prompt_tokens_details` and `completion_tokens_details`
- Cache-read tokens then fall back to fresh-input pricing and reasoning tokens disappear from usage accounting

How it solves it:

- Convert raw pydantic usage models to litellm `Usage` at the stream chunk extraction boundary
- Add a regression test using the raw `openai.CompletionUsage` shape

## User Flow

Before: a developer streams chat completions through an OpenAI-compatible endpoint and their cost dashboard never sees cached-token or reasoning-token detail.

1. They send `POST /v1/chat/completions` with `"stream": true` and `"stream_options": {"include_usage": true}`
2. The final SSE chunk arrives with `prompt_tokens`/`completion_tokens`, but `prompt_tokens_details` is missing
3. Their cost dashboard bills the full input at the uncached input rate and shows no reasoning-token breakdown

After: the same request keeps the provider-reported usage details.

1. They send the same `POST /v1/chat/completions` with `"stream": true` and `"stream_options": {"include_usage": true}`
2. The final SSE chunk now carries `prompt_tokens_details.cached_tokens` and `completion_tokens_details.reasoning_tokens`
3. Their cost dashboard bills cached tokens at the cache-read rate and shows the reasoning-token breakdown

## Relevant issues

Related: #34801 (upstream #34812 fixed the generic stream-reassembly path; this covers raw OpenAI SDK pydantic usage shapes that still lost the details).

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

E2E proof against the real DeepSeek API through a litellm proxy, streamed chat completions with `stream_options.include_usage`.

Before (v1.97.0-rc.1 without this patch, second call with a shared prefix):

```text
call 1: usage=CompletionUsage(completion_tokens=1, prompt_tokens=1462, total_tokens=1463, completion_tokens_details=..., prompt_tokens_details=None)
```

After (same proxy image plus this patch; original capture at commit `96af89842c`, rebased onto `litellm_internal_staging` as `c3db2800e3` with no production code changes):

```text
call 0: usage=CompletionUsage(..., completion_tokens_details=..., reasoning_tokens=12, prompt_tokens_details=PromptTokensDetails(..., cached_tokens=1664))
call 1: usage=CompletionUsage(..., completion_tokens_details=..., reasoning_tokens=8, prompt_tokens_details=PromptTokensDetails(..., cached_tokens=1664))
```

The regression test also fails on unpatched `litellm_internal_staging`:

```text
>       assert usage.prompt_tokens == 1714
E       assert 0 == 1714
E        +  where 0 = Usage(..., prompt_tokens_details=None, ...).prompt_tokens
```

## Type

🐛 Bug Fix

## Changes

- `litellm/litellm_core_utils/streaming_chunk_builder_utils.py`: in `_extract_usage_chunk()`, convert raw pydantic usage objects (e.g. OpenAI SDK `CompletionUsage`) to litellm `Usage` via `model_dump()` before the chunk builder reads them.
- `tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py`: add a regression test using a raw `openai.CompletionUsage` on a stream chunk, asserting `cached_tokens` and `reasoning_tokens` survive `calculate_usage()`.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
