### PR TITLE
fix(proxy): isolate guardrail load failures per row

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6860,9 +6860,19 @@ class ProxyConfig:
                 guardrail_id = guardrail.get("guardrail_id")
                 if guardrail_id:
                     db_guardrail_ids.add(guardrail_id)
-                IN_MEMORY_GUARDRAIL_HANDLER.sync_guardrail_from_db(
-                    guardrail=cast(Guardrail, guardrail),
-                )
+                try:
+                    IN_MEMORY_GUARDRAIL_HANDLER.sync_guardrail_from_db(
+                        guardrail=cast(Guardrail, guardrail),
+                    )
+                except Exception as e:  # noqa: BLE001  # one unloadable row must not stop the remaining guardrails
+                    verbose_proxy_logger.error(
+                        "litellm.proxy.proxy_server.py::ProxyConfig:_init_guardrails_in_db - "
+                        "skipping guardrail '%s' (ID: %s): %s: %s",
+                        guardrail.get("guardrail_name"),
+                        guardrail_id,
+                        type(e).__name__,
+                        e,
+                    )
 
             # Drop in-memory DB-backed entries whose row was deleted on another
             # pod. Config-loaded entries are never touched.

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -2639,3 +2639,68 @@ async def test_ProxyConfig__init_non_llm_configs_empty_agents_key_clears_remembe
     assert clean_agent_registry.config_agents == ()
     clean_agent_registry.load_agents_from_db_and_config(db_agents=None)
     assert clean_agent_registry.get_agent_list() == ()
