### PR TITLE
fix(azure): normalize empty namespace tool descriptions

### DIFF
--- a/litellm/llms/azure/responses/transformation.py
+++ b/litellm/llms/azure/responses/transformation.py
@@ -98,15 +98,39 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         if isinstance(validated_input, list):
             filtered_input: Final[list[Any]] = []
             for item in validated_input:
-                if isinstance(item, dict) and item.get("type") == "message":
-                    # Filter out status field from message items
-                    filtered_item = {k: v for k, v in item.items() if k != "status"}
-                    filtered_input.append(filtered_item)
-                else:
-                    filtered_input.append(item)
+                filtered_item = (
+                    {k: v for k, v in item.items() if k != "status"}
+                    if isinstance(item, dict) and item.get("type") == "message"
+                    else item
+                )
+                filtered_input.append(self._normalize_additional_tools_item(filtered_item))
             return cast(ResponseInputParam, filtered_input)
 
         return validated_input
+
+    @staticmethod
+    def _normalize_namespace_tool_description(tool: Any) -> Any:
+        if not isinstance(tool, dict) or tool.get("type") != "namespace":
+            return tool
+
+        description: Final = tool.get("description")
+        if not isinstance(description, str) or description.strip():
+            return tool
+
+        name: Final = tool.get("name")
+        fallback_description: Final = name.strip() if isinstance(name, str) and name.strip() else "namespace"
+        return {**tool, "description": fallback_description}
+
+    @classmethod
+    def _normalize_additional_tools_item(cls, item: Any) -> Any:
+        if not isinstance(item, dict) or item.get("type") != "additional_tools":
+            return item
+
+        tools: Final = item.get("tools")
+        if not isinstance(tools, list):
+            return item
+
+        return {**item, "tools": [cls._normalize_namespace_tool_description(tool) for tool in tools]}
 
     def transform_responses_api_request(
         self,

--- a/litellm/llms/azure/responses/transformation.py
+++ b/litellm/llms/azure/responses/transformation.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal
 
 import httpx
 from openai.types.responses import ResponseReasoningItem
+from pydantic import JsonValue, TypeAdapter
 
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.url_utils import encode_url_path_segment
@@ -19,6 +20,9 @@ if TYPE_CHECKING:
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
     LiteLLMLoggingObj = Any
+
+
+_JSON_VALUE_ADAPTER: Final[TypeAdapter[JsonValue]] = TypeAdapter(JsonValue)
 
 
 class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
@@ -96,20 +100,24 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
 
         # Then filter out status from message items
         if isinstance(validated_input, list):
-            filtered_input: Final[list[Any]] = []
+            filtered_input: Final[list[object]] = []
             for item in validated_input:
                 filtered_item = (
                     {k: v for k, v in item.items() if k != "status"}
                     if isinstance(item, dict) and item.get("type") == "message"
                     else item
                 )
-                filtered_input.append(self._normalize_additional_tools_item(filtered_item))
+                if filtered_item.get("type") == "additional_tools":
+                    validated_additional_tools_item: JsonValue = _JSON_VALUE_ADAPTER.validate_python(filtered_item)
+                    filtered_input.append(self._normalize_additional_tools_item(validated_additional_tools_item))
+                else:
+                    filtered_input.append(filtered_item)
             return cast(ResponseInputParam, filtered_input)
 
         return validated_input
 
     @staticmethod
-    def _normalize_namespace_tool_description(tool: Any) -> Any:
+    def _normalize_namespace_tool_description(tool: JsonValue) -> JsonValue:
         if not isinstance(tool, dict) or tool.get("type") != "namespace":
             return tool
 
@@ -122,7 +130,7 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         return {**tool, "description": fallback_description}
 
     @classmethod
-    def _normalize_additional_tools_item(cls, item: Any) -> Any:
+    def _normalize_additional_tools_item(cls, item: JsonValue) -> JsonValue:
         if not isinstance(item, dict) or item.get("type") != "additional_tools":
             return item
 

--- a/tests/test_litellm/llms/azure/response/test_azure_transformation.py
+++ b/tests/test_litellm/llms/azure/response/test_azure_transformation.py
@@ -534,6 +534,61 @@ class TestAzureResponsesAPIConfig:
 
         assert "tools" not in response_api_params
 
+    @pytest.mark.parametrize(
+        ("description", "expected_description"),
+        [
+            ("", "functions"),
+            (" \t ", "functions"),
+            ("Existing description", "Existing description"),
+        ],
+    )
+    def test_azure_responses_api_normalizes_additional_tools_namespace_description(
+        self, description, expected_description
+    ):
+        namespace_tool = {
+            "type": "namespace",
+            "name": "functions",
+            "description": description,
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "ping",
+                    "description": "Return pong.",
+                    "parameters": {"type": "object", "properties": {}},
+                    "strict": False,
+                }
+            ],
+        }
+        function_tool = {
+            "type": "function",
+            "name": "empty_description_is_allowed_here",
+            "description": "",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        input_items = [
+            {
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": [namespace_tool, function_tool],
+            }
+        ]
+        original_input_items = deepcopy(input_items)
+
+        result = self.config.transform_responses_api_request(
+            model=self.model,
+            input=input_items,
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert result["input"][0]["tools"][0] == {
+            **namespace_tool,
+            "description": expected_description,
+        }
+        assert result["input"][0]["tools"][1] == function_tool
+        assert input_items == original_input_items
+
     def test_azure_responses_api_context_management_unsupported(self):
         """Test that context_management is not in Azure supported params.
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure rejects blank namespace descriptions before inference

How it solves it:

- Fill blank descriptions from their namespace names
- Preserve populated descriptions and all other tool metadata

## User Flow

Before: a developer sending namespace tools through Azure Responses receives an HTTP 400 before inference

1. They send `POST https://litellm-domain/v1/responses` with an Azure model and an `additional_tools` namespace whose description is empty
2. The request returns HTTP 400 with `Invalid 'input[0].tools[0].description': empty string`

After: the same request reaches inference with a valid namespace description

1. They send the same `POST https://litellm-domain/v1/responses` request with the same Azure model and tools
2. The namespace name fills the blank description, so Azure can process the request instead of rejecting that field

## Relevant issues

Fixes #36366

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live Azure before-and-after proof is not included in this revision

The focused regression test covers empty, whitespace-only, and populated namespace descriptions while preserving the remaining tool metadata. A local transformation comparison showed that the previous path forwarded blank descriptions and the updated path substitutes the namespace name

## Type

🐛 Bug Fix

## Changes

Azure Responses now normalizes blank namespace descriptions inside `additional_tools`. Other input item types, non-namespace tools, and populated descriptions remain unchanged

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
