### PR TITLE
feat(rate-limiting): tag-scoped token/request/dollar/concurrency rate limits

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -117,6 +117,7 @@ _custom_logger_compatible_callbacks_literal = Literal[
     "litellm_agent",
     "dynamic_rate_limiter",
     "dynamic_rate_limiter_v3",
+    "tag_rate_limiter",
     "langsmith",
     "prometheus",
     "otel",

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3914,6 +3914,24 @@ def _init_custom_logger_compatible_class(
                 dynamic_rate_limiter_obj_v3.update_variables(llm_router=llm_router)
             _in_memory_loggers.append(dynamic_rate_limiter_obj_v3)
             return dynamic_rate_limiter_obj_v3  # type: ignore
+        elif logging_integration == "tag_rate_limiter":
+            from litellm.proxy.hooks.tag_rate_limiter import _PROXY_TagRateLimiter
+
+            for callback in _in_memory_loggers:
+                if isinstance(callback, _PROXY_TagRateLimiter):
+                    return callback  # type: ignore
+
+            if internal_usage_cache is None:
+                raise Exception(
+                    "Internal Error: Cache cannot be empty - internal_usage_cache={}".format(internal_usage_cache)
+                )
+
+            tag_rate_limiter_obj = _PROXY_TagRateLimiter(internal_usage_cache=internal_usage_cache)
+
+            if llm_router is not None and isinstance(llm_router, litellm.Router):
+                tag_rate_limiter_obj.update_variables(llm_router=llm_router)
+            _in_memory_loggers.append(tag_rate_limiter_obj)
+            return tag_rate_limiter_obj  # type: ignore
         elif logging_integration == "langtrace":
             if "LANGTRACE_API_KEY" not in os.environ:
                 raise ValueError("LANGTRACE_API_KEY not found in environment variables")
@@ -4336,6 +4354,13 @@ def get_custom_logger_compatible_class(
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, _PROXY_DynamicRateLimitHandlerV3):
+                    return callback  # type: ignore
+
+        elif logging_integration == "tag_rate_limiter":
+            from litellm.proxy.hooks.tag_rate_limiter import _PROXY_TagRateLimiter
+
+            for callback in _in_memory_loggers:
+                if isinstance(callback, _PROXY_TagRateLimiter):
                     return callback  # type: ignore
 
         elif logging_integration == "langtrace":

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -374,49 +374,24 @@ def _inflight_key(
     return f"{{{hash_tag}}}:inflight"
 
 
-# Key under which accumulated-but-not-yet-released concurrency reservation
-# keys are stashed on `Logging.model_call_details` -- the one piece of state
-# litellm itself guarantees persists, mutated in place, across every hop of
-# one logical request (retries and fallbacks alike). litellm's own
-# `has_logged_async_failure` dedup flag lives in the same dict for the same
-# reason: it's the only reliably request-scoped, cross-hop-surviving state
-# available from inside a CustomLogger hook.
-_PENDING_CONCURRENCY_KEYS_ATTR = "_tag_rl_pending_concurrency_keys"
-
-
-def _accumulate_pending_concurrency_keys(request_kwargs: dict, keys: list[str]) -> None:
+def _extract_call_id(kwargs: dict) -> Optional[str]:
     """
-    Called from `async_filter_deployments` right after a hop's concurrency
-    admission succeeds. `async_log_failure_event` fires once per logical
-    request, not once per hop -- litellm dedupes it after the first failed
-    hop (`Logging.has_run_logging`'s `has_logged_async_failure` guard) -- so
-    a later failed hop (a retry, or a further fallback) has no event of its
-    own to release its reservation. Stashing every hop's keys here lets
-    whichever release path fires next (the single `async_log_failure_event`,
-    `async_log_success_event`, or the terminal `async_post_call_failure_hook`)
-    release everything accumulated since the last release, not just the
-    current hop's own.
+    `litellm_call_id` is set once, early, directly on the request's own data
+    dict (`common_request_processing.py`'s `self.data["litellm_call_id"]`),
+    and baked into `Logging.model_call_details` at construction time -- it
+    reaches every one of `async_filter_deployments`'s `request_kwargs`,
+    `async_log_success_event`/`async_log_failure_event`'s `kwargs` (which
+    *is* `model_call_details`), and `async_post_call_failure_hook`'s
+    `request_data`, without exception. Deliberately not `litellm_logging_obj`
+    or its `model_call_details`: `ProxyLogging.post_call_failure_hook` pops
+    `litellm_logging_obj` off `request_data` before dispatching to any
+    callback ("Remove before callbacks iterate -- not serialisable"), so a
+    design keyed on that object is unreachable from
+    `async_post_call_failure_hook` in production, silently never releasing
+    the reservations it exists to clean up.
     """
-    if not keys:
-        return
-    logging_obj = request_kwargs.get("litellm_logging_obj")
-    model_call_details = getattr(logging_obj, "model_call_details", None)
-    if not isinstance(model_call_details, dict):
-        return
-    existing = model_call_details.get(_PENDING_CONCURRENCY_KEYS_ATTR, [])
-    model_call_details[_PENDING_CONCURRENCY_KEYS_ATTR] = [*existing, *keys]
-
-
-def _pop_pending_concurrency_keys(model_call_details: dict) -> list[str]:
-    """
-    `kwargs` in `async_log_success_event`/`async_log_failure_event` IS the
-    `Logging` object's own `model_call_details` (the same dict `Logging`
-    passes to itself), so popping here both reads and clears the state
-    `_accumulate_pending_concurrency_keys` wrote -- clearing matters since a
-    hop after this one (a further fallback) must accumulate into a fresh
-    list, not one still holding an already-released key.
-    """
-    return model_call_details.pop(_PENDING_CONCURRENCY_KEYS_ATTR, [])
+    call_id = kwargs.get("litellm_call_id")
+    return call_id if isinstance(call_id, str) else None
 
 
 class _PROXY_TagRateLimiter(CustomLogger):
@@ -430,6 +405,11 @@ class _PROXY_TagRateLimiter(CustomLogger):
         self._time_provider = time_provider or datetime.now
         self._index = _TagRateLimitIndex(time_provider=self._time_provider)
         self._lock = asyncio.Lock()
+        # Accumulated-but-not-yet-released concurrency reservation keys,
+        # keyed by litellm_call_id -- see _extract_call_id's docstring for
+        # why this in-process registry exists instead of stashing state on
+        # litellm's own Logging object.
+        self._pending_concurrency_keys: dict[str, list[str]] = {}
         self.llm_router: Optional[Router] = None
         redis_cache = self.internal_usage_cache.dual_cache.redis_cache
         self._check_and_incr_script = (
@@ -574,8 +554,8 @@ class _PROXY_TagRateLimiter(CustomLogger):
                 configured_limit, tag_value, _key = atomic_checks[failing_index]
                 self._raise_over_limit(configured_limit, tag_value, model, current=values[0])
 
-            _accumulate_pending_concurrency_keys(
-                request_kwargs,
+            self._accumulate_pending_concurrency_keys(
+                _extract_call_id(request_kwargs),
                 [key for configured_limit, _tag_value, key in atomic_checks if configured_limit.unit == "concurrency"],
             )
 
@@ -653,6 +633,34 @@ class _PROXY_TagRateLimiter(CustomLogger):
             llm_provider="litellm_proxy",
         )
 
+    def _accumulate_pending_concurrency_keys(self, call_id: Optional[str], keys: list[str]) -> None:
+        """
+        Called from `async_filter_deployments` right after a hop's
+        concurrency admission succeeds. `async_log_failure_event` fires once
+        per logical request, not once per hop -- litellm dedupes it after
+        the first failed hop (`Logging.has_run_logging`'s
+        `has_logged_async_failure` guard) -- so a later failed hop (a retry,
+        or a further fallback) has no event of its own to release its
+        reservation. Accumulating every hop's keys here lets whichever
+        release path fires next release everything accumulated since the
+        last release, not just the current hop's own. No `await` between
+        the read and the write below, so this is safe under asyncio's
+        cooperative scheduling without a lock.
+        """
+        if not keys or call_id is None:
+            return
+        existing = self._pending_concurrency_keys.get(call_id, [])
+        self._pending_concurrency_keys[call_id] = [*existing, *keys]
+
+    def _pop_pending_concurrency_keys(self, call_id: Optional[str]) -> list[str]:
+        """Reads and clears the state `_accumulate_pending_concurrency_keys`
+        wrote -- clearing matters since a hop after this one (a further
+        fallback) must accumulate into a fresh list, not one still holding
+        an already-released key."""
+        if call_id is None:
+            return []
+        return self._pending_concurrency_keys.pop(call_id, [])
+
     async def _release_keys(self, keys: list[str]) -> None:
         """
         Release each key by one slot. This does not verify the completing
@@ -685,19 +693,13 @@ class _PROXY_TagRateLimiter(CustomLogger):
         event's per-request dedup can't cover on its own: if hop 1 fails
         (releasing via that event, which clears the accumulated list) and
         every hop after it also fails, those later hops' reservations sit in
-        the list with no event left to release them, since the dedup means
-        `async_log_failure_event` won't fire again for this request. Reads
-        `request_data["litellm_logging_obj"]` directly rather than
-        `request_data` itself, since `request_data` is not the same dict as
-        `Logging.model_call_details`. No double-release risk against
-        `async_log_failure_event`: whichever fires first clears the list, so
-        there's nothing left in it for the other to release.
+        the registry with no event left to release them, since the dedup
+        means `async_log_failure_event` won't fire again for this request.
+        No double-release risk against `async_log_failure_event`: whichever
+        fires first pops the registry entry, so there's nothing left for the
+        other to release.
         """
-        logging_obj = request_data.get("litellm_logging_obj")
-        model_call_details = getattr(logging_obj, "model_call_details", None)
-        if not isinstance(model_call_details, dict):
-            return
-        release_keys = _pop_pending_concurrency_keys(model_call_details)
+        release_keys = self._pop_pending_concurrency_keys(_extract_call_id(request_data))
         if release_keys:
             await self._release_keys(release_keys)
 
@@ -708,17 +710,16 @@ class _PROXY_TagRateLimiter(CustomLogger):
         request, not once per hop -- litellm dedupes it after the first
         failed hop -- so this can't just recompute the current hop's own
         key; it releases everything `async_filter_deployments` has
-        accumulated onto `kwargs` (which IS `Logging.model_call_details`)
-        across every hop so far, covering hops this event's dedup would
-        otherwise skip. Any hop after this one accumulates fresh into the
-        list this clears.
+        accumulated for this `litellm_call_id` across every hop so far,
+        covering hops this event's dedup would otherwise skip. Any hop after
+        this one accumulates fresh into the registry entry this clears.
         """
-        release_keys = _pop_pending_concurrency_keys(kwargs)
+        release_keys = self._pop_pending_concurrency_keys(_extract_call_id(kwargs))
         if release_keys:
             await self._release_keys(release_keys)
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time) -> None:
-        release_keys = _pop_pending_concurrency_keys(kwargs)
+        release_keys = self._pop_pending_concurrency_keys(_extract_call_id(kwargs))
         if release_keys:
             asyncio.create_task(self._release_keys(release_keys))
 

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -55,7 +55,6 @@ _LIMIT_UNITS: tuple[_LimitUnit, ...] = ("tokens", "requests", "dollars", "concur
 # they stay a read-then-account-on-success check with a documented,
 # unavoidable admit-vs-account race.
 _ATOMIC_UNITS: frozenset[_LimitUnit] = frozenset({"requests", "concurrency"})
-_CONCURRENCY_STASH_KEY = "_tag_rate_limit_concurrency_keys"
 
 _UNIT_TO_GROUP_FIELD: dict[_LimitUnit, str] = {
     "tokens": "token_limits",
@@ -369,10 +368,6 @@ class _PROXY_TagRateLimiter(CustomLogger):
             if failing_index is not None:
                 configured_limit, tag_value, _key = atomic_checks[failing_index]
                 self._raise_over_limit(configured_limit, tag_value, model, current=values[0])
-            concurrency_keys = [key for (cfg, _tv, key) in atomic_checks if cfg.unit == "concurrency"]
-            if concurrency_keys:
-                metadata = request_kwargs.setdefault(metadata_variable_name, {})
-                metadata.setdefault(_CONCURRENCY_STASH_KEY, []).extend(concurrency_keys)
 
         return healthy_deployments
 
@@ -442,12 +437,7 @@ class _PROXY_TagRateLimiter(CustomLogger):
             llm_provider="litellm_proxy",
         )
 
-    async def _release_concurrency_keys(self, kwargs: dict) -> None:
-        metadata_variable_name = get_metadata_variable_name_from_kwargs(kwargs)
-        metadata = kwargs.get(metadata_variable_name) or {}
-        keys = metadata.get(_CONCURRENCY_STASH_KEY)
-        if not keys:
-            return
+    async def _release_keys(self, keys: list[str]) -> None:
         for key in keys:
             try:
                 await self.internal_usage_cache.async_increment_cache(
@@ -463,12 +453,42 @@ class _PROXY_TagRateLimiter(CustomLogger):
         user_api_key_dict: UserAPIKeyAuth,
         traceback_str: Optional[str] = None,
     ) -> None:
-        await self._release_concurrency_keys(request_data)
+        """
+        Release any concurrency slot reserved for this hop before the call
+        failed. request_data carries no resolved model_group/deployment_id
+        the way a successful call's standard_logging_object does, so this
+        re-derives identity from request_data["model"] (the hop's own model
+        group -- reliable, since a hop that reserved a slot did so under
+        this exact name) and releases only chain-wide entries; a
+        per-deployment-scoped entry can't be resolved without knowing which
+        deployment was actually dispatched, so it's left to its TTL instead
+        of guessed at.
+        """
+        if self.llm_router is None:
+            return
+        model_group = request_data.get("model")
+        if not model_group:
+            return
+        configured = self._index.get(self.llm_router).get(model_group)
+        if not configured:
+            return
+        metadata_variable_name = get_metadata_variable_name_from_kwargs(request_data)
+        tags = _get_tags_from_request_kwargs(request_data, metadata_variable_name=metadata_variable_name)
+        if not tags:
+            return
+
+        release_keys = [
+            _inflight_key(model_group, configured_limit, tag_value)
+            for configured_limit in configured
+            if configured_limit.unit == "concurrency"
+            and configured_limit.deployment_scope is None
+            and (tag_value := _extract_identity(tags, configured_limit.entry.tag_id)) is not None
+        ]
+        if release_keys:
+            await self._release_keys(release_keys)
         return None
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time) -> None:
-        asyncio.create_task(self._release_concurrency_keys(kwargs))
-
         if self.llm_router is None:
             return
 
@@ -497,14 +517,18 @@ class _PROXY_TagRateLimiter(CustomLogger):
         }
 
         operations: list[RedisPipelineIncrementOperation] = []
+        release_keys: list[str] = []
         for configured_limit in configured:
-            if configured_limit.unit not in increment_by_unit:
-                continue  # "requests" is accounted atomically at admission; "concurrency" is released, not incremented here
             if configured_limit.deployment_scope is not None and deployment_id not in configured_limit.deployment_scope:
                 continue
             tag_value = _extract_identity(tags, configured_limit.entry.tag_id)
             if tag_value is None:
                 continue
+            if configured_limit.unit == "concurrency":
+                release_keys.append(_inflight_key(model_group, configured_limit, tag_value))
+                continue
+            if configured_limit.unit not in increment_by_unit:
+                continue  # "requests" is accounted atomically at admission, not here
             increment_value = increment_by_unit[configured_limit.unit]
             if increment_value == 0:
                 continue
@@ -517,6 +541,9 @@ class _PROXY_TagRateLimiter(CustomLogger):
                     ttl=configured_limit.entry.period_seconds + 3600,
                 )
             )
+
+        if release_keys:
+            asyncio.create_task(self._release_keys(release_keys))
 
         if not operations:
             return

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -14,6 +14,7 @@ limiter every proxy already runs.
 """
 
 import asyncio
+import contextvars
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -338,6 +339,37 @@ _INDEX_TTL_SECONDS = 5.0
 # slowly. period_seconds can still raise the TTL further, never lower it.
 _CONCURRENCY_MIN_SAFETY_TTL_SECONDS = 3600
 
+# Concurrency reservation keys accumulated for the current logical request,
+# not yet released. A `ContextVar` rather than a plain module-level
+# collection or a dict keyed by anything from `kwargs`, because every
+# candidate for "correlate this hop with its logical request" that litellm
+# itself exposes turns out to be either caller-controlled (`litellm_call_id`
+# is `request.headers["x-litellm-call-id"]`, falling back to a fresh uuid
+# only when absent -- two unrelated concurrent requests reusing the same
+# caller-chosen value would merge their reservations under one key) or
+# task-discontinuous (the success path runs `async_log_success_event` from
+# inside a process-global `LoggingWorker` task, never the admission-time
+# task, so `id(asyncio.current_task())` differs even for one hop's own
+# success). `ContextVar` is the one mechanism immune to both problems: its
+# value is pure Python-runtime state, never caller-visible or
+# caller-settable, and litellm's own logging pipeline is already built to
+# propagate it correctly across every task boundary a hop crosses --
+# `asyncio.create_task()` copies the calling context by default (used for
+# `wrapper_async`'s success dispatch in `litellm/utils.py` and for this
+# hook's own rejections propagating through `Router.async_callback_filter_
+# deployments`), and `LoggingWorker.enqueue()` (`litellm/litellm_core_utils/
+# logging_worker.py`) explicitly calls `contextvars.copy_context()` at
+# enqueue time and later runs the queued coroutine via
+# `task["context"].run(asyncio.create_task, ...)`, so a value set during
+# admission is still visible when the eventual release callback executes,
+# however many hops or worker hops later that turns out to be. Each
+# concurrent request gets its own isolated context (forked at whatever
+# `create_task` call started it), so two unrelated requests never share a
+# value regardless of what identifiers they happen to reuse.
+_pending_concurrency_keys: contextvars.ContextVar[tuple[str, ...]] = contextvars.ContextVar(
+    "tag_rate_limiter_pending_concurrency_keys", default=()
+)
+
 
 class _TagRateLimitIndex:
     """Rebuilds the limits index when `llm_router.model_list` changes, or at
@@ -547,6 +579,12 @@ class _PROXY_TagRateLimiter(CustomLogger):
                 configured_limit, tag_value, _key = atomic_checks[failing_index]
                 self._raise_over_limit(configured_limit, tag_value, model, current=values[0])
 
+            concurrency_keys = tuple(
+                key for configured_limit, _tag_value, key in atomic_checks if configured_limit.unit == "concurrency"
+            )
+            if concurrency_keys:
+                _pending_concurrency_keys.set(_pending_concurrency_keys.get() + concurrency_keys)
+
         return healthy_deployments
 
     @staticmethod
@@ -640,97 +678,55 @@ class _PROXY_TagRateLimiter(CustomLogger):
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time) -> None:
         """
-        Release any concurrency slot reserved for this specific hop. This is
-        the only place concurrency gets released on failure -- there is no
-        `async_post_call_failure_hook` override here, deliberately: that hook
-        only fires once, if and when the entire request (every fallback
-        exhausted) ultimately fails, while this fires per hop, on every
-        failure, covering both that terminal case and a hop that fails but
-        gets recovered by a later fallback (which `async_post_call_failure_hook`
-        never sees at all). Implementing both would double-release the same
-        terminal failure's reservation: since the inflight counter is
-        aggregate, not per-request, that would silently free capacity
-        belonging to a different, still-running request sharing the same
-        tag, admitting one more concurrent request than configured rather
-        than merely under-counting.
+        Release every concurrency slot accumulated onto `_pending_concurrency_keys`
+        for the current logical request. Never recomputes a key from
+        `standard_logging_object`: only releases exactly what admission
+        itself accumulated, so a rejection this hook raises for being over
+        its own limit -- which `_atomic_check_and_increment` already
+        refunded synchronously, inside that same call, before ever adding
+        anything here -- naturally has nothing new to release, by
+        construction, rather than needing a special case for it.
+
+        The explicit `ProxyRateLimitError` check below is belt-and-suspenders
+        on top of that: hops of one logical request run strictly
+        sequentially today (a fallback is only ever attempted after the
+        previous hop has fully concluded, including firing its own
+        completion event), so a rejected hop's own `_pending_concurrency_keys`
+        is provably empty by the time this fires. If a future routing
+        strategy ever dispatches hops concurrently instead, that invariant
+        would break silently; this check means a rejection never releases
+        anything even if it does. `ProxyRateLimitError.detail` carries
+        `{"error": "tag_rate_limit_exceeded", ...}`, a string unique to this
+        module, so it's distinguishable from a genuine provider failure.
 
         litellm dedupes this event to fire once per logical request (the
         first failed hop only, via `Logging.has_run_logging`'s
-        `has_logged_async_failure` guard), so a later failed hop (a retry or
-        a further fallback) never gets a release of its own here; that
-        reservation self-heals via its safety TTL instead. An earlier design
-        accumulated every hop's keys in a registry keyed by
-        `litellm_call_id` specifically to close that gap, but
-        `litellm_call_id` is caller-controlled (`request.headers["x-litellm-
-        call-id"]`, falling back to a fresh uuid only when absent) -- two
-        genuinely concurrent, unrelated requests that happen to reuse the
-        same caller-chosen value would merge their reservations into one
-        registry entry, letting one request's completion release the
-        other's still-active slot and bypass the configured concurrency cap.
-        Recomputing the release key independently per hop, with no shared
-        registry at all, closes that vulnerability by construction: nothing
-        here is ever keyed by anything a caller supplies.
-
-        `Router.async_callback_filter_deployments` fires this same event for
-        an exception raised from *inside* `async_filter_deployments` itself
-        (its own except block re-raises after calling
-        `logging_obj.async_failure_handler`), not only for an actual
-        provider-call failure -- including a rejection this hook raises for
-        being over its own limit, before ever reserving anything for this
-        hop. `_atomic_check_and_increment` already refunds any of its own
-        earlier admissions synchronously, inside that same call, whenever it
-        rejects, so there is nothing left for this event to release for that
-        specific rejection; releasing anyway would decrement a live,
-        unrelated reservation actually held by some other in-flight request
-        sharing the same tag, letting a caller free up capacity simply by
-        retrying against an already-full bucket. `ProxyRateLimitError.detail`
-        carries `{"error": "tag_rate_limit_exceeded", ...}`, a string unique
-        to this module (no other rate-limit hook raises it), so this can be
-        distinguished reliably from a genuine provider failure.
+        `has_logged_async_failure` guard). That no longer matters for
+        correctness here: whichever event fires next for this request --
+        this one, `async_log_success_event`, or another failed hop's -- pops
+        and releases whatever has accumulated in `_pending_concurrency_keys`
+        since the last release, covering every hop this event's dedup would
+        otherwise skip. See that variable's module-level docstring for why a
+        `ContextVar` is what makes this safe: it survives every task
+        boundary a hop crosses (litellm's own logging pipeline is built to
+        propagate it), without ever depending on anything a caller supplies.
         """
         if isinstance(kwargs.get("exception"), ProxyRateLimitError):
             detail = kwargs["exception"].detail if isinstance(kwargs["exception"].detail, dict) else {}
             if detail.get("error") == "tag_rate_limit_exceeded":
                 return
 
-        if self.llm_router is None:
-            return
-
-        standard_logging_object: Optional[StandardLoggingPayload] = kwargs.get("standard_logging_object")
-        if standard_logging_object is None:
-            return
-
-        model_group = standard_logging_object.get("model_group")
-        if not model_group:
-            return
-
-        standard_logging_metadata = standard_logging_object.get("metadata") or {}
-        team_id = standard_logging_metadata.get("user_api_key_team_id")
-        key_hash = standard_logging_metadata.get("user_api_key_hash")
-        configured = self._index.get(self.llm_router).resolve(model_group, team_id)
-        if not configured:
-            return
-
-        metadata_variable_name = get_metadata_variable_name_from_kwargs(kwargs)
-        tags = _get_tags_from_request_kwargs(kwargs, metadata_variable_name=metadata_variable_name)
-        if not tags:
-            return
-
-        release_keys = [
-            _inflight_key(
-                model_group,
-                configured_limit,
-                tag_value,
-                key_hash=key_hash if configured_limit.entry.scope_by_key_hash else None,
-            )
-            for configured_limit in configured
-            if configured_limit.unit == "concurrency"
-            and (tag_value := _extract_identity(tags, configured_limit.entry.tag_id)) is not None
-        ]
+        release_keys = _pending_concurrency_keys.get()
         if release_keys:
-            await self._release_keys(release_keys)
+            _pending_concurrency_keys.set(())
+            await self._release_keys(list(release_keys))
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time) -> None:
+        release_keys = _pending_concurrency_keys.get()
+        if release_keys:
+            _pending_concurrency_keys.set(())
+            asyncio.create_task(self._release_keys(list(release_keys)))
+
         if self.llm_router is None:
             return
 
@@ -762,18 +758,13 @@ class _PROXY_TagRateLimiter(CustomLogger):
         }
 
         operations: list[RedisPipelineIncrementOperation] = []
-        release_keys: list[str] = []
         for configured_limit in configured:
+            if configured_limit.unit == "concurrency":
+                continue  # released above, from _pending_concurrency_keys
             if configured_limit.deployment_scope is not None and deployment_id not in configured_limit.deployment_scope:
                 continue
             tag_value = _extract_identity(tags, configured_limit.entry.tag_id)
             if tag_value is None:
-                continue
-            key_hash_for_limit = key_hash if configured_limit.entry.scope_by_key_hash else None
-            if configured_limit.unit == "concurrency":
-                release_keys.append(
-                    _inflight_key(model_group, configured_limit, tag_value, key_hash=key_hash_for_limit)
-                )
                 continue
             if configured_limit.unit not in increment_by_unit:
                 continue  # "requests" is accounted atomically at admission, not here
@@ -781,6 +772,7 @@ class _PROXY_TagRateLimiter(CustomLogger):
             if increment_value == 0:
                 continue
             bucket_id = int(now) // configured_limit.entry.period_seconds
+            key_hash_for_limit = key_hash if configured_limit.entry.scope_by_key_hash else None
             key = _bucket_key(model_group, configured_limit, tag_value, bucket_id, key_hash=key_hash_for_limit)
             operations.append(
                 RedisPipelineIncrementOperation(
@@ -789,9 +781,6 @@ class _PROXY_TagRateLimiter(CustomLogger):
                     ttl=configured_limit.entry.period_seconds + 3600,
                 )
             )
-
-        if release_keys:
-            asyncio.create_task(self._release_keys(release_keys))
 
         if not operations:
             return

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -156,6 +156,17 @@ def _extract_team_id(request_kwargs: dict) -> Optional[str]:
     return team_id if isinstance(team_id, str) else None
 
 
+def _extract_key_hash(request_kwargs: dict) -> Optional[str]:
+    """Same two-channel lookup as `_extract_team_id`, but for the calling
+    virtual key's hash: `LiteLLMProxyRequestSetup` sets `metadata["user_api_key"]`
+    to `user_api_key_dict.api_key`, which despite the plain name is already
+    the hashed token (see `litellm_pre_call_utils.py`)."""
+    metadata = request_kwargs.get("metadata") or {}
+    litellm_metadata = request_kwargs.get("litellm_metadata") or {}
+    key_hash = metadata.get("user_api_key") or litellm_metadata.get("user_api_key")
+    return key_hash if isinstance(key_hash, str) else None
+
+
 def _entries_for_unit(deployment: dict, unit: _LimitUnit) -> list[TagRateLimitEntry]:
     raw_tag_rate_limits = (deployment.get("model_info") or {}).get("tag_rate_limits")
     if not raw_tag_rate_limits:
@@ -192,24 +203,24 @@ def _build_group_limits(deployments: list[dict], unit: _LimitUnit) -> list[_Conf
     creating a bucket that can leak; only chain-wide concurrency entries
     (identical across every deployment in the group) are supported.
     """
-    declaring_ids_by_signature: dict[tuple[str, str, float, int], list[str]] = {}
+    declaring_ids_by_signature: dict[tuple[str, str, float, int, bool], list[str]] = {}
     for deployment in deployments:
         dep_id = _deployment_id(deployment)
         if dep_id is None:
             continue
         for entry in _entries_for_unit(deployment, unit):
-            signature = (entry.tag_id, entry.name, entry.limit, entry.period_seconds)
+            signature = (entry.tag_id, entry.name, entry.limit, entry.period_seconds, entry.scope_by_key_hash)
             declaring_ids_by_signature.setdefault(signature, []).append(dep_id)
 
     distinct_signatures_by_name: dict[tuple[str, str], int] = {}
-    for tag_id, name, _limit, _period in declaring_ids_by_signature:
+    for tag_id, name, _limit, _period, _scope_by_key_hash in declaring_ids_by_signature:
         key = (tag_id, name)
         distinct_signatures_by_name[key] = distinct_signatures_by_name.get(key, 0) + 1
 
     total_deployments = len(deployments)
     configured: list[_ConfiguredLimit] = []
     for signature, declaring_ids in declaring_ids_by_signature.items():
-        tag_id, name, limit, period_seconds = signature
+        tag_id, name, limit, period_seconds, scope_by_key_hash = signature
         is_chain_wide = distinct_signatures_by_name[(tag_id, name)] == 1 and len(declaring_ids) == total_deployments
         if unit == "concurrency" and not is_chain_wide:
             verbose_proxy_logger.warning(
@@ -223,7 +234,13 @@ def _build_group_limits(deployments: list[dict], unit: _LimitUnit) -> list[_Conf
         configured.append(
             _ConfiguredLimit(
                 unit=unit,
-                entry=TagRateLimitEntry(name=name, tag_id=tag_id, limit=limit, period_seconds=period_seconds),
+                entry=TagRateLimitEntry(
+                    name=name,
+                    tag_id=tag_id,
+                    limit=limit,
+                    period_seconds=period_seconds,
+                    scope_by_key_hash=scope_by_key_hash,
+                ),
                 deployment_scope=None if is_chain_wide else tuple(sorted(declaring_ids)),
             )
         )
@@ -329,18 +346,31 @@ def _scope_suffix(deployment_scope: Optional[tuple[str, ...]]) -> str:
     return "chain" if deployment_scope is None else "dep:" + "+".join(deployment_scope)
 
 
-def _bucket_key(model_group: str, configured: _ConfiguredLimit, tag_value: str, bucket_id: int) -> str:
+def _bucket_key(
+    model_group: str,
+    configured: _ConfiguredLimit,
+    tag_value: str,
+    bucket_id: int,
+    key_hash: Optional[str] = None,
+) -> str:
     scope = _scope_suffix(configured.deployment_scope)
-    hash_tag = f"tag_rl:{model_group}:{configured.unit}:{configured.entry.name}:{scope}:{tag_value}"
+    key_suffix = f":key:{key_hash}" if key_hash is not None else ""
+    hash_tag = f"tag_rl:{model_group}:{configured.unit}:{configured.entry.name}:{scope}:{tag_value}{key_suffix}"
     return f"{{{hash_tag}}}:{bucket_id}"
 
 
-def _inflight_key(model_group: str, configured: _ConfiguredLimit, tag_value: str) -> str:
+def _inflight_key(
+    model_group: str,
+    configured: _ConfiguredLimit,
+    tag_value: str,
+    key_hash: Optional[str] = None,
+) -> str:
     """Concurrency counter key: not epoch-bucketed, since "how many are in
     flight right now" has no window to reset on -- it's released explicitly
     on completion, with a TTL fallback only for a leaked (crashed) reservation."""
     scope = _scope_suffix(configured.deployment_scope)
-    hash_tag = f"tag_rl:{model_group}:{configured.unit}:{configured.entry.name}:{scope}:{tag_value}"
+    key_suffix = f":key:{key_hash}" if key_hash is not None else ""
+    hash_tag = f"tag_rl:{model_group}:{configured.unit}:{configured.entry.name}:{scope}:{tag_value}{key_suffix}"
     return f"{{{hash_tag}}}:inflight"
 
 
@@ -517,16 +547,17 @@ class _PROXY_TagRateLimiter(CustomLogger):
             tag_value = _extract_identity(tags, configured_limit.entry.tag_id)
             if tag_value is None:
                 continue
+            key_hash = _extract_key_hash(request_kwargs) if configured_limit.entry.scope_by_key_hash else None
             if configured_limit.unit == "concurrency":
-                key = _inflight_key(model, configured_limit, tag_value)
+                key = _inflight_key(model, configured_limit, tag_value, key_hash=key_hash)
                 atomic_checks.append((configured_limit, tag_value, key))
             elif configured_limit.unit in _ATOMIC_UNITS:
                 bucket_id = int(now) // configured_limit.entry.period_seconds
-                key = _bucket_key(model, configured_limit, tag_value, bucket_id)
+                key = _bucket_key(model, configured_limit, tag_value, bucket_id, key_hash=key_hash)
                 atomic_checks.append((configured_limit, tag_value, key))
             else:
                 bucket_id = int(now) // configured_limit.entry.period_seconds
-                key = _bucket_key(model, configured_limit, tag_value, bucket_id)
+                key = _bucket_key(model, configured_limit, tag_value, bucket_id, key_hash=key_hash)
                 read_only_checks.append((configured_limit, tag_value, key))
 
         current_values = await self._read_only_values(read_only_checks, parent_otel_span)
@@ -704,6 +735,7 @@ class _PROXY_TagRateLimiter(CustomLogger):
 
         standard_logging_metadata = standard_logging_object.get("metadata") or {}
         team_id = standard_logging_metadata.get("user_api_key_team_id")
+        key_hash = standard_logging_metadata.get("user_api_key_hash")
         configured = self._index.get(self.llm_router).resolve(model_group, team_id)
         if not configured:
             return
@@ -735,7 +767,13 @@ class _PROXY_TagRateLimiter(CustomLogger):
             if increment_value == 0:
                 continue
             bucket_id = int(now) // configured_limit.entry.period_seconds
-            key = _bucket_key(model_group, configured_limit, tag_value, bucket_id)
+            key = _bucket_key(
+                model_group,
+                configured_limit,
+                tag_value,
+                bucket_id,
+                key_hash=key_hash if configured_limit.entry.scope_by_key_hash else None,
+            )
             operations.append(
                 RedisPipelineIncrementOperation(
                     key=key,

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -371,6 +371,12 @@ class _PROXY_TagRateLimiter(CustomLogger):
         is enforced here by refunding every earlier admission the moment a
         later key is rejected, not by a single multi-key script call.
 
+        Refunds are best-effort: a refund that fails (e.g. a transient Redis
+        error) is logged and skipped rather than raised, so one bad refund
+        can't stop the rest of the batch from being refunded, and can't turn
+        a clean rejection into an unhandled exception. A skipped refund
+        self-heals via the key's TTL -- see `_ttl_for`.
+
         Returns (failing_index, values). On success, failing_index is None
         and values holds each key's new post-increment value, same order as
         `checks`. On rejection, failing_index is the 0-based index of the
@@ -388,7 +394,10 @@ class _PROXY_TagRateLimiter(CustomLogger):
                 continue
             for refund_index in range(index):
                 refund_key, _limit, refund_increment, _ttl = checks[refund_index]
-                await self._decrement_floor_zero(refund_key, -refund_increment)
+                try:
+                    await self._decrement_floor_zero(refund_key, -refund_increment)
+                except Exception as e:  # noqa: BLE001 - one failed refund must not block refunding the rest
+                    verbose_proxy_logger.warning(f"tag_rate_limiter: failed to refund {refund_key} on rollback: {e}")
             return index, [value]
 
         return None, admitted_values

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -145,6 +145,17 @@ def _deployment_id(deployment: dict) -> Optional[str]:
     return (deployment.get("model_info") or {}).get("id")
 
 
+def _extract_team_id(request_kwargs: dict) -> Optional[str]:
+    """Same two-channel lookup Router itself uses to resolve a caller's own
+    team-scoped deployment (see `Router._common_checks_available_deployment`,
+    which reads `user_api_key_team_id` from `metadata` falling back to
+    `litellm_metadata`)."""
+    metadata = request_kwargs.get("metadata") or {}
+    litellm_metadata = request_kwargs.get("litellm_metadata") or {}
+    team_id = metadata.get("user_api_key_team_id") or litellm_metadata.get("user_api_key_team_id")
+    return team_id if isinstance(team_id, str) else None
+
+
 def _entries_for_unit(deployment: dict, unit: _LimitUnit) -> list[TagRateLimitEntry]:
     raw_tag_rate_limits = (deployment.get("model_info") or {}).get("tag_rate_limits")
     if not raw_tag_rate_limits:
@@ -219,11 +230,34 @@ def _build_group_limits(deployments: list[dict], unit: _LimitUnit) -> list[_Conf
     return configured
 
 
-def _build_limits_index(model_list: list[dict]) -> dict[str, list[_ConfiguredLimit]]:
+@dataclass(frozen=True, slots=True)
+class _LimitsIndex:
     """
-    Keyed by every name a caller could pass as the `model` this hop is for.
-    That's not always `deployment["model_name"]`: a team calling through its
-    own `team_public_model_name` alias reaches `async_filter_deployments`
+    Two lookup tables because a `team_public_model_name` alias is only
+    unique per team, not globally: Router itself lets different teams
+    publish the identical alias string for different deployments, and
+    resolves each caller's own team's deployment by `(team_id, name)`, not
+    by `name` alone (see `Router._update_team_model_index`). Keying alias
+    limits by name alone here would let one team's config silently
+    overwrite another's.
+    """
+
+    by_model_name: dict[str, list[_ConfiguredLimit]]
+    by_team_alias: dict[tuple[str, str], list[_ConfiguredLimit]]
+
+    def resolve(self, model: str, team_id: Optional[str]) -> list[_ConfiguredLimit]:
+        if team_id is not None:
+            scoped = self.by_team_alias.get((team_id, model))
+            if scoped is not None:
+                return scoped
+        return self.by_model_name.get(model, [])
+
+
+def _build_limits_index(model_list: list[dict]) -> _LimitsIndex:
+    """
+    `by_model_name` is keyed by every deployment's own `model_name`.
+    `by_team_alias` additionally covers `team_public_model_name`: a team
+    calling through its own public alias reaches `async_filter_deployments`
     with that alias as `model`, while the deployment dicts in
     `healthy_deployments` still carry their own real `model_name` --
     `Router` never rewrites it for this path (unlike `model_group_alias`,
@@ -231,23 +265,27 @@ def _build_limits_index(model_list: list[dict]) -> dict[str, list[_ConfiguredLim
     Without this, tag limits configured on a team-aliased chain would never
     be looked up at all. Grouping (which deployments share one bucket) is
     still by the deployment's own `model_name`; the alias is only an
-    additional key pointing at that same computed group.
+    additional key pointing at that same computed group, scoped by the
+    `team_id` Router itself requires alongside `team_public_model_name`.
     """
     groups: dict[str, list[dict]] = {}
     for deployment in model_list:
         groups.setdefault(deployment["model_name"], []).append(deployment)
 
-    index: dict[str, list[_ConfiguredLimit]] = {}
+    by_model_name: dict[str, list[_ConfiguredLimit]] = {}
+    by_team_alias: dict[tuple[str, str], list[_ConfiguredLimit]] = {}
     for model_name, deployments in groups.items():
         configured = [limit for unit in _LIMIT_UNITS for limit in _build_group_limits(deployments, unit)]
         if not configured:
             continue
-        index[model_name] = configured
+        by_model_name[model_name] = configured
         for deployment in deployments:
-            team_public_model_name = (deployment.get("model_info") or {}).get("team_public_model_name")
-            if team_public_model_name:
-                index[team_public_model_name] = configured
-    return index
+            model_info = deployment.get("model_info") or {}
+            team_id = model_info.get("team_id")
+            team_public_model_name = model_info.get("team_public_model_name")
+            if team_id and team_public_model_name:
+                by_team_alias[(team_id, team_public_model_name)] = configured
+    return _LimitsIndex(by_model_name=by_model_name, by_team_alias=by_team_alias)
 
 
 # Upper bound on how stale the limits index may be after a length-preserving
@@ -274,9 +312,9 @@ class _TagRateLimitIndex:
         self._time_provider = time_provider
         self._cache_key: Optional[tuple[int, int]] = None
         self._built_at: float = 0.0
-        self._index: dict[str, list[_ConfiguredLimit]] = {}
+        self._index: _LimitsIndex = _LimitsIndex(by_model_name={}, by_team_alias={})
 
-    def get(self, llm_router: Router) -> dict[str, list[_ConfiguredLimit]]:
+    def get(self, llm_router: Router) -> _LimitsIndex:
         model_list = llm_router.model_list or []
         cache_key = (id(llm_router), len(model_list))
         now = self._time_provider().timestamp()
@@ -413,11 +451,11 @@ class _PROXY_TagRateLimiter(CustomLogger):
         if not healthy_deployments or not isinstance(healthy_deployments, list) or self.llm_router is None:
             return healthy_deployments
 
-        configured = self._index.get(self.llm_router).get(model)
+        request_kwargs = request_kwargs or {}
+        configured = self._index.get(self.llm_router).resolve(model, _extract_team_id(request_kwargs))
         if not configured:
             return healthy_deployments
 
-        request_kwargs = request_kwargs or {}
         metadata_variable_name = get_metadata_variable_name_from_kwargs(request_kwargs)
         tags = _get_tags_from_request_kwargs(request_kwargs, metadata_variable_name=metadata_variable_name)
 
@@ -573,7 +611,7 @@ class _PROXY_TagRateLimiter(CustomLogger):
         model_group = request_data.get("model")
         if not model_group:
             return
-        configured = self._index.get(self.llm_router).get(model_group)
+        configured = self._index.get(self.llm_router).resolve(model_group, _extract_team_id(request_data))
         if not configured:
             return
         metadata_variable_name = get_metadata_variable_name_from_kwargs(request_data)
@@ -592,6 +630,52 @@ class _PROXY_TagRateLimiter(CustomLogger):
             await self._release_keys(release_keys)
         return None
 
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time) -> None:
+        """
+        Release any concurrency slot reserved for this specific hop.
+        `async_post_call_failure_hook` only fires once, if and when the
+        entire request (every fallback exhausted) ultimately fails; a hop
+        that fails but gets recovered by a later fallback never reaches it,
+        so without this, that hop's reservation would sit until its safety
+        TTL expires (up to an hour) even though the overall call succeeded.
+        This fires per hop, on every failure, so it covers that case as well
+        as the one `async_post_call_failure_hook` already covers -- the rare
+        overlap where both fire for the same terminal failure is a harmless
+        double release, bounded the same way a lone release already is (see
+        `_release_keys`): floor-at-zero turns it into brief under-counting,
+        never a negative counter.
+        """
+        if self.llm_router is None:
+            return
+
+        standard_logging_object: Optional[StandardLoggingPayload] = kwargs.get("standard_logging_object")
+        if standard_logging_object is None:
+            return
+
+        model_group = standard_logging_object.get("model_group")
+        if not model_group:
+            return
+
+        standard_logging_metadata = standard_logging_object.get("metadata") or {}
+        team_id = standard_logging_metadata.get("user_api_key_team_id")
+        configured = self._index.get(self.llm_router).resolve(model_group, team_id)
+        if not configured:
+            return
+
+        metadata_variable_name = get_metadata_variable_name_from_kwargs(kwargs)
+        tags = _get_tags_from_request_kwargs(kwargs, metadata_variable_name=metadata_variable_name)
+        if not tags:
+            return
+
+        release_keys = [
+            _inflight_key(model_group, configured_limit, tag_value)
+            for configured_limit in configured
+            if configured_limit.unit == "concurrency"
+            and (tag_value := _extract_identity(tags, configured_limit.entry.tag_id)) is not None
+        ]
+        if release_keys:
+            await self._release_keys(release_keys)
+
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time) -> None:
         if self.llm_router is None:
             return
@@ -604,7 +688,9 @@ class _PROXY_TagRateLimiter(CustomLogger):
         if not model_group:
             return
 
-        configured = self._index.get(self.llm_router).get(model_group)
+        standard_logging_metadata = standard_logging_object.get("metadata") or {}
+        team_id = standard_logging_metadata.get("user_api_key_team_id")
+        configured = self._index.get(self.llm_router).resolve(model_group, team_id)
         if not configured:
             return
 

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -27,6 +27,7 @@ from litellm.litellm_core_utils.core_helpers import (
     _get_parent_otel_span_from_kwargs,
     get_metadata_variable_name_from_kwargs,
 )
+from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
 from litellm.proxy.hooks.parallel_request_limiter_v3 import (
     _PROXY_MaxParallelRequestsHandler_v3,
@@ -343,6 +344,51 @@ def _inflight_key(model_group: str, configured: _ConfiguredLimit, tag_value: str
     return f"{{{hash_tag}}}:inflight"
 
 
+# Key under which accumulated-but-not-yet-released concurrency reservation
+# keys are stashed on `Logging.model_call_details` -- the one piece of state
+# litellm itself guarantees persists, mutated in place, across every hop of
+# one logical request (retries and fallbacks alike). litellm's own
+# `has_logged_async_failure` dedup flag lives in the same dict for the same
+# reason: it's the only reliably request-scoped, cross-hop-surviving state
+# available from inside a CustomLogger hook.
+_PENDING_CONCURRENCY_KEYS_ATTR = "_tag_rl_pending_concurrency_keys"
+
+
+def _accumulate_pending_concurrency_keys(request_kwargs: dict, keys: list[str]) -> None:
+    """
+    Called from `async_filter_deployments` right after a hop's concurrency
+    admission succeeds. `async_log_failure_event` fires once per logical
+    request, not once per hop -- litellm dedupes it after the first failed
+    hop (`Logging.has_run_logging`'s `has_logged_async_failure` guard) -- so
+    a later failed hop (a retry, or a further fallback) has no event of its
+    own to release its reservation. Stashing every hop's keys here lets
+    whichever release path fires next (the single `async_log_failure_event`,
+    `async_log_success_event`, or the terminal `async_post_call_failure_hook`)
+    release everything accumulated since the last release, not just the
+    current hop's own.
+    """
+    if not keys:
+        return
+    logging_obj = request_kwargs.get("litellm_logging_obj")
+    model_call_details = getattr(logging_obj, "model_call_details", None)
+    if not isinstance(model_call_details, dict):
+        return
+    existing = model_call_details.get(_PENDING_CONCURRENCY_KEYS_ATTR, [])
+    model_call_details[_PENDING_CONCURRENCY_KEYS_ATTR] = [*existing, *keys]
+
+
+def _pop_pending_concurrency_keys(model_call_details: dict) -> list[str]:
+    """
+    `kwargs` in `async_log_success_event`/`async_log_failure_event` IS the
+    `Logging` object's own `model_call_details` (the same dict `Logging`
+    passes to itself), so popping here both reads and clears the state
+    `_accumulate_pending_concurrency_keys` wrote -- clearing matters since a
+    hop after this one (a further fallback) must accumulate into a fresh
+    list, not one still holding an already-released key.
+    """
+    return model_call_details.pop(_PENDING_CONCURRENCY_KEYS_ATTR, [])
+
+
 class _PROXY_TagRateLimiter(CustomLogger):
     def __init__(
         self,
@@ -497,6 +543,11 @@ class _PROXY_TagRateLimiter(CustomLogger):
                 configured_limit, tag_value, _key = atomic_checks[failing_index]
                 self._raise_over_limit(configured_limit, tag_value, model, current=values[0])
 
+            _accumulate_pending_concurrency_keys(
+                request_kwargs,
+                [key for configured_limit, _tag_value, key in atomic_checks if configured_limit.unit == "concurrency"],
+            )
+
         return healthy_deployments
 
     @staticmethod
@@ -588,54 +639,58 @@ class _PROXY_TagRateLimiter(CustomLogger):
             except Exception as e:  # noqa: BLE001 - releasing a slot must never raise into the caller's request path
                 verbose_proxy_logger.warning("tag_rate_limiter: failed to release concurrency slot %s: %s", key, e)
 
+    async def async_post_call_failure_hook(
+        self,
+        request_data: dict,
+        original_exception: Exception,
+        user_api_key_dict: UserAPIKeyAuth,
+        traceback_str: Optional[str] = None,
+    ) -> None:
+        """
+        Release every concurrency reservation accumulated for this request
+        that `async_log_failure_event` never got to release. This fires once,
+        from the proxy route handler, only when the entire request (every
+        retry and fallback) is ultimately exhausted -- exactly the case that
+        event's per-request dedup can't cover on its own: if hop 1 fails
+        (releasing via that event, which clears the accumulated list) and
+        every hop after it also fails, those later hops' reservations sit in
+        the list with no event left to release them, since the dedup means
+        `async_log_failure_event` won't fire again for this request. Reads
+        `request_data["litellm_logging_obj"]` directly rather than
+        `request_data` itself, since `request_data` is not the same dict as
+        `Logging.model_call_details`. No double-release risk against
+        `async_log_failure_event`: whichever fires first clears the list, so
+        there's nothing left in it for the other to release.
+        """
+        logging_obj = request_data.get("litellm_logging_obj")
+        model_call_details = getattr(logging_obj, "model_call_details", None)
+        if not isinstance(model_call_details, dict):
+            return
+        release_keys = _pop_pending_concurrency_keys(model_call_details)
+        if release_keys:
+            await self._release_keys(release_keys)
+
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time) -> None:
         """
-        Release any concurrency slot reserved for this specific hop. This is
-        the only place concurrency gets released on failure -- there is no
-        `async_post_call_failure_hook` override here, deliberately: that hook
-        only fires once, if and when the entire request (every fallback
-        exhausted) ultimately fails, while this fires per hop, on every
-        failure, covering both that terminal case and a hop that fails but
-        gets recovered by a later fallback (which `async_post_call_failure_hook`
-        never sees at all). Implementing both would double-release the same
-        terminal failure's reservation: since the inflight counter is
-        aggregate, not per-request, that would silently free capacity
-        belonging to a different, still-running request sharing the same
-        tag, admitting one more concurrent request than configured rather
-        than merely under-counting.
+        Release every concurrency reservation accumulated since the last
+        release. `async_log_failure_event` itself fires once per logical
+        request, not once per hop -- litellm dedupes it after the first
+        failed hop -- so this can't just recompute the current hop's own
+        key; it releases everything `async_filter_deployments` has
+        accumulated onto `kwargs` (which IS `Logging.model_call_details`)
+        across every hop so far, covering hops this event's dedup would
+        otherwise skip. Any hop after this one accumulates fresh into the
+        list this clears.
         """
-        if self.llm_router is None:
-            return
-
-        standard_logging_object: Optional[StandardLoggingPayload] = kwargs.get("standard_logging_object")
-        if standard_logging_object is None:
-            return
-
-        model_group = standard_logging_object.get("model_group")
-        if not model_group:
-            return
-
-        standard_logging_metadata = standard_logging_object.get("metadata") or {}
-        team_id = standard_logging_metadata.get("user_api_key_team_id")
-        configured = self._index.get(self.llm_router).resolve(model_group, team_id)
-        if not configured:
-            return
-
-        metadata_variable_name = get_metadata_variable_name_from_kwargs(kwargs)
-        tags = _get_tags_from_request_kwargs(kwargs, metadata_variable_name=metadata_variable_name)
-        if not tags:
-            return
-
-        release_keys = [
-            _inflight_key(model_group, configured_limit, tag_value)
-            for configured_limit in configured
-            if configured_limit.unit == "concurrency"
-            and (tag_value := _extract_identity(tags, configured_limit.entry.tag_id)) is not None
-        ]
+        release_keys = _pop_pending_concurrency_keys(kwargs)
         if release_keys:
             await self._release_keys(release_keys)
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time) -> None:
+        release_keys = _pop_pending_concurrency_keys(kwargs)
+        if release_keys:
+            asyncio.create_task(self._release_keys(release_keys))
+
         if self.llm_router is None:
             return
 
@@ -666,15 +721,13 @@ class _PROXY_TagRateLimiter(CustomLogger):
         }
 
         operations: list[RedisPipelineIncrementOperation] = []
-        release_keys: list[str] = []
         for configured_limit in configured:
+            if configured_limit.unit == "concurrency":
+                continue  # released above, from the accumulated per-request list
             if configured_limit.deployment_scope is not None and deployment_id not in configured_limit.deployment_scope:
                 continue
             tag_value = _extract_identity(tags, configured_limit.entry.tag_id)
             if tag_value is None:
-                continue
-            if configured_limit.unit == "concurrency":
-                release_keys.append(_inflight_key(model_group, configured_limit, tag_value))
                 continue
             if configured_limit.unit not in increment_by_unit:
                 continue  # "requests" is accounted atomically at admission, not here
@@ -690,9 +743,6 @@ class _PROXY_TagRateLimiter(CustomLogger):
                     ttl=configured_limit.entry.period_seconds + 3600,
                 )
             )
-
-        if release_keys:
-            asyncio.create_task(self._release_keys(release_keys))
 
         if not operations:
             return

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -69,42 +69,50 @@ _UNIT_TO_RATE_LIMIT_TYPE: dict[_LimitUnit, RateLimitType] = {
     "concurrency": RateLimitType.CONCURRENT_REQUESTS,
 }
 
-# All-or-nothing atomic check-and-increment across every key in one hop's
-# atomic_checks batch (e.g. a requests-unit entry and a concurrency-unit
-# entry checked together for the same routing attempt). Two-phase, mirroring
-# `CHECK_AND_INCREMENT_BY_N_SCRIPT` in parallel_request_limiter_v3.py: if any
-# key would exceed its limit, NONE are incremented -- a single hop's
-# requests-unit check must never commit while its concurrency-unit check
-# (checked in the same call) rejects the hop, or vice versa. Independent
-# entries in different hops/calls are unaffected: each async_filter_deployments
-# call gets its own script invocation.
+# Single-key atomic check-and-increment. Deliberately one key per script call
+# (never a batch of differently-hash-tagged keys in one call): every tag_rl
+# key carries its own self-contained {..} hash tag so unrelated buckets never
+# forcibly co-locate on the same Redis Cluster shard, which means a single Lua
+# invocation can never span more than one key's slot without risking a
+# cross-slot error. All-or-nothing across a hop's multiple atomic checks
+# (e.g. requests + concurrency checked together) is achieved in Python by
+# calling this once per key and refunding every earlier admission in the same
+# batch if a later one is rejected -- the same refund-on-rollback shape as
+# `atomic_check_and_increment_by_n` in parallel_request_limiter_v3.py, applied
+# per-key instead of per-descriptor since each key already is one hash-tag
+# group by construction.
 TAG_RL_CHECK_AND_INCR_SCRIPT = """
-local n = #KEYS
-for i = 1, n do
-    local key = KEYS[i]
-    local arg_base = (i - 1) * 3
-    local limit = tonumber(ARGV[arg_base + 1])
-    local increment = tonumber(ARGV[arg_base + 2])
-    local current = tonumber(redis.call('GET', key) or 0)
-    if current + increment > limit then
-        return { 0, i, current, limit }
-    end
+local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local increment = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+local current = tonumber(redis.call('GET', key) or 0)
+if current + increment > limit then
+    return { 0, current }
 end
+local new_value = redis.call('INCRBY', key, increment)
+local current_ttl = redis.call('TTL', key)
+if current_ttl == -1 and ttl > 0 then
+    redis.call('EXPIRE', key, ttl)
+end
+return { 1, new_value }
+"""
 
-local results = { 1 }
-for i = 1, n do
-    local key = KEYS[i]
-    local arg_base = (i - 1) * 3
-    local increment = tonumber(ARGV[arg_base + 2])
-    local ttl = tonumber(ARGV[arg_base + 3])
-    local new_value = redis.call('INCRBY', key, increment)
-    local current_ttl = redis.call('TTL', key)
-    if current_ttl == -1 and ttl > 0 then
-        redis.call('EXPIRE', key, ttl)
-    end
-    table.insert(results, new_value)
+# Atomic decrement that never leaves a counter negative. Used both to refund
+# an earlier admission when a later key in the same batch is rejected, and to
+# release a concurrency reservation -- floors at 0 so a decrement that can't
+# be attributed to the exact reservation that caused it (see
+# `_release_keys`'s docstring) degrades to under-counting rather than a
+# negative counter that would admit unlimited requests.
+TAG_RL_DECR_FLOOR_ZERO_SCRIPT = """
+local key = KEYS[1]
+local delta = tonumber(ARGV[1])
+local new_value = redis.call('INCRBY', key, delta)
+if new_value < 0 then
+    redis.call('SET', key, 0)
+    new_value = 0
 end
-return results
+return new_value
 """
 
 
@@ -159,6 +167,19 @@ def _build_group_limits(deployments: list[dict], unit: _LimitUnit) -> list[_Conf
     declared that value -- silently dropping a divergent deployment's config
     (as a naive dedupe-by-name index would) is the exact bug this guards
     against.
+
+    `concurrency` is the one exception: a per-deployment-scoped reservation
+    is never created for it. Admission for a hop reserves every scope whose
+    deployments overlap `healthy_deployments`, but only one deployment ends
+    up actually serving -- releasing the exact reservation(s) that were never
+    used, without a per-request slot identity to track which reservation
+    belongs to which hop, isn't solved correctly by this design (a
+    since-fixed live bug: an admitted-then-failed call's per-deployment
+    reservation was never released; a caller could also strand a sibling
+    deployment's reservation just by never being routed to it). A divergent
+    concurrency signature is dropped with a warning instead of silently
+    creating a bucket that can leak; only chain-wide concurrency entries
+    (identical across every deployment in the group) are supported.
     """
     declaring_ids_by_signature: dict[tuple[str, str, float, int], list[str]] = {}
     for deployment in deployments:
@@ -179,6 +200,15 @@ def _build_group_limits(deployments: list[dict], unit: _LimitUnit) -> list[_Conf
     for signature, declaring_ids in declaring_ids_by_signature.items():
         tag_id, name, limit, period_seconds = signature
         is_chain_wide = distinct_signatures_by_name[(tag_id, name)] == 1 and len(declaring_ids) == total_deployments
+        if unit == "concurrency" and not is_chain_wide:
+            verbose_proxy_logger.warning(
+                "tag_rate_limiter: concurrency_limits entry %r (tag_id=%s) is not declared identically by every "
+                "deployment sharing this model_name; per-deployment-scoped concurrency limits are not supported "
+                "and this entry is being skipped entirely.",
+                name,
+                tag_id,
+            )
+            continue
         configured.append(
             _ConfiguredLimit(
                 unit=unit,
@@ -190,6 +220,19 @@ def _build_group_limits(deployments: list[dict], unit: _LimitUnit) -> list[_Conf
 
 
 def _build_limits_index(model_list: list[dict]) -> dict[str, list[_ConfiguredLimit]]:
+    """
+    Keyed by every name a caller could pass as the `model` this hop is for.
+    That's not always `deployment["model_name"]`: a team calling through its
+    own `team_public_model_name` alias reaches `async_filter_deployments`
+    with that alias as `model`, while the deployment dicts in
+    `healthy_deployments` still carry their own real `model_name` --
+    `Router` never rewrites it for this path (unlike `model_group_alias`,
+    which is resolved to the real model_name before routing even starts).
+    Without this, tag limits configured on a team-aliased chain would never
+    be looked up at all. Grouping (which deployments share one bucket) is
+    still by the deployment's own `model_name`; the alias is only an
+    additional key pointing at that same computed group.
+    """
     groups: dict[str, list[dict]] = {}
     for deployment in model_list:
         groups.setdefault(deployment["model_name"], []).append(deployment)
@@ -197,8 +240,13 @@ def _build_limits_index(model_list: list[dict]) -> dict[str, list[_ConfiguredLim
     index: dict[str, list[_ConfiguredLimit]] = {}
     for model_name, deployments in groups.items():
         configured = [limit for unit in _LIMIT_UNITS for limit in _build_group_limits(deployments, unit)]
-        if configured:
-            index[model_name] = configured
+        if not configured:
+            continue
+        index[model_name] = configured
+        for deployment in deployments:
+            team_public_model_name = (deployment.get("model_info") or {}).get("team_public_model_name")
+            if team_public_model_name:
+                index[team_public_model_name] = configured
     return index
 
 
@@ -208,6 +256,14 @@ def _build_limits_index(model_list: list[dict]) -> dict[str, list[_ConfiguredLim
 # exposes no generic "config changed" version counter to key off instead, so
 # this bounds staleness by simply re-checking periodically.
 _INDEX_TTL_SECONDS = 5.0
+
+# Floor for a concurrency reservation's self-heal TTL, regardless of the
+# configured period_seconds. A reservation that expires while its request is
+# still genuinely in flight silently admits requests past the limit; this
+# generous floor keeps that window far larger than any realistic request
+# duration, at the cost of a leaked (crashed-worker) slot self-healing more
+# slowly. period_seconds can still raise the TTL further, never lower it.
+_CONCURRENCY_MIN_SAFETY_TTL_SECONDS = 3600
 
 
 class _TagRateLimitIndex:
@@ -266,9 +322,41 @@ class _PROXY_TagRateLimiter(CustomLogger):
         self._check_and_incr_script = (
             redis_cache.async_register_script(TAG_RL_CHECK_AND_INCR_SCRIPT) if redis_cache is not None else None
         )
+        self._decr_floor_zero_script = (
+            redis_cache.async_register_script(TAG_RL_DECR_FLOOR_ZERO_SCRIPT) if redis_cache is not None else None
+        )
 
     def update_variables(self, llm_router: Router) -> None:
         self.llm_router = llm_router
+
+    async def _check_and_increment_one(self, key: str, limit: float, increment: float, ttl: int) -> tuple[bool, float]:
+        """Single-key atomic check-and-increment. Always one key per Lua
+        call -- see TAG_RL_CHECK_AND_INCR_SCRIPT's module docstring for why."""
+        if self._check_and_incr_script is not None:
+            raw = await self._check_and_incr_script(keys=[key], args=[limit, increment, ttl])
+            return bool(raw[0]), float(raw[1])
+
+        async with self._lock:
+            current_value = await self.internal_usage_cache.async_get_cache(key=key, litellm_parent_otel_span=None)
+            current = float(current_value) if current_value is not None else 0.0
+            if current + increment > limit:
+                return False, current
+            new_value = current + increment
+            await self.internal_usage_cache.async_set_cache(
+                key=key, value=new_value, ttl=ttl, litellm_parent_otel_span=None
+            )
+            return True, new_value
+
+    async def _decrement_floor_zero(self, key: str, delta: float) -> None:
+        if self._decr_floor_zero_script is not None:
+            await self._decr_floor_zero_script(keys=[key], args=[delta])
+            return
+        async with self._lock:
+            current_value = await self.internal_usage_cache.async_get_cache(key=key, litellm_parent_otel_span=None)
+            current = float(current_value) if current_value is not None else 0.0
+            await self.internal_usage_cache.async_set_cache(
+                key=key, value=max(0.0, current + delta), litellm_parent_otel_span=None
+            )
 
     async def _atomic_check_and_increment(
         self,
@@ -278,7 +366,10 @@ class _PROXY_TagRateLimiter(CustomLogger):
         All-or-nothing across every (key, limit, increment, ttl) in `checks`:
         if any would exceed its limit, none are incremented -- a single hop's
         requests-unit and concurrency-unit checks must commit together or not
-        at all.
+        at all. Each key is checked/incremented in its own single-key Lua
+        call (cluster-safe by construction); all-or-nothing across the batch
+        is enforced here by refunding every earlier admission the moment a
+        later key is rejected, not by a single multi-key script call.
 
         Returns (failing_index, values). On success, failing_index is None
         and values holds each key's new post-increment value, same order as
@@ -288,28 +379,19 @@ class _PROXY_TagRateLimiter(CustomLogger):
         """
         if not checks:
             return None, []
-        if self._check_and_incr_script is not None:
-            keys = [key for key, _limit, _increment, _ttl in checks]
-            args = [value for _key, limit, increment, ttl in checks for value in (limit, increment, ttl)]
-            raw = await self._check_and_incr_script(keys=keys, args=args)
-            if int(raw[0]) == 0:
-                return int(raw[1]) - 1, [float(raw[2])]
-            return None, [float(v) for v in raw[1:]]
 
-        async with self._lock:
-            current_values: list[float] = []
-            for key, limit, increment, _ttl in checks:
-                current_value = await self.internal_usage_cache.async_get_cache(key=key, litellm_parent_otel_span=None)
-                current = float(current_value) if current_value is not None else 0.0
-                if current + increment > limit:
-                    return len(current_values), [current]
-                current_values.append(current)
+        admitted_values: list[float] = []
+        for index, (key, limit, increment, ttl) in enumerate(checks):
+            admitted, value = await self._check_and_increment_one(key, limit, increment, ttl)
+            if admitted:
+                admitted_values.append(value)
+                continue
+            for refund_index in range(index):
+                refund_key, _limit, refund_increment, _ttl = checks[refund_index]
+                await self._decrement_floor_zero(refund_key, -refund_increment)
+            return index, [value]
 
-            for i, (key, _limit, increment, ttl) in enumerate(checks):
-                await self.internal_usage_cache.async_set_cache(
-                    key=key, value=current_values[i] + increment, ttl=ttl, litellm_parent_otel_span=None
-                )
-            return None, [current_values[i] + checks[i][2] for i in range(len(checks))]
+        return None, admitted_values
 
     async def async_filter_deployments(
         self,
@@ -374,7 +456,13 @@ class _PROXY_TagRateLimiter(CustomLogger):
     @staticmethod
     def _ttl_for(configured_limit: _ConfiguredLimit) -> int:
         if configured_limit.unit == "concurrency":
-            return configured_limit.entry.period_seconds
+            # A reservation's TTL must comfortably outlast any real in-flight
+            # request, or a slow request's reservation self-heals (expires)
+            # while it is still genuinely running, silently admitting extra
+            # requests past the configured limit. period_seconds is still
+            # honored if the operator wants an even longer safety margin, but
+            # never shortens the floor below it.
+            return max(configured_limit.entry.period_seconds, _CONCURRENCY_MIN_SAFETY_TTL_SECONDS)
         return configured_limit.entry.period_seconds + 3600
 
     async def _read_only_values(
@@ -438,11 +526,19 @@ class _PROXY_TagRateLimiter(CustomLogger):
         )
 
     async def _release_keys(self, keys: list[str]) -> None:
+        """
+        Release each key by one slot. This does not verify the completing
+        request still owns a live reservation (no per-request slot identity
+        is tracked -- see the concurrency design note above), so a request
+        that outlives the safety TTL and gets its key reused by a fresh
+        reservation could in principle decrement a reservation it never
+        held. Flooring at 0 (TAG_RL_DECR_FLOOR_ZERO_SCRIPT) bounds the
+        damage to under-counting (briefly under-enforcing the limit) rather
+        than a negative counter, which would admit unlimited requests.
+        """
         for key in keys:
             try:
-                await self.internal_usage_cache.async_increment_cache(
-                    key=key, value=-1.0, litellm_parent_otel_span=None
-                )
+                await self._decrement_floor_zero(key, -1.0)
             except Exception as e:  # noqa: BLE001 - releasing a slot must never raise into the caller's request path
                 verbose_proxy_logger.warning("tag_rate_limiter: failed to release concurrency slot %s: %s", key, e)
 
@@ -459,10 +555,9 @@ class _PROXY_TagRateLimiter(CustomLogger):
         the way a successful call's standard_logging_object does, so this
         re-derives identity from request_data["model"] (the hop's own model
         group -- reliable, since a hop that reserved a slot did so under
-        this exact name) and releases only chain-wide entries; a
-        per-deployment-scoped entry can't be resolved without knowing which
-        deployment was actually dispatched, so it's left to its TTL instead
-        of guessed at.
+        this exact name). Concurrency entries are always chain-wide (see
+        `_build_group_limits`'s docstring), so no deployment_id is needed to
+        resolve which bucket to release here.
         """
         if self.llm_router is None:
             return

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -355,7 +355,7 @@ def _bucket_key(
 ) -> str:
     scope = _scope_suffix(configured.deployment_scope)
     key_suffix = f":key:{key_hash}" if key_hash is not None else ""
-    hash_tag = f"tag_rl:{model_group}:{configured.unit}:{configured.entry.name}:{scope}:{tag_value}{key_suffix}"
+    hash_tag = f"tag_rl:{model_group}:{configured.unit}:{configured.entry.name}:{configured.entry.tag_id}:{scope}:{tag_value}{key_suffix}"
     return f"{{{hash_tag}}}:{bucket_id}"
 
 
@@ -370,7 +370,7 @@ def _inflight_key(
     on completion, with a TTL fallback only for a leaked (crashed) reservation."""
     scope = _scope_suffix(configured.deployment_scope)
     key_suffix = f":key:{key_hash}" if key_hash is not None else ""
-    hash_tag = f"tag_rl:{model_group}:{configured.unit}:{configured.entry.name}:{scope}:{tag_value}{key_suffix}"
+    hash_tag = f"tag_rl:{model_group}:{configured.unit}:{configured.entry.name}:{configured.entry.tag_id}:{scope}:{tag_value}{key_suffix}"
     return f"{{{hash_tag}}}:inflight"
 
 

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -27,7 +27,6 @@ from litellm.litellm_core_utils.core_helpers import (
     _get_parent_otel_span_from_kwargs,
     get_metadata_variable_name_from_kwargs,
 )
-from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
 from litellm.proxy.hooks.parallel_request_limiter_v3 import (
     _PROXY_MaxParallelRequestsHandler_v3,
@@ -589,61 +588,21 @@ class _PROXY_TagRateLimiter(CustomLogger):
             except Exception as e:  # noqa: BLE001 - releasing a slot must never raise into the caller's request path
                 verbose_proxy_logger.warning("tag_rate_limiter: failed to release concurrency slot %s: %s", key, e)
 
-    async def async_post_call_failure_hook(
-        self,
-        request_data: dict,
-        original_exception: Exception,
-        user_api_key_dict: UserAPIKeyAuth,
-        traceback_str: Optional[str] = None,
-    ) -> None:
-        """
-        Release any concurrency slot reserved for this hop before the call
-        failed. request_data carries no resolved model_group/deployment_id
-        the way a successful call's standard_logging_object does, so this
-        re-derives identity from request_data["model"] (the hop's own model
-        group -- reliable, since a hop that reserved a slot did so under
-        this exact name). Concurrency entries are always chain-wide (see
-        `_build_group_limits`'s docstring), so no deployment_id is needed to
-        resolve which bucket to release here.
-        """
-        if self.llm_router is None:
-            return
-        model_group = request_data.get("model")
-        if not model_group:
-            return
-        configured = self._index.get(self.llm_router).resolve(model_group, _extract_team_id(request_data))
-        if not configured:
-            return
-        metadata_variable_name = get_metadata_variable_name_from_kwargs(request_data)
-        tags = _get_tags_from_request_kwargs(request_data, metadata_variable_name=metadata_variable_name)
-        if not tags:
-            return
-
-        release_keys = [
-            _inflight_key(model_group, configured_limit, tag_value)
-            for configured_limit in configured
-            if configured_limit.unit == "concurrency"
-            and configured_limit.deployment_scope is None
-            and (tag_value := _extract_identity(tags, configured_limit.entry.tag_id)) is not None
-        ]
-        if release_keys:
-            await self._release_keys(release_keys)
-        return None
-
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time) -> None:
         """
-        Release any concurrency slot reserved for this specific hop.
-        `async_post_call_failure_hook` only fires once, if and when the
-        entire request (every fallback exhausted) ultimately fails; a hop
-        that fails but gets recovered by a later fallback never reaches it,
-        so without this, that hop's reservation would sit until its safety
-        TTL expires (up to an hour) even though the overall call succeeded.
-        This fires per hop, on every failure, so it covers that case as well
-        as the one `async_post_call_failure_hook` already covers -- the rare
-        overlap where both fire for the same terminal failure is a harmless
-        double release, bounded the same way a lone release already is (see
-        `_release_keys`): floor-at-zero turns it into brief under-counting,
-        never a negative counter.
+        Release any concurrency slot reserved for this specific hop. This is
+        the only place concurrency gets released on failure -- there is no
+        `async_post_call_failure_hook` override here, deliberately: that hook
+        only fires once, if and when the entire request (every fallback
+        exhausted) ultimately fails, while this fires per hop, on every
+        failure, covering both that terminal case and a hop that fails but
+        gets recovered by a later fallback (which `async_post_call_failure_hook`
+        never sees at all). Implementing both would double-release the same
+        terminal failure's reservation: since the inflight counter is
+        aggregate, not per-request, that would silently free capacity
+        belonging to a different, still-running request sharing the same
+        tag, admitting one more concurrent request than configured rather
+        than merely under-counting.
         """
         if self.llm_router is None:
             return

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -1,5 +1,5 @@
 """
-Tag-scoped token, request, and dollar rate limits.
+Tag-scoped token, request, dollar, and concurrency rate limits.
 
 Each limit entry is keyed by an arbitrary caller-supplied tag value (not a
 DB-provisioned entity, not composed with the calling API key) and enforced on
@@ -17,7 +17,7 @@ import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.dual_cache import DualCache
@@ -27,6 +27,7 @@ from litellm.litellm_core_utils.core_helpers import (
     _get_parent_otel_span_from_kwargs,
     get_metadata_variable_name_from_kwargs,
 )
+from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
 from litellm.proxy.hooks.parallel_request_limiter_v3 import (
     _PROXY_MaxParallelRequestsHandler_v3,
@@ -39,19 +40,73 @@ from litellm.types.llms.openai import AllMessageValues
 from litellm.types.router import TagRateLimitEntry, TagRateLimits
 from litellm.types.utils import StandardLoggingPayload
 
-_LimitUnit = Literal["tokens", "requests", "dollars"]
-_LIMIT_UNITS: tuple[_LimitUnit, ...] = ("tokens", "requests", "dollars")
+if TYPE_CHECKING:
+    from opentelemetry.trace import Span as _Span
+
+    Span = _Span | Any
+else:
+    Span = Any
+
+_LimitUnit = Literal["tokens", "requests", "dollars", "concurrency"]
+_LIMIT_UNITS: tuple[_LimitUnit, ...] = ("tokens", "requests", "dollars", "concurrency")
+# Units whose admission must be atomic (check-and-increment in one Redis
+# round trip) because the increment amount is known upfront (always 1).
+# tokens/dollars can't be: real usage is only known after the response, so
+# they stay a read-then-account-on-success check with a documented,
+# unavoidable admit-vs-account race.
+_ATOMIC_UNITS: frozenset[_LimitUnit] = frozenset({"requests", "concurrency"})
+_CONCURRENCY_STASH_KEY = "_tag_rate_limit_concurrency_keys"
 
 _UNIT_TO_GROUP_FIELD: dict[_LimitUnit, str] = {
     "tokens": "token_limits",
     "requests": "request_limits",
     "dollars": "dollar_limits",
+    "concurrency": "concurrency_limits",
 }
 _UNIT_TO_RATE_LIMIT_TYPE: dict[_LimitUnit, RateLimitType] = {
     "tokens": RateLimitType.TOKENS,
     "requests": RateLimitType.REQUESTS,
     "dollars": RateLimitType.BUDGET,
+    "concurrency": RateLimitType.CONCURRENT_REQUESTS,
 }
+
+# All-or-nothing atomic check-and-increment across every key in one hop's
+# atomic_checks batch (e.g. a requests-unit entry and a concurrency-unit
+# entry checked together for the same routing attempt). Two-phase, mirroring
+# `CHECK_AND_INCREMENT_BY_N_SCRIPT` in parallel_request_limiter_v3.py: if any
+# key would exceed its limit, NONE are incremented -- a single hop's
+# requests-unit check must never commit while its concurrency-unit check
+# (checked in the same call) rejects the hop, or vice versa. Independent
+# entries in different hops/calls are unaffected: each async_filter_deployments
+# call gets its own script invocation.
+TAG_RL_CHECK_AND_INCR_SCRIPT = """
+local n = #KEYS
+for i = 1, n do
+    local key = KEYS[i]
+    local arg_base = (i - 1) * 3
+    local limit = tonumber(ARGV[arg_base + 1])
+    local increment = tonumber(ARGV[arg_base + 2])
+    local current = tonumber(redis.call('GET', key) or 0)
+    if current + increment > limit then
+        return { 0, i, current, limit }
+    end
+end
+
+local results = { 1 }
+for i = 1, n do
+    local key = KEYS[i]
+    local arg_base = (i - 1) * 3
+    local increment = tonumber(ARGV[arg_base + 2])
+    local ttl = tonumber(ARGV[arg_base + 3])
+    local new_value = redis.call('INCRBY', key, increment)
+    local current_ttl = redis.call('TTL', key)
+    if current_ttl == -1 and ttl > 0 then
+        redis.call('EXPIRE', key, ttl)
+    end
+    table.insert(results, new_value)
+end
+return results
+"""
 
 
 @dataclass(frozen=True)
@@ -148,19 +203,32 @@ def _build_limits_index(model_list: list[dict]) -> dict[str, list[_ConfiguredLim
     return index
 
 
-class _TagRateLimitIndex:
-    """Rebuilds the limits index only when `llm_router.model_list` changes."""
+# Upper bound on how stale the limits index may be after a length-preserving
+# deployment update (e.g. editing an existing deployment's tag_rate_limits
+# in place via the admin API, which never changes len(model_list)). Router
+# exposes no generic "config changed" version counter to key off instead, so
+# this bounds staleness by simply re-checking periodically.
+_INDEX_TTL_SECONDS = 5.0
 
-    def __init__(self) -> None:
+
+class _TagRateLimitIndex:
+    """Rebuilds the limits index when `llm_router.model_list` changes, or at
+    least every `_INDEX_TTL_SECONDS`, whichever comes first."""
+
+    def __init__(self, time_provider: Callable[[], datetime]) -> None:
+        self._time_provider = time_provider
         self._cache_key: Optional[tuple[int, int]] = None
+        self._built_at: float = 0.0
         self._index: dict[str, list[_ConfiguredLimit]] = {}
 
     def get(self, llm_router: Router) -> dict[str, list[_ConfiguredLimit]]:
         model_list = llm_router.model_list or []
         cache_key = (id(llm_router), len(model_list))
-        if cache_key != self._cache_key:
+        now = self._time_provider().timestamp()
+        if cache_key != self._cache_key or (now - self._built_at) >= _INDEX_TTL_SECONDS:
             self._index = _build_limits_index(model_list)
             self._cache_key = cache_key
+            self._built_at = now
         return self._index
 
 
@@ -174,6 +242,15 @@ def _bucket_key(model_group: str, configured: _ConfiguredLimit, tag_value: str, 
     return f"{{{hash_tag}}}:{bucket_id}"
 
 
+def _inflight_key(model_group: str, configured: _ConfiguredLimit, tag_value: str) -> str:
+    """Concurrency counter key: not epoch-bucketed, since "how many are in
+    flight right now" has no window to reset on -- it's released explicitly
+    on completion, with a TTL fallback only for a leaked (crashed) reservation."""
+    scope = _scope_suffix(configured.deployment_scope)
+    hash_tag = f"tag_rl:{model_group}:{configured.unit}:{configured.entry.name}:{scope}:{tag_value}"
+    return f"{{{hash_tag}}}:inflight"
+
+
 class _PROXY_TagRateLimiter(CustomLogger):
     def __init__(
         self,
@@ -183,11 +260,57 @@ class _PROXY_TagRateLimiter(CustomLogger):
         self.internal_usage_cache = InternalUsageCache(dual_cache=internal_usage_cache)
         self._v3 = _PROXY_MaxParallelRequestsHandler_v3(self.internal_usage_cache, time_provider=time_provider)
         self._time_provider = time_provider or datetime.now
-        self._index = _TagRateLimitIndex()
+        self._index = _TagRateLimitIndex(time_provider=self._time_provider)
+        self._lock = asyncio.Lock()
         self.llm_router: Optional[Router] = None
+        redis_cache = self.internal_usage_cache.dual_cache.redis_cache
+        self._check_and_incr_script = (
+            redis_cache.async_register_script(TAG_RL_CHECK_AND_INCR_SCRIPT) if redis_cache is not None else None
+        )
 
     def update_variables(self, llm_router: Router) -> None:
         self.llm_router = llm_router
+
+    async def _atomic_check_and_increment(
+        self,
+        checks: list[tuple[str, float, float, int]],
+    ) -> tuple[Optional[int], list[float]]:
+        """
+        All-or-nothing across every (key, limit, increment, ttl) in `checks`:
+        if any would exceed its limit, none are incremented -- a single hop's
+        requests-unit and concurrency-unit checks must commit together or not
+        at all.
+
+        Returns (failing_index, values). On success, failing_index is None
+        and values holds each key's new post-increment value, same order as
+        `checks`. On rejection, failing_index is the 0-based index of the
+        first key that would have exceeded its limit and values holds that
+        one key's current (unmodified) value.
+        """
+        if not checks:
+            return None, []
+        if self._check_and_incr_script is not None:
+            keys = [key for key, _limit, _increment, _ttl in checks]
+            args = [value for _key, limit, increment, ttl in checks for value in (limit, increment, ttl)]
+            raw = await self._check_and_incr_script(keys=keys, args=args)
+            if int(raw[0]) == 0:
+                return int(raw[1]) - 1, [float(raw[2])]
+            return None, [float(v) for v in raw[1:]]
+
+        async with self._lock:
+            current_values: list[float] = []
+            for key, limit, increment, _ttl in checks:
+                current_value = await self.internal_usage_cache.async_get_cache(key=key, litellm_parent_otel_span=None)
+                current = float(current_value) if current_value is not None else 0.0
+                if current + increment > limit:
+                    return len(current_values), [current]
+                current_values.append(current)
+
+            for i, (key, _limit, increment, ttl) in enumerate(checks):
+                await self.internal_usage_cache.async_set_cache(
+                    key=key, value=current_values[i] + increment, ttl=ttl, litellm_parent_otel_span=None
+                )
+            return None, [current_values[i] + checks[i][2] for i in range(len(checks))]
 
     async def async_filter_deployments(
         self,
@@ -195,7 +318,7 @@ class _PROXY_TagRateLimiter(CustomLogger):
         healthy_deployments: list[dict],
         messages: Optional[list[AllMessageValues]],
         request_kwargs: Optional[dict] = None,
-        parent_otel_span=None,
+        parent_otel_span: Optional[Span] = None,
     ) -> list[dict]:
         if not healthy_deployments or not isinstance(healthy_deployments, list) or self.llm_router is None:
             return healthy_deployments
@@ -211,7 +334,8 @@ class _PROXY_TagRateLimiter(CustomLogger):
         present_deployment_ids = {dep_id for d in healthy_deployments if (dep_id := _deployment_id(d)) is not None}
 
         now = self._time_provider().timestamp()
-        to_check: list[tuple[_ConfiguredLimit, str, str]] = []
+        read_only_checks: list[tuple[_ConfiguredLimit, str, str]] = []
+        atomic_checks: list[tuple[_ConfiguredLimit, str, str]] = []
         for configured_limit in configured:
             if configured_limit.deployment_scope is not None and not (
                 present_deployment_ids & set(configured_limit.deployment_scope)
@@ -220,55 +344,131 @@ class _PROXY_TagRateLimiter(CustomLogger):
             tag_value = _extract_identity(tags, configured_limit.entry.tag_id)
             if tag_value is None:
                 continue
-            bucket_id = int(now) // configured_limit.entry.period_seconds
-            key = _bucket_key(model, configured_limit, tag_value, bucket_id)
-            to_check.append((configured_limit, tag_value, key))
+            if configured_limit.unit == "concurrency":
+                key = _inflight_key(model, configured_limit, tag_value)
+                atomic_checks.append((configured_limit, tag_value, key))
+            elif configured_limit.unit in _ATOMIC_UNITS:
+                bucket_id = int(now) // configured_limit.entry.period_seconds
+                key = _bucket_key(model, configured_limit, tag_value, bucket_id)
+                atomic_checks.append((configured_limit, tag_value, key))
+            else:
+                bucket_id = int(now) // configured_limit.entry.period_seconds
+                key = _bucket_key(model, configured_limit, tag_value, bucket_id)
+                read_only_checks.append((configured_limit, tag_value, key))
 
-        if not to_check:
-            return healthy_deployments
+        current_values = await self._read_only_values(read_only_checks, parent_otel_span)
+        self._raise_if_over_limit(read_only_checks, current_values, model)
 
-        keys = [key for _, _, key in to_check]
+        if atomic_checks:
+            failing_index, values = await self._atomic_check_and_increment(
+                [
+                    (key, configured_limit.entry.limit, 1.0, self._ttl_for(configured_limit))
+                    for configured_limit, _tag_value, key in atomic_checks
+                ]
+            )
+            if failing_index is not None:
+                configured_limit, tag_value, _key = atomic_checks[failing_index]
+                self._raise_over_limit(configured_limit, tag_value, model, current=values[0])
+            concurrency_keys = [key for (cfg, _tv, key) in atomic_checks if cfg.unit == "concurrency"]
+            if concurrency_keys:
+                metadata = request_kwargs.setdefault(metadata_variable_name, {})
+                metadata.setdefault(_CONCURRENCY_STASH_KEY, []).extend(concurrency_keys)
+
+        return healthy_deployments
+
+    @staticmethod
+    def _ttl_for(configured_limit: _ConfiguredLimit) -> int:
+        if configured_limit.unit == "concurrency":
+            return configured_limit.entry.period_seconds
+        return configured_limit.entry.period_seconds + 3600
+
+    async def _read_only_values(
+        self,
+        read_only_checks: list[tuple[_ConfiguredLimit, str, str]],
+        parent_otel_span: Optional[Span],
+    ) -> list[Optional[float]]:
+        if not read_only_checks:
+            return []
+        keys = [key for _cfg, _tag_value, key in read_only_checks]
         current_values = await self.internal_usage_cache.async_batch_get_cache(
             keys=keys,
             parent_otel_span=parent_otel_span,
             local_only=False,
         )
-        if current_values is None:
-            current_values = [None] * len(keys)
+        return current_values if current_values is not None else [None] * len(keys)
 
-        for (configured_limit, tag_value, _key), current_value in zip(to_check, current_values):
+    def _raise_if_over_limit(
+        self,
+        read_only_checks: list[tuple[_ConfiguredLimit, str, str]],
+        current_values: list[Optional[float]],
+        model: str,
+    ) -> None:
+        for (configured_limit, tag_value, _key), current_value in zip(read_only_checks, current_values):
             current = float(current_value) if current_value is not None else 0.0
             if current < configured_limit.entry.limit:
                 continue
-            verbose_proxy_logger.debug(
-                "tag_rate_limiter: OVER_LIMIT model=%s unit=%s name=%s tag_id=%s tag_value=%s current=%s limit=%s",
-                model,
-                configured_limit.unit,
-                configured_limit.entry.name,
-                configured_limit.entry.tag_id,
-                tag_value,
-                current,
-                configured_limit.entry.limit,
-            )
-            raise ProxyRateLimitError(
-                detail={
-                    "error": "tag_rate_limit_exceeded",
-                    "type": configured_limit.unit,
-                    "tag_id": configured_limit.entry.tag_id,
-                    "tag_value": tag_value,
-                    "limit_name": configured_limit.entry.name,
-                    "limit": configured_limit.entry.limit,
-                    "period_seconds": configured_limit.entry.period_seconds,
-                },
-                headers={"retry-after": str(configured_limit.entry.period_seconds)},
-                rate_limit_type=_UNIT_TO_RATE_LIMIT_TYPE[configured_limit.unit],
-                model=model,
-                llm_provider="litellm_proxy",
-            )
+            self._raise_over_limit(configured_limit, tag_value, model, current=current)
 
-        return healthy_deployments
+    def _raise_over_limit(
+        self,
+        configured_limit: _ConfiguredLimit,
+        tag_value: str,
+        model: str,
+        current: float,
+    ) -> None:
+        verbose_proxy_logger.debug(
+            "tag_rate_limiter: OVER_LIMIT model=%s unit=%s name=%s tag_id=%s tag_value=%s current=%s limit=%s",
+            model,
+            configured_limit.unit,
+            configured_limit.entry.name,
+            configured_limit.entry.tag_id,
+            tag_value,
+            current,
+            configured_limit.entry.limit,
+        )
+        raise ProxyRateLimitError(
+            detail={
+                "error": "tag_rate_limit_exceeded",
+                "type": configured_limit.unit,
+                "tag_id": configured_limit.entry.tag_id,
+                "tag_value": tag_value,
+                "limit_name": configured_limit.entry.name,
+                "limit": configured_limit.entry.limit,
+                "period_seconds": configured_limit.entry.period_seconds,
+            },
+            headers={"retry-after": str(configured_limit.entry.period_seconds)},
+            rate_limit_type=_UNIT_TO_RATE_LIMIT_TYPE[configured_limit.unit],
+            model=model,
+            llm_provider="litellm_proxy",
+        )
+
+    async def _release_concurrency_keys(self, kwargs: dict) -> None:
+        metadata_variable_name = get_metadata_variable_name_from_kwargs(kwargs)
+        metadata = kwargs.get(metadata_variable_name) or {}
+        keys = metadata.get(_CONCURRENCY_STASH_KEY)
+        if not keys:
+            return
+        for key in keys:
+            try:
+                await self.internal_usage_cache.async_increment_cache(
+                    key=key, value=-1.0, litellm_parent_otel_span=None
+                )
+            except Exception as e:  # noqa: BLE001 - releasing a slot must never raise into the caller's request path
+                verbose_proxy_logger.warning("tag_rate_limiter: failed to release concurrency slot %s: %s", key, e)
+
+    async def async_post_call_failure_hook(
+        self,
+        request_data: dict,
+        original_exception: Exception,
+        user_api_key_dict: UserAPIKeyAuth,
+        traceback_str: Optional[str] = None,
+    ) -> None:
+        await self._release_concurrency_keys(request_data)
+        return None
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time) -> None:
+        asyncio.create_task(self._release_concurrency_keys(kwargs))
+
         if self.llm_router is None:
             return
 
@@ -293,12 +493,13 @@ class _PROXY_TagRateLimiter(CustomLogger):
         now = self._time_provider().timestamp()
         increment_by_unit: dict[_LimitUnit, float] = {
             "tokens": float(standard_logging_object.get("total_tokens") or 0),
-            "requests": 1.0,
             "dollars": float(standard_logging_object.get("response_cost") or 0),
         }
 
         operations: list[RedisPipelineIncrementOperation] = []
         for configured_limit in configured:
+            if configured_limit.unit not in increment_by_unit:
+                continue  # "requests" is accounted atomically at admission; "concurrency" is released, not incremented here
             if configured_limit.deployment_scope is not None and deployment_id not in configured_limit.deployment_scope:
                 continue
             tag_value = _extract_identity(tags, configured_limit.entry.tag_id)

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -1,0 +1,328 @@
+"""
+Tag-scoped token, request, and dollar rate limits.
+
+Each limit entry is keyed by an arbitrary caller-supplied tag value (not a
+DB-provisioned entity, not composed with the calling API key) and enforced on
+every routing attempt for a chain/model-group -- the primary hop and every
+fallback hop, each checked against its own configuration.
+
+Opt-in via `litellm_settings.callbacks: ["tag_rate_limiter"]` (not part of
+`PROXY_HOOKS`), following the `dynamic_rate_limiter_v3` precedent: this hook
+reuses `_PROXY_MaxParallelRequestsHandler_v3`'s Redis/TTL-preserving increment
+machinery rather than duplicating it, and is never joined onto the default
+limiter every proxy already runs.
+"""
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, Optional
+
+from litellm._logging import verbose_proxy_logger
+from litellm.caching.dual_cache import DualCache
+from litellm.exceptions import RateLimitType
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.core_helpers import (
+    _get_parent_otel_span_from_kwargs,
+    get_metadata_variable_name_from_kwargs,
+)
+from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
+from litellm.proxy.hooks.parallel_request_limiter_v3 import (
+    _PROXY_MaxParallelRequestsHandler_v3,
+)
+from litellm.proxy.utils import InternalUsageCache
+from litellm.router import Router
+from litellm.router_strategy.tag_based_routing import _get_tags_from_request_kwargs
+from litellm.types.caching import RedisPipelineIncrementOperation
+from litellm.types.llms.openai import AllMessageValues
+from litellm.types.router import TagRateLimitEntry, TagRateLimits
+from litellm.types.utils import StandardLoggingPayload
+
+_LimitUnit = Literal["tokens", "requests", "dollars"]
+_LIMIT_UNITS: tuple[_LimitUnit, ...] = ("tokens", "requests", "dollars")
+
+_UNIT_TO_GROUP_FIELD: dict[_LimitUnit, str] = {
+    "tokens": "token_limits",
+    "requests": "request_limits",
+    "dollars": "dollar_limits",
+}
+_UNIT_TO_RATE_LIMIT_TYPE: dict[_LimitUnit, RateLimitType] = {
+    "tokens": RateLimitType.TOKENS,
+    "requests": RateLimitType.REQUESTS,
+    "dollars": RateLimitType.BUDGET,
+}
+
+
+@dataclass(frozen=True)
+class _ConfiguredLimit:
+    unit: _LimitUnit
+    entry: TagRateLimitEntry
+    # None => chain-wide (every deployment in the model_group shares one
+    # bucket). Otherwise the sorted deployment ids that declared this exact
+    # value -- the bucket is shared among only those deployments.
+    deployment_scope: Optional[tuple[str, ...]]
+
+
+def _extract_identity(tags: list[str], tag_id: str) -> Optional[str]:
+    """
+    First tag matching `f"{tag_id}:"`, value after the colon. Tags starting
+    with `!` are tag-routing negation markers, not identity tags, and are
+    skipped so they can never be misread as an identity value.
+    """
+    prefix = f"{tag_id}:"
+    for tag in tags:
+        if tag.startswith("!"):
+            continue
+        if tag.startswith(prefix):
+            return tag[len(prefix) :]
+    return None
+
+
+def _deployment_id(deployment: dict) -> Optional[str]:
+    return (deployment.get("model_info") or {}).get("id")
+
+
+def _entries_for_unit(deployment: dict, unit: _LimitUnit) -> list[TagRateLimitEntry]:
+    raw_tag_rate_limits = (deployment.get("model_info") or {}).get("tag_rate_limits")
+    if not raw_tag_rate_limits:
+        return []
+    tag_rate_limits = TagRateLimits.model_validate(raw_tag_rate_limits)
+    group = getattr(tag_rate_limits, _UNIT_TO_GROUP_FIELD[unit])
+    return group.limits if group is not None else []
+
+
+def _build_group_limits(deployments: list[dict], unit: _LimitUnit) -> list[_ConfiguredLimit]:
+    """
+    One `_ConfiguredLimit` per distinct (tag_id, name, limit, period_seconds)
+    declared for `unit` across `deployments` (all sharing one `model_name`).
+
+    A signature declared identically by every deployment in the group is
+    chain-wide (one shared bucket, regardless of which deployment serves).
+    A signature declared by only some deployments, or where deployments
+    genuinely disagree on the value for the same (tag_id, name), becomes a
+    per-deployment-scoped bucket shared by exactly the deployments that
+    declared that value -- silently dropping a divergent deployment's config
+    (as a naive dedupe-by-name index would) is the exact bug this guards
+    against.
+    """
+    declaring_ids_by_signature: dict[tuple[str, str, float, int], list[str]] = {}
+    for deployment in deployments:
+        dep_id = _deployment_id(deployment)
+        if dep_id is None:
+            continue
+        for entry in _entries_for_unit(deployment, unit):
+            signature = (entry.tag_id, entry.name, entry.limit, entry.period_seconds)
+            declaring_ids_by_signature.setdefault(signature, []).append(dep_id)
+
+    distinct_signatures_by_name: dict[tuple[str, str], int] = {}
+    for tag_id, name, _limit, _period in declaring_ids_by_signature:
+        key = (tag_id, name)
+        distinct_signatures_by_name[key] = distinct_signatures_by_name.get(key, 0) + 1
+
+    total_deployments = len(deployments)
+    configured: list[_ConfiguredLimit] = []
+    for signature, declaring_ids in declaring_ids_by_signature.items():
+        tag_id, name, limit, period_seconds = signature
+        is_chain_wide = distinct_signatures_by_name[(tag_id, name)] == 1 and len(declaring_ids) == total_deployments
+        configured.append(
+            _ConfiguredLimit(
+                unit=unit,
+                entry=TagRateLimitEntry(name=name, tag_id=tag_id, limit=limit, period_seconds=period_seconds),
+                deployment_scope=None if is_chain_wide else tuple(sorted(declaring_ids)),
+            )
+        )
+    return configured
+
+
+def _build_limits_index(model_list: list[dict]) -> dict[str, list[_ConfiguredLimit]]:
+    groups: dict[str, list[dict]] = {}
+    for deployment in model_list:
+        groups.setdefault(deployment["model_name"], []).append(deployment)
+
+    index: dict[str, list[_ConfiguredLimit]] = {}
+    for model_name, deployments in groups.items():
+        configured = [limit for unit in _LIMIT_UNITS for limit in _build_group_limits(deployments, unit)]
+        if configured:
+            index[model_name] = configured
+    return index
+
+
+class _TagRateLimitIndex:
+    """Rebuilds the limits index only when `llm_router.model_list` changes."""
+
+    def __init__(self) -> None:
+        self._cache_key: Optional[tuple[int, int]] = None
+        self._index: dict[str, list[_ConfiguredLimit]] = {}
+
+    def get(self, llm_router: Router) -> dict[str, list[_ConfiguredLimit]]:
+        model_list = llm_router.model_list or []
+        cache_key = (id(llm_router), len(model_list))
+        if cache_key != self._cache_key:
+            self._index = _build_limits_index(model_list)
+            self._cache_key = cache_key
+        return self._index
+
+
+def _scope_suffix(deployment_scope: Optional[tuple[str, ...]]) -> str:
+    return "chain" if deployment_scope is None else "dep:" + "+".join(deployment_scope)
+
+
+def _bucket_key(model_group: str, configured: _ConfiguredLimit, tag_value: str, bucket_id: int) -> str:
+    scope = _scope_suffix(configured.deployment_scope)
+    hash_tag = f"tag_rl:{model_group}:{configured.unit}:{configured.entry.name}:{scope}:{tag_value}"
+    return f"{{{hash_tag}}}:{bucket_id}"
+
+
+class _PROXY_TagRateLimiter(CustomLogger):
+    def __init__(
+        self,
+        internal_usage_cache: DualCache,
+        time_provider: Optional[Callable[[], datetime]] = None,
+    ):
+        self.internal_usage_cache = InternalUsageCache(dual_cache=internal_usage_cache)
+        self._v3 = _PROXY_MaxParallelRequestsHandler_v3(self.internal_usage_cache, time_provider=time_provider)
+        self._time_provider = time_provider or datetime.now
+        self._index = _TagRateLimitIndex()
+        self.llm_router: Optional[Router] = None
+
+    def update_variables(self, llm_router: Router) -> None:
+        self.llm_router = llm_router
+
+    async def async_filter_deployments(
+        self,
+        model: str,
+        healthy_deployments: list[dict],
+        messages: Optional[list[AllMessageValues]],
+        request_kwargs: Optional[dict] = None,
+        parent_otel_span=None,
+    ) -> list[dict]:
+        if not healthy_deployments or not isinstance(healthy_deployments, list) or self.llm_router is None:
+            return healthy_deployments
+
+        configured = self._index.get(self.llm_router).get(model)
+        if not configured:
+            return healthy_deployments
+
+        request_kwargs = request_kwargs or {}
+        metadata_variable_name = get_metadata_variable_name_from_kwargs(request_kwargs)
+        tags = _get_tags_from_request_kwargs(request_kwargs, metadata_variable_name=metadata_variable_name)
+
+        present_deployment_ids = {dep_id for d in healthy_deployments if (dep_id := _deployment_id(d)) is not None}
+
+        now = self._time_provider().timestamp()
+        to_check: list[tuple[_ConfiguredLimit, str, str]] = []
+        for configured_limit in configured:
+            if configured_limit.deployment_scope is not None and not (
+                present_deployment_ids & set(configured_limit.deployment_scope)
+            ):
+                continue
+            tag_value = _extract_identity(tags, configured_limit.entry.tag_id)
+            if tag_value is None:
+                continue
+            bucket_id = int(now) // configured_limit.entry.period_seconds
+            key = _bucket_key(model, configured_limit, tag_value, bucket_id)
+            to_check.append((configured_limit, tag_value, key))
+
+        if not to_check:
+            return healthy_deployments
+
+        keys = [key for _, _, key in to_check]
+        current_values = await self.internal_usage_cache.async_batch_get_cache(
+            keys=keys,
+            parent_otel_span=parent_otel_span,
+            local_only=False,
+        )
+        if current_values is None:
+            current_values = [None] * len(keys)
+
+        for (configured_limit, tag_value, _key), current_value in zip(to_check, current_values):
+            current = float(current_value) if current_value is not None else 0.0
+            if current < configured_limit.entry.limit:
+                continue
+            verbose_proxy_logger.debug(
+                "tag_rate_limiter: OVER_LIMIT model=%s unit=%s name=%s tag_id=%s tag_value=%s current=%s limit=%s",
+                model,
+                configured_limit.unit,
+                configured_limit.entry.name,
+                configured_limit.entry.tag_id,
+                tag_value,
+                current,
+                configured_limit.entry.limit,
+            )
+            raise ProxyRateLimitError(
+                detail={
+                    "error": "tag_rate_limit_exceeded",
+                    "type": configured_limit.unit,
+                    "tag_id": configured_limit.entry.tag_id,
+                    "tag_value": tag_value,
+                    "limit_name": configured_limit.entry.name,
+                    "limit": configured_limit.entry.limit,
+                    "period_seconds": configured_limit.entry.period_seconds,
+                },
+                headers={"retry-after": str(configured_limit.entry.period_seconds)},
+                rate_limit_type=_UNIT_TO_RATE_LIMIT_TYPE[configured_limit.unit],
+                model=model,
+                llm_provider="litellm_proxy",
+            )
+
+        return healthy_deployments
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time) -> None:
+        if self.llm_router is None:
+            return
+
+        standard_logging_object: Optional[StandardLoggingPayload] = kwargs.get("standard_logging_object")
+        if standard_logging_object is None:
+            return
+
+        model_group = standard_logging_object.get("model_group")
+        if not model_group:
+            return
+
+        configured = self._index.get(self.llm_router).get(model_group)
+        if not configured:
+            return
+
+        metadata_variable_name = get_metadata_variable_name_from_kwargs(kwargs)
+        tags = _get_tags_from_request_kwargs(kwargs, metadata_variable_name=metadata_variable_name)
+        if not tags:
+            return
+
+        deployment_id = standard_logging_object.get("model_id")
+        now = self._time_provider().timestamp()
+        increment_by_unit: dict[_LimitUnit, float] = {
+            "tokens": float(standard_logging_object.get("total_tokens") or 0),
+            "requests": 1.0,
+            "dollars": float(standard_logging_object.get("response_cost") or 0),
+        }
+
+        operations: list[RedisPipelineIncrementOperation] = []
+        for configured_limit in configured:
+            if configured_limit.deployment_scope is not None and deployment_id not in configured_limit.deployment_scope:
+                continue
+            tag_value = _extract_identity(tags, configured_limit.entry.tag_id)
+            if tag_value is None:
+                continue
+            increment_value = increment_by_unit[configured_limit.unit]
+            if increment_value == 0:
+                continue
+            bucket_id = int(now) // configured_limit.entry.period_seconds
+            key = _bucket_key(model_group, configured_limit, tag_value, bucket_id)
+            operations.append(
+                RedisPipelineIncrementOperation(
+                    key=key,
+                    increment_value=increment_value,
+                    ttl=configured_limit.entry.period_seconds + 3600,
+                )
+            )
+
+        if not operations:
+            return
+
+        asyncio.create_task(
+            self._v3.async_increment_tokens_with_ttl_preservation(
+                pipeline_operations=operations,
+                parent_otel_span=_get_parent_otel_span_from_kwargs(kwargs),
+            )
+        )

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -670,7 +670,29 @@ class _PROXY_TagRateLimiter(CustomLogger):
         Recomputing the release key independently per hop, with no shared
         registry at all, closes that vulnerability by construction: nothing
         here is ever keyed by anything a caller supplies.
+
+        `Router.async_callback_filter_deployments` fires this same event for
+        an exception raised from *inside* `async_filter_deployments` itself
+        (its own except block re-raises after calling
+        `logging_obj.async_failure_handler`), not only for an actual
+        provider-call failure -- including a rejection this hook raises for
+        being over its own limit, before ever reserving anything for this
+        hop. `_atomic_check_and_increment` already refunds any of its own
+        earlier admissions synchronously, inside that same call, whenever it
+        rejects, so there is nothing left for this event to release for that
+        specific rejection; releasing anyway would decrement a live,
+        unrelated reservation actually held by some other in-flight request
+        sharing the same tag, letting a caller free up capacity simply by
+        retrying against an already-full bucket. `ProxyRateLimitError.detail`
+        carries `{"error": "tag_rate_limit_exceeded", ...}`, a string unique
+        to this module (no other rate-limit hook raises it), so this can be
+        distinguished reliably from a genuine provider failure.
         """
+        if isinstance(kwargs.get("exception"), ProxyRateLimitError):
+            detail = kwargs["exception"].detail if isinstance(kwargs["exception"].detail, dict) else {}
+            if detail.get("error") == "tag_rate_limit_exceeded":
+                return
+
         if self.llm_router is None:
             return
 

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -271,7 +271,9 @@ class _LimitsIndex:
 
 def _build_limits_index(model_list: list[dict]) -> _LimitsIndex:
     """
-    `by_model_name` is keyed by every deployment's own `model_name`.
+    `by_model_name` is keyed by every deployment's own `model_name`, grouping
+    deployments that share one.
+
     `by_team_alias` additionally covers `team_public_model_name`: a team
     calling through its own public alias reaches `async_filter_deployments`
     with that alias as `model`, while the deployment dicts in
@@ -279,28 +281,45 @@ def _build_limits_index(model_list: list[dict]) -> _LimitsIndex:
     `Router` never rewrites it for this path (unlike `model_group_alias`,
     which is resolved to the real model_name before routing even starts).
     Without this, tag limits configured on a team-aliased chain would never
-    be looked up at all. Grouping (which deployments share one bucket) is
-    still by the deployment's own `model_name`; the alias is only an
-    additional key pointing at that same computed group, scoped by the
-    `team_id` Router itself requires alongside `team_public_model_name`.
+    be looked up at all.
+
+    This is a genuinely separate grouping from `by_model_name`, not a lookup
+    into it: litellm auto-generates each team-added deployment's own
+    `model_name` as `model_name_{team_id}_{uuid}` (see
+    `model_listing_utils.py`), so multiple deployments sharing one
+    `team_public_model_name` alias routinely have different, unique
+    `model_name` values -- Router's own `team_model_to_deployment_indices`
+    aggregates them by `(team_id, team_public_model_name)` regardless.
+    Computing alias limits once per `model_name` group and keying the alias
+    to whichever group happened to declare it would drop every other
+    same-alias group's limits whenever more than one model_name shares an
+    alias, since the last one processed would silently overwrite the rest.
+    `_build_group_limits` has no `model_name`-specific logic (it only reads
+    each deployment's own id and its own entries), so it's safe to reuse
+    unchanged for a deployment set spanning multiple `model_name` values.
     """
     groups: dict[str, list[dict]] = {}
+    alias_groups: dict[tuple[str, str], list[dict]] = {}
     for deployment in model_list:
         groups.setdefault(deployment["model_name"], []).append(deployment)
+        model_info = deployment.get("model_info") or {}
+        team_id = model_info.get("team_id")
+        team_public_model_name = model_info.get("team_public_model_name")
+        if team_id and team_public_model_name:
+            alias_groups.setdefault((team_id, team_public_model_name), []).append(deployment)
 
     by_model_name: dict[str, list[_ConfiguredLimit]] = {}
-    by_team_alias: dict[tuple[str, str], list[_ConfiguredLimit]] = {}
     for model_name, deployments in groups.items():
         configured = [limit for unit in _LIMIT_UNITS for limit in _build_group_limits(deployments, unit)]
-        if not configured:
-            continue
-        by_model_name[model_name] = configured
-        for deployment in deployments:
-            model_info = deployment.get("model_info") or {}
-            team_id = model_info.get("team_id")
-            team_public_model_name = model_info.get("team_public_model_name")
-            if team_id and team_public_model_name:
-                by_team_alias[(team_id, team_public_model_name)] = configured
+        if configured:
+            by_model_name[model_name] = configured
+
+    by_team_alias: dict[tuple[str, str], list[_ConfiguredLimit]] = {}
+    for alias_key, deployments in alias_groups.items():
+        configured = [limit for unit in _LIMIT_UNITS for limit in _build_group_limits(deployments, unit)]
+        if configured:
+            by_team_alias[alias_key] = configured
+
     return _LimitsIndex(by_model_name=by_model_name, by_team_alias=by_team_alias)
 
 

--- a/litellm/proxy/hooks/tag_rate_limiter.py
+++ b/litellm/proxy/hooks/tag_rate_limiter.py
@@ -27,7 +27,6 @@ from litellm.litellm_core_utils.core_helpers import (
     _get_parent_otel_span_from_kwargs,
     get_metadata_variable_name_from_kwargs,
 )
-from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
 from litellm.proxy.hooks.parallel_request_limiter_v3 import (
     _PROXY_MaxParallelRequestsHandler_v3,
@@ -374,26 +373,6 @@ def _inflight_key(
     return f"{{{hash_tag}}}:inflight"
 
 
-def _extract_call_id(kwargs: dict) -> Optional[str]:
-    """
-    `litellm_call_id` is set once, early, directly on the request's own data
-    dict (`common_request_processing.py`'s `self.data["litellm_call_id"]`),
-    and baked into `Logging.model_call_details` at construction time -- it
-    reaches every one of `async_filter_deployments`'s `request_kwargs`,
-    `async_log_success_event`/`async_log_failure_event`'s `kwargs` (which
-    *is* `model_call_details`), and `async_post_call_failure_hook`'s
-    `request_data`, without exception. Deliberately not `litellm_logging_obj`
-    or its `model_call_details`: `ProxyLogging.post_call_failure_hook` pops
-    `litellm_logging_obj` off `request_data` before dispatching to any
-    callback ("Remove before callbacks iterate -- not serialisable"), so a
-    design keyed on that object is unreachable from
-    `async_post_call_failure_hook` in production, silently never releasing
-    the reservations it exists to clean up.
-    """
-    call_id = kwargs.get("litellm_call_id")
-    return call_id if isinstance(call_id, str) else None
-
-
 class _PROXY_TagRateLimiter(CustomLogger):
     def __init__(
         self,
@@ -405,11 +384,6 @@ class _PROXY_TagRateLimiter(CustomLogger):
         self._time_provider = time_provider or datetime.now
         self._index = _TagRateLimitIndex(time_provider=self._time_provider)
         self._lock = asyncio.Lock()
-        # Accumulated-but-not-yet-released concurrency reservation keys,
-        # keyed by litellm_call_id -- see _extract_call_id's docstring for
-        # why this in-process registry exists instead of stashing state on
-        # litellm's own Logging object.
-        self._pending_concurrency_keys: dict[str, list[str]] = {}
         self.llm_router: Optional[Router] = None
         redis_cache = self.internal_usage_cache.dual_cache.redis_cache
         self._check_and_incr_script = (
@@ -554,11 +528,6 @@ class _PROXY_TagRateLimiter(CustomLogger):
                 configured_limit, tag_value, _key = atomic_checks[failing_index]
                 self._raise_over_limit(configured_limit, tag_value, model, current=values[0])
 
-            self._accumulate_pending_concurrency_keys(
-                _extract_call_id(request_kwargs),
-                [key for configured_limit, _tag_value, key in atomic_checks if configured_limit.unit == "concurrency"],
-            )
-
         return healthy_deployments
 
     @staticmethod
@@ -633,34 +602,6 @@ class _PROXY_TagRateLimiter(CustomLogger):
             llm_provider="litellm_proxy",
         )
 
-    def _accumulate_pending_concurrency_keys(self, call_id: Optional[str], keys: list[str]) -> None:
-        """
-        Called from `async_filter_deployments` right after a hop's
-        concurrency admission succeeds. `async_log_failure_event` fires once
-        per logical request, not once per hop -- litellm dedupes it after
-        the first failed hop (`Logging.has_run_logging`'s
-        `has_logged_async_failure` guard) -- so a later failed hop (a retry,
-        or a further fallback) has no event of its own to release its
-        reservation. Accumulating every hop's keys here lets whichever
-        release path fires next release everything accumulated since the
-        last release, not just the current hop's own. No `await` between
-        the read and the write below, so this is safe under asyncio's
-        cooperative scheduling without a lock.
-        """
-        if not keys or call_id is None:
-            return
-        existing = self._pending_concurrency_keys.get(call_id, [])
-        self._pending_concurrency_keys[call_id] = [*existing, *keys]
-
-    def _pop_pending_concurrency_keys(self, call_id: Optional[str]) -> list[str]:
-        """Reads and clears the state `_accumulate_pending_concurrency_keys`
-        wrote -- clearing matters since a hop after this one (a further
-        fallback) must accumulate into a fresh list, not one still holding
-        an already-released key."""
-        if call_id is None:
-            return []
-        return self._pending_concurrency_keys.pop(call_id, [])
-
     async def _release_keys(self, keys: list[str]) -> None:
         """
         Release each key by one slot. This does not verify the completing
@@ -678,51 +619,77 @@ class _PROXY_TagRateLimiter(CustomLogger):
             except Exception as e:  # noqa: BLE001 - releasing a slot must never raise into the caller's request path
                 verbose_proxy_logger.warning("tag_rate_limiter: failed to release concurrency slot %s: %s", key, e)
 
-    async def async_post_call_failure_hook(
-        self,
-        request_data: dict,
-        original_exception: Exception,
-        user_api_key_dict: UserAPIKeyAuth,
-        traceback_str: Optional[str] = None,
-    ) -> None:
-        """
-        Release every concurrency reservation accumulated for this request
-        that `async_log_failure_event` never got to release. This fires once,
-        from the proxy route handler, only when the entire request (every
-        retry and fallback) is ultimately exhausted -- exactly the case that
-        event's per-request dedup can't cover on its own: if hop 1 fails
-        (releasing via that event, which clears the accumulated list) and
-        every hop after it also fails, those later hops' reservations sit in
-        the registry with no event left to release them, since the dedup
-        means `async_log_failure_event` won't fire again for this request.
-        No double-release risk against `async_log_failure_event`: whichever
-        fires first pops the registry entry, so there's nothing left for the
-        other to release.
-        """
-        release_keys = self._pop_pending_concurrency_keys(_extract_call_id(request_data))
-        if release_keys:
-            await self._release_keys(release_keys)
-
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time) -> None:
         """
-        Release every concurrency reservation accumulated since the last
-        release. `async_log_failure_event` itself fires once per logical
-        request, not once per hop -- litellm dedupes it after the first
-        failed hop -- so this can't just recompute the current hop's own
-        key; it releases everything `async_filter_deployments` has
-        accumulated for this `litellm_call_id` across every hop so far,
-        covering hops this event's dedup would otherwise skip. Any hop after
-        this one accumulates fresh into the registry entry this clears.
+        Release any concurrency slot reserved for this specific hop. This is
+        the only place concurrency gets released on failure -- there is no
+        `async_post_call_failure_hook` override here, deliberately: that hook
+        only fires once, if and when the entire request (every fallback
+        exhausted) ultimately fails, while this fires per hop, on every
+        failure, covering both that terminal case and a hop that fails but
+        gets recovered by a later fallback (which `async_post_call_failure_hook`
+        never sees at all). Implementing both would double-release the same
+        terminal failure's reservation: since the inflight counter is
+        aggregate, not per-request, that would silently free capacity
+        belonging to a different, still-running request sharing the same
+        tag, admitting one more concurrent request than configured rather
+        than merely under-counting.
+
+        litellm dedupes this event to fire once per logical request (the
+        first failed hop only, via `Logging.has_run_logging`'s
+        `has_logged_async_failure` guard), so a later failed hop (a retry or
+        a further fallback) never gets a release of its own here; that
+        reservation self-heals via its safety TTL instead. An earlier design
+        accumulated every hop's keys in a registry keyed by
+        `litellm_call_id` specifically to close that gap, but
+        `litellm_call_id` is caller-controlled (`request.headers["x-litellm-
+        call-id"]`, falling back to a fresh uuid only when absent) -- two
+        genuinely concurrent, unrelated requests that happen to reuse the
+        same caller-chosen value would merge their reservations into one
+        registry entry, letting one request's completion release the
+        other's still-active slot and bypass the configured concurrency cap.
+        Recomputing the release key independently per hop, with no shared
+        registry at all, closes that vulnerability by construction: nothing
+        here is ever keyed by anything a caller supplies.
         """
-        release_keys = self._pop_pending_concurrency_keys(_extract_call_id(kwargs))
+        if self.llm_router is None:
+            return
+
+        standard_logging_object: Optional[StandardLoggingPayload] = kwargs.get("standard_logging_object")
+        if standard_logging_object is None:
+            return
+
+        model_group = standard_logging_object.get("model_group")
+        if not model_group:
+            return
+
+        standard_logging_metadata = standard_logging_object.get("metadata") or {}
+        team_id = standard_logging_metadata.get("user_api_key_team_id")
+        key_hash = standard_logging_metadata.get("user_api_key_hash")
+        configured = self._index.get(self.llm_router).resolve(model_group, team_id)
+        if not configured:
+            return
+
+        metadata_variable_name = get_metadata_variable_name_from_kwargs(kwargs)
+        tags = _get_tags_from_request_kwargs(kwargs, metadata_variable_name=metadata_variable_name)
+        if not tags:
+            return
+
+        release_keys = [
+            _inflight_key(
+                model_group,
+                configured_limit,
+                tag_value,
+                key_hash=key_hash if configured_limit.entry.scope_by_key_hash else None,
+            )
+            for configured_limit in configured
+            if configured_limit.unit == "concurrency"
+            and (tag_value := _extract_identity(tags, configured_limit.entry.tag_id)) is not None
+        ]
         if release_keys:
             await self._release_keys(release_keys)
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time) -> None:
-        release_keys = self._pop_pending_concurrency_keys(_extract_call_id(kwargs))
-        if release_keys:
-            asyncio.create_task(self._release_keys(release_keys))
-
         if self.llm_router is None:
             return
 
@@ -754,13 +721,18 @@ class _PROXY_TagRateLimiter(CustomLogger):
         }
 
         operations: list[RedisPipelineIncrementOperation] = []
+        release_keys: list[str] = []
         for configured_limit in configured:
-            if configured_limit.unit == "concurrency":
-                continue  # released above, from the accumulated per-request list
             if configured_limit.deployment_scope is not None and deployment_id not in configured_limit.deployment_scope:
                 continue
             tag_value = _extract_identity(tags, configured_limit.entry.tag_id)
             if tag_value is None:
+                continue
+            key_hash_for_limit = key_hash if configured_limit.entry.scope_by_key_hash else None
+            if configured_limit.unit == "concurrency":
+                release_keys.append(
+                    _inflight_key(model_group, configured_limit, tag_value, key_hash=key_hash_for_limit)
+                )
                 continue
             if configured_limit.unit not in increment_by_unit:
                 continue  # "requests" is accounted atomically at admission, not here
@@ -768,13 +740,7 @@ class _PROXY_TagRateLimiter(CustomLogger):
             if increment_value == 0:
                 continue
             bucket_id = int(now) // configured_limit.entry.period_seconds
-            key = _bucket_key(
-                model_group,
-                configured_limit,
-                tag_value,
-                bucket_id,
-                key_hash=key_hash if configured_limit.entry.scope_by_key_hash else None,
-            )
+            key = _bucket_key(model_group, configured_limit, tag_value, bucket_id, key_hash=key_hash_for_limit)
             operations.append(
                 RedisPipelineIncrementOperation(
                     key=key,
@@ -782,6 +748,9 @@ class _PROXY_TagRateLimiter(CustomLogger):
                     ttl=configured_limit.entry.period_seconds + 3600,
                 )
             )
+
+        if release_keys:
+            asyncio.create_task(self._release_keys(release_keys))
 
         if not operations:
             return

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -121,6 +121,39 @@ class UpdateRouterConfig(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
 
+class TagRateLimitEntry(BaseModel):
+    """
+    One tag-scoped limit: a caller-supplied tag value (identified by `tag_id`,
+    e.g. `end_user_id` in a request tag like `end_user_id:user-123`) is capped
+    at `limit` units per rolling `period_seconds`-second window. Bucketing is
+    `epoch_second // period_seconds`, so `period_seconds=86400` resets at UTC
+    midnight and `period_seconds=60` resets on real clock-minute boundaries.
+    """
+
+    name: str
+    tag_id: str = "end_user_id"
+    limit: float
+    period_seconds: int
+
+    model_config = ConfigDict(protected_namespaces=())
+
+
+class TagRateLimitGroup(BaseModel):
+    limits: list[TagRateLimitEntry] = Field(default_factory=list)
+
+
+class TagRateLimits(BaseModel):
+    """
+    Per-chain/model-group tag rate limits, set under a deployment's
+    `model_info.tag_rate_limits`. Each entry carries its own `tag_id`, so two
+    entries of the same unit on the same chain can key by different tags.
+    """
+
+    token_limits: TagRateLimitGroup | None = None
+    request_limits: TagRateLimitGroup | None = None
+    dollar_limits: TagRateLimitGroup | None = None
+
+
 class ModelInfo(BaseModel):
     id: Optional[str]  # Allow id to be optional on input, but it will always be present as a str in the model instance
     db_model: bool = False  # used for proxy - to separate models which are stored in the db vs. config.
@@ -144,6 +177,9 @@ class ModelInfo(BaseModel):
 
     # admin-toggled pause flag; mirrors LiteLLM_ProxyModelTable.blocked
     blocked: Optional[bool] = None
+
+    # tag-scoped token/request/dollar rate limits (see `tag_rate_limiter.py`)
+    tag_rate_limits: TagRateLimits | None = None
 
     def __init__(self, id: Optional[Union[str, int]] = None, **params):
         if id is None:

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -130,8 +130,15 @@ class TagRateLimitEntry(BaseModel):
     midnight and `period_seconds=60` resets on real clock-minute boundaries.
 
     For a `concurrency_limits` entry specifically, `period_seconds` is not a
-    window: it is the safety TTL a reserved in-flight slot self-heals after,
-    in case a worker crashes before releasing it (the counter, not a window).
+    window: it is a floor under the safety TTL a reserved in-flight slot
+    self-heals after, in case a worker crashes before releasing it (the
+    counter, not a window). The effective TTL is at least one hour regardless
+    of this value, so a slow but genuinely still-running request never has
+    its reservation expire out from under it; set this higher only if an
+    even longer self-heal window is wanted. `concurrency_limits` also only
+    supports chain-wide entries (declared identically by every deployment
+    sharing a `model_name`) -- a divergent per-deployment value is dropped
+    with a warning, not silently scoped to a subset of deployments.
     """
 
     name: str

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -128,6 +128,10 @@ class TagRateLimitEntry(BaseModel):
     at `limit` units per rolling `period_seconds`-second window. Bucketing is
     `epoch_second // period_seconds`, so `period_seconds=86400` resets at UTC
     midnight and `period_seconds=60` resets on real clock-minute boundaries.
+
+    For a `concurrency_limits` entry specifically, `period_seconds` is not a
+    window: it is the safety TTL a reserved in-flight slot self-heals after,
+    in case a worker crashes before releasing it (the counter, not a window).
     """
 
     name: str
@@ -152,6 +156,7 @@ class TagRateLimits(BaseModel):
     token_limits: TagRateLimitGroup | None = None
     request_limits: TagRateLimitGroup | None = None
     dollar_limits: TagRateLimitGroup | None = None
+    concurrency_limits: TagRateLimitGroup | None = None
 
 
 class ModelInfo(BaseModel):

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -145,6 +145,17 @@ class TagRateLimitEntry(BaseModel):
     tag_id: str = "end_user_id"
     limit: float
     period_seconds: int
+    scope_by_key_hash: bool = False
+    """
+    When `True`, the bucket is additionally scoped by the calling virtual
+    key's hash, on top of the existing `tag_id`/tag-value match. Without
+    this, two different keys (e.g. two separate services) that both happen
+    to send the same tag value (e.g. the same `end_user_id`) share one
+    bucket and one counter; opting in gives each calling key its own
+    independent counter for the same tag value. Defaults to `False`, which
+    is today's existing behavior: the bucket is scoped by tag value alone,
+    shared across every key that sends it.
+    """
 
     model_config = ConfigDict(protected_namespaces=())
 

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -523,7 +523,7 @@ async def test_concurrency_slot_released_on_failure_frees_capacity(time_controll
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    kwargs = {"metadata": {"tags": ["end_user_id:u1"]}}
+    kwargs = {"model": "grp", "metadata": {"tags": ["end_user_id:u1"]}}
     await limiter.async_filter_deployments(model="grp", healthy_deployments=healthy, messages=None, request_kwargs=kwargs)
 
     await limiter.async_post_call_failure_hook(

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -1,0 +1,305 @@
+"""
+Unit tests for tag-scoped token/request/dollar rate limiting.
+"""
+
+import asyncio
+from datetime import datetime, timedelta
+
+import pytest
+
+import litellm
+from litellm.caching.dual_cache import DualCache
+from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
+from litellm.proxy.hooks.tag_rate_limiter import (
+    _build_group_limits,
+    _extract_identity,
+    _PROXY_TagRateLimiter,
+)
+
+
+class TimeController:
+    def __init__(self):
+        self._current = datetime(2026, 1, 1, 0, 0, 0)
+
+    def now(self) -> datetime:
+        return self._current
+
+    def advance(self, seconds: float) -> None:
+        self._current += timedelta(seconds=seconds)
+
+
+@pytest.fixture
+def time_controller():
+    return TimeController()
+
+
+def _make_limiter(time_controller: TimeController) -> _PROXY_TagRateLimiter:
+    return _PROXY_TagRateLimiter(
+        internal_usage_cache=DualCache(),
+        time_provider=time_controller.now,
+    )
+
+
+def _deployment(model_name: str, deployment_id: str, tag_rate_limits: dict) -> dict:
+    return {
+        "model_name": model_name,
+        "litellm_params": {"model": "gpt-4o", "mock_response": "ok"},
+        "model_info": {"id": deployment_id, "tag_rate_limits": tag_rate_limits},
+    }
+
+
+# ---------------------------------------------------------------------------
+# _extract_identity
+# ---------------------------------------------------------------------------
+
+
+def test_extract_identity_matches_prefixed_tag():
+    assert _extract_identity(["team_id:t1", "end_user_id:u1"], "end_user_id") == "u1"
+
+
+def test_extract_identity_returns_none_when_absent():
+    assert _extract_identity(["team_id:t1"], "end_user_id") is None
+
+
+def test_extract_identity_skips_negation_tags():
+    """A `!end_user_id:u1` routing-negation marker must never be read as identity."""
+    assert _extract_identity(["!end_user_id:u1"], "end_user_id") is None
+
+
+# ---------------------------------------------------------------------------
+# _build_group_limits -- chain-wide vs per-deployment scoping
+# ---------------------------------------------------------------------------
+
+
+def test_build_group_limits_chain_wide_when_all_deployments_agree():
+    deployments = [
+        _deployment("grp", "dep-1", {"token_limits": {"limits": [{"name": "daily", "limit": 500, "period_seconds": 86400}]}}),
+        _deployment("grp", "dep-2", {"token_limits": {"limits": [{"name": "daily", "limit": 500, "period_seconds": 86400}]}}),
+    ]
+    configured = _build_group_limits(deployments, "tokens")
+    assert len(configured) == 1
+    assert configured[0].deployment_scope is None
+
+
+def test_build_group_limits_per_deployment_when_values_diverge():
+    """
+    Regression test: a naive index that dedupes by (model_name, limit name) and
+    keeps whichever deployment it encounters first silently drops the second
+    deployment's config. Divergent values must produce two independent
+    per-deployment-scoped entries instead.
+    """
+    deployments = [
+        _deployment("grp", "dep-1", {"token_limits": {"limits": [{"name": "daily", "limit": 500, "period_seconds": 86400}]}}),
+        _deployment("grp", "dep-2", {"token_limits": {"limits": [{"name": "daily", "limit": 999, "period_seconds": 86400}]}}),
+    ]
+    configured = _build_group_limits(deployments, "tokens")
+    assert len(configured) == 2
+    scopes = {c.deployment_scope for c in configured}
+    assert scopes == {("dep-1",), ("dep-2",)}
+    limits = {c.deployment_scope: c.entry.limit for c in configured}
+    assert limits[("dep-1",)] == 500
+    assert limits[("dep-2",)] == 999
+
+
+def test_build_group_limits_per_deployment_when_only_some_declare_it():
+    deployments = [
+        _deployment("grp", "dep-1", {"token_limits": {"limits": [{"name": "daily", "limit": 500, "period_seconds": 86400}]}}),
+        _deployment("grp", "dep-2", {}),
+    ]
+    configured = _build_group_limits(deployments, "tokens")
+    assert len(configured) == 1
+    assert configured[0].deployment_scope == ("dep-1",)
+
+
+def test_build_group_limits_empty_when_no_deployment_configures_unit():
+    deployments = [_deployment("grp", "dep-1", {}), _deployment("grp", "dep-2", {})]
+    assert _build_group_limits(deployments, "tokens") == []
+
+
+# ---------------------------------------------------------------------------
+# async_filter_deployments -- enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_filter_deployments_noop_without_config(time_controller):
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(model_list=[_deployment("grp", "dep-1", {})])
+    limiter.update_variables(llm_router=router)
+
+    healthy = router.model_list
+    result = await limiter.async_filter_deployments(
+        model="grp",
+        healthy_deployments=healthy,
+        messages=None,
+        request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}},
+    )
+    assert result == healthy
+
+
+@pytest.mark.asyncio
+async def test_filter_deployments_allows_under_limit_and_rejects_at_limit(time_controller):
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {"request_limits": {"limits": [{"name": "per_minute", "tag_id": "end_user_id", "limit": 2, "period_seconds": 60}]}},
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+    request_kwargs = {"metadata": {"tags": ["end_user_id:u1"]}}
+
+    # Under limit: allowed, no bucket seeded yet.
+    result = await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=request_kwargs
+    )
+    assert result == healthy
+
+    # Seed the bucket at the limit (2 requests already accounted).
+    now = time_controller.now().timestamp()
+    bucket_id = int(now) // 60
+    key = f"{{tag_rl:grp:requests:per_minute:chain:u1}}:{bucket_id}"
+    await limiter.internal_usage_cache.async_set_cache(key=key, value=2, ttl=60, litellm_parent_otel_span=None)
+
+    with pytest.raises(ProxyRateLimitError) as exc_info:
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs=request_kwargs
+        )
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.detail["tag_value"] == "u1"
+    assert exc_info.value.detail["limit_name"] == "per_minute"
+
+
+@pytest.mark.asyncio
+async def test_filter_deployments_per_entry_fail_open_when_tag_absent(time_controller):
+    """
+    Two entries on the same chain, different tag_ids. Only the tag that's
+    actually present in the request gets checked; the other has zero effect.
+    """
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {
+                    "request_limits": {
+                        "limits": [
+                            {"name": "daily", "tag_id": "end_user_id", "limit": 1, "period_seconds": 86400},
+                            {"name": "monthly", "tag_id": "team_id", "limit": 1, "period_seconds": 2592000},
+                        ]
+                    }
+                },
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    # Only end_user_id is present -- team_id-keyed entry must not raise or touch Redis.
+    result = await limiter.async_filter_deployments(
+        model="grp",
+        healthy_deployments=healthy,
+        messages=None,
+        request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}},
+    )
+    assert result == healthy
+
+    now = time_controller.now().timestamp()
+    team_bucket_id = int(now) // 2592000
+    team_key = f"{{tag_rl:grp:requests:monthly:chain:whatever}}:{team_bucket_id}"
+    assert await limiter.internal_usage_cache.async_get_cache(key=team_key, litellm_parent_otel_span=None) is None
+
+
+# ---------------------------------------------------------------------------
+# Load-balanced group: chain-wide vs per-deployment enforcement end to end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_balanced_group_per_deployment_breach_rejects_whole_hop(time_controller):
+    """
+    Two deployments share one model_name with divergent per-deployment
+    limits. Breaching one deployment's bucket rejects the hop even though the
+    other deployment (still present in healthy_deployments) is comfortably
+    under its own limit -- this does NOT filter the breaching deployment out
+    and let the router retry the sibling.
+    """
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {"request_limits": {"limits": [{"name": "daily", "tag_id": "end_user_id", "limit": 1, "period_seconds": 86400}]}},
+            ),
+            _deployment(
+                "grp",
+                "dep-2",
+                {"request_limits": {"limits": [{"name": "daily", "tag_id": "end_user_id", "limit": 999, "period_seconds": 86400}]}},
+            ),
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+    request_kwargs = {"metadata": {"tags": ["end_user_id:u1"]}}
+
+    now = time_controller.now().timestamp()
+    bucket_id = int(now) // 86400
+    dep1_key = f"{{tag_rl:grp:requests:daily:dep:dep-1:u1}}:{bucket_id}"
+    await limiter.internal_usage_cache.async_set_cache(key=dep1_key, value=1, ttl=86400, litellm_parent_otel_span=None)
+
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs=request_kwargs
+        )
+
+
+# ---------------------------------------------------------------------------
+# async_log_success_event -- accounting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_log_success_event_increments_configured_units(time_controller):
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {
+                    "token_limits": {"limits": [{"name": "daily", "tag_id": "end_user_id", "limit": 500000, "period_seconds": 86400}]},
+                    "request_limits": {"limits": [{"name": "daily", "tag_id": "end_user_id", "limit": 100, "period_seconds": 86400}]},
+                    "dollar_limits": {"limits": [{"name": "monthly", "tag_id": "end_user_id", "limit": 50.0, "period_seconds": 2592000}]},
+                },
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+
+    kwargs = {
+        "metadata": {"tags": ["end_user_id:u1"]},
+        "standard_logging_object": {
+            "model_group": "grp",
+            "model_id": "dep-1",
+            "total_tokens": 42,
+            "response_cost": 0.01,
+        },
+    }
+    await limiter.async_log_success_event(kwargs=kwargs, response_obj=None, start_time=0, end_time=0)
+    # accounting is fired via asyncio.create_task; let it run.
+    await asyncio.sleep(0)
+
+    now = time_controller.now().timestamp()
+    token_key = f"{{tag_rl:grp:tokens:daily:chain:u1}}:{int(now) // 86400}"
+    request_key = f"{{tag_rl:grp:requests:daily:chain:u1}}:{int(now) // 86400}"
+    dollar_key = f"{{tag_rl:grp:dollars:monthly:chain:u1}}:{int(now) // 2592000}"
+
+    assert float(await limiter.internal_usage_cache.async_get_cache(key=token_key, litellm_parent_otel_span=None)) == 42.0
+    assert float(await limiter.internal_usage_cache.async_get_cache(key=request_key, litellm_parent_otel_span=None)) == 1.0
+    assert float(await limiter.internal_usage_cache.async_get_cache(key=dollar_key, litellm_parent_otel_span=None)) == 0.01

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -14,9 +14,13 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
 from litellm.proxy.hooks.tag_rate_limiter import (
     _build_group_limits,
+    _build_limits_index,
+    _ConfiguredLimit,
+    _CONCURRENCY_MIN_SAFETY_TTL_SECONDS,
     _extract_identity,
     _PROXY_TagRateLimiter,
 )
+from litellm.types.router import TagRateLimitEntry
 
 
 class TimeController:
@@ -701,3 +705,161 @@ async def test_redis_backed_cross_unit_rejection_does_not_leave_a_phantom_increm
 
     # cleanup: this key persists in the shared scratch Redis instance beyond the test's TTL otherwise
     await redis_cache.async_delete_cache(key=request_key)
+
+
+# ---------------------------------------------------------------------------
+# team_public_model_name alias -- index lookup must not miss
+# ---------------------------------------------------------------------------
+
+
+def test_build_limits_index_is_also_keyed_by_team_public_model_name():
+    """
+    Router threads a team's public alias, not the deployment's own
+    model_name, into async_filter_deployments's `model` param when a caller
+    requests via that alias (Router never rewrites it for this path, unlike
+    model_group_alias). The index must resolve either name to the same
+    configured limits, or a team-aliased chain's limits are silently never
+    checked.
+    """
+    deployment = _deployment("real-model-name", "dep-1", {"token_limits": {"limits": [{"name": "daily", "limit": 500, "period_seconds": 86400}]}})
+    deployment["model_info"]["team_public_model_name"] = "team-alias-name"
+    index = _build_limits_index([deployment])
+    assert "real-model-name" in index
+    assert "team-alias-name" in index
+    assert index["real-model-name"] == index["team-alias-name"]
+
+
+@pytest.mark.asyncio
+async def test_filter_deployments_enforces_limit_when_called_with_team_alias(time_controller):
+    limiter = _make_limiter(time_controller)
+    deployment = _deployment("real-model-name", "dep-1", {"request_limits": {"limits": [{"name": "daily", "tag_id": "end_user_id", "limit": 1, "period_seconds": 86400}]}})
+    deployment["model_info"]["team_public_model_name"] = "team-alias-name"
+    router = litellm.Router(model_list=[deployment])
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    # Router passes the alias as `model`, not "real-model-name".
+    await limiter.async_filter_deployments(
+        model="team-alias-name", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="team-alias-name", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
+
+
+# ---------------------------------------------------------------------------
+# concurrency_limits -- chain-wide only, divergent config dropped not leaked
+# ---------------------------------------------------------------------------
+
+
+def test_concurrency_divergent_config_is_dropped_not_scoped_per_deployment():
+    """
+    Unlike tokens/requests/dollars, a concurrency entry declared with
+    different values per deployment must not become a per-deployment-scoped
+    reservation -- that shape leaks (see the regression tests below this
+    plan superseded). It should be dropped entirely, with the group left
+    with no concurrency entry at all.
+    """
+    deployments = [
+        _deployment("grp", "dep-1", {"concurrency_limits": {"limits": [{"name": "inflight", "limit": 2, "period_seconds": 60}]}}),
+        _deployment("grp", "dep-2", {"concurrency_limits": {"limits": [{"name": "inflight", "limit": 5, "period_seconds": 60}]}}),
+    ]
+    configured = _build_group_limits(deployments, "concurrency")
+    assert configured == []
+
+
+def test_concurrency_partial_declaration_is_dropped_not_scoped_per_deployment():
+    deployments = [
+        _deployment("grp", "dep-1", {"concurrency_limits": {"limits": [{"name": "inflight", "limit": 2, "period_seconds": 60}]}}),
+        _deployment("grp", "dep-2", {}),
+    ]
+    configured = _build_group_limits(deployments, "concurrency")
+    assert configured == []
+
+
+def test_concurrency_identical_across_all_deployments_is_still_chain_wide():
+    deployments = [
+        _deployment("grp", "dep-1", {"concurrency_limits": {"limits": [{"name": "inflight", "limit": 2, "period_seconds": 60}]}}),
+        _deployment("grp", "dep-2", {"concurrency_limits": {"limits": [{"name": "inflight", "limit": 2, "period_seconds": 60}]}}),
+    ]
+    configured = _build_group_limits(deployments, "concurrency")
+    assert len(configured) == 1
+    assert configured[0].deployment_scope is None
+
+
+# ---------------------------------------------------------------------------
+# concurrency TTL floor -- a short period_seconds must not shorten the
+# self-heal safety TTL below the floor
+# ---------------------------------------------------------------------------
+
+
+def test_concurrency_ttl_floor_overrides_a_too_short_period_seconds():
+    entry = TagRateLimitEntry(name="inflight", tag_id="end_user_id", limit=1, period_seconds=5)
+    configured_limit = _ConfiguredLimit(unit="concurrency", entry=entry, deployment_scope=None)
+    assert _PROXY_TagRateLimiter._ttl_for(configured_limit) == _CONCURRENCY_MIN_SAFETY_TTL_SECONDS
+
+
+def test_concurrency_ttl_floor_does_not_shorten_a_longer_period_seconds():
+    entry = TagRateLimitEntry(name="inflight", tag_id="end_user_id", limit=1, period_seconds=_CONCURRENCY_MIN_SAFETY_TTL_SECONDS + 100)
+    configured_limit = _ConfiguredLimit(unit="concurrency", entry=entry, deployment_scope=None)
+    assert _PROXY_TagRateLimiter._ttl_for(configured_limit) == _CONCURRENCY_MIN_SAFETY_TTL_SECONDS + 100
+
+
+# ---------------------------------------------------------------------------
+# refund-on-rollback across differently-hash-tagged keys (Redis Cluster safety)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_unit_refund_leaves_no_phantom_increment_in_memory(time_controller):
+    """
+    In-memory equivalent of the Redis Cluster cross-slot fix: requests and
+    concurrency keys carry different hash tags by construction, so the
+    all-or-nothing guarantee across them must come from a refund, not a
+    single multi-key atomic call. Confirms the refund path itself (not just
+    the end observable behavior already covered by
+    test_cross_unit_rejection_does_not_leave_a_phantom_increment).
+    """
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {
+                    "request_limits": {"limits": [{"name": "per_minute", "tag_id": "end_user_id", "limit": 10, "period_seconds": 60}]},
+                    "concurrency_limits": {"limits": [{"name": "inflight", "tag_id": "end_user_id", "limit": 1, "period_seconds": 60}]},
+                },
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:refund-check"]}}
+    )
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:refund-check"]}}
+        )
+
+    now = time_controller.now().timestamp()
+    request_key = f"{{tag_rl:grp:requests:per_minute:chain:refund-check}}:{int(now) // 60}"
+    value = await limiter.internal_usage_cache.async_get_cache(key=request_key, litellm_parent_otel_span=None)
+    assert (float(value) if value is not None else 0.0) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# release floors at zero -- never goes negative
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_release_floors_at_zero_instead_of_going_negative(time_controller):
+    limiter = _make_limiter(time_controller)
+    key = "{tag_rl:test:concurrency:floor:chain:u1}:inflight"
+    await limiter._decrement_floor_zero(key, -1.0)
+    value = await limiter.internal_usage_cache.async_get_cache(key=key, litellm_parent_otel_span=None)
+    assert (float(value) if value is not None else 0.0) == 0.0

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -527,13 +527,15 @@ async def test_concurrency_slot_released_on_failure_frees_capacity(time_controll
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    kwargs = {"model": "grp", "metadata": {"tags": ["end_user_id:u1"]}}
-    await limiter.async_filter_deployments(model="grp", healthy_deployments=healthy, messages=None, request_kwargs=kwargs)
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
 
-    await limiter.async_post_call_failure_hook(
-        request_data=kwargs,
-        original_exception=Exception("provider error"),
-        user_api_key_dict=UserAPIKeyAuth(),
+    await limiter.async_log_failure_event(
+        kwargs={"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
+        response_obj=None,
+        start_time=0,
+        end_time=0,
     )
 
     result = await limiter.async_filter_deployments(
@@ -546,11 +548,13 @@ async def test_concurrency_slot_released_on_failure_frees_capacity(time_controll
 async def test_concurrency_slot_released_on_fallback_recovered_hop_failure(time_controller):
     """
     A hop that fails but gets recovered by a later fallback never reaches
-    async_post_call_failure_hook, which only fires once, if and when the
-    entire request (every fallback exhausted) ultimately fails. Only
-    async_log_failure_event fires for a per-hop failure that a fallback
-    recovers, so it alone must release that hop's reservation, or it leaks
-    until its safety TTL (up to an hour).
+    `async_post_call_failure_hook` (which this limiter deliberately does not
+    implement -- see its removal note on `async_log_failure_event`), since
+    that hook only fires once, if and when the entire request (every
+    fallback exhausted) ultimately fails. Only `async_log_failure_event`
+    fires for a per-hop failure that a fallback recovers, so it alone must
+    release that hop's reservation, or it leaks until its safety TTL (up to
+    an hour).
     """
     limiter = _make_limiter(time_controller)
     router = _concurrency_router(limit=1)
@@ -568,12 +572,62 @@ async def test_concurrency_slot_released_on_fallback_recovered_hop_failure(time_
     }
     await limiter.async_log_failure_event(kwargs=failure_kwargs, response_obj=None, start_time=0, end_time=0)
 
-    # async_post_call_failure_hook never fires for this hop (a fallback
-    # recovered it) -- capacity must already be free without it.
     result = await limiter.async_filter_deployments(
         model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
     )
     assert result == healthy
+
+
+@pytest.mark.asyncio
+async def test_terminal_failure_does_not_double_release_and_steal_another_requests_slot(time_controller):
+    """
+    The inflight counter is aggregate per tag, not per-request: if a terminal
+    failure's reservation were released twice (once each by
+    `async_post_call_failure_hook` and `async_log_failure_event`), the second
+    release would silently free capacity belonging to a different,
+    still-running request sharing the same tag, admitting one more
+    concurrent request than configured. This limiter deliberately does not
+    implement `async_post_call_failure_hook`, so calling it (as the proxy
+    still would, falling through to the CustomLogger base no-op) must have
+    no effect on the counter.
+    """
+    limiter = _make_limiter(time_controller)
+    router = _concurrency_router(limit=2)
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    # Two concurrent requests at capacity.
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+
+    # One of them fails terminally.
+    await limiter.async_log_failure_event(
+        kwargs={"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
+        response_obj=None,
+        start_time=0,
+        end_time=0,
+    )
+    await limiter.async_post_call_failure_hook(
+        request_data={"model": "grp", "metadata": {"tags": ["end_user_id:u1"]}},
+        original_exception=Exception("provider error"),
+        user_api_key_dict=UserAPIKeyAuth(),
+    )
+
+    # Exactly one slot was freed: a third request is admitted (back to 2 in flight)...
+    result = await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+    assert result == healthy
+    # ...but a fourth would exceed the limit of 2. If the failure had freed a
+    # second slot, this would wrongly be admitted instead of rejected.
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -342,22 +342,11 @@ def _concurrency_router(limit: int) -> "litellm.Router":
     )
 
 
-class _FakeLoggingObj:
-    """
-    Stands in for litellm's real `Logging` object: the same instance is
-    threaded through every hop of one logical request (retries and
-    fallbacks alike), and its `model_call_details` dict is exactly the
-    `kwargs` a logging callback receives -- see
-    `_accumulate_pending_concurrency_keys`'s docstring for why this is the
-    one piece of state that reliably survives across hops.
-    """
-
-    def __init__(self):
-        self.model_call_details: dict = {}
-
-
-def _hop_kwargs(logging_obj: "_FakeLoggingObj", tags: list[str]) -> dict:
-    return {"metadata": {"tags": tags}, "litellm_logging_obj": logging_obj}
+def _hop_kwargs(call_id: str, tags: list[str]) -> dict:
+    """`litellm_call_id` is the one identifier `_extract_call_id` relies on
+    to correlate every hop of one logical request (retries and fallbacks
+    alike) -- see its docstring for why."""
+    return {"metadata": {"tags": tags}, "litellm_call_id": call_id}
 
 
 @pytest.mark.asyncio
@@ -518,9 +507,9 @@ async def test_concurrency_slot_released_on_success_frees_capacity(time_controll
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    logging_obj = _FakeLoggingObj()
+    call_id = str(uuid.uuid4())
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
     )
 
     # At capacity: a second concurrent request is rejected.
@@ -530,13 +519,16 @@ async def test_concurrency_slot_released_on_success_frees_capacity(time_controll
         )
 
     # The first request completes -- its slot is released -- freeing capacity again.
-    logging_obj.model_call_details.update(
-        {
+    await limiter.async_log_success_event(
+        kwargs={
+            "litellm_call_id": call_id,
             "standard_logging_object": {"model_group": "grp", "model_id": "dep-1", "total_tokens": 0, "response_cost": 0},
             "metadata": {"tags": ["end_user_id:u1"]},
-        }
+        },
+        response_obj=None,
+        start_time=0,
+        end_time=0,
     )
-    await limiter.async_log_success_event(kwargs=logging_obj.model_call_details, response_obj=None, start_time=0, end_time=0)
     await asyncio.sleep(0)
 
     result = await limiter.async_filter_deployments(
@@ -552,13 +544,17 @@ async def test_concurrency_slot_released_on_failure_frees_capacity(time_controll
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    logging_obj = _FakeLoggingObj()
+    call_id = str(uuid.uuid4())
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
     )
 
-    logging_obj.model_call_details.update({"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}})
-    await limiter.async_log_failure_event(kwargs=logging_obj.model_call_details, response_obj=None, start_time=0, end_time=0)
+    await limiter.async_log_failure_event(
+        kwargs={"litellm_call_id": call_id, "standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
+        response_obj=None,
+        start_time=0,
+        end_time=0,
+    )
 
     result = await limiter.async_filter_deployments(
         model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
@@ -582,30 +578,39 @@ async def test_concurrency_released_for_every_hop_when_only_the_first_failure_fi
     router = _concurrency_router(limit=2)
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
-    logging_obj = _FakeLoggingObj()
+    call_id = str(uuid.uuid4())
 
     # Hop 1 admits and fails; its failure event is the one that fires.
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
     )
-    logging_obj.model_call_details.update({"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}})
-    await limiter.async_log_failure_event(kwargs=logging_obj.model_call_details, response_obj=None, start_time=0, end_time=0)
+    await limiter.async_log_failure_event(
+        kwargs={"litellm_call_id": call_id, "standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
+        response_obj=None,
+        start_time=0,
+        end_time=0,
+    )
 
     # Hop 2 (a retry or fallback) admits and also fails, but -- per litellm's
     # dedup -- no async_log_failure_event call follows it.
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
     )
 
     # Hop 3 admits and succeeds. Its success event must release both hop 2's
     # still-pending reservation and its own.
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
     )
-    logging_obj.model_call_details.update(
-        {"standard_logging_object": {"model_group": "grp", "model_id": "dep-1", "total_tokens": 0, "response_cost": 0}}
+    await limiter.async_log_success_event(
+        kwargs={
+            "litellm_call_id": call_id,
+            "standard_logging_object": {"model_group": "grp", "model_id": "dep-1", "total_tokens": 0, "response_cost": 0},
+        },
+        response_obj=None,
+        start_time=0,
+        end_time=0,
     )
-    await limiter.async_log_success_event(kwargs=logging_obj.model_call_details, response_obj=None, start_time=0, end_time=0)
     await asyncio.sleep(0)
 
     # Full capacity (2) is free again -- both hops admit.
@@ -632,23 +637,30 @@ async def test_concurrency_released_by_terminal_hook_when_every_hop_fails(time_c
     router = _concurrency_router(limit=2)
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
-    logging_obj = _FakeLoggingObj()
+    call_id = str(uuid.uuid4())
 
-    # Hop 1 admits and fails; its failure event fires and clears the list.
+    # Hop 1 admits and fails; its failure event fires and clears the registry entry.
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
     )
-    logging_obj.model_call_details.update({"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}})
-    await limiter.async_log_failure_event(kwargs=logging_obj.model_call_details, response_obj=None, start_time=0, end_time=0)
+    await limiter.async_log_failure_event(
+        kwargs={"litellm_call_id": call_id, "standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
+        response_obj=None,
+        start_time=0,
+        end_time=0,
+    )
 
     # Hop 2 admits and is the terminal failure -- no fallback left. Per
     # litellm's dedup, its own async_log_failure_event never fires either.
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
     )
 
+    # request_data deliberately has no litellm_logging_obj: ProxyLogging.post_call_failure_hook
+    # always pops it before dispatching to callbacks in production, so a
+    # correct fix cannot depend on it being present here either.
     await limiter.async_post_call_failure_hook(
-        request_data={"model": "grp", "litellm_logging_obj": logging_obj, "metadata": {"tags": ["end_user_id:u1"]}},
+        request_data={"model": "grp", "litellm_call_id": call_id, "metadata": {"tags": ["end_user_id:u1"]}},
         original_exception=Exception("provider error"),
         user_api_key_dict=UserAPIKeyAuth(),
     )
@@ -681,21 +693,25 @@ async def test_terminal_failure_does_not_double_release_and_steal_another_reques
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    logging_obj_a = _FakeLoggingObj()
-    logging_obj_b = _FakeLoggingObj()
+    call_id_a = str(uuid.uuid4())
+    call_id_b = str(uuid.uuid4())
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj_a, ["end_user_id:u1"])
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id_a, ["end_user_id:u1"])
     )
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj_b, ["end_user_id:u1"])
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id_b, ["end_user_id:u1"])
     )
 
     # A fails terminally: both its failure event and the terminal post-call
-    # hook fire for the same single hop, against the same shared state.
-    logging_obj_a.model_call_details.update({"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}})
-    await limiter.async_log_failure_event(kwargs=logging_obj_a.model_call_details, response_obj=None, start_time=0, end_time=0)
+    # hook fire for the same single hop, against the same registry entry.
+    await limiter.async_log_failure_event(
+        kwargs={"litellm_call_id": call_id_a, "standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
+        response_obj=None,
+        start_time=0,
+        end_time=0,
+    )
     await limiter.async_post_call_failure_hook(
-        request_data={"model": "grp", "litellm_logging_obj": logging_obj_a, "metadata": {"tags": ["end_user_id:u1"]}},
+        request_data={"model": "grp", "litellm_call_id": call_id_a, "metadata": {"tags": ["end_user_id:u1"]}},
         original_exception=Exception("provider error"),
         user_api_key_dict=UserAPIKeyAuth(),
     )
@@ -1301,7 +1317,7 @@ async def test_concurrency_scope_by_key_hash_gives_independent_reservations_per_
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    logging_obj_a = _FakeLoggingObj()
+    call_id_a = str(uuid.uuid4())
 
     # keyA occupies its own single slot.
     await limiter.async_filter_deployments(
@@ -1310,7 +1326,7 @@ async def test_concurrency_scope_by_key_hash_gives_independent_reservations_per_
         messages=None,
         request_kwargs={
             "metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyA"},
-            "litellm_logging_obj": logging_obj_a,
+            "litellm_call_id": call_id_a,
         },
     )
 
@@ -1332,8 +1348,9 @@ async def test_concurrency_scope_by_key_hash_gives_independent_reservations_per_
         )
 
     # Release keyA's reservation via the success event, matching its key hash.
-    logging_obj_a.model_call_details.update(
-        {
+    await limiter.async_log_success_event(
+        kwargs={
+            "litellm_call_id": call_id_a,
             "standard_logging_object": {
                 "model_group": "grp",
                 "model_id": "dep-1",
@@ -1342,9 +1359,11 @@ async def test_concurrency_scope_by_key_hash_gives_independent_reservations_per_
                 "metadata": {"user_api_key_hash": "keyA"},
             },
             "metadata": {"tags": ["end_user_id:u1"]},
-        }
+        },
+        response_obj=None,
+        start_time=0,
+        end_time=0,
     )
-    await limiter.async_log_success_event(kwargs=logging_obj_a.model_call_details, response_obj=None, start_time=0, end_time=0)
     await asyncio.sleep(0)
 
     # keyA's capacity is freed -- a fresh keyA request now admits.

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -902,6 +902,35 @@ def test_build_limits_index_keeps_different_teams_same_alias_separate():
     assert resolved_b[0].entry.limit == 999
 
 
+def test_build_limits_index_merges_alias_limits_across_different_model_names():
+    """
+    litellm auto-generates each team-added deployment's own internal
+    model_name as model_name_{team_id}_{uuid}, so multiple deployments
+    sharing one team_public_model_name alias routinely have different
+    model_name values -- Router's own team_model_to_deployment_indices
+    aggregates them by (team_id, alias) regardless of that. Computing alias
+    limits once per model_name group and keying the alias to whichever
+    group happened to declare it would silently drop every other same-alias
+    group's limits: with two deployments under different model_names but
+    the same alias, only the entry declared by whichever model_name group
+    is processed last would survive.
+    """
+    dep_a = _deployment("model_name_team1_aaa", "dep-a", {"token_limits": {"limits": [{"name": "daily", "limit": 100, "period_seconds": 86400}]}})
+    dep_a["model_info"]["team_id"] = "team-1"
+    dep_a["model_info"]["team_public_model_name"] = "shared-alias"
+
+    dep_b = _deployment(
+        "model_name_team1_bbb", "dep-b", {"dollar_limits": {"limits": [{"name": "monthly", "limit": 50.0, "period_seconds": 2592000}]}}
+    )
+    dep_b["model_info"]["team_id"] = "team-1"
+    dep_b["model_info"]["team_public_model_name"] = "shared-alias"
+
+    index = _build_limits_index([dep_a, dep_b])
+    resolved = index.resolve("shared-alias", team_id="team-1")
+    units = {c.unit for c in resolved}
+    assert units == {"tokens", "dollars"}
+
+
 @pytest.mark.asyncio
 async def test_filter_deployments_enforces_limit_when_called_with_team_alias(time_controller):
     limiter = _make_limiter(time_controller)

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -10,7 +10,6 @@ import pytest
 
 import litellm
 from litellm.caching.dual_cache import DualCache
-from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
 from litellm.proxy.hooks.tag_rate_limiter import (
     _build_group_limits,
@@ -397,13 +396,6 @@ def _concurrency_router(limit: int) -> "litellm.Router":
     )
 
 
-def _hop_kwargs(call_id: str, tags: list[str]) -> dict:
-    """`litellm_call_id` is the one identifier `_extract_call_id` relies on
-    to correlate every hop of one logical request (retries and fallbacks
-    alike) -- see its docstring for why."""
-    return {"metadata": {"tags": tags}, "litellm_call_id": call_id}
-
-
 @pytest.mark.asyncio
 async def test_cross_unit_rejection_does_not_leave_a_phantom_increment(time_controller):
     """
@@ -562,10 +554,8 @@ async def test_concurrency_slot_released_on_success_frees_capacity(time_controll
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    call_id = str(uuid.uuid4())
-    await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
-    )
+    kwargs = {"metadata": {"tags": ["end_user_id:u1"]}}
+    await limiter.async_filter_deployments(model="grp", healthy_deployments=healthy, messages=None, request_kwargs=kwargs)
 
     # At capacity: a second concurrent request is rejected.
     with pytest.raises(ProxyRateLimitError):
@@ -574,16 +564,8 @@ async def test_concurrency_slot_released_on_success_frees_capacity(time_controll
         )
 
     # The first request completes -- its slot is released -- freeing capacity again.
-    await limiter.async_log_success_event(
-        kwargs={
-            "litellm_call_id": call_id,
-            "standard_logging_object": {"model_group": "grp", "model_id": "dep-1", "total_tokens": 0, "response_cost": 0},
-            "metadata": {"tags": ["end_user_id:u1"]},
-        },
-        response_obj=None,
-        start_time=0,
-        end_time=0,
-    )
+    kwargs["standard_logging_object"] = {"model_group": "grp", "model_id": "dep-1", "total_tokens": 0, "response_cost": 0}
+    await limiter.async_log_success_event(kwargs=kwargs, response_obj=None, start_time=0, end_time=0)
     await asyncio.sleep(0)
 
     result = await limiter.async_filter_deployments(
@@ -599,13 +581,12 @@ async def test_concurrency_slot_released_on_failure_frees_capacity(time_controll
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    call_id = str(uuid.uuid4())
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
     )
 
     await limiter.async_log_failure_event(
-        kwargs={"litellm_call_id": call_id, "standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
+        kwargs={"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
         response_obj=None,
         start_time=0,
         end_time=0,
@@ -618,167 +599,93 @@ async def test_concurrency_slot_released_on_failure_frees_capacity(time_controll
 
 
 @pytest.mark.asyncio
-async def test_concurrency_released_for_every_hop_when_only_the_first_failure_fires(time_controller):
+async def test_concurrency_slot_released_on_fallback_recovered_hop_failure(time_controller):
     """
-    litellm dedupes `async_log_failure_event` to fire once per logical
-    request: only the first failed hop's failure reaches it (see
-    `Logging.has_run_logging`'s `has_logged_async_failure` guard); a later
-    failed hop (a retry, or a further fallback) never gets its own failure
-    event at all. Reservations still accumulate at admission for every hop
-    regardless, so whichever event fires next must release everything
-    accumulated since the last release, not just its own hop's key, or a
-    hop whose failure event never fired leaks until its safety TTL.
+    A hop that fails but gets recovered by a later fallback never reaches
+    a terminal, request-level hook -- there is none, deliberately, since
+    there's no reliable, caller-uncontrolled way to correlate multiple hops
+    of one logical request from inside a CustomLogger hook (see
+    async_log_failure_event's docstring for why litellm_call_id, the one
+    candidate, can't be trusted for this). async_log_failure_event fires
+    per hop, on every failure, recomputing this hop's own key independently,
+    so this specific case -- exactly one prior failure, then a fallback that
+    succeeds -- is still handled correctly.
     """
     limiter = _make_limiter(time_controller)
-    router = _concurrency_router(limit=2)
+    router = _concurrency_router(limit=1)
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
-    call_id = str(uuid.uuid4())
 
-    # Hop 1 admits and fails; its failure event is the one that fires.
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
     )
     await limiter.async_log_failure_event(
-        kwargs={"litellm_call_id": call_id, "standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
+        kwargs={"standard_logging_object": {"model_group": "grp", "model_id": "dep-1"}, "metadata": {"tags": ["end_user_id:u1"]}},
         response_obj=None,
         start_time=0,
         end_time=0,
     )
 
-    # Hop 2 (a retry or fallback) admits and also fails, but -- per litellm's
-    # dedup -- no async_log_failure_event call follows it.
+    result = await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+    assert result == healthy
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_sharing_a_caller_chosen_call_id_do_not_merge_reservations(time_controller):
+    """
+    Security regression test: litellm_call_id is caller-controlled (a
+    request can set the x-litellm-call-id header to any value; litellm only
+    generates one itself when the header is absent). An earlier design
+    correlated reservations across hops using litellm_call_id as a registry
+    key; two genuinely concurrent, unrelated requests that happened to reuse
+    the same caller-chosen value would have had their reservations merged
+    into one registry entry, so one request completing released the other's
+    still-active slot -- bypassing the configured concurrency cap entirely
+    for that identity. Release must never depend on any caller-supplied
+    identifier: two concurrent admissions sharing the identical
+    litellm_call_id must still each require their own release.
+    """
+    limiter = _make_limiter(time_controller)
+    router = _concurrency_router(limit=2)
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    shared_call_id = "attacker-chosen-value"
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
+        model="grp",
+        healthy_deployments=healthy,
+        messages=None,
+        request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}, "litellm_call_id": shared_call_id},
+    )
+    await limiter.async_filter_deployments(
+        model="grp",
+        healthy_deployments=healthy,
+        messages=None,
+        request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}, "litellm_call_id": shared_call_id},
     )
 
-    # Hop 3 admits and succeeds. Its success event must release both hop 2's
-    # still-pending reservation and its own.
-    await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
-    )
-    await limiter.async_log_success_event(
+    # Both concurrent requests admitted (2/2 in flight, sharing the same
+    # caller-chosen litellm_call_id). One of them fails.
+    await limiter.async_log_failure_event(
         kwargs={
-            "litellm_call_id": call_id,
-            "standard_logging_object": {"model_group": "grp", "model_id": "dep-1", "total_tokens": 0, "response_cost": 0},
+            "litellm_call_id": shared_call_id,
+            "standard_logging_object": {"model_group": "grp"},
+            "metadata": {"tags": ["end_user_id:u1"]},
         },
         response_obj=None,
         start_time=0,
         end_time=0,
     )
-    await asyncio.sleep(0)
 
-    # Full capacity (2) is free again -- both hops admit.
-    await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
-    )
+    # Exactly one slot was freed: a third request is admitted (back to 2 in flight)...
     result = await limiter.async_filter_deployments(
         model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
     )
     assert result == healthy
-
-
-@pytest.mark.asyncio
-async def test_concurrency_released_by_terminal_hook_when_every_hop_fails(time_controller):
-    """
-    Same dedup as above, but no hop ever succeeds: the whole request is
-    exhausted after every retry/fallback fails. Neither `async_log_success_event`
-    nor a second `async_log_failure_event` will ever fire for this request,
-    so `async_post_call_failure_hook` -- which fires once, from the proxy
-    route handler, only when the entire request is exhausted -- must release
-    everything still accumulated.
-    """
-    limiter = _make_limiter(time_controller)
-    router = _concurrency_router(limit=2)
-    limiter.update_variables(llm_router=router)
-    healthy = router.model_list
-    call_id = str(uuid.uuid4())
-
-    # Hop 1 admits and fails; its failure event fires and clears the registry entry.
-    await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
-    )
-    await limiter.async_log_failure_event(
-        kwargs={"litellm_call_id": call_id, "standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
-        response_obj=None,
-        start_time=0,
-        end_time=0,
-    )
-
-    # Hop 2 admits and is the terminal failure -- no fallback left. Per
-    # litellm's dedup, its own async_log_failure_event never fires either.
-    await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id, ["end_user_id:u1"])
-    )
-
-    # request_data deliberately has no litellm_logging_obj: ProxyLogging.post_call_failure_hook
-    # always pops it before dispatching to callbacks in production, so a
-    # correct fix cannot depend on it being present here either.
-    await limiter.async_post_call_failure_hook(
-        request_data={"model": "grp", "litellm_call_id": call_id, "metadata": {"tags": ["end_user_id:u1"]}},
-        original_exception=Exception("provider error"),
-        user_api_key_dict=UserAPIKeyAuth(),
-    )
-
-    # Full capacity (2) is free again.
-    await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
-    )
-    result = await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
-    )
-    assert result == healthy
-
-
-@pytest.mark.asyncio
-async def test_terminal_failure_does_not_double_release_and_steal_another_requests_slot(time_controller):
-    """
-    The inflight counter is aggregate per tag, not per-request: if a
-    terminal failure's reservation were released twice (once each by
-    `async_post_call_failure_hook` and `async_log_failure_event`, both
-    firing for the same single-hop failure), the second release would
-    silently free capacity belonging to a different, still-running request
-    sharing the same tag, admitting one more concurrent request than
-    configured. Both hooks release from the same shared accumulated-keys
-    state, so whichever fires first drains it and the other finds nothing
-    left.
-    """
-    limiter = _make_limiter(time_controller)
-    router = _concurrency_router(limit=2)
-    limiter.update_variables(llm_router=router)
-    healthy = router.model_list
-
-    call_id_a = str(uuid.uuid4())
-    call_id_b = str(uuid.uuid4())
-    await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id_a, ["end_user_id:u1"])
-    )
-    await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(call_id_b, ["end_user_id:u1"])
-    )
-
-    # A fails terminally: both its failure event and the terminal post-call
-    # hook fire for the same single hop, against the same registry entry.
-    await limiter.async_log_failure_event(
-        kwargs={"litellm_call_id": call_id_a, "standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
-        response_obj=None,
-        start_time=0,
-        end_time=0,
-    )
-    await limiter.async_post_call_failure_hook(
-        request_data={"model": "grp", "litellm_call_id": call_id_a, "metadata": {"tags": ["end_user_id:u1"]}},
-        original_exception=Exception("provider error"),
-        user_api_key_dict=UserAPIKeyAuth(),
-    )
-
-    # Exactly A's one slot was freed: B's reservation is untouched, so a
-    # third request is admitted (back to 2 in flight)...
-    result = await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
-    )
-    assert result == healthy
-    # ...but a fourth would exceed the limit of 2. If A's failure had freed a
-    # second slot (double release), this would wrongly be admitted.
+    # ...but a fourth would exceed the limit of 2. If the shared call_id had
+    # merged both reservations into one release, this would wrongly admit.
     with pytest.raises(ProxyRateLimitError):
         await limiter.async_filter_deployments(
             model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
@@ -1372,17 +1279,12 @@ async def test_concurrency_scope_by_key_hash_gives_independent_reservations_per_
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    call_id_a = str(uuid.uuid4())
-
     # keyA occupies its own single slot.
     await limiter.async_filter_deployments(
         model="grp",
         healthy_deployments=healthy,
         messages=None,
-        request_kwargs={
-            "metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyA"},
-            "litellm_call_id": call_id_a,
-        },
+        request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyA"}},
     )
 
     # keyB, same tag value, different key -- must still admit since it has its own bucket.
@@ -1405,7 +1307,6 @@ async def test_concurrency_scope_by_key_hash_gives_independent_reservations_per_
     # Release keyA's reservation via the success event, matching its key hash.
     await limiter.async_log_success_event(
         kwargs={
-            "litellm_call_id": call_id_a,
             "standard_logging_object": {
                 "model_group": "grp",
                 "model_id": "dep-1",

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -1141,3 +1141,227 @@ async def test_refund_failure_on_one_key_does_not_block_others_or_raise(time_con
 
     other_value = await flaky.internal_usage_cache.async_get_cache(key=other_key, litellm_parent_otel_span=None)
     assert (float(other_value) if other_value is not None else 0.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# scope_by_key_hash -- opt-in per-calling-key bucket separation
+# ---------------------------------------------------------------------------
+
+
+def _concurrency_router_scoped_by_key(limit: int) -> "litellm.Router":
+    return litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {
+                    "concurrency_limits": {
+                        "limits": [
+                            {
+                                "name": "inflight",
+                                "tag_id": "end_user_id",
+                                "limit": limit,
+                                "period_seconds": 300,
+                                "scope_by_key_hash": True,
+                            }
+                        ]
+                    }
+                },
+            )
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_limit_scope_by_key_hash_gives_independent_counters_per_key(time_controller):
+    """
+    scope_by_key_hash=True: the identical tag value sent by two different
+    calling keys must get independent request counters -- exhausting keyA's
+    limit must not affect keyB's admission for the same tag.
+    """
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {
+                    "request_limits": {
+                        "limits": [
+                            {
+                                "name": "per_minute",
+                                "tag_id": "end_user_id",
+                                "limit": 2,
+                                "period_seconds": 60,
+                                "scope_by_key_hash": True,
+                            }
+                        ]
+                    }
+                },
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    for _ in range(2):
+        result = await limiter.async_filter_deployments(
+            model="grp",
+            healthy_deployments=healthy,
+            messages=None,
+            request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyA"}},
+        )
+        assert result == healthy
+
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp",
+            healthy_deployments=healthy,
+            messages=None,
+            request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyA"}},
+        )
+
+    # keyB, identical tag value, is unaffected -- it gets its own bucket and
+    # can admit up to the same limit independently of keyA's exhausted one.
+    for _ in range(2):
+        result = await limiter.async_filter_deployments(
+            model="grp",
+            healthy_deployments=healthy,
+            messages=None,
+            request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyB"}},
+        )
+        assert result == healthy
+
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp",
+            healthy_deployments=healthy,
+            messages=None,
+            request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyB"}},
+        )
+
+
+@pytest.mark.asyncio
+async def test_request_limit_without_scope_by_key_hash_still_shares_one_counter(time_controller):
+    """
+    Regression guard: scope_by_key_hash defaults to False, so today's
+    existing behavior -- the bucket is shared across every key sending the
+    same tag value -- must be unchanged. Two different keys sending the
+    identical tag value must still share one counter.
+    """
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {"request_limits": {"limits": [{"name": "per_minute", "tag_id": "end_user_id", "limit": 2, "period_seconds": 60}]}},
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    # keyA and keyB share the same bucket -- one call each exhausts the
+    # shared limit of 2.
+    await limiter.async_filter_deployments(
+        model="grp",
+        healthy_deployments=healthy,
+        messages=None,
+        request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyA"}},
+    )
+    await limiter.async_filter_deployments(
+        model="grp",
+        healthy_deployments=healthy,
+        messages=None,
+        request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyB"}},
+    )
+
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp",
+            healthy_deployments=healthy,
+            messages=None,
+            request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyA"}},
+        )
+
+
+@pytest.mark.asyncio
+async def test_concurrency_scope_by_key_hash_gives_independent_reservations_per_key(time_controller):
+    """
+    scope_by_key_hash=True on a concurrency_limits entry: two different
+    calling keys sending the identical tag value must not share one
+    reservation bucket -- keyA exhausting its own single slot must not
+    block keyB's admission, and releasing keyA's reservation (via the
+    standard_logging_object.metadata.user_api_key_hash channel) must free
+    keyA's capacity, not keyB's.
+    """
+    limiter = _make_limiter(time_controller)
+    router = _concurrency_router_scoped_by_key(limit=1)
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    logging_obj_a = _FakeLoggingObj()
+
+    # keyA occupies its own single slot.
+    await limiter.async_filter_deployments(
+        model="grp",
+        healthy_deployments=healthy,
+        messages=None,
+        request_kwargs={
+            "metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyA"},
+            "litellm_logging_obj": logging_obj_a,
+        },
+    )
+
+    # keyB, same tag value, different key -- must still admit since it has its own bucket.
+    await limiter.async_filter_deployments(
+        model="grp",
+        healthy_deployments=healthy,
+        messages=None,
+        request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyB"}},
+    )
+
+    # keyA is now at its own capacity -- a second keyA request is rejected.
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp",
+            healthy_deployments=healthy,
+            messages=None,
+            request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyA"}},
+        )
+
+    # Release keyA's reservation via the success event, matching its key hash.
+    logging_obj_a.model_call_details.update(
+        {
+            "standard_logging_object": {
+                "model_group": "grp",
+                "model_id": "dep-1",
+                "total_tokens": 0,
+                "response_cost": 0,
+                "metadata": {"user_api_key_hash": "keyA"},
+            },
+            "metadata": {"tags": ["end_user_id:u1"]},
+        }
+    )
+    await limiter.async_log_success_event(kwargs=logging_obj_a.model_call_details, response_obj=None, start_time=0, end_time=0)
+    await asyncio.sleep(0)
+
+    # keyA's capacity is freed -- a fresh keyA request now admits.
+    result = await limiter.async_filter_deployments(
+        model="grp",
+        healthy_deployments=healthy,
+        messages=None,
+        request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyA"}},
+    )
+    assert result == healthy
+
+    # keyB's own reservation is untouched by keyA's release -- a second keyB
+    # request is still rejected.
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp",
+            healthy_deployments=healthy,
+            messages=None,
+            request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyB"}},
+        )

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -692,6 +692,60 @@ async def test_concurrent_requests_sharing_a_caller_chosen_call_id_do_not_merge_
         )
 
 
+@pytest.mark.asyncio
+async def test_own_rejection_does_not_release_a_live_reservation(time_controller):
+    """
+    Security regression test: Router.async_callback_filter_deployments fires
+    async_log_failure_event for an exception raised from inside
+    async_filter_deployments itself (its own except block calls
+    logging_obj.async_failure_handler before re-raising) -- not only for an
+    actual provider-call failure. A rejection this hook raises for being
+    over its own limit never reserved anything for that specific attempt
+    (_atomic_check_and_increment already refunds any of its own earlier
+    admissions synchronously whenever it rejects), so releasing anyway would
+    decrement a live reservation belonging to a different, genuinely
+    in-flight request sharing the same tag -- letting a caller free up
+    capacity simply by retrying against an already-full bucket, no
+    coordination with another request required.
+    """
+    limiter = _make_limiter(time_controller)
+    router = _concurrency_router(limit=1)
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    # One legitimate request holds the only slot.
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+
+    # A second attempt is rejected -- capture the real exception this hook raises.
+    with pytest.raises(ProxyRateLimitError) as exc_info:
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
+
+    # Router's own exception handling fires async_log_failure_event for that
+    # rejection, exactly as Router.async_callback_filter_deployments does.
+    await limiter.async_log_failure_event(
+        kwargs={
+            "exception": exc_info.value,
+            "standard_logging_object": {"model_group": "grp"},
+            "metadata": {"tags": ["end_user_id:u1"]},
+        },
+        response_obj=None,
+        start_time=0,
+        end_time=0,
+    )
+
+    # The first request's reservation must still be held: a third attempt is
+    # still rejected. If the rejection's failure event had wrongly released
+    # it, this would wrongly admit instead.
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
+
+
 # ---------------------------------------------------------------------------
 # tokens / dollars -- read-then-account-on-success rejection path
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -863,3 +863,43 @@ async def test_release_floors_at_zero_instead_of_going_negative(time_controller)
     await limiter._decrement_floor_zero(key, -1.0)
     value = await limiter.internal_usage_cache.async_get_cache(key=key, litellm_parent_otel_span=None)
     assert (float(value) if value is not None else 0.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# a failed refund must not block refunding the rest of the batch or raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refund_failure_on_one_key_does_not_block_others_or_raise(time_controller):
+    """
+    If `_decrement_floor_zero` fails for one key mid-rollback (e.g. a
+    transient Redis error), the failure must be logged and swallowed, not
+    raised: otherwise it would surface as an unhandled exception in place of
+    the clean rejection the caller expects, and would abort the loop before
+    refunding every other already-committed key in the same batch.
+    """
+    failing_key = "{tag_rl:test:refund-fail:a}:requests"
+    other_key = "{tag_rl:test:refund-fail:b}:requests"
+    rejecting_key = "{tag_rl:test:refund-fail:c}:requests"
+
+    class _FlakyLimiter(_PROXY_TagRateLimiter):
+        async def _decrement_floor_zero(self, key: str, delta: float) -> None:
+            if key == failing_key:
+                raise RuntimeError("simulated transient redis failure")
+            await super()._decrement_floor_zero(key, delta)
+
+    flaky = _FlakyLimiter(internal_usage_cache=DualCache(), time_provider=time_controller.now)
+
+    failing_index, values = await flaky._atomic_check_and_increment(
+        [
+            (failing_key, 10.0, 1.0, 60),
+            (other_key, 10.0, 1.0, 60),
+            (rejecting_key, 0.0, 1.0, 60),
+        ]
+    )
+
+    assert failing_index == 2
+
+    other_value = await flaky.internal_usage_cache.async_get_cache(key=other_key, litellm_parent_otel_span=None)
+    assert (float(other_value) if other_value is not None else 0.0) == 0.0

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -542,6 +542,40 @@ async def test_concurrency_slot_released_on_failure_frees_capacity(time_controll
     assert result == healthy
 
 
+@pytest.mark.asyncio
+async def test_concurrency_slot_released_on_fallback_recovered_hop_failure(time_controller):
+    """
+    A hop that fails but gets recovered by a later fallback never reaches
+    async_post_call_failure_hook, which only fires once, if and when the
+    entire request (every fallback exhausted) ultimately fails. Only
+    async_log_failure_event fires for a per-hop failure that a fallback
+    recovers, so it alone must release that hop's reservation, or it leaks
+    until its safety TTL (up to an hour).
+    """
+    limiter = _make_limiter(time_controller)
+    router = _concurrency_router(limit=1)
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    request_kwargs = {"metadata": {"tags": ["end_user_id:u1"]}}
+    await limiter.async_filter_deployments(model="grp", healthy_deployments=healthy, messages=None, request_kwargs=request_kwargs)
+
+    # The failed hop's own logging kwargs, as they'd look mid-fallback-chain:
+    # model_group/model_id/metadata reflect this hop, not a later fallback.
+    failure_kwargs = {
+        "standard_logging_object": {"model_group": "grp", "model_id": "dep-1"},
+        "metadata": {"tags": ["end_user_id:u1"]},
+    }
+    await limiter.async_log_failure_event(kwargs=failure_kwargs, response_obj=None, start_time=0, end_time=0)
+
+    # async_post_call_failure_hook never fires for this hop (a fallback
+    # recovered it) -- capacity must already be free without it.
+    result = await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+    assert result == healthy
+
+
 # ---------------------------------------------------------------------------
 # tokens / dollars -- read-then-account-on-success rejection path
 # ---------------------------------------------------------------------------
@@ -722,30 +756,96 @@ def test_build_limits_index_is_also_keyed_by_team_public_model_name():
     checked.
     """
     deployment = _deployment("real-model-name", "dep-1", {"token_limits": {"limits": [{"name": "daily", "limit": 500, "period_seconds": 86400}]}})
+    deployment["model_info"]["team_id"] = "team-1"
     deployment["model_info"]["team_public_model_name"] = "team-alias-name"
     index = _build_limits_index([deployment])
-    assert "real-model-name" in index
-    assert "team-alias-name" in index
-    assert index["real-model-name"] == index["team-alias-name"]
+    assert index.resolve("real-model-name", team_id=None) == index.resolve("team-alias-name", team_id="team-1")
+    assert index.resolve("real-model-name", team_id=None) != []
+
+
+def test_build_limits_index_keeps_different_teams_same_alias_separate():
+    """
+    `team_public_model_name` is only unique per team: Router itself lets two
+    different teams publish the identical alias string for different
+    deployments, resolving each caller's own team's deployment by
+    `(team_id, name)` rather than by name alone. Keying the limits index by
+    name alone would let one team's config silently overwrite another's.
+    """
+    team_a = _deployment("model-a", "dep-a", {"token_limits": {"limits": [{"name": "daily", "limit": 100, "period_seconds": 86400}]}})
+    team_a["model_info"]["team_id"] = "team-a"
+    team_a["model_info"]["team_public_model_name"] = "shared-alias"
+
+    team_b = _deployment("model-b", "dep-b", {"token_limits": {"limits": [{"name": "daily", "limit": 999, "period_seconds": 86400}]}})
+    team_b["model_info"]["team_id"] = "team-b"
+    team_b["model_info"]["team_public_model_name"] = "shared-alias"
+
+    index = _build_limits_index([team_a, team_b])
+    resolved_a = index.resolve("shared-alias", team_id="team-a")
+    resolved_b = index.resolve("shared-alias", team_id="team-b")
+    assert resolved_a[0].entry.limit == 100
+    assert resolved_b[0].entry.limit == 999
 
 
 @pytest.mark.asyncio
 async def test_filter_deployments_enforces_limit_when_called_with_team_alias(time_controller):
     limiter = _make_limiter(time_controller)
     deployment = _deployment("real-model-name", "dep-1", {"request_limits": {"limits": [{"name": "daily", "tag_id": "end_user_id", "limit": 1, "period_seconds": 86400}]}})
+    deployment["model_info"]["team_id"] = "team-1"
     deployment["model_info"]["team_public_model_name"] = "team-alias-name"
     router = litellm.Router(model_list=[deployment])
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    # Router passes the alias as `model`, not "real-model-name".
+    # Router passes the alias as `model`, not "real-model-name", and threads
+    # the caller's team_id through request metadata.
+    request_kwargs = {"metadata": {"tags": ["end_user_id:u1"], "user_api_key_team_id": "team-1"}}
+    await limiter.async_filter_deployments(model="team-alias-name", healthy_deployments=healthy, messages=None, request_kwargs=request_kwargs)
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(model="team-alias-name", healthy_deployments=healthy, messages=None, request_kwargs=request_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_filter_deployments_does_not_cross_team_alias_boundary(time_controller):
+    """
+    Two teams sharing the same team_public_model_name must not share a
+    counter: a caller on team-b hitting the alias must not be limited (or
+    counted) by team-a's configured limit and usage.
+    """
+    limiter = _make_limiter(time_controller)
+    team_a = _deployment("model-a", "dep-a", {"request_limits": {"limits": [{"name": "daily", "tag_id": "end_user_id", "limit": 1, "period_seconds": 86400}]}})
+    team_a["model_info"]["team_id"] = "team-a"
+    team_a["model_info"]["team_public_model_name"] = "shared-alias"
+
+    team_b = _deployment("model-b", "dep-b", {"request_limits": {"limits": [{"name": "daily", "tag_id": "end_user_id", "limit": 5, "period_seconds": 86400}]}})
+    team_b["model_info"]["team_id"] = "team-b"
+    team_b["model_info"]["team_public_model_name"] = "shared-alias"
+
+    router = litellm.Router(model_list=[team_a, team_b])
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    # team-a exhausts its own limit of 1.
     await limiter.async_filter_deployments(
-        model="team-alias-name", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        model="shared-alias",
+        healthy_deployments=healthy,
+        messages=None,
+        request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key_team_id": "team-a"}},
     )
     with pytest.raises(ProxyRateLimitError):
         await limiter.async_filter_deployments(
-            model="team-alias-name", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+            model="shared-alias",
+            healthy_deployments=healthy,
+            messages=None,
+            request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key_team_id": "team-a"}},
         )
+
+    # team-b, same alias string and same tag value, is unaffected by team-a's exhausted limit.
+    await limiter.async_filter_deployments(
+        model="shared-alias",
+        healthy_deployments=healthy,
+        messages=None,
+        request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key_team_id": "team-b"}},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -9,6 +9,7 @@ import pytest
 
 import litellm
 from litellm.caching.dual_cache import DualCache
+from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
 from litellm.proxy.hooks.tag_rate_limiter import (
     _build_group_limits,
@@ -139,6 +140,14 @@ async def test_filter_deployments_noop_without_config(time_controller):
 
 @pytest.mark.asyncio
 async def test_filter_deployments_allows_under_limit_and_rejects_at_limit(time_controller):
+    """
+    "requests" admission is atomic check-and-increment at the filter step
+    itself (not a separate read-then-account-later pass), so two concurrent
+    requests can never both read "1 under limit" and both get admitted past
+    a limit of 2 -- each call's own increment is immediately visible to the
+    next. Calling the filter 3 times with limit=2 must admit exactly 2 and
+    reject the 3rd.
+    """
     limiter = _make_limiter(time_controller)
     router = litellm.Router(
         model_list=[
@@ -151,23 +160,22 @@ async def test_filter_deployments_allows_under_limit_and_rejects_at_limit(time_c
     )
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
-    request_kwargs = {"metadata": {"tags": ["end_user_id:u1"]}}
 
-    # Under limit: allowed, no bucket seeded yet.
-    result = await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=request_kwargs
-    )
-    assert result == healthy
-
-    # Seed the bucket at the limit (2 requests already accounted).
-    now = time_controller.now().timestamp()
-    bucket_id = int(now) // 60
-    key = f"{{tag_rl:grp:requests:per_minute:chain:u1}}:{bucket_id}"
-    await limiter.internal_usage_cache.async_set_cache(key=key, value=2, ttl=60, litellm_parent_otel_span=None)
+    for _ in range(2):
+        result = await limiter.async_filter_deployments(
+            model="grp",
+            healthy_deployments=healthy,
+            messages=None,
+            request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}},
+        )
+        assert result == healthy
 
     with pytest.raises(ProxyRateLimitError) as exc_info:
         await limiter.async_filter_deployments(
-            model="grp", healthy_deployments=healthy, messages=None, request_kwargs=request_kwargs
+            model="grp",
+            healthy_deployments=healthy,
+            messages=None,
+            request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}},
         )
     assert exc_info.value.status_code == 429
     assert exc_info.value.detail["tag_value"] == "u1"
@@ -297,9 +305,233 @@ async def test_log_success_event_increments_configured_units(time_controller):
 
     now = time_controller.now().timestamp()
     token_key = f"{{tag_rl:grp:tokens:daily:chain:u1}}:{int(now) // 86400}"
-    request_key = f"{{tag_rl:grp:requests:daily:chain:u1}}:{int(now) // 86400}"
     dollar_key = f"{{tag_rl:grp:dollars:monthly:chain:u1}}:{int(now) // 2592000}"
 
     assert float(await limiter.internal_usage_cache.async_get_cache(key=token_key, litellm_parent_otel_span=None)) == 42.0
-    assert float(await limiter.internal_usage_cache.async_get_cache(key=request_key, litellm_parent_otel_span=None)) == 1.0
     assert float(await limiter.internal_usage_cache.async_get_cache(key=dollar_key, litellm_parent_otel_span=None)) == 0.01
+
+    # "requests" is accounted atomically at admission (async_filter_deployments),
+    # not here -- async_log_success_event must not touch its bucket at all.
+    request_key = f"{{tag_rl:grp:requests:daily:chain:u1}}:{int(now) // 86400}"
+    assert await limiter.internal_usage_cache.async_get_cache(key=request_key, litellm_parent_otel_span=None) is None
+
+
+# ---------------------------------------------------------------------------
+# concurrency limits -- reserve at admission, release on success/failure
+# ---------------------------------------------------------------------------
+
+
+def _concurrency_router(limit: int) -> "litellm.Router":
+    return litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {
+                    "concurrency_limits": {
+                        "limits": [{"name": "inflight", "tag_id": "end_user_id", "limit": limit, "period_seconds": 300}]
+                    }
+                },
+            )
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_cross_unit_rejection_does_not_leave_a_phantom_increment(time_controller):
+    """
+    Regression test: a chain with BOTH a requests limit and a concurrency
+    limit on the same tag checks both atomically in one
+    async_filter_deployments call. If the concurrency check rejects the hop,
+    the requests-unit check (evaluated in the same call, and which would have
+    been admitted on its own) must NOT have incremented its counter --
+    otherwise a rejected hop silently burns through the caller's requests
+    budget for a call that never actually went through.
+    """
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {
+                    "request_limits": {
+                        "limits": [{"name": "per_minute", "tag_id": "end_user_id", "limit": 10, "period_seconds": 60}]
+                    },
+                    "concurrency_limits": {
+                        "limits": [{"name": "inflight", "tag_id": "end_user_id", "limit": 1, "period_seconds": 300}]
+                    },
+                },
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    # Occupy the one concurrency slot.
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+
+    # A second attempt: requests-unit alone would admit (well under 10), but
+    # concurrency is exhausted, so the whole hop must reject -- and the
+    # requests counter must remain untouched by this rejected attempt.
+    with pytest.raises(ProxyRateLimitError) as exc_info:
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
+    assert exc_info.value.detail["type"] == "concurrency"
+
+    now = time_controller.now().timestamp()
+    request_key = f"{{tag_rl:grp:requests:per_minute:chain:u1}}:{int(now) // 60}"
+    requests_value = await limiter.internal_usage_cache.async_get_cache(key=request_key, litellm_parent_otel_span=None)
+    assert (float(requests_value) if requests_value is not None else 0.0) == 1.0
+
+
+@pytest.mark.asyncio
+async def test_concurrency_limit_rejects_third_concurrent_reservation(time_controller):
+    limiter = _make_limiter(time_controller)
+    router = _concurrency_router(limit=2)
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    kwargs_1 = {"metadata": {"tags": ["end_user_id:u1"]}}
+    kwargs_2 = {"metadata": {"tags": ["end_user_id:u1"]}}
+    await limiter.async_filter_deployments(model="grp", healthy_deployments=healthy, messages=None, request_kwargs=kwargs_1)
+    await limiter.async_filter_deployments(model="grp", healthy_deployments=healthy, messages=None, request_kwargs=kwargs_2)
+
+    with pytest.raises(ProxyRateLimitError) as exc_info:
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
+    assert exc_info.value.detail["type"] == "concurrency"
+
+
+@pytest.mark.asyncio
+async def test_requests_admission_is_race_free_under_genuine_concurrency(time_controller):
+    """
+    The concrete race a read-then-account-later design would allow: N
+    coroutines all read "under limit" before any of them increments, and all
+    N get admitted even past the limit. Firing many concurrent filter calls
+    at once (asyncio.gather, not sequential awaits) must admit exactly
+    `limit`, never more -- the atomic check-and-increment closes the window
+    a plain GET-then-SET could not.
+    """
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {"request_limits": {"limits": [{"name": "per_minute", "tag_id": "end_user_id", "limit": 5, "period_seconds": 60}]}},
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    async def attempt():
+        try:
+            await limiter.async_filter_deployments(
+                model="grp",
+                healthy_deployments=healthy,
+                messages=None,
+                request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}},
+            )
+            return True
+        except ProxyRateLimitError:
+            return False
+
+    results = await asyncio.gather(*(attempt() for _ in range(20)))
+    assert sum(results) == 5
+
+
+@pytest.mark.asyncio
+async def test_index_refreshes_after_ttl_for_length_preserving_update(time_controller):
+    """
+    Editing an existing deployment's tag_rate_limits in place (same
+    len(model_list), so the (id(router), len) staleness check alone can't
+    detect it) must eventually be picked up -- bounded by the index TTL,
+    not indefinitely stale.
+    """
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {"request_limits": {"limits": [{"name": "daily", "tag_id": "end_user_id", "limit": 1, "period_seconds": 86400}]}},
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
+
+    # Same length, deployment mutated in place -- raise the limit to 100.
+    router.model_list[0]["model_info"]["tag_rate_limits"] = {
+        "request_limits": {"limits": [{"name": "daily", "tag_id": "end_user_id", "limit": 100, "period_seconds": 86400}]}
+    }
+
+    time_controller.advance(6)  # past _INDEX_TTL_SECONDS
+
+    result = await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=router.model_list, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+    assert result == router.model_list
+
+
+@pytest.mark.asyncio
+async def test_concurrency_slot_released_on_success_frees_capacity(time_controller):
+    limiter = _make_limiter(time_controller)
+    router = _concurrency_router(limit=1)
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    kwargs = {"metadata": {"tags": ["end_user_id:u1"]}}
+    await limiter.async_filter_deployments(model="grp", healthy_deployments=healthy, messages=None, request_kwargs=kwargs)
+
+    # At capacity: a second concurrent request is rejected.
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
+
+    # The first request completes -- its slot is released -- freeing capacity again.
+    kwargs["standard_logging_object"] = {"model_group": "grp", "model_id": "dep-1", "total_tokens": 0, "response_cost": 0}
+    await limiter.async_log_success_event(kwargs=kwargs, response_obj=None, start_time=0, end_time=0)
+    await asyncio.sleep(0)
+
+    result = await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+    assert result == healthy
+
+
+@pytest.mark.asyncio
+async def test_concurrency_slot_released_on_failure_frees_capacity(time_controller):
+    limiter = _make_limiter(time_controller)
+    router = _concurrency_router(limit=1)
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    kwargs = {"metadata": {"tags": ["end_user_id:u1"]}}
+    await limiter.async_filter_deployments(model="grp", healthy_deployments=healthy, messages=None, request_kwargs=kwargs)
+
+    await limiter.async_post_call_failure_hook(
+        request_data=kwargs,
+        original_exception=Exception("provider error"),
+        user_api_key_dict=UserAPIKeyAuth(),
+    )
+
+    result = await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+    assert result == healthy

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -3,6 +3,7 @@ Unit tests for tag-scoped token/request/dollar rate limiting.
 """
 
 import asyncio
+import uuid
 from datetime import datetime, timedelta
 
 import pytest
@@ -535,3 +536,168 @@ async def test_concurrency_slot_released_on_failure_frees_capacity(time_controll
         model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
     )
     assert result == healthy
+
+
+# ---------------------------------------------------------------------------
+# tokens / dollars -- read-then-account-on-success rejection path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_token_limit_rejects_once_bucket_is_seeded_at_limit(time_controller):
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {"token_limits": {"limits": [{"name": "daily", "tag_id": "end_user_id", "limit": 1000, "period_seconds": 86400}]}},
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    now = time_controller.now().timestamp()
+    key = f"{{tag_rl:grp:tokens:daily:chain:u1}}:{int(now) // 86400}"
+    await limiter.internal_usage_cache.async_set_cache(key=key, value=1000, ttl=86400, litellm_parent_otel_span=None)
+
+    with pytest.raises(ProxyRateLimitError) as exc_info:
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
+    assert exc_info.value.detail["type"] == "tokens"
+    assert exc_info.value.detail["limit_name"] == "daily"
+
+
+@pytest.mark.asyncio
+async def test_dollar_limit_rejects_once_bucket_is_seeded_at_limit(time_controller):
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {"dollar_limits": {"limits": [{"name": "monthly", "tag_id": "team_id", "limit": 50.0, "period_seconds": 2592000}]}},
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    now = time_controller.now().timestamp()
+    key = f"{{tag_rl:grp:dollars:monthly:chain:t1}}:{int(now) // 2592000}"
+    await limiter.internal_usage_cache.async_set_cache(key=key, value=50.0, ttl=2592000, litellm_parent_otel_span=None)
+
+    with pytest.raises(ProxyRateLimitError) as exc_info:
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["team_id:t1"]}}
+        )
+    assert exc_info.value.detail["type"] == "dollars"
+    assert exc_info.value.detail["tag_value"] == "t1"
+
+
+# ---------------------------------------------------------------------------
+# Real Redis -- the atomic Lua path, not just the in-memory fallback
+# ---------------------------------------------------------------------------
+
+
+def _redis_limiter(time_controller: TimeController):
+    import os
+
+    from litellm.caching.redis_cache import RedisCache
+
+    redis_host = os.getenv("REDIS_HOST")
+    redis_port = os.getenv("REDIS_PORT")
+    if not redis_host or not redis_port:
+        pytest.skip("Redis environment variables (REDIS_HOST, REDIS_PORT) not set")
+    redis_cache = RedisCache(host=redis_host, port=int(redis_port), password=os.getenv("REDIS_PASSWORD"))
+    dual_cache = DualCache(redis_cache=redis_cache)
+    return _PROXY_TagRateLimiter(internal_usage_cache=dual_cache, time_provider=time_controller.now), redis_cache
+
+
+@pytest.mark.asyncio
+async def test_redis_backed_requests_admission_is_race_free_under_genuine_concurrency(time_controller):
+    """
+    Same race-freedom guarantee as the in-memory test, but against a real
+    Redis instance so the Lua script path (not just the asyncio.Lock
+    fallback) is exercised -- this is the code path every multi-instance
+    proxy deployment actually runs.
+    """
+    limiter, redis_cache = _redis_limiter(time_controller)
+    try:
+        await redis_cache.ping()
+    except Exception as e:
+        pytest.skip(f"Redis connection failed: {str(e)}")
+
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {"request_limits": {"limits": [{"name": "per_minute", "tag_id": "end_user_id", "limit": 5, "period_seconds": 60}]}},
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+    tag = f"redis-race-{uuid.uuid4().hex}"
+
+    async def attempt():
+        try:
+            await limiter.async_filter_deployments(
+                model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": [f"end_user_id:{tag}"]}}
+            )
+            return True
+        except ProxyRateLimitError:
+            return False
+
+    results = await asyncio.gather(*(attempt() for _ in range(20)))
+    assert sum(results) == 5
+
+
+@pytest.mark.asyncio
+async def test_redis_backed_cross_unit_rejection_does_not_leave_a_phantom_increment(time_controller):
+    """Redis-Lua-script equivalent of the in-memory phantom-increment regression test."""
+    limiter, redis_cache = _redis_limiter(time_controller)
+    try:
+        await redis_cache.ping()
+    except Exception as e:
+        pytest.skip(f"Redis connection failed: {str(e)}")
+
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {
+                    "request_limits": {
+                        "limits": [{"name": "per_minute", "tag_id": "end_user_id", "limit": 10, "period_seconds": 60}]
+                    },
+                    "concurrency_limits": {
+                        "limits": [{"name": "inflight", "tag_id": "end_user_id", "limit": 1, "period_seconds": 300}]
+                    },
+                },
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+    tag = f"redis-phantom-check-{uuid.uuid4().hex}"
+
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": [f"end_user_id:{tag}"]}}
+    )
+    with pytest.raises(ProxyRateLimitError) as exc_info:
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": [f"end_user_id:{tag}"]}}
+        )
+    assert exc_info.value.detail["type"] == "concurrency"
+
+    now = time_controller.now().timestamp()
+    request_key = f"{{tag_rl:grp:requests:per_minute:chain:{tag}}}:{int(now) // 60}"
+    requests_value = await limiter.internal_usage_cache.async_get_cache(key=request_key, litellm_parent_otel_span=None)
+    assert (float(requests_value) if requests_value is not None else 0.0) == 1.0
+
+    # cleanup: this key persists in the shared scratch Redis instance beyond the test's TTL otherwise
+    await redis_cache.async_delete_cache(key=request_key)

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -342,6 +342,24 @@ def _concurrency_router(limit: int) -> "litellm.Router":
     )
 
 
+class _FakeLoggingObj:
+    """
+    Stands in for litellm's real `Logging` object: the same instance is
+    threaded through every hop of one logical request (retries and
+    fallbacks alike), and its `model_call_details` dict is exactly the
+    `kwargs` a logging callback receives -- see
+    `_accumulate_pending_concurrency_keys`'s docstring for why this is the
+    one piece of state that reliably survives across hops.
+    """
+
+    def __init__(self):
+        self.model_call_details: dict = {}
+
+
+def _hop_kwargs(logging_obj: "_FakeLoggingObj", tags: list[str]) -> dict:
+    return {"metadata": {"tags": tags}, "litellm_logging_obj": logging_obj}
+
+
 @pytest.mark.asyncio
 async def test_cross_unit_rejection_does_not_leave_a_phantom_increment(time_controller):
     """
@@ -500,8 +518,10 @@ async def test_concurrency_slot_released_on_success_frees_capacity(time_controll
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    kwargs = {"metadata": {"tags": ["end_user_id:u1"]}}
-    await limiter.async_filter_deployments(model="grp", healthy_deployments=healthy, messages=None, request_kwargs=kwargs)
+    logging_obj = _FakeLoggingObj()
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+    )
 
     # At capacity: a second concurrent request is rejected.
     with pytest.raises(ProxyRateLimitError):
@@ -510,8 +530,13 @@ async def test_concurrency_slot_released_on_success_frees_capacity(time_controll
         )
 
     # The first request completes -- its slot is released -- freeing capacity again.
-    kwargs["standard_logging_object"] = {"model_group": "grp", "model_id": "dep-1", "total_tokens": 0, "response_cost": 0}
-    await limiter.async_log_success_event(kwargs=kwargs, response_obj=None, start_time=0, end_time=0)
+    logging_obj.model_call_details.update(
+        {
+            "standard_logging_object": {"model_group": "grp", "model_id": "dep-1", "total_tokens": 0, "response_cost": 0},
+            "metadata": {"tags": ["end_user_id:u1"]},
+        }
+    )
+    await limiter.async_log_success_event(kwargs=logging_obj.model_call_details, response_obj=None, start_time=0, end_time=0)
     await asyncio.sleep(0)
 
     result = await limiter.async_filter_deployments(
@@ -527,16 +552,13 @@ async def test_concurrency_slot_released_on_failure_frees_capacity(time_controll
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
+    logging_obj = _FakeLoggingObj()
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
     )
 
-    await limiter.async_log_failure_event(
-        kwargs={"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
-        response_obj=None,
-        start_time=0,
-        end_time=0,
-    )
+    logging_obj.model_call_details.update({"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}})
+    await limiter.async_log_failure_event(kwargs=logging_obj.model_call_details, response_obj=None, start_time=0, end_time=0)
 
     result = await limiter.async_filter_deployments(
         model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
@@ -545,33 +567,96 @@ async def test_concurrency_slot_released_on_failure_frees_capacity(time_controll
 
 
 @pytest.mark.asyncio
-async def test_concurrency_slot_released_on_fallback_recovered_hop_failure(time_controller):
+async def test_concurrency_released_for_every_hop_when_only_the_first_failure_fires(time_controller):
     """
-    A hop that fails but gets recovered by a later fallback never reaches
-    `async_post_call_failure_hook` (which this limiter deliberately does not
-    implement -- see its removal note on `async_log_failure_event`), since
-    that hook only fires once, if and when the entire request (every
-    fallback exhausted) ultimately fails. Only `async_log_failure_event`
-    fires for a per-hop failure that a fallback recovers, so it alone must
-    release that hop's reservation, or it leaks until its safety TTL (up to
-    an hour).
+    litellm dedupes `async_log_failure_event` to fire once per logical
+    request: only the first failed hop's failure reaches it (see
+    `Logging.has_run_logging`'s `has_logged_async_failure` guard); a later
+    failed hop (a retry, or a further fallback) never gets its own failure
+    event at all. Reservations still accumulate at admission for every hop
+    regardless, so whichever event fires next must release everything
+    accumulated since the last release, not just its own hop's key, or a
+    hop whose failure event never fired leaks until its safety TTL.
     """
     limiter = _make_limiter(time_controller)
-    router = _concurrency_router(limit=1)
+    router = _concurrency_router(limit=2)
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
+    logging_obj = _FakeLoggingObj()
 
-    request_kwargs = {"metadata": {"tags": ["end_user_id:u1"]}}
-    await limiter.async_filter_deployments(model="grp", healthy_deployments=healthy, messages=None, request_kwargs=request_kwargs)
+    # Hop 1 admits and fails; its failure event is the one that fires.
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+    )
+    logging_obj.model_call_details.update({"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}})
+    await limiter.async_log_failure_event(kwargs=logging_obj.model_call_details, response_obj=None, start_time=0, end_time=0)
 
-    # The failed hop's own logging kwargs, as they'd look mid-fallback-chain:
-    # model_group/model_id/metadata reflect this hop, not a later fallback.
-    failure_kwargs = {
-        "standard_logging_object": {"model_group": "grp", "model_id": "dep-1"},
-        "metadata": {"tags": ["end_user_id:u1"]},
-    }
-    await limiter.async_log_failure_event(kwargs=failure_kwargs, response_obj=None, start_time=0, end_time=0)
+    # Hop 2 (a retry or fallback) admits and also fails, but -- per litellm's
+    # dedup -- no async_log_failure_event call follows it.
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+    )
 
+    # Hop 3 admits and succeeds. Its success event must release both hop 2's
+    # still-pending reservation and its own.
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+    )
+    logging_obj.model_call_details.update(
+        {"standard_logging_object": {"model_group": "grp", "model_id": "dep-1", "total_tokens": 0, "response_cost": 0}}
+    )
+    await limiter.async_log_success_event(kwargs=logging_obj.model_call_details, response_obj=None, start_time=0, end_time=0)
+    await asyncio.sleep(0)
+
+    # Full capacity (2) is free again -- both hops admit.
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+    result = await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+    assert result == healthy
+
+
+@pytest.mark.asyncio
+async def test_concurrency_released_by_terminal_hook_when_every_hop_fails(time_controller):
+    """
+    Same dedup as above, but no hop ever succeeds: the whole request is
+    exhausted after every retry/fallback fails. Neither `async_log_success_event`
+    nor a second `async_log_failure_event` will ever fire for this request,
+    so `async_post_call_failure_hook` -- which fires once, from the proxy
+    route handler, only when the entire request is exhausted -- must release
+    everything still accumulated.
+    """
+    limiter = _make_limiter(time_controller)
+    router = _concurrency_router(limit=2)
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+    logging_obj = _FakeLoggingObj()
+
+    # Hop 1 admits and fails; its failure event fires and clears the list.
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+    )
+    logging_obj.model_call_details.update({"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}})
+    await limiter.async_log_failure_event(kwargs=logging_obj.model_call_details, response_obj=None, start_time=0, end_time=0)
+
+    # Hop 2 admits and is the terminal failure -- no fallback left. Per
+    # litellm's dedup, its own async_log_failure_event never fires either.
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj, ["end_user_id:u1"])
+    )
+
+    await limiter.async_post_call_failure_hook(
+        request_data={"model": "grp", "litellm_logging_obj": logging_obj, "metadata": {"tags": ["end_user_id:u1"]}},
+        original_exception=Exception("provider error"),
+        user_api_key_dict=UserAPIKeyAuth(),
+    )
+
+    # Full capacity (2) is free again.
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
     result = await limiter.async_filter_deployments(
         model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
     )
@@ -581,49 +666,48 @@ async def test_concurrency_slot_released_on_fallback_recovered_hop_failure(time_
 @pytest.mark.asyncio
 async def test_terminal_failure_does_not_double_release_and_steal_another_requests_slot(time_controller):
     """
-    The inflight counter is aggregate per tag, not per-request: if a terminal
-    failure's reservation were released twice (once each by
-    `async_post_call_failure_hook` and `async_log_failure_event`), the second
-    release would silently free capacity belonging to a different,
-    still-running request sharing the same tag, admitting one more
-    concurrent request than configured. This limiter deliberately does not
-    implement `async_post_call_failure_hook`, so calling it (as the proxy
-    still would, falling through to the CustomLogger base no-op) must have
-    no effect on the counter.
+    The inflight counter is aggregate per tag, not per-request: if a
+    terminal failure's reservation were released twice (once each by
+    `async_post_call_failure_hook` and `async_log_failure_event`, both
+    firing for the same single-hop failure), the second release would
+    silently free capacity belonging to a different, still-running request
+    sharing the same tag, admitting one more concurrent request than
+    configured. Both hooks release from the same shared accumulated-keys
+    state, so whichever fires first drains it and the other finds nothing
+    left.
     """
     limiter = _make_limiter(time_controller)
     router = _concurrency_router(limit=2)
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    # Two concurrent requests at capacity.
+    logging_obj_a = _FakeLoggingObj()
+    logging_obj_b = _FakeLoggingObj()
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj_a, ["end_user_id:u1"])
     )
     await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs=_hop_kwargs(logging_obj_b, ["end_user_id:u1"])
     )
 
-    # One of them fails terminally.
-    await limiter.async_log_failure_event(
-        kwargs={"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
-        response_obj=None,
-        start_time=0,
-        end_time=0,
-    )
+    # A fails terminally: both its failure event and the terminal post-call
+    # hook fire for the same single hop, against the same shared state.
+    logging_obj_a.model_call_details.update({"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}})
+    await limiter.async_log_failure_event(kwargs=logging_obj_a.model_call_details, response_obj=None, start_time=0, end_time=0)
     await limiter.async_post_call_failure_hook(
-        request_data={"model": "grp", "metadata": {"tags": ["end_user_id:u1"]}},
+        request_data={"model": "grp", "litellm_logging_obj": logging_obj_a, "metadata": {"tags": ["end_user_id:u1"]}},
         original_exception=Exception("provider error"),
         user_api_key_dict=UserAPIKeyAuth(),
     )
 
-    # Exactly one slot was freed: a third request is admitted (back to 2 in flight)...
+    # Exactly A's one slot was freed: B's reservation is untouched, so a
+    # third request is admitted (back to 2 in flight)...
     result = await limiter.async_filter_deployments(
         model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
     )
     assert result == healthy
-    # ...but a fourth would exceed the limit of 2. If the failure had freed a
-    # second slot, this would wrongly be admitted instead of rejected.
+    # ...but a fourth would exceed the limit of 2. If A's failure had freed a
+    # second slot (double release), this would wrongly be admitted.
     with pytest.raises(ProxyRateLimitError):
         await limiter.async_filter_deployments(
             model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -224,8 +224,63 @@ async def test_filter_deployments_per_entry_fail_open_when_tag_absent(time_contr
 
     now = time_controller.now().timestamp()
     team_bucket_id = int(now) // 2592000
-    team_key = f"{{tag_rl:grp:requests:monthly:chain:whatever}}:{team_bucket_id}"
+    team_key = f"{{tag_rl:grp:requests:monthly:team_id:chain:whatever}}:{team_bucket_id}"
     assert await limiter.internal_usage_cache.async_get_cache(key=team_key, litellm_parent_otel_span=None) is None
+
+
+@pytest.mark.asyncio
+async def test_different_tag_ids_with_same_name_do_not_share_a_counter(time_controller):
+    """
+    Regression test: the key format used to omit `tag_id`, so two
+    independently configured entries sharing the same unit/name (here both
+    named "daily") but keyed on different tag_ids would collide whenever a
+    caller's value for one tag_id happened to equal another caller's value
+    for the other tag_id. With equal limits of 1, a colliding shared counter
+    would make team_id "u1"'s very first request get wrongly rejected right
+    after end_user_id "u1"'s own first (and separately limited) request --
+    the failure mode a higher team_id limit would have masked.
+    """
+    limiter = _make_limiter(time_controller)
+    router = litellm.Router(
+        model_list=[
+            _deployment(
+                "grp",
+                "dep-1",
+                {
+                    "request_limits": {
+                        "limits": [
+                            {"name": "daily", "tag_id": "end_user_id", "limit": 1, "period_seconds": 86400},
+                            {"name": "daily", "tag_id": "team_id", "limit": 1, "period_seconds": 86400},
+                        ]
+                    }
+                },
+            )
+        ]
+    )
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    # end_user_id "u1" makes its one allowed request.
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
+
+    # team_id "u1" -- identical value, different tag_id, its own untouched
+    # limit of 1 -- must still admit its first request.
+    result = await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["team_id:u1"]}}
+    )
+    assert result == healthy
+
+    # Both identities are now genuinely at their own limit of 1.
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["team_id:u1"]}}
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -263,7 +318,7 @@ async def test_load_balanced_group_per_deployment_breach_rejects_whole_hop(time_
 
     now = time_controller.now().timestamp()
     bucket_id = int(now) // 86400
-    dep1_key = f"{{tag_rl:grp:requests:daily:dep:dep-1:u1}}:{bucket_id}"
+    dep1_key = f"{{tag_rl:grp:requests:daily:end_user_id:dep:dep-1:u1}}:{bucket_id}"
     await limiter.internal_usage_cache.async_set_cache(key=dep1_key, value=1, ttl=86400, litellm_parent_otel_span=None)
 
     with pytest.raises(ProxyRateLimitError):
@@ -309,15 +364,15 @@ async def test_log_success_event_increments_configured_units(time_controller):
     await asyncio.sleep(0)
 
     now = time_controller.now().timestamp()
-    token_key = f"{{tag_rl:grp:tokens:daily:chain:u1}}:{int(now) // 86400}"
-    dollar_key = f"{{tag_rl:grp:dollars:monthly:chain:u1}}:{int(now) // 2592000}"
+    token_key = f"{{tag_rl:grp:tokens:daily:end_user_id:chain:u1}}:{int(now) // 86400}"
+    dollar_key = f"{{tag_rl:grp:dollars:monthly:end_user_id:chain:u1}}:{int(now) // 2592000}"
 
     assert float(await limiter.internal_usage_cache.async_get_cache(key=token_key, litellm_parent_otel_span=None)) == 42.0
     assert float(await limiter.internal_usage_cache.async_get_cache(key=dollar_key, litellm_parent_otel_span=None)) == 0.01
 
     # "requests" is accounted atomically at admission (async_filter_deployments),
     # not here -- async_log_success_event must not touch its bucket at all.
-    request_key = f"{{tag_rl:grp:requests:daily:chain:u1}}:{int(now) // 86400}"
+    request_key = f"{{tag_rl:grp:requests:daily:end_user_id:chain:u1}}:{int(now) // 86400}"
     assert await limiter.internal_usage_cache.async_get_cache(key=request_key, litellm_parent_otel_span=None) is None
 
 
@@ -395,7 +450,7 @@ async def test_cross_unit_rejection_does_not_leave_a_phantom_increment(time_cont
     assert exc_info.value.detail["type"] == "concurrency"
 
     now = time_controller.now().timestamp()
-    request_key = f"{{tag_rl:grp:requests:per_minute:chain:u1}}:{int(now) // 60}"
+    request_key = f"{{tag_rl:grp:requests:per_minute:end_user_id:chain:u1}}:{int(now) // 60}"
     requests_value = await limiter.internal_usage_cache.async_get_cache(key=request_key, litellm_parent_otel_span=None)
     assert (float(requests_value) if requests_value is not None else 0.0) == 1.0
 
@@ -751,7 +806,7 @@ async def test_token_limit_rejects_once_bucket_is_seeded_at_limit(time_controlle
     healthy = router.model_list
 
     now = time_controller.now().timestamp()
-    key = f"{{tag_rl:grp:tokens:daily:chain:u1}}:{int(now) // 86400}"
+    key = f"{{tag_rl:grp:tokens:daily:end_user_id:chain:u1}}:{int(now) // 86400}"
     await limiter.internal_usage_cache.async_set_cache(key=key, value=1000, ttl=86400, litellm_parent_otel_span=None)
 
     with pytest.raises(ProxyRateLimitError) as exc_info:
@@ -778,7 +833,7 @@ async def test_dollar_limit_rejects_once_bucket_is_seeded_at_limit(time_controll
     healthy = router.model_list
 
     now = time_controller.now().timestamp()
-    key = f"{{tag_rl:grp:dollars:monthly:chain:t1}}:{int(now) // 2592000}"
+    key = f"{{tag_rl:grp:dollars:monthly:team_id:chain:t1}}:{int(now) // 2592000}"
     await limiter.internal_usage_cache.async_set_cache(key=key, value=50.0, ttl=2592000, litellm_parent_otel_span=None)
 
     with pytest.raises(ProxyRateLimitError) as exc_info:
@@ -887,7 +942,7 @@ async def test_redis_backed_cross_unit_rejection_does_not_leave_a_phantom_increm
     assert exc_info.value.detail["type"] == "concurrency"
 
     now = time_controller.now().timestamp()
-    request_key = f"{{tag_rl:grp:requests:per_minute:chain:{tag}}}:{int(now) // 60}"
+    request_key = f"{{tag_rl:grp:requests:per_minute:end_user_id:chain:{tag}}}:{int(now) // 60}"
     requests_value = await limiter.internal_usage_cache.async_get_cache(key=request_key, litellm_parent_otel_span=None)
     assert (float(requests_value) if requests_value is not None else 0.0) == 1.0
 
@@ -1100,7 +1155,7 @@ async def test_cross_unit_refund_leaves_no_phantom_increment_in_memory(time_cont
         )
 
     now = time_controller.now().timestamp()
-    request_key = f"{{tag_rl:grp:requests:per_minute:chain:refund-check}}:{int(now) // 60}"
+    request_key = f"{{tag_rl:grp:requests:per_minute:end_user_id:chain:refund-check}}:{int(now) // 60}"
     value = await limiter.internal_usage_cache.async_get_cache(key=request_key, litellm_parent_otel_span=None)
     assert (float(value) if value is not None else 0.0) == 1.0
 

--- a/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py
@@ -633,63 +633,155 @@ async def test_concurrency_slot_released_on_fallback_recovered_hop_failure(time_
 
 
 @pytest.mark.asyncio
-async def test_concurrent_requests_sharing_a_caller_chosen_call_id_do_not_merge_reservations(time_controller):
+async def test_pending_concurrency_context_does_not_leak_across_concurrent_tasks(time_controller):
     """
-    Security regression test: litellm_call_id is caller-controlled (a
-    request can set the x-litellm-call-id header to any value; litellm only
-    generates one itself when the header is absent). An earlier design
-    correlated reservations across hops using litellm_call_id as a registry
-    key; two genuinely concurrent, unrelated requests that happened to reuse
-    the same caller-chosen value would have had their reservations merged
-    into one registry entry, so one request completing released the other's
-    still-active slot -- bypassing the configured concurrency cap entirely
-    for that identity. Release must never depend on any caller-supplied
-    identifier: two concurrent admissions sharing the identical
-    litellm_call_id must still each require their own release.
+    Security regression test, current design: `_pending_concurrency_keys` is
+    a `contextvars.ContextVar`, isolated per asyncio task/context rather
+    than a plain shared dict or list -- which matters because two genuinely
+    concurrent, unrelated requests each get their own task in production (a
+    hard ASGI guarantee, not something litellm or this hook controls), so
+    they can never share a context regardless of what identifiers (tags,
+    keys, litellm_call_id) they happen to reuse. Prove this directly: if
+    this were a shared collection instead of a real `ContextVar`, one task's
+    own release would incorrectly drain the other task's still-pending
+    reservation too, since nothing would distinguish which task accumulated
+    which key. An earlier design correlated reservations using
+    litellm_call_id specifically -- caller-controlled via the
+    x-litellm-call-id header -- as a registry key; that's what let two
+    unrelated concurrent requests merge reservations in the first place, and
+    is why this test isolates via real tasks rather than a shared id at all.
     """
     limiter = _make_limiter(time_controller)
     router = _concurrency_router(limit=2)
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    shared_call_id = "attacker-chosen-value"
-    await limiter.async_filter_deployments(
-        model="grp",
-        healthy_deployments=healthy,
-        messages=None,
-        request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}, "litellm_call_id": shared_call_id},
-    )
-    await limiter.async_filter_deployments(
-        model="grp",
-        healthy_deployments=healthy,
-        messages=None,
-        request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}, "litellm_call_id": shared_call_id},
-    )
+    async def _admit(tag_value):
+        await limiter.async_filter_deployments(
+            model="grp",
+            healthy_deployments=healthy,
+            messages=None,
+            request_kwargs={"metadata": {"tags": [f"end_user_id:{tag_value}"]}},
+        )
 
-    # Both concurrent requests admitted (2/2 in flight, sharing the same
-    # caller-chosen litellm_call_id). One of them fails.
-    await limiter.async_log_failure_event(
-        kwargs={
-            "litellm_call_id": shared_call_id,
-            "standard_logging_object": {"model_group": "grp"},
-            "metadata": {"tags": ["end_user_id:u1"]},
-        },
-        response_obj=None,
-        start_time=0,
-        end_time=0,
-    )
+    async def _release(tag_value):
+        await limiter.async_log_success_event(
+            kwargs={
+                "standard_logging_object": {"model_group": "grp", "model_id": "dep-1", "total_tokens": 0, "response_cost": 0},
+                "metadata": {"tags": [f"end_user_id:{tag_value}"]},
+            },
+            response_obj=None,
+            start_time=0,
+            end_time=0,
+        )
 
-    # Exactly one slot was freed: a third request is admitted (back to 2 in flight)...
+    # Two separate, genuinely concurrent tasks admit -- reaching capacity.
+    task_a = asyncio.create_task(_admit("a"))
+    task_b = asyncio.create_task(_admit("b"))
+    await task_a
+    await task_b
+
+    # Task A releases its own reservation, in its own task -- this must not
+    # also release task B's still-pending one.
+    await asyncio.create_task(_release("a"))
+    await asyncio.sleep(0)
+
+    # Exactly one slot was freed: a fresh request is admitted (back to 2 in flight)...
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:a"]}}
+    )
+    # ...but a second one does not, since B's reservation is genuinely still
+    # held. If task isolation were broken, task A's release would have
+    # drained B's reservation too, and this would wrongly admit.
+    with pytest.raises(ProxyRateLimitError):
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:a"]}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_concurrency_released_for_every_hop_across_a_real_task_boundary(time_controller):
+    """
+    litellm dedupes `async_log_failure_event` to fire once per logical
+    request: only the first failed hop's failure reaches it (see
+    `Logging.has_run_logging`'s `has_logged_async_failure` guard); a later
+    failed hop (a retry or a further fallback) never gets its own failure
+    event at all. Reservations still accumulate at admission for every hop
+    regardless (onto `_pending_concurrency_keys`), so whichever event fires
+    next must release everything accumulated since the last release, not
+    just its own hop's key.
+
+    Hop 3's eventual success is fired as a child task of the same admission
+    chain -- exactly like litellm's real dispatch, where `wrapper_async`
+    create_task's the success path and `LoggingWorker.enqueue` explicitly
+    propagates the calling context -- to prove the fix survives the actual
+    task boundary a real success event crosses in production, not just a
+    same-coroutine call that would pass regardless of whether
+    `_pending_concurrency_keys` were a real `ContextVar` or an ordinary
+    variable.
+    """
+    limiter = _make_limiter(time_controller)
+    router = _concurrency_router(limit=2)
+    limiter.update_variables(llm_router=router)
+    healthy = router.model_list
+
+    async def _one_logical_request():
+        # Hop 1 admits and fails; its failure event is the one that fires
+        # (dedup allows exactly the first failure through), releasing its
+        # own key immediately.
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
+        await limiter.async_log_failure_event(
+            kwargs={"standard_logging_object": {"model_group": "grp"}, "metadata": {"tags": ["end_user_id:u1"]}},
+            response_obj=None,
+            start_time=0,
+            end_time=0,
+        )
+
+        # Hop 2 (a retry or fallback) admits and also fails, but -- per
+        # litellm's dedup -- no async_log_failure_event call follows it.
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
+
+        # Hop 3 admits and succeeds. Its success event, dispatched as a
+        # child task (mirroring the real worker hop), must release both
+        # hop 2's still-pending reservation and its own.
+        await limiter.async_filter_deployments(
+            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+        )
+
+        async def _hop_3_success_event():
+            await limiter.async_log_success_event(
+                kwargs={
+                    "standard_logging_object": {
+                        "model_group": "grp",
+                        "model_id": "dep-1",
+                        "total_tokens": 0,
+                        "response_cost": 0,
+                    }
+                },
+                response_obj=None,
+                start_time=0,
+                end_time=0,
+            )
+
+        await asyncio.create_task(_hop_3_success_event())
+
+    await asyncio.create_task(_one_logical_request())
+    await asyncio.sleep(0)
+
+    # Full capacity (2) is free again -- both hop 2's leaked reservation and
+    # hop 3's own were released. If the earlier hop's leaked reservation
+    # hadn't been released too, only one of these two admissions would succeed.
+    await limiter.async_filter_deployments(
+        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+    )
     result = await limiter.async_filter_deployments(
         model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
     )
     assert result == healthy
-    # ...but a fourth would exceed the limit of 2. If the shared call_id had
-    # merged both reservations into one release, this would wrongly admit.
-    with pytest.raises(ProxyRateLimitError):
-        await limiter.async_filter_deployments(
-            model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
-        )
 
 
 @pytest.mark.asyncio
@@ -707,35 +799,49 @@ async def test_own_rejection_does_not_release_a_live_reservation(time_controller
     in-flight request sharing the same tag -- letting a caller free up
     capacity simply by retrying against an already-full bucket, no
     coordination with another request required.
+
+    The holder and the rejected attempt are modeled as two separate tasks
+    (matching how two independent real requests are always isolated in
+    production, each in its own asyncio task) so this actually exercises the
+    explicit ProxyRateLimitError guard rather than the ContextVar's own
+    per-task isolation, which would otherwise mask the same bug: two
+    admissions made directly in one shared coroutine would (correctly, but
+    for the wrong reason) never be able to explain away the bug this test is
+    for.
     """
     limiter = _make_limiter(time_controller)
     router = _concurrency_router(limit=1)
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    # One legitimate request holds the only slot.
-    await limiter.async_filter_deployments(
-        model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
-    )
-
-    # A second attempt is rejected -- capture the real exception this hook raises.
-    with pytest.raises(ProxyRateLimitError) as exc_info:
+    # One legitimate request, in its own task, holds the only slot.
+    async def _admit():
         await limiter.async_filter_deployments(
             model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
         )
 
-    # Router's own exception handling fires async_log_failure_event for that
-    # rejection, exactly as Router.async_callback_filter_deployments does.
-    await limiter.async_log_failure_event(
-        kwargs={
-            "exception": exc_info.value,
-            "standard_logging_object": {"model_group": "grp"},
-            "metadata": {"tags": ["end_user_id:u1"]},
-        },
-        response_obj=None,
-        start_time=0,
-        end_time=0,
-    )
+    await asyncio.create_task(_admit())
+
+    # A second, unrelated request (its own task) is rejected, and Router's
+    # own exception handling fires async_log_failure_event for it, exactly
+    # as Router.async_callback_filter_deployments does.
+    async def _reject_and_fire_failure_event():
+        with pytest.raises(ProxyRateLimitError) as exc_info:
+            await limiter.async_filter_deployments(
+                model="grp", healthy_deployments=healthy, messages=None, request_kwargs={"metadata": {"tags": ["end_user_id:u1"]}}
+            )
+        await limiter.async_log_failure_event(
+            kwargs={
+                "exception": exc_info.value,
+                "standard_logging_object": {"model_group": "grp"},
+                "metadata": {"tags": ["end_user_id:u1"]},
+            },
+            response_obj=None,
+            start_time=0,
+            end_time=0,
+        )
+
+    await asyncio.create_task(_reject_and_fire_failure_event())
 
     # The first request's reservation must still be held: a third attempt is
     # still rejected. If the rejection's failure event had wrongly released
@@ -1355,28 +1461,60 @@ async def test_concurrency_scope_by_key_hash_gives_independent_reservations_per_
     reservation bucket -- keyA exhausting its own single slot must not
     block keyB's admission, and releasing keyA's reservation (via the
     standard_logging_object.metadata.user_api_key_hash channel) must free
-    keyA's capacity, not keyB's.
+    keyA's capacity, not keyB's. Each key is modeled as its own logical
+    request: one task does admission and then spawns its own release as a
+    child task, exactly like litellm's real dispatch (`wrapper_async`
+    create_task's the success path, itself a descendant of the same
+    admission-time task/context chain) -- release must never be spawned as
+    an unrelated sibling task from the test's own top level, which would
+    start from a fresh context that never saw the admission's `ContextVar`
+    write at all, an artifact of this test's own construction rather than a
+    real bug.
     """
     limiter = _make_limiter(time_controller)
     router = _concurrency_router_scoped_by_key(limit=1)
     limiter.update_variables(llm_router=router)
     healthy = router.model_list
 
-    # keyA occupies its own single slot.
-    await limiter.async_filter_deployments(
-        model="grp",
-        healthy_deployments=healthy,
-        messages=None,
-        request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyA"}},
-    )
+    async def _admit(key: str):
+        await limiter.async_filter_deployments(
+            model="grp",
+            healthy_deployments=healthy,
+            messages=None,
+            request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": key}},
+        )
 
-    # keyB, same tag value, different key -- must still admit since it has its own bucket.
-    await limiter.async_filter_deployments(
-        model="grp",
-        healthy_deployments=healthy,
-        messages=None,
-        request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyB"}},
-    )
+    async def _release(key: str):
+        await limiter.async_log_success_event(
+            kwargs={
+                "standard_logging_object": {
+                    "model_group": "grp",
+                    "model_id": "dep-1",
+                    "total_tokens": 0,
+                    "response_cost": 0,
+                    "metadata": {"user_api_key_hash": key},
+                },
+                "metadata": {"tags": ["end_user_id:u1"]},
+            },
+            response_obj=None,
+            start_time=0,
+            end_time=0,
+        )
+
+    ready_to_release = asyncio.Event()
+
+    async def _key_a_admits_then_waits_then_releases_from_the_same_context_chain():
+        await _admit("keyA")
+        await ready_to_release.wait()
+        await asyncio.create_task(_release("keyA"))
+
+    # keyA occupies its own single slot; keyB, same tag value, different
+    # key, still admits since it has its own bucket.
+    key_a_task = asyncio.create_task(_key_a_admits_then_waits_then_releases_from_the_same_context_chain())
+    key_b_task = asyncio.create_task(_admit("keyB"))
+    await key_b_task
+    # Let key_a_task's admission run up to (but not past) `ready_to_release.wait()`.
+    await asyncio.sleep(0)
 
     # keyA is now at its own capacity -- a second keyA request is rejected.
     with pytest.raises(ProxyRateLimitError):
@@ -1387,22 +1525,9 @@ async def test_concurrency_scope_by_key_hash_gives_independent_reservations_per_
             request_kwargs={"metadata": {"tags": ["end_user_id:u1"], "user_api_key": "keyA"}},
         )
 
-    # Release keyA's reservation via the success event, matching its key hash.
-    await limiter.async_log_success_event(
-        kwargs={
-            "standard_logging_object": {
-                "model_group": "grp",
-                "model_id": "dep-1",
-                "total_tokens": 0,
-                "response_cost": 0,
-                "metadata": {"user_api_key_hash": "keyA"},
-            },
-            "metadata": {"tags": ["end_user_id:u1"]},
-        },
-        response_obj=None,
-        start_time=0,
-        end_time=0,
-    )
+    # Let keyA's task proceed to its own child-task release.
+    ready_to_release.set()
+    await key_a_task
     await asyncio.sleep(0)
 
     # keyA's capacity is freed -- a fresh keyA request now admits.
@@ -1415,7 +1540,8 @@ async def test_concurrency_scope_by_key_hash_gives_independent_reservations_per_
     assert result == healthy
 
     # keyB's own reservation is untouched by keyA's release -- a second keyB
-    # request is still rejected.
+    # request is still rejected. If task isolation were broken, keyA's
+    # release would have drained keyB's reservation too.
     with pytest.raises(ProxyRateLimitError):
         await limiter.async_filter_deployments(
             model="grp",

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -30657,6 +30657,11 @@ export interface components {
             /** Period Seconds */
             period_seconds: number;
             /**
+             * Scope By Key Hash
+             * @default false
+             */
+            scope_by_key_hash: boolean;
+            /**
              * Tag Id
              * @default end_user_id
              */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -30639,8 +30639,15 @@ export interface components {
          *     midnight and `period_seconds=60` resets on real clock-minute boundaries.
          *
          *     For a `concurrency_limits` entry specifically, `period_seconds` is not a
-         *     window: it is the safety TTL a reserved in-flight slot self-heals after,
-         *     in case a worker crashes before releasing it (the counter, not a window).
+         *     window: it is a floor under the safety TTL a reserved in-flight slot
+         *     self-heals after, in case a worker crashes before releasing it (the
+         *     counter, not a window). The effective TTL is at least one hour regardless
+         *     of this value, so a slow but genuinely still-running request never has
+         *     its reservation expire out from under it; set this higher only if an
+         *     even longer self-heal window is wanted. `concurrency_limits` also only
+         *     supports chain-wide entries (declared identically by every deployment
+         *     sharing a `model_name`) -- a divergent per-deployment value is dropped
+         *     with a warning, not silently scoped to a subset of deployments.
          */
         TagRateLimitEntry: {
             /** Limit */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -30631,6 +30631,43 @@ export interface components {
             tpm_limit?: number | null;
         };
         /**
+         * TagRateLimitEntry
+         * @description One tag-scoped limit: a caller-supplied tag value (identified by `tag_id`,
+         *     e.g. `end_user_id` in a request tag like `end_user_id:user-123`) is capped
+         *     at `limit` units per rolling `period_seconds`-second window. Bucketing is
+         *     `epoch_second // period_seconds`, so `period_seconds=86400` resets at UTC
+         *     midnight and `period_seconds=60` resets on real clock-minute boundaries.
+         */
+        TagRateLimitEntry: {
+            /** Limit */
+            limit: number;
+            /** Name */
+            name: string;
+            /** Period Seconds */
+            period_seconds: number;
+            /**
+             * Tag Id
+             * @default end_user_id
+             */
+            tag_id: string;
+        };
+        /** TagRateLimitGroup */
+        TagRateLimitGroup: {
+            /** Limits */
+            limits?: components["schemas"]["TagRateLimitEntry"][];
+        };
+        /**
+         * TagRateLimits
+         * @description Per-chain/model-group tag rate limits, set under a deployment's
+         *     `model_info.tag_rate_limits`. Each entry carries its own `tag_id`, so two
+         *     entries of the same unit on the same chain can key by different tags.
+         */
+        TagRateLimits: {
+            dollar_limits?: components["schemas"]["TagRateLimitGroup"] | null;
+            request_limits?: components["schemas"]["TagRateLimitGroup"] | null;
+            token_limits?: components["schemas"]["TagRateLimitGroup"] | null;
+        };
+        /**
          * TagSummaryMetrics
          * @description Summary metrics for a tag
          */
@@ -33000,6 +33037,7 @@ export interface components {
             db_model: boolean;
             /** Id */
             id: string | null;
+            tag_rate_limits?: components["schemas"]["TagRateLimits"] | null;
             /** Team Id */
             team_id?: string | null;
             /** Team Public Model Name */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -30637,6 +30637,10 @@ export interface components {
          *     at `limit` units per rolling `period_seconds`-second window. Bucketing is
          *     `epoch_second // period_seconds`, so `period_seconds=86400` resets at UTC
          *     midnight and `period_seconds=60` resets on real clock-minute boundaries.
+         *
+         *     For a `concurrency_limits` entry specifically, `period_seconds` is not a
+         *     window: it is the safety TTL a reserved in-flight slot self-heals after,
+         *     in case a worker crashes before releasing it (the counter, not a window).
          */
         TagRateLimitEntry: {
             /** Limit */
@@ -30663,6 +30667,7 @@ export interface components {
          *     entries of the same unit on the same chain can key by different tags.
          */
         TagRateLimits: {
+            concurrency_limits?: components["schemas"]["TagRateLimitGroup"] | null;
             dollar_limits?: components["schemas"]["TagRateLimitGroup"] | null;
             request_limits?: components["schemas"]["TagRateLimitGroup"] | null;
             token_limits?: components["schemas"]["TagRateLimitGroup"] | null;


### PR DESCRIPTION
## TLDR

Problem this solves:

- No native mechanism caps usage per an arbitrary caller-supplied tag identity, independent of the calling API key, with a genuinely configurable window
- Existing tag budgets are dollars-only and reset on a schedule rather than a rolling window
- Existing tpm/rpm limits are process-global and only scoped to key/user/team, not to a tag value
- Fallback hops never get their own tag-scoped enforcement
- No native mechanism caps concurrent in-flight requests per tag identity either

How it solves it:

- A model group declares token_limits / request_limits / dollar_limits / concurrency_limits under model_info.tag_rate_limits, each entry carrying its own tag_id and period_seconds window
- Checked on every routing attempt via async_filter_deployments, so a fallback hop is checked against its own configuration, not just the primary
- Bucketed by epoch_second // period_seconds, so period_seconds=86400 resets at UTC midnight and period_seconds=60 resets on real clock-minute boundaries, the same mechanism covering both a daily cap and a genuine RPM-style cap
- requests and concurrency admission is an atomic check-and-increment at the filter step itself (not a separate read-then-account-later pass), all-or-nothing across every unit checked in the same hop, so a rejected concurrency check can never leave a requests-unit increment committed for a call that never went through. tokens and dollars stay read-then-account-on-success in async_log_success_event, since real usage is only known after the response; that is a documented, accepted race window
- concurrency reserves a slot at admission and releases it on success or failure, with a TTL as the only safety net for a leaked reservation
- Load-balanced model groups (multiple deployments sharing one model_name) are handled explicitly: a limit declared identically by every deployment in the group is chain-wide (one shared bucket); a limit that only some deployments declare, or where deployments disagree on the value, becomes a per-deployment-scoped bucket shared by exactly the deployments that declared it, so a divergent deployment's config is never silently dropped
- The limits index is rebuilt when Router.model_list changes and also on a 5-second TTL, since a length-preserving deployment update (editing an existing deployment's tag_rate_limits in place) would otherwise leave it stale indefinitely

Shipped as an opt-in litellm_settings.callbacks entry (tag_rate_limiter), not part of PROXY_HOOKS, following the same pattern as dynamic_rate_limiter_v3: it reuses the existing rate limiter's Redis/TTL-preserving increment machinery rather than duplicating it, and never touches the default limiter every proxy already runs.

Example config:

```yaml
model_list:
  - model_name: my-chain
    litellm_params:
      model: anthropic/claude-haiku-4-5
    model_info:
      tag_rate_limits:
        request_limits:
          limits:
            - name: per_minute
              tag_id: end_user_id
              limit: 5
              period_seconds: 60
        concurrency_limits:
          limits:
            - name: inflight
              tag_id: end_user_id
              limit: 2
              period_seconds: 300

litellm_settings:
  callbacks: ["tag_rate_limiter"]
```

## Relevant issues

Fixes #35116

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified against a live local proxy (proxy_cli.py --config ... --detailed_debug), no mocked tests. The sandbox this PR was prepared in has no real LLM provider API keys configured, so mock_response was used on the deployment to exercise the full request path (auth, the hook, the router's per-hop filter, standard_logging_object population, and the accounting/release callbacks) without a real provider call; the config, hook resolution, enforcement, and accounting are all genuinely exercised end to end, only the outbound HTTP call to Anthropic itself is mocked.

Config used, a chain with a 2-requests-per-60-seconds limit and a 1-concurrent-request limit, both keyed on end_user_id:

```yaml
model_list:
  - model_name: haiku-tagged
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
      mock_response: "pineapple"
    model_info:
      tag_rate_limits:
        request_limits:
          limits:
            - name: per_minute
              tag_id: end_user_id
              limit: 2
              period_seconds: 60
        concurrency_limits:
          limits:
            - name: inflight
              tag_id: end_user_id
              limit: 1
              period_seconds: 300

litellm_settings:
  callbacks: ["tag_rate_limiter"]
```

Two truly parallel requests from the same tag; exactly one succeeds and the other gets a 429 attributing the rejection to the concurrency limit specifically:

```
$ curl -s -o /tmp/r1.json -w "%{http_code}\n" http://localhost:4003/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "X-Litellm-Tags: end_user_id:fix-check" \
  -d '{"model":"haiku-tagged","messages":[{"role":"user","content":"say pineapple"}]}' &
$ curl -s -o /tmp/r2.json -w "%{http_code}\n" http://localhost:4003/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "X-Litellm-Tags: end_user_id:fix-check" \
  -d '{"model":"haiku-tagged","messages":[{"role":"user","content":"say pineapple"}]}' &
wait
200
429

$ cat /tmp/r2.json
{"error":{"message":"tag_rate_limit_exceeded","type":"throttling_error","code":"429","provider_specific_fields":{"error":"tag_rate_limit_exceeded","type":"concurrency","tag_id":"end_user_id","tag_value":"fix-check","limit_name":"inflight","limit":1.0,"period_seconds":300}}}
```

Grepping the debug log for this tag across the router's automatic retries of the rejected request confirms every rejection is attributed to the concurrency unit, never to requests, proof that the earlier per-key-independent version of the atomic script (which let a rejected hop's requests-unit check commit anyway) is fixed by the current all-or-nothing script.

Sequential 2-requests-per-60-seconds behavior (unaffected by the atomicity rework, re-verified): 2 requests from the same tag succeed, the 3rd gets a 429 with the tag identity and the offending limit in the detail. A different tag value succeeds while the first is exhausted, confirming per-identity isolation, and a request with no X-Litellm-Tags header at all also succeeds, confirming an unresolved entry fails open.

## Type

🆕 New Feature

## Changes

- `litellm/proxy/hooks/tag_rate_limiter.py`: new opt-in `CustomLogger`. Builds a `model_info.tag_rate_limits`-driven limits index per model group (rebuilt when `Router.model_list` changes or every 5 seconds, whichever comes first), resolves tag identity from `metadata.tags` by scanning for a `f"{tag_id}:"` prefix (skipping `!`-prefixed tag-routing negation markers), enforces via `async_filter_deployments` on every routing attempt. `requests`/`concurrency` admission is an atomic, all-or-nothing check-and-increment across every unit checked in one hop (new `TAG_RL_CHECK_AND_INCR_SCRIPT`, two-phase like the existing `CHECK_AND_INCREMENT_BY_N_SCRIPT`); `tokens`/`dollars` stay a read-then-account-on-success check, accounted in `async_log_success_event` via `_PROXY_MaxParallelRequestsHandler_v3.async_increment_tokens_with_ttl_preservation`. Concurrency slots release in `async_log_success_event` and the new `async_post_call_failure_hook`.
- `litellm/types/router.py`: new `TagRateLimitEntry` / `TagRateLimitGroup` / `TagRateLimits` models and a `ModelInfo.tag_rate_limits` field.
- `litellm/litellm_core_utils/litellm_logging.py`, `litellm/__init__.py`: register `tag_rate_limiter` as a resolvable opt-in callback string, mirroring the existing `dynamic_rate_limiter_v3` registration.
- `ui/litellm-dashboard/src/lib/http/schema.d.ts`: regenerated for the new `ModelInfo.tag_rate_limits` field.
- `tests/test_litellm/proxy/hooks/test_tag_rate_limiter.py`: unit tests for tag identity extraction, chain-wide vs per-deployment limit resolution (including the regression case where deployments in a load-balanced group declare divergent values), enforcement, per-entry fail-open, accounting, the atomic requests race fix (genuine concurrent `asyncio.gather`, not sequential calls), the cross-unit phantom-increment regression, concurrency reserve/release on success and failure, and the index TTL refresh for a length-preserving deployment update.