### PR TITLE
ci: cache Prisma CLI and engine binaries, split test timeout from setup

### DIFF
--- a/.github/actions/cache-prisma-binaries/action.yml
+++ b/.github/actions/cache-prisma-binaries/action.yml
@@ -1,0 +1,40 @@
+name: "Cache Prisma binaries"
+description: >-
+  Cache the Prisma CLI and engine binaries that `prisma generate` downloads, so
+  only the first job on a given prisma-client-py version pays for the download.
+
+  prisma-client-py shells out to `npm install prisma@<version>` whenever its
+  binary cache directory has no CLI entrypoint, which pulls ~85 MB of query and
+  schema engines over the network. That normally takes a few seconds, but it is
+  unbounded: one shard of a proxy-db run took 5m18s on that single step versus
+  3.8s on its eleven siblings, which pushed the job past its timeout and got a
+  fully passing test run cancelled.
+
+  Callers must not set PRISMA_BINARY_CACHE_DIR. The prisma-client-py default
+  (~/.cache/prisma-python/binaries/<prisma-version>/<engine-version>) is already
+  keyed by both versions, so a cache entry can never be served to a run that
+  expects different binaries.
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve prisma-client-py version
+      id: version
+      shell: bash
+      run: |
+        version="$(grep -A1 '^name = "prisma"$' uv.lock | sed -n 's/^version = "\(.*\)"$/\1/p' | head -1)"
+        if [ -z "${version}" ]; then
+          echo "could not resolve the prisma package version from uv.lock" >&2
+          exit 1
+        fi
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Prisma binaries
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        # ~/.cache/prisma-python holds the npm install tree prisma-client-py
+        # drives; ~/.cache/prisma is where @prisma/engines stages its downloads.
+        path: |
+          ~/.cache/prisma-python
+          ~/.cache/prisma
+        key: ${{ runner.os }}-prisma-binaries-${{ steps.version.outputs.version }}

--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -18,10 +18,18 @@ on:
         type: number
         default: 2
       timeout-minutes:
-        description: "Job timeout in minutes"
+        description: >-
+          Timeout for the test step alone. Setup (checkout, dependency install,
+          Prisma client generation) gets its own allowance on top, so a slow
+          runner or a cold binary download can never cancel passing tests.
         required: false
         type: number
         default: 20
+      setup-timeout-minutes:
+        description: "Timeout allowance for everything before the test step"
+        required: false
+        type: number
+        default: 12
       max-failures:
         description: "Stop after this many failures"
         required: false
@@ -44,7 +52,7 @@ jobs:
   run:
     name: Run tests
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ inputs.timeout-minutes }}
+    timeout-minutes: ${{ inputs.timeout-minutes + inputs.setup-timeout-minutes }}
     outputs:
       decision: ${{ steps.changes.outputs.decision }}
 
@@ -82,15 +90,18 @@ jobs:
         run: |
           .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router --extra saml
 
+      - name: Cache Prisma binaries
+        if: steps.changes.outputs.decision != 'skip'
+        uses: ./.github/actions/cache-prisma-binaries
+
       - name: Generate Prisma client
         if: steps.changes.outputs.decision != 'skip'
-        env:
-          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
           uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 
       - name: Run tests
         if: steps.changes.outputs.decision != 'skip'
+        timeout-minutes: ${{ inputs.timeout-minutes }}
         env:
           TEST_PATH: ${{ inputs.test-path }}
           MAX_FAILURES: ${{ inputs.max-failures }}

--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -25,15 +25,18 @@ on:
         required: false
         type: number
         default: 20
-      setup-timeout-minutes:
+      job-timeout-minutes:
         description: >-
-          Timeout allowance for everything before the test step. Must stay >= the
-          sum of the per-step timeouts on the setup steps below, which is what
-          makes the test budget above a floor rather than a hope: setup cannot
-          overrun into it without failing its own step first.
+          Backstop for the whole job. Keep it >= `timeout-minutes` plus 35: 30 for
+          the per-step ceilings on the setup steps below, and 5 for the runner
+          overhead the job clock charges but no step owns (job init, step
+          transitions, post-job cleanup). That headroom is what makes the test
+          budget a floor rather than a hope, since setup cannot overrun into it
+          without failing its own step first. GitHub expressions have no
+          arithmetic, so the sum is passed in rather than computed.
         required: false
         type: number
-        default: 30
+        default: 55
       max-failures:
         description: "Stop after this many failures"
         required: false
@@ -56,7 +59,7 @@ jobs:
   run:
     name: Run tests
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ inputs.timeout-minutes + inputs.setup-timeout-minutes }}
+    timeout-minutes: ${{ inputs.job-timeout-minutes }}
     outputs:
       decision: ${{ steps.changes.outputs.decision }}
 

--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -26,10 +26,14 @@ on:
         type: number
         default: 20
       setup-timeout-minutes:
-        description: "Timeout allowance for everything before the test step"
+        description: >-
+          Timeout allowance for everything before the test step. Must stay >= the
+          sum of the per-step timeouts on the setup steps below, which is what
+          makes the test budget above a floor rather than a hope: setup cannot
+          overrun into it without failing its own step first.
         required: false
         type: number
-        default: 12
+        default: 30
       max-failures:
         description: "Stop after this many failures"
         required: false
@@ -58,24 +62,29 @@ jobs:
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        timeout-minutes: 3
         with:
           persist-credentials: false
 
       - name: Detect backend-relevant changes
         id: changes
+        timeout-minutes: 2
         uses: ./.github/actions/detect-backend-changes
 
       - name: Set up Python
+        timeout-minutes: 3
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
       - name: Set up uv
+        timeout-minutes: 3
         uses: ./.github/actions/setup-uv-with-retries
         with:
           version: "0.10.9"
 
       - name: Cache uv dependencies
+        timeout-minutes: 5
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
@@ -87,15 +96,18 @@ jobs:
 
       - name: Install dependencies
         if: steps.changes.outputs.decision != 'skip'
+        timeout-minutes: 8
         run: |
           .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router --extra saml
 
       - name: Cache Prisma binaries
         if: steps.changes.outputs.decision != 'skip'
+        timeout-minutes: 3
         uses: ./.github/actions/cache-prisma-binaries
 
       - name: Generate Prisma client
         if: steps.changes.outputs.decision != 'skip'
+        timeout-minutes: 3
         run: |
           uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 

--- a/.github/workflows/check-ui-api-types.yml
+++ b/.github/workflows/check-ui-api-types.yml
@@ -71,10 +71,12 @@ jobs:
         if: steps.changes.outputs.relevant == 'true'
         run: .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
 
+      - name: Cache Prisma binaries
+        if: steps.changes.outputs.relevant == 'true'
+        uses: ./.github/actions/cache-prisma-binaries
+
       - name: Generate Prisma client
         if: steps.changes.outputs.relevant == 'true'
-        env:
-          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 
       - name: Set up Node.js

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -57,9 +57,10 @@ jobs:
         run: |
           .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router --extra saml
 
+      - name: Cache Prisma binaries
+        uses: ./.github/actions/cache-prisma-binaries
+
       - name: Generate Prisma client
-        env:
-          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
           uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 

