### PR TITLE
fix(responses): announce, index and identify every streamed output item

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -1,6 +1,5 @@
 import time
 import uuid
-from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Final, Literal, cast
 
@@ -142,41 +141,54 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             self._cached_reasoning_item_id = f"rs_{uuid.uuid4()}"
         return self._cached_reasoning_item_id
 
-    def _open_output_item(
-        self,
-        kind: Literal["message", "reasoning"],
-        item_id: str,
-        item: Mapping[str, Any],
-    ) -> None:
-        """Announce an item, after closing whichever item was open before it.
+    def _open_message_item(self, item_id: str) -> None:
+        """Announce a message item, after closing whichever item was open before it.
 
-        A message item is followed by ``content_part.added``, which the spec requires
+        The added event is followed by ``content_part.added``, which the spec requires
         before any ``output_text.delta``.
         """
         self._close_open_output_item()
         self._open_item = _OpenOutputItem(
             index=self._allocate_output_index(),
             id=item_id,
-            kind=kind,
+            kind="message",
         )
-        if kind == "message":
-            self._emitted_message_item = True
-            self._pending_response_events.append(self.create_output_item_added_event())
-            self.sent_content_part_added_event = True
-            self._pending_response_events.append(self.create_content_part_added_event())
-            return
+        self._emitted_message_item = True
+        self._pending_response_events.append(self.create_output_item_added_event())
+        self.sent_content_part_added_event = True
+        self._pending_response_events.append(self.create_content_part_added_event())
 
+    def _open_reasoning_item(self, item_id: str) -> None:
+        """Announce a reasoning item, after closing whichever item was open before it."""
+        self._close_open_output_item()
+        self._open_item = _OpenOutputItem(
+            index=self._allocate_output_index(),
+            id=item_id,
+            kind="reasoning",
+        )
         self._sequence_number += 1
         event: Final = OutputItemAddedEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
             output_index=self._open_item.index,
-            item=BaseLiteLLMOpenAIResponseObject(**item),
+            item=self._reasoning_item_payload(item_id),
         )
         event.__dict__["sequence_number"] = self._sequence_number
         self._pending_response_events.append(event)
+        self._pending_response_events.append(self.create_reasoning_summary_part_added_event())
 
-        if kind == "reasoning":
-            self._pending_response_events.append(self.create_reasoning_summary_part_added_event())
+    @staticmethod
+    def _reasoning_item_payload(item_id: str) -> BaseLiteLLMOpenAIResponseObject:
+        """The announced reasoning item.
+
+        ``summary`` is an empty array rather than null: a client whose reasoning item requires
+        a summary list drops the whole item when the field is null or absent.
+        """
+        return BaseLiteLLMOpenAIResponseObject(
+            id=item_id,
+            type="reasoning",
+            status="in_progress",
+            summary=(),
+        )
 
     def create_reasoning_summary_part_added_event(self) -> ResponsePartAddedEvent:
         """Announce the summary part the reasoning deltas that follow belong to.
@@ -909,18 +921,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             item_id = f"rs_{uuid.uuid4()}"
             if self._cached_reasoning_item_id is None:
                 self._cached_reasoning_item_id = item_id
-            self._open_output_item(
-                "reasoning",
-                item_id,
-                {
-                    "id": item_id,
-                    "type": "reasoning",
-                    "status": "in_progress",
-                    # An empty array, never null: a client whose reasoning item requires a
-                    # summary list drops the whole item when the field is null or absent.
-                    "summary": [],
-                },
-            )
+            self._open_reasoning_item(item_id)
             self._accumulated_reasoning_content_parts = []
             return
 
@@ -941,17 +942,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         if self._cached_item_id is None and chunk.id:
             self._cached_item_id = chunk.id
         item_id = f"msg_{uuid.uuid4()}" if self._emitted_message_item else self._message_item_id()
-        self._open_output_item(
-            "message",
-            item_id,
-            {
-                "id": item_id,
-                "type": "message",
-                "role": "assistant",
-                "status": "in_progress",
-                "content": [],
-            },
-        )
+        self._open_message_item(item_id)
 
     def _handle_reasoning_content_for_chunk(self, chunk: ModelResponseStream) -> None:
         """Accumulate the open reasoning item's content, and close it when it ends."""

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -1,6 +1,8 @@
 import time
 import uuid
-from typing import Any, Final, cast
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Final, Literal, cast
 
 import litellm
 from litellm.main import stream_chunk_builder
