### PR TITLE
feat(ui): opt-in IPv6 listen via ui.listenIPv6 / NGINX_LISTEN_IPV6

### DIFF
--- a/helm/litellm/templates/ui/deployment.yaml
+++ b/helm/litellm/templates/ui/deployment.yaml
@@ -53,6 +53,10 @@ spec:
             - name: LITELLM_BACKEND_URL
               value: {{ .Values.ui.backendUrl | quote }}
             {{- end }}
+            {{- with .Values.ui.listenIPv6 }}
+            - name: NGINX_LISTEN_IPV6
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.ui.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/litellm/tests/ui_listen_ipv6_tests.yaml
+++ b/helm/litellm/tests/ui_listen_ipv6_tests.yaml
@@ -1,0 +1,33 @@
+suite: test ui IPv6 listener toggle
+templates:
+  - ui/deployment.yaml
+values:
+  - ./values/required.yaml
+tests:
+  - it: renders no NGINX_LISTEN_IPV6 env by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: NGINX_LISTEN_IPV6
+
+  - it: renders NGINX_LISTEN_IPV6=auto when listenIPv6 is auto
+    set:
+      ui.listenIPv6: auto
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NGINX_LISTEN_IPV6
+            value: auto
+
+  - it: renders NGINX_LISTEN_IPV6=true when listenIPv6 forces the listener on
+    set:
+      ui.listenIPv6: "true"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NGINX_LISTEN_IPV6
+            value: "true"

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -347,6 +347,11 @@ backend:
 ui:
   enabled: true
   logLevel: INFO
+  # IPv6 listener for the ui nginx, rendered as NGINX_LISTEN_IPV6 on the
+  # container: "auto" listens on [::]:3000 when the pod has an IPv6 stack
+  # (dual-stack clusters), "true" forces it, "false"/empty keeps today's
+  # IPv4-only bind. Leave empty unless kubelet probes reach the pod over IPv6.
+  listenIPv6: ""
   extraEnv: []
   envConfigMaps: []
   envSecrets: []

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -27,7 +27,10 @@ RUN npm run build
 FROM nginx:${NGINX_VERSION} AS runtime
 
 # Drop the upstream default :80 server; we own the config.
-RUN rm -f /etc/nginx/conf.d/default.conf
+RUN rm -f /etc/nginx/conf.d/default.conf && mkdir /etc/nginx/listen-ipv6
+
+# Opt-in IPv6 listen (NGINX_LISTEN_IPV6=true|auto) — see the script header.
+COPY --chmod=755 ui/docker-entrypoint.d/15-listen-on-ipv6.sh /docker-entrypoint.d/
 
 # Static export → web root.
 COPY --from=builder /app/out /usr/share/nginx/html