--- a/.github/workflows/publish-basedpyright-base-counts.yml
+++ b/.github/workflows/publish-basedpyright-base-counts.yml
@@ -43,12 +43,13 @@ jobs:
         with:
           version: "0.10.9"
 
+      - name: Cache Prisma binaries
+        uses: ./.github/actions/cache-prisma-binaries
+
       # The gate provisions its own measurement env (.venv-typecheck: a frozen
       # uv sync of its canonical dependency groups plus a generated Prisma
       # client), so no install step here can drift from what local runs measure.
       - name: Emit basedpyright counts for HEAD
-        env:
-          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
           python scripts/type_check_gate.py --emit-counts-dir "$RUNNER_TEMP/basedpyright-counts"
           counts_file=$(ls "$RUNNER_TEMP"/basedpyright-counts/basedpyright-counts-*.json)

--- a/.github/workflows/test-code-quality.yml
+++ b/.github/workflows/test-code-quality.yml
@@ -68,6 +68,9 @@ jobs:
       - name: check_prisma_binary_cache
         run: uv run --no-sync python ./tests/code_coverage_tests/check_prisma_binary_cache.py
 
+      - name: check_workflow_startup_safety
+        run: uv run --no-sync python ./tests/code_coverage_tests/check_workflow_startup_safety.py
+
       - name: router_code_coverage
         run: uv run --no-sync python ./tests/code_coverage_tests/router_code_coverage.py
 

--- a/.github/workflows/test-code-quality.yml
+++ b/.github/workflows/test-code-quality.yml
@@ -65,6 +65,9 @@ jobs:
       - name: check_provider_folders_documented
         run: uv run --no-sync python ./tests/code_coverage_tests/check_provider_folders_documented.py
 
+      - name: check_prisma_binary_cache
+        run: uv run --no-sync python ./tests/code_coverage_tests/check_prisma_binary_cache.py
+
       - name: router_code_coverage
         run: uv run --no-sync python ./tests/code_coverage_tests/router_code_coverage.py
 

--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -71,12 +71,13 @@ jobs:
         run: |
           uv sync --frozen --group proxy-dev --group e2e-dev
 
+      - name: Cache Prisma binaries
+        uses: ./.github/actions/cache-prisma-binaries
+
       # basedpyright resolves Prisma's generated client (litellm/proxy/schema.prisma)
       # only after `prisma generate` writes prisma/client.py et al. Without this the
       # DB wrappers typed against the generated client would degrade to Unknown.
       - name: Generate Prisma client
-        env:
-          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
           uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 
@@ -119,7 +120,6 @@ jobs:
       - name: Check basedpyright budget (delta vs base)
         env:
           GH_TOKEN: ${{ github.token }}
-          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
           uv run --no-sync python scripts/type_check_gate.py --base "$GATE_BASE_SHA"
 

--- a/.github/workflows/test-terraform-provider.yml
+++ b/.github/workflows/test-terraform-provider.yml
@@ -92,9 +92,10 @@ jobs:
         run: |
           .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
 
+      - name: Cache Prisma binaries
+        uses: ./.github/actions/cache-prisma-binaries
+
       - name: Generate Prisma client
-        env:
-          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
           uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 

--- a/.github/workflows/test-unit-documentation.yml
+++ b/.github/workflows/test-unit-documentation.yml
@@ -65,10 +65,12 @@ jobs:
         run: |
           .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
 
+      - name: Cache Prisma binaries
+        if: steps.changes.outputs.decision != 'skip'
+        uses: ./.github/actions/cache-prisma-binaries
+
       - name: Generate Prisma client
         if: steps.changes.outputs.decision != 'skip'
-        env:
-          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
           uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 

--- a/.github/workflows/test-unit-proxy-db.yml
+++ b/.github/workflows/test-unit-proxy-db.yml
@@ -28,6 +28,10 @@ concurrency:
 #     Most of a shard's time is pytest plugin load + xdist worker imports +
 #     pytest-cov instrumentation, not the tests themselves. Keeping per-shard
 #     work low and matching worker count to runner cores is what controls it.
+#   * `timeout` bounds the pytest step only. Checkout, dependency install, and
+#     Prisma client generation draw on a separate allowance in the base
+#     workflow, so slow setup shows up as a slow job rather than as a
+#     cancelled shard whose tests were passing.
 #   * workers: 4 matches the 4-core ubuntu-latest runner. -n 8 on 4 cores
 #     oversubscribes 2x and workers fight for CPU during their cold-start
 #     imports (measured ~441% CPU for -n 8 locally, i.e. ~55% effective).

--- a/.github/workflows/test-unit-proxy-endpoints.yml
+++ b/.github/workflows/test-unit-proxy-endpoints.yml
@@ -76,4 +76,5 @@ jobs:
       workers: 4
       reruns: 2
       timeout-minutes: 60
+      job-timeout-minutes: 95
       artifact-name: proxy-server

--- a/.github/workflows/test-unit-proxy-legacy.yml
+++ b/.github/workflows/test-unit-proxy-legacy.yml
@@ -82,10 +82,12 @@ jobs:
         run: |
           .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
 
+      - name: Cache Prisma binaries
+        if: steps.changes.outputs.decision != 'skip'
+        uses: ./.github/actions/cache-prisma-binaries
+
       - name: Generate Prisma client
         if: steps.changes.outputs.decision != 'skip'
-        env:
-          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
           uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 

--- a/.github/workflows/weekly_load_anomaly.yml
+++ b/.github/workflows/weekly_load_anomaly.yml
@@ -51,9 +51,10 @@ jobs:
         run: |
           .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra proxy
 
+      - name: Cache Prisma binaries
+        uses: ./.github/actions/cache-prisma-binaries
+
       - name: Generate Prisma client
-        env:
-          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
           uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 

--- a/tests/code_coverage_tests/check_prisma_binary_cache.py
+++ b/tests/code_coverage_tests/check_prisma_binary_cache.py
@@ -20,11 +20,12 @@ Three invariants keep that download off the critical path:
 
 import re
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import Final
 
 import yaml
+from pydantic import BaseModel, Field, ValidationError
 
 REPO_ROOT: Final = Path(__file__).resolve().parent.parent.parent
 WORKFLOWS_DIR: Final = REPO_ROOT / ".github" / "workflows"
@@ -50,25 +51,38 @@ def resolve_prisma_version(lock_text: str) -> str | None:
     return match.group("version") if match else None
 
 
