### PR TITLE
feat(terraform-provider): support custom HTTP headers

### DIFF
--- a/terraform/provider/CHANGELOG.md
+++ b/terraform/provider/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **provider**: Optional `custom_headers` map to send extra HTTP headers on every LiteLLM API request (e.g. proxy or gateway headers). `x-api-key` from `api_key` always takes precedence
+
 ## [0.4.0] - 2026-08-06
 
 ### Fixed

--- a/terraform/provider/CHANGELOG.md
+++ b/terraform/provider/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **provider**: Optional `custom_headers` map to send extra HTTP headers on every LiteLLM API request (e.g. proxy or gateway headers). `x-api-key` from `api_key` always takes precedence
+- **provider**: Optional `custom_headers` map to send extra HTTP headers on every LiteLLM API request (e.g. proxy or gateway headers). Applied by both request helpers. `x-api-key` from `api_key` always takes precedence. Cross-origin redirects drop custom headers and `x-api-key`
 
 ## [0.4.0] - 2026-08-06
 

--- a/terraform/provider/CHANGELOG.md
+++ b/terraform/provider/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **provider**: Optional `custom_headers` map to send extra HTTP headers on every LiteLLM API request (e.g. proxy or gateway headers). Applied by both request helpers. `x-api-key` from `api_key` always takes precedence. Cross-origin redirects drop custom headers and `x-api-key`
+- **provider**: Optional `custom_headers` map to send extra HTTP headers on every LiteLLM API request (e.g. proxy or gateway headers). Applied by both request helpers. `x-api-key` from `api_key` always takes precedence
 
 ## [0.4.0] - 2026-08-06
 

--- a/terraform/provider/docs/index.md
+++ b/terraform/provider/docs/index.md
@@ -16,6 +16,11 @@ terraform {
 provider "litellm" {
   api_base = "https://your-litellm-proxy.com"
   api_key  = var.litellm_api_key
+
+  # Optional: extra headers on every API request (e.g. proxy / gateway auth)
+  custom_headers = {
+    "X-Proxy-Auth" = var.proxy_token
+  }
 }
 
 # Basic model configuration
@@ -94,6 +99,8 @@ The following arguments are supported in the provider block:
 
 * `api_base` - (Required) The base URL of your LiteLLM instance. This can also be provided via the `LITELLM_API_BASE` environment variable.
 * `api_key` - (Required) The API key used to authenticate with LiteLLM. This can also be provided via the `LITELLM_API_KEY` environment variable.
+* `custom_headers` - (Optional) Map of HTTP headers to include on every request to the LiteLLM API. Useful for proxy or gateway authentication headers. Marked sensitive.
+* `insecure_skip_verify` - (Optional) Skip TLS certificate verification. Defaults to `false`. Can also be set via `LITELLM_INSECURE_SKIP_VERIFY`.
 
 ## Getting Started
 

--- a/terraform/provider/litellm/client.go
+++ b/terraform/provider/litellm/client.go
@@ -17,6 +17,7 @@ type Client struct {
 	APIKey             string
 	httpClient         *http.Client
 	InsecureSkipVerify bool
+	CustomHeaders      map[string]string
 }
 
 func NewClient(apiBase, apiKey string, insecureSkipVerify bool) *Client {
@@ -29,6 +30,7 @@ func NewClient(apiBase, apiKey string, insecureSkipVerify bool) *Client {
 		APIKey:             apiKey,
 		httpClient:         &http.Client{Transport: tr},
 		InsecureSkipVerify: insecureSkipVerify,
+		CustomHeaders:      map[string]string{},
 	}
 }
 
@@ -280,8 +282,11 @@ func (c *Client) sendRequest(method, path string, body interface{}) (map[string]
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", c.APIKey)
 	req.Header.Set("accept", "application/json")
+	for k, v := range c.CustomHeaders {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("x-api-key", c.APIKey)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/terraform/provider/litellm/client.go
+++ b/terraform/provider/litellm/client.go
@@ -20,18 +20,48 @@ type Client struct {
 	CustomHeaders      map[string]string
 }
 
-func NewClient(apiBase, apiKey string, insecureSkipVerify bool) *Client {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
+func NewClient(cfg ProviderConfig) *Client {
+	headers := make(map[string]string, len(cfg.CustomHeaders))
+	for k, v := range cfg.CustomHeaders {
+		headers[k] = v
 	}
 
-	return &Client{
-		APIBase:            apiBase,
-		APIKey:             apiKey,
-		httpClient:         &http.Client{Transport: tr},
-		InsecureSkipVerify: insecureSkipVerify,
-		CustomHeaders:      map[string]string{},
+	c := &Client{
+		APIBase:            cfg.APIBase,
+		APIKey:             cfg.APIKey,
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		CustomHeaders:      headers,
 	}
+	c.httpClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify},
+		},
+		CheckRedirect: c.checkRedirect,
+	}
+	return c
+}
+
+func (c *Client) checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return fmt.Errorf("stopped after 10 redirects")
+	}
+	orig := via[0].URL
+	if req.URL.Scheme != orig.Scheme || req.URL.Host != orig.Host {
+		for k := range c.CustomHeaders {
+			req.Header.Del(k)
+		}
+		req.Header.Del("x-api-key")
+	}
+	return nil
+}
+
+func (c *Client) applyRequestHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("accept", "application/json")
+	for k, v := range c.CustomHeaders {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("x-api-key", c.APIKey)
 }
 
 // Organization member methods
