### PR TITLE
feat(bedrock): make the IAM credential cache bounds env configurable

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -374,10 +374,10 @@ MAX_STRING_LENGTH_PROMPT_IN_DB: Final = int(os.getenv("MAX_STRING_LENGTH_PROMPT_
 BEDROCK_MAX_POLICY_SIZE: Final = int(os.getenv("BEDROCK_MAX_POLICY_SIZE", 75))
 # One entry per distinct AWS credential-argument set. Per-user cost attribution passes the attributed
 # identity as aws_session_name, so this bounds how many attributed identities keep a cached STS session.
-BEDROCK_IAM_CACHE_MAX_ENTRIES: Final = 1000
+BEDROCK_IAM_CACHE_MAX_ENTRIES: Final = int(os.getenv("BEDROCK_IAM_CACHE_MAX_ENTRIES", 1000))
 # Single-flight lock stripes over that cache. Only keys landing on the same stripe wait for each
 # other, so a burst of distinct identities still resolves its credentials in parallel.
-BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES: Final = 64
+BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES: Final = int(os.getenv("BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES", 64))
 # Retire a cached STS credential this many seconds before AWS expires it, so a request that reads it
 # still has a usable credential for the whole call.
 STS_CREDENTIAL_EXPIRY_SAFETY_MARGIN_SECONDS: Final = 60

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -374,10 +374,10 @@ MAX_STRING_LENGTH_PROMPT_IN_DB: Final = int(os.getenv("MAX_STRING_LENGTH_PROMPT_
 BEDROCK_MAX_POLICY_SIZE: Final = int(os.getenv("BEDROCK_MAX_POLICY_SIZE", 75))
 # One entry per distinct AWS credential-argument set. Per-user cost attribution passes the attributed
 # identity as aws_session_name, so this bounds how many attributed identities keep a cached STS session.
-BEDROCK_IAM_CACHE_MAX_ENTRIES: Final = int(os.getenv("BEDROCK_IAM_CACHE_MAX_ENTRIES", 1000))
+BEDROCK_IAM_CACHE_MAX_ENTRIES: Final = int(os.getenv("BEDROCK_IAM_CACHE_MAX_ENTRIES", "1000"))
 # Single-flight lock stripes over that cache. Only keys landing on the same stripe wait for each
 # other, so a burst of distinct identities still resolves its credentials in parallel.
-BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES: Final = int(os.getenv("BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES", 64))
+BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES: Final = int(os.getenv("BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES", "64"))
 # Retire a cached STS credential this many seconds before AWS expires it, so a request that reads it
 # still has a usable credential for the whole call.
 STS_CREDENTIAL_EXPIRY_SAFETY_MARGIN_SECONDS: Final = 60

--- a/tests/test_litellm/test_constants.py
+++ b/tests/test_litellm/test_constants.py
@@ -71,3 +71,36 @@ def _build_constant_env_var_map() -> dict[str, str]:
             env_var_map[constant_name] = env_var_name
 
     return env_var_map
+
+
+@pytest.mark.parametrize(
+    "constant_name, override",
+    [
+        ("BEDROCK_IAM_CACHE_MAX_ENTRIES", 4096),
+        ("BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES", 128),
+    ],
+)
+def test_bedrock_iam_cache_bounds_are_env_overridable(constant_name: str, override: int) -> None:
+    try:
+        with mock.patch.dict(os.environ, {constant_name: str(override)}):
+            reloaded = importlib.reload(constants)
+            assert getattr(reloaded, constant_name) == override
+    finally:
+        importlib.reload(constants)
+
+
+@pytest.mark.parametrize(
+    "constant_name, expected_default",
+    [
+        ("BEDROCK_IAM_CACHE_MAX_ENTRIES", 1000),
+        ("BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES", 64),
+    ],
+)
+def test_bedrock_iam_cache_bounds_keep_their_defaults(constant_name: str, expected_default: int) -> None:
+    try:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(constant_name, None)
+            reloaded = importlib.reload(constants)
+            assert getattr(reloaded, constant_name) == expected_default
+    finally:
+        importlib.reload(constants)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `BEDROCK_IAM_CACHE_MAX_ENTRIES` and `BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES` are compile-time literals, so the only way to raise the bound is to patch the installed package
- when a deployment's live credential-key cardinality exceeds 1000, the cache evicts and re-assumes instead of failing loudly, quietly restoring the `sts:AssumeRole` volume the cache was added to remove

How it solves it:

- both constants now read from the environment with `int(os.getenv(...))`, the same pattern the large majority of `constants.py` already uses, keeping 1000 and 64 as defaults

## User Flow

An operator attributing cost per end user passes the attributed identity as `aws_session_name`, which puts one cache entry per identity. Above roughly a thousand identities inside a credential lifetime the cache starts thrashing. They can now set `BEDROCK_IAM_CACHE_MAX_ENTRIES=8000` in the gateway environment and the working set fits again, with no package patching and no restart of anything but the gateway itself

Nothing changes for anyone who does not set the variables

## Relevant issues

Closes #36445

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

I do not have an AWS account with a role I can assume, so I can't show a real proxy round trip through the AssumeRole branch here. What I can show is that the bound is now read from the environment rather than baked in

```bash
$ python -c "from litellm.constants import BEDROCK_IAM_CACHE_MAX_ENTRIES as m, BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES as s; print(m, s)"
1000 64

$ BEDROCK_IAM_CACHE_MAX_ENTRIES=8000 BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES=256 \
    python -c "from litellm.constants import BEDROCK_IAM_CACHE_MAX_ENTRIES as m, BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES as s; print(m, s)"
8000 256
```

`BaseAWSLLM` builds `_shared_iam_cache` with `InMemoryCache(max_size_in_memory=BEDROCK_IAM_CACHE_MAX_ENTRIES)` and sizes its lock stripe array from `BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES` at class definition time, so the override lands on both

## Type

🆕 New Feature

## Caveats (if any)

The values are read at import time, so changing them requires a process restart. That matches every other env-driven constant in the file, and a live-reloadable cache bound would mean rebuilding the process-wide `ClassVar` cache underneath in-flight requests, which is a much bigger change than this issue asks for

Also worth knowing: the cache is a process-wide `ClassVar`, so a gateway running N uvicorn workers holds N independent caches. The variable sets the per-process bound, not an aggregate one

## QA runbook

Start the proxy with `BEDROCK_IAM_CACHE_MAX_ENTRIES` set to something small and distinctive, say 3, then send Bedrock requests with four different `aws_session_name` values and confirm from CloudTrail that the fourth distinct identity evicts the oldest and triggers a fresh `sts:AssumeRole`. Raise the variable above four, restart, repeat, and the extra call should be gone

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
