### PR TITLE
fix(proxy): keep disconnect billing off the event loop

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -6,7 +6,7 @@ import time
 import traceback
 from collections.abc import AsyncGenerator, Callable, Mapping
 from datetime import datetime
-from functools import lru_cache
+from functools import lru_cache, partial
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal, Protocol, overload
 
@@ -62,6 +62,8 @@ from litellm.types.utils import ServerToolUse
 StreamChunkSerializer = Callable[[Any], str]
 # Type alias for streaming error serializer (ProxyException -> wire format)
 StreamErrorSerializer = Callable[[ProxyException], str]
+
+_disconnect_stream_assembly_limiter: Final = anyio.CapacityLimiter(1)
 
 if TYPE_CHECKING:
     from litellm.proxy.proxy_server import ProxyConfig as _ProxyConfig
@@ -212,10 +214,15 @@ async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, respons
     )
     messages: Final[object] = getattr(response, "messages", None)
     try:
-        partial_response: Final = litellm.stream_chunk_builder(
+        build_partial_response: Final = partial(
+            litellm.stream_chunk_builder,
             chunks=chunks,
             messages=messages if isinstance(messages, list) else None,
             logging_obj=logging_obj,
+        )
+        partial_response: Final = await anyio.to_thread.run_sync(
+            build_partial_response,
+            limiter=_disconnect_stream_assembly_limiter,
         )
     except Exception as e:  # noqa: BLE001  # partial billing is best-effort; never break stream teardown
         verbose_proxy_logger.debug("Failed to assemble partial streamed response for disconnect billing: %s", e)

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -2,6 +2,8 @@ import asyncio
 import copy
 import datetime
 import json
+import threading
+import time
 from types import SimpleNamespace
 from typing import AsyncGenerator, Callable, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -5128,6 +5130,84 @@ class TestStreamingClientDisconnectBilling:
         standard_logging_object = recorder.success_events[0]["kwargs"]["standard_logging_object"]
         assert standard_logging_object["total_tokens"] > 0
         assert standard_logging_object["response_cost"] >= 0.002
+
+    @pytest.mark.asyncio
+    async def test_disconnect_partial_response_assembly_does_not_block_event_loop(self):
+        response = await self._start_partial_stream()
+        builder_started = threading.Event()
+        builder_finished = threading.Event()
+
+        def blocking_builder(*args, **kwargs):
+            builder_started.set()
+            time.sleep(0.2)
+            builder_finished.set()
+
+        async def event_loop_progressed_during_assembly():
+            while not builder_started.is_set():
+                await asyncio.sleep(0)
+            await asyncio.sleep(0.01)
+            return not builder_finished.is_set()
+
+        with patch(
+            "litellm.proxy.common_request_processing.litellm.stream_chunk_builder",
+            side_effect=blocking_builder,
+        ):
+            billing_task = asyncio.create_task(
+                _bill_partial_streamed_spend_on_disconnect(
+                    {"litellm_logging_obj": response.logging_obj}, response
+                )
+            )
+            event_loop_progressed = await event_loop_progressed_during_assembly()
+            billed = await billing_task
+
+        assert event_loop_progressed is True
+        assert billed is False
+
+    @pytest.mark.asyncio
+    async def test_disconnect_partial_response_assembly_limits_cpu_concurrency(self):
+        response = await self._start_partial_stream()
+        first_builder_started = threading.Event()
+        release_first_builder = threading.Event()
+        second_builder_started = threading.Event()
+        builder_claim_lock = threading.Lock()
+
+        def blocking_builder(*args, **kwargs):
+            with builder_claim_lock:
+                if first_builder_started.is_set():
+                    second_builder_started.set()
+                    return
+                first_builder_started.set()
+            release_first_builder.wait(timeout=5)
+
+        with patch(
+            "litellm.proxy.common_request_processing.litellm.stream_chunk_builder",
+            side_effect=blocking_builder,
+        ):
+            billing_tasks = (
+                asyncio.create_task(
+                    _bill_partial_streamed_spend_on_disconnect(
+                        {"litellm_logging_obj": response.logging_obj}, response
+                    )
+                ),
+                asyncio.create_task(
+                    _bill_partial_streamed_spend_on_disconnect(
+                        {"litellm_logging_obj": response.logging_obj}, response
+                    )
+                ),
+            )
+            try:
+                for _ in range(100):
+                    if first_builder_started.is_set():
+                        break
+                    await asyncio.sleep(0.01)
+                assert first_builder_started.is_set()
+                await asyncio.sleep(0.05)
+                assert second_builder_started.is_set() is False
+            finally:
+                release_first_builder.set()
+                await asyncio.gather(*billing_tasks)
+
+        assert second_builder_started.is_set() is True
 
     @pytest.mark.asyncio
     async def test_completed_stream_does_not_double_bill_on_late_disconnect(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Disconnect billing can block the Proxy event loop

How it solves it:

- Runs partial-response assembly in a worker thread
- Limits concurrent disconnect calculations to one

## User Flow

Before:

1. A client starts `POST /v1/chat/completions` with `"stream": true`
2. The client disconnects before a large response completes
3. Readiness and other requests time out during partial-spend calculation

After:

1. The client sends and interrupts the same request
2. Partial usage and spend are still calculated
3. Readiness and other requests remain responsive

## Relevant issues

Fixes #36429

Related to #35958

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all local CI-equivalent checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5**

## Screenshots / Proof of Fix

Local C30 profile with one Proxy worker and clients disconnected during large SSE responses:

| Version | CPU | Readiness |
| --- | ---: | --- |
| Before | 86%–91% | Timed out after 3 seconds |
| After | 96.9%–98.0% | HTTP 200 in 1–2 ms |

Token calculation still uses approximately one CPU core, but it runs in a bounded worker instead of blocking the event loop.

Regression coverage:

- The event loop progresses while partial-response assembly is running
- Concurrent disconnect calculations are limited to one
- Existing disconnect billing tests continue to pass

## Type

🐛 Bug Fix

## Changes

- Offload partial-response assembly with `anyio.to_thread.run_sync`
- Limit disconnect assembly concurrency with `CapacityLimiter(1)`
- Preserve exact partial usage and spend calculation
- Add event-loop responsiveness and concurrency regression tests

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
