### PR TITLE
fix(proxy): let uvicorn inherit LITELLM_LOG when it is quieter than INFO

### DIFF
--- a/helm/litellm-helm/values.yaml
+++ b/helm/litellm-helm/values.yaml
@@ -457,6 +457,11 @@ migrationJob:
 #
 # Setting LITELLM_LOG inside `envVars:` below also wins: the template skips
 # this injection entirely when envVars already defines LITELLM_LOG.
+#
+# At WARNING or above, uvicorn inherits this level too, which silences the
+# per-request access log line that liveness and readiness probes would
+# otherwise emit on every poll. At INFO or below uvicorn keeps its own
+# default, so access logs stay on.
 logLevel: INFO
 
 # Additional environment variables to be added to the deployment as a map of key-value pairs

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -5,6 +5,7 @@ import os
 import sys
 from datetime import datetime
 from logging import Formatter
+from types import MappingProxyType
 from typing import Any, Final
 
 import litellm
@@ -511,6 +512,28 @@ def _get_uvicorn_json_log_config():
     }
 
     return log_config
+
+
+_UVICORN_LOG_LEVELS_QUIETER_THAN_INFO: Final = MappingProxyType(
+    {
+        "WARN": "warning",
+        "WARNING": "warning",
+        "ERROR": "error",
+        "FATAL": "critical",
+        "CRITICAL": "critical",
+    }
+)
+
+
+def get_uvicorn_log_level() -> str | None:
+    """Uvicorn's log level to inherit from LITELLM_LOG, or None to leave uvicorn's default alone.
+
+    Only levels quieter than INFO are inherited. uvicorn.access logs one line per request, so at
+    WARNING or above an operator asking for less noise also means the health probe access lines.
+    Levels at or below INFO are not propagated: LITELLM_LOG defaults to DEBUG, and mapping that
+    onto uvicorn would turn on asgi-internals logging nobody asked for.
+    """
+    return _UVICORN_LOG_LEVELS_QUIETER_THAN_INFO.get(log_level.upper())
 
 
 def _turn_on_json():

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -256,7 +256,7 @@ class ProxyInitializationHelpers:
         import uvicorn
 
         import litellm
-        from litellm._logging import _get_uvicorn_json_log_config
+        from litellm._logging import _get_uvicorn_json_log_config, get_uvicorn_log_level
 
         uvicorn_args: Final = {
             "app": "litellm.proxy.proxy_server:app",
@@ -269,6 +269,10 @@ class ProxyInitializationHelpers:
         elif litellm.json_logs:
             # Use JSON log config for uvicorn to ensure all logs (including exceptions) are JSON
             uvicorn_args["log_config"] = _get_uvicorn_json_log_config()
+        else:
+            uvicorn_log_level = get_uvicorn_log_level()
+            if uvicorn_log_level is not None:
+                uvicorn_args["log_level"] = uvicorn_log_level
         if keepalive_timeout is not None:
             uvicorn_args["timeout_keep_alive"] = keepalive_timeout
         if timeout_worker_healthcheck is not None:

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -139,6 +139,44 @@ class TestProxyInitializationHelpers:
             )
             assert args["timeout_worker_healthcheck"] == 15
 
