### PR TITLE
fix(bedrock): use actual file size when Content-Length missing (#36388)

### DIFF
--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -861,6 +861,9 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         )
 
         litellm_params["upload_url"] = api_base
+        # Store file size for response transformation (S3 PUT response
+        # doesn't include Content-Length, so we pass it through).
+        litellm_params["_file_content_size"] = len(file_content) if isinstance(file_content, (str, bytes)) else 0
 
         # Return a dict that tells the HTTP handler exactly what to do
         return {
@@ -1024,6 +1027,12 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         # S3 PUT object returns ETag and other metadata in headers
         content_length: Final = response_headers.get("Content-Length", "0")
 
+        # S3 PUT responses may not include Content-Length, so fall back
+        # to the actual content size captured during request transformation.
+        file_size: int = int(content_length) if content_length.isdigit() else 0
+        if file_size == 0:
+            file_size = litellm_params.get("_file_content_size", 0)
+
         # Use the actual upload URL that was used for the S3 upload
         upload_url: Final = litellm_params.get("upload_url")
         file_id: str = ""
@@ -1038,7 +1047,7 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
             filename=filename,
             created_at=int(time.time()),  # Current timestamp
             status="uploaded",
-            bytes=int(content_length) if content_length.isdigit() else 0,
+            bytes=file_size,
             object="file",
         )
 

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -863,7 +863,13 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         litellm_params["upload_url"] = api_base
         # Store file size for response transformation (S3 PUT response
         # doesn't include Content-Length, so we pass it through).
-        litellm_params["_file_content_size"] = len(file_content) if isinstance(file_content, (str, bytes)) else 0
+        # Use UTF-8 byte length, not decoded string length, so multi-byte
+        # characters are counted correctly.
+        if isinstance(file_content, bytes):
+            _file_content_bytes = len(file_content)
+        else:
+            _file_content_bytes = len(file_content.encode("utf-8"))
+        litellm_params["_file_content_size"] = _file_content_bytes
 
         # Return a dict that tells the HTTP handler exactly what to do
         return {

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -1035,17 +1035,16 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
 
         # S3 PUT responses may not include Content-Length, so fall back
         # to the actual content size captured during request transformation.
-        file_size: int = int(content_length) if content_length.isdigit() else 0
-        if file_size == 0:
-            file_size = litellm_params.get("_file_content_size", 0)
+        _content_length: Final = int(content_length) if content_length.isdigit() else 0
+        file_size: Final[int] = _content_length or int(litellm_params.get("_file_content_size", 0))
 
         # Use the actual upload URL that was used for the S3 upload
         upload_url: Final = litellm_params.get("upload_url")
-        file_id: str = ""
-        filename: str = ""
+        file_id: str = ""  # rebind-ok: reassigned below if upload_url present
+        filename: str = ""  # rebind-ok: reassigned below if upload_url present
         if upload_url:
             # Convert HTTPS S3 URL to s3:// URI format
-            file_id, filename = self._convert_https_url_to_s3_uri(upload_url)
+            file_id, filename = self._convert_https_url_to_s3_uri(upload_url)  # rebind-ok: intentional unpacking reassignment
 
         return OpenAIFileObject(
             purpose="batch",  # Default purpose for Bedrock files

--- a/tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py
+++ b/tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py
@@ -2093,6 +2093,38 @@ class TestBedrockFilesS3SignatureEncoding:
 
         assert result.bytes == 2048
 
+    def test_file_content_size_counts_utf8_bytes_not_characters(self):
+        """Multi-byte characters must count as their encoded byte length.
+
+        Regression test for Greptile review on #36388: len() on a decoded
+        string undercounts multi-byte (e.g. CJK) content.
+        """
+        import httpx
+
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        raw_response = httpx.Response(
+            status_code=200,
+            headers={},  # S3 PUT omits Content-Length
+            content=b"",
+            request=httpx.Request(
+                "PUT",
+                "https://s3.us-east-1.amazonaws.com/my-bucket/litellm-bedrock-files-abc.jsonl",
+            ),
+        )
+
+        # 3 CJK characters = 9 UTF-8 bytes, not 3 characters.
+        content_size = len("日本語".encode("utf-8"))
+
+        result = BedrockFilesConfig().transform_create_file_response(
+            model=None,
+            raw_response=raw_response,
+            logging_obj=MagicMock(),
+            litellm_params={"_file_content_size": content_size},
+        )
+
+        assert result.bytes == 9
+
     def test_file_content_signs_spaced_object_key_the_way_s3_does(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py
+++ b/tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py
@@ -2038,6 +2038,61 @@ class TestBedrockFilesS3SignatureEncoding:
             headers=signed["headers"],
         )
 
+    def test_transform_create_file_response_bytes_from_content_length(self):
+        """bytes should reflect actual file size when Content-Length is present."""
+        import httpx
+
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        raw_response = httpx.Response(
+            status_code=200,
+            headers={"Content-Length": "4096"},
+            content=b"",
+            request=httpx.Request(
+                "PUT",
+                "https://s3.us-east-1.amazonaws.com/my-bucket/litellm-bedrock-files-anthropic.claude-3-5-sonnet-20240620-v1:0-abc123.jsonl",
+            ),
+        )
+
+        result = BedrockFilesConfig().transform_create_file_response(
+            model=None,
+            raw_response=raw_response,
+            logging_obj=MagicMock(),
+            litellm_params={},
+        )
+
+        assert result.bytes == 4096
+
+    def test_transform_create_file_response_bytes_falls_back_to_content_size(self):
+        """When S3 PUT response omits Content-Length, bytes should fall back
+        to the actual content size captured during request transformation.
+
+        Regression test for #36388.
+        """
+        import httpx
+
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        raw_response = httpx.Response(
+            status_code=200,
+            # S3 PUT responses typically omit Content-Length
+            headers={},
+            content=b"",
+            request=httpx.Request(
+                "PUT",
+                "https://s3.us-east-1.amazonaws.com/my-bucket/litellm-bedrock-files-anthropic.claude-3-5-sonnet-20240620-v1:0-abc123.jsonl",
+            ),
+        )
+
+        result = BedrockFilesConfig().transform_create_file_response(
+            model=None,
+            raw_response=raw_response,
+            logging_obj=MagicMock(),
+            litellm_params={"_file_content_size": 2048},
+        )
+
+        assert result.bytes == 2048
+
     def test_file_content_signs_spaced_object_key_the_way_s3_does(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## What
Bedrock file upload now reports correct bytes in FileObject instead of always 0.

## Evidence
- transformation.py:863-865 — _file_content_size passed through litellm_params
- transformation.py:1030-1034 — fallback to _file_content_size when Content-Length missing

## Fix
S3 PUT responses often omit Content-Length. We capture the actual file size during request transformation and use it as a fallback when building the FileObject.

## Test plan
- test_transform_create_file_response_bytes_from_content_length: Content-Length present → use it
- test_transform_create_file_response_bytes_falls_back_to_content_size: Content-Length missing → fallback to _file_content_size

## Duplicate Scan
- No open PRs for #36388

## Risk
- Minimal: only affects Bedrock file upload response
- Content-Length path unchanged
- Fallback only activates when Content-Length is 0 or missing

Closes #36388