@@ -19,7 +21,6 @@ from litellm.types.llms.openai import (
     ContentPartAddedEvent,
     ContentPartDoneEvent,
     ContentPartDonePartOutputText,
-    ContentPartDonePartReasoningText,
     FunctionCallArgumentsDeltaEvent,
     FunctionCallArgumentsDoneEvent,
     OutputItemAddedEvent,
@@ -34,6 +35,7 @@ from litellm.types.llms.openai import (
     ResponseCreatedEvent,
     ResponseInProgressEvent,
     ResponseInputParam,
+    ResponsePartAddedEvent,
     ResponsesAPIOptionalRequestParams,
     ResponsesAPIResponse,
     ResponsesAPIStreamEvents,
@@ -46,6 +48,16 @@ from litellm.types.utils import (
     StreamingChoices,
     TextCompletionResponse,
 )
+
+
+@dataclass(slots=True)
+class _OpenOutputItem:
+    """The output item currently being streamed, and the state its done events need."""
+
+    index: int
+    id: str
+    kind: Literal["message", "reasoning"]
+    text_parts: list[str] = field(default_factory=list)  # mutable-ok: appended per streamed delta
 
 
 class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
@@ -75,7 +87,6 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self.litellm_logging_obj = litellm_custom_stream_wrapper.logging_obj
         self.sent_response_created_event: bool = False
         self.sent_response_in_progress_event: bool = False
-        self.sent_output_item_added_event: bool = False
         self.sent_content_part_added_event: bool = False
         self.sent_output_text_done_event: bool = False
         self.sent_output_content_part_done_event: bool = False
@@ -90,7 +101,11 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._tool_args_by_call_id: dict[str, str] = {}
         self._tool_call_id_by_index: dict[int, str] = {}
         self._ambiguous_tool_call_indexes: set[int] = set()
-        self._next_tool_output_index: int = 1  # output_index=0 reserved for the message item
+        # output_index is one monotonic counter over every item in the turn -- reasoning,
+        # message and tool call alike.
+        self._next_output_index: int = 0
+        self._open_item: _OpenOutputItem | None = None
+        self._emitted_message_item: bool = False
         self._final_tool_events_queued: bool = False
         self._sequence_number: int = 0
         self._cached_reasoning_item_id: str | None = None
@@ -99,9 +114,6 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._reasoning_summary_text: str = ""
         # -- GENERIC RESPONSE-EVENTS PENDING QUEUE as required by fix --
         self._pending_response_events: list[BaseLiteLLMOpenAIResponseObject] = []
-        self._reasoning_active = False
-        self._reasoning_done_emitted = False
-        self._reasoning_item_id: str | None = None
         self._accumulated_reasoning_content_parts: list[str] = []
         self._accumulated_provider_specific_fields: dict[str, Any] = {}
         self._custom_tool_names: set[str] = extract_custom_tool_names(self.responses_api_request.get("tools"))
@@ -110,10 +122,159 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         existing: Final = self._tool_output_index_by_call_id.get(call_id)
         if existing is not None:
             return existing
-        idx: Final = self._next_tool_output_index
-        self._next_tool_output_index += 1
+        idx: Final = self._allocate_output_index()
         self._tool_output_index_by_call_id[call_id] = idx
         return idx
+
+    def _allocate_output_index(self) -> int:
+        idx: Final = self._next_output_index
+        self._next_output_index += 1
+        return idx
+
+    def _open_item_index(self) -> int:
+        return self._open_item.index if self._open_item is not None else 0
+
+    def _reasoning_item_id(self) -> str:
+        """The id of the reasoning item every event in this reasoning block carries."""
+        if self._open_item is not None and self._open_item.kind == "reasoning":
+            return str(self._open_item.id)
+        if self._cached_reasoning_item_id is None:
+            self._cached_reasoning_item_id = f"rs_{uuid.uuid4()}"
+        return self._cached_reasoning_item_id
+
+    def _open_output_item(
+        self,
+        kind: Literal["message", "reasoning"],
+        item_id: str,
+        item: Mapping[str, Any],
+    ) -> None:
+        """Announce an item, after closing whichever item was open before it.
+
+        A message item is followed by ``content_part.added``, which the spec requires
+        before any ``output_text.delta``.
+        """
+        self._close_open_output_item()
+        self._open_item = _OpenOutputItem(
+            index=self._allocate_output_index(),
+            id=item_id,
+            kind=kind,
+        )
+        if kind == "message":
+            self._emitted_message_item = True
+            self._pending_response_events.append(self.create_output_item_added_event())
+            self.sent_content_part_added_event = True
+            self._pending_response_events.append(self.create_content_part_added_event())
+            return
+
+        self._sequence_number += 1
+        event: Final = OutputItemAddedEvent(
+            type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
+            output_index=self._open_item.index,
+            item=BaseLiteLLMOpenAIResponseObject(**item),
+        )
+        event.__dict__["sequence_number"] = self._sequence_number
+        self._pending_response_events.append(event)
+
+        if kind == "reasoning":
+            self._pending_response_events.append(self.create_reasoning_summary_part_added_event())
+
+    def create_reasoning_summary_part_added_event(self) -> ResponsePartAddedEvent:
+        """Announce the summary part the reasoning deltas that follow belong to.
+
+        The spec sends this before the first delta of a part; a client that opens its summary
+        part here drops any delta that arrives before it.
+        """
+        self._sequence_number += 1
+        event: Final = ResponsePartAddedEvent(
+            type=ResponsesAPIStreamEvents.RESPONSE_PART_ADDED,
+            item_id=self._reasoning_item_id(),
+            output_index=self._open_item_index(),
+            summary_index=0,
+            part={"type": "summary_text", "text": ""},
+        )
+        event.__dict__["sequence_number"] = self._sequence_number
+        return event
+
+    def _close_open_output_item(self) -> None:
+        """Queue the open item's done events and leave no item open."""
+        item: Final = self._open_item
+        if item is None:
+            return
+        self._open_item = None
+        if item.kind == "reasoning":
+            self._queue_reasoning_done_events(item)
+        elif item.kind == "message":
+            self._queue_message_done_events(item)
+
+    def _queue_message_done_events(self, item: _OpenOutputItem) -> None:
+        text: Final = "".join(item.text_parts)
+        self._sequence_number += 1
+        text_done: Final = OutputTextDoneEvent(
+            type=ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE,
+            item_id=item.id,
+            output_index=item.index,
+            content_index=0,
+            text=text,
+        )
+        text_done.__dict__["sequence_number"] = self._sequence_number
+        self._sequence_number += 1
+        part_done: Final = ContentPartDoneEvent(
+            type=ResponsesAPIStreamEvents.CONTENT_PART_DONE,
+            item_id=item.id,
+            output_index=item.index,
+            content_index=0,
+            part=ContentPartDonePartOutputText(
+                type="output_text",
+                text=text,
+                annotations=[],
+                logprobs=None,
+            ),
+        )
+        part_done.__dict__["sequence_number"] = self._sequence_number
+        self._sequence_number += 1
+        item_done: Final = OutputItemDoneEvent(
+            type=ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
+            output_index=item.index,
+            sequence_number=self._sequence_number,
+            item=BaseLiteLLMOpenAIResponseObject(
+                **{
+                    "id": item.id,
+                    "status": "completed",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": text, "annotations": []}],
+                }
+            ),
+        )
+        self._pending_response_events.extend((text_done, part_done, item_done))
+
+    def _queue_reasoning_done_events(self, item: _OpenOutputItem) -> None:
+        reasoning_content: Final = "".join(self._accumulated_reasoning_content_parts)
+
+        self._sequence_number += 1
+        text_done_event: Final = self.create_reasoning_summary_text_done_event(
+            reasoning_item_id=item.id,
+            reasoning_content=reasoning_content,
+            sequence_number=self._sequence_number,
+            output_index=item.index,
+        )
+
+        self._sequence_number += 1
+        part_done_event: Final = self.create_reasoning_summary_part_done_event(
+            reasoning_item_id=item.id,
+            reasoning_content=reasoning_content,
+            sequence_number=self._sequence_number,
+            output_index=item.index,
+        )
+
+        self._sequence_number += 1
+        item_done_event = self.create_reasoning_output_item_done_event(
+            reasoning_item_id=item.id,
+            reasoning_content=reasoning_content,
+            sequence_number=self._sequence_number,
+            output_index=item.index,
+        )
+        self._pending_response_events.extend((text_done_event, part_done_event, item_done_event))
 
     def _normalize_tool_call_index(self, tool_call: object) -> int | None:
         idx_raw: Final = tool_call.get("index") if isinstance(tool_call, dict) else getattr(tool_call, "index", None)
@@ -384,17 +545,21 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         event.__dict__["sequence_number"] = self._sequence_number
         return event
 
-    def create_output_item_added_event(self) -> OutputItemAddedEvent:
+    def _message_item_id(self) -> str:
+        if self._open_item is not None and self._open_item.kind == "message":
+            return str(self._open_item.id)
         if self._cached_item_id is None:
             self._cached_item_id = f"msg_{uuid.uuid4()}"
+        return self._cached_item_id
 
+    def create_output_item_added_event(self) -> OutputItemAddedEvent:
         self._sequence_number += 1
         event: Final = OutputItemAddedEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
-            output_index=0,
+            output_index=self._open_item_index(),
             item=BaseLiteLLMOpenAIResponseObject(
                 **{
-                    "id": self._cached_item_id,
+                    "id": self._message_item_id(),
                     "type": "message",
                     "status": "in_progress",
                     "role": "assistant",
@@ -406,14 +571,11 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         return event
 
     def create_content_part_added_event(self) -> ContentPartAddedEvent:
-        if self._cached_item_id is None:
-            self._cached_item_id = f"msg_{uuid.uuid4()}"
-
         self._sequence_number += 1
         event: Final = ContentPartAddedEvent(
             type=ResponsesAPIStreamEvents.CONTENT_PART_ADDED,
-            item_id=self._cached_item_id,
-            output_index=0,
+            item_id=self._message_item_id(),
+            output_index=self._open_item_index(),
             content_index=0,
             part=BaseLiteLLMOpenAIResponseObject(**{"type": "output_text", "text": "", "annotations": []}),
         )
@@ -467,6 +629,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         reasoning_item_id: str,
         reasoning_content: str,
         sequence_number: int,
+        output_index: int = 0,
     ) -> ReasoningSummaryTextDoneEvent:
         """
         Create response.reasoning_summary_text.done event.
@@ -484,7 +647,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         return ReasoningSummaryTextDoneEvent(
             type=ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DONE,
             item_id=reasoning_item_id,
-            output_index=0,
+            output_index=output_index,
             sequence_number=sequence_number,
             summary_index=0,
             text=reasoning_content,
@@ -495,6 +658,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         reasoning_item_id: str,
         reasoning_content: str,
         sequence_number: int,
+        output_index: int = 0,
     ) -> ReasoningSummaryPartDoneEvent:
         """
         Create response.reasoning_summary_part.done event.
@@ -515,7 +679,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         return ReasoningSummaryPartDoneEvent(
             type=ResponsesAPIStreamEvents.REASONING_SUMMARY_PART_DONE,
             item_id=reasoning_item_id,
-            output_index=0,
+            output_index=output_index,
             sequence_number=sequence_number,
             summary_index=0,
             part=BaseLiteLLMOpenAIResponseObject(
@@ -527,59 +691,47 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         )
 
     def create_output_text_done_event(self, litellm_complete_object: ModelResponse) -> OutputTextDoneEvent:
-        if self._cached_item_id is None:
-            self._cached_item_id = f"msg_{uuid.uuid4()}"
-
         return OutputTextDoneEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE,
-            item_id=self._cached_item_id,
-            output_index=0,
+            item_id=self._message_item_id(),
+            output_index=self._open_item_index(),
             content_index=0,
             text=getattr(litellm_complete_object.choices[0].message, "content", "") or "",
         )
 
     def create_output_content_part_done_event(self, litellm_complete_object: ModelResponse) -> ContentPartDoneEvent:
-        if self._cached_item_id is None:
-            self._cached_item_id = f"msg_{uuid.uuid4()}"
+        """Close the message item's content part.
 
+        The part is the message's own text, matching what ``content_part.added`` announced. A
+        reasoning part here would describe the reasoning item, which carries its own summary
+        part events.
+        """
         text: Final = getattr(litellm_complete_object.choices[0].message, "content", "") or ""
-        reasoning_content = getattr(litellm_complete_object.choices[0].message, "reasoning_content", "") or ""
         annotations: Final = getattr(litellm_complete_object.choices[0].message, "annotations", None)
 
-        part: PART_UNION_TYPES | None = None
-        if reasoning_content:
-            part = ContentPartDonePartReasoningText(
-                type="reasoning_text",
-                reasoning=reasoning_content,
+        response_annotations = (
+            LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
+                annotations=annotations
             )
-
-        else:
-            response_annotations: Final = (
-                LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
-                    annotations=annotations
-                )
-            )
-            part = ContentPartDonePartOutputText(
-                type="output_text",
-                text=text,
-                annotations=response_annotations,
-                logprobs=None,
-            )
+        )
+        part: PART_UNION_TYPES = ContentPartDonePartOutputText(
+            type="output_text",
+            text=text,
+            annotations=response_annotations,
+            logprobs=None,
+        )
 
         return ContentPartDoneEvent(
             type=ResponsesAPIStreamEvents.CONTENT_PART_DONE,
-            item_id=self._cached_item_id,
-            output_index=0,
+            item_id=self._message_item_id(),
+            output_index=self._open_item_index(),
             content_index=0,
             part=part,
         )
 
     def create_output_item_done_event(self, litellm_complete_object: ModelResponse) -> OutputItemDoneEvent:
-        if self._cached_item_id is None:
-            self._cached_item_id = f"msg_{uuid.uuid4()}"
-
         text: Final = self.litellm_model_response.choices[0].message.content or ""
-        annotations = getattr(self.litellm_model_response.choices[0].message, "annotations", None)
+        annotations: Final = getattr(self.litellm_model_response.choices[0].message, "annotations", None)
 
         response_annotations: Final = (
             LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
@@ -588,11 +740,11 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         )
         return OutputItemDoneEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
-            output_index=0,
+            output_index=self._open_item_index(),
             sequence_number=1,
             item=BaseLiteLLMOpenAIResponseObject(
                 **{
-                    "id": self._cached_item_id,
+                    "id": self._message_item_id(),
                     "status": "completed",
                     "type": "message",
                     "role": "assistant",
@@ -612,6 +764,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         reasoning_item_id: str,
         reasoning_content: str,
         sequence_number: int,
+        output_index: int = 0,
     ) -> OutputItemDoneEvent:
         """
         Create response.output_item.done event for reasoning items.
@@ -635,7 +788,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         """
         return OutputItemDoneEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
-            output_index=0,
+            output_index=output_index,
             sequence_number=sequence_number,
             item=BaseLiteLLMOpenAIResponseObject(
                 **{
@@ -654,6 +807,17 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
     def return_default_done_events(
         self, litellm_complete_object: ModelResponse
     ) -> BaseLiteLLMOpenAIResponseObject | None:
+        """Close the message item the stream ended inside.
+
+        A turn that never opened a message item, or whose message item was already closed
+        when the content changed kind, has no message done events to send: emitting them
+        would describe an item the client was never told about.
+        """
+        if self._open_item is None or self._open_item.kind != "message":
+            self.sent_output_text_done_event = True
+            self.sent_output_content_part_done_event = True
+            self.sent_output_item_done_event = True
+            return None
         if self.sent_output_text_done_event is False:
             self.sent_output_text_done_event = True
             return self.create_output_text_done_event(litellm_complete_object)
@@ -662,7 +826,9 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             return self.create_output_content_part_done_event(litellm_complete_object)
         if self.sent_output_item_done_event is False:
             self.sent_output_item_done_event = True
-            return self.create_output_item_done_event(litellm_complete_object)
+            event = self.create_output_item_done_event(litellm_complete_object)
+            self._open_item = None
+            return event
         return None
 
     def return_default_initial_events(
@@ -689,6 +855,12 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         if not self.litellm_model_response or isinstance(self.litellm_model_response, TextCompletionResponse):
             self.litellm_model_response = self.create_litellm_model_response()
         if self.litellm_model_response:
+            # A non-message item still open at the end of the stream is closed here, so
+            # response.completed is never preceded by an item that was never finished.
+            if self._open_item is not None and self._open_item.kind != "message":
+                self._close_open_output_item()
+            if self._pending_response_events:
+                return self._pending_response_events.pop(0)
             # If tool calls exist, emit tool events before finishing/response.completed.
             if isinstance(self.litellm_model_response, ModelResponse):
                 self._queue_final_tool_call_done_events(self.litellm_model_response)
@@ -718,70 +890,79 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 raise StopAsyncIteration
 
     def _ensure_output_item_for_chunk(self, chunk: ModelResponseStream) -> None:
-        # Change: Never return a value, just enqueue output item events
-        if self.sent_output_item_added_event:
+        """Announce the item this chunk's content belongs to, if it is not already open.
+
+        The kind of content in the chunk decides the item, so a change of kind -- reasoning
+        to text, text to a tool call, text again after it -- closes the open item and opens
+        the next one. A chunk carrying no content at all, such as a keep-alive or a usage
+        update, opens nothing.
+        """
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta is None:
             return
-        delta: Final = chunk.choices[0].delta
 
-        self._sequence_number += 1
-        self.sent_output_item_added_event = True
-
-        # Reasoning-first
-        if hasattr(delta, "reasoning_content") and delta.reasoning_content:
-            self._reasoning_active = True
+        if getattr(delta, "reasoning_content", None):
+            if self._open_item is not None and self._open_item.kind == "reasoning":
+                return
+            # A turn may reason more than once, around a tool call or between answers, and each
+            # block is its own item with its own id.
+            item_id = f"rs_{uuid.uuid4()}"
             if self._cached_reasoning_item_id is None:
-                self._cached_reasoning_item_id = f"rs_{uuid.uuid4()}"
-            self._reasoning_item_id = self._cached_reasoning_item_id
-
-            event = OutputItemAddedEvent(
-                type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
-                output_index=0,
-                item=BaseLiteLLMOpenAIResponseObject(
-                    **{
-                        "id": self._cached_reasoning_item_id,
-                        "type": "reasoning",
-                        "status": "in_progress",
-                        "summary": None,
-                    }
-                ),
-            )
-            event.__dict__["sequence_number"] = self._sequence_number
-            self._pending_response_events.append(event)
-            return
-
-        # Tool-first
-        if hasattr(delta, "tool_calls") and delta.tool_calls:
-            # Tool calls already handled via _queue_tool_call_delta_events
-            # DO NOT create message item
-            return
-
-        # Default: message
-        self._cached_item_id = self._cached_item_id or f"msg_{uuid.uuid4()}"
-        event = OutputItemAddedEvent(
-            type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
-            output_index=0,
-            item=BaseLiteLLMOpenAIResponseObject(
-                **{
-                    "id": self._cached_item_id,
-                    "type": "message",
-                    "role": "assistant",
+                self._cached_reasoning_item_id = item_id
+            self._open_output_item(
+                "reasoning",
+                item_id,
+                {
+                    "id": item_id,
+                    "type": "reasoning",
                     "status": "in_progress",
-                    "content": [],
-                }
-            ),
-        )
-        event.__dict__["sequence_number"] = self._sequence_number
-        self._pending_response_events.append(event)
+                    # An empty array, never null: a client whose reasoning item requires a
+                    # summary list drops the whole item when the field is null or absent.
+                    "summary": [],
+                },
+            )
+            self._accumulated_reasoning_content_parts = []
+            return
 
-        # Emit content_part.added immediately after output_item.added for message
-        # items. The OpenAI Responses spec requires this event before any
-        # output_text.delta events so downstream parsers can initialize the
-        # text part structure.
-        if not self.sent_content_part_added_event:
-            self.sent_content_part_added_event = True
-            content_part_event: Final = self.create_content_part_added_event()
-            self._pending_response_events.append(content_part_event)
-        return
+        if getattr(delta, "tool_calls", None):
+            # The tool path announces and closes its own items; it only needs the message
+            # or reasoning item that preceded it closed.
+            self._close_open_output_item()
+            return
+
+        if not self._get_delta_string_from_streaming_choices(chunk.choices):
+            return
+
+        if self._open_item is not None and self._open_item.kind == "message":
+            return
+
+        # The completed response gives its message item the chat-completion id, so the first
+        # streamed message item takes the same one and the two can be reconciled.
+        if self._cached_item_id is None and chunk.id:
+            self._cached_item_id = chunk.id
+        item_id = f"msg_{uuid.uuid4()}" if self._emitted_message_item else self._message_item_id()
+        self._open_output_item(
+            "message",
+            item_id,
+            {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "status": "in_progress",
+                "content": [],
+            },
+        )
+
+    def _handle_reasoning_content_for_chunk(self, chunk: ModelResponseStream) -> None:
+        """Accumulate the open reasoning item's content, and close it when it ends."""
+        if self._open_item is None or self._open_item.kind != "reasoning":
+            return
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta is not None and getattr(delta, "reasoning_content", None):
+            self._accumulated_reasoning_content_parts.append(delta.reasoning_content)
+            return
+        if chunk.choices and self._is_reasoning_end(chunk):
+            self._close_open_output_item()
 
     async def __anext__(
         self,
@@ -805,7 +986,6 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     chunk = await self.litellm_custom_stream_wrapper.__anext__()
                     if chunk is not None:
                         chunk = cast(ModelResponseStream, chunk)
-                        self._ensure_output_item_for_chunk(chunk)
                         # Accumulate provider_specific_fields from chunk and delta
                         for src in (
                             getattr(chunk, "provider_specific_fields", None),
@@ -821,51 +1001,8 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                         self.collected_chat_completion_chunks.append(
                             self._snapshot_chunk_for_stream_chunk_builder(chunk)
                         )
-                        if self._reasoning_active and not self._reasoning_done_emitted:
-                            # Incrementally accumulate reasoning content instead of
-                            # calling stream_chunk_builder on every chunk (O(n²))
-                            delta = chunk.choices[0].delta if chunk.choices else None
-                            if delta and hasattr(delta, "reasoning_content") and delta.reasoning_content:
-                                self._accumulated_reasoning_content_parts.append(delta.reasoning_content)
-                            if self._is_reasoning_end(chunk):
-                                reasoning_content = "".join(self._accumulated_reasoning_content_parts)
-
-                                # Ensure we have a valid reasoning_item_id
-                                reasoning_item_id = (
-                                    self._reasoning_item_id or self._cached_reasoning_item_id or f"rs_{uuid.uuid4()}"
-                                )
-
-                                # Create text.done event first with its own sequence number
-                                self._sequence_number += 1
-                                text_done_event = self.create_reasoning_summary_text_done_event(
-                                    reasoning_item_id=reasoning_item_id,
-                                    reasoning_content=reasoning_content,
-                                    sequence_number=self._sequence_number,
-                                )
-
-                                # Create part.done event second with its own sequence number
-                                self._sequence_number += 1
-                                part_done_event = self.create_reasoning_summary_part_done_event(
-                                    reasoning_item_id=reasoning_item_id,
-                                    reasoning_content=reasoning_content,
-                                    sequence_number=self._sequence_number,
-                                )
-
-                                self._sequence_number += 1
-                                reasoning_output_item_done_event = self.create_reasoning_output_item_done_event(
-                                    reasoning_item_id=reasoning_item_id,
-                                    reasoning_content=reasoning_content,
-                                    sequence_number=self._sequence_number,
-                                )
-                                self._pending_response_events.extend(
-                                    [
-                                        text_done_event,
-                                        part_done_event,
-                                        reasoning_output_item_done_event,
-                                    ]
-                                )
-                                self._reasoning_done_emitted = True
-                                self._reasoning_active = False
+                        self._ensure_output_item_for_chunk(chunk)
+                        self._handle_reasoning_content_for_chunk(chunk)
 
                         response_api_chunk = self._transform_chat_completion_chunk_to_response_api_chunk(chunk)
                         if response_api_chunk:
@@ -903,7 +1040,6 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     return self._pending_tool_events.pop(0)
                 try:
                     chunk = self.litellm_custom_stream_wrapper.__next__()
-                    self._ensure_output_item_for_chunk(chunk)
                     # Accumulate provider_specific_fields from chunk and delta
                     for src in (
                         getattr(chunk, "provider_specific_fields", None),
@@ -922,12 +1058,14 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     self.collected_chat_completion_chunks.append(
                         self._snapshot_chunk_for_stream_chunk_builder(cast(ModelResponseStream, chunk))
                     )
-                    # Emit any just-queued output_item event
-                    if self._pending_response_events:
-                        return self._pending_response_events.pop(0)
+                    self._ensure_output_item_for_chunk(chunk)
+                    self._handle_reasoning_content_for_chunk(chunk)
+
                     response_api_chunk = self._transform_chat_completion_chunk_to_response_api_chunk(chunk)
                     if response_api_chunk:
-                        return response_api_chunk
+                        self._pending_response_events.append(response_api_chunk)
+                    if self._pending_response_events:
+                        return self._pending_response_events.pop(0)
                     # Otherwise, loop to next chunk
                 except StopIteration:
                     return self.common_done_event_logic(sync_mode=True)
@@ -969,7 +1107,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                         event = OutputTextAnnotationAddedEvent(
                             type=ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED,
                             item_id=item_id,
-                            output_index=0,
+                            output_index=self._open_item_index(),
                             content_index=0,
                             annotation_index=idx,
                             annotation=annotation_dict,
@@ -985,19 +1123,29 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
             return ReasoningSummaryTextDeltaEvent(
                 type=ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA,
-                item_id=f"rs_{hash(str(reasoning_content))}",
-                output_index=0,
+                item_id=self._reasoning_item_id(),
+                output_index=self._open_item_index(),
+                summary_index=0,
                 delta=reasoning_content,
             )
 
         # Priority 2: Handle text deltas
         delta_content: Final = self._get_delta_string_from_streaming_choices(chunk.choices)
         if delta_content:
+            if self._open_item is not None and self._open_item.kind == "message":
+                self._open_item.text_parts.append(delta_content)
+            # The delta belongs to the open message item where there is one, so it carries that
+            # item's id rather than the chunk's.
+            delta_item_id: Final = (
+                str(self._open_item.id)
+                if self._open_item is not None and self._open_item.kind == "message"
+                else item_id
+            )
             self._sequence_number += 1
             text_delta_event: Final = OutputTextDeltaEvent(
                 type=ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA,
-                item_id=item_id,
-                output_index=0,
+                item_id=delta_item_id,
+                output_index=self._open_item_index(),
                 content_index=0,
                 delta=delta_content,
             )
@@ -1054,6 +1202,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     request_input=self.request_input,
                     chat_completion_response=litellm_model_response,
                     responses_api_request=self.responses_api_request,
+                    reasoning_item_id=self._cached_reasoning_item_id,
                 )
             )
 

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -1,7 +1,7 @@
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Final, Literal, cast
+from typing import Any, Final, Literal, TypeAlias, cast
 
 import litellm
 from litellm.main import stream_chunk_builder
@@ -47,6 +47,9 @@ from litellm.types.utils import (
     StreamingChoices,
     TextCompletionResponse,
 )
+
+# An item the stream closed, paired with the output_index it was announced at.
+_StreamedItem: TypeAlias = tuple[int, "BaseLiteLLMOpenAIResponseObject"]
 
 
 @dataclass(slots=True)
@@ -104,6 +107,9 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         # message and tool call alike.
         self._next_output_index: int = 0
         self._open_item: _OpenOutputItem | None = None
+        # The items whose done events the stream emitted, in order. response.completed
+        # is built from these so the final output is exactly what was streamed.
+        self._streamed_items: list[_StreamedItem] = []  # mutable-ok: appended as each item closes
         self._emitted_message_item: bool = False
         self._final_tool_events_queued: bool = False
         self._sequence_number: int = 0
@@ -258,6 +264,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 }
             ),
         )
+        self._streamed_items.append((item.index, item_done.item))
         self._pending_response_events.extend((text_done, part_done, item_done))
 
     def _queue_reasoning_done_events(self, item: _OpenOutputItem) -> None:
@@ -286,6 +293,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             sequence_number=self._sequence_number,
             output_index=item.index,
         )
+        self._streamed_items.append((item.index, item_done_event.item))
         self._pending_response_events.extend((text_done_event, part_done_event, item_done_event))
 
     def _normalize_tool_call_index(self, tool_call: object) -> int | None:
@@ -481,6 +489,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 sequence_number=self._sequence_number,
                 item=BaseLiteLLMOpenAIResponseObject(**item_kwargs),
             )
+            self._streamed_items.append((output_index, item_done_event.item))
             self._pending_tool_events.append(item_done_event)
 
     def _default_response_created_event_data(self) -> dict:
@@ -838,7 +847,8 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             return self.create_output_content_part_done_event(litellm_complete_object)
         if self.sent_output_item_done_event is False:
             self.sent_output_item_done_event = True
-            event = self.create_output_item_done_event(litellm_complete_object)
+            event: Final = self.create_output_item_done_event(litellm_complete_object)
+            self._streamed_items.append((event.output_index, event.item))
             self._open_item = None
             return event
         return None
@@ -1196,6 +1206,17 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     reasoning_item_id=self._cached_reasoning_item_id,
                 )
             )
+
+            # The completed response lists exactly the items the stream announced and closed,
+            # in that order. Rebuilding it from the merged chat completion instead would give
+            # one item per content kind, which disagrees with the stream whenever a turn's
+            # content kinds repeat or interleave.
+            # Ordered by output_index rather than by close time: a tool item is announced
+            # mid-stream but closed at the end, so close order is not the turn's order.
+            if self._streamed_items:
+                responses_api_response.output = [
+                    item for _, item in sorted(self._streamed_items, key=lambda pair: pair[0])
+                ]
 
             # Use the cached response ID to ensure consistency across all events
             if self._cached_response_id:

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2,6 +2,7 @@
 Handles transforming from Responses API -> LiteLLM completion  (Chat Completion API)
 """
 
+import hashlib
 import json
 import re
 from collections.abc import Iterator, Mapping, Sequence
@@ -1653,9 +1654,13 @@ class LiteLLMCompletionResponsesConfig:
         request_input: str | ResponseInputParam,
         responses_api_request: ResponsesAPIOptionalRequestParams,
         chat_completion_response: ModelResponse | dict,
+        reasoning_item_id: str | None = None,
     ) -> ResponsesAPIResponse:
         """
         Transform a Chat Completion response into a Responses API response
+
+        ``reasoning_item_id`` is the id a streamed reasoning item was already announced with;
+        passing it keeps the item in this response and the item in the stream the same item.
         """
         if isinstance(chat_completion_response, dict):
             chat_completion_response = ModelResponse(**chat_completion_response)
@@ -1678,6 +1683,7 @@ class LiteLLMCompletionResponsesConfig:
                 chat_completion_response=chat_completion_response,
                 choices=getattr(chat_completion_response, "choices", []),
                 responses_api_request=responses_api_request,
+                reasoning_item_id=reasoning_item_id,
             ),
             parallel_tool_calls=getattr(chat_completion_response, "parallel_tool_calls", False),
             temperature=getattr(chat_completion_response, "temperature", 0),
@@ -1711,6 +1717,7 @@ class LiteLLMCompletionResponsesConfig:
         chat_completion_response: ModelResponse,
         choices: list[Choices],
         responses_api_request: ResponsesAPIOptionalRequestParams | None = None,
+        reasoning_item_id: str | None = None,
     ) -> list[
         GenericResponseOutputItem
         | OutputCodeInterpreterCall
@@ -1729,7 +1736,9 @@ class LiteLLMCompletionResponsesConfig:
         ] = []
 
         responses_output.extend(
-            LiteLLMCompletionResponsesConfig._extract_reasoning_output_items(chat_completion_response, choices)
+            LiteLLMCompletionResponsesConfig._extract_reasoning_output_items(
+                chat_completion_response, choices, reasoning_item_id
+            )
         )
         responses_output.extend(
             LiteLLMCompletionResponsesConfig._extract_message_output_items(chat_completion_response, choices)
@@ -1797,6 +1806,7 @@ class LiteLLMCompletionResponsesConfig:
     def _extract_reasoning_output_items(
         chat_completion_response: ModelResponse,
         choices: list[Choices],
+        reasoning_item_id: str | None = None,
     ) -> list[GenericResponseOutputItem]:
         for choice in choices:
             if hasattr(choice, "message") and choice.message:
@@ -1806,7 +1816,8 @@ class LiteLLMCompletionResponsesConfig:
                     return [
                         GenericResponseOutputItem(
                             type="reasoning",
-                            id=f"rs_{hash(str(message.reasoning_content))}",
+                            id=reasoning_item_id
+                            or LiteLLMCompletionResponsesConfig._reasoning_item_id(message.reasoning_content),
                             status=LiteLLMCompletionResponsesConfig._map_chat_completion_finish_reason_to_responses_status(
                                 choice.finish_reason
                             ),
@@ -1821,6 +1832,15 @@ class LiteLLMCompletionResponsesConfig:
                         )
                     ]
         return []
+
+    @staticmethod
+    def _reasoning_item_id(reasoning_content: str | None) -> str:
+        """Derive a reasoning item's id from its content.
+
+        A digest rather than ``hash()``: the value goes on the wire, and ``hash()`` for str is
+        randomised per process, so the same content yields a different id on every worker.
+        """
+        return f"rs_{hashlib.sha256(str(reasoning_content).encode()).hexdigest()[:32]}"
 
     @staticmethod
     def _extract_image_generation_output_items(
@@ -1931,7 +1951,10 @@ class LiteLLMCompletionResponsesConfig:
                     choice=choice,
                 )
                 message_output_items.extend(image_generation_items)
-            else:
+            # A turn that produced no assistant text has no message item. Emitting one anyway
+            # puts an item in the final output that was never streamed, which a client that
+            # reconciles the two reads as an item it missed.
+            elif choice.message.content:
                 # Regular message output
                 message_output_items.append(
                     GenericResponseOutputItem(

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1441,6 +1441,9 @@ class ResponsePartAddedEvent(BaseLiteLLMOpenAIResponseObject):
     type: Literal[ResponsesAPIStreamEvents.RESPONSE_PART_ADDED]
     item_id: str
     output_index: int
+    # A client attributes the part to a summary by this index, as it does for the matching
+    # done event, and discards a part.added without one.
+    summary_index: int = 0
     part: dict
 
 

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2612,23 +2612,20 @@ class TestEnsureOutputItemContentPartAdded:
 
     def _make_iterator(self):
         """Create a minimal LiteLLMCompletionStreamingIterator for testing."""
-        from unittest.mock import MagicMock
+        from unittest.mock import Mock
 
         from litellm.responses.litellm_completion_transformation.streaming_iterator import (
             LiteLLMCompletionStreamingIterator,
         )
 
-        iterator = LiteLLMCompletionStreamingIterator.__new__(
-            LiteLLMCompletionStreamingIterator
+        mock_stream_wrapper = Mock()
+        mock_stream_wrapper.logging_obj = Mock()
+        return LiteLLMCompletionStreamingIterator(
+            model="test-model",
+            litellm_custom_stream_wrapper=mock_stream_wrapper,
+            request_input="test input",
+            responses_api_request={},
         )
-        iterator.sent_output_item_added_event = False
-        iterator.sent_content_part_added_event = False
-        iterator._sequence_number = 0
-        iterator._cached_item_id = None
-        iterator._cached_reasoning_item_id = None
-        iterator._reasoning_active = False
-        iterator._pending_response_events = []
-        return iterator
 
     def _make_text_chunk(self):
         """Create a mock ModelResponseStream with a text delta."""
@@ -2707,7 +2704,7 @@ class TestEnsureOutputItemContentPartAdded:
                 Choices(
                     finish_reason="content_filter",
                     index=0,
-                    message=Message(content="", role="assistant"),
+                    message=Message(content="partial answer", role="assistant"),
                 )
             ],
             usage=Usage(prompt_tokens=10, completion_tokens=1, total_tokens=11),
@@ -2722,8 +2719,11 @@ class TestEnsureOutputItemContentPartAdded:
         assert completed_event.response.output[0].status == "incomplete"
 
     def test_reasoning_item_does_not_emit_content_part_added(self):
-        """Reasoning items should not get a content_part.added event."""
-        from litellm.types.llms.openai import OutputItemAddedEvent
+        """Reasoning items get a summary part, not a message content part."""
+        from litellm.types.llms.openai import (
+            OutputItemAddedEvent,
+            ResponsePartAddedEvent,
+        )
 
         iterator = self._make_iterator()
         chunk = self._make_reasoning_chunk()
@@ -2731,8 +2731,10 @@ class TestEnsureOutputItemContentPartAdded:
         iterator._ensure_output_item_for_chunk(chunk)
 
         events = iterator._pending_response_events
-        assert len(events) == 1
-        assert isinstance(events[0], OutputItemAddedEvent)
+        assert [type(event) for event in events] == [
+            OutputItemAddedEvent,
+            ResponsePartAddedEvent,
+        ]
         assert iterator.sent_content_part_added_event is False
 
     def test_only_emits_once(self):

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_item_lifecycle.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_item_lifecycle.py
@@ -183,8 +183,9 @@ def analyse(events: Sequence[BaseLiteLLMOpenAIResponseObject]) -> Lifecycle:
         if name == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value:
             added_indexes.append(output_index)
             open_items[output_index] = getattr(event.item, "id", None)
-            if getattr(event.item, "type", None) == "reasoning" and not isinstance(
-                getattr(event.item, "summary", None), list
+            summary = getattr(event.item, "summary", None)
+            if getattr(event.item, "type", None) == "reasoning" and (
+                not isinstance(summary, Sequence) or isinstance(summary, (str, bytes))
             ):
                 missing_fields.append(
                     "a reasoning output_item.added carries no summary array, so the item fails to deserialise"
@@ -501,5 +502,3 @@ async def test_completed_response_holds_no_item_the_stream_never_announced(drive
     completed = [event for event in events if event_type(event) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value]
     assert len(completed) == 1
     assert [str(item.type) for item in completed[0].response.output] == ["function_call"]
-
-

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_item_lifecycle.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_item_lifecycle.py
@@ -158,6 +158,7 @@ class Lifecycle(NamedTuple):
     id_mismatches: list[str]
     unclosed: list[int]
     missing_fields: list[str]
+    unreconciled: list[str]
 
 
 def event_type(event: BaseLiteLLMOpenAIResponseObject) -> str:
@@ -172,6 +173,8 @@ def analyse(events: Sequence[BaseLiteLLMOpenAIResponseObject]) -> Lifecycle:
     orphans: list[str] = []
     id_mismatches: list[str] = []
     missing_fields: list[str] = []
+    announced_ids: list[str] = []
+    completed_ids: list[str] = []
 
     for event in events:
         name = event_type(event)
@@ -183,6 +186,7 @@ def analyse(events: Sequence[BaseLiteLLMOpenAIResponseObject]) -> Lifecycle:
         if name == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value:
             added_indexes.append(output_index)
             open_items[output_index] = getattr(event.item, "id", None)
+            announced_ids.append(str(getattr(event.item, "id", None)))
             summary = getattr(event.item, "summary", None)
             if getattr(event.item, "type", None) == "reasoning" and (
                 not isinstance(summary, Sequence) or isinstance(summary, (str, bytes))
@@ -191,6 +195,9 @@ def analyse(events: Sequence[BaseLiteLLMOpenAIResponseObject]) -> Lifecycle:
                     "a reasoning output_item.added carries no summary array, so the item fails to deserialise"
                 )
             continue
+
+        if name == ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value:
+            completed_ids.extend(str(getattr(item, "id", None)) for item in event.response.output)
 
         if name == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE.value:
             done_indexes.append(output_index)
@@ -211,6 +218,10 @@ def analyse(events: Sequence[BaseLiteLLMOpenAIResponseObject]) -> Lifecycle:
                 f"but output_index {output_index} was announced as {open_items[output_index]!r}"
             )
 
+    unreconciled: list[str] = []
+    if completed_ids and completed_ids != announced_ids:
+        unreconciled.append(f"response.completed lists {completed_ids} but the stream announced {announced_ids}")
+
     return Lifecycle(
         added_indexes=added_indexes,
         done_indexes=done_indexes,
@@ -218,6 +229,7 @@ def analyse(events: Sequence[BaseLiteLLMOpenAIResponseObject]) -> Lifecycle:
         id_mismatches=id_mismatches,
         unclosed=sorted(open_items),
         missing_fields=missing_fields,
+        unreconciled=unreconciled,
     )
 
 
@@ -227,6 +239,7 @@ def assert_well_formed(events: Sequence[BaseLiteLLMOpenAIResponseObject], expect
     assert lifecycle.id_mismatches == []
     assert lifecycle.unclosed == []
     assert lifecycle.missing_fields == []
+    assert lifecycle.unreconciled == []
     assert sorted(lifecycle.added_indexes) == list(range(expected_items))
     assert sorted(lifecycle.done_indexes) == list(range(expected_items))
 

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_item_lifecycle.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_item_lifecycle.py
@@ -1,0 +1,505 @@
+"""Tests for the streamed output-item lifecycle of the Responses API completion bridge.
+
+A Responses client builds its item list from the event stream: an item exists only once
+``response.output_item.added`` has announced it, every content event must arrive inside that
+item's ``added``..``done`` window, and it must carry that item's id. A client that trusts the
+protocol therefore drops -- or fails on -- content that belongs to an item it was never told
+about, or that names an id it has never seen.
+
+These tests drive the iterator over synthetic chat-completion chunks, once through the async
+implementation and once through the sync one, and assert those invariants for the six content
+shapes real providers produce.
+"""
+
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any, NamedTuple
+
+import pytest
+
+from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+    LiteLLMCompletionStreamingIterator,
+)
+from litellm.types.llms.openai import (
+    BaseLiteLLMOpenAIResponseObject,
+    ResponsesAPIStreamEvents,
+)
+from litellm.types.utils import (
+    Delta,
+    ModelResponseStream,
+    StreamingChoices,
+)
+
+ITEM_SCOPED_PREFIXES = (
+    "response.output_text",
+    "response.content_part",
+    "response.reasoning_summary",
+    "response.function_call_arguments",
+)
+
+MAX_EVENTS = 500
+
+Events = list[BaseLiteLLMOpenAIResponseObject]
+Driver = Callable[[list[ModelResponseStream]], Events | Awaitable[Events]]
+
+
+def chunk(
+    *,
+    text: str | None = None,
+    reasoning: str | None = None,
+    thinking_blocks: list[dict[str, Any]] | None = None,
+    tool: dict[str, Any] | None = None,
+    finish_reason: str | None = None,
+    chunk_id: str = "chatcmpl-lifecycle",
+) -> ModelResponseStream:
+    """One chat-completion chunk carrying at most one kind of content."""
+    delta = Delta(
+        content=text,
+        reasoning_content=reasoning,
+        tool_calls=[tool] if tool is not None else None,
+    )
+    if thinking_blocks is not None:
+        delta.thinking_blocks = thinking_blocks
+    return ModelResponseStream(
+        id=chunk_id,
+        created=1700000000,
+        model="test-model",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=delta,
+                finish_reason=finish_reason,
+            )
+        ],
+    )
+
+
+def tool_call(
+    call_id: str = "call_lifecycle_1",
+    name: str = "get_weather",
+    arguments: str = '{"city":"Paris"}',
+) -> dict[str, Any]:
+    return {
+        "index": 0,
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+class FakeStream:
+    """Stands in for ``CustomStreamWrapper``, supporting sync and async iteration."""
+
+    logging_obj = None
+
+    def __init__(self, chunks: Sequence[ModelResponseStream]) -> None:
+        self._chunks = list(chunks)
+
+    def __aiter__(self) -> "FakeStream":
+        return self
+
+    async def __anext__(self) -> ModelResponseStream:
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+    def __iter__(self) -> "FakeStream":
+        return self
+
+    def __next__(self) -> ModelResponseStream:
+        if not self._chunks:
+            raise StopIteration
+        return self._chunks.pop(0)
+
+
+def build_iterator(chunks: Sequence[ModelResponseStream]) -> LiteLLMCompletionStreamingIterator:
+    return LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=FakeStream(chunks),  # pyright: ignore[reportArgumentType]  # test double
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+
+async def collect_async(chunks: list[ModelResponseStream]) -> Events:
+    """Drive ``__anext__`` to exhaustion and return every event it emitted."""
+    iterator = build_iterator(chunks)
+    events: Events = []
+    while len(events) < MAX_EVENTS:
+        try:
+            events.append(await iterator.__anext__())
+        except StopAsyncIteration:
+            return events
+    raise AssertionError(f"the async iterator emitted more than {MAX_EVENTS} events without finishing")
+
+
+def collect_sync(chunks: list[ModelResponseStream]) -> Events:
+    """Drive ``__next__`` to exhaustion and return every event it emitted."""
+    iterator = build_iterator(chunks)
+    events: Events = []
+    while len(events) < MAX_EVENTS:
+        try:
+            events.append(iterator.__next__())
+        except StopIteration:
+            return events
+    raise AssertionError(f"the sync iterator emitted more than {MAX_EVENTS} events without finishing")
+
+
+async def collect(driver: Driver, chunks: list[ModelResponseStream]) -> Events:
+    result = driver(chunks)
+    return await result if inspect.isawaitable(result) else result
+
+
+class Lifecycle(NamedTuple):
+    added_indexes: list[int]
+    done_indexes: list[int]
+    orphans: list[str]
+    id_mismatches: list[str]
+    unclosed: list[int]
+    missing_fields: list[str]
+
+
+def event_type(event: BaseLiteLLMOpenAIResponseObject) -> str:
+    return str(getattr(event.type, "value", event.type))
+
+
+def analyse(events: Sequence[BaseLiteLLMOpenAIResponseObject]) -> Lifecycle:
+    """Replay the stream the way a client does and report where it breaks its own contract."""
+    open_items: dict[int, str | None] = {}
+    added_indexes: list[int] = []
+    done_indexes: list[int] = []
+    orphans: list[str] = []
+    id_mismatches: list[str] = []
+    missing_fields: list[str] = []
+
+    for event in events:
+        name = event_type(event)
+        output_index = getattr(event, "output_index", None)
+
+        if name.startswith("response.reasoning_summary") and not hasattr(event, "summary_index"):
+            missing_fields.append(f"{name} carries no summary_index, so a client discards it")
+
+        if name == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value:
+            added_indexes.append(output_index)
+            open_items[output_index] = getattr(event.item, "id", None)
+            if getattr(event.item, "type", None) == "reasoning" and not isinstance(
+                getattr(event.item, "summary", None), list
+            ):
+                missing_fields.append(
+                    "a reasoning output_item.added carries no summary array, so the item fails to deserialise"
+                )
+            continue
+
+        if name == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE.value:
+            done_indexes.append(output_index)
+            open_items.pop(output_index, None)
+            continue
+
+        if not name.startswith(ITEM_SCOPED_PREFIXES):
+            continue
+
+        if output_index not in open_items:
+            orphans.append(f"{name} at output_index {output_index}, which no open item holds")
+            continue
+
+        item_id = getattr(event, "item_id", None)
+        if item_id is not None and item_id != open_items[output_index]:
+            id_mismatches.append(
+                f"{name} carries item_id {item_id!r}, "
+                f"but output_index {output_index} was announced as {open_items[output_index]!r}"
+            )
+
+    return Lifecycle(
+        added_indexes=added_indexes,
+        done_indexes=done_indexes,
+        orphans=orphans,
+        id_mismatches=id_mismatches,
+        unclosed=sorted(open_items),
+        missing_fields=missing_fields,
+    )
+
+
+def assert_well_formed(events: Sequence[BaseLiteLLMOpenAIResponseObject], expected_items: int) -> None:
+    lifecycle = analyse(events)
+    assert lifecycle.orphans == []
+    assert lifecycle.id_mismatches == []
+    assert lifecycle.unclosed == []
+    assert lifecycle.missing_fields == []
+    assert sorted(lifecycle.added_indexes) == list(range(expected_items))
+    assert sorted(lifecycle.done_indexes) == list(range(expected_items))
+
+
+def assert_reasoning_events_address_the_reasoning_item(
+    events: Sequence[BaseLiteLLMOpenAIResponseObject],
+) -> None:
+    announced = {
+        event.item.id
+        for event in events
+        if event_type(event) == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value
+        and getattr(event.item, "type", None) == "reasoning"
+    }
+    streamed = {
+        getattr(event, "item_id", None)
+        for event in events
+        if event_type(event).startswith("response.reasoning_summary")
+    }
+    assert len(announced) == 1
+    assert streamed == announced
+
+
+def text_only() -> list[ModelResponseStream]:
+    return [
+        chunk(text="Hel"),
+        chunk(text="lo, "),
+        chunk(text="world"),
+        chunk(finish_reason="stop"),
+    ]
+
+
+def text_then_tool() -> list[ModelResponseStream]:
+    return [
+        chunk(text="Let me "),
+        chunk(text="check."),
+        chunk(tool=tool_call()),
+        chunk(finish_reason="tool_calls"),
+    ]
+
+
+def reasoning_then_text() -> list[ModelResponseStream]:
+    return [
+        chunk(reasoning="The user "),
+        chunk(reasoning="wants a "),
+        chunk(reasoning="greeting."),
+        chunk(text="Hel"),
+        chunk(text="lo, "),
+        chunk(text="world"),
+        chunk(finish_reason="stop"),
+    ]
+
+
+def reasoning_then_text_then_tool() -> list[ModelResponseStream]:
+    return [
+        chunk(reasoning="The user "),
+        chunk(reasoning="wants the "),
+        chunk(reasoning="weather."),
+        chunk(text="Let me "),
+        chunk(text="check."),
+        chunk(tool=tool_call()),
+        chunk(finish_reason="tool_calls"),
+    ]
+
+
+def text_then_reasoning() -> list[ModelResponseStream]:
+    return [
+        chunk(text="Hel"),
+        chunk(text="lo, world"),
+        chunk(reasoning="That "),
+        chunk(reasoning="was "),
+        chunk(reasoning="easy."),
+        chunk(finish_reason="stop"),
+    ]
+
+
+def tool_only() -> list[ModelResponseStream]:
+    return [
+        chunk(tool=tool_call()),
+        chunk(finish_reason="tool_calls"),
+    ]
+
+
+def text_tool_text() -> list[ModelResponseStream]:
+    return [
+        chunk(text="Let me check."),
+        chunk(tool=tool_call()),
+        chunk(text="It is "),
+        chunk(text="sunny."),
+        chunk(finish_reason="stop"),
+    ]
+
+
+def text_then_reasoning_then_text() -> list[ModelResponseStream]:
+    return [
+        chunk(text="Let me check."),
+        chunk(reasoning="The tool "),
+        chunk(reasoning="said sunny."),
+        chunk(text="It is sunny."),
+        chunk(finish_reason="stop"),
+    ]
+
+
+def reasoning_text_tool_reasoning() -> list[ModelResponseStream]:
+    return [
+        chunk(reasoning="I need the "),
+        chunk(reasoning="weather."),
+        chunk(text="Let me check."),
+        chunk(tool=tool_call()),
+        chunk(reasoning="Now I can "),
+        chunk(reasoning="answer."),
+        chunk(finish_reason="stop"),
+    ]
+
+
+drivers = pytest.mark.parametrize("driver", [collect_async, collect_sync], ids=["async", "sync"])
+
+
+@drivers
+async def test_text_only_announces_one_message_item(driver: Driver) -> None:
+    """Plain text is one message item, and its deltas belong to it."""
+    assert_well_formed(await collect(driver, text_only()), expected_items=1)
+
+
+@drivers
+async def test_text_then_tool_announces_a_message_and_a_function_call(driver: Driver) -> None:
+    """Text followed by a tool call is two items, each with its own output_index."""
+    assert_well_formed(await collect(driver, text_then_tool()), expected_items=2)
+
+
+@drivers
+async def test_reasoning_then_text_announces_a_reasoning_item_and_a_message(driver: Driver) -> None:
+    """Reasoning followed by text is two items; the text may not be delivered inside the
+    reasoning item's window, nor after it has closed with no message announced."""
+    events = await collect(driver, reasoning_then_text())
+    assert_well_formed(events, expected_items=2)
+    assert_reasoning_events_address_the_reasoning_item(events)
+
+
+@drivers
+async def test_reasoning_then_text_then_tool_announces_all_three_items(driver: Driver) -> None:
+    """The full assistant turn -- reasoning, then text, then a tool call -- is three items."""
+    events = await collect(driver, reasoning_then_text_then_tool())
+    assert_well_formed(events, expected_items=3)
+    assert_reasoning_events_address_the_reasoning_item(events)
+
+
+@drivers
+async def test_text_then_reasoning_announces_a_message_and_a_reasoning_item(driver: Driver) -> None:
+    """Some providers stream text before reasoning; the reasoning still needs its own item
+    rather than being delivered inside the message's window."""
+    events = await collect(driver, text_then_reasoning())
+    assert_well_formed(events, expected_items=2)
+    assert_reasoning_events_address_the_reasoning_item(events)
+
+
+@drivers
+async def test_text_tool_text_announces_a_second_message_item(driver: Driver) -> None:
+    """Text resuming after a tool call is a new message item, not a continuation of the first."""
+    assert_well_formed(await collect(driver, text_tool_text()), expected_items=3)
+
+
+@drivers
+async def test_tool_only_turn_emits_no_message_done_events(driver: Driver) -> None:
+    """A turn whose only content is a tool call has no message item, so the message's done
+    events must not be emitted: they would describe an item the client was never told about."""
+    events = await collect(driver, tool_only())
+    assert_well_formed(events, expected_items=1)
+    emitted = {event_type(event) for event in events}
+    assert ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE.value not in emitted
+    assert ResponsesAPIStreamEvents.CONTENT_PART_DONE.value not in emitted
+    assert ResponsesAPIStreamEvents.CONTENT_PART_ADDED.value not in emitted
+
+
+@drivers
+async def test_text_then_reasoning_then_text_announces_three_items(driver: Driver) -> None:
+    """Reasoning between two answers closes the first message item and opens a second."""
+    events = await collect(driver, text_then_reasoning_then_text())
+    assert_well_formed(events, expected_items=3)
+
+
+@drivers
+async def test_two_reasoning_blocks_in_one_turn_are_two_items(driver: Driver) -> None:
+    """A turn that reasons again after a tool call gets a second reasoning item, with its own
+    id -- reusing the first item's id would merge two blocks into one for the client."""
+    events = await collect(driver, reasoning_text_tool_reasoning())
+    assert_well_formed(events, expected_items=4)
+    reasoning_ids = [
+        str(event.item.id)
+        for event in events
+        if event_type(event) == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value
+        and getattr(event.item, "type", None) == "reasoning"
+    ]
+    assert len(reasoning_ids) == 2
+    assert len(set(reasoning_ids)) == 2
+
+
+@drivers
+async def test_reasoning_summary_part_added_precedes_its_deltas(driver: Driver) -> None:
+    """A client opens its summary part on part.added and drops any delta that arrives first."""
+    events = await collect(driver, reasoning_then_text())
+    names = [event_type(event) for event in events]
+    part_added = names.index("response.reasoning_summary_part.added")
+    first_delta = names.index(ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA.value)
+    assert part_added < first_delta
+
+    reasoning_id = announced_item_ids_by_type(events)["reasoning"]
+    assert events[part_added].item_id == reasoning_id
+    assert events[part_added].summary_index == events[first_delta].summary_index
+
+
+@drivers
+async def test_message_content_part_is_a_text_part(driver: Driver) -> None:
+    """The message item's content part describes the message's own text. A reasoning part here
+    describes an item this one is not, and overwrites the answer with the thinking."""
+    events = await collect(driver, reasoning_then_text())
+    parts = [
+        event.part
+        for event in events
+        if event_type(event)
+        in (
+            ResponsesAPIStreamEvents.CONTENT_PART_ADDED.value,
+            ResponsesAPIStreamEvents.CONTENT_PART_DONE.value,
+        )
+    ]
+    assert parts
+    assert {getattr(part, "type", None) for part in parts} == {"output_text"}
+
+
+def announced_item_ids_by_type(events: Sequence[BaseLiteLLMOpenAIResponseObject]) -> dict[str, str]:
+    return {
+        str(getattr(event.item, "type", None)): str(getattr(event.item, "id", None))
+        for event in events
+        if event_type(event) == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value
+    }
+
+
+def completed_item_ids_by_type(events: Sequence[BaseLiteLLMOpenAIResponseObject]) -> dict[str, str]:
+    completed = [event for event in events if event_type(event) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value]
+    assert len(completed) == 1
+    return {str(item.type): str(item.id) for item in completed[0].response.output}
+
+
+@drivers
+async def test_completed_response_carries_the_ids_the_stream_announced(driver: Driver) -> None:
+    """A client reconciles the items it built from the stream against the completed response by
+    id, so an item must not be renamed between the two."""
+    events = await collect(driver, reasoning_then_text())
+    announced = announced_item_ids_by_type(events)
+    completed = completed_item_ids_by_type(events)
+    assert completed["reasoning"] == announced["reasoning"]
+    assert completed["message"] == announced["message"]
+
+
+@drivers
+async def test_reasoning_item_ids_are_minted_per_turn_not_derived_from_content(driver: Driver) -> None:
+    """Two turns that reason identically are still two different items. Deriving the id from the
+    content also made it depend on hash randomisation, so it differed across workers."""
+    first = announced_item_ids_by_type(await collect(driver, reasoning_then_text()))
+    second = announced_item_ids_by_type(await collect(driver, reasoning_then_text()))
+    assert first["reasoning"] != second["reasoning"]
+
+
+@drivers
+async def test_completed_response_holds_no_item_the_stream_never_announced(driver: Driver) -> None:
+    """A turn that produced no assistant text has no message item. Putting an empty one in the
+    completed response gives a reconciling client an item it never saw announced, which reads as
+    an item it missed rather than one that does not exist."""
+    chunks = [
+        chunk(tool=tool_call(call_id="call_no_message_item")),
+        chunk(finish_reason="tool_calls"),
+    ]
+    events = await collect(driver, chunks)
+    completed = [event for event in events if event_type(event) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value]
+    assert len(completed) == 1
+    assert [str(item.type) for item in completed[0].response.output] == ["function_call"]
+
+

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
@@ -58,14 +58,14 @@ def test_tool_call_delta_is_emitted_as_responses_events():
     evt1 = iterator._transform_chat_completion_chunk_to_response_api_chunk(chunk)
     assert evt1 is not None
     assert evt1.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
-    assert evt1.output_index == 1
+    assert evt1.output_index == 0
 
     # The arguments are now chunked, so we get the first delta chunk
     evt2 = iterator._transform_chat_completion_chunk_to_response_api_chunk(chunk)
     assert evt2 is not None
     assert evt2.type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA
     assert evt2.item_id == "call_1"
-    assert evt2.output_index == 1
+    assert evt2.output_index == 0
     # The delta will be a chunk of the arguments, not the full arguments
     assert len(evt2.delta) <= 10  # Chunks are max 10 characters
 
@@ -106,10 +106,11 @@ def test_tool_calls_present_only_in_final_response_are_emitted_before_completed(
     )
     iterator.litellm_model_response = response
 
-    # First common_done_event_logic call should yield tool events, not response.completed.
+    # The turn has no message content, so the tool call is the turn's only item and holds
+    # output_index 0.
     evt1 = iterator.common_done_event_logic(sync_mode=True)
     assert evt1.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
-    assert evt1.output_index == 1
+    assert evt1.output_index == 0
 
     # Now delta events are emitted (arguments split into chunks)
     # Collect all delta events
@@ -130,12 +131,12 @@ def test_tool_calls_present_only_in_final_response_are_emitted_before_completed(
     # The last event should be FUNCTION_CALL_ARGUMENTS_DONE
     assert evt.type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DONE
     assert evt.item_id == "call_2"
-    assert evt.output_index == 1
+    assert evt.output_index == 0
     assert evt.arguments == '{"y":2}'
 
     evt_final = iterator.common_done_event_logic(sync_mode=True)
     assert evt_final.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE
-    assert evt_final.output_index == 1
+    assert evt_final.output_index == 0
 
 
 def test_tool_call_arguments_are_chunked_to_match_openai_behavior():
@@ -190,7 +191,7 @@ def test_tool_call_arguments_are_chunked_to_match_openai_behavior():
     # First event should be OUTPUT_ITEM_ADDED
     assert evt is not None
     assert evt.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
-    assert evt.output_index == 1
+    assert evt.output_index == 0
     assert hasattr(evt, "__dict__") and "sequence_number" in evt.__dict__
 
     # Collect all remaining delta events from the pending queue by creating empty chunks
@@ -224,7 +225,7 @@ def test_tool_call_arguments_are_chunked_to_match_openai_behavior():
     for evt in delta_events:
         assert len(evt.delta) <= 10
         assert evt.item_id == "call_test"
-        assert evt.output_index == 1
+        assert evt.output_index == 0
         assert hasattr(evt, "__dict__") and "sequence_number" in evt.__dict__
 
     # Verify all deltas concatenated equal the original arguments


### PR DESCRIPTION
## TLDR

Problem this solves:

- Content events arrive belonging to no announced item
- `output_index` names several items at once
- Reasoning item ids differ on every delta

How it solves it:

- Drive the item lifecycle from the content kind in the stream
- One monotonic `output_index` across all item kinds
- Mint each item's id once and reuse it everywhere

## User Flow

Before: a developer streaming a Responses turn cannot reliably rebuild the assistant's output from the events, and what breaks depends on the provider

1. They send POST https://litellm-domain/v1/responses with `"stream": true`, a tool defined, and a prompt that makes the model reason, answer, then call the tool
2. They build their item list from the stream, creating each item when `response.output_item.added` announces it and attaching content events to the item that is open
3. `response.completed` arrives listing an item whose id never appeared in any `output_item.added`, so their list and the final response disagree about what the turn produced
4. On a Gemini model it is worse: nine content events arrive while no item is open at all, so a strict client drops them or aborts the turn, and the stream closes more items than it opened
5. Nothing in the response reports any of this, so the loss is silent until a client that validates the protocol rejects the turn

After: the stream is well formed on its own terms, for every provider

1. They send the same streaming request
2. Every content event arrives between its item's `added` and `done`, carrying that item's id
3. Every id in `response.completed` is one the stream announced
4. `output_index` counts once across reasoning, message and tool-call items, and `response.completed` lists those same items in that order
5. A turn that streams no assistant text reports no message item, rather than an empty one the stream never announced

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Two proxies built from source, identical but for this change, streaming a reasoning-then-answer-then-tool turn against live Bedrock Converse, Vertex Anthropic and Vertex Gemini models. Before is `litellm_internal_staging` at `f6b9518ddb`, after is that commit plus this change at `0c601d8b82`. Each run replays the event stream the way a client does and reports whether it is well formed: how many items were announced and closed, how many `response.completed` lists, how many content events arrived while no item was open, and whether the completed response reconciles with the stream, checked in both directions and for order

```bash
for m in claude-4-5-sonnet claude-5-sonnet vertex-claude-5-sonnet gemini-3-1-pro; do
  curl -sN http://localhost:PORT/v1/responses \
    -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d "{\"model\":\"$m\",\"stream\":true,\"tools\":[...],
         \"reasoning\":{\"effort\":\"high\",\"summary\":\"auto\"},
         \"input\":\"<reasoning prompt>, then call get_weather for Paris.\"}" \
  | <replay the events and report the four columns below>
done
```

Before, at `f6b9518ddb`:

```
MODEL                    ADDED/DONE  FINAL  ORPHANS  RECONCILED
claude-4-5-sonnet        2/2         2      0        NO (1 unannounced, 1 missing, order differs)
claude-5-sonnet          2/2         2      0        NO (1 unannounced, 1 missing, order differs)
vertex-claude-5-sonnet   2/2         2      0        NO (1 unannounced, 1 missing, order differs)
gemini-3-1-pro           2/3         3      9        NO (2 unannounced, 1 missing, order differs)
```

After, at `0c601d8b82`:

```
MODEL                    ADDED/DONE  FINAL  ORPHANS  RECONCILED
claude-4-5-sonnet        2/2         2      0        yes
claude-5-sonnet          2/2         2      0        yes
vertex-claude-5-sonnet   2/2         2      0        yes
gemini-3-1-pro           3/3         3      0        yes
```

Every model went from a completed response that disagreed with its own stream, naming an item the stream never announced while omitting one it did and listing them in a different order, to one that reconciles exactly. Gemini additionally closed more items than it opened and delivered nine content events with no item open at all; both are gone

The invariants are pinned offline by `test_streaming_item_lifecycle.py`, which drives the iterator over synthetic chunks through both the sync and async implementations for every content shape a provider produces: text only, text then tool, reasoning then text, text then reasoning, text-tool-text, repeated reasoning blocks, and a tool-only turn. Those cover the repeated-content-kind turns the four live models above do not happen to produce, where the disagreement was largest: a text-reasoning-text turn announced three items and completed with two

## Type

🐛 Bug Fix

## Changes

`sent_output_item_added_event` was a single boolean for the whole stream, but it guarded reasoning, message and tool-call items alike. The first chunk therefore decided which one item was ever announced and every later item got none. On the ordinary reasoning-then-answer turn the reasoning item was announced and the entire answer then streamed as text deltas belonging to nothing

`output_index` was hardcoded to 0 for both reasoning and message while tool calls drew from a separate counter, so one index named several items and none matched the positions in `response.completed`. The message's done events were emitted whether or not a message item had been announced. Reasoning deltas carried `rs_{hash(content)}`, which changes on every delta and matches neither the announced item nor the one in `response.completed`; `hash()` for `str` is randomised per process, so it was not stable across workers either

The lifecycle is now driven by the kind of content observed in the chunk stream rather than by provider name. A change of content kind closes the open item and opens the next, one monotonic counter allocates `output_index` across all three item kinds, and an item's id is minted once when it opens and used by every event about it including the completed response. One rule covers reasoning-then-text, text-then-reasoning, text-tool-text and repeated reasoning blocks with no per-provider special case, which is what makes a provider family nobody has configured yet correct on arrival

Reasoning events also now carry what a client needs to place them: the item's `summary` array, a `reasoning_summary_part.added` ahead of its deltas, and `summary_index` on every delta. Without those the events arrive correctly attributed and are still discarded

Two consequences worth calling out rather than leaving for a reviewer to find. A turn that produced no assistant text no longer carries an empty message item, and that applies to the non-streaming path too, since `_extract_message_output_items` appended one per choice unconditionally; emitting it puts an item in the final output that the stream never announced, and it is not what the Responses API returns for a tool-only turn. And the existing `content_filter` test built its fixture with empty message content, which under this change produces no message item, so its fixture now carries partial text and it still exercises the incomplete mapping it was written for

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