@@ -281,12 +311,7 @@ func (c *Client) sendRequest(method, path string, body interface{}) (map[string]
 		return nil, fmt.Errorf("error creating request: %v", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("accept", "application/json")
-	for k, v := range c.CustomHeaders {
-		req.Header.Set(k, v)
-	}
-	req.Header.Set("x-api-key", c.APIKey)
+	c.applyRequestHeaders(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/terraform/provider/litellm/client.go
+++ b/terraform/provider/litellm/client.go
@@ -26,33 +26,17 @@ func NewClient(cfg ProviderConfig) *Client {
 		headers[k] = v
 	}
 
-	c := &Client{
+	return &Client{
 		APIBase:            cfg.APIBase,
 		APIKey:             cfg.APIKey,
 		InsecureSkipVerify: cfg.InsecureSkipVerify,
 		CustomHeaders:      headers,
-	}
-	c.httpClient = &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify},
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify},
+			},
 		},
-		CheckRedirect: c.checkRedirect,
 	}
-	return c
-}
-
-func (c *Client) checkRedirect(req *http.Request, via []*http.Request) error {
-	if len(via) >= 10 {
-		return fmt.Errorf("stopped after 10 redirects")
-	}
-	orig := via[0].URL
-	if req.URL.Scheme != orig.Scheme || req.URL.Host != orig.Host {
-		for k := range c.CustomHeaders {
-			req.Header.Del(k)
-		}
-		req.Header.Del("x-api-key")
-	}
-	return nil
 }
 
 func (c *Client) applyRequestHeaders(req *http.Request) {

--- a/terraform/provider/litellm/client_test.go
+++ b/terraform/provider/litellm/client_test.go
@@ -2,11 +2,21 @@ package litellm
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+func testClient(apiBase, apiKey string, insecure bool, headers map[string]string) *Client {
+	return NewClient(ProviderConfig{
+		APIBase:            apiBase,
+		APIKey:             apiKey,
+		InsecureSkipVerify: insecure,
+		CustomHeaders:      headers,
+	})
+}
 
 func TestSendRequestCustomHeaders(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -24,20 +34,84 @@ func TestSendRequestCustomHeaders(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.URL, "sk-real-key", false)
-	client.CustomHeaders = map[string]string{
+	client := testClient(srv.URL, "sk-real-key", false, map[string]string{
 		"X-Proxy-Auth":     "proxy-token",
 		"X-Request-Source": "terraform",
 		"x-api-key":        "should-not-win",
-	}
+	})
 
 	if _, err := client.sendRequest("GET", "/health", nil); err != nil {
 		t.Fatalf("sendRequest: %v", err)
 	}
 }
 
+func TestMakeRequestCustomHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Proxy-Auth"); got != "proxy-token" {
+			t.Errorf("X-Proxy-Auth = %q, want %q", got, "proxy-token")
+		}
+		if got := r.Header.Get("x-api-key"); got != "sk-real-key" {
+			t.Errorf("x-api-key = %q, want configured API key (must not be overridden)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
+	}))
+	defer srv.Close()
+
+	client := testClient(srv.URL, "sk-real-key", false, map[string]string{
+		"X-Proxy-Auth": "proxy-token",
+		"x-api-key":    "should-not-win",
+	})
+
+	resp, err := MakeRequest(client, "GET", "/health", nil)
+	if err != nil {
+		t.Fatalf("MakeRequest: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestCrossOriginRedirectStripsSensitiveHeaders(t *testing.T) {
+	var finalAuth, finalAPIKey string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		finalAuth = r.Header.Get("X-Proxy-Auth")
+		finalAPIKey = r.Header.Get("x-api-key")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
+	}))
+	defer target.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Proxy-Auth"); got != "proxy-token" {
+			t.Errorf("origin X-Proxy-Auth = %q, want proxy-token", got)
+		}
+		http.Redirect(w, r, target.URL+"/final", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	client := testClient(origin.URL, "sk-real-key", false, map[string]string{
+		"X-Proxy-Auth": "proxy-token",
+	})
+
+	resp, err := MakeRequest(client, "GET", "/start", nil)
+	if err != nil {
+		t.Fatalf("MakeRequest: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if finalAuth != "" {
+		t.Errorf("cross-origin redirect kept X-Proxy-Auth = %q", finalAuth)
+	}
+	if finalAPIKey != "" {
+		t.Errorf("cross-origin redirect kept x-api-key = %q", finalAPIKey)
+	}
+}
+
 func TestRedactSensitiveDataNestedCredentialValues(t *testing.T) {
-	c := NewClient("http://localhost:4000", "sk-test", false)
+	c := testClient("http://localhost:4000", "sk-test", false, nil)
 
 	input := `{"credential_name":"azure-cred","credential_values":{"api_key":"sk-secret-123","config":{"region":"us-east-1","client_secret":"nested-secret"}}}`
 	got := c.redactSensitiveData(input)
@@ -56,7 +130,7 @@ func TestRedactSensitiveDataNestedCredentialValues(t *testing.T) {
 }
 
 func TestRedactSensitiveDataDeeplyNestedSensitiveKeys(t *testing.T) {
-	c := NewClient("http://localhost:4000", "sk-test", false)
+	c := testClient("http://localhost:4000", "sk-test", false, nil)
 
 	input := `{"data":[{"litellm_params":{"model":"gpt-4","api_key":"sk-deep-456","aws_secret_access_key":"aws-secret"}}]}`
 	got := c.redactSensitiveData(input)
@@ -72,7 +146,7 @@ func TestRedactSensitiveDataDeeplyNestedSensitiveKeys(t *testing.T) {
 }
 
 func TestRedactSensitiveDataTopLevelStringFields(t *testing.T) {
-	c := NewClient("http://localhost:4000", "sk-test", false)
+	c := testClient("http://localhost:4000", "sk-test", false, nil)
 
 	input := `{"model_api_key":"sk-top-789","vertex_credentials":"{\"type\":\"service_account\"}","team_alias":"eng"}`
 	got := c.redactSensitiveData(input)
@@ -88,7 +162,7 @@ func TestRedactSensitiveDataTopLevelStringFields(t *testing.T) {
 }
 
 func TestRedactSensitiveDataNonJSONFallback(t *testing.T) {
-	c := NewClient("http://localhost:4000", "sk-test", false)
+	c := testClient("http://localhost:4000", "sk-test", false, nil)
 
 	input := `error before "api_key": "sk-fallback-000" after`
 	got := c.redactSensitiveData(input)

--- a/terraform/provider/litellm/client_test.go
+++ b/terraform/provider/litellm/client_test.go
@@ -1,9 +1,40 @@
 package litellm
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+func TestSendRequestCustomHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Proxy-Auth"); got != "proxy-token" {
+			t.Errorf("X-Proxy-Auth = %q, want %q", got, "proxy-token")
+		}
+		if got := r.Header.Get("X-Request-Source"); got != "terraform" {
+			t.Errorf("X-Request-Source = %q, want %q", got, "terraform")
+		}
+		if got := r.Header.Get("x-api-key"); got != "sk-real-key" {
+			t.Errorf("x-api-key = %q, want configured API key (must not be overridden)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "sk-real-key", false)
+	client.CustomHeaders = map[string]string{
+		"X-Proxy-Auth":     "proxy-token",
+		"X-Request-Source": "terraform",
+		"x-api-key":        "should-not-win",
+	}
+
+	if _, err := client.sendRequest("GET", "/health", nil); err != nil {
+		t.Fatalf("sendRequest: %v", err)
+	}
+}
 
 func TestRedactSensitiveDataNestedCredentialValues(t *testing.T) {
 	c := NewClient("http://localhost:4000", "sk-test", false)

--- a/terraform/provider/litellm/client_test.go
+++ b/terraform/provider/litellm/client_test.go
@@ -2,7 +2,6 @@ package litellm
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -70,43 +69,6 @@ func TestMakeRequestCustomHeaders(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
-	}
-}
-
-func TestCrossOriginRedirectStripsSensitiveHeaders(t *testing.T) {
-	var finalAuth, finalAPIKey string
-	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		finalAuth = r.Header.Get("X-Proxy-Auth")
-		finalAPIKey = r.Header.Get("x-api-key")
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
-	}))
-	defer target.Close()
-
-	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("X-Proxy-Auth"); got != "proxy-token" {
-			t.Errorf("origin X-Proxy-Auth = %q, want proxy-token", got)
-		}
-		http.Redirect(w, r, target.URL+"/final", http.StatusFound)
-	}))
-	defer origin.Close()
-
-	client := testClient(origin.URL, "sk-real-key", false, map[string]string{
-		"X-Proxy-Auth": "proxy-token",
-	})
-
-	resp, err := MakeRequest(client, "GET", "/start", nil)
-	if err != nil {
-		t.Fatalf("MakeRequest: %v", err)
-	}
-	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, resp.Body)
-
-	if finalAuth != "" {
-		t.Errorf("cross-origin redirect kept X-Proxy-Auth = %q", finalAuth)
-	}
-	if finalAPIKey != "" {
-		t.Errorf("cross-origin redirect kept x-api-key = %q", finalAPIKey)
 	}
 }
 