--- a/ui/docker-entrypoint.d/15-listen-on-ipv6.sh
+++ b/ui/docker-entrypoint.d/15-listen-on-ipv6.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Renders the UI server's IPv6 listen directive, opt-in via NGINX_LISTEN_IPV6:
+# "true" forces it on, "auto" enables it only when the container has an IPv6
+# stack (same /proc/net/if_inet6 gate as the stock
+# 10-listen-on-ipv6-by-default.sh), anything else keeps today's IPv4-only bind.
+
+set -eu
+
+ME=$(basename "$0")
+SNIPPET="/etc/nginx/listen-ipv6/enabled.conf"
+
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$ME: $*"
+    fi
+}
+
+case "${NGINX_LISTEN_IPV6:-}" in
+    true|on|1)
+        ;;
+    auto)
+        if [ ! -f /proc/net/if_inet6 ]; then
+            entrypoint_log "info: NGINX_LISTEN_IPV6=auto and ipv6 not available, keeping IPv4 only"
+            exit 0
+        fi
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+if ! touch "$SNIPPET" 2>/dev/null; then
+    entrypoint_log "info: can not write $SNIPPET (read-only file system?), keeping IPv4 only"
+    exit 0
+fi
+
+echo "listen [::]:3000 default_server;" > "$SNIPPET"
+entrypoint_log "info: enabled listen on [::]:3000"

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -23,6 +23,9 @@ http {
 
   server {
     listen 3000 default_server;
+    # Populated by docker-entrypoint.d/15-listen-on-ipv6.sh when
+    # NGINX_LISTEN_IPV6 opts in; empty by default (IPv4 only).
+    include /etc/nginx/listen-ipv6/*.conf;
     server_name _;
     root /usr/share/nginx/html;
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- UI container only listens on IPv4, IPv6 connections are refused
- dual-stack Kubernetes probes hit the pod's IPv6 address and crash-loop the pod
- an unconditional [::] bind would break IPv6-disabled kernels instead

How it solves it:

- entrypoint renders listen [::]:3000 when NGINX_LISTEN_IPV6 opts in
- "true" forces it, "auto" gates on /proc/net/if_inet6, default stays IPv4 only
- new chart value ui.listenIPv6 renders that env on the ui container

## User Flow

Before: an operator deploying the chart on a dual-stack Kubernetes cluster watches the UI pod crash-loop despite the app being healthy

1. They install the chart on a cluster whose primary pod IP family is IPv6
2. Kubelet probes GET http://[pod-ipv6]:3000/healthz and gets connection refused
3. kubectl get pods shows the UI pod restarting with READY 0/1
4. From inside the pod, curl -g http://[::1]:3000/healthz fails with "Couldn't connect to server" while curl http://127.0.0.1:3000/healthz returns 200

After: the same operator sets one value and the deploy goes Ready

1. They set ui.listenIPv6: auto in their values and upgrade
2. Kubelet probes GET http://[pod-ipv6]:3000/healthz and gets 200 with body "ok"
3. kubectl get pods shows READY 1/1
4. Deployments that never set the value render byte-identical manifests and keep today's IPv4-only bind

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Ran the real config and entrypoint script in nginx:1.27-alpine (this image's own base and entrypoint mechanism) with host networking, at 80ab87d4bf; each row is curl -4 http://127.0.0.1:3000/healthz and curl -g -6 http://[::1]:3000/healthz against a fresh container:

```
unset (default)         | ipv4: 200 | ipv6: curl: (7) Failed to connect to ::1 port 3000
NGINX_LISTEN_IPV6=auto  | ipv4: 200 | ipv6: ok
NGINX_LISTEN_IPV6=true  | ipv4: 200 | ipv6: ok
NGINX_LISTEN_IPV6=false | ipv4: 200 | ipv6: curl: (7) Failed to connect to ::1 port 3000
```

Chart wiring at 8e2afc0865, helm template with tests/values/required.yaml: the default render carries no NGINX_LISTEN_IPV6 env and is unchanged from before this PR, while --set ui.listenIPv6=auto renders

```
            - name: NGINX_LISTEN_IPV6
              value: "auto"
```

helm unittest: 8 suites, 74 tests, all passing, including the new ui_listen_ipv6_tests.yaml covering default absence, auto, and forced true

## Type

🆕 New Feature

## Changes

Image: the server block gains include /etc/nginx/listen-ipv6/*.conf, an empty directory by default so a glob match on nothing renders nothing. A new docker-entrypoint.d/15-listen-on-ipv6.sh writes listen [::]:3000 default_server into that directory when NGINX_LISTEN_IPV6 is "true" (unconditional) or "auto" (only when /proc/net/if_inet6 exists, the same gate the stock image's 10-listen-on-ipv6-by-default.sh applies to the default.conf this image deletes). Any other value, including unset, changes nothing, so existing deployments keep exactly today's behavior. A read-only filesystem degrades to IPv4 with a log line instead of failing the entrypoint

Chart: ui.listenIPv6 (default empty) renders NGINX_LISTEN_IPV6 on the ui container, following the existing logLevel/backendUrl pattern. Empty renders no env at all

The auto gate never crashes an IPv6-less environment because nothing binds [::] unless the stack is present. Known limitation: a seccomp profile that denies socket(AF_INET6) while the kernel stack is loaded would still fail a forced "true"; such an environment cannot run stock nginx images either, and "auto" or leaving the value unset covers it