### PR TITLE
feat(gemini): allow disabling thought summaries while keeping thinking on

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -371,6 +371,7 @@ enable_key_alias_format_validation: bool = (
 enable_gemini_default_thinking_level_low: bool = (
     False  # opt-in: force thinkingLevel low/minimal for Gemini 3 thinking param mapping
 )
+gemini_include_thoughts_default: bool = True  # set False to keep Gemini thinking on while dropping thought summaries
 ####################
 logging: bool = True
 enable_loadbalancing_on_batch_endpoints: Optional[bool] = None

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -794,6 +794,16 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 optional_params["response_schema"] = self._map_response_schema(value=schema)
 
     @staticmethod
+    def _include_thoughts() -> bool:
+        """Whether to ask Gemini for thought summaries when thinking is on.
+
+        Thought summaries are the narration, not the reasoning: turning them off leaves
+        thinkingBudget/thinkingLevel untouched and the model still reasons, the response
+        just does not carry the summary back.
+        """
+        return litellm.gemini_include_thoughts_default
+
+    @staticmethod
     def _map_reasoning_effort_to_thinking_budget(
         reasoning_effort: str,
         model: str | None = None,
@@ -812,22 +822,22 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
             return {
                 "thinkingBudget": budget,
-                "includeThoughts": True,
+                "includeThoughts": VertexGeminiConfig._include_thoughts(),
             }
         elif reasoning_effort == "low":
             return {
                 "thinkingBudget": DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
-                "includeThoughts": True,
+                "includeThoughts": VertexGeminiConfig._include_thoughts(),
             }
         elif reasoning_effort == "medium":
             return {
                 "thinkingBudget": DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
-                "includeThoughts": True,
+                "includeThoughts": VertexGeminiConfig._include_thoughts(),
             }
         elif reasoning_effort == "high":
             return {
                 "thinkingBudget": DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
-                "includeThoughts": True,
+                "includeThoughts": VertexGeminiConfig._include_thoughts(),
             }
         elif reasoning_effort == "disable":
             return {
@@ -863,18 +873,18 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         is_gemini31pro: Final = model and ("gemini-3.1-pro-preview" in model.lower())
         if reasoning_effort == "minimal":
             if is_gemini3flash:
-                return {"thinkingLevel": "minimal", "includeThoughts": True}
+                return {"thinkingLevel": "minimal", "includeThoughts": VertexGeminiConfig._include_thoughts()}
             else:
-                return {"thinkingLevel": "low", "includeThoughts": True}
+                return {"thinkingLevel": "low", "includeThoughts": VertexGeminiConfig._include_thoughts()}
         elif reasoning_effort == "low":
-            return {"thinkingLevel": "low", "includeThoughts": True}
+            return {"thinkingLevel": "low", "includeThoughts": VertexGeminiConfig._include_thoughts()}
         elif reasoning_effort == "medium":
             if is_gemini31pro or is_gemini3flash:
-                return {"thinkingLevel": "medium", "includeThoughts": True}
+                return {"thinkingLevel": "medium", "includeThoughts": VertexGeminiConfig._include_thoughts()}
             else:
-                return {"thinkingLevel": "high", "includeThoughts": True}
+                return {"thinkingLevel": "high", "includeThoughts": VertexGeminiConfig._include_thoughts()}
         elif reasoning_effort == "high":
-            return {"thinkingLevel": "high", "includeThoughts": True}
+            return {"thinkingLevel": "high", "includeThoughts": VertexGeminiConfig._include_thoughts()}
         elif reasoning_effort == "disable":
             # Gemini 3 cannot fully disable thinking, so we use "minimal" for gemini-3-flash-preview, "low" for others
             if is_gemini3flash:
@@ -950,7 +960,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 if thinking_budget is None or thinking_budget == 0:
                     params["includeThoughts"] = False
                 else:
-                    params["includeThoughts"] = True
+                    params["includeThoughts"] = VertexGeminiConfig._include_thoughts()
                     # Follow provider defaults unless explicitly opted into legacy behavior.
                     if litellm.enable_gemini_default_thinking_level_low is True:
                         is_gemini3flash: Final = "gemini-3" in model.lower() and "flash" in model.lower()
@@ -961,7 +971,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         else:
             # For older Gemini models, use thinkingBudget
             if thinking_enabled and not VertexGeminiConfig._is_thinking_budget_zero(thinking_budget):
-                params["includeThoughts"] = True
+                params["includeThoughts"] = VertexGeminiConfig._include_thoughts()
             if thinking_budget is not None and isinstance(thinking_budget, int):
                 params["thinkingBudget"] = thinking_budget
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5553,3 +5553,64 @@ def test_accumulated_json_skips_non_dict_leading_value():
 
     assert len(out) == 1
     assert out[0].choices[0].delta.content == "a"
+
+
+@pytest.fixture
+def gemini_thought_summaries_off():
+    original = litellm.gemini_include_thoughts_default
+    litellm.gemini_include_thoughts_default = False
+    try:
+        yield
+    finally:
+        litellm.gemini_include_thoughts_default = original
+
+
+@pytest.mark.parametrize("reasoning_effort", ["minimal", "low", "medium", "high"])
+def test_thinking_budget_includes_thoughts_by_default(reasoning_effort):
+    config = VertexGeminiConfig._map_reasoning_effort_to_thinking_budget(
+        reasoning_effort=reasoning_effort, model="gemini-2.5-pro"
+    )
+    assert config["includeThoughts"] is True
+
+
+@pytest.mark.parametrize("reasoning_effort", ["minimal", "low", "medium", "high"])
+def test_thinking_budget_can_drop_thought_summaries_while_still_thinking(
+    reasoning_effort, gemini_thought_summaries_off
+):
+    config = VertexGeminiConfig._map_reasoning_effort_to_thinking_budget(
+        reasoning_effort=reasoning_effort, model="gemini-2.5-pro"
+    )
+    assert config["includeThoughts"] is False
+    assert config["thinkingBudget"] > 0
+
+
+@pytest.mark.parametrize("reasoning_effort", ["minimal", "low", "medium", "high"])
+def test_thinking_level_can_drop_thought_summaries_while_still_thinking(
+    reasoning_effort, gemini_thought_summaries_off
+):
+    config = VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
+        reasoning_effort=reasoning_effort, model="gemini-3-pro-preview"
+    )
+    assert config["includeThoughts"] is False
+    assert config["thinkingLevel"] in ("minimal", "low", "medium", "high")
+
+
+@pytest.mark.parametrize("reasoning_effort", ["disable", "none"])
+def test_disabling_thinking_still_disables_thought_summaries(reasoning_effort):
+    budget_config = VertexGeminiConfig._map_reasoning_effort_to_thinking_budget(
+        reasoning_effort=reasoning_effort, model="gemini-2.5-pro"
+    )
+    level_config = VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
+        reasoning_effort=reasoning_effort, model="gemini-3-pro-preview"
+    )
+    assert budget_config["includeThoughts"] is False
+    assert level_config["includeThoughts"] is False
+
+
+def test_thinking_param_can_drop_thought_summaries(gemini_thought_summaries_off):
+    config = VertexGeminiConfig._map_thinking_param(
+        thinking_param={"type": "enabled", "budget_tokens": 2048},
+        model="gemini-2.5-pro",
+    )
+    assert config["includeThoughts"] is False
+    assert config["thinkingBudget"] == 2048


### PR DESCRIPTION
## TLDR

Problem this solves:

- both reasoning-effort mappers hardcode `includeThoughts: True` whenever thinking is on, so thinking ON with summaries OFF is unreachable, even though that is the default of Google's own SDK
- for callers who discard the summaries, they are pure added latency: the model reasons the same either way, the response just carries the narration back

How it solves it:

- adds `litellm.gemini_include_thoughts_default`, defaulting to `True` so nothing changes for anyone who does not set it

## User Flow

An operator fronting Vertex Gemini sets `litellm.gemini_include_thoughts_default = False` once at gateway startup. Requests then go out with `thinkingLevel`/`thinkingBudget` intact and no `includeThoughts`, matching what a direct google SDK call sends. Reasoning is unchanged, the summary text is not returned

Leaving it alone sends exactly what LiteLLM sends today

## Relevant issues

Closes #36401

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

I went with option 2 from the issue, the module flag, rather than option 1, the request param. It mirrors `litellm.enable_gemini_default_thinking_level_low` which already lives in this same file for the same kind of decision, and it needs no `supported_openai_params` plumbing or per-provider passthrough. The reported use case is a gateway-wide latency choice, which a module flag covers. Happy to add the request param on top if you would rather have per-request control

```bash
$ python -c "
import litellm
from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexGeminiConfig as C
print('default    ', C._map_reasoning_effort_to_thinking_level('medium', model='gemini-3-pro-preview'))
litellm.gemini_include_thoughts_default = False
print('summaries off', C._map_reasoning_effort_to_thinking_level('medium', model='gemini-3-pro-preview'))
print('disable    ', C._map_reasoning_effort_to_thinking_level('disable', model='gemini-3-pro-preview'))"
default     {'thinkingLevel': 'high', 'includeThoughts': True}
summaries off {'thinkingLevel': 'high', 'includeThoughts': False}
disable     {'thinkingLevel': 'low', 'includeThoughts': False}
```

The whole gemini suite still passes:

```bash
$ pytest tests/test_litellm/llms/vertex_ai/gemini/ -q
278 passed, 1 skipped
```

## Type

🆕 New Feature

## Caveats (if any)

The flag gates three call sites, not two: the `thinkingBudget` mapper, the `thinkingLevel` mapper, and `_map_thinking_param`, which handles the anthropic-style `thinking={"type": "enabled"}` shape. All three answer the same question, so leaving the third one hardcoded would have made the flag behave differently depending on which parameter spelling the caller reached for

The `disable` and `none` paths still force `includeThoughts: False` regardless of the flag. With thinking off there is nothing to summarise, and the flag is about reachability rather than forcing summaries on

## QA runbook

Point the proxy at Vertex Gemini, send a request with `reasoning_effort: "medium"` and `--detailed_debug`, and confirm the outbound `thinkingConfig` carries `includeThoughts: true`. Set `litellm.gemini_include_thoughts_default = False`, restart, resend, and confirm it is `false` while `thinkingLevel` is unchanged and `reasoning_tokens` in the response stays in the same range

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