--- a/terraform/provider/litellm/provider.go
+++ b/terraform/provider/litellm/provider.go
@@ -60,18 +60,23 @@ func Provider() *schema.Provider {
 
 // providerConfigure configures the provider with the given schema data.
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	customHeaders := map[string]string{}
-	if v, ok := d.GetOk("custom_headers"); ok {
-		for k, val := range v.(map[string]interface{}) {
-			customHeaders[k] = val.(string)
-		}
-	}
+	return NewClient(ProviderConfig{
+		APIBase:            d.Get("api_base").(string),
+		APIKey:             d.Get("api_key").(string),
+		InsecureSkipVerify: d.Get("insecure_skip_verify").(bool),
+		CustomHeaders:      customHeadersFromSchema(d),
+	}), nil
+}
 
-	client := NewClient(
-		d.Get("api_base").(string),
-		d.Get("api_key").(string),
-		d.Get("insecure_skip_verify").(bool),
-	)
-	client.CustomHeaders = customHeaders
-	return client, nil
+func customHeadersFromSchema(d *schema.ResourceData) map[string]string {
+	v, ok := d.GetOk("custom_headers")
+	if !ok {
+		return map[string]string{}
+	}
+	raw := v.(map[string]interface{})
+	headers := make(map[string]string, len(raw))
+	for k, val := range raw {
+		headers[k] = val.(string)
+	}
+	return headers
 }

