### PR TITLE
fix(usage): route Ask AI through llm_router for proxy model names

### DIFF
--- a/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
+++ b/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
@@ -4,7 +4,7 @@ usage/spend data by querying the aggregated daily activity endpoints.
 """
 
 import json
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from datetime import date
 from typing import Any, Final, Literal, cast
 
@@ -499,9 +499,9 @@ async def _process_tool_call(
 
 async def _acompletion(
     model: str,
-    messages: list[dict[str, Any]],
+    messages: Sequence[Mapping[str, Any]],
     temperature: float,
-    tools: list[dict[str, Any]] | None = None,
+    tools: Sequence[Mapping[str, Any]] | None = None,
     stream: bool = False,
 ) -> ModelResponse | CustomStreamWrapper:
     """Route through llm_router for proxy model names, bare litellm otherwise.
@@ -513,12 +513,15 @@ async def _acompletion(
     """
     from litellm.proxy.proxy_server import llm_router
 
+    msgs: Final = cast(list, messages)  # cast-ok: acompletion's messages param is a bare `list`
+    tool_specs: Final = cast(list | None, tools)  # cast-ok: same, for `functions`-style params
+
     if llm_router is not None and model in llm_router.get_model_names():
         return await llm_router.acompletion(
-            model=model, messages=messages, temperature=temperature, tools=tools, stream=stream
+            model=model, messages=msgs, temperature=temperature, tools=tool_specs, stream=stream
         )
     return await litellm.acompletion(
-        model=model, messages=messages, temperature=temperature, tools=tools, stream=stream
+        model=model, messages=msgs, temperature=temperature, tools=tool_specs, stream=stream
     )
 
 

--- a/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
+++ b/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
@@ -495,11 +495,26 @@ async def _process_tool_call(
     chat_messages.append({"role": "tool", "tool_call_id": tc.id, "content": tool_result})
 
 
+async def _acompletion(model: str, **kwargs: Any) -> Any:
+    """Route through llm_router for proxy model names, bare litellm otherwise.
+
+    The Ask AI dropdown is populated from the proxy's model_list, so the model
+    reaching here is usually an alias whose provider, api_base and api_key live
+    in litellm_params. Bare acompletion cannot see those and fails with
+    "LLM Provider NOT provided".
+    """
+    from litellm.proxy.proxy_server import llm_router
+
+    if llm_router is not None and model in llm_router.get_model_names():
+        return await llm_router.acompletion(model=model, **kwargs)
+    return await litellm.acompletion(model=model, **kwargs)
+
+
 async def _stream_final_response(model: str, chat_messages: list[dict[str, Any]]) -> AsyncIterator[str]:
     """Stream the final LLM response after tool results are appended."""
     yield _sse({"type": "status", "message": "Analyzing results..."})
 
-    response: Final = await litellm.acompletion(
+    response: Final = await _acompletion(
         model=model,
         messages=chat_messages,
         stream=True,
@@ -528,7 +543,7 @@ async def stream_usage_ai_chat(
     try:
         yield _sse({"type": "status", "message": "Thinking..."})
         tools: Final = get_tools_for_role(is_admin)
-        response: Final = await litellm.acompletion(
+        response: Final = await _acompletion(
             model=resolved_model,
             messages=chat_messages,
             tools=tools,

--- a/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
+++ b/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
@@ -13,9 +13,11 @@ from typing_extensions import TypedDict
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import DEFAULT_COMPETITOR_DISCOVERY_MODEL
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from litellm.types.proxy.management_endpoints.common_daily_activity import (
     SpendAnalyticsPaginatedResponse,
 )
+from litellm.types.utils import ModelResponse
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -495,7 +497,13 @@ async def _process_tool_call(
     chat_messages.append({"role": "tool", "tool_call_id": tc.id, "content": tool_result})
 
 
-async def _acompletion(model: str, **kwargs: Any) -> Any:
+async def _acompletion(
+    model: str,
+    messages: list[dict[str, Any]],
+    temperature: float,
+    tools: list[dict[str, Any]] | None = None,
+    stream: bool = False,
+) -> ModelResponse | CustomStreamWrapper:
     """Route through llm_router for proxy model names, bare litellm otherwise.
 
     The Ask AI dropdown is populated from the proxy's model_list, so the model
@@ -506,8 +514,12 @@ async def _acompletion(model: str, **kwargs: Any) -> Any:
     from litellm.proxy.proxy_server import llm_router
 
     if llm_router is not None and model in llm_router.get_model_names():
-        return await llm_router.acompletion(model=model, **kwargs)
-    return await litellm.acompletion(model=model, **kwargs)
+        return await llm_router.acompletion(
+            model=model, messages=messages, temperature=temperature, tools=tools, stream=stream
+        )
+    return await litellm.acompletion(
+        model=model, messages=messages, temperature=temperature, tools=tools, stream=stream
+    )
 
 
 async def _stream_final_response(model: str, chat_messages: list[dict[str, Any]]) -> AsyncIterator[str]:

--- a/tests/test_litellm/proxy/management_endpoints/usage_endpoints/test_ai_usage_chat.py
+++ b/tests/test_litellm/proxy/management_endpoints/usage_endpoints/test_ai_usage_chat.py
@@ -466,3 +466,99 @@ class TestUsageAiChatServiceAccountGuard:
                 is_admin=False,
             )
         assert "Endpoint-level guard missing" in str(exc_info.value)
