### PR TITLE
fix(bedrock): sign rerank requests with the shared, header-filtered SigV4 helper

### DIFF
--- a/litellm/llms/bedrock/rerank/handler.py
+++ b/litellm/llms/bedrock/rerank/handler.py
@@ -135,11 +135,6 @@ class BedrockRerankHandler(BaseAWSLLM):
         data: dict,
         optional_params: dict,
     ) -> BedrockPreparedRequest:
-        try:
-            from botocore.auth import SigV4Auth
-            from botocore.awsrequest import AWSRequest
-        except ImportError:
-            raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
         boto3_credentials_info: Final = self._get_boto_credentials_from_optional_params(optional_params, model)
 
         ### SET RUNTIME ENDPOINT ###
@@ -150,24 +145,20 @@ class BedrockRerankHandler(BaseAWSLLM):
         )
         proxy_endpoint_url = proxy_endpoint_url.replace("bedrock-runtime", "bedrock-agent-runtime")
         proxy_endpoint_url = f"{proxy_endpoint_url}/rerank"
-        sigv4: Final = SigV4Auth(
-            boto3_credentials_info.credentials,
-            "bedrock",
-            boto3_credentials_info.aws_region_name,
-        )
-        # Make POST Request
-        body: Final = json.dumps(data).encode("utf-8")
 
+        body: Final = json.dumps(data).encode("utf-8")
         headers = {"Content-Type": "application/json"}
         if extra_headers is not None:
             headers = {"Content-Type": "application/json", **extra_headers}
