### PR TITLE
fix(a2a): stop sending stream in the JSON-RPC body for message/stream

### DIFF
--- a/litellm/llms/a2a/chat/transformation.py
+++ b/litellm/llms/a2a/chat/transformation.py
@@ -89,6 +89,10 @@ class A2AConfig(BaseConfig):
 
         return api_base, api_key, headers
 
+    @property
+    def supports_stream_param_in_request_body(self) -> bool:
+        return False
+
     def get_supported_openai_params(self, model: str) -> List[str]:
         """Return list of supported OpenAI parameters"""
         return [

--- a/tests/test_litellm/llms/a2a/chat/test_a2a_chat_transformation.py
+++ b/tests/test_litellm/llms/a2a/chat/test_a2a_chat_transformation.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 from litellm.llms.a2a.chat.transformation import A2AConfig
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.types.utils import ModelResponse
 
 
@@ -40,3 +41,27 @@ def test_transform_response_sets_usage():
     assert result.usage.prompt_tokens > 0
     assert result.usage.completion_tokens > 0
     assert result.usage.total_tokens == (result.usage.prompt_tokens + result.usage.completion_tokens)
+
+
+def test_stream_param_never_reaches_the_jsonrpc_body():
+    """Regression: A2A servers validate JSON-RPC strictly and reject a top-level
+    `stream` field with -32600 "Invalid Request. Extra fields: {'stream'}", answering
+    application/json instead of an SSE stream; the caller then sees an empty stream
+    with no error. Streaming is carried by the message/stream method alone."""
+    config = A2AConfig()
+    request_body = config.transform_request(
+        model="a2a/test-agent",
+        messages=[{"role": "user", "content": "hi there agent"}],
+        optional_params={"stream": True},
+        litellm_params={},
+        headers={},
+    )
+
+    body = BaseLLMHTTPHandler()._add_stream_param_to_request_body(
+        data=request_body,
+        provider_config=config,
+        fake_stream=False,
+    )
+
+    assert body["method"] == "message/stream"
+    assert "stream" not in body


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real A2A agent, no mocks. The agent hostname is redacted; everything else is verbatim. The agent runs the a2a-python SDK and answers analytical questions against a warehouse, so a full streaming run takes minutes and costs real money

**What the agent rejects.** The extra top-level `stream` field alone is what breaks it; the same body without that field streams SSE normally

```
$ curl -s -D - -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":"probe-stream-field","method":"message/stream","params":{"message":{"role":"user","parts":[{"kind":"text","text":"user: hi"}],"messageId":"aaaa1111-bbbb-2222-cccc-333333333333"}},"stream":true}' \
  https://<agent-host>/

HTTP/2 200
content-type: application/json
{"error":{"code":-32600,"message":"Invalid Request","data":"Invalid request. Extra fields: {'stream'}, Missed fields: set()"},"id":"probe-stream-field","jsonrpc":"2.0"}
```

**Before**, captured on `ghcr.io/berriai/litellm:v1.95.0`. The proxy answers 200 with a single empty chunk and no error, 0.45s for a request that takes the agent minutes

```
$ curl -sN -m 120 -w 'HTTP %{http_code} time=%{time_total}s\n' \
  -H 'Authorization: Bearer sk-local-repro' -H 'Content-Type: application/json' \
  -d '{"model":"a2a/analyst","stream":true,"messages":[{"role":"user","content":"How does win rate differ across skill bands on EU in May 2026?"}]}' \
  http://127.0.0.1:14000/v1/chat/completions

data: {"id":"chatcmpl-e0befbb4-13b4-4873-a4f7-bd58d2371761","object":"chat.completion.chunk","created":1786368227,"model":"a2a/analyst","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}

data: [DONE]

HTTP 200 time=0.458284s
```

Relaying that same run through a logging proxy shows what left LiteLLM and what came back

```
REQ  body={"jsonrpc": "2.0", "id": "6f3e0726-3471-4ab1-ac86-f2a70f0e8830", "method": "message/stream", "params": {"message": {"role": "user", "parts": [{"kind": "text", "text": "user: ..."}], "messageId": "34c6f5b4-daad-46c1-9f7a-ce5776d76c4b"}}, "stream": true}
RESP status=200 headers={'Content-Type': 'application/json', 'Content-Length': '186', ...}
```

**After**, same image and same config with this commit's `transformation.py` mounted over the installed one, captured at `c7c948cb0c`. 24 SSE events over 111s, carrying the agent's live progress and its answer

```
$ curl -sN -m 180 -w 'HTTP %{http_code} time=%{time_total}s\n' \
  -H 'Authorization: Bearer sk-local-repro' -H 'Content-Type: application/json' \
  -d '{"model":"a2a/analyst","stream":true,"messages":[{"role":"user","content":"How does win rate differ across skill bands on EU in May 2026?"}]}' \
  http://127.0.0.1:14000/v1/chat/completions

HTTP 200 time=111.831325s
events: 24
"content":"[..] planning with gemma-4-26b\n
"content":"[..] metric win_rate_pct, realm EU\n
"content":"[..] retrieved: PLAYERS.md - Players - skill-band profiles > 2. Win-rate by band
"content":"[..] retrieved: PLAYERS.md - Players - skill-band profiles > Caveats (read before quoting
```

## Type

🐛 Bug Fix

## Changes

`BaseLLMHTTPHandler._add_stream_param_to_request_body` writes `stream: true` into the request body for every provider that does not opt out through `supports_stream_param_in_request_body`. A2A speaks JSON-RPC 2.0, whose request object is closed: servers built on the a2a-python SDK reject an unknown top-level member with `-32600 Invalid Request` and answer `application/json` rather than an SSE stream

`A2AModelResponseIterator.chunk_parser` catches every parse failure and returns an empty chunk, so that error body surfaces as one `delta: {}` chunk with `finish_reason: stop`. A streaming caller sees an empty answer and no error at all, which is what makes this hard to spot from the outside

A2AConfig now returns False from `supports_stream_param_in_request_body`, matching the other agent providers (langflow, langgraph, azure_ai agents, vertex agent_engine). Streaming intent is already carried by the JSON-RPC method name, which `transform_request` sets to `message/stream`, so nothing else needs to change

The regression test drives the real path, `A2AConfig.transform_request` followed by `BaseLLMHTTPHandler._add_stream_param_to_request_body`, and asserts the method stays `message/stream` while `stream` never appears in the body. Flipping the property back to True fails it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
