### PR TITLE
ci: stop unit-test shards flaking on uncached Prisma CLI downloads

### DIFF
--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -77,6 +77,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-uv-
 
+      # Without this cache, `prisma generate` runs `npm install prisma@<ver>`
+      # plus engine downloads on every job; a slow npm fetch once took 5+ min
+      # and pushed a shard past its job timeout with all tests passing.
+      # prisma-client-py versions its binaries under this dir, and uv.lock pins
+      # the prisma package, so keying on uv.lock rotates the cache exactly when
+      # the binaries can change.
+      - name: Cache Prisma binaries
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/prisma-python
+          key: ${{ runner.os }}-prisma-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-prisma-
+
       - name: Install dependencies
         if: steps.changes.outputs.decision != 'skip'
         run: |
@@ -84,8 +98,6 @@ jobs:
 
       - name: Generate Prisma client
         if: steps.changes.outputs.decision != 'skip'
-        env:
-          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
           uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 

--- a/.github/workflows/test-unit-proxy-db.yml
+++ b/.github/workflows/test-unit-proxy-db.yml
@@ -24,10 +24,13 @@ concurrency:
 # to whichever group it belongs to, not reshuffling slices.
 #
 # Design targets:
-#   * Every shard runs in <= 7 minutes of wall-clock on the default runner.
-#     Most of a shard's time is pytest plugin load + xdist worker imports +
-#     pytest-cov instrumentation, not the tests themselves. Keeping per-shard
-#     work low and matching worker count to runner cores is what controls it.
+#   * Shards take 7-13 minutes of job wall-clock on the default runner, mostly
+#     setup + pytest plugin load + xdist worker imports + pytest-cov
+#     instrumentation rather than the tests themselves. Keeping per-shard work
+#     low and matching worker count to runner cores is what controls it.
+#     Shards inherit the base workflow's 20-minute default timeout; tighter
+#     per-shard ceilings have killed healthy runs on runner/network variance,
+#     so don't add them back.
 #   * workers: 4 matches the 4-core ubuntu-latest runner. -n 8 on 4 cores
 #     oversubscribes 2x and workers fight for CPU during their cold-start
 #     imports (measured ~441% CPU for -n 8 locally, i.e. ~55% effective).
@@ -81,7 +84,7 @@ jobs:
   proxy-db:
     needs: assert-shard-coverage
     # Display only the semantic shard name in the checks UI instead of GHA's
-    # default "proxy-db (key-generation, tests/proxy_unit_tests/…, 0, loadscope, 20)"
+    # default "proxy-db (key-generation, tests/proxy_unit_tests/…, 0, loadscope)"
     # which includes every matrix field and gets truncated past the test-path.
     name: ${{ matrix.test-group }}
     permissions:
@@ -97,7 +100,6 @@ jobs:
             test-path: "tests/proxy_unit_tests/test_key_generate_prisma.py"
             workers: 0
             dist: loadscope
-            timeout: 20
 
           # ---- auth: split into 2 shards ----
           - test-group: auth-checks
@@ -107,7 +109,6 @@ jobs:
               tests/proxy_unit_tests/test_deprecated_key_grace_period.py
             workers: 4
             dist: loadscope
-            timeout: 15
           - test-group: jwt-and-keys
             test-path: >-
               tests/proxy_unit_tests/test_jwt.py
@@ -117,14 +118,12 @@ jobs:
               tests/proxy_unit_tests/test_deployed_proxy_keygen.py
             workers: 4
             dist: loadscope
-            timeout: 15
 
           # ---- test_proxy_utils.py, single shard, worksteal distribution ----
           - test-group: proxy-utils
             test-path: "tests/proxy_unit_tests/test_proxy_utils.py"
             workers: 4
             dist: worksteal
-            timeout: 15
 
           # ---- proxy server: split into 2 shards ----
           - test-group: proxy-server-core
@@ -137,7 +136,6 @@ jobs:
               tests/proxy_unit_tests/test_aproxy_startup.py
             workers: 4
             dist: loadscope
-            timeout: 15
           - test-group: proxy-runtime
             test-path: >-
               tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -150,7 +148,6 @@ jobs:
               tests/proxy_unit_tests/test_multipart_bypass_repro.py
             workers: 4
             dist: loadscope
-            timeout: 15
 
           # ---- logging: split into 2 shards ----
           - test-group: custom-logging
@@ -160,7 +157,6 @@ jobs:
               tests/proxy_unit_tests/test_proxy_custom_logger.py
             workers: 4
             dist: loadscope
-            timeout: 15
           - test-group: logging-misc
             test-path: >-
               tests/proxy_unit_tests/test_proxy_reject_logging.py
@@ -168,7 +164,6 @@ jobs:
               tests/proxy_unit_tests/test_search_api_logging.py
             workers: 4
             dist: loadscope
-            timeout: 15
 
           - test-group: db-and-spend
             test-path: >-
@@ -181,7 +176,6 @@ jobs:
               tests/proxy_unit_tests/test_proxy_encrypt_decrypt.py
             workers: 4
             dist: loadscope
