### PR TITLE
fix(bedrock): forward litellm_params AWS auth to batch create signing

### DIFF
--- a/litellm/llms/bedrock/batches/transformation.py
+++ b/litellm/llms/bedrock/batches/transformation.py
@@ -232,14 +232,15 @@ class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
 
         # For Bedrock, we need to return a pre-signed request with AWS auth headers
         # Use common utility for AWS signing
+        signing_params: Final = {**optional_params, **litellm_params}
         endpoint_url: Final = (
-            f"https://bedrock.{self._get_aws_region_name(optional_params, model)}.amazonaws.com/model-invocation-job"
+            f"https://bedrock.{self._get_aws_region_name(signing_params, model)}.amazonaws.com/model-invocation-job"
         )
         signed_headers, signed_data = self.common_utils.sign_aws_request(
             service_name="bedrock",
             data=bedrock_request,
             endpoint_url=endpoint_url,
-            optional_params=optional_params,
+            optional_params=signing_params,
             method="POST",
         )
 

--- a/tests/test_litellm/llms/bedrock/batches/test_transformation.py
+++ b/tests/test_litellm/llms/bedrock/batches/test_transformation.py
@@ -124,6 +124,35 @@ def test_create_request_builds_s3_input_output_and_arn(config):
     assert result["headers"] == {"Authorization": "signed"}
 
 
+def test_create_request_forwards_cross_account_aws_auth_from_litellm_params_to_signer(
+    config,
+):
+    with patch.object(
+        config.common_utils,
+        "generate_unique_job_name",
+        return_value="litellm-batch-1",
+    ), patch.object(config.common_utils, "sign_aws_request") as mock_sign:
+        mock_sign.return_value = ({}, b"{}")
+        config.transform_create_batch_request(
+            model="m",
+            create_batch_data={"input_file_id": "s3://b/in.jsonl"},
+            optional_params={},
+            litellm_params={
+                "aws_batch_role_arn": "arn:aws:iam::999999999999:role/cross-account-batch-role",
+                "aws_role_name": "arn:aws:iam::999999999999:role/cross-account-assume-role",
+                "aws_region_name": "eu-west-1",
+            },
+        )
+    signing_params = mock_sign.call_args.kwargs["optional_params"]
+    assert (
+        signing_params["aws_role_name"]
+        == "arn:aws:iam::999999999999:role/cross-account-assume-role"
+    )
+    assert mock_sign.call_args.kwargs["endpoint_url"] == (
+        "https://bedrock.eu-west-1.amazonaws.com/model-invocation-job"
+    )
+
+
 def test_create_request_defaults_output_bucket_to_input_bucket(config):
     with patch.object(
         config.common_utils,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cross-account Bedrock batch jobs fail with "Cross-account pass role is not allowed"
- Deployment-level AWS auth (litellm_params) was dropped before signing the request

How it solves it:

- Merge litellm_params into the params used for region lookup and SigV4 signing
- The cross-account role configured on the deployment now signs the request

## User Flow

Before: an admin who configured a Bedrock deployment with a cross-account batch role gets every batch job rejected by AWS

1. They POST to http://litellm-domain/v1/files with purpose=batch, staging an input file against a Bedrock deployment whose config sets a cross-account IAM role
2. They POST to http://litellm-domain/v1/batches with that file id, endpoint /v1/chat/completions, and completion_window 24h
3. The response body carries an AWS error saying the cross-account pass role is not allowed, even though the deployment's role ARN is correct

After: the same batch job is accepted

1. The admin sends the same POST http://litellm-domain/v1/files
2. They send the same POST http://litellm-domain/v1/batches
3. The response now returns a batch object with a job id and a validating/in-progress status instead of an error

## Relevant issues

## Linear ticket

Resolves LIT-4223

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproducing this needs a Bedrock deployment with a real cross-account IAM role (aws_role_name for the assume-role hop, aws_batch_role_arn for the job's roleArn), which I don't have credentials for. Steps below reproduce it against a live proxy for anyone who does.

Config (dev_config.yaml), pointed at a Bedrock model whose account differs from the calling identity's account:

```yaml
model_list:
  - model_name: bedrock-cross-account-batch
    litellm_params:
      model: bedrock/anthropic.claude-3-haiku-20240307-v1:0
      aws_region_name: us-east-1
      aws_role_name: arn:aws:iam::<TARGET_ACCOUNT_ID>:role/<cross-account-assume-role>
      aws_batch_role_arn: arn:aws:iam::<TARGET_ACCOUNT_ID>:role/<bedrock-batch-execution-role>
      s3_bucket_name: <your-bucket>
```

Start the proxy against that config, then:

```bash
FILE_ID=$(curl -s -X POST http://localhost:4000/v1/files \
  -H "Authorization: Bearer sk-1234" \
  -F purpose="batch" \
  -F file="@input.jsonl" | jq -r .id)

curl -s -X POST http://localhost:4000/v1/batches \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d "{\"input_file_id\": \"$FILE_ID\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\", \"model\": \"bedrock-cross-account-batch\"}"
```

Before the fix (checked out at `9de3315dad`, the commit this branch is based on): the batches call fails, and the proxy log shows the AWS error body containing "Cross-account pass role is not allowed."

After the fix (this branch, `6b50fcc8a5`): the same call returns a batch object with an id and a validating/in-progress status.

## Type

🐛 Bug Fix

## Caveats (if any)

- The equivalent file-upload signing path (files/transformation.py) has a similar-looking gap; left untouched to keep this PR scoped to batch creation

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

