### PR TITLE
feat(mcp): propagate request tags for direct gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,12 +255,16 @@ curl -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
     "LiteLLM": {
       "url": "http://localhost:4000/mcp/",
       "headers": {
-        "x-litellm-api-key": "Bearer sk-1234"
+        "x-litellm-api-key": "Bearer sk-1234",
+        "x-litellm-end-user-id": "user-123",
+        "x-litellm-tags": "application:orders,service:checkout"
       }
     }
   }
 }
 ```
+
+`x-litellm-end-user-id` associates the request with a canonical end-user identity. `x-litellm-tags` uses comma-separated tags for additional spend attribution dimensions. LiteLLM does not forward either header to the upstream MCP server.
 
 [**Docs: MCP Gateway**](https://docs.litellm.ai/docs/mcp)
 

--- a/README.md
+++ b/README.md
@@ -255,16 +255,12 @@ curl -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
     "LiteLLM": {
       "url": "http://localhost:4000/mcp/",
       "headers": {
-        "x-litellm-api-key": "Bearer sk-1234",
-        "x-litellm-end-user-id": "user-123",
-        "x-litellm-tags": "application:orders,service:checkout"
+        "x-litellm-api-key": "Bearer sk-1234"
       }
     }
   }
 }
 ```
-
-`x-litellm-end-user-id` associates the request with a canonical end-user identity. `x-litellm-tags` uses comma-separated tags for additional spend attribution dimensions. LiteLLM does not forward either header to the upstream MCP server.
 
 [**Docs: MCP Gateway**](https://docs.litellm.ai/docs/mcp)
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -4844,11 +4844,11 @@ class MCPServerManager:
                 user_api_key_auth=user_api_key_auth,
             )
 