+    @pytest.mark.parametrize(
+        "litellm_log, expected_uvicorn_level",
+        [
+            ("WARNING", "warning"),
+            ("WARN", "warning"),
+            ("warning", "warning"),
+            ("ERROR", "error"),
+            ("CRITICAL", "critical"),
+            ("FATAL", "critical"),
+        ],
+    )
+    def test_uvicorn_log_level_follows_litellm_log_when_quieter_than_info(
+        self, litellm_log, expected_uvicorn_level
+    ):
+        with patch("litellm._logging.log_level", litellm_log):
+            args = ProxyInitializationHelpers._get_default_unvicorn_init_args(
+                "localhost", 8000
+            )
+        assert args["log_level"] == expected_uvicorn_level
+
+    @pytest.mark.parametrize("litellm_log", ["DEBUG", "INFO", "NOTSET", "nonsense"])
+    def test_uvicorn_log_level_is_left_alone_when_litellm_log_is_not_quieter(
+        self, litellm_log
+    ):
+        with patch("litellm._logging.log_level", litellm_log):
+            args = ProxyInitializationHelpers._get_default_unvicorn_init_args(
+                "localhost", 8000
+            )
+        assert "log_level" not in args
+
+    def test_explicit_log_config_wins_over_litellm_log(self):
+        with patch("litellm._logging.log_level", "WARNING"):
+            args = ProxyInitializationHelpers._get_default_unvicorn_init_args(
+                "localhost", 8000, "log_config.json"
+            )
+        assert args["log_config"] == "log_config.json"
+        assert "log_level" not in args
+
     def test_installed_uvicorn_supports_worker_flags(self):
         params = inspect.signature(uvicorn.Config.__init__).parameters
         assert "timeout_worker_healthcheck" in params


### PR DESCRIPTION
## TLDR

Problem this solves:

- setting the helm chart's `logLevel` to `WARN` quiets LiteLLM's own loggers but not uvicorn, whose default config puts `uvicorn.access` at INFO
- liveness and readiness probes keep emitting one access log line per poll, and there is no way to turn them off short of writing a full custom `--log_config` file

How it solves it:

- uvicorn now inherits the level from `LITELLM_LOG`, but only when that level is WARNING or above, so an operator asking for less noise actually gets it
- levels at or below INFO are deliberately not propagated, because `LITELLM_LOG` defaults to DEBUG and mapping that onto uvicorn would switch on asgi-internals logging nobody asked for

## User Flow

An operator running the chart with `logLevel: WARN` gets a proxy whose stdout no longer carries a `GET /health/liveliness HTTP/1.1 200 OK` line every probe interval. Warnings and errors from uvicorn still come through, since only the INFO-and-below access chatter is below the bar

Anyone on the default `logLevel: INFO` sees exactly what they see today. An explicit `--log_config` still wins outright, and so does the JSON log config path when `JSON_LOGS` is on, neither is touched here

## Relevant issues

Closes #36424

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Before, with `LITELLM_LOG=WARNING`, uvicorn is still handed no level and falls back to its own default:

```bash
$ LITELLM_LOG=WARNING python -c "
from litellm.proxy.proxy_cli import ProxyInitializationHelpers as H
print(H._get_default_unvicorn_init_args('localhost', 4000))"
{'app': 'litellm.proxy.proxy_server:app', 'host': 'localhost', 'port': 4000}
```

After:

```bash
$ LITELLM_LOG=WARNING python -c "
from litellm.proxy.proxy_cli import ProxyInitializationHelpers as H
print(H._get_default_unvicorn_init_args('localhost', 4000))"
{'app': 'litellm.proxy.proxy_server:app', 'host': 'localhost', 'port': 4000, 'log_level': 'warning'}

$ LITELLM_LOG=INFO python -c "
from litellm.proxy.proxy_cli import ProxyInitializationHelpers as H
print(H._get_default_unvicorn_init_args('localhost', 4000))"
{'app': 'litellm.proxy.proxy_server:app', 'host': 'localhost', 'port': 4000}
```

`uvicorn.run(log_level="warning")` sets both `uvicorn.error` and `uvicorn.access` to WARNING, which is what drops the probe lines

## Type

🐛 Bug Fix

## Caveats (if any)

`WARN` and `FATAL` are accepted alongside `WARNING` and `CRITICAL`, since `LITELLM_LOG` already accepts both spellings via `getattr(logging, ...)` and uvicorn only understands the long ones. An unrecognized value leaves uvicorn's default in place rather than raising, matching how the rest of the log level handling treats junk input

## QA runbook

Run the proxy with `LITELLM_LOG=WARNING python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml`, then `curl localhost:4000/health/liveliness` a few times and confirm no access lines appear. Restart with `LITELLM_LOG=INFO` and confirm they come back

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
