### PR TITLE
fix(proxy): stop listing literal wildcard routes as models

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -232,14 +232,14 @@ def get_complete_model_list(
                 model_access_groups_to_return.append(model)
         return model_access_groups_to_return
 
-    all_wildcard_models: Final = _get_wildcard_models(
+    wildcard: Final = _get_wildcard_models(
         unique_models=unique_models,
         return_wildcard_routes=return_wildcard_routes,
         llm_router=llm_router,
         team_id=team_id,
     )
 
-    complete_model_list: Final = unique_models + all_wildcard_models
+    complete_model_list: Final = list(wildcard.kept_models + wildcard.expanded_models)
 
     return complete_model_list
 
@@ -407,34 +407,34 @@ def _expand_wildcard_model(model: str, llm_router: Router | None, team_id: str |
     return _WildcardExpansion(concrete_models, True)
 
 
+class _WildcardModels(NamedTuple):
+    kept_models: tuple[str, ...]
+    expanded_models: tuple[str, ...]
+
+
 def _get_wildcard_models(
-    unique_models: list[str],
+    unique_models: Sequence[str],
     return_wildcard_routes: bool | None = False,
     llm_router: Router | None = None,
     team_id: str | None = None,
-) -> list[str]:
+) -> _WildcardModels:
     expansions: Final = {
         model: _expand_wildcard_model(model=model, llm_router=llm_router, team_id=team_id)
         for model in unique_models
         if _check_wildcard_routing(model=model)
     }
 
-    all_wildcard_models: Final = [
+    expanded_models: Final = tuple(
         item
         for model, expansion in expansions.items()
         for item in [*([model] if return_wildcard_routes else []), *expansion.concrete_models]
-    ]
+    )
 
-    # The literal pattern (e.g. "openai/*") is a routing directive, not a callable
-    # model, so drop it from the listing once expanded. It is re-surfaced above only
-    # when return_wildcard_routes is set (#13752).
-    models_to_remove: Final = {
+    literals_to_drop: Final = frozenset(
         model for model, expansion in expansions.items() if expansion.has_router_deployment or expansion.concrete_models
-    }
-    for model in models_to_remove:
-        unique_models.remove(model)
-
-    return all_wildcard_models
+    )
+    kept_models: Final = tuple(model for model in unique_models if model not in literals_to_drop)
+    return _WildcardModels(kept_models=kept_models, expanded_models=expanded_models)
 
 
 def get_all_fallbacks(

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -2,7 +2,7 @@
 ## Common checks for /v1/models and `/model/info`
 import copy
 from collections.abc import Sequence
-from typing import Any, Final
+from typing import Any, Final, NamedTuple
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -377,44 +377,60 @@ def expand_wildcard_deployments_for_model_info(
     return expanded
 
 
+class _WildcardExpansion(NamedTuple):
+    concrete_models: tuple[str, ...]
+    has_router_deployment: bool
+
+
+def _expand_wildcard_model(model: str, llm_router: Router | None, team_id: str | None) -> _WildcardExpansion:
+    if llm_router is None:
+        return _WildcardExpansion(
+            tuple(get_known_models_from_wildcard(wildcard_model=model, litellm_params=None)), False
+        )
+
+    router_deployments: Final = llm_router.get_model_list(model_name=model, team_id=team_id)
+    if not router_deployments:
+        # Router has no deployment for this wildcard (e.g. BYOK team models); fall
+        # back to expanding from known provider models.
+        return _WildcardExpansion(
+            tuple(get_known_models_from_wildcard(wildcard_model=model, litellm_params=None)), False
+        )
+
+    concrete_models: Final = tuple(
+        concrete
+        for router_model in router_deployments
+        for concrete in get_known_models_from_wildcard(
+            wildcard_model=model,
+            litellm_params=LiteLLM_Params(**router_model["litellm_params"]),
+        )
+    )
+    return _WildcardExpansion(concrete_models, True)
+
+
 def _get_wildcard_models(
     unique_models: list[str],
     return_wildcard_routes: bool | None = False,
     llm_router: Router | None = None,
     team_id: str | None = None,
 ) -> list[str]:
-    models_to_remove: Final = set()
-    all_wildcard_models: Final = []
-    for model in unique_models:
-        if _check_wildcard_routing(model=model):
-            if return_wildcard_routes:  # will add the wildcard route to the list eg: anthropic/*.
-                all_wildcard_models.append(model)
+    expansions: Final = {
+        model: _expand_wildcard_model(model=model, llm_router=llm_router, team_id=team_id)
+        for model in unique_models
+        if _check_wildcard_routing(model=model)
+    }
 
-            ## get litellm params from model
-            if llm_router is not None:
-                model_list = llm_router.get_model_list(model_name=model, team_id=team_id)
-                if model_list:
-                    for router_model in model_list:
-                        wildcard_models = get_known_models_from_wildcard(
-                            wildcard_model=model,
-                            litellm_params=LiteLLM_Params(**router_model["litellm_params"]),
-                        )
-                        all_wildcard_models.extend(wildcard_models)
-                else:
-                    # Router has no deployment for this wildcard (e.g., BYOK team models)
-                    # Fall back to expanding from known provider models
-                    wildcard_models = get_known_models_from_wildcard(wildcard_model=model, litellm_params=None)
-                    if wildcard_models:
-                        models_to_remove.add(model)
-                        all_wildcard_models.extend(wildcard_models)
-            else:
-                # get all known provider models
-                wildcard_models = get_known_models_from_wildcard(wildcard_model=model, litellm_params=None)
+    all_wildcard_models: Final = [
+        item
+        for model, expansion in expansions.items()
+        for item in [*([model] if return_wildcard_routes else []), *expansion.concrete_models]
+    ]
 
-                if wildcard_models:
-                    models_to_remove.add(model)
-                    all_wildcard_models.extend(wildcard_models)
-
+    # The literal pattern (e.g. "openai/*") is a routing directive, not a callable
+    # model, so drop it from the listing once expanded. It is re-surfaced above only
+    # when return_wildcard_routes is set (#13752).
+    models_to_remove: Final = {
+        model for model, expansion in expansions.items() if expansion.has_router_deployment or expansion.concrete_models
+    }
     for model in models_to_remove:
         unique_models.remove(model)
 

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -853,3 +853,25 @@ def test_get_complete_model_list_omits_literal_wildcard_when_router_has_deployme
     )
     assert "openai/*" not in no_router_result
     assert any(m.startswith("openai/") and m != "openai/*" for m in no_router_result)
+
+
+def test_get_wildcard_models_does_not_mutate_input_and_drops_all_literals():
+    """Regression for #13752: _get_wildcard_models must not mutate the caller's list and
+    must drop every expanded wildcard literal from kept_models, even when the same literal
+    appears more than once, so no literal route leaks back into the listing."""
+    from unittest.mock import MagicMock
+
+    from litellm.proxy.auth.model_checks import _get_wildcard_models
+
+    router = MagicMock()
+    router.get_model_list.return_value = [{"litellm_params": {"model": "openai/*"}}]
+
+    unique_models = ["openai/*", "openai/*"]
+    original = list(unique_models)
+
+    result = _get_wildcard_models(unique_models=unique_models, llm_router=router)
+
+    assert unique_models == original
+    assert "openai/*" not in result.kept_models
+    assert result.expanded_models
+    assert all(m != "openai/*" for m in result.expanded_models)

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -804,3 +804,52 @@ def test_get_complete_model_list_sentinel_only_grants_nothing():
         infer_model_from_keys=False,
     )
     assert result == []
+
+
+def test_get_complete_model_list_omits_literal_wildcard_when_router_has_deployment():
+    """Regression for #13752: a configured wildcard route (e.g. openai/*) with a real
+    router deployment must expand to concrete models without listing the literal pattern
+    itself, unless return_wildcard_routes is requested."""
+    from unittest.mock import MagicMock
+
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    router = MagicMock()
+    router.get_model_list.return_value = [{"litellm_params": {"model": "openai/*"}}]
+
+    default_result = get_complete_model_list(
+        key_models=[],
+        team_models=[],
+        proxy_model_list=["openai/*"],
+        user_model=None,
+        infer_model_from_keys=False,
+        return_wildcard_routes=False,
+        llm_router=router,
+    )
+    assert "openai/*" not in default_result
+    assert any(m.startswith("openai/") and m != "openai/*" for m in default_result)
+
+    with_routes_result = get_complete_model_list(
+        key_models=[],
+        team_models=[],
+        proxy_model_list=["openai/*"],
+        user_model=None,
+        infer_model_from_keys=False,
+        return_wildcard_routes=True,
+        llm_router=router,
+    )
+    assert with_routes_result.count("openai/*") == 1
+
+    # No router at all: the wildcard still expands from known provider models and
+    # the literal is not listed.
+    no_router_result = get_complete_model_list(
+        key_models=[],
+        team_models=[],
+        proxy_model_list=["openai/*"],
+        user_model=None,
+        infer_model_from_keys=False,
+        return_wildcard_routes=False,
+        llm_router=None,
+    )
+    assert "openai/*" not in no_router_result
+    assert any(m.startswith("openai/") and m != "openai/*" for m in no_router_result)


### PR DESCRIPTION
## TLDR

Problem this solves:

- With wildcard routes configured (`model_name: "openai/*"`, `anthropic/*`), the `/v1/models` and `/models` listing correctly expands them into concrete provider models, but it also returns the literal `openai/*` and `anthropic/*` entries
- Clients read those literals as callable model ids, which is misleading

How it solves it:

- `get_complete_model_list` expands wildcards via `_get_wildcard_models`. Two of its three branches already dropped the literal pattern after expansion, but the branch used when the router holds a deployment for the wildcard did not, so the literal leaked into the list
- Drop the literal in that branch as well. The pattern is still surfaced when a caller passes `return_wildcard_routes=true`, so that opt-in behavior is unchanged
- `_get_wildcard_models` no longer mutates its `unique_models` argument in place. It returns an immutable `_WildcardModels` tuple of kept and expanded models, and `get_complete_model_list` builds the final list functionally. This also removes a duplicate-leak edge Greptile flagged, where the old `set` plus `list.remove` loop dropped only the first occurrence of a repeated literal

## User Flow

An operator configures wildcard passthrough (`openai/*`, `anthropic/*`). A consumer calls `GET /v1/models`. They now see only concrete, callable model ids, not the `*` routing patterns.

## Relevant issues

Fixes #13752

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Unit RED to GREEN on the listing helper.

RED on `litellm_internal_staging` (before the fix), the literal wildcard is still listed:

```
tests/test_litellm/proxy/auth/test_model_checks.py:785: AssertionError
1 failed, 1 warning in 4.63s
```

GREEN with the fix:

```
tests/test_litellm/proxy/auth/test_model_checks.py::test_get_complete_model_list_omits_literal_wildcard_when_router_has_deployment PASSED
1 passed, 1 warning in 3.13s
```

Follow-up regression for the mutation and duplicate-leak edge, RED on the pre-fix remove-in-place code:

```
>       assert unique_models == original
E       AssertionError: assert ['openai/*'] == ['openai/*', 'openai/*']
1 failed, 1 warning in 3.71s
```

GREEN after returning the immutable tuple:

```
tests/test_litellm/proxy/auth/test_model_checks.py::test_get_wildcard_models_does_not_mutate_input_and_drops_all_literals PASSED
30 passed, 1 warning in 3.41s
```

Live check runbook for a proxy with a wildcard config (`model_name: "openai/*"`):

```
curl -s http://localhost:4000/v1/models -H "Authorization: Bearer $LITELLM_KEY" | jq -r '.data[].id' | grep -c '^openai/\*$'
```

Before the fix this prints `1` (the literal is listed), after the fix it prints `0` while concrete `openai/...` ids are still returned.

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/auth/model_checks.py`: `_get_wildcard_models` now drops the literal wildcard pattern from the listing once expanded, in every branch including the router-backed one that previously kept it. It returns an immutable `_WildcardModels` tuple instead of mutating its `unique_models` argument, so `get_complete_model_list` builds the result functionally and no repeated literal can leak. Wildcard expansion itself lives in the typed `_expand_wildcard_model` helper
- `tests/test_litellm/proxy/auth/test_model_checks.py`: regression tests covering `return_wildcard_routes` false (literal absent, concretes present) and true (literal present exactly once), plus non-mutation of the input and removal of duplicated literals

## QA runbook

Configure a wildcard model, start the proxy, call `GET /v1/models`, and confirm the response contains expanded provider models but not the `*` pattern. Run `make test-unit` for `tests/test_litellm/proxy/auth/test_model_checks.py`.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
