### PR TITLE
fix(bedrock_mantle): align GPT-5.6 pricing with OpenAI/Azure entries

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -45254,16 +45254,21 @@
     },
     "bedrock_mantle/openai.gpt-5.6-sol": {
         "input_cost_per_token": 5.5e-06,
+        "input_cost_per_token_above_272k_tokens": 1.1e-05,
         "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
         "cache_read_input_token_cost": 5.5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "output_cost_per_token": 3.3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.95e-05,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "responses",
+        "mode": "chat",
         "use_openai_responses_path": true,
         "supported_endpoints": [
+            "/v1/chat/completions",
             "/v1/responses"
         ],
         "supported_modalities": [
@@ -45274,24 +45279,32 @@
             "text"
         ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "bedrock_mantle/openai.gpt-5.6-terra": {
         "input_cost_per_token": 2.2e-06,
+        "input_cost_per_token_above_272k_tokens": 4.4e-06,
         "cache_creation_input_token_cost": 2.75e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-06,
         "cache_read_input_token_cost": 2.2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
         "output_cost_per_token": 1.32e-05,
+        "output_cost_per_token_above_272k_tokens": 1.98e-05,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "responses",
+        "mode": "chat",
         "use_openai_responses_path": true,
         "supported_endpoints": [
+            "/v1/chat/completions",
             "/v1/responses"
         ],
         "supported_modalities": [
@@ -45302,24 +45315,32 @@
             "text"
         ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "bedrock_mantle/openai.gpt-5.6-luna": {
         "input_cost_per_token": 2.2e-07,
+        "input_cost_per_token_above_272k_tokens": 4.4e-07,
         "cache_creation_input_token_cost": 2.75e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-07,
         "cache_read_input_token_cost": 2.2e-08,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
         "output_cost_per_token": 1.32e-06,
+        "output_cost_per_token_above_272k_tokens": 1.98e-06,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "responses",
+        "mode": "chat",
         "use_openai_responses_path": true,
         "supported_endpoints": [
+            "/v1/chat/completions",
             "/v1/responses"
         ],
         "supported_modalities": [
@@ -45330,11 +45351,14 @@
             "text"
         ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "bedrock_mantle/openai.gpt-5.5": {
         "input_cost_per_token": 5.5e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -45375,16 +45375,21 @@
     },
     "bedrock_mantle/openai.gpt-5.6-sol": {
         "input_cost_per_token": 5.5e-06,
+        "input_cost_per_token_above_272k_tokens": 1.1e-05,
         "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
         "cache_read_input_token_cost": 5.5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "output_cost_per_token": 3.3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.95e-05,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "responses",
+        "mode": "chat",
         "use_openai_responses_path": true,
         "supported_endpoints": [
+            "/v1/chat/completions",
             "/v1/responses"
         ],
         "supported_modalities": [
@@ -45395,24 +45400,32 @@
             "text"
         ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "bedrock_mantle/openai.gpt-5.6-terra": {
         "input_cost_per_token": 2.2e-06,
+        "input_cost_per_token_above_272k_tokens": 4.4e-06,
         "cache_creation_input_token_cost": 2.75e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-06,
         "cache_read_input_token_cost": 2.2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
         "output_cost_per_token": 1.32e-05,
+        "output_cost_per_token_above_272k_tokens": 1.98e-05,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "responses",
+        "mode": "chat",
         "use_openai_responses_path": true,
         "supported_endpoints": [
+            "/v1/chat/completions",
             "/v1/responses"
         ],
         "supported_modalities": [
@@ -45423,24 +45436,32 @@
             "text"
         ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "bedrock_mantle/openai.gpt-5.6-luna": {
         "input_cost_per_token": 2.2e-07,
+        "input_cost_per_token_above_272k_tokens": 4.4e-07,
         "cache_creation_input_token_cost": 2.75e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-07,
         "cache_read_input_token_cost": 2.2e-08,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
         "output_cost_per_token": 1.32e-06,
+        "output_cost_per_token_above_272k_tokens": 1.98e-06,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "responses",
+        "mode": "chat",
         "use_openai_responses_path": true,
         "supported_endpoints": [
+            "/v1/chat/completions",
             "/v1/responses"
         ],
         "supported_modalities": [
@@ -45451,11 +45472,14 @@
             "text"
         ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "bedrock_mantle/openai.gpt-5.5": {
         "input_cost_per_token": 5.5e-06,

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -1527,12 +1527,14 @@ class TestBedrockMantleResponsesPricing:
         self, local_cost_map, model, input_cost, cache_creation_cost, cache_read_cost, output_cost
     ):
         info = litellm.get_model_info(f"bedrock_mantle/{model}")
-        assert info["mode"] == "responses"
+        assert info["mode"] == "chat"
         assert info["input_cost_per_token"] == pytest.approx(input_cost)
         assert info["cache_creation_input_token_cost"] == pytest.approx(cache_creation_cost)
         assert info["cache_read_input_token_cost"] == pytest.approx(cache_read_cost)
         assert info["output_cost_per_token"] == pytest.approx(output_cost)
-        assert info["max_input_tokens"] == 272000
+        assert info["max_input_tokens"] == 1050000
+        assert info["input_cost_per_token_above_272k_tokens"] == pytest.approx(input_cost * 2)
+        assert info["output_cost_per_token_above_272k_tokens"] == pytest.approx(output_cost * 1.5)
 
     @pytest.mark.parametrize(
         "model, input_cost, output_cost",
@@ -1566,6 +1568,33 @@ class TestBedrockMantleResponsesPricing:
         )
 
         assert cost == pytest.approx(input_tokens * input_cost + output_tokens * output_cost)
+
+    @pytest.mark.parametrize(
+        "model, input_cost_above_272k, output_cost_above_272k",
+        [
+            ("openai.gpt-5.6-sol", 1.1e-05, 4.95e-05),
+            ("openai.gpt-5.6-terra", 4.4e-06, 1.98e-05),
+            ("openai.gpt-5.6-luna", 4.4e-07, 1.98e-06),
+        ],
+    )
+    def test_gpt_5_6_above_272k_cost(self, local_cost_map, model, input_cost_above_272k, output_cost_above_272k):
+        from litellm.types.utils import Usage
+        from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+
+        prompt_tokens = 300000
+        completion_tokens = 1000
+        usage = Usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        )
+        prompt_cost, completion_cost = generic_cost_per_token(
+            model=model,
+            usage=usage,
+            custom_llm_provider="bedrock_mantle",
+        )
+        assert prompt_cost == pytest.approx(input_cost_above_272k * prompt_tokens)
+        assert completion_cost == pytest.approx(output_cost_above_272k * completion_tokens)
 
     def test_models_registered(self, local_cost_map):
         assert "bedrock_mantle/openai.gpt-5.5" in litellm.bedrock_mantle_models


### PR DESCRIPTION
## Relevant issues

Fixes #36016

## What happened

The `bedrock_mantle/openai.gpt-5.6-{sol,terra,luna}` entries in `model_prices_and_context_window.json` diverged from the OpenAI/Azure GPT-5.6 entries:

- `mode` was `"responses"` instead of `"chat"`
- `max_input_tokens` was `272000` instead of `1050000`
- No `*_above_272k_tokens` pricing tiers for input, output, or cache

This caused incorrect cost calculation for long-context requests and inconsistent model metadata.

## Changes

For all three GPT-5.6 Bedrock Mantle variants:

- Set `max_input_tokens` to `1050000` (1M context, per AWS announcement)
- Change `mode` to `"chat"` and add `/v1/chat/completions` to `supported_endpoints`
- Add above-272k pricing tiers at 1.1× OpenAI rates (matching the existing Bedrock base-price markup)
- Keep `use_openai_responses_path: true` so routing to `/openai/v1` is unchanged; `/v1/responses` remains in `supported_endpoints` so native Responses API support is preserved

## Tests

Updated `TestBedrockMantleResponsesPricing` and added `test_gpt_5_6_above_272k_cost`:

```bash
pytest tests/test_litellm/llms/bedrock_mantle/ -q
# 166 passed
```