-def iter_jobs(workflow: object) -> Iterator[tuple[str, dict]]:
-    jobs: Final = workflow.get("jobs") if isinstance(workflow, dict) else None
-    if not isinstance(jobs, dict):
-        return
-    yield from ((name, job) for name, job in jobs.items() if isinstance(job, dict))
+class WorkflowStep(BaseModel):
+    """The two step fields this guard reads; every other key is ignored."""
+
+    run: str | None = None
+    uses: str | None = None
+
+    def generates_prisma_client(self) -> bool:
+        return self.run is not None and any(m in self.run for m in PRISMA_GENERATE_MARKERS)
+
+    def restores_cache(self) -> bool:
+        return self.uses == CACHE_ACTION
 
 
-def job_steps(job: dict) -> tuple[dict, ...]:
-    steps: Final = job.get("steps")
-    return tuple(s for s in steps if isinstance(s, dict)) if isinstance(steps, list) else ()
+class WorkflowJob(BaseModel):
+    # Absent for jobs that delegate to a reusable workflow via a job-level `uses`.
+    steps: tuple[WorkflowStep, ...] = ()
 
 
-def step_generates_prisma_client(step: dict) -> bool:
-    run: Final = step.get("run")
-    return isinstance(run, str) and any(m in run for m in PRISMA_GENERATE_MARKERS)
+class Workflow(BaseModel):
+    jobs: Mapping[str, WorkflowJob] = Field(default_factory=dict)
 
 
-def step_restores_cache(step: dict) -> bool:
-    return step.get("uses") == CACHE_ACTION
+def parse_workflow(text: str) -> Workflow | str:
+    """Validate untyped YAML at the boundary so the checks below stay typed.
+
+    Returns the parsed workflow, or a description of why it could not be read.
+    """
+    parsed: Final = yaml.safe_load(text)
+    try:
+        return Workflow.model_validate(parsed if isinstance(parsed, dict) else {})
+    except ValidationError as exc:
+        return f"does not parse as a workflow: {exc.error_count()} schema error(s)"
 
 
 def lock_errors(lock_text: str) -> Iterator[str]:
@@ -87,10 +101,14 @@ def workflow_errors(rel: Path, text: str) -> Iterator[str]:
             f"land in the version-keyed default path the {CACHE_ACTION} action restores."
         )
 
