### PR TITLE
fix(xai): correct grok-4.5 cached-input pricing

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -40192,8 +40192,8 @@
         "supports_web_search": true
     },
     "xai/grok-4.5": {
-        "cache_read_input_token_cost": 5e-07,
-        "cache_read_input_token_cost_above_200k_tokens": 1e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_above_200k_tokens": 4e-06,
         "litellm_provider": "xai",
@@ -40213,8 +40213,8 @@
         "supports_web_search": true
     },
     "xai/grok-4.5-latest": {
-        "cache_read_input_token_cost": 5e-07,
-        "cache_read_input_token_cost_above_200k_tokens": 1e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_above_200k_tokens": 4e-06,
         "litellm_provider": "xai",


### PR DESCRIPTION
## What changed

`xai/grok-4.5` and `xai/grok-4.5-latest` have stale cached-input prices:

| field | before | after |
|---|---|---|
| `cache_read_input_token_cost` (base tier, <200k tokens) | `5e-07` ($0.50/1M) | `3e-07` ($0.30/1M) |
| `cache_read_input_token_cost_above_200k_tokens` (long-context tier, ≥200k tokens) | `1e-06` ($1.00/1M) | `6e-07` ($0.60/1M) |

Base `input_cost_per_token` / `output_cost_per_token` (and their `_above_200k_tokens` counterparts) were already correct and are untouched.

## Sources checked 2026-08-10

- https://docs.x.ai/developers/pricing — current pricing table, both tiers
- https://docs.x.ai/developers/models/grok-4.5 — model-specific pricing page
- https://docs.x.ai/docs/models — this entry's own `source` field; already shows the corrected numbers, so this looks like a sync that just never landed for these two fields specifically

All three currently agree on $0.30 / $0.60 for cached input.

## How this was found

Cross-checking a hand-verified pricing catalog (input/output/cache rates confirmed independently against vendor docs) against this feed. Every other field on these two entries matched; only the cached-input rates had drifted.