### PR TITLE
fix(bedrock_guardrails): skip ApplyGuardrail when there is no content to scan

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -826,7 +826,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         guardrail call and is logged exactly once here.
         """
         start_time: Final = datetime.now(timezone.utc)
-        credentials, aws_region_name = self._load_credentials()
         bedrock_request_data: Final[dict] = dict(
             self.convert_to_bedrock_format(source=source, messages=messages, response=response)
         )
@@ -850,6 +849,16 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         )
 
         content: Final[tuple[BedrockContentItem, ...]] = tuple(bedrock_request_data.get("content") or ())
+        if not content:
+            # ApplyGuardrail rejects an empty content list with a 400, so a turn this extractor
+            # found no text in is skipped rather than turned into a failed request
+            verbose_proxy_logger.debug(
+                "Bedrock Guardrail %s: no %s content to scan, skipping ApplyGuardrail",
+                self.guardrail_name,
+                source,
+            )
+            return BedrockGuardrailResponse()
+        credentials, aws_region_name = self._load_credentials()
         allow_chunking: Final = not self._content_uses_contextual_grounding(content)
 
         try:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -987,6 +987,134 @@ async def test_bedrock_apply_guardrail_with_only_tool_calls_response():
         print("✅ apply_guardrail with tool_calls test passed - no API call made")
 
 
+def _anthropic_tool_result_conversation(
+    extra_blocks: tuple[dict[str, str], ...] = (),
+) -> list[dict[str, object]]:
+    """Anthropic /v1/messages history whose latest user turn is a tool_result follow-up."""
+    return [
+        {"role": "user", "content": "What is the weather in Paris?"},
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "toolu_01A", "name": "get_weather", "input": {"city": "Paris"}}],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_01A", "content": "18C and sunny"},
+                *extra_blocks,
+            ],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_during_call_hook_skips_bedrock_call_for_tool_result_only_turn():
+    """A tool_result-only latest user turn must not post an empty content list to Bedrock.
+
+    Regression for `400: At least one GuardrailContentBlock must be provided` on
+    /v1/messages: with experimental_use_latest_role_message_only the scanned turn is the
+    Anthropic tool_result block, which carries no text, so ApplyGuardrail rejected the call.
+    """
+    guardrail = BedrockGuardrail(
+        guardrail_name="bedrock-tool-result",
+        guardrailIdentifier="test-guardrail",
+        guardrailVersion="DRAFT",
+        event_hook=GuardrailEventHooks.during_call,
+        default_on=True,
+        experimental_use_latest_role_message_only=True,
+    )
+    data = {"model": "claude-sonnet-4-5", "messages": _anthropic_tool_result_conversation()}
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
+        await guardrail.async_moderation_hook(
+            data=data,
+            user_api_key_dict=UserAPIKeyAuth(),
+            call_type=CallTypes.anthropic_messages.value,
+        )
+
+    mock_post.assert_not_called()
+    assert data["messages"] == _anthropic_tool_result_conversation()
+
+
+@pytest.mark.asyncio
+async def test_during_call_hook_still_scans_tool_result_turn_carrying_text():
+    """The skip must be limited to turns with nothing to scan, never to tool_result turns as such."""
+    guardrail = BedrockGuardrail(
+        guardrail_name="bedrock-tool-result-text",
+        guardrailIdentifier="test-guardrail",
+        guardrailVersion="DRAFT",
+        event_hook=GuardrailEventHooks.during_call,
+        default_on=True,
+        experimental_use_latest_role_message_only=True,
+    )
+    data = {
+        "model": "claude-sonnet-4-5",
+        "messages": _anthropic_tool_result_conversation(({"type": "text", "text": "now summarize that"},)),
+    }
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "test-access-key"
+    mock_credentials.secret_key = "test-secret-key"
+    mock_credentials.token = None
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"action": "NONE", "assessments": []}
+
+    with (
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+    ):
+        mock_post.return_value = mock_response
+        await guardrail.async_moderation_hook(
+            data=data,
+            user_api_key_dict=UserAPIKeyAuth(),
+            call_type=CallTypes.anthropic_messages.value,
+        )
+
+    mock_post.assert_called_once()
+    sent = mock_post.call_args.kwargs["data"].decode()
+    assert "now summarize that" in sent
+    # tool_result text is not extracted by this path (https://github.com/BerriAI/litellm/issues/33086)
+    assert "18C and sunny" not in sent
+
+
+@pytest.mark.asyncio
+async def test_make_apply_guardrail_request_skips_output_scan_without_response_text():
+    """A tool-calls-only assistant response yields no OUTPUT content, so it must not be posted."""
+    guardrail = BedrockGuardrail(guardrailIdentifier="test-guardrail", guardrailVersion="DRAFT")
+    response = ModelResponse(
+        choices=[
+            litellm.Choices(
+                index=0,
+                message=litellm.Message(role="assistant", content=None, tool_calls=[]),
+                finish_reason="tool_calls",
+            )
+        ]
+    )
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
+        bedrock_response = await guardrail.make_bedrock_api_request(source="OUTPUT", response=response)
+
+    mock_post.assert_not_called()
+    assert bedrock_response == {}
+
+
+@pytest.mark.asyncio
+async def test_make_apply_guardrail_request_skips_scan_without_credentials():
+    """Skipping happens before credential resolution, so an empty scan costs no AWS work."""
+    guardrail = BedrockGuardrail(guardrailIdentifier="test-guardrail", guardrailVersion="DRAFT")
+
+    with (
+        patch.object(guardrail, "_load_credentials", side_effect=AssertionError("credentials must not be loaded")),
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+    ):
+        await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=[{"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "out"}]}],
+        )
+
+    mock_post.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_bedrock_apply_guardrail_response_uses_OUTPUT_source():
     """input_type='response' must call Bedrock with source=OUTPUT and assistant content.

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -912,7 +912,7 @@ async def test_bedrock_guardrail_make_api_request_passes_api_key():
     ):
 
         mock_load_creds.return_value = (Mock(), "us-east-1")