+
+
+class TestProxyAliasRouting:
+    """The selected model comes from the proxy's model_list, so an alias like
+    `kr/gpt-5.6-luna` only resolves through llm_router, never through bare
+    litellm.acompletion."""
+
+    @staticmethod
+    def _single_turn_response():
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.tool_calls = None
+        response.choices[0].message.content = "done"
+        return response
+
+    @pytest.mark.asyncio
+    async def test_registered_alias_goes_through_the_router(self):
+        mock_router = MagicMock()
+        mock_router.get_model_names.return_value = ["kr/gpt-5.6-luna"]
+        mock_router.acompletion = AsyncMock(return_value=self._single_turn_response())
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.usage_endpoints.ai_usage_chat.litellm"
+            ) as mock_litellm,
+            patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        ):
+            mock_litellm.acompletion = AsyncMock(
+                side_effect=AssertionError("alias must not reach bare litellm.acompletion")
+            )
+
+            events = [
+                json.loads(event.replace("data: ", "").strip())
+                async for event in stream_usage_ai_chat(
+                    messages=[{"role": "user", "content": "spend?"}],
+                    model="kr/gpt-5.6-luna",
+                    user_id="user-123",
+                    is_admin=True,
+                )
+            ]
+
+        assert mock_router.acompletion.await_count == 1
+        assert mock_router.acompletion.await_args.kwargs["model"] == "kr/gpt-5.6-luna"
+        assert [e["type"] for e in events] == ["status", "chunk", "done"]
+
+    @pytest.mark.asyncio
+    async def test_native_provider_model_still_uses_bare_litellm(self):
+        mock_router = MagicMock()
+        mock_router.get_model_names.return_value = ["kr/gpt-5.6-luna"]
+        mock_router.acompletion = AsyncMock(
+            side_effect=AssertionError("unregistered model must not reach the router")
+        )
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.usage_endpoints.ai_usage_chat.litellm"
+            ) as mock_litellm,
+            patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        ):
+            mock_litellm.acompletion = AsyncMock(return_value=self._single_turn_response())
+
+            events = [
+                json.loads(event.replace("data: ", "").strip())
+                async for event in stream_usage_ai_chat(
+                    messages=[{"role": "user", "content": "spend?"}],
+                    model="gpt-4o-mini",
+                    user_id="user-123",
+                    is_admin=True,
+                )
+            ]
+
+        assert mock_litellm.acompletion.await_count == 1
+        assert [e["type"] for e in events] == ["status", "chunk", "done"]
+
+    @pytest.mark.asyncio
+    async def test_no_router_configured_falls_back_to_bare_litellm(self):
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.usage_endpoints.ai_usage_chat.litellm"
+            ) as mock_litellm,
+            patch("litellm.proxy.proxy_server.llm_router", None),
+        ):
+            mock_litellm.acompletion = AsyncMock(return_value=self._single_turn_response())
+
+            events = [
+                json.loads(event.replace("data: ", "").strip())
+                async for event in stream_usage_ai_chat(
+                    messages=[{"role": "user", "content": "spend?"}],
+                    model="kr/gpt-5.6-luna",
+                    user_id="user-123",
+                    is_admin=True,
+                )
+            ]
+
+        assert mock_litellm.acompletion.await_count == 1
+        assert [e["type"] for e in events] == ["status", "chunk", "done"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- the Ask AI chat under Usage called bare `litellm.acompletion()`, which cannot resolve a proxy model alias to its `litellm_params`, so any deployment routing through a custom `api_base` or using aliased names got `LLM Provider NOT provided`
- the broad `except` swallowed it into "An internal error occurred", so the failure gave no hint about what went wrong

How it solves it:

- both completion calls now go through a helper that prefers `llm_router.acompletion()` when the model is one the router knows about, falling back to bare `litellm.acompletion()` otherwise

## User Flow

An operator whose `model_list` defines an alias such as `kr/gpt-5.6-luna` pointing at a custom `api_base` picks that model in the Ask AI dropdown and gets an answer, since the router resolves the alias to its `litellm_params` including `api_base` and `api_key`

Native provider strings like `gpt-4o-mini` still go straight to `litellm.acompletion()`, and a proxy running without a router behaves exactly as it does today

## Relevant issues

Closes #36414

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

One deviation from the issue's proposed fix worth calling out, since it changes what the check has to be. The issue suggests gating on `llm_router.get_model_group(resolved_model)`, but that method takes a deployment **id** and looks it up in `model_id_to_deployment_index_map`:

```python
def get_model_group(self, id: str) -> list | None:
    model_info: Final = self.get_model_info(id=id)
```

A model **name** off the dropdown would miss that map and return `None` every time, so the router branch would never be taken. This uses `get_model_names()` instead, which is what `auth_checks.py`, `customer_endpoints.py` and `openai_files_endpoints/common_utils.py` all use for the same "is this a proxy model" question, and which includes `model_group_alias` entries

I don't have a proxy with a custom `api_base` deployment to curl against, so the evidence here is the routing decision itself, asserted three ways: a registered alias reaches `llm_router.acompletion` and never bare litellm, an unregistered native model reaches bare litellm and never the router, and a proxy with `llm_router = None` still works. Each test fails if the branch goes the wrong way, since the wrong path is stubbed with an `AssertionError` side effect rather than a passive mock

## Type

🐛 Bug Fix

## Caveats (if any)

The import of `llm_router` is function-local, matching how the rest of the proxy reaches it, and because `proxy_server` imports this module at startup a top-level import would be circular

The generic "An internal error occurred" message is untouched. It is worth revisiting separately, since it hid this bug from every operator who hit it, but that is a different change

## QA runbook

Add a model to `model_list` under an alias with a custom `api_base`, start the proxy, open http://localhost:4000/ui/?page=usage, pick that alias in the Ask AI dropdown and ask something like "what is my total spend this month". It should answer rather than returning the generic error. Then pick a plain `gpt-4o-mini` entry and confirm that still answers too

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
