### PR TITLE
fix(bedrock): stop claiming native web_search support on Bedrock

### DIFF
--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -77,6 +77,15 @@ class AmazonAnthropicClaudeMessagesConfig(
         BaseAnthropicMessagesConfig.__init__(self, **kwargs)
         AmazonInvokeConfig.__init__(self, **kwargs)
 
+    def handles_web_search_natively(self) -> bool:
+        """
+        Bedrock does not host Anthropic's ``web_search_20250305`` server tool on
+        any of its APIs, so forwarding it reaches AWS and is rejected. Reporting
+        False keeps the web-search interception short-circuit in play, which is
+        the only way this tool can be served on Bedrock.
+        """
+        return False
+
     def validate_anthropic_messages_environment(
         self,
         headers: dict,

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_short_circuit.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_short_circuit.py
@@ -122,27 +122,41 @@ class TestTryShortCircuitSearch:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_does_not_short_circuit_bedrock(self):
-        """Bedrock has native agentic loop support → NOT short-circuited.
+    async def test_short_circuits_bedrock(self):
+        """Bedrock → short-circuit fires.
 
-        Providers with a BaseAnthropicMessagesConfig (bedrock, vertex_ai, etc.)
-        use the agentic loop which includes a follow-up LLM synthesis step.
-        The short-circuit must not fire for them.
+        Bedrock does not host Anthropic's web_search_20250305 server tool on any
+        of its APIs, so forwarding the request reaches AWS and is rejected with a
+        400. Short-circuiting is the only way the tool can be served there, so a
+        regression that makes the bedrock config claim native handling again puts
+        the deterministic 400 straight back.
         """
         logger = WebSearchInterceptionLogger(
             enabled_providers=["bedrock", "github_copilot"]
         )
 
-        result = await logger.try_short_circuit_search(
-            model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-            messages=[{"role": "user", "content": "Search for something"}],
-            tools=[
-                {"type": "web_search_20250305", "name": "web_search", "max_uses": 8}
-            ],
-            custom_llm_provider="bedrock",
-        )
+        with patch.object(
+            logger, "_execute_search", new_callable=AsyncMock
+        ) as mock_search:
+            mock_search.return_value = (
+                "Title: Result\nURL: https://example.com\nSnippet: test",
+                None,
+            )
 
-        assert result is None
+            result = await logger.try_short_circuit_search(
+                model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                messages=[{"role": "user", "content": "Search for something"}],
+                tools=[
+                    {"type": "web_search_20250305", "name": "web_search", "max_uses": 8}
+                ],
+                custom_llm_provider="bedrock",
+            )
+
+        assert result is not None
+        block_types = [b["type"] for b in result["content"]]
+        assert "server_tool_use" in block_types
+        assert "web_search_tool_result" in block_types
+        mock_search.assert_called_once_with("Search for something")
 
     @pytest.mark.asyncio
     async def test_does_not_short_circuit_no_messages(self):

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -2580,3 +2580,22 @@ def test_replayed_intercepted_search_turn_leaves_no_unsupported_block_for_bedroc
     assert "server_tool_use" not in serialized
     assert expected_evidence in serialized
     assert "Rome was founded in 753 BC." in serialized
+
+
+def test_bedrock_messages_config_does_not_handle_web_search_natively():
+    """Bedrock hosts none of Anthropic's ``web_search_*`` server tools, so the
+    config must report ``handles_web_search_natively() is False``. That is what
+    keeps the web-search interception short-circuit in play; when it reported
+    True the tool was forwarded verbatim and AWS rejected the request. The
+    mantle subclass inherits the same answer, and the direct Anthropic config
+    must keep reporting True so the fix stays scoped to Bedrock."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+        AnthropicMessagesConfig,
+    )
+    from litellm.llms.bedrock.messages.mantle_transformation import (
+        AmazonMantleMessagesConfig,
+    )
+
+    assert AmazonAnthropicClaudeMessagesConfig().handles_web_search_natively() is False
+    assert AmazonMantleMessagesConfig().handles_web_search_natively() is False
+    assert AnthropicMessagesConfig().handles_web_search_natively() is True


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock 400s every Anthropic `web_search` server-tool request
- The bedrock config wrongly claims it runs web search itself
- So the gateway's interception skips Bedrock and forwards the tool

How it solves it:

- Override `handles_web_search_natively()` to False for Bedrock
- Interception now serves the search, as it already does elsewhere
- Mantle subclasses the same config and is fixed with it

## User Flow

Before: a developer using Claude on Bedrock through the gateway cannot use web search at all, and the error tells them nothing about why

1. They send POST https://litellm-domain/v1/messages with `"model": "<their bedrock claude alias>"` and `"tools": [{"type": "web_search_20250305", "name": "web_search", "max_uses": 3}]`
2. The gateway hands the tool to AWS, which returns 400 `{"message":"The provided request is not valid"}`
3. Nothing in the message names the tool, so the same request fails on every Claude model they try
4. Dropping the tool from the body makes the request succeed, which is the only hint that the tool is the cause

After: the same request comes back with a real answer, and the search results are in the response

1. The proxy admin enables web-search interception for bedrock and declares a search backend in the proxy config
2. The developer sends the same POST https://litellm-domain/v1/messages with the same `web_search_20250305` tool
3. The response is a 200 whose text carries the search results, with titles, URLs and snippets
4. https://litellm-domain/ui/?page=logs shows the request logged against the search backend the admin configured

## Relevant issues

Related to #26252

## Linear ticket

Resolves LIT-5391

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on both sides, same request, same config, same searxng search backend. Before captured at `ea6c18baa5` (current `litellm_internal_staging`), after at `446a790aa4`. The listening PID changed between runs (12816 then 13466), so the after leg is genuinely the rebuilt process

Config the proxy ran with:

```yaml
model_list:
  - model_name: bedrock-haiku
    litellm_params:
      model: bedrock/invoke/us.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: us-east-1

search_tools:
  - search_tool_name: lit5391-search
    litellm_params:
      search_provider: searxng
      api_base: http://127.0.0.1:8391

litellm_settings:
  callbacks: ["websearch_interception"]
  websearch_interception_params:
    enabled_providers: ["bedrock"]
    search_tool_name: lit5391-search
```

The request, identical on both legs:

```bash
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://127.0.0.1:4391/v1/messages \
  -H 'Authorization: Bearer sk-lit5391' -H 'content-type: application/json' \
  -d '{"model":"bedrock-haiku","max_tokens":512,
       "messages":[{"role":"user","content":"Anthropic Claude news"}],
       "tools":[{"type":"web_search_20250305","name":"web_search","max_uses":3}]}'
```

Before, at `ea6c18baa5`. The tool is carried down the Bedrock InvokeModel path and the request is dispatched to AWS:

```
{"error":{"message":"Unable to locate credentials","type":"None","param":"None","code":"500"}}
HTTP_STATUS:500
```

```
litellm_logging.py:581 - self.optional_params: {'max_tokens': 512, 'stream': False,
  'tools': [{'type': 'web_search_20250305', 'name': 'web_search', 'max_uses': 3}]}
```

After, at `446a790aa4`. Interception serves the request and AWS is never contacted:

```
{"id":"msg_e26197b4-4a8b-4ffb-a1a8-5909b289dc27","type":"message","role":"assistant",
 "model":"bedrock-haiku","content":[{"type":"text","text":
 "Title: Newsroom - Anthropic\nURL: https://www.anthropic.com/news\nSnippet: The Making of
 Claude Code The inside story of how Claude Code went from an internal CLI to Anthropic's
 coding agent...\n\nTitle: Home \\ Anthropic\nURL: https://www.anthropic.com/\nSnippet: Claude
 Science is a customizable app that integrates the tools and packages researchers most often
 use...\n\nTitle: Investigating three real-world incidents in our cybersecurity ...\nURL:
 https://www.anthropic.com/news/investigating-incidents-cybersecurity-evals\nSnippet: Jul 30,
 2026 ..."}],"stop_reason":"end_turn","stop_sequence":null,
 "usage":{"input_tokens":0,"output_tokens":0}}
HTTP_STATUS:200
```

```
handler.py:256 - WebSearchInterception: Short-circuit search completed,
  returning synthetic response (8763 chars, native_blocks=False)

$ grep -c 'Unable to locate credentials' after.log
0
```

That zero is the discriminator: after the fix the request is answered without a single call to AWS, which is why it succeeds on a host with no Bedrock credentials at all

One honest limitation. This machine's AWS session is expired, so the before leg surfaces as the credential failure at the point of dispatch rather than as Bedrock's own `400 {"message":"The provided request is not valid"}`. What it does prove is the mechanism under test, that the unfixed build sends the tool to AWS and the fixed build does not. AWS's documentation for Anthropic Claude tool use states that the `web_search_20250305` server tool is not supported on Amazon Bedrock, and the accepted server-tool table on that page lists only the `computer_*`, `text_editor_*` and `bash_*` types, so a request that reaches Bedrock carrying it cannot succeed on either wire

Companion e2e coverage is #36443, which fails red on this base and passes on this fix

## Type

🐛 Bug Fix

## Caveats (if any)

- Only helps when web-search interception is configured
- Unconfigured deployments still get Bedrock's 400
- Base class still defaults to True, which is backwards
- vertex_ai and azure_ai inherit that default, unaudited
- Converse silently drops the tool instead, tracked separately
- The intermittent 401 in the same ticket is not addressed here
- Before leg shows dispatch to AWS, not Bedrock's own 400
- Native `web_search_tool_result` blocks are not emitted, see below

Separate gap found while capturing the proof, not fixed here. The interception hooks rewrite the native tool into LiteLLM's own search tool before the short-circuit runs, so `is_anthropic_native_web_search_tool` no longer matches and the short-circuit logs `native_blocks=False`. The result is a plain text block where the code's own comment says native clients expect `server_tool_use` plus `web_search_tool_result` for their citations panel. Happy to file it if that is the right call

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
