### PR TITLE
feat(helm): add startupProbe and hpa.behavior to the componentized chart

### DIFF
--- a/helm/litellm/templates/backend/deployment.yaml
+++ b/helm/litellm/templates/backend/deployment.yaml
@@ -81,6 +81,10 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.backend.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.backend.lifecycle }}
           lifecycle:
             {{- toYaml . | nindent 12 }}

--- a/helm/litellm/templates/backend/hpa.yaml
+++ b/helm/litellm/templates/backend/hpa.yaml
@@ -30,4 +30,8 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.backend.hpa.targetMemoryUtilizationPercentage }}
     {{- end }}
+  {{- with .Values.backend.hpa.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/litellm/templates/gateway/deployment.yaml
+++ b/helm/litellm/templates/gateway/deployment.yaml
@@ -83,6 +83,10 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.gateway.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.gateway.lifecycle }}
           lifecycle:
             {{- toYaml . | nindent 12 }}

--- a/helm/litellm/templates/gateway/hpa.yaml
+++ b/helm/litellm/templates/gateway/hpa.yaml
@@ -30,4 +30,8 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.gateway.hpa.targetMemoryUtilizationPercentage }}
     {{- end }}
+  {{- with .Values.gateway.hpa.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/litellm/templates/ui/deployment.yaml
+++ b/helm/litellm/templates/ui/deployment.yaml
@@ -69,6 +69,10 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.ui.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.ui.lifecycle }}
           lifecycle:
             {{- toYaml . | nindent 12 }}

--- a/helm/litellm/templates/ui/hpa.yaml
+++ b/helm/litellm/templates/ui/hpa.yaml
@@ -30,4 +30,8 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.ui.hpa.targetMemoryUtilizationPercentage }}
     {{- end }}