-    for job_name, job in iter_jobs(yaml.safe_load(text)):
-        steps: Final = job_steps(job)
-        if any(map(step_generates_prisma_client, steps)) and not any(
-            map(step_restores_cache, steps)
+    workflow: Final = parse_workflow(text)
+    if isinstance(workflow, str):
+        yield f"{rel}: {workflow}"
+        return
+
+    for job_name, job in workflow.jobs.items():
+        if any(s.generates_prisma_client() for s in job.steps) and not any(
+            s.restores_cache() for s in job.steps
         ):
             yield (
                 f"{rel}: job `{job_name}` generates the Prisma client without a "

--- a/tests/code_coverage_tests/check_prisma_binary_cache.py
+++ b/tests/code_coverage_tests/check_prisma_binary_cache.py
@@ -1,0 +1,125 @@
+"""Guard the CI cache for Prisma's CLI and engine binaries.
+
+``prisma generate`` shells out to ``npm install prisma@<version>`` whenever the
+prisma-client-py binary cache directory has no CLI entrypoint, pulling ~85 MB of
+engines over the network. The download is normally seconds and occasionally
+minutes, and a job timeout cannot tell the difference from a hung test, so an
+uncached job is one slow npm response away from cancelling a passing test run.
+
+Three invariants keep that download off the critical path:
+
+1. No workflow sets ``PRISMA_BINARY_CACHE_DIR``. The prisma-client-py default is
+   ``~/.cache/prisma-python/binaries/<prisma-version>/<engine-version>``, already
+   keyed by both versions and the only path the cache action restores. Pointing
+   it elsewhere (``runner.temp`` especially, which is wiped every job) silently
+   guarantees a cold download.
+2. Every job that generates the client also restores the cache.
+3. The cache key resolves to a real version from ``uv.lock``. The action fails
+   the job when it cannot, so a lock format change must break here instead.
+"""
+
+import re
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Final
+
+import yaml
+
+REPO_ROOT: Final = Path(__file__).resolve().parent.parent.parent
+WORKFLOWS_DIR: Final = REPO_ROOT / ".github" / "workflows"
+UV_LOCK: Final = REPO_ROOT / "uv.lock"
+CACHE_ACTION: Final = "./.github/actions/cache-prisma-binaries"
+
+# Commands that reach the prisma binary cache: a direct generate, or a script
+# that runs one on the caller's behalf.
+PRISMA_GENERATE_MARKERS: Final = ("prisma generate", "type_check_gate.py")
+
+
+class PrismaBinaryCacheError(Exception):
+    pass
+
+
+def resolve_prisma_version(lock_text: str) -> str | None:
+    """Mirror of the shell lookup in the cache action's version step."""
+    match: Final = re.search(
+        r'^name = "prisma"\n^version = "(?P<version>[^"]+)"$',
+        lock_text,
+        re.MULTILINE,
+    )
+    return match.group("version") if match else None
+
+
+def iter_jobs(workflow: object) -> Iterator[tuple[str, dict]]:
+    jobs: Final = workflow.get("jobs") if isinstance(workflow, dict) else None
+    if not isinstance(jobs, dict):
+        return
+    yield from ((name, job) for name, job in jobs.items() if isinstance(job, dict))
+
+
+def job_steps(job: dict) -> tuple[dict, ...]:
+    steps: Final = job.get("steps")
+    return tuple(s for s in steps if isinstance(s, dict)) if isinstance(steps, list) else ()
+
+
+def step_generates_prisma_client(step: dict) -> bool:
+    run: Final = step.get("run")
+    return isinstance(run, str) and any(m in run for m in PRISMA_GENERATE_MARKERS)
+
+
+def step_restores_cache(step: dict) -> bool:
+    return step.get("uses") == CACHE_ACTION
+
+
+def lock_errors(lock_text: str) -> Iterator[str]:
+    if not resolve_prisma_version(lock_text):
+        yield (
+            "uv.lock has no resolvable `prisma` package version. The version step "
+            f"in {CACHE_ACTION} greps the same shape and will fail every job that "
+            "generates the Prisma client."
+        )
+
+
+def workflow_errors(rel: Path, text: str) -> Iterator[str]:
+    if "PRISMA_BINARY_CACHE_DIR" in text:
+        yield (
+            f"{rel}: sets PRISMA_BINARY_CACHE_DIR. Leave it unset so the binaries "
+            f"land in the version-keyed default path the {CACHE_ACTION} action restores."
+        )
+
+    for job_name, job in iter_jobs(yaml.safe_load(text)):
+        steps: Final = job_steps(job)
+        if any(map(step_generates_prisma_client, steps)) and not any(
+            map(step_restores_cache, steps)
+        ):
+            yield (
+                f"{rel}: job `{job_name}` generates the Prisma client without a "
+                f"`uses: {CACHE_ACTION}` step, so it downloads ~85 MB of engines "
+                "on every run."
+            )
+
+
+def main() -> None:
+    errors: Final = (
+        *lock_errors(UV_LOCK.read_text()),
+        *(
+            error
+            for path in sorted(WORKFLOWS_DIR.glob("*.y*ml"))
+            for error in workflow_errors(path.relative_to(REPO_ROOT), path.read_text())
+        ),
+    )
+
+    if errors:
+        raise PrismaBinaryCacheError(
+            "Prisma binary cache invariants violated:\n  - " + "\n  - ".join(errors)
+        )
+
+    print("Prisma binary cache invariants hold across .github/workflows/")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except PrismaBinaryCacheError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/code_coverage_tests/check_workflow_startup_safety.py
+++ b/tests/code_coverage_tests/check_workflow_startup_safety.py
@@ -1,0 +1,172 @@
+"""Catch workflow mistakes that GitHub reports as nothing at all.
+
+A workflow whose YAML is valid but whose expressions are not fails at *startup*:
+the run is marked failed, no jobs are created, and no check run is ever posted.
+Nothing turns red on the PR, so an entire test suite can silently stop running
+while the checks list stays green. These invariants have to be enforced here
+because CI cannot enforce them on itself.
+
+1. No arithmetic inside ``${{ }}``. GitHub expressions support grouping, index,
+   dereference, ``!``, the comparisons, ``&&`` and ``||``, and nothing else. A
+   ``${{ a + b }}`` is a startup failure, not a value. Only ``+`` and ``*`` are
+   flagged: ``-`` appears in hyphenated input names like ``inputs.timeout-minutes``
+   and ``/`` inside ref strings, so neither can be told apart from arithmetic by
+   inspection alone.
+2. Callers of the reusable unit-test workflow keep the job timeout at or above
+   the test budget plus the setup ceilings. Otherwise the job deadline preempts
+   pytest inside its own advertised budget, which is the failure the split
+   timeouts exist to prevent, and it shows up as a cancelled shard whose tests
+   were passing.
+"""
+
+import re
+import sys
+from collections.abc import Iterator, Mapping, Sequence
+from pathlib import Path
+from typing import Final
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError
+
+REPO_ROOT: Final = Path(__file__).resolve().parent.parent.parent
+WORKFLOWS_DIR: Final = REPO_ROOT / ".github" / "workflows"
+BASE_WORKFLOW: Final = "./.github/workflows/_test-unit-base.yml"
+BASE_WORKFLOW_PATH: Final = WORKFLOWS_DIR / "_test-unit-base.yml"
+
+# Runner time the job clock charges but no step owns: job init, the gaps between
+# steps, and post-job cleanup. Without it a job capped at exactly test + setup
+# would still preempt pytest inside its own budget.
+JOB_OVERHEAD_MINUTES: Final = 5
+
+EXPRESSION: Final = re.compile(r"\$\{\{(?P<body>.*?)\}\}", re.DOTALL)
+QUOTED: Final = re.compile(r"'[^']*'")
+ARITHMETIC: Final = re.compile(r"[+*]")
+MATRIX_REF: Final = re.compile(r"^\$\{\{\s*matrix\.(?P<key>[\w-]+)\s*\}\}$")
+
+
+class WorkflowStartupError(Exception):
+    pass
+
+
+class ReusableCall(BaseModel):
+    uses: str | None = None
+    with_: Mapping[str, object] = Field(default_factory=dict, alias="with")
+    strategy: Mapping[str, object] = Field(default_factory=dict)
+    steps: tuple[Mapping[str, object], ...] = ()
+
+    model_config = {"populate_by_name": True}
+
+
+class WorkflowFile(BaseModel):
+    jobs: Mapping[str, ReusableCall] = Field(default_factory=dict)
+
+
+def parse_workflow(text: str) -> WorkflowFile | str:
+    parsed: Final = yaml.safe_load(text)
+    try:
+        return WorkflowFile.model_validate(parsed if isinstance(parsed, dict) else {})
+    except ValidationError as exc:
+        return f"does not parse as a workflow: {exc.error_count()} schema error(s)"
+
+
+def arithmetic_expressions(text: str) -> Iterator[str]:
+    for match in EXPRESSION.finditer(text):
+        body: Final = match.group("body")
+        if ARITHMETIC.search(QUOTED.sub("", body)):
+            yield body.strip()
+
+
+def setup_ceiling_minutes(base_text: str) -> int:
+    """Sum the per-step timeouts on everything the base workflow runs before pytest."""
+    base: Final = yaml.safe_load(base_text)
+    steps: Final = base["jobs"]["run"]["steps"]
+    return sum(
+        s["timeout-minutes"]
+        for s in steps
+        if s.get("name") != "Run tests" and isinstance(s.get("timeout-minutes"), int)
+    )
+
+
+def base_default(base_text: str, name: str) -> int:
+    base: Final = yaml.safe_load(base_text)
+    return base[True]["workflow_call"]["inputs"][name]["default"]
+
+
+def resolve_budgets(job: ReusableCall, key: str, fallback: int) -> Sequence[int]:
+    """A caller passes a literal, or `${{ matrix.x }}` naming a column of its matrix."""
+    value: Final = job.with_.get(key)
+    if value is None:
+        return (fallback,)
+    if isinstance(value, int):
+        return (value,)
+
+    matrix_ref: Final = MATRIX_REF.match(str(value))
+    if not matrix_ref:
+        return ()
+
+    include: Final = job.strategy.get("matrix", {})
+    entries: Final = include.get("include", ()) if isinstance(include, dict) else ()
+    return tuple(
+        e[matrix_ref.group("key")]
+        for e in entries
+        if isinstance(e, dict) and isinstance(e.get(matrix_ref.group("key")), int)
+    )
+
+
+def timeout_contract_errors(rel: Path, workflow: WorkflowFile, ceiling: int, base_text: str) -> Iterator[str]:
+    for job_name, job in workflow.jobs.items():
+        if job.uses != BASE_WORKFLOW:
+            continue
+
+        test_budgets: Final = resolve_budgets(job, "timeout-minutes", base_default(base_text, "timeout-minutes"))
+        job_budgets: Final = resolve_budgets(job, "job-timeout-minutes", base_default(base_text, "job-timeout-minutes"))
+        for test_budget in test_budgets:
+            for job_budget in job_budgets:
+                required = test_budget + ceiling + JOB_OVERHEAD_MINUTES
+                if job_budget < required:
+                    yield (
+                        f"{rel}: job `{job_name}` gives pytest {test_budget}m but caps the job at "
+                        f"{job_budget}m. Setup can use up to {ceiling}m plus {JOB_OVERHEAD_MINUTES}m of "
+                        f"runner overhead, so the job deadline would preempt pytest; raise "
+                        f"job-timeout-minutes to at least {required}."
+                    )
+
+
+def workflow_errors(rel: Path, text: str, ceiling: int, base_text: str) -> Iterator[str]:
+    for expression in arithmetic_expressions(text):
+        yield (
+            f"{rel}: `${{{{ {expression} }}}}` uses arithmetic, which GitHub expressions do not "
+            "support. The workflow will fail at startup with no jobs and no check run."
+        )
+
+    workflow: Final = parse_workflow(text)
+    if isinstance(workflow, str):
+        yield f"{rel}: {workflow}"
+        return
+
+    yield from timeout_contract_errors(rel, workflow, ceiling, base_text)
+
+
+def main() -> None:
+    base_text: Final = BASE_WORKFLOW_PATH.read_text()
+    ceiling: Final = setup_ceiling_minutes(base_text)
+    errors: Final = tuple(
+        error
+        for path in sorted(WORKFLOWS_DIR.glob("*.y*ml"))
+        for error in workflow_errors(path.relative_to(REPO_ROOT), path.read_text(), ceiling, base_text)
+    )
+
+    if errors:
+        raise WorkflowStartupError(
+            "Workflow startup invariants violated:\n  - " + "\n  - ".join(errors)
+        )
+
+    print(f"Workflow startup invariants hold (setup ceiling {ceiling}m)")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except WorkflowStartupError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/code_coverage_tests/check_workflow_startup_safety.py
+++ b/tests/code_coverage_tests/check_workflow_startup_safety.py
@@ -13,10 +13,10 @@ because CI cannot enforce them on itself.
    and ``/`` inside ref strings, so neither can be told apart from arithmetic by
    inspection alone.
 2. Callers of the reusable unit-test workflow keep the job timeout at or above
-   the test budget plus the setup ceilings. Otherwise the job deadline preempts
-   pytest inside its own advertised budget, which is the failure the split
-   timeouts exist to prevent, and it shows up as a cancelled shard whose tests
-   were passing.
+   the test budget plus the setup ceilings plus the runner overhead below.
+   Otherwise the job deadline preempts pytest inside its own advertised budget,
+   which is the failure the split timeouts exist to prevent, and it shows up as
+   a cancelled shard whose tests were passing.
 """
 
 import re

--- a/tests/code_coverage_tests/check_workflow_startup_safety.py
+++ b/tests/code_coverage_tests/check_workflow_startup_safety.py
@@ -16,12 +16,15 @@ because CI cannot enforce them on itself.
    the test budget plus the setup ceilings plus the runner overhead below.
    Otherwise the job deadline preempts pytest inside its own advertised budget,
    which is the failure the split timeouts exist to prevent, and it shows up as
-   a cancelled shard whose tests were passing.
+   a cancelled shard whose tests were passing. A budget this check cannot resolve
+   is reported rather than skipped, so a mistyped input or matrix column surfaces
+   here instead of leaving the pair silently unchecked.
 """
 
 import re
 import sys
 from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
 
@@ -92,8 +95,19 @@ def base_default(base_text: str, name: str) -> int:
     return base[True]["workflow_call"]["inputs"][name]["default"]
 
 
-def budget_source(job: ReusableCall, key: str, fallback: int) -> int | str | None:
-    """A caller passes a literal, or `${{ matrix.x }}` naming a column of its matrix."""
+@dataclass(frozen=True, slots=True)
+class Column:
+    """A budget the caller reads from one column of its own matrix."""
+
+    name: str
+
+
+def budget_source(job: ReusableCall, key: str, fallback: int) -> int | Column | str:
+    """A caller passes a literal, or `${{ matrix.x }}` naming a column of its matrix.
+
+    Anything else comes back as the reason it could not be read, since a budget
+    nothing can resolve has to be reported rather than passed over.
+    """
     value: Final = job.with_.get(key)
     if value is None:
         return fallback
@@ -101,7 +115,9 @@ def budget_source(job: ReusableCall, key: str, fallback: int) -> int | str | Non
         return value
 
     matrix_ref: Final = MATRIX_REF.match(str(value))
-    return matrix_ref.group("key") if matrix_ref else None
+    if not matrix_ref:
+        return f"passes `{key}: {value}`, which is neither a number nor a `matrix` reference."
+    return Column(matrix_ref.group("key"))
 
 
 def matrix_rows(job: ReusableCall) -> Sequence[Mapping[str, object]]:
@@ -110,7 +126,7 @@ def matrix_rows(job: ReusableCall) -> Sequence[Mapping[str, object]]:
     return tuple(e for e in entries if isinstance(e, dict))
 
 
-def budget_pairs(job: ReusableCall, test_source: int | str, job_source: int | str) -> Iterator[tuple[int, int]]:
+def budget_pairs(job: ReusableCall, test_source: int | Column, job_source: int | Column) -> Iterator[tuple[int, int]]:
     """Pair each shard's test budget with the job budget of that same shard.
 
     Matrix-sourced budgets resolve per `include` row, so two matrix columns are
@@ -121,31 +137,66 @@ def budget_pairs(job: ReusableCall, test_source: int | str, job_source: int | st
         return
 
     for row in matrix_rows(job):
-        test_budget = row.get(test_source) if isinstance(test_source, str) else test_source
-        job_budget = row.get(job_source) if isinstance(job_source, str) else job_source
+        test_budget = row.get(test_source.name) if isinstance(test_source, Column) else test_source
+        job_budget = row.get(job_source.name) if isinstance(job_source, Column) else job_source
         if isinstance(test_budget, int) and isinstance(job_budget, int):
             yield test_budget, job_budget
 
 
+def unresolved_message(where: str, job: ReusableCall, sources: Sequence[int | Column]) -> str:
+    """Why no shard yielded a pair of budgets to compare.
+
+    Naming only the columns that resolve nowhere keeps the message honest: a
+    column every row supplies is not what left the pair unchecked.
+    """
+    rows: Final = matrix_rows(job)
+    missing: Final = tuple(
+        f"`matrix.{s.name}`"
+        for s in sources
+        if isinstance(s, Column) and not any(isinstance(row.get(s.name), int) for row in rows)
+    )
+    if missing:
+        return (
+            f"{where} reads a budget from {', '.join(missing)}, which no `include` row supplies "
+            "as a number, so the pair would go unchecked."
+        )
+    return (
+        f"{where} reads both budgets from its matrix, but no single `include` row supplies both "
+        "as numbers, so the pair would go unchecked."
+    )
+
+
+def job_errors(rel: Path, job_name: str, job: ReusableCall, ceiling: int, base_text: str) -> Iterator[str]:
+    where: Final = f"{rel}: job `{job_name}`"
+    test_source: Final = budget_source(job, "timeout-minutes", base_default(base_text, "timeout-minutes"))
+    job_source: Final = budget_source(job, "job-timeout-minutes", base_default(base_text, "job-timeout-minutes"))
+    sources: Final = (test_source, job_source)
+
+    unreadable: Final = tuple(f"{where} {reason}" for reason in sources if isinstance(reason, str))
+    if unreadable:
+        yield from unreadable
+        return
+
+    pairs: Final = tuple(budget_pairs(job, test_source, job_source))
+    if not pairs:
+        yield unresolved_message(where, job, sources)
+        return
+
+    for test_budget, job_budget in pairs:
+        required = test_budget + ceiling + JOB_OVERHEAD_MINUTES
+        if job_budget < required:
+            yield (
+                f"{where} gives pytest {test_budget}m but caps the job at "
+                f"{job_budget}m. Setup can use up to {ceiling}m plus {JOB_OVERHEAD_MINUTES}m of "
+                f"runner overhead, so the job deadline would preempt pytest; raise "
+                f"job-timeout-minutes to at least {required}."
+            )
+
+
 def timeout_contract_errors(rel: Path, workflow: WorkflowFile, ceiling: int, base_text: str) -> Iterator[str]:
     for job_name, job in workflow.jobs.items():
-        if job.uses != BASE_WORKFLOW:
-            continue
-
-        test_source: Final = budget_source(job, "timeout-minutes", base_default(base_text, "timeout-minutes"))
-        job_source: Final = budget_source(job, "job-timeout-minutes", base_default(base_text, "job-timeout-minutes"))
-        if test_source is None or job_source is None:
-            continue
-
-        for test_budget, job_budget in budget_pairs(job, test_source, job_source):
-            required = test_budget + ceiling + JOB_OVERHEAD_MINUTES
-            if job_budget < required:
-                yield (
-                    f"{rel}: job `{job_name}` gives pytest {test_budget}m but caps the job at "
-                    f"{job_budget}m. Setup can use up to {ceiling}m plus {JOB_OVERHEAD_MINUTES}m of "
-                    f"runner overhead, so the job deadline would preempt pytest; raise "
-                    f"job-timeout-minutes to at least {required}."
-                )
+        if job.uses == BASE_WORKFLOW:
+            yield from job_errors(rel, job_name, job, ceiling, base_text)
 
 
 def workflow_errors(rel: Path, text: str, ceiling: int, base_text: str) -> Iterator[str]:

--- a/tests/code_coverage_tests/check_workflow_startup_safety.py
+++ b/tests/code_coverage_tests/check_workflow_startup_safety.py
@@ -92,25 +92,39 @@ def base_default(base_text: str, name: str) -> int:
     return base[True]["workflow_call"]["inputs"][name]["default"]
 
 
-def resolve_budgets(job: ReusableCall, key: str, fallback: int) -> Sequence[int]:
+def budget_source(job: ReusableCall, key: str, fallback: int) -> int | str | None:
     """A caller passes a literal, or `${{ matrix.x }}` naming a column of its matrix."""
     value: Final = job.with_.get(key)
     if value is None:
-        return (fallback,)
+        return fallback
     if isinstance(value, int):
-        return (value,)
+        return value
 
     matrix_ref: Final = MATRIX_REF.match(str(value))
-    if not matrix_ref:
-        return ()
+    return matrix_ref.group("key") if matrix_ref else None
 
-    include: Final = job.strategy.get("matrix", {})
-    entries: Final = include.get("include", ()) if isinstance(include, dict) else ()
-    return tuple(
-        e[matrix_ref.group("key")]
-        for e in entries
-        if isinstance(e, dict) and isinstance(e.get(matrix_ref.group("key")), int)
-    )
+
+def matrix_rows(job: ReusableCall) -> Sequence[Mapping[str, object]]:
+    matrix: Final = job.strategy.get("matrix", {})
+    entries: Final = matrix.get("include", ()) if isinstance(matrix, dict) else ()
+    return tuple(e for e in entries if isinstance(e, dict))
+
+
+def budget_pairs(job: ReusableCall, test_source: int | str, job_source: int | str) -> Iterator[tuple[int, int]]:
+    """Pair each shard's test budget with the job budget of that same shard.
+
+    Matrix-sourced budgets resolve per `include` row, so two matrix columns are
+    read off the same row rather than cross-producted across rows.
+    """
+    if isinstance(test_source, int) and isinstance(job_source, int):
+        yield test_source, job_source
+        return
+
+    for row in matrix_rows(job):
+        test_budget = row.get(test_source) if isinstance(test_source, str) else test_source
+        job_budget = row.get(job_source) if isinstance(job_source, str) else job_source
+        if isinstance(test_budget, int) and isinstance(job_budget, int):
+            yield test_budget, job_budget
 
 
 def timeout_contract_errors(rel: Path, workflow: WorkflowFile, ceiling: int, base_text: str) -> Iterator[str]:
@@ -118,18 +132,20 @@ def timeout_contract_errors(rel: Path, workflow: WorkflowFile, ceiling: int, bas
         if job.uses != BASE_WORKFLOW:
             continue
 
-        test_budgets: Final = resolve_budgets(job, "timeout-minutes", base_default(base_text, "timeout-minutes"))
-        job_budgets: Final = resolve_budgets(job, "job-timeout-minutes", base_default(base_text, "job-timeout-minutes"))
-        for test_budget in test_budgets:
-            for job_budget in job_budgets:
-                required = test_budget + ceiling + JOB_OVERHEAD_MINUTES
-                if job_budget < required:
-                    yield (
-                        f"{rel}: job `{job_name}` gives pytest {test_budget}m but caps the job at "
-                        f"{job_budget}m. Setup can use up to {ceiling}m plus {JOB_OVERHEAD_MINUTES}m of "
-                        f"runner overhead, so the job deadline would preempt pytest; raise "
-                        f"job-timeout-minutes to at least {required}."
-                    )
+        test_source: Final = budget_source(job, "timeout-minutes", base_default(base_text, "timeout-minutes"))
+        job_source: Final = budget_source(job, "job-timeout-minutes", base_default(base_text, "job-timeout-minutes"))
+        if test_source is None or job_source is None:
+            continue
+
+        for test_budget, job_budget in budget_pairs(job, test_source, job_source):
+            required = test_budget + ceiling + JOB_OVERHEAD_MINUTES
+            if job_budget < required:
+                yield (
+                    f"{rel}: job `{job_name}` gives pytest {test_budget}m but caps the job at "
+                    f"{job_budget}m. Setup can use up to {ceiling}m plus {JOB_OVERHEAD_MINUTES}m of "
+                    f"runner overhead, so the job deadline would preempt pytest; raise "
+                    f"job-timeout-minutes to at least {required}."
+                )
 
 
 def workflow_errors(rel: Path, text: str, ceiling: int, base_text: str) -> Iterator[str]:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every CI job re-downloads ~85 MB of Prisma engines
- `PRISMA_BINARY_CACHE_DIR` pointed at `runner.temp`, wiped per job
- That download took 5m18s once, cancelling a passing shard
- Job timeouts charged setup time against the test budget

How it solves it:

- Cache the Prisma CLI and engines, keyed by version
- Stop overriding the already version-keyed default path
- `timeout-minutes` now bounds pytest, every setup step capped
- Guards catch silent workflow startup failures before merge

## User Flow

Before: a contributor opens a PR, every test shard passes, and one gets cancelled anyway, so they have to rerun the suite by hand

1. They push a commit and watch the checks on their PR
2. Eleven `Unit Tests: Proxy DB Operations` shards go green
3. The `proxy-utils` shard reports "cancelled" after 15 minutes, with its own log showing 99% of tests passed and none failed
4. Their PR sits at "blocked" because a required check is not green
5. They open the run and click "Re-run failed jobs", then wait another 15 minutes for an answer they already had

After: the same push gets a straight answer on the first try

1. They push a commit and watch the checks on their PR
2. All twelve shards go green, including `proxy-utils`
3. Their PR moves to mergeable without anyone touching the Actions UI

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This change only moves CI setup work, so no LLM call exercises it. The live proof is the checks on this PR itself, and the numbers below come from the run that motivated it

The incident, at base `f6b9518d`. `Generate Prisma client` across the twelve shards of one `Unit Tests: Proxy DB Operations` run, sorted slowest first:

```
shard                     prisma     tests   conclusion
proxy-utils                 384s      396s   cancelled
db-and-spend                 34s      562s   success
auth-checks                  32s      542s   success
key-generation               31s      220s   success
jwt-and-keys                 30s      550s   success
guardrails-hooks             29s      540s   success
endpoints-and-responses      29s      551s   success
proxy-runtime                28s      531s   success
budgets                      28s      373s   success
custom-logging               27s      536s   success
logging-misc                 24s      467s   success
proxy-server-core            21s      308s   success
```

Inside that step, the npm install of the Prisma CLI is the whole difference. The cancelled shard:

```
14:19:59.7217584Z Installing Prisma CLI
14:25:17.7670340Z Prisma schema loaded from litellm/proxy/schema.prisma
```

and a sibling shard on the same run:

```
14:19:43.0381206Z Installing Prisma CLI
14:19:46.8797318Z Prisma schema loaded from litellm/proxy/schema.prisma
```

5m18s against 3.8s, for a step that downloads the same bytes both times. The job died 17 seconds past its 15 minute timeout with the tests at 99% and nothing failing:

```
2026-08-10T14:32:23.7653190Z [gw2] [ 99%] PASSED tests/proxy_unit_tests/test_proxy_utils.py::test_enforced_params_check[...]
2026-08-10T14:32:49.3559016Z ##[error]The operation was canceled.
```

Why the cache could never hit, at base `f6b9518d`. prisma-client-py runs `npm install prisma@<version>` whenever its cache dir has no CLI entrypoint, and the workflows pointed that dir at a path GitHub recreates per job:

```
$ .venv/bin/python -c "from prisma import config; print(config.binary_cache_dir)"
/root/.cache/prisma-python/binaries/5.4.2/ac9d7041ed77bcc8a8dbd2ab6616b39013829574

$ git grep -c 'PRISMA_BINARY_CACHE_DIR' f6b9518d -- .github/workflows/ | awk -F: '{s+=$NF} END {print s" lines across "NR" files"}'
10 lines across 9 files
$ git grep -ho 'PRISMA_BINARY_CACHE_DIR: .*' f6b9518d -- .github/workflows/ | sort -u
PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
```

The default path already carries the prisma version and the engine hash, so it can never serve stale binaries. The override traded that for a directory that is empty on arrival, every time

What the cache has to hold, measured at `6a83a84f` by running generate repeatedly until the directories stop growing:

```
# cold, with an empty binary cache dir
$ time PRISMA_BINARY_CACHE_DIR=$D/prisma-cache .venv/bin/python -m prisma generate --schema litellm/proxy/schema.prisma
Installing Prisma CLI
...
real  0m40.776s
$ du -sh $D/prisma-cache
85M

# the engines staging cache is repopulated even when the binary dir is warm,
# so it is not redundant: removed before this run, 51M after it
$ du -sh ~/.cache/prisma
51M

# repeated generates keep fetching the schema's other binaryTargets until both settle
$ du -sm $D/prisma-cache ~/.cache/prisma   # before
135
152
$ PRISMA_BINARY_CACHE_DIR=$D/prisma-cache .venv/bin/python -m prisma generate --schema litellm/proxy/schema.prisma >/dev/null
$ du -sm $D/prisma-cache ~/.cache/prisma   # after, unchanged
135
152
```

Both directories are load bearing and both converge, which is why the action restores the pair. The schema's extra `binaryTargets` are what make the first couple of runs keep growing

The cache doing its job, on run 31412955839 for `c22a749f`. The npm install is gone from the path entirely, and the restore is a bounded 3.7s transfer instead of an unbounded registry round trip:

```
17:16:47.4153349Z Cache hit for: Linux-prisma-binaries-0.11.0
17:16:48.7099479Z Received 4194304 of 102197363 (4.1%), 4.0 MBs/sec
17:16:50.7571734Z Received 102197363 of 102197363 (100.0%), 32.0 MBs/sec
17:16:51.1502255Z Cache restored successfully
17:16:51.1634219Z Cache restored from key: Linux-prisma-binaries-0.11.0
17:17:03.1962421Z Prisma schema loaded from litellm/proxy/schema.prisma
17:17:11.4874810Z ✔ Generated Prisma Client Python (v0.11.0) to ./.venv/lib/python3.12/site-packages/prisma in 922ms
```

`Installing Prisma CLI` appears zero times in that log, against once per job on every shard before this change. The post step declines to re-upload what it just restored:

```
$ grep -c "Installing Prisma CLI" job-logs.txt
0
17:20:57.3122582Z Cache hit occurred on the primary key Linux-prisma-binaries-0.11.0, not saving cache.
```

The shard that started this, `proxy-utils`, on head `8835b598`. The step that took 384s and cancelled the job now finishes in 24s, and the tests land well inside their own budget:

```
Cache Prisma binaries    17:24:58 -> 17:24:59     1s
Generate Prisma client   17:24:59 -> 17:25:23    24s   (384s on the incident run)
Run tests                17:25:23 -> 17:34:10   527s   success, budget 15m
```

The guard, at `6a83a84f`. It passes on the branch, and it fails on each fix reverted one at a time:

```
$ .venv/bin/python tests/code_coverage_tests/check_prisma_binary_cache.py
Prisma binary cache invariants hold across .github/workflows/

$ # reintroduce the override on one workflow
$ .venv/bin/python tests/code_coverage_tests/check_prisma_binary_cache.py; echo "exit=$?"
ERROR: Prisma binary cache invariants violated:
  - .github/workflows/test-linting.yml: sets PRISMA_BINARY_CACHE_DIR. Leave it unset so the binaries land in the version-keyed default path the ./.github/actions/cache-prisma-binaries action restores.
exit=1

$ # drop the cache step from a job that generates the client
$ .venv/bin/python tests/code_coverage_tests/check_prisma_binary_cache.py; echo "exit=$?"
ERROR: Prisma binary cache invariants violated:
  - .github/workflows/weekly_load_anomaly.yml: job `weekly-load-anomaly` generates the Prisma client without a `uses: ./.github/actions/cache-prisma-binaries` step, so it downloads ~85 MB of engines on every run.
exit=1

$ # change the shape the action greps out of uv.lock
$ .venv/bin/python tests/code_coverage_tests/check_prisma_binary_cache.py; echo "exit=$?"
ERROR: Prisma binary cache invariants violated:
  - uv.lock has no resolvable `prisma` package version. The version step in ./.github/actions/cache-prisma-binaries greps the same shape and will fail every job that generates the Prisma client.
exit=1
```

Five mutants, five kills. The two not shown above are dropping the cache step from `_test-unit-base.yml`, and a workflow whose `jobs` key is not a mapping, which now reports as `does not parse as a workflow: 1 schema error(s)` rather than raising. The shell lookup in the action also agrees with the Python mirror the guard checks:

```
$ grep -A1 '^name = "prisma"$' uv.lock | sed -n 's/^version = "\(.*\)"$/\1/p' | head -1
0.11.0
```

The setup ceilings and the job budget, at `c22a749f`:

```
$ .venv/bin/python check_setup_budget.py
   3m  actions/checkout@08eba0b27e820071cde6df949e0
   2m  Detect backend-relevant changes
   3m  Set up Python
   3m  Set up uv
   5m  Cache uv dependencies
   8m  Install dependencies
   3m  Cache Prisma binaries
   3m  Generate Prisma client
setup ceilings sum = 30m

$ .venv/bin/python tests/code_coverage_tests/check_workflow_startup_safety.py
Workflow startup invariants hold (setup ceiling 30m)
```

The first two commits on this branch shipped `${{ inputs.timeout-minutes + inputs.setup-timeout-minutes }}`, and GitHub expressions have no arithmetic operators. That is a startup failure, which creates no jobs and posts no check run, so the proxy-db suite stopped running entirely while the PR's check list stayed green. The runs record it, and the giveaway is `name`: a run that failed to start reports the file path because GitHub never parsed far enough to read the workflow's declared name

```
run 31407871408  6a83a84f  .github/workflows/test-unit-proxy-db.yml   failure   0 jobs
run 31408578156  efd98bb1  .github/workflows/test-unit-proxy-db.yml   failure   0 jobs
run 31412955839  c22a749f  Unit Tests: Proxy DB Operations            success   jobs created
```

`check_workflow_startup_safety.py` exists so that never reaches a reviewer again. Reverting each fix one at a time:

```
$ # put the arithmetic back exactly as it shipped
ERROR: Workflow startup invariants violated:
  - .github/workflows/_test-unit-base.yml: `${{ inputs.timeout-minutes + inputs.setup-timeout-minutes }}` uses arithmetic, which GitHub expressions do not support. The workflow will fail at startup with no jobs and no check run.

$ # shrink a caller's job budget below its test budget
ERROR: Workflow startup invariants violated:
  - .github/workflows/test-unit-proxy-endpoints.yml: job `proxy-server` gives pytest 60m but caps the job at 70m. Setup can use up to 30m plus 5m of runner overhead, so the job deadline would preempt pytest; raise job-timeout-minutes to at least 95.

$ # raise a setup ceiling without raising the callers' job budgets
ERROR: Workflow startup invariants violated:
  - .github/workflows/test-unit-core-utils.yml: job `core-utils` gives pytest 20m but caps the job at 55m. Setup can use up to 42m plus 5m of runner overhead, so the job deadline would preempt pytest; raise job-timeout-minutes to at least 67.
  ... one per caller
```

A caller can set either budget from a column of its own matrix, so the two have to resolve off the same `include` row. Pairing them independently would reject a matrix whose every row is valid, and refusing to pair them at all would let a budget through unchecked. Against a scratch caller with rows `(15, 50)` and `(20, 55)`:

```
$ # both budgets matrix-sourced, every row individually valid
Workflow startup invariants hold (setup ceiling 30m)

$ # drop the second row's job budget to 51, below what that same row's 20m test budget needs
ERROR: Workflow startup invariants violated:
  - .github/workflows/test-unit-shards.yml: job `shards` gives pytest 20m but caps the job at 51m. Setup can use up to 30m plus 5m of runner overhead, so the job deadline would preempt pytest; raise job-timeout-minutes to at least 55.

$ # mistype one column name
ERROR: Workflow startup invariants violated:
  - .github/workflows/test-unit-shards.yml: job `shards` reads a budget from `matrix.tmieout`, which no `include` row supplies as a number, so the pair would go unchecked.

$ # split the two columns across rows so no single row supplies both
ERROR: Workflow startup invariants violated:
  - .github/workflows/test-unit-shards.yml: job `shards` reads both budgets from its matrix, but no single `include` row supplies both as numbers, so the pair would go unchecked.

$ # pass something that is neither a number nor a matrix reference
ERROR: Workflow startup invariants violated:
  - .github/workflows/test-unit-shards.yml: job `shards` passes `timeout-minutes: ${{ inputs.whatever }}`, which is neither a number nor a `matrix` reference.
```

The last three matter because the guard's own failure mode is the one it exists to catch. Before this, each of them resolved to no budgets, no errors, and a printed "invariants hold" over a caller nothing had checked

## Type

🚄 Infrastructure

## Changes

`.github/actions/cache-prisma-binaries` is a new composite action. It resolves the pinned prisma-client-py version out of `uv.lock`, fails loudly if it cannot, and restores `~/.cache/prisma-python` together with `~/.cache/prisma` under a key carrying that version. Nine workflows drop the `PRISMA_BINARY_CACHE_DIR` override and gain the action ahead of whatever generates the client, whether that is a direct `prisma generate` or `type_check_gate.py` provisioning its own env

`_test-unit-base.yml` splits the two things its single timeout was doing. `timeout-minutes` now applies to the pytest step, which is what the per-shard budget in `test-unit-proxy-db.yml` was always describing, and `job-timeout-minutes` caps the job as a whole. Every setup step carries its own ceiling, summing to 30 minutes, and callers keep the job budget at or above the test budget plus that 30 plus 5 minutes of runner overhead the job clock charges but no step owns. Setup therefore cannot overrun into the test budget without failing its own step first. A hung test still fails fast on the budget its author picked, and slow setup surfaces as a red step naming itself instead of a cancelled shard whose tests were passing

`tests/code_coverage_tests/check_workflow_startup_safety.py` rejects arithmetic inside a `${{ }}` expression and checks every caller of the reusable workflow keeps a job budget the deadline cannot use to preempt pytest. Both classes are invisible in CI, the first because a startup failure posts no check run at all, so they have to be caught before merge. Budgets a caller reads from its matrix resolve per `include` row, so a shard's test budget is only ever compared against that same shard's job budget, and a budget the check cannot resolve is reported instead of skipped

`tests/code_coverage_tests/check_prisma_binary_cache.py` runs in `test-code-quality.yml` next to the other repo invariants. It enforces that no workflow sets `PRISMA_BINARY_CACHE_DIR`, that every job generating the client also restores the cache, and that the version lookup still resolves against the current `uv.lock`. The workflow YAML it reads is validated once through Pydantic models rather than passed around as bare dicts, and a file that does not parse is reported as a finding instead of a traceback

## QA runbook

1. Open the checks on this PR and confirm all twelve `Unit Tests: Proxy DB Operations` shards report success, `proxy-utils` included
2. Open any one of those jobs and confirm `Cache Prisma binaries` reports a cache hit, `Generate Prisma client` finishes in seconds rather than minutes, and `Installing Prisma CLI` appears nowhere in the log
3. Locally, `uv run --no-sync python tests/code_coverage_tests/check_prisma_binary_cache.py` and `uv run --no-sync python tests/code_coverage_tests/check_workflow_startup_safety.py` both exit 0
4. Lower any caller's `job-timeout-minutes` below its `timeout-minutes` plus 35, rerun the second guard, and confirm it exits 1 naming that job and the minimum it needs

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions and CI guard scripts; no runtime application, auth, or data-path behavior changes.
> 
> **Overview**
> Addresses flaky **cancelled** unit-test shards where slow Prisma CLI/engine downloads during setup consumed the same clock as pytest.
> 
> Adds a composite action **`cache-prisma-binaries`** that restores `~/.cache/prisma-python` and `~/.cache/prisma` keyed by the `prisma` version from **`uv.lock`**, and wires it into every workflow that runs **`prisma generate`** (or **`type_check_gate.py`**). Workflows **remove** `PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache`, which forced a cold ~85 MB download every job.
> 
> **`_test-unit-base.yml`** now treats **`timeout-minutes`** as the pytest step budget only, adds **`job-timeout-minutes`** for the whole job, and puts **`timeout-minutes`** on each setup step (checkout, install, cache, generate). Callers pass explicit job backstops where needed (e.g. proxy-server **95m** vs **60m** tests).
> 
> **`test-code-quality.yml`** runs two new guards: **`check_prisma_binary_cache.py`** (no cache-dir override, cache step paired with generate, lock version resolvable) and **`check_workflow_startup_safety.py`** (no `+`/`*` in `${{ }}` expressions; reusable workflow callers keep `job-timeout-minutes` ≥ test budget + setup ceiling + overhead).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b997a28c533283458a69cd5cd2096c35d203d2ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->