+
+
+# ---------------------------------------------------------------------------
+# _init_guardrails_in_db
+# ---------------------------------------------------------------------------
+
+
+def _db_guardrail_row(guardrail_id: str, guardrail_type: str) -> dict[str, object]:
+    return {
+        "guardrail_id": guardrail_id,
+        "guardrail_name": f"name-{guardrail_id}",
+        "litellm_params": {"guardrail": guardrail_type, "mode": "pre_call"},
+        "guardrail_info": None,
+        "team_id": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__init_guardrails_in_db_skips_only_the_unloadable_row(monkeypatch):
+    """
+    A single DB row that fails to initialize used to abort the whole loop, so one
+    typo'd guardrail type left the proxy running with zero guardrails loaded.
+
+    The failing row's id must still reach reconcile_db_guardrails so that eviction
+    pass cannot treat a row that is alive in the DB as one that was deleted.
+    """
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.proxy.guardrails import guardrail_registry as registry_module
+    from litellm.types.guardrails import Guardrail, GuardrailEventHooks, LitellmParams
+
+    handler = registry_module.InMemoryGuardrailHandler()
+    monkeypatch.setattr(registry_module, "IN_MEMORY_GUARDRAIL_HANDLER", handler)
+
+    def _initializer(litellm_params: LitellmParams, guardrail: Guardrail) -> CustomGuardrail:
+        return CustomGuardrail(
+            guardrail_name=guardrail["guardrail_name"],
+            event_hook=GuardrailEventHooks.pre_call,
+            default_on=False,
+        )
+
+    monkeypatch.setitem(registry_module.guardrail_initializer_registry, "lit5367_ok", _initializer)
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_guardrailstable.find_many = AsyncMock(
+        return_value=[
+            _db_guardrail_row("first", "lit5367_ok"),
+            # real failure shape from the report: a type that is not registered
+            _db_guardrail_row("broken", "litellm_tool_permission"),
+            _db_guardrail_row("last", "lit5367_ok"),
+        ]
+    )
+
+    reconciled_with: list[set[str]] = []
+    real_reconcile = handler.reconcile_db_guardrails
+
+    def _spy_reconcile(db_guardrail_ids: set[str]) -> list[str]:
+        reconciled_with.append(set(db_guardrail_ids))
+        return real_reconcile(db_guardrail_ids)
+
+    monkeypatch.setattr(handler, "reconcile_db_guardrails", _spy_reconcile)
+
+    await ProxyConfig()._init_guardrails_in_db(prisma_client=prisma_client)
+
+    assert sorted(handler.IN_MEMORY_GUARDRAILS) == ["first", "last"]
+    assert reconciled_with == [{"first", "broken", "last"}]

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -2669,7 +2669,16 @@ async def test_ProxyConfig__init_guardrails_in_db_skips_only_the_unloadable_row(
     from litellm.proxy.guardrails import guardrail_registry as registry_module
     from litellm.types.guardrails import Guardrail, GuardrailEventHooks, LitellmParams
 
-    handler = registry_module.InMemoryGuardrailHandler()
+    class _RecordingHandler(registry_module.InMemoryGuardrailHandler):
+        def __init__(self) -> None:
+            super().__init__()
+            self.reconciled_with: list[set[str]] = []
+
+        def reconcile_db_guardrails(self, db_guardrail_ids: set[str]) -> list[str]:
+            self.reconciled_with.append(set(db_guardrail_ids))
+            return super().reconcile_db_guardrails(db_guardrail_ids)
+
+    handler = _RecordingHandler()
     monkeypatch.setattr(registry_module, "IN_MEMORY_GUARDRAIL_HANDLER", handler)
 
     def _initializer(litellm_params: LitellmParams, guardrail: Guardrail) -> CustomGuardrail:
@@ -2685,22 +2694,12 @@ async def test_ProxyConfig__init_guardrails_in_db_skips_only_the_unloadable_row(
     prisma_client.db.litellm_guardrailstable.find_many = AsyncMock(
         return_value=[
             _db_guardrail_row("first", "lit5367_ok"),
-            # real failure shape from the report: a type that is not registered
             _db_guardrail_row("broken", "litellm_tool_permission"),
             _db_guardrail_row("last", "lit5367_ok"),
         ]
     )
 
-    reconciled_with: list[set[str]] = []
-    real_reconcile = handler.reconcile_db_guardrails
-
-    def _spy_reconcile(db_guardrail_ids: set[str]) -> list[str]:
-        reconciled_with.append(set(db_guardrail_ids))
-        return real_reconcile(db_guardrail_ids)
-
-    monkeypatch.setattr(handler, "reconcile_db_guardrails", _spy_reconcile)
-
     await ProxyConfig()._init_guardrails_in_db(prisma_client=prisma_client)
 
     assert sorted(handler.IN_MEMORY_GUARDRAILS) == ["first", "last"]
-    assert reconciled_with == [{"first", "broken", "last"}]
+    assert handler.reconciled_with == [{"first", "broken", "last"}]


### PR DESCRIPTION
## TLDR

Problem this solves:

- One unloadable guardrail row in the DB stops every other guardrail from loading. `ProxyConfig._init_guardrails_in_db` wraps the whole `for guardrail in guardrails_in_db` loop in a single try/except, so the first row that raises inside `sync_guardrail_from_db` aborts the loop and the proxy comes up with zero DB guardrails registered
- The failure is silent from the caller's point of view. Requests that should be blocked are answered by the provider instead, so a single bad row turns into a fleet-wide guardrail outage
- Because the raise escapes the loop, `reconcile_db_guardrails` never runs on that cycle either, so stale DB-backed entries stop being purged as well

How it solves it:

- Wrap only the `sync_guardrail_from_db` call in a per-row try/except, log an error naming the guardrail_name and guardrail_id along with the underlying error, and carry on with the remaining rows
- The failing row's id is still added to `db_guardrail_ids` before the sync attempt, so `reconcile_db_guardrails` keeps treating it as present in the DB rather than as deleted. Dropping it would make reconcile evict in-memory state for a row that is alive
- `.error` rather than `.exception`: this runs on the config-reload poll timer, so a traceback per bad row per tick is a lot of log volume for a condition the message already describes. It matches the existing in-loop skip style in this file

## User Flow

An operator with a DB-backed guardrail that cannot be initialized (typo'd guardrail type, missing required param) now keeps every other guardrail working. The proxy logs one line per bad row naming it, so the operator can find and fix the row instead of discovering that guardrails silently stopped running

## Relevant issues

## Linear ticket

Resolves LIT-5367

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy on real Postgres, guardrails stored in the DB, real Gemini calls. Three valid `litellm_content_filter` rows each blocking their own trigger word, plus bad rows carrying the two error shapes from the report

Setup, with the three valid guardrails created through the public API:

```bash
for n in alpha beta gamma; do
curl -s -X POST http://127.0.0.1:20367/guardrails \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"guardrail\": {\"guardrail_name\": \"cf-$n\", \"litellm_params\": {
        \"guardrail\": \"litellm_content_filter\", \"mode\": \"pre_call\", \"default_on\": true,
        \"patterns\": [{\"pattern_type\": \"regex\", \"pattern\": \"SECRET-$n\", \"action\": \"BLOCK\", \"name\": \"$n-rule\"}]}}}"
done
```

Baseline with only valid rows, every guardrail enforcing:

```
  SECRET-alpha  -> HTTP 400  Content blocked: alpha-rule pattern detected
  SECRET-beta   -> HTTP 400  Content blocked: beta-rule pattern detected
  SECRET-gamma  -> HTTP 400  Content blocked: gamma-rule pattern detected
```

One bad row is then added to the DB. Note that `POST /guardrails` rejects both shapes today, so a row like this comes from an older version or a direct write:

```bash
docker exec <pg> psql -U llmproxy -d litellm -c "
INSERT INTO \"LiteLLM_GuardrailsTable\" (guardrail_id, guardrail_name, litellm_params, created_at, updated_at, status)
VALUES ('bad-typo-row', 'cf-typo',
  '{\"guardrail\": \"litellm_tool_permission\", \"mode\": \"pre_call\", \"default_on\": true}'::jsonb,
  NOW(), NOW(), 'active');"
```

Before, on `litellm_internal_staging`. Same three valid rows, now none of them enforce and the blocked content reaches the provider:

```
  SECRET-alpha  -> NOT BLOCKED, reached provider -> 'SECRET-alpha is a specific type of **sid' | HTTP 200
  SECRET-beta   -> NOT BLOCKED, reached provider -> 'When you say "SECRET-beta," you are most' | HTTP 200
  SECRET-gamma  -> NOT BLOCKED, reached provider -> '"SECRET-gamma" is not a standard, widely' | HTTP 200
```

with the loop aborting on every poll tick:

```
ERROR: proxy_server.py:6871 - ProxyConfig:_init_guardrails_in_db - Unsupported guardrail: litellm_tool_permission
Traceback (most recent call last):
  File "litellm/proxy/proxy_server.py", line 6863, in _init_guardrails_in_db
    IN_MEMORY_GUARDRAIL_HANDLER.sync_guardrail_from_db(
```

After, same DB contents, all three valid guardrails enforce again:

```
  SECRET-alpha  -> BLOCKED: Content blocked: alpha-rule pattern detected | HTTP 400
  SECRET-beta   -> BLOCKED: Content blocked: beta-rule pattern detected | HTTP 400
  SECRET-gamma  -> BLOCKED: Content blocked: gamma-rule pattern detected | HTTP 400
```

and a clean prompt still reaches the real provider:

```bash
curl -s -X POST http://127.0.0.1:20367/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"say OK and nothing else"}]}'
# content: 'OK' | model: gemini-flash
```

With both reported error shapes present at once, each bad row is named on its own line and the valid three still enforce (HTTP 400 each):

```
skipping guardrail 'cf-nullpattern' (ID: bad-nullpattern-row): ValueError: pattern is required for regex patterns
skipping guardrail 'cf-typo' (ID: bad-typo-row): ValueError: Unsupported guardrail: litellm_tool_permission
```

The same run seen from the bundled dashboard. The Guardrails page lists all five rows, including the two that cannot be initialized, which is why the DB view alone never revealed that nothing was loading:

![Guardrails page](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr36432/guardrails-page-with-bad-rows.png)

Request Logs for the whole session, oldest at the bottom. At 10:34 the valid guardrails block three requests and let the clean one through. At 10:35, with one bad row added and the fix absent, the same three blocked prompts come back as Success against real Gemini at about $0.0045 and 10s each, which is the bug. From 10:36 onward, with the fix in place, they are Failure again while the clean prompt still succeeds:

![Request logs](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr36432/request-logs-before-after.png)

### Multi-worker A/B for the reconcile behavior change

Because the raise used to escape the loop, `reconcile_db_guardrails` never ran on a cycle that contained a bad row. It now does, so this was A/B'd on a real rig rather than argued: base and head each running four uvicorn workers with `--num_workers 4`, a separate Postgres per side, real Gemini calls, both sides driven simultaneously

With three valid guardrails loaded on every worker, a bad row was then inserted and `cf-gamma` was deleted straight from the database, which is how a delete on another pod looks to this one since no in-process invalidation is involved. Twelve requests per cell:

| | gamma (deleted from DB) | alpha (still in DB) |
|---|---|---|
| base | blocked 12, passed 0 | blocked 12, passed 0 |
| head | blocked 0, passed 12 | blocked 12, passed 0 |

Both sides blocked 12 of 12 before the deletion, so the only behavior that moved is the row that was actually deleted, and the alpha control rules out a general loss of enforcement on head

Base logged 20 aborts, no skips and no reconciles. Head logged the per-row skip and, once the level was raised to INFO, exactly one reconcile removal per worker naming the deleted id:

```
   4 Reconcile: removing stale DB-backed guardrail '80cd66b8-f025-4e0b-952c-cb2d3fd43a2d'
```

Worth calling out for reviewers: on base a guardrail deleted by an admin keeps enforcing on every pod for as long as any unloadable row exists, since the reconcile pass never gets reached. That is fail-closed rather than a security hole, but it means a delete silently does not take effect. This PR resolves it as a consequence of letting the loop finish

## Type

🐛 Bug Fix

## Caveats (if any)

The fix covers rows that cannot be initialized at load time, which is the reported failure. It does not preserve the previously working instance of a row that is *edited* into an invalid state while the proxy is running: `reinitialize_guardrail` deletes the in-memory entry before calling `initialize_guardrail`, so the old callback is already gone by the time the new params raise. That fail-open on edit is a separate defect and wants its own ticket

Related, and pre-existing: `initialize_guardrail` runs its `scan_only_tool_results` validation after the initializer has already registered the callback, so a failure in that window leaves an orphaned entry in `litellm.callbacks` that nothing can reclaim. Base already leaked one per poll tick; now that the loop no longer stops at the first bad row, N such rows leak N per tick. Neither error shape in this report reaches that window, since both raise before the callback is registered, so the reported scenario is unaffected. It belongs with the same follow-up as the paragraph above

The dropped traceback is deliberate. This runs on the config-reload poll timer, so a traceback per bad row per tick is a lot of volume for a condition the message already names; the log line carries the guardrail name, its id, the exception type, and the message

Sibling loaders in this file share the same one-bad-row-aborts-all shape (`_init_prompts_in_db`, `_init_vector_stores_in_db`, `_init_vector_store_indexes_in_db`, `_init_agents_in_db`, `get_credentials`, and the pass-through loader). They are deliberately left alone here to keep this PR to the reported defect, and are worth a follow-up

## QA runbook

1. Start a proxy with `store_model_in_db: true` and `supported_db_objects: ["models", "guardrails"]` against a real Postgres
2. Create two or three valid guardrails through `POST /guardrails` and confirm each one blocks its trigger content
3. Insert a row whose `litellm_params.guardrail` is a type that does not exist, then restart the proxy
4. Confirm the valid guardrails still block, and that the log carries one `skipping guardrail '<name>' (ID: <id>)` line for the bad row

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proxy startup/reload behavior for DB guardrails—a security-sensitive path—but narrows failure blast radius and is covered by a targeted test; remaining bad rows stay unloaded until fixed.
> 
> **Overview**
> Fixes a **fleet-wide guardrail outage** when a single DB row cannot initialize: `ProxyConfig._init_guardrails_in_db` now wraps each `sync_guardrail_from_db` call in its own try/except, logs a single **error** line (name, id, exception type/message), and continues loading other rows.
> 
> Failed rows still have their `guardrail_id` in `db_guardrail_ids` before sync is attempted, so **`reconcile_db_guardrails` still sees them as present** in the DB and does not treat them as deleted. A regression test covers good / broken / good rows and asserts reconcile receives all three ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d6c591f5fb7251924d0b1438ded41954507e58c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