-            timeout: 15
 
           # ---- guardrails + budget + hooks: split into 2 ----
           - test-group: guardrails-hooks
@@ -191,7 +185,6 @@ jobs:
               tests/proxy_unit_tests/test_unit_test_proxy_hooks.py
             workers: 4
             dist: loadscope
-            timeout: 15
           - test-group: budgets
             test-path: >-
               tests/proxy_unit_tests/test_default_end_user_budget_simple.py
@@ -199,7 +192,6 @@ jobs:
               tests/proxy_unit_tests/test_zero_cost_model_budget_bypass.py
             workers: 4
             dist: loadscope
-            timeout: 15
 
           - test-group: endpoints-and-responses
             test-path: >-
@@ -223,12 +215,10 @@ jobs:
               tests/proxy_unit_tests/test_model_response_typing
             workers: 4
             dist: loadscope
-            timeout: 15
     uses: ./.github/workflows/_test-unit-base.yml
     with:
       test-path: ${{ matrix.test-path }}
       workers: ${{ matrix.workers }}
       reruns: 2
-      timeout-minutes: ${{ matrix.timeout }}
       dist: ${{ matrix.dist }}
       artifact-name: proxy-db-${{ matrix.test-group }}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every unit-test job re-downloads the Prisma CLI and engines from npm
- One slow fetch took 5m18s and killed a shard at 99% passed
- proxy-db shards capped at 15 min despite 12m41s healthy runs
- Result: green code shows red checks, needing manual reruns

How it solves it:

- Cache ~/.cache/prisma-python across jobs, keyed on uv.lock
- Drop the runner.temp PRISMA_BINARY_CACHE_DIR override that defeated caching
- Remove per-shard 15-minute overrides; shards inherit the 20-minute default

## User Flow

Before: a contributor's PR shows a red unit test check that no failing test caused

1. They push a commit and watch https://github.com/BerriAI/litellm/pull/36386/checks
2. After 15 minutes the proxy-utils check under "Unit Tests: Proxy DB Operations" turns red with "The operation was canceled", while the log's final lines show tests at 99% with every one passing
3. Scrolling up, the log shows "Installing Prisma CLI" sitting for 5m18s before pytest even started
4. They click "Re-run failed jobs", wait another 13 minutes, and the identical commit goes green with zero code changes

After: the same push goes green on the first run even when npm is slow

1. They push a commit and watch the same checks page
2. The "Cache Prisma binaries" step restores the binaries, so "Generate Prisma client" finishes in seconds with no "Installing Prisma CLI" line
3. The proxy-utils check completes green in about 13 minutes, and even a cold-cache run that hits a slow download fits inside the 20-minute ceiling
4. Nobody clicks "Re-run failed jobs"

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests (CI-config change: the workflow's own assert-shard-coverage guard was re-run locally against the edited matrix and passes; this PR's CI runs are the live verification)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before, at commit 8febd8ca on PR #36386: [run 31397334779](https://github.com/BerriAI/litellm/actions/runs/31397334779), same commit, two attempts, is a natural A/B of the root cause. Attempt 1 timestamps from the proxy-utils job log:

```
14:17:50  uv sync starts (cache hit on Linux-uv-33f33521...)
14:19:59  Installing Prisma CLI          <- npm install prisma@5.4.2, no cache
14:25:17  Prisma schema loaded           <- 5m18s later
14:26:10  Generated Prisma Client Python
14:32:23  pytest at [ 99%], every test PASSED
14:32:49  ##[error]The operation was canceled.   <- 15-minute job timeout
```

Attempt 2 (manual rerun, identical commit, same cache key restored): "Installing Prisma CLI" 15:54:53, "Prisma schema loaded" 15:54:57, so 4s instead of 5m18s, and the job finished green in 12m43s with `200 passed in 364.18s`. The only difference between red and green was npm download speed for a package no job should be downloading

After, at this PR's head commit: the first "Unit Tests: ..." runs on this PR seed the cache (the "Cache Prisma binaries" step reports a save), and subsequent runs restore it and skip "Installing Prisma CLI" entirely. Verify on any unit-test job of this PR: open the job log, check the "Cache Prisma binaries" step shows a restore, and confirm the "Generate Prisma client" step contains no "Installing Prisma CLI" line and completes in seconds

## Type

🚄 Infrastructure

## Changes

- `_test-unit-base.yml`: add a "Cache Prisma binaries" actions/cache step for `~/.cache/prisma-python`, keyed on `uv.lock` (which pins the prisma package, and prisma versions its binaries inside that dir, so stale restores are harmless), and remove the `PRISMA_BINARY_CACHE_DIR` override that pointed prisma at a per-job temp dir wiped between runs. This covers all 12 "Unit Tests: ..." workflows that call the base
- `test-unit-proxy-db.yml`: delete the per-shard `timeout` matrix field and the `timeout-minutes` passthrough so every shard inherits the base default of 20 minutes (key-generation already used 20), and correct the stale "every shard runs in <= 7 minutes" design comment to the observed 7 to 13 minutes. This was the only unit-test workflow overriding shard timeouts below the default

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR