### PR TITLE
feat(helm): allow extra annotations on the migrations Job

### DIFF
--- a/helm/litellm/templates/migrations-job.yaml
+++ b/helm/litellm/templates/migrations-job.yaml
@@ -14,10 +14,12 @@ metadata:
   labels:
     {{- include "litellm.commonLabels" . | nindent 4 }}
     app.kubernetes.io/component: migrations
+  {{- /* Same merge rationale as podLabels below: an override replaces the
+         key, so tools that ignore helm.sh hooks (ArgoCD inflating the chart
+         through Kustomize) can stamp their own hook annotations. */}}
+  {{- $hookAnnotations := dict "helm.sh/hook" "pre-install,pre-upgrade" "helm.sh/hook-delete-policy" "before-hook-creation" "helm.sh/hook-weight" "0" }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "0"
+    {{- toYaml (merge (deepCopy .Values.migrationJob.annotations) $hookAnnotations) | nindent 4 }}
 spec:
   backoffLimit: {{ .Values.migrationJob.backoffLimit }}
   ttlSecondsAfterFinished: {{ .Values.migrationJob.ttlSecondsAfterFinished }}

--- a/helm/litellm/tests/migration_job_tests.yaml
+++ b/helm/litellm/tests/migration_job_tests.yaml
@@ -167,3 +167,43 @@ tests:
       - equal:
           path: spec.template.metadata.labels['app.kubernetes.io/component']
           value: batch-migrations
+
+  - it: renders only the helm hook annotations by default
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            helm.sh/hook: pre-install,pre-upgrade
+            helm.sh/hook-delete-policy: before-hook-creation
+            helm.sh/hook-weight: "0"
+
+  - it: merges extra annotations with the helm hook annotations
+    set:
+      migrationJob.annotations:
+        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/sync-wave: "-1"
+    asserts:
+      - equal:
+          path: metadata.annotations['argocd.argoproj.io/hook']
+          value: PreSync
+      - equal:
+          path: metadata.annotations['argocd.argoproj.io/sync-wave']
+          value: "-1"
+      - equal:
+          path: metadata.annotations['helm.sh/hook']
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations['helm.sh/hook-delete-policy']
+          value: before-hook-creation
+
+  - it: lets an annotation override replace a helm hook annotation
+    set:
+      migrationJob.annotations:
+        helm.sh/hook-delete-policy: hook-succeeded
+    asserts:
+      - equal:
+          path: metadata.annotations['helm.sh/hook-delete-policy']
+          value: hook-succeeded
+      - equal:
+          path: metadata.annotations['helm.sh/hook']
+          value: pre-install,pre-upgrade

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -89,6 +89,11 @@ migrationJob:
   securityContext: {}
   # Extra pod labels on the Job pod, merged into the chart's common labels.
   podLabels: {}
+  # Extra annotations on the Job itself, merged over the chart's helm.sh hook
+  # annotations so an override replaces the key. Lets ArgoCD users stamp
+  # argocd.argoproj.io/hook annotations, since ArgoCD ignores helm.sh hooks
+  # when the chart is inflated outside Helm (e.g. Kustomize --enable-helm).
+  annotations: {}
   # Additional volumes on the Job pod and volumeMounts on its container, e.g.
   # the writable scratch space a read-only root filesystem needs.
   volumes: []


### PR DESCRIPTION
## TLDR

Problem this solves:

- helm.sh hooks are inert when the chart is inflated outside Helm
- migrations Job then applies unordered, pods roll before migrations finish
- no knob today to re-order the Job against other PreSync hooks

How it solves it:

- new migrationJob.annotations value, merged over the helm.sh hook annotations
- an override replaces the key, mirroring the existing podLabels merge semantics

## User Flow

Before: an ArgoCD operator inflating the chart through Kustomize sees new pods roll before migrations complete

1. They point an ArgoCD Application at a kustomization that inflates the litellm chart with kustomize build --enable-helm, the documented workaround for ArgoCD having no post-renderer support
2. The rendered Job carries only helm.sh annotations, which nothing on this path reads, so ArgoCD applies it as an ordinary resource in the same sync wave as the Deployments
3. New gateway and backend pods start against the previous schema while the Job is still running
4. To get ordering back they maintain a hand-written Kustomize patch that stamps argocd.argoproj.io/hook: PreSync onto the Job

After: the same operator sets two values lines and the Job runs before the app pods

1. They add migrationJob.annotations with argocd.argoproj.io/hook: PreSync and a sync wave to their values file
2. The rendered Job carries those annotations alongside the helm.sh ones
3. ArgoCD runs the Job as a PreSync hook at the requested wave and only then rolls the Deployments
4. They delete the hand-written Kustomize patch

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Rendered the chart at faf8a6f6be. Default render is byte-identical to before the change:

```
$ helm template litellm helm/litellm -f helm/litellm/tests/values/required.yaml --show-only templates/migrations-job.yaml
...
  annotations:
    helm.sh/hook: pre-install,pre-upgrade
    helm.sh/hook-delete-policy: before-hook-creation
    helm.sh/hook-weight: "0"
```

With the new value set:

```
$ helm template litellm helm/litellm -f helm/litellm/tests/values/required.yaml \
    --set-string 'migrationJob.annotations.argocd\.argoproj\.io/hook=PreSync' \
    --set-string 'migrationJob.annotations.argocd\.argoproj\.io/sync-wave=-1' \
    --show-only templates/migrations-job.yaml
...
  annotations:
    argocd.argoproj.io/hook: PreSync
    argocd.argoproj.io/sync-wave: "-1"
    helm.sh/hook: pre-install,pre-upgrade
    helm.sh/hook-delete-policy: before-hook-creation
    helm.sh/hook-weight: "0"
```

helm unittest run for the chart: 7 suites, 74 tests, all passing, including the three new annotation cases

## Type

🆕 New Feature

## Changes

Adds a migrationJob.annotations value rendered into the Job's metadata. User annotations are merged over the chart's helm.sh hook annotations so an override replaces the key, the same semantics migrationJob.podLabels already has for labels. Default output is unchanged

Why not rely on ArgoCD's Helm-hook translation: ArgoCD only maps helm.sh hooks to its own hooks when it renders the chart itself as a Helm source. Charts inflated to plain manifests first, such as ArgoCD Kustomize sources using --enable-helm or helm template piped to kubectl, get no ordering at all. And even on the Helm path the mapping is fixed, so there is no way to re-order the Job against other PreSync hooks in the same Application (for example external-secrets hooks that must create the database credentials Secret before migrations run). An annotations knob is the generic escape hatch most community charts expose on their Jobs, with ArgoCD as the motivating example rather than anything ArgoCD-specific in the chart

Tests added to helm/litellm/tests/migration_job_tests.yaml: default render keeps exactly the helm.sh hook annotations, extra annotations merge alongside them, and an override replaces a hook annotation