--- a/terraform/provider/litellm/provider.go
+++ b/terraform/provider/litellm/provider.go
@@ -46,6 +46,13 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("LITELLM_INSECURE_SKIP_VERIFY", false),
 				Description: "Skip TLS certificate verification. Only use for development or when using self-signed certificates",
 			},
+			"custom_headers": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Sensitive:   true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Optional HTTP headers to include on every request to the LiteLLM API (e.g. proxy or gateway headers)",
+			},
 		},
 		ConfigureFunc: providerConfigure,
 	}
@@ -53,11 +60,18 @@ func Provider() *schema.Provider {
 
 // providerConfigure configures the provider with the given schema data.
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	config := ProviderConfig{
-		APIBase:            d.Get("api_base").(string),
-		APIKey:             d.Get("api_key").(string),
-		InsecureSkipVerify: d.Get("insecure_skip_verify").(bool),
+	customHeaders := map[string]string{}
+	if v, ok := d.GetOk("custom_headers"); ok {
+		for k, val := range v.(map[string]interface{}) {
+			customHeaders[k] = val.(string)
+		}
 	}
 
-	return NewClient(config.APIBase, config.APIKey, config.InsecureSkipVerify), nil
+	client := NewClient(
+		d.Get("api_base").(string),
+		d.Get("api_key").(string),
+		d.Get("insecure_skip_verify").(bool),
+	)
+	client.CustomHeaders = customHeaders
+	return client, nil
 }

--- a/terraform/provider/litellm/provider_test.go
+++ b/terraform/provider/litellm/provider_test.go
@@ -48,7 +48,7 @@ func createTestUsers(t *testing.T) {
 		return
 	}
 
-	client := NewClient(apiBase, apiKey, false)
+	client := NewClient(ProviderConfig{APIBase: apiBase, APIKey: apiKey, InsecureSkipVerify: false})
 
 	// Create test users
 	users := []map[string]interface{}{

--- a/terraform/provider/litellm/resource_credential_crud_test.go
+++ b/terraform/provider/litellm/resource_credential_crud_test.go
@@ -39,7 +39,7 @@ func TestRetryCredentialRead_SuccessOnFirstAttempt(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.URL, "test-key", true)
+	client := NewClient(ProviderConfig{APIBase: srv.URL, APIKey: "test-key", InsecureSkipVerify: true})
 	d := newTestResourceData(t, "test-cred")
 
 	err := retryCredentialRead(d, client, 3)
@@ -72,7 +72,7 @@ func TestRetryCredentialRead_SuccessAfterRetries(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.URL, "test-key", true)
+	client := NewClient(ProviderConfig{APIBase: srv.URL, APIKey: "test-key", InsecureSkipVerify: true})
 	d := newTestResourceData(t, "test-cred")
 
 	err := retryCredentialRead(d, client, 3)
@@ -93,7 +93,7 @@ func TestRetryCredentialRead_ExhaustsRetries(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.URL, "test-key", true)
+	client := NewClient(ProviderConfig{APIBase: srv.URL, APIKey: "test-key", InsecureSkipVerify: true})
 	d := newTestResourceData(t, "test-cred")
 
 	err := retryCredentialRead(d, client, 2)
@@ -118,7 +118,7 @@ func TestRetryCredentialRead_NonRetryableError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.URL, "test-key", true)
+	client := NewClient(ProviderConfig{APIBase: srv.URL, APIKey: "test-key", InsecureSkipVerify: true})
 	d := newTestResourceData(t, "test-cred")
 
 	err := retryCredentialRead(d, client, 3)
@@ -154,7 +154,7 @@ func TestRetryCredentialRead_IDRestoredBetweenRetries(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.URL, "test-key", true)
+	client := NewClient(ProviderConfig{APIBase: srv.URL, APIKey: "test-key", InsecureSkipVerify: true})
 	d := newTestResourceData(t, "my-cred")
 
 	err := retryCredentialRead(d, client, 2)
@@ -172,7 +172,7 @@ func TestRetryCredentialRead_MaxRetriesOne(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.URL, "test-key", true)
+	client := NewClient(ProviderConfig{APIBase: srv.URL, APIKey: "test-key", InsecureSkipVerify: true})
 	d := newTestResourceData(t, "test-cred")
 
 	err := retryCredentialRead(d, client, 1)
@@ -189,7 +189,7 @@ func TestRetryCredentialRead_ConnectionError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	srv.Close()
 
-	client := NewClient(srv.URL, "test-key", true)
+	client := NewClient(ProviderConfig{APIBase: srv.URL, APIKey: "test-key", InsecureSkipVerify: true})
 	d := newTestResourceData(t, "test-cred")
 
 	err := retryCredentialRead(d, client, 1)

--- a/terraform/provider/litellm/resource_team_member_test.go
+++ b/terraform/provider/litellm/resource_team_member_test.go
@@ -21,7 +21,7 @@ func TestTeamMemberUpdateSendsRole(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.URL, "test-key", true)
+	client := NewClient(ProviderConfig{APIBase: srv.URL, APIKey: "test-key", InsecureSkipVerify: true})
 	d := schema.TestResourceDataRaw(t, resourceLiteLLMTeamMember().Schema, map[string]interface{}{
 		"team_id":    "team-1",
 		"user_id":    "user-1",

--- a/terraform/provider/litellm/resource_vector_store_crud_test.go
+++ b/terraform/provider/litellm/resource_vector_store_crud_test.go
@@ -28,7 +28,7 @@ func TestVectorStoreReadDoesNotPersistServerLitellmParams(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.URL, "test-key", true)
+	client := NewClient(ProviderConfig{APIBase: srv.URL, APIKey: "test-key", InsecureSkipVerify: true})
 	d := schema.TestResourceDataRaw(t, resourceLiteLLMVectorStore().Schema, map[string]interface{}{
 		"vector_store_name":   "kb",
 		"custom_llm_provider": "openai",

--- a/terraform/provider/litellm/types.go
+++ b/terraform/provider/litellm/types.go
@@ -5,6 +5,7 @@ type ProviderConfig struct {
 	APIBase            string
 	APIKey             string
 	InsecureSkipVerify bool
+	CustomHeaders      map[string]string
 }
 
 // ErrorResponse represents an error response from the API.

--- a/terraform/provider/litellm/utils.go
+++ b/terraform/provider/litellm/utils.go
@@ -79,8 +79,7 @@ func MakeRequest(client *Client, method, endpoint string, body interface{}) (*ht
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", client.APIKey)
+	client.applyRequestHeaders(req)
 
 	return client.httpClient.Do(req)
 }


### PR DESCRIPTION
Disclaimer: Grok 4.5 was used to create this PR, with a human in the loop.


Allow optional custom_headers on the litellm provider so every API request can carry proxy or gateway headers. 

x-api-key always wins

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- Being able to pass proxies that require headers

How it solves it:

- By adding the headers for each request made

## User Flow

<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision

Example:

Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request comes back with real token counts, so the dashboard shows real spend

1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
-->

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
