### PR TITLE
fix(responses): stop internal metadata reaching strict upstreams

### DIFF
--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -231,32 +231,31 @@ class ResponsesAPIRequestUtils:
             )
             non_default_params["previous_response_id"] = decoded_previous_response_id
 
-        litellm_metadata = params.get("litellm_metadata")
-        if not isinstance(litellm_metadata, dict):
-            litellm_metadata = {}
+        litellm_metadata_raw = params.get("litellm_metadata")
+        litellm_metadata: Final = litellm_metadata_raw if isinstance(litellm_metadata_raw, dict) else {}
 
-        requester_metadata = litellm_metadata.get("requester_metadata")
+        proxy_requester_metadata = litellm_metadata.get("requester_metadata")
         metadata_in_params = non_default_params.get("metadata")
-        is_proxy_internal_metadata = any(key.startswith("user_api_key_") for key in litellm_metadata)
+        is_proxy_internal_metadata: Final = any(key.startswith("user_api_key_") for key in litellm_metadata)
 
         metadata_source: dict | None = None
-        if isinstance(requester_metadata, dict):
-            metadata_source = requester_metadata
+        if isinstance(proxy_requester_metadata, dict):
+            metadata_source = proxy_requester_metadata
         elif not is_proxy_internal_metadata and isinstance(metadata_in_params, dict):
             metadata_source = metadata_in_params
 
-        if metadata_source is not None:
-            from litellm.utils import get_requester_metadata
+        from litellm.utils import add_openai_metadata
 
-            converted_metadata: Final = get_requester_metadata(metadata_source)
-            if converted_metadata:
-                non_default_params["metadata"] = converted_metadata
-            else:
-                non_default_params.pop("metadata", None)
-        else:
-            non_default_params.pop("metadata", None)
+        converted_metadata: Final = (
+            add_openai_metadata(metadata_source) if metadata_source is not None else None
+        )
+        non_default_params_with_metadata: Final = (
+            {**non_default_params, "metadata": converted_metadata}
+            if converted_metadata
+            else {key: value for key, value in non_default_params.items() if key != "metadata"}
+        )
 
-        return cast(ResponsesAPIOptionalRequestParams, non_default_params)
+        return cast(ResponsesAPIOptionalRequestParams, non_default_params_with_metadata)
 
     # fmt: off
     @overload

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -246,9 +246,7 @@ class ResponsesAPIRequestUtils:
 
         from litellm.utils import add_openai_metadata
 
-        converted_metadata: Final = (
-            add_openai_metadata(metadata_source) if metadata_source is not None else None
-        )
+        converted_metadata: Final = add_openai_metadata(metadata_source) if metadata_source is not None else None
         non_default_params_with_metadata: Final = (
             {**non_default_params, "metadata": converted_metadata}
             if converted_metadata

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -231,14 +231,30 @@ class ResponsesAPIRequestUtils:
             )
             non_default_params["previous_response_id"] = decoded_previous_response_id
 
-        if "metadata" in non_default_params:
-            from litellm.utils import add_openai_metadata
+        litellm_metadata = params.get("litellm_metadata")
+        if not isinstance(litellm_metadata, dict):
+            litellm_metadata = {}
 
-            converted_metadata: Final = add_openai_metadata(non_default_params["metadata"])
-            if converted_metadata is not None:
+        requester_metadata = litellm_metadata.get("requester_metadata")
+        metadata_in_params = non_default_params.get("metadata")
+        is_proxy_internal_metadata = any(key.startswith("user_api_key_") for key in litellm_metadata)
+
+        metadata_source: dict | None = None
+        if isinstance(requester_metadata, dict):
+            metadata_source = requester_metadata
+        elif not is_proxy_internal_metadata and isinstance(metadata_in_params, dict):
+            metadata_source = metadata_in_params
+
+        if metadata_source is not None:
+            from litellm.utils import get_requester_metadata
+
+            converted_metadata: Final = get_requester_metadata(metadata_source)
+            if converted_metadata:
                 non_default_params["metadata"] = converted_metadata
             else:
                 non_default_params.pop("metadata", None)
+        else:
+            non_default_params.pop("metadata", None)
 
         return cast(ResponsesAPIOptionalRequestParams, non_default_params)
 

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -231,18 +231,20 @@ class ResponsesAPIRequestUtils:
             )
             non_default_params["previous_response_id"] = decoded_previous_response_id
 
-        litellm_metadata_raw = params.get("litellm_metadata")
+        litellm_metadata_raw: Final = params.get("litellm_metadata")
         litellm_metadata: Final = litellm_metadata_raw if isinstance(litellm_metadata_raw, dict) else {}
 
-        proxy_requester_metadata = litellm_metadata.get("requester_metadata")
-        metadata_in_params = non_default_params.get("metadata")
+        proxy_requester_metadata: Final = litellm_metadata.get("requester_metadata")
+        metadata_in_params: Final = non_default_params.get("metadata")
         is_proxy_internal_metadata: Final = any(key.startswith("user_api_key_") for key in litellm_metadata)
 
-        metadata_source: dict | None = None
-        if isinstance(proxy_requester_metadata, dict):
-            metadata_source = proxy_requester_metadata
-        elif not is_proxy_internal_metadata and isinstance(metadata_in_params, dict):
-            metadata_source = metadata_in_params
+        metadata_source: Final = (
+            proxy_requester_metadata
+            if isinstance(proxy_requester_metadata, dict)
+            else (
+                metadata_in_params if not is_proxy_internal_metadata and isinstance(metadata_in_params, dict) else None
+            )
+        )
 
         from litellm.utils import add_openai_metadata
 

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -185,6 +185,34 @@ class TestResponsesAPIRequestUtils:
         )
         assert result["metadata"] == {"customer_id": "cust-456"}
 
