### PR TITLE
fix(cost_calculator): return (0.0, 0.0) for unknown openai model inst…

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -606,7 +606,9 @@ def cost_per_token(
                 service_tier=service_tier,
                 data_residency=data_residency,
             )
-        except Exception:
+        except Exception as e:  # noqa: BLE001
+            if "isn't mapped yet" not in str(e):
+                raise
             verbose_logger.debug(
                 "cost_per_token: unknown model=%s, custom_llm_provider=openai. Returning 0.0, 0.0",
                 model,

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -599,12 +599,19 @@ def cost_per_token(
     elif custom_llm_provider == "bedrock":
         return bedrock_cost_per_token(model=model, usage=usage_block, service_tier=service_tier)
     elif custom_llm_provider == "openai":
-        return openai_cost_per_token(
-            model=model,
-            usage=usage_block,
-            service_tier=service_tier,
-            data_residency=data_residency,
-        )
+        try:
+            return openai_cost_per_token(
+                model=model,
+                usage=usage_block,
+                service_tier=service_tier,
+                data_residency=data_residency,
+            )
+        except Exception:
+            verbose_logger.debug(
+                "cost_per_token: unknown model=%s, custom_llm_provider=openai. Returning 0.0, 0.0",
+                model,
+            )
+            return 0.0, 0.0
     elif custom_llm_provider == "databricks":
         return databricks_cost_per_token(model=model, usage=usage_block)
     elif custom_llm_provider == "fireworks_ai":

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3549,3 +3549,26 @@ def test_cost_per_token_unknown_model_with_explicit_provider():
         completion_tokens=5,
     )
     assert result == (0.0, 0.0), f"Expected (0.0, 0.0) for unknown model, got {result}"
+
+
+def test_cost_per_token_openai_non_model_error_propagates():
+    """
+    Test: cost_per_token() with openai provider re-raises exceptions that are
+    NOT about unknown models (e.g. real pricing calculation failures).
+    Ensures the narrow except only swallows model-not-found errors.
+    """
+    from unittest.mock import patch
+    import pytest
+    from litellm import cost_per_token
+
+    with patch(
+        "litellm.cost_calculator.openai_cost_per_token",
+        side_effect=Exception("Some unrelated pricing error"),
+    ):
+        with pytest.raises(Exception, match="Some unrelated pricing error"):
+            cost_per_token(
+                model="gpt-4o",
+                custom_llm_provider="openai",
+                prompt_tokens=10,
+                completion_tokens=5,
+            )

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3530,3 +3530,22 @@ def test_completion_cost_prices_anthropic_shaped_cache_read_tokens():
     )
 
     assert cost == pytest.approx(3 * 5e-6 + 4014 * 5e-7 + 5 * 3e-5, rel=1e-9)
+def test_cost_per_token_unknown_model_with_explicit_provider():
+    """
+    Test: cost_per_token() with a known provider but unknown model.
+    This is the second guard point flagged in PR #27587 review.
+    A fake model name with explicit custom_llm_provider="openai"
+    should not crash — it should return (0.0, 0.0).
+    
+    Ref: https://github.com/BerriAI/litellm/pull/27587
+    """
+    import litellm
+    from litellm import cost_per_token
+
+    result = cost_per_token(
+        model="fake-model-xyz-123",
+        custom_llm_provider="openai",
+        prompt_tokens=10,
+        completion_tokens=5,
+    )
+    assert result == (0.0, 0.0), f"Expected (0.0, 0.0) for unknown model, got {result}"


### PR DESCRIPTION
## Summary

When `cost_per_token()` is called with `custom_llm_provider="openai"` and an
unrecognized model name, `openai_cost_per_token()` raises an unhandled Exception
instead of gracefully returning `(0.0, 0.0)`.

Wraps the `openai_cost_per_token()` call in a try/except so unknown models fall
back to `(0.0, 0.0)`, consistent with how other provider branches handle this.

## TLDR

- `cost_per_token(model="unknown-model", custom_llm_provider="openai")` crashed instead of returning `(0.0, 0.0)`
- Wrapped `openai_cost_per_token()` in try/except in `cost_calculator.py`
- Added regression test in `test_cost_calculator.py`
- 4 related tests pass

## Related

Ref: https://github.com/BerriAI/litellm/pull/27587 (credit to @Zem-0)

Note: `make test-unit` has a pre-existing failure in `nvidia_riva/` due to
missing `libsndfile.so` — unrelated to this change.