### PR TITLE
Litellm fix sap streaming mockvalser

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1746,7 +1746,9 @@ class CustomStreamWrapper:
                             self.chunks[-1] = response.model_copy()
                             response.usage = None
                             ## check if empty
-                            is_empty = is_model_response_stream_empty(model_response=cast(ModelResponseStream, response))
+                            is_empty = is_model_response_stream_empty(
+                                model_response=cast(ModelResponseStream, response)
+                            )
 
                             if is_empty:
                                 continue

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1736,21 +1736,19 @@ class CustomStreamWrapper:
                     # hasattr(response, "usage") is always True — must check
                     # `is not None` to avoid running this path on every chunk.
                     if getattr(response, "usage", None) is not None:
-                        usage_to_preserve = response.usage
-                        if usage_to_preserve:
-                            response._hidden_params["usage"] = usage_to_preserve
+                        # self.chunks already holds the full response (appended above).
+                        # When include_usage is NOT requested, strip usage in-place
+                        # rather than round-tripping through model_dump(), which fails
+                        # when Pydantic's lazy schema compiler hasn't run yet
+                        # (MockValSer not yet replaced).
+                        if self.stream_options is None:
+                            response._hidden_params["usage"] = response.usage
+                            response.usage = None
+                            ## check if empty
+                            is_empty = is_model_response_stream_empty(model_response=cast(ModelResponseStream, response))
 
-                        obj_dict = response.model_dump()
-
-                        if "usage" in obj_dict:
-                            del obj_dict["usage"]
-
-                        response = self.model_response_creator(chunk=obj_dict, hidden_params=response._hidden_params)
-                        ## check if empty
-                        is_empty = is_model_response_stream_empty(model_response=cast(ModelResponseStream, response))
-
-                        if is_empty:
-                            continue
+                            if is_empty:
+                                continue
                     # add usage as hidden param
                     if self.sent_last_chunk is True and self.stream_options is None:
                         usage = calculate_total_usage(chunks=self.chunks)
@@ -1920,19 +1918,17 @@ class CustomStreamWrapper:
                         # directly to avoid expensive model_copy() per chunk.
                         self.chunks.append(processed_chunk.model_copy())
 
-                        # Strip usage from the outgoing chunk so it's not sent twice
-                        # (once in the chunk, once in _hidden_params).
-                        obj_dict = processed_chunk.model_dump()
-                        if "usage" in obj_dict:
-                            del obj_dict["usage"]
-                        processed_chunk = self.model_response_creator(
-                            chunk=obj_dict, hidden_params=processed_chunk._hidden_params
-                        )
-                        is_empty = is_model_response_stream_empty(
-                            model_response=cast(ModelResponseStream, processed_chunk)
-                        )
-                        if is_empty:
-                            continue
+                        # When include_usage is NOT requested, strip usage in-place
+                        # rather than round-tripping through model_dump(), which fails
+                        # when Pydantic's lazy schema compiler hasn't run yet
+                        # (MockValSer not yet replaced).
+                        if self.stream_options is None:
+                            processed_chunk.usage = None
+                            is_empty = is_model_response_stream_empty(
+                                model_response=cast(ModelResponseStream, processed_chunk)
+                            )
+                            if is_empty:
+                                continue
                     else:
                         # No usage data — safe to store directly without copying
                         self.chunks.append(processed_chunk)

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1743,6 +1743,7 @@ class CustomStreamWrapper:
                         # (MockValSer not yet replaced).
                         if self.stream_options is None:
                             response._hidden_params["usage"] = response.usage
+                            self.chunks[-1] = response.model_copy()
                             response.usage = None
                             ## check if empty
                             is_empty = is_model_response_stream_empty(model_response=cast(ModelResponseStream, response))

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -3551,3 +3551,69 @@ def test_openai_custom_tool_call_stream_deltas_survive_conversion(logging_obj: L
     assert combined_input == "*** Begin Patch\n*** End Patch\n"
     finish_reasons = [chunk.choices[0].finish_reason for chunk in emitted if chunk.choices]
     assert "tool_calls" in finish_reasons
+
+@pytest.mark.asyncio
+async def test_usage_strip_does_not_call_model_dump():
+    """Regression: the _has_usage branch in __anext__ must not call model_dump().
+
+    Before the fix, usage was stripped by round-tripping through model_dump() -> dict
+    -> model_response_creator(). model_dump() on a ModelResponseStream whose Pydantic
+    serializer hasn't been built yet (MockValSer cold-start) raises PydanticUserError /
+    TypeError depending on pydantic version, causing MidStreamFallbackError and
+    premature stream termination.
+
+    The fix strips usage via direct attribute assignment. This test poisons model_dump()
+    on the processed_chunk to raise, verifying the _has_usage branch never calls it.
+    """
+    usage_chunk = ModelResponseStream(
+        id="test-usage",
+        created=1000,
+        model="test-model",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content="", role="assistant"),
+            )
+        ],
+        usage=Usage(completion_tokens=5, prompt_tokens=3, total_tokens=8),
+    )
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=ModelResponseListIterator(model_responses=[usage_chunk]),
+        model="test-model",
+        custom_llm_provider="openai",
+        logging_obj=Logging(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            call_type="completion",
+            start_time=time.time(),
+            litellm_call_id="mockvalser-regression",
+            function_id="1",
+        ),
+    )
+
+    # Poison model_dump() on whatever model_response_creator returns so that if the
+    # _has_usage branch calls it, the stream raises instead of completing.
+    original_creator = wrapper.model_response_creator
+
+    def poisoned_creator(chunk=None, hidden_params=None):
+        result = original_creator(chunk=chunk, hidden_params=hidden_params)
+
+        def boom(**kwargs):
+            raise RuntimeError(
+                "model_dump() called on processed_chunk — MockValSer crash path re-introduced"
+            )
+
+        result.model_dump = boom  # type: ignore[method-assign]
+        return result
+
+    wrapper.model_response_creator = poisoned_creator  # type: ignore[method-assign]
+
+    yielded = [c async for c in wrapper]
+
+    assert all(
+        getattr(c, "usage", None) is None for c in yielded
+    ), "usage must be stripped from all yielded chunks"


### PR DESCRIPTION
## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- <blah>
- ...

How it solves it:

- <blah>
- ...

## User Flow

<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision

Example:

Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request comes back with real token counts, so the dashboard shows real spend

1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
-->

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