+    def test_get_requested_response_api_optional_param_preserves_sibling_metadata_keys(self):
+        result = ResponsesAPIRequestUtils.get_requested_response_api_optional_param(
+            {
+                "temperature": 0.7,
+                "metadata": {
+                    "customer_id": "cust-123",
+                    "requester_metadata": {"nested": "value"},
+                },
+            }
+        )
+        assert result["metadata"] == {"customer_id": "cust-123"}
+
+    def test_get_requested_response_api_optional_param_proxy_snapshot_no_double_unwrap(self):
+        result = ResponsesAPIRequestUtils.get_requested_response_api_optional_param(
+            {
+                "temperature": 0.7,
+                "metadata": {"model_group": "test-model"},
+                "litellm_metadata": {
+                    "requester_metadata": {
+                        "customer_id": "cust-789",
+                        "requester_metadata": {"nested": "value"},
+                    },
+                    "user_api_key_team_id": "team-1",
+                },
+            }
+        )
+        assert result["metadata"] == {"customer_id": "cust-789"}
+
     def test_decode_previous_response_id_to_original_previous_response_id(self):
         """Test decoding a LiteLLM encoded previous_response_id to the original previous_response_id"""
         # Setup

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -132,6 +132,59 @@ class TestResponsesAPIRequestUtils:
         assert result["max_output_tokens"] == 100
         assert result["prompt"] == {"id": "pmpt_456"}
 
+    def test_get_requested_response_api_optional_param_strips_empty_metadata(self):
+        """Regression #35780: empty metadata dict must not reach upstream."""
+        result = ResponsesAPIRequestUtils.get_requested_response_api_optional_param(
+            {"temperature": 0.7, "metadata": {}}
+        )
+        assert "metadata" not in result
+
+    def test_get_requested_response_api_optional_param_strips_internal_metadata(self):
+        """Regression #35780: proxy/router internal metadata must not reach upstream."""
+        result = ResponsesAPIRequestUtils.get_requested_response_api_optional_param(
+            {
+                "temperature": 0.7,
+                "metadata": {
+                    "model_group": "test-model",
+                    "deployment": "openai/gpt-4o",
+                    "model_info": {"id": "dep-1"},
+                    "user_api_key_user_id": "user-1",
+                },
+                "litellm_metadata": {
+                    "user_api_key_team_id": "team-1",
+                    "tags": ["internal-tag"],
+                },
+            }
+        )
+        assert "metadata" not in result
+
+    def test_get_requested_response_api_optional_param_preserves_caller_metadata(self):
+        """Caller-supplied string metadata should still be forwarded."""
+        result = ResponsesAPIRequestUtils.get_requested_response_api_optional_param(
+            {
+                "temperature": 0.7,
+                "metadata": {"customer_id": "cust-123", "campaign": "spring"},
+            }
+        )
+        assert result["metadata"] == {"customer_id": "cust-123", "campaign": "spring"}
+
+    def test_get_requested_response_api_optional_param_uses_requester_metadata(self):
+        """Proxy snapshots caller metadata under litellm_metadata.requester_metadata."""
+        result = ResponsesAPIRequestUtils.get_requested_response_api_optional_param(
+            {
+                "temperature": 0.7,
+                "metadata": {
+                    "model_group": "test-model",
+                    "user_api_key_user_id": "user-1",
+                },
+                "litellm_metadata": {
+                    "requester_metadata": {"customer_id": "cust-456"},
+                    "user_api_key_team_id": "team-1",
+                },
+            }
+        )
+        assert result["metadata"] == {"customer_id": "cust-456"}
+
     def test_decode_previous_response_id_to_original_previous_response_id(self):
         """Test decoding a LiteLLM encoded previous_response_id to the original previous_response_id"""
         # Setup


### PR DESCRIPTION
## Summary

Fixes #35780

Strict OpenAI-compatible `/v1/responses` upstreams were rejecting proxy requests with `HTTP 400: Unsupported parameter: metadata` even when the client did not pass a `metadata` argument.

Root cause: internal/proxy metadata (including empty `{}`) was being serialized into the provider-facing `metadata` request field during optional-param assembly.

## Changes

- Update `ResponsesAPIRequestUtils.get_requested_response_api_optional_param()` to:
  - Prefer `litellm_metadata.requester_metadata` (proxy snapshot of caller metadata)
  - Ignore polluted top-level `metadata` on proxy routes (detected via `user_api_key_*` keys in `litellm_metadata`)
  - Drop empty/non-caller metadata instead of forwarding `{}` upstream
- Add regression tests covering empty metadata, internal metadata, caller metadata, and `requester_metadata` routing

## Test plan

- [x] `pytest tests/test_litellm/responses/test_responses_utils.py` (32 passed)
- [x] `pytest tests/llm_responses_api_testing/test_openai_responses_api.py::test_openai_responses_litellm_router_no_metadata`
- [x] `pytest tests/llm_responses_api_testing/test_openai_responses_api.py::test_openai_responses_litellm_router_with_metadata`
- [x] Manual mocked e2e: internal/empty metadata no longer appears in upstream JSON; explicit caller metadata still forwarded