-            for header in mcp_server.extra_headers:
-                if not isinstance(header, str):
-                    continue
-                if _is_gateway_attribution_header(header):
-                    continue
+            for header in (
+                header
+                for header in mcp_server.extra_headers
+                if isinstance(header, str) and not _is_gateway_attribution_header(header)
+            ):
                 if header.lower() == "authorization" and strip_caller_authorization:
                     continue
                 header_value = normalized_raw_headers.get(header.lower())

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -773,6 +773,10 @@ def _without_authorization(
     return filtered or None
 
 
+def _is_gateway_attribution_header(header_name: str) -> bool:
+    return header_name.lower() in {"x-litellm-tags", "x-litellm-end-user-id"}
+
+
 def _format_byok_openapi_auth_header(mcp_server: MCPServer, mcp_auth_header: str) -> str:
     """Format a raw BYOK credential for OpenAPI tool ``Authorization`` injection."""
     if mcp_server.auth_type == MCPAuth.api_key:
@@ -798,6 +802,8 @@ def _openapi_forwarded_extra_headers(
     forwarded: Final[dict[str, str]] = {}
     for header_name in mcp_server.extra_headers:
         if not isinstance(header_name, str):
+            continue
+        if _is_gateway_attribution_header(header_name):
             continue
         if skip_caller_authorization and header_name.lower() == "authorization":
             continue
@@ -4840,6 +4846,8 @@ class MCPServerManager:
 
             for header in mcp_server.extra_headers:
                 if not isinstance(header, str):
+                    continue
+                if _is_gateway_attribution_header(header):
                     continue
                 if header.lower() == "authorization" and strip_caller_authorization:
                     continue

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -774,7 +774,7 @@ def _without_authorization(
 
 
 def _is_gateway_attribution_header(header_name: str) -> bool:
-    return header_name.lower() in {"x-litellm-tags", "x-litellm-end-user-id"}
+    return header_name.lower() in frozenset(("x-litellm-tags", "x-litellm-end-user-id"))
 
 
 def _format_byok_openapi_auth_header(mcp_server: MCPServer, mcp_auth_header: str) -> str:

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1763,11 +1763,11 @@ if MCP_AVAILABLE:
                 user_api_key_auth=user_api_key_auth,
             )
 
-            for header in server.extra_headers:
-                if not isinstance(header, str):
-                    continue
-                if _is_gateway_attribution_header(header):
-                    continue
+            for header in (
+                header
+                for header in server.extra_headers
+                if isinstance(header, str) and not _is_gateway_attribution_header(header)
+            ):
                 if header.lower() == "authorization" and (
                     strip_caller_authorization or withhold_forwarded_authorization
                 ):

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -428,6 +428,7 @@ if MCP_AVAILABLE:
         MCPServerManager,
         _caller_authorization_fans_out,
         _client_forwarded_authorization_headers,
+        _is_gateway_attribution_header,
         _should_strip_caller_authorization,
         _without_authorization,
         global_mcp_server_manager,
@@ -1765,7 +1766,7 @@ if MCP_AVAILABLE:
             for header in server.extra_headers:
                 if not isinstance(header, str):
                     continue
-                if header.lower() in {"x-litellm-tags", "x-litellm-end-user-id"}:
+                if _is_gateway_attribution_header(header):
                     continue
                 if header.lower() == "authorization" and (
                     strip_caller_authorization or withhold_forwarded_authorization

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -782,6 +782,13 @@ if MCP_AVAILABLE:
 
             # Get mcp_servers from context variable
             verbose_logger.debug("MCP list_tools - Calling _list_mcp_tools")
+            from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
+
+            request_tags: Final = LiteLLMProxyRequestSetup.add_request_tag_to_metadata(
+                llm_router=None,
+                headers={key.lower(): value for key, value in (raw_headers or {}).items()},
+                data={},
+            )
             listing: Final = await _list_mcp_tools(
                 user_api_key_auth=user_api_key_auth,
                 mcp_auth_header=mcp_auth_header,
@@ -791,6 +798,7 @@ if MCP_AVAILABLE:
                 raw_headers=raw_headers,
                 log_list_tools_to_spendlogs=True,
                 list_tools_log_source="mcp_protocol",
+                request_tags=request_tags,
             )
             verbose_logger.info("MCP list_tools - Successfully returned %s tools", len(listing.tools))
             if not listing.outcomes:
@@ -1030,12 +1038,19 @@ if MCP_AVAILABLE:
                     body_data["litellm_trace_id"] = chain_id
                     body_data["litellm_session_id"] = chain_id
 
+                tags_header: Final = next(
+                    (value for key, value in (raw_headers or {}).items() if key.lower() == "x-litellm-tags"),
+                    None,
+                )
+                tags_scope_header: Final = (
+                    ((b"x-litellm-tags", tags_header.encode("latin-1")),) if tags_header is not None else ()
+                )
                 request: Final = Request(
                     scope={
                         "type": "http",
                         "method": "POST",
                         "path": "/mcp/tools/call",
-                        "headers": [(b"content-type", b"application/json")],
+                        "headers": [(b"content-type", b"application/json"), *tags_scope_header],
                     }
                 )
                 if user_api_key_auth is not None:
@@ -1750,6 +1765,8 @@ if MCP_AVAILABLE:
             for header in server.extra_headers:
                 if not isinstance(header, str):
                     continue
+                if header.lower() in {"x-litellm-tags", "x-litellm-end-user-id"}:
+                    continue
                 if header.lower() == "authorization" and (
                     strip_caller_authorization or withhold_forwarded_authorization
                 ):
@@ -2330,6 +2347,7 @@ if MCP_AVAILABLE:
         raw_headers: dict[str, str] | None = None,
         log_list_tools_to_spendlogs: bool = False,
         list_tools_log_source: str | None = None,
+        request_tags: list[str] | None = None,
         client_ip: str | None = None,
     ) -> AggregateToolListing:
         """
@@ -2359,6 +2377,7 @@ if MCP_AVAILABLE:
                 raw_headers=raw_headers,
                 log_list_tools_to_spendlogs=log_list_tools_to_spendlogs,
                 list_tools_log_source=list_tools_log_source,
+                request_tags=request_tags,
                 client_ip=client_ip,
             )
             verbose_logger.debug("Successfully fetched %s tools from managed MCP servers", len(listing.tools))

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -788,8 +788,10 @@ if MCP_AVAILABLE:
 
             request_tags: Final = LiteLLMProxyRequestSetup.add_request_tag_to_metadata(
                 llm_router=None,
-                headers={key.lower(): value for key, value in (raw_headers or {}).items()},
-                data={},
+                headers={  # mutable-ok: request-tag helper accepts a mutable header mapping
+                    key.lower(): value for key, value in (raw_headers or {}).items()
+                },
+                data={},  # mutable-ok: request-tag helper mutates request metadata in place
             )
             listing: Final = await _list_mcp_tools(
                 user_api_key_auth=user_api_key_auth,

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -429,6 +429,7 @@ if MCP_AVAILABLE:
         _caller_authorization_fans_out,
         _client_forwarded_authorization_headers,
         _is_gateway_attribution_header,
+        _openapi_forwarded_extra_headers,
         _should_strip_caller_authorization,
         _without_authorization,
         global_mcp_server_manager,
@@ -2854,30 +2855,11 @@ if MCP_AVAILABLE:
                 else:
                     auth_header_value = f"Bearer {mcp_auth_header}"
 
-            # Forward named client headers to OpenAPI tool upstream requests.
-            # MCPServer.extra_headers lists header names to copy from raw_headers.
-            # The strip decision is centralized in _should_strip_caller_authorization so this
-            # OpenAPI/local path agrees with the managed paths: M2M and the resolver-owned modes
-            # (token_exchange's raw subject token, authorization_code's stored token) must never
-            # have the caller's Authorization forwarded verbatim upstream.
-            forwarded_headers: dict[str, str] | None = None
-            if mcp_server and mcp_server.extra_headers and raw_headers:
-                normalized_raw: Final = {str(k).lower(): v for k, v in raw_headers.items() if isinstance(k, str)}
-                skip_caller_authorization: Final = _should_strip_caller_authorization(
-                    mcp_server=mcp_server,
-                    raw_headers=raw_headers,
-                    user_api_key_auth=user_api_key_auth,
-                )
-                for header_name in mcp_server.extra_headers:
-                    if not isinstance(header_name, str):
-                        continue
-                    if skip_caller_authorization and header_name.lower() == "authorization":
-                        continue
-                    value = normalized_raw.get(header_name.lower())
-                    if value is not None:
-                        if forwarded_headers is None:
-                            forwarded_headers = {}
-                        forwarded_headers[header_name] = value
+            forwarded_headers: Final = _openapi_forwarded_extra_headers(
+                mcp_server=mcp_server,
+                raw_headers=raw_headers,
+                user_api_key_auth=user_api_key_auth,
+            )
 
             resolved_auth_headers: dict[str, str] | None = None
             if mcp_server:

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2857,7 +2857,7 @@ if MCP_AVAILABLE:
                 else:
                     auth_header_value = f"Bearer {mcp_auth_header}"
 
-            forwarded_headers: Final = _openapi_forwarded_extra_headers(
+            initial_forwarded_headers: Final = _openapi_forwarded_extra_headers(
                 mcp_server=mcp_server,
                 raw_headers=raw_headers,
                 user_api_key_auth=user_api_key_auth,
@@ -2867,15 +2867,19 @@ if MCP_AVAILABLE:
             if mcp_server:
                 (
                     resolved_auth_headers,
-                    forwarded_headers,
+                    resolved_forwarded_headers,
                 ) = await global_mcp_server_manager.resolve_openapi_upstream_auth(
                     mcp_server=mcp_server,
                     oauth2_headers=oauth2_headers,
                     raw_headers=raw_headers,
                     mcp_auth_header=mcp_auth_header,
                     user_api_key_auth=user_api_key_auth,
-                    forwarded_headers=forwarded_headers,
+                    forwarded_headers=initial_forwarded_headers,
                 )
+            else:
+                resolved_forwarded_headers = initial_forwarded_headers
+
+            forwarded_headers: Final = resolved_forwarded_headers
 
             _auth_token: Final = _request_auth_header.set(auth_header_value)
             _extra_token: Final = _request_extra_headers.set(forwarded_headers)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -117,6 +117,45 @@ async def test_mcp_server_tool_call_body_contains_request_data():
 
 
 @pytest.mark.asyncio
+async def test_mcp_server_tool_call_uses_canonical_request_tags_header():
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            mcp_server_tool_call,
+            set_auth_context,
+        )
+        from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    set_auth_context(
+        UserAPIKeyAuth(api_key="test_key", user_id="test_user"),
+        raw_headers={"X-LiteLLM-Tags": "application:orders, service:checkout"},
+    )
+    captured_tags = {}
+
+    async def mock_add_litellm_data_to_request(data, request, user_api_key_dict, proxy_config):
+        captured_tags["tags"] = LiteLLMProxyRequestSetup.add_request_tag_to_metadata(
+            llm_router=None,
+            headers=dict(request.headers),
+            data={},
+        )
+        return data
+
+    with patch(
+        "litellm.proxy.litellm_pre_call_utils.add_litellm_data_to_request",
+        mock_add_litellm_data_to_request,
+    ):
+        with patch(
+            "litellm.proxy._experimental.mcp_server.server.call_mcp_tool",
+            new=AsyncMock(return_value=CallToolResult(content=[])),
+        ):
+            with patch("litellm.proxy.proxy_server.proxy_config", MagicMock()):
+                await mcp_server_tool_call("test_tool", {"value": "test"})
+
+    assert captured_tags["tags"] == ["application:orders", "service:checkout"]
+
+
+@pytest.mark.asyncio
 async def test_mcp_server_tool_call_relays_upstream_auth_error_as_iserror():
     """The MCP session manager serializes handler exceptions as JSON-RPC errors, so a mid-session
     tool call cannot emit a raw 401 the way the REST path does. mcp_server_tool_call must turn an
@@ -193,6 +232,69 @@ def test_prepare_mcp_server_headers_case_insensitive_extra_headers():
 
     assert server_auth_header is None
     assert extra_headers == {"Authorization": "Bearer token"}
+
+
+def test_prepare_mcp_server_headers_does_not_forward_gateway_attribution_headers():
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _prepare_mcp_server_headers,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    server = MCPServer(
+        server_id="server-attribution",
+        name="server",
+        transport=MCPTransport.http,
+        extra_headers=["x-request-id", "X-LiteLLM-Tags", "X-LiteLLM-End-User-Id"],
+    )
+
+    server_auth_header, extra_headers = _prepare_mcp_server_headers(
+        server=server,
+        mcp_server_auth_headers=None,
+        mcp_auth_header=None,
+        oauth2_headers=None,
+        raw_headers={
+            "x-request-id": "request-123",
+            "x-litellm-tags": "application:orders,service:checkout",
+            "x-litellm-end-user-id": "user-123@example",
+        },
+    )
+
+    assert server_auth_header is None
+    assert extra_headers == {"x-request-id": "request-123"}
+
+
+@pytest.mark.asyncio
+async def test_handle_list_tools_uses_canonical_request_tags_header():
+    try:
+        from litellm.proxy._experimental.mcp_server.faults.list_outcomes import AggregateToolListing
+        from litellm.proxy._experimental.mcp_server.server import handle_list_tools
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    list_tools = AsyncMock(return_value=AggregateToolListing(tools=[], outcomes={}))
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.get_or_extract_auth_context",
+        new=AsyncMock(
+            return_value=(
+                UserAPIKeyAuth(api_key="test_key", user_id="test_user"),
+                None,
+                ["server"],
+                None,
+                None,
+                {"X-LiteLLM-Tags": "application:orders, service:checkout"},
+                None,
+            )
+        ),
+    ):
+        with patch(
+            "litellm.proxy._experimental.mcp_server.server._list_mcp_tools",
+            new=list_tools,
+        ):
+            await handle_list_tools()
+
+    assert list_tools.await_args.kwargs["request_tags"] == ["application:orders", "service:checkout"]
 
 
 def test_prepare_mcp_server_headers_passthrough_strips_authorization_without_admission_header():

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -117,7 +117,14 @@ async def test_mcp_server_tool_call_body_contains_request_data():
 
 
 @pytest.mark.asyncio
-async def test_mcp_server_tool_call_uses_canonical_request_tags_header():
+@pytest.mark.parametrize(
+    ("raw_headers", "expected_tags"),
+    [
+        ({"X-LiteLLM-Tags": "application:orders, service:checkout"}, ["application:orders", "service:checkout"]),
+        (None, None),
+    ],
+)
+async def test_mcp_server_tool_call_uses_canonical_request_tags_header(raw_headers, expected_tags):
     try:
         from litellm.proxy._experimental.mcp_server.server import (
             mcp_server_tool_call,
@@ -129,7 +136,7 @@ async def test_mcp_server_tool_call_uses_canonical_request_tags_header():
 
     set_auth_context(
         UserAPIKeyAuth(api_key="test_key", user_id="test_user"),
-        raw_headers={"X-LiteLLM-Tags": "application:orders, service:checkout"},
+        raw_headers=raw_headers,
     )
     captured_tags = {}
 
@@ -139,6 +146,7 @@ async def test_mcp_server_tool_call_uses_canonical_request_tags_header():
             headers=dict(request.headers),
             data={},
         )
+        captured_tags["headers"] = dict(request.headers)
         return data
 
     with patch(
@@ -152,7 +160,11 @@ async def test_mcp_server_tool_call_uses_canonical_request_tags_header():
             with patch("litellm.proxy.proxy_server.proxy_config", MagicMock()):
                 await mcp_server_tool_call("test_tool", {"value": "test"})
 
-    assert captured_tags["tags"] == ["application:orders", "service:checkout"]
+    assert captured_tags["tags"] == expected_tags
+    if raw_headers is None:
+        assert "x-litellm-tags" not in captured_tags["headers"]
+    else:
+        assert captured_tags["headers"]["x-litellm-tags"] == raw_headers["X-LiteLLM-Tags"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -6676,6 +6676,75 @@ async def test_execute_mcp_tool_sets_model_in_model_call_details():
 
 
 @pytest.mark.asyncio
+async def test_execute_mcp_tool_local_openapi_does_not_forward_gateway_attribution_headers():
+    from litellm.proxy._experimental.mcp_server import server as mcp_module
+    from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+        _request_extra_headers,
+    )
+
+    server = MCPServer(
+        server_id="local-openapi-server",
+        name="local_openapi",
+        server_name="local_openapi",
+        url="https://example.com",
+        transport=MCPTransport.http,
+        spec_path="/specs/openapi.yaml",
+        extra_headers=["x-request-id", "X-LiteLLM-Tags", "X-LiteLLM-End-User-Id"],
+    )
+    captured_extra_headers = None
+
+    async def capture_local_tool(*args, **kwargs):
+        nonlocal captured_extra_headers
+        captured_extra_headers = _request_extra_headers.get()
+        return []
+
+    with (
+        patch.object(
+            mcp_module.global_mcp_server_manager,
+            "_get_mcp_server_from_tool_name",
+            return_value=server,
+        ),
+        patch.object(
+            mcp_module.global_mcp_server_manager,
+            "pre_call_tool_check",
+            new=AsyncMock(return_value={}),
+        ),
+        patch.object(
+            mcp_module.global_mcp_server_manager,
+            "resolve_openapi_upstream_auth",
+            new=AsyncMock(side_effect=lambda **kwargs: (None, kwargs["forwarded_headers"])),
+        ),
+        patch.object(
+            mcp_module.global_mcp_tool_registry,
+            "get_tool",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._handle_local_mcp_tool",
+            new=AsyncMock(side_effect=capture_local_tool),
+        ),
+        patch.object(
+            mcp_module.MCPRequestHandler,
+            "is_tool_allowed",
+            return_value=True,
+        ),
+    ):
+        await mcp_module.execute_mcp_tool(
+            name="local_openapi-list_pets",
+            arguments={},
+            allowed_mcp_servers=[server],
+            start_time=datetime.now(),
+            raw_headers={
+                "x-request-id": "request-123",
+                "x-litellm-tags": "application:orders,service:checkout",
+                "x-litellm-end-user-id": "user-123",
+            },
+        )
+
+    assert captured_extra_headers == {"x-request-id": "request-123"}
+
+
+@pytest.mark.asyncio
 async def test_execute_mcp_tool_rest_unresolved_prefixed_name_routes_to_requested_server():
     """A prefixed REST name that resolves to no tool must still dispatch to the server_id.
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -37,6 +37,7 @@ from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
     MCPServerManager,
     _deserialize_json_dict,
     _flow_endpoints_missing,
+    _openapi_forwarded_extra_headers,
     _oauth_endpoints_unresolved,
     _deserialize_json_list,
     _normalize_mcp_server_cost_info,
@@ -912,7 +913,7 @@ class TestMCPServerManager:
 
         async def capture_create_mcp_client(
             server, mcp_auth_header, extra_headers, stdio_env, **kwargs
-        ):  # pragma: no cover - helper
+        ):
             nonlocal captured_extra_headers
             captured_extra_headers = extra_headers
             return mock_client
@@ -933,6 +934,70 @@ class TestMCPServerManager:
 
         assert captured_extra_headers == {"Authorization": "Bearer token"}
         assert isinstance(result, CallToolResult)
+
+    @pytest.mark.asyncio
+    async def test_call_regular_mcp_tool_does_not_forward_gateway_attribution_headers(self):
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="server-attribution-call",
+            name="attribution-call-server",
+            url="https://example.com",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.authorization,
+            extra_headers=["x-request-id", "X-LiteLLM-Tags", "X-LiteLLM-End-User-Id"],
+        )
+        mock_client = AsyncMock()
+        mock_client.call_tool = AsyncMock(return_value=CallToolResult(content=[], isError=False))
+        captured_extra_headers = None
+
+        async def capture_create_mcp_client(
+            server, mcp_auth_header, extra_headers, stdio_env, **kwargs
+        ):  # pragma: no cover - helper
+            nonlocal captured_extra_headers
+            captured_extra_headers = extra_headers
+            return mock_client
+
+        manager._create_mcp_client = AsyncMock(side_effect=capture_create_mcp_client)
+
+        await manager._call_regular_mcp_tool(
+            mcp_server=server,
+            original_tool_name="tool",
+            arguments={},
+            tasks=[],
+            mcp_auth_header=None,
+            mcp_server_auth_headers=None,
+            oauth2_headers=None,
+            raw_headers={
+                "x-request-id": "request-123",
+                "x-litellm-tags": "application:orders,service:checkout",
+                "x-litellm-end-user-id": "user-123",
+            },
+            proxy_logging_obj=None,
+        )
+
+        assert captured_extra_headers == {"x-request-id": "request-123"}
+
+    def test_openapi_forwarded_extra_headers_excludes_gateway_attribution_headers(self):
+        server = MCPServer(
+            server_id="server-attribution-openapi",
+            name="attribution-openapi-server",
+            url="https://example.com",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.authorization,
+            extra_headers=["x-request-id", "X-LiteLLM-Tags", "X-LiteLLM-End-User-Id"],
+        )
+
+        forwarded_headers = _openapi_forwarded_extra_headers(
+            mcp_server=server,
+            raw_headers={
+                "x-request-id": "request-123",
+                "x-litellm-tags": "application:orders,service:checkout",
+                "x-litellm-end-user-id": "user-123",
+            },
+            user_api_key_auth=None,
+        )
+
+        assert forwarded_headers == {"x-request-id": "request-123"}
 
     async def _capture_list_subject_token(self, server, oauth2_headers, raw_headers=None):
         """Run _get_tools_from_server and return the subject_token it threaded to _create_mcp_client."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Direct MCP operations missed request tag attribution
- Gateway attribution headers could reach upstream MCP servers

How it solves it:

- Reuses LiteLLM canonical CSV tag parsing for list and call
- Keeps gateway-only identity and tag headers out of upstream requests

## Relevant issues

Fixes #36393

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Type

New Feature

## Changes

Direct MCP `tools/list` now parses `x-litellm-tags` with `LiteLLMProxyRequestSetup.add_request_tag_to_metadata()` and passes the result to spend logging

Direct MCP `tools/call` preserves the canonical tag header in the internal request setup path, so normal LiteLLM request preparation adds the same parsed tags to metadata

`x-litellm-tags` and `x-litellm-end-user-id` are filtered from configured upstream `extra_headers`. End-user identity remains resolved through standard MCP admission authentication

The README direct-MCP client example now documents the canonical end-user header and comma-separated tag header

## Test coverage

Focused regressions cover canonical tag propagation for direct `tools/list` and `tools/call`, plus case-insensitive exclusion of both gateway-only attribution headers from upstream forwarding

Validated locally with Python 3.13.9, the repository-supported range includes Python 3.13

```text
.venv/bin/python -m pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py -q
197 passed

.venv/bin/ruff check litellm/proxy/_experimental/mcp_server/server.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
All checks passed

git diff --check
```

### Final Attestation

- [x] The tests check the right things, including the relevant attribution and header-isolation regressions