### PR TITLE
fix(bridge): restore logging_obj.stream after inner responses call

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/handler.py
+++ b/litellm/completion_extras/litellm_responses_transformation/handler.py
@@ -187,9 +187,11 @@ class ResponsesToCompletionBridgeHandler:
         # than adding an explicit kwarg) avoids the duplicate-keyword
         # TypeError that would otherwise fire on the real bridge path.
         request_data["custom_llm_provider"] = custom_llm_provider
+        _saved_stream = getattr(logging_obj, "stream", None)
         result = responses(
             **request_data,
         )
+        logging_obj.stream = _saved_stream
 
         from litellm.types.utils import ModelResponse
 
@@ -276,10 +278,12 @@ class ResponsesToCompletionBridgeHandler:
         # keyword TypeError when `sanitized_litellm_params` already
         # carries `custom_llm_provider`.
         request_data["custom_llm_provider"] = custom_llm_provider
+        _saved_stream = getattr(logging_obj, "stream", None)
         result = await aresponses(
             **request_data,
             aresponses=True,
         )
+        logging_obj.stream = _saved_stream
 
         from litellm.types.utils import ModelResponse
 

--- a/tests/test_litellm/test_responses_api_bridge_non_stream.py
+++ b/tests/test_litellm/test_responses_api_bridge_non_stream.py
@@ -410,6 +410,98 @@ def test_all_providers_transformation_scenarios():
     print("\n✓ All provider scenarios work correctly")
 
 
+@pytest.mark.asyncio
+async def test_acompletion_restores_stream_flag_after_forced_provider_stream():
+    """
+    Regression test for: bridge drops SpendLogs row when provider forces stream=True.
+
+    When a non-streaming /v1/chat/completions request goes through the bridge and
+    the provider forces stream=True on the inner aresponses() call, the inner
+    @client wrapper mutates logging_obj.stream = True on the shared logging object.
+    The bridge must restore logging_obj.stream to its original value so the outer
+    success handler builds standard_logging_object and writes the SpendLogs row.
+    """
+    import datetime
+    from unittest.mock import patch
+
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+    from litellm.types.utils import ModelResponse, Usage
+
+    handler = ResponsesToCompletionBridgeHandler()
+
+    model_response = ModelResponse(
+        id="chatcmpl-test",
+        created=1234567890,
+        model="chatgpt/gpt-5.6-terra",
+        object="chat.completion",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(content="hello", role="assistant"),
+            )
+        ],
+        usage=Usage(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+    )
+
+    responses_api_response = ResponsesAPIResponse.model_construct(
+        id="resp-x",
+        created_at=0,
+        output=[],
+        object="response",
+        model="chatgpt/gpt-5.6-terra",
+        usage=None,
+    )
+
+    logging_obj = LiteLLMLoggingObj(
+        model="chatgpt/gpt-5.6-terra",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="acompletion",
+        start_time=datetime.datetime.now(tz=datetime.timezone.utc),
+        litellm_call_id="test-call-id",
+        function_id="test-function-id",
+    )
+
+    def _fake_transform_request(**kwargs):
+        return {
+            "model": "chatgpt/gpt-5.6-terra",
+            "input": [],
+            "litellm_logging_obj": logging_obj,
+        }
+
+    def _fake_transform_response(**kwargs):
+        return model_response
+
+    handler.transformation_handler.transform_request = Mock(side_effect=_fake_transform_request)
+    handler.transformation_handler.transform_response = Mock(side_effect=_fake_transform_response)
+
+    async def _fake_aresponses(**kwargs):
+        logging_obj.stream = True
+        return responses_api_response
+
+    with patch(
+        "litellm.aresponses",
+        side_effect=_fake_aresponses,
+    ):
+        result = await handler.acompletion(
+            model="chatgpt/gpt-5.6-terra",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={},
+            litellm_params={},
+            headers={},
+            model_response=model_response,
+            logging_obj=logging_obj,
+            custom_llm_provider="chatgpt",
+        )
+
+    assert logging_obj.stream is False, (
+        "bridge must restore logging_obj.stream to its pre-call value; "
+        "if it stays True the outer success handler skips building standard_logging_object"
+    )
+    assert isinstance(result, ModelResponse)
+
+
 if __name__ == "__main__":
     # Run all tests
     test_transform_usage_no_token_details()


### PR DESCRIPTION
The bridge shares the outer completion's LiteLLMLoggingObj with the inner aresponses() sub-call. When a provider forces stream=True, the inner @client wrapper mutates logging_obj.stream = True on the shared object. On return, the outer async_success_handler sees self.stream is True and skips building standard_logging_object, so response_cost stays None and no SpendLogs row is written.

Fix: save logging_obj.stream before calling responses()/aresponses() and restore it after. Both sync and async paths are covered.

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- <blah>
- ...

How it solves it:

- <blah>
- ...

## User Flow

<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision

Example:

Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request comes back with real token counts, so the dashboard shows real spend

1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
-->

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Caveats (if any)

<!-- Short bullet points, just like the TLDR: one line per bullet, roughly 10 words max
     Call out known limitations, follow-up work, or anything a reviewer should watch out for
     Leave this section empty if there are none -->

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