+  {{- with .Values.ui.hpa.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/litellm/tests/hpa_behavior_tests.yaml
+++ b/helm/litellm/tests/hpa_behavior_tests.yaml
@@ -1,0 +1,58 @@
+suite: test HPA scaling behavior passthrough
+templates:
+  - gateway/hpa.yaml
+  - backend/hpa.yaml
+  - ui/hpa.yaml
+values:
+  - ./values/required.yaml
+tests:
+  - it: HPA omits spec.behavior by default, so Kubernetes' default scaling applies
+    templates:
+      - gateway/hpa.yaml
+      - backend/hpa.yaml
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - notExists:
+          path: spec.behavior
+
+  - it: gateway HPA renders spec.behavior verbatim when configured
+    template: gateway/hpa.yaml
+    set:
+      gateway.hpa.behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - { type: Percent, value: 50, periodSeconds: 60 }
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          selectPolicy: Max
+          policies:
+            - { type: Percent, value: 100, periodSeconds: 30 }
+            - { type: Pods, value: 2, periodSeconds: 30 }
+    asserts:
+      - equal:
+          path: spec.behavior
+          value:
+            scaleDown:
+              stabilizationWindowSeconds: 300
+              policies:
+                - { type: Percent, value: 50, periodSeconds: 60 }
+            scaleUp:
+              stabilizationWindowSeconds: 0
+              selectPolicy: Max
+              policies:
+                - { type: Percent, value: 100, periodSeconds: 30 }
+                - { type: Pods, value: 2, periodSeconds: 30 }
+
+  - it: behavior passthrough works on every autoscaled component (ui parity)
+    template: ui/hpa.yaml
+    set:
+      ui.hpa.enabled: true
+      ui.hpa.behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+    asserts:
+      - equal:
+          path: spec.behavior.scaleUp.stabilizationWindowSeconds
+          value: 0

--- a/helm/litellm/tests/probe_tests.yaml
+++ b/helm/litellm/tests/probe_tests.yaml
@@ -104,3 +104,30 @@ tests:
             periodSeconds: 15
             timeoutSeconds: 4
             failureThreshold: 3
+
+  - it: no startupProbe by default, so existing installs are unchanged
+    templates:
+      - gateway/deployment.yaml
+      - backend/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: startupProbe renders verbatim when configured, gating a slow cold start
+    template: gateway/deployment.yaml
+    set:
+      gateway.startupProbe:
+        httpGet: { path: /health/readiness, port: http }
+        failureThreshold: 30
+        periodSeconds: 10
+        timeoutSeconds: 5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /health/readiness
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -223,12 +223,28 @@ gateway:
     initialDelaySeconds: 5
     periodSeconds: 10
     timeoutSeconds: 10
+  # Optional startupProbe. Empty by default, so existing installs are unchanged
+  # and liveness/readiness apply from container start. Set it to gate
+  # liveness/readiness until a slow cold start finishes — a high failureThreshold
+  # tolerates long first-boot times without a liveness-kill loop, e.g.:
+  #   httpGet: { path: /health/readiness, port: http }
+  #   failureThreshold: 30
+  #   periodSeconds: 10
+  startupProbe: {}
   hpa:
     enabled: true
     minReplicas: 1
     maxReplicas: 10
     targetCPUUtilizationPercentage: 70
     targetMemoryUtilizationPercentage: 80
+    # Optional autoscaling/v2 scaling behavior (scaleUp / scaleDown policies and
+    # stabilization windows). Empty by default -> Kubernetes' default behavior.
+    # Rendered verbatim under spec.behavior, e.g.:
+    #   scaleUp:
+    #     stabilizationWindowSeconds: 0
+    #     policies:
+    #       - { type: Percent, value: 100, periodSeconds: 30 }
+    behavior: {}
   # PodDisruptionBudget for the gateway pods. Set exactly one of
   # `minAvailable` / `maxUnavailable` (minAvailable wins if both are set;
   # enabling without either falls back to `maxUnavailable: 1`). Disabled by
@@ -319,11 +335,15 @@ backend:
     initialDelaySeconds: 5
     periodSeconds: 10
     timeoutSeconds: 10
+  # Optional startupProbe; same shape as gateway.startupProbe. Empty by default.
+  startupProbe: {}
   hpa:
     enabled: true
     minReplicas: 1
     maxReplicas: 4
     targetCPUUtilizationPercentage: 70
+    # Optional autoscaling/v2 scaling behavior; same shape as gateway.hpa.behavior.
+    behavior: {}
   # Same shape as gateway.pdb.
   pdb:
     enabled: false
@@ -379,11 +399,15 @@ ui:
     httpGet: { path: /, port: http }
     initialDelaySeconds: 2
     periodSeconds: 10
+  # Optional startupProbe; same shape as gateway.startupProbe. Empty by default.
+  startupProbe: {}
   hpa:
     enabled: false
     minReplicas: 1
     maxReplicas: 3
     targetCPUUtilizationPercentage: 80
+    # Optional autoscaling/v2 scaling behavior; same shape as gateway.hpa.behavior.
+    behavior: {}
   # Same shape as gateway.pdb.
   pdb:
     enabled: false


### PR DESCRIPTION
## TLDR

Problem this solves:

- Componentized chart cannot set a `startupProbe` on any component
- Slow cold starts get liveness-killed before they finish booting
- Componentized chart cannot set HPA `spec.behavior`
- No control over scale-up/scale-down policies or stabilization windows

How it solves it:

- Adds a `startupProbe` knob to gateway/backend/ui deployments
- Adds an `hpa.behavior` passthrough to gateway/backend/ui HPAs
- Both empty by default, so existing renders are unchanged
- Same `{{- with ... }}` / `toYaml` pattern already used for other knobs

## User Flow

Before: an operator deploying the componentized chart onto a cluster where the proxy has a slow cold start cannot express either knob through values.

1. They set `gateway.startupProbe` in their values and run `helm upgrade`
2. `kubectl get deploy litellm-gateway -o yaml` shows **no** `startupProbe` — the value is silently dropped, so a slow first boot is liveness-killed and the pod crash-loops on scale-up
3. They set `gateway.hpa.behavior` to slow scale-down and run `helm upgrade`
4. `kubectl get hpa litellm-gateway -o yaml` shows **no** `spec.behavior`; scaling uses the Kubernetes defaults and the value is ignored

After: the same values render onto the manifests.

1. They set `gateway.startupProbe` in their values and run `helm upgrade`
2. `kubectl get deploy litellm-gateway -o yaml` now shows the `startupProbe` verbatim; liveness/readiness only begin once startup succeeds, so a slow boot no longer crash-loops
3. They set `gateway.hpa.behavior` and run `helm upgrade`
4. `kubectl get hpa litellm-gateway -o yaml` now shows `spec.behavior` verbatim, so their scale-up/scale-down policies take effect

## Relevant issues

<!-- none filed; parity gap in the componentized chart -->

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

<!-- Note: two small, closely-related pod-spec passthrough knobs for the
componentized chart (startupProbe + hpa.behavior), grouped in one PR by request. -->
