### PR TITLE
fix: resolve PydanticUserError for ChatCompletionReasoningSummaryTextBlock forward reference

### DIFF
--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -534,7 +534,7 @@ class ChatCompletionReasoningItem(TypedDict, total=False):
     type: Required[Literal["reasoning"]]
     id: str
     encrypted_content: str | None
-    summary: list["ChatCompletionReasoningSummaryTextBlock"]
+    summary: list[ChatCompletionReasoningSummaryTextBlock]
 
 
 class WebSearchOptionsUserLocationApproximate(TypedDict, total=False):


### PR DESCRIPTION
## Summary

Fixes #36384

Calling `ModelResponse()` with no arguments crashes with:
```
pydantic.errors.PydanticUserError: `Message` is not fully defined; you should define `ChatCompletionReasoningSummaryTextBlock`, then call `Message.model_rebuild()`.
```

## Root Cause

In `litellm/types/llms/openai.py`, the `ChatCompletionReasoningItem` TypedDict has a field:
```python
summary: List["ChatCompletionReasoningSummaryTextBlock"]
```

The type annotation uses a **string forward reference** (`"ChatCompletionReasoningSummaryTextBlock"`), even though `ChatCompletionReasoningSummaryTextBlock` is already defined earlier in the same file (line 548 vs line 553).

When Pydantic builds the `Message` model (in `litellm/types/utils.py`), it recursively resolves all type annotations, including those inside TypedDicts used as field types. The string forward reference `"ChatCompletionReasoningSummaryTextBlock"` cannot be resolved in the namespace of `utils.py` because `ChatCompletionReasoningSummaryTextBlock` is not imported there. This causes the `PydanticUserError`.

## Fix

Remove the unnecessary string quotes from the forward reference:
```python
# Before
summary: List["ChatCompletionReasoningSummaryTextBlock"]

# After  
summary: List[ChatCompletionReasoningSummaryTextBlock]
```

Since `ChatCompletionReasoningSummaryTextBlock` is defined before `ChatCompletionReasoningItem` in the same file, the direct reference works correctly and Pydantic can resolve the type without needing it in the importing module's namespace.