-        request: Final = AWSRequest(method="POST", url=proxy_endpoint_url, data=body, headers=headers)
-        sigv4.add_auth(request)
-        if (
-            extra_headers is not None and "Authorization" in extra_headers
-        ):  # prevent sigv4 from overwriting the auth header
-            request.headers["Authorization"] = extra_headers["Authorization"]
-        prepped: Final = request.prepare()
+
+        prepped: Final = self.get_request_headers(
+            credentials=boto3_credentials_info.credentials,
+            aws_region_name=boto3_credentials_info.aws_region_name,
+            extra_headers=extra_headers,
+            endpoint_url=proxy_endpoint_url,
+            data=body,
+            headers=headers,
+        )
 
         return BedrockPreparedRequest(
             endpoint_url=proxy_endpoint_url,

--- a/tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_header_forwarding.py
+++ b/tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_header_forwarding.py
@@ -418,27 +418,19 @@ def test_bedrock_rerank_forwarded_headers_excluded_from_sigv4_signature():
     balancer), which invalidates the signature if that header was part of
     the signed set. It must still reach Bedrock, just unsigned.
     """
-    from botocore.credentials import Credentials
-
     handler = BedrockRerankHandler()
-    mock_credentials_info = Boto3CredentialsInfo(
-        credentials=Credentials("test-access-key", "test-secret-key", "test-token"),
-        aws_region_name="us-east-1",
-        aws_bedrock_runtime_endpoint=None,
-    )
 
-    with patch.object(
-        BedrockRerankHandler,
-        "_get_boto_credentials_from_optional_params",
-        return_value=mock_credentials_info,
-    ):
-        prepared_request = handler._prepare_request(
-            model="cohere.rerank-v3-5:0",
-            api_base=None,
-            extra_headers={"x-forwarded-for": "203.0.113.5"},
-            data={"query": test_query, "documents": test_documents},
-            optional_params={},
-        )
+    prepared_request = handler._prepare_request(
+        model="cohere.rerank-v3-5:0",
+        api_base=None,
+        extra_headers={"x-forwarded-for": "203.0.113.5"},
+        data={"query": test_query, "documents": test_documents},
+        optional_params={
+            "aws_access_key_id": "test-access-key",
+            "aws_secret_access_key": "test-secret-key",
+            "aws_region_name": "us-east-1",
+        },
+    )
 
     headers = prepared_request["prepped"].headers
     signed_headers = headers["Authorization"].split("SignedHeaders=")[1].split(",")[0].split(";")

--- a/tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_header_forwarding.py
+++ b/tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_header_forwarding.py
@@ -17,6 +17,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 import litellm
 from litellm.llms.bedrock.base_aws_llm import Boto3CredentialsInfo
+from litellm.llms.bedrock.rerank.handler import BedrockRerankHandler
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 
 # Mock response for Bedrock rerank
@@ -408,3 +409,41 @@ def test_bedrock_rerank_extra_headers_and_headers_merge():
 
         except Exception as e:
             pytest.fail(f"Failed to merge and forward headers: {str(e)}")
+
+
+def test_bedrock_rerank_forwarded_headers_excluded_from_sigv4_signature():
+    """
+    A forwarded header like x-forwarded-for can be rewritten between LiteLLM
+    signing the request and AWS receiving it (e.g. by an intermediate load
+    balancer), which invalidates the signature if that header was part of
+    the signed set. It must still reach Bedrock, just unsigned.
+    """
+    from botocore.credentials import Credentials
+
+    handler = BedrockRerankHandler()
+    mock_credentials_info = Boto3CredentialsInfo(
+        credentials=Credentials("test-access-key", "test-secret-key", "test-token"),
+        aws_region_name="us-east-1",
+        aws_bedrock_runtime_endpoint=None,
+    )
+
+    with patch.object(
+        BedrockRerankHandler,
+        "_get_boto_credentials_from_optional_params",
+        return_value=mock_credentials_info,
+    ):
+        prepared_request = handler._prepare_request(
+            model="cohere.rerank-v3-5:0",
+            api_base=None,
+            extra_headers={"x-forwarded-for": "203.0.113.5"},
+            data={"query": test_query, "documents": test_documents},
+            optional_params={},
+        )
+
+    headers = prepared_request["prepped"].headers
+    signed_headers = headers["Authorization"].split("SignedHeaders=")[1].split(",")[0].split(";")
+
+    assert "x-forwarded-for" not in signed_headers, (
+        f"x-forwarded-for must not be part of the SigV4 signature, got SignedHeaders={signed_headers}"
+    )
+    assert headers["x-forwarded-for"] == "203.0.113.5", "forwarded header must still reach Bedrock, unsigned"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock rerank calls fail with a SigV4 signature mismatch when the proxy forwards client headers
- The rerank handler signs every header instead of only the ones AWS actually includes in the signature

How it solves it:

- Route rerank request signing through the shared `get_request_headers` helper other Bedrock handlers already use
- That helper filters headers before signing, then re-attaches the rest unsigned, so forwarded headers can't corrupt the signature

## User Flow

Before: an admin whose proxy forwards client headers to backend LLM APIs (`forward_client_headers_to_llm_api`) gets every Bedrock rerank call rejected by AWS

1. The proxy has that setting on and a Bedrock rerank deployment, e.g. `cohere.rerank-v3-5:0`
2. A user's app sends POST https://litellm-domain/v1/rerank with a query and a list of documents
3. The response carries an AWS error: "The request signature we calculated does not match the signature you provided"

After: the same call succeeds

1. Same proxy config
2. The user sends the same POST https://litellm-domain/v1/rerank
3. The response returns ranked results with relevance scores, same shape as before this bug

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I don't have access to a proxy deployment with header forwarding enabled and a live Bedrock rerank model to capture end-to-end curl output for this one, so I can't post real request/response logs. What I can show:

Deterministic before/after on the actual signing code, not a mock of it: `tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_header_forwarding.py::test_bedrock_rerank_forwarded_headers_excluded_from_sigv4_signature` builds a real `AWSRequest` through `BedrockRerankHandler._prepare_request` with a forwarded `x-forwarded-for` header and inspects the actual computed `Authorization` header.

Before the fix (checked out at `3726bceb53`, the commit this branch is based on): `SignedHeaders` includes `x-forwarded-for`, so any hop that rewrites that header between LiteLLM signing the request and AWS receiving it invalidates the signature.

After the fix (this branch): `SignedHeaders` is `content-type;host;x-amz-date;x-amz-security-token`, no longer including `x-forwarded-for`, while the header itself is still present and forwarded on the wire.

For anyone who can reproduce this against real AWS, this is the config that should trigger it (a Bedrock rerank deployment behind a proxy forwarding client headers):

```yaml
general_settings:
  forward_client_headers_to_llm_api: true

model_list:
  - model_name: bedrock-rerank
    litellm_params:
      model: bedrock/cohere.rerank-v3-5:0
      aws_region_name: us-east-1
```

```bash
curl -s -X POST http://localhost:4000/v1/rerank \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -H "X-Forwarded-For: 203.0.113.5" \
  -d '{
    "model": "bedrock-rerank",
    "query": "What is the capital of the United States?",
    "documents": [
      "Carson City is the capital of Nevada.",
      "Washington, D.C. is the capital of the United States."
    ]
  }'
```

## Type

🐛 Bug Fix

## Caveats (if any)

- I found this while checking a related cross-account Bedrock batch signing bug (#36449); I couldn't confirm live against real AWS which specific forwarded header was corrupting the signature, since I don't have access to that proxy's `general_settings` or a way to deploy a patched build to it
- This closes the same class of bug already fixed for the Bedrock invoke path in #19111, just never ported to rerank

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AWS request signing for Bedrock rerank. Behavior is aligned with other Bedrock handlers and covered by a signature-inspection test, but a signing bug would break all rerank calls.
> 
> **Overview**
> Fixes Bedrock rerank SigV4 mismatches when the proxy forwards client headers (`forward_client_headers_to_llm_api`). Headers like `x-forwarded-for` were previously signed, then rewritten in transit, so AWS rejected the request.
> 
> `BedrockRerankHandler._prepare_request` now uses the shared `get_request_headers` helper instead of signing every header inline. Forwarded headers still go to Bedrock, but they are excluded from `SignedHeaders`.
> 
> Adds a unit test that inspects the real `Authorization` header and asserts `x-forwarded-for` is present but unsigned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d80608eca6e9a1a98c3b0c2f7620c6d6496712e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->