### PR TITLE
fix(ui): open the classifier prompt editor above the edit auto-router form

### DIFF
--- a/ui/litellm-dashboard/src/app/globals.css
+++ b/ui/litellm-dashboard/src/app/globals.css
@@ -235,3 +235,10 @@
 .custom-border {
   border: 1px solid var(--neutral-border);
 }
+
+/* A dialog opened from inside another dialog reads as a drill-down, not a stack: base-ui stamps
+   this attribute on the parent while a child is open, so the parent steps aside instead of
+   showing its own edges around a differently sized child. */
+[data-slot="dialog-content"][data-nested-dialog-open] {
+  visibility: hidden;
+}

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
@@ -6,12 +6,19 @@ import { fireEvent, renderWithProviders, screen, waitFor, within } from "@/../te
 import NotificationsManager from "@/components/molecules/notifications_manager";
 import EditAutoRouterModal from "./edit_auto_router_modal";
 
-const { modelPatchUpdateCall, modelAvailableCall } = vi.hoisted(() => ({
+const { modelPatchUpdateCall, modelAvailableCall, getAutoRouterClassifierDefaultPromptCall } = vi.hoisted(() => ({
   modelPatchUpdateCall: vi.fn().mockResolvedValue({}),
   modelAvailableCall: vi.fn().mockResolvedValue({ data: [] }),
+  getAutoRouterClassifierDefaultPromptCall: vi.fn().mockResolvedValue("Classify the request into exactly one tier."),
 }));
 
-vi.mock("../networking", () => ({ modelPatchUpdateCall, modelAvailableCall }));
+vi.mock("../networking", () => ({
+  modelPatchUpdateCall,
+  modelAvailableCall,
+  getAutoRouterClassifierDefaultPromptCall,
+}));
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({ default: () => ({ accessToken: "sk-test" }) }));
 
 vi.mock("@/components/llm_calls/fetch_models", () => ({
   fetchAvailableModels: vi.fn().mockResolvedValue([{ model_group: "gpt-4o-mini" }]),
@@ -241,6 +248,22 @@ describe("EditAutoRouterModal classifier context window", () => {
     const config = savedConfig();
     expect(config.classifier_context_window_size).toBe(5);
     expect(config.classifier_context_per_turn_chars).toBe(300);
+  });
+
+  // The prompt editor is a base-ui Dialog at z-index 50. Housing this form in an antd Modal put a
+  // z-index 1000 overlay between the operator and it, so the editor opened underneath and could
+  // not be read or typed into. jsdom does not paint, so the assertion is the invariant behind the
+  // stacking: both overlays come from the one Dialog primitive the create form already uses.
+  it("opens the classifier prompt editor in the same overlay layer as the form", async () => {
+    const user = userEvent.setup();
+    const { baseElement } = renderLlmModal();
+
+    await user.click(await screen.findByText("Advanced: Classification Method"));
+    await user.click(await screen.findByRole("button", { name: /prompt/i }));
+
+    expect(await screen.findByLabelText("Classifier system prompt")).toBeInTheDocument();
+    expect(baseElement.querySelectorAll('[data-slot="dialog-content"]')).toHaveLength(2);
+    expect(baseElement.querySelector(".ant-modal")).toBeNull();
   });
 
   it("persists an edited classifier context window size", async () => {

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { Modal, Form, Button, Select as AntdSelect, Tooltip } from "antd";
-import { Text, TextInput } from "@tremor/react";
+import { Form, Button, Select as AntdSelect, Tooltip } from "antd";
+import { TextInput } from "@tremor/react";
 import { modelAvailableCall, modelPatchUpdateCall } from "../networking";
 import { fetchAvailableModels, ModelGroup } from "@/components/llm_calls/fetch_models";
 import RouterConfigBuilder from "../add_model/RouterConfigBuilder";
@@ -24,6 +24,14 @@ import ComplexityRouterConfig, {
   DEFAULT_TIER_DISTANCE_PENALTY,
 } from "../add_model/ComplexityRouterConfig";
 import NotificationsManager from "../molecules/notifications_manager";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 interface EditAutoRouterModalProps {
   isVisible: boolean;
@@ -432,27 +440,14 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
   }));
 
   return (
-    <Modal
-      title="Edit Auto Router Configuration"
-      open={isVisible}
-      onCancel={onCancel}
-      footer={[
-        <Button key="cancel" onClick={onCancel}>
-          Cancel
-        </Button>,
-        <Tooltip key="submit" title={submitBlockedReason}>
-          <Button loading={loading} disabled={submitBlockedReason !== null} onClick={handleSubmit}>
-            Save Changes
-          </Button>
-        </Tooltip>,
-      ]}
-      width={1000}
-      destroyOnHidden
-    >
-      <div className="space-y-6">
-        <Text className="text-gray-600">
-          Edit the auto router configuration including routing logic, default models, and access settings.
-        </Text>
+    <Dialog open={isVisible} onOpenChange={(open) => !open && onCancel()}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Edit Auto Router Configuration</DialogTitle>
+          <DialogDescription>
+            Edit the auto router configuration including routing logic, default models, and access settings.
+          </DialogDescription>
+        </DialogHeader>
 
         <Form form={form} layout="vertical" className="space-y-4">
           {/* Auto Router Name */}
@@ -552,8 +547,17 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
             </Form.Item>
           )}
         </Form>
-      </div>
-    </Modal>
+
+        <DialogFooter>
+          <Button onClick={onCancel}>Cancel</Button>
+          <Tooltip title={submitBlockedReason}>
+            <Button loading={loading} disabled={submitBlockedReason !== null} onClick={handleSubmit}>
+              Save Changes
+            </Button>
+          </Tooltip>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Opening "Edit custom prompt" from the Edit Auto Router form made the Classifier prompt editor appear *behind* the form, so the prompt could not be read or typed into
- The same editor opened correctly on top in the Add Auto Router flow, which is why this looked like a modal-specific glitch rather than a stacking one

How it solves it:

- The prompt editor is a base-ui `Dialog` fixed at z-index 50; the create form houses it in the same base-ui `Dialog`, but the edit form was an antd `Modal` whose portal computes to z-index 1000
- Moves the edit form onto the `Dialog` the create form already uses, so the whole nesting chain sits in one overlay layer

## User Flow

Models + Endpoints -> Auto-Routers -> click a complexity router -> Edit Auto Router -> Advanced: Classification Method -> Edit custom prompt. The editor now opens on top of the form, with the saved rubric in it, and Save prompt returns to the form with the form still open.

## Relevant issues

- The classifier prompt editor opened underneath the Edit Auto Router form and could not be used
- Both auto-router forms now render through the same Dialog primitive, so the two flows stack identically
- No backend, payload or query change

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Same router, same clicks, same proxy. The only thing that differs between the two runs is the bundle served out of `litellm/proxy/_experimental/out`.

**Before.** Opening "Edit custom prompt" mounts the editor, and it paints underneath the form. Only its top edge is visible behind the modal, and clicks at its own coordinates land on the antd modal instead.

<img alt="Classifier prompt editor rendered behind the Edit Auto Router Configuration modal" src="https://github.com/user-attachments/assets/8944e146-6202-43f5-9fb8-15698c567543" />

```
antd  "Edit Auto Router Configuration"  z-index=1000
base-ui "Classifier prompt"             z-index=50
topmost element at the classifier dialog's own header -> div.ant-modal-wrap
document order: the antd wrap comes BEFORE the base-ui portal, so only z-index decides
```

**After.** Same clicks, editor on top, rubric readable and editable.

<img width="1094" height="1123" alt="image" src="https://github.com/user-attachments/assets/1ca8985a-0bbc-4dc4-a018-61b90306afb0" />

To reproduce it yourself:

Run a proxy with a Postgres and any three chat models, then create a complexity auto-router whose classification method is LLM Classifier and whose Classifier Prompt has been overridden through "Change default prompt".

1. Start the rig

```
createdb -h localhost litellm_clfmodal
DATABASE_URL="postgresql://$(whoami)@localhost:5432/litellm_clfmodal" .venv/bin/prisma db push --schema litellm/proxy/schema.prisma --skip-generate
python litellm/proxy/proxy_cli.py --config <config with three anthropic models> --detailed_debug 2>&1 | tee litellm.log
```

2. In the browser, go to `http://localhost:4000/ui/models-and-endpoints/`, open the Auto-Routers tab, click your router, then Edit Auto Router, expand Advanced: Classification Method, and click Edit custom prompt

3. Before, on the committed bundle, the editor is invisible. Measured in the console:

```
antd  "Edit Auto Router Configuration"  z-index=1000
base-ui "Classifier prompt"             z-index=50
hit-test at the classifier dialog's own header -> div.ant-card-body
document order: the antd wrap comes BEFORE the base-ui portal, so only z-index decides
```

4. After, on this branch's bundle, same clicks, same console probe:

```
"Edit Auto Router Configuration"  z-index=50
"Classifier prompt"               z-index=50
antd-modal count=0
hit-test at the classifier dialog's header -> THE CLASSIFIER DIALOG
textarea present=true disabled=false starts="CUSTOM RUBRIC clfmodal probe."
```

5. Save prompt closes the editor and leaves the form open; Save Changes PATCHes `/model/{id}/update` with 200 and the stored `classifier_llm_config.system_prompt` round-trips:

```
curl -s -H "Authorization: Bearer $KEY" "http://localhost:4000/model/info?litellm_model_id=$ID"
model: clfmodal-router
classifier_type: llm
system_prompt first line: 'CUSTOM RUBRIC clfmodal probe.'
```

## Type

🐛 Bug Fix

## Caveats (if any)

jsdom does not lay out or paint, so stacking itself is not assertable in a component test. The regression test pins the invariant behind it instead: with the prompt editor open, both overlays must come from the one Dialog primitive and no antd modal may be in the document. It fails on the unfixed component and passes with the fix.

The audit that found this turned up one more base-ui overlay nested under an antd Modal, two tooltips inside the MCP server create form (`MCPLogoSelector.tsx`, `mcp_server_cost_config.tsx`). Different feature and cosmetic rather than blocking, so it is left for its own change rather than widening this one.

Raising the base-ui layer above antd globally was considered and rejected: overlays nest in both directions here, so no pair of static numbers works. The Add Auto Router dialog is itself a base-ui Dialog containing two antd Modals and eighteen antd Select and Tooltip popups, all of which would fall behind their own container.

## QA runbook

Open the Add Auto Router form and confirm the prompt editor still opens on top there, then repeat through Edit Auto Router. Check that Escape, the X, Cancel and a successful Save Changes each close the edit form, and that a long form still scrolls to reach the footer.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only overlay and modal shell change for one edit form; no API or routing payload changes.
> 
> **Overview**
> Fixes the **Edit Auto Router** flow so the nested **classifier prompt** dialog is usable: the form no longer uses an antd `Modal` (z-index ~1000) and instead uses the same base-ui `Dialog` as the create flow, so the prompt editor (also a `Dialog`) stacks on top instead of behind the form.
> 
> Adds global CSS so when a child dialog is open, the parent `[data-slot="dialog-content"]` is hidden (`data-nested-dialog-open`), avoiding a double-frame “stack” look during drill-down.
> 
> A component test asserts the invariant behind stacking in jsdom: with the prompt editor open, two `dialog-content` nodes exist and no `.ant-modal` is present; test mocks were extended for the classifier default-prompt fetch and auth hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e620a2f6bde9fae66ad3e156c53a2c4ca57de918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

