### PR TITLE
fix background polling request being cancelled on disconnect (superseded)

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1162,7 +1162,7 @@ class ProxyBaseLLMRequestProcessing:
             data=request_data,
             user_api_key_dict=user_api_key_dict,
             response=response,
-            request_headers=dict(request.headers),
+            request_headers=dict(request.headers) if request is not None else {},
         )
         if callback_headers:
             custom_headers.update(callback_headers)
@@ -1171,7 +1171,7 @@ class ProxyBaseLLMRequestProcessing:
 
     async def common_processing_pre_call_logic(
         self,
-        request: Request,
+        request: Request | None,
         general_settings: dict,
         user_api_key_dict: UserAPIKeyAuth,
         proxy_logging_obj: ProxyLogging,
@@ -1378,7 +1378,7 @@ class ProxyBaseLLMRequestProcessing:
                 if alias_target is not None:
                     self.data["model"] = alias_target
 
-        self.data["litellm_call_id"] = request.headers.get("x-litellm-call-id", str(uuid.uuid4()))
+        self.data["litellm_call_id"] = request.headers.get("x-litellm-call-id", str(uuid.uuid4())) if request is not None else str(uuid.uuid4())
         DDSpanTagger.tag_call_id(self.data.get("litellm_call_id"))
         DDSpanTagger.tag_request(
             user_api_key_dict=user_api_key_dict,
@@ -1439,7 +1439,7 @@ class ProxyBaseLLMRequestProcessing:
 
     async def _pre_call_with_fallbacks(
         self,
-        request: Request,
+        request: Request | None,
         general_settings: dict,
         proxy_logging_obj: ProxyLogging,
         user_api_key_dict: UserAPIKeyAuth,
@@ -1622,7 +1622,7 @@ class ProxyBaseLLMRequestProcessing:
 
     async def base_process_llm_request(
         self,
-        request: Request,
+        request: Request | None,
         fastapi_response: Response,
         user_api_key_dict: UserAPIKeyAuth,
         route_type: Literal[
@@ -1873,7 +1873,7 @@ class ProxyBaseLLMRequestProcessing:
                     data=self.data,
                     user_api_key_dict=user_api_key_dict,
                     response=response,
-                    request_headers=dict(request.headers),
+                    request_headers=dict(request.headers) if request is not None else {},
                 )
                 if callback_headers:
                     custom_headers.update(callback_headers)
@@ -1958,7 +1958,7 @@ class ProxyBaseLLMRequestProcessing:
                             proxy_logging_obj=proxy_logging_obj,
                             user_api_key_dict=user_api_key_dict,
                             custom_headers=custom_headers,
-                            request_headers=dict(request.headers),
+                            request_headers=dict(request.headers) if request is not None else {},
                         )
                         if _early is not None:
                             return _early
@@ -2050,7 +2050,7 @@ class ProxyBaseLLMRequestProcessing:
                     proxy_logging_obj=proxy_logging_obj,
                     user_api_key_dict=user_api_key_dict,
                     custom_headers=_non_streaming_custom_headers,
-                    request_headers=dict(request.headers),
+                    request_headers=dict(request.headers) if request is not None else {},
                 )
                 if _early is not None:
                     return _early
@@ -2140,7 +2140,7 @@ class ProxyBaseLLMRequestProcessing:
             data=self.data,
             user_api_key_dict=user_api_key_dict,
             response=response,
-            request_headers=dict(request.headers),
+            request_headers=dict(request.headers) if request is not None else {},
         )
         if callback_headers:
             fastapi_response.headers.update(callback_headers)

--- a/litellm/proxy/response_polling/background_streaming.py
+++ b/litellm/proxy/response_polling/background_streaming.py
@@ -70,7 +70,7 @@ async def background_streaming_task(
         # Pre-call checks (rate limits, guardrails, budget) were already run
         # before polling ID creation, so skip them here to avoid double-counting.
         response: Final = await processor.base_process_llm_request(
-            request=request,
+            request=None,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
             route_type="aresponses",

--- a/tests/proxy_unit_tests/test_response_polling_handler.py
+++ b/tests/proxy_unit_tests/test_response_polling_handler.py
@@ -1749,3 +1749,22 @@ class TestEdgeCases:
         stored = json.loads(call_args.kwargs["value"])
 
         assert stored["output"] == []
+
+
+class TestBackgroundStreamingRequestNone:
+    """Regression tests for background polling passing request=None."""
+
+    def test_background_streaming_passes_none_request(self):
+        """background_streaming_task must pass request=None to base_process_llm_request.
+
+        The client disconnects immediately on background requests, so the
+        disconnect buffer must not arm and cancel the upstream LLM call.
+        """
+        from litellm.proxy.response_polling.background_streaming import background_streaming_task
+        import inspect, textwrap
+
+        source = textwrap.dedent(inspect.getsource(background_streaming_task))
+        assert "request=None," in source or "request = None" in source, (
+            "background_streaming_task should pass request=None to base_process_llm_request"
+        )
+


### PR DESCRIPTION
Hi LiteLLM team,

This fixes background `/v1/responses` polling returning empty output when `polling_via_cache` is enabled.

Root cause: PR #31499 added a disconnect buffer that cancels the upstream LLM call if the client disconnects before the first chunk. Background polling clients disconnect immediately by design, so the detached task was killed before caching any results.

Changes:
- `background_streaming_task` now passes `request=None` to `base_process_llm_request`.
- `base_process_llm_request`, `_pre_call_with_fallbacks`, and `common_processing_pre_call_logic` accept `Request | None`.
- Header-copy call sites and the `x-litellm-call-id` fallback now handle a missing request.
- Added a regression test verifying the background task passes `request=None`.

Fixes #36275