-        mock_convert.return_value = {"source": "INPUT", "content": []}
+        mock_convert.return_value = {"source": "INPUT", "content": [{"text": {"text": "test"}}]}
         mock_get_params.return_value = {}
 
         mock_request_instance = Mock()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock guardrails 400 on a tool-only turn, breaking agent workloads
- A tool result carries no text, so an empty scan list is sent
- AWS rejects an empty content list, so the whole request fails

How it solves it:

- Skip the ApplyGuardrail call when there is no text to scan
- Nothing to scan means nothing to block, so the request is allowed
- Mirrors the guard the InvokeGuardrailChecks path already has

## User Flow

Before: a developer building an agent on `/v1/messages` with a Bedrock guardrail attached gets a hard failure the moment their assistant calls a tool

1. They send POST https://litellm-domain/v1/messages with a user question and a `get_weather` tool, and get back a `tool_use` block
2. They run the tool and send the same conversation again, now ending with the `tool_result` block the API asks for
3. The call comes back `400` with `At least one GuardrailContentBlock must be provided`, so the agent cannot take a second turn
4. Adding `"stream": true` gives the same `400`, so there is no way to work around it
5. Plain chat with no tools keeps working, so the guardrail looks fine until tools are used

After: the same tool-using conversation completes, and the guardrail still blocks what it should

1. They send POST https://litellm-domain/v1/messages with a user question and a `get_weather` tool, and get back a `tool_use` block
2. They run the tool and send the same conversation again, now ending with the `tool_result` block the API asks for
3. The call returns `200` with the assistant's answer, so the agent takes its second turn
4. Adding `"stream": true` streams that same answer back
5. If the tool result turn also carries a text block with prohibited wording, the call is still refused with the guardrail's violation message

## Relevant issues

## Linear ticket

Refs LIT-4746

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy, real AWS Bedrock guardrail (word policy blocking `FORBIDDENWORD`), real Gemini calls, real Postgres. No mocks. Guardrail config is the reported one:

```yaml
guardrails:
  - guardrail_name: bedrock-during
    litellm_params:
      guardrail: bedrock
      mode: during_call
      guardrailIdentifier: b9aduya1zr20
      guardrailVersion: DRAFT
      aws_region_name: us-east-1
      default_on: true
      experimental_use_latest_role_message_only: true
litellm_settings:
  skip_tool_message_in_guardrail: true
  skip_system_message_in_guardrail: true
```

The empty request AWS rejects, reproduced against the API directly with no LiteLLM in the picture:

```
$ aws bedrock-runtime apply-guardrail --guardrail-identifier b9aduya1zr20 \
    --guardrail-version DRAFT --source INPUT --content '[]' --region us-east-1
An error occurred (ValidationException) when calling the ApplyGuardrail operation:
At least one GuardrailContentBlock must be provided.
```

```
########## BEFORE, at litellm_internal_staging 61218f5f9f ##########

$ # 1. plain text turn (control, always worked)
{"id":"IhJ6asuqNJjQjMcPkYiFsQc","type":"message","role":"assistant","model":"gemini-tools","stop_sequence":null,"usage":{"input_tokens":7,"output_tokens":60},"content":[{"type":"text","text":"Hello there"}],"stop_reason":"max_tokens"}
HTTP 200


$ # 2. tool_result follow-up turn, non-streaming
{"error":{"message":"400: At least one GuardrailContentBlock must be provided.","type":"None","param":"None","code":"400"}}
HTTP 400


$ # 3. tool_result follow-up turn, streaming
{"error":{"message":"400: At least one GuardrailContentBlock must be provided.","type":"None","param":"None","code":"400"}}
HTTP 400

$ # 4. tool_result turn that ALSO carries text (guardrail must still block)
{"error":{"message":"400: {'error': 'Violated guardrail policy', 'bedrock_guardrail_response': 'Blocked by guardrail', 'guardrailIdentifier': 'b9aduya1zr20', 'guardrailVersion': 'DRAFT', 'assessments': [{'policy': 'wordPolicy', 'matches': [{'category': 'customWords', 'match': '[REDACTED]', 'action':
```

```
########## AFTER, at b98f2f9def (this PR, code identical to the 1172bcce39 run below it was captured at) ##########

$ # 1. plain text turn (control, always worked)
{"id":"yRh6atieMInSjMcP-v_YoQ4","type":"message","role":"assistant","model":"gemini-tools","stop_sequence":null,"usage":{"input_tokens":7,"output_tokens":60},"content":[{"type":"text","text":"Hello there!"}],"stop_reason":"max_tokens"}
HTTP 200


$ # 2. tool_result follow-up turn, non-streaming
{"id":"yhh6ao6WIpbTjMcPu4bZyQY","type":"message","role":"assistant","model":"gemini-tools","stop_sequence":null,"usage":{"input_tokens":81,"output_tokens":12},"content":[{"type":"text","text":"The weather in Paris is 18C and sunny."}],"stop_reason":"end_turn"}
HTTP 200


$ # 3. tool_result follow-up turn, streaming
data: {"type": "message_stop"}


HTTP 200

$ # 4. tool_result turn that ALSO carries text (guardrail must still block)
{"error":{"message":"400: {'error': 'Violated guardrail policy', 'bedrock_guardrail_response': 'Blocked by guardrail', 'guardrailIdentifier': 'b9aduya1zr20', 'guardrailVersion': 'DRAFT', 'assessments': [{'policy': 'wordPolicy', 'matches': [{'category': 'customWords', 'match': '[REDACTED]', 'action':
```

## Type

🐛 Bug Fix

## Caveats (if any)

- LIT-4746 stays open; its second error, a 500, is not fixed here
- It survives this fix and needs no tools, so it is not the same bug
- `skip_*_in_guardrail` stays unwired on the native hook, noted on LIT-4746
- Image-only and audio-only turns now pass instead of 400ing
- Tool output text is still not extracted here, see #33086
- A skipped scan writes no guardrail log row, matching the other skip paths
- PR #25355 does not fix this; a tool_result turn is still a user message

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
