### PR TITLE
feat(proxy): per-key prompt caching toggle via enable_prompt_caching

### DIFF
--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -382,19 +382,23 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         model: str,
         custom_llm_provider: str | None,
         tools: list | None = None,
+        enable_prompt_caching: bool | None = None,
     ) -> list[CacheControlInjectionPoint]:
         """Default breakpoints when ``litellm.enable_anthropic_prompt_caching`` is on.
 
-        Caches the system prompt and the trailing turn, so the stable prefix
-        (system + tools + history) is reused while the breakpoint advances with
-        the conversation. Returns [] (stand down) when the flag is off, the
-        provider does not consume cache_control breakpoints (only anthropic /
-        bedrock do), the model lacks prompt-caching support, or the request
-        already carries client-supplied cache_control.
+        ``enable_prompt_caching`` is the per-request override (stamped from key
+        metadata by the proxy); True turns auto-injection on for this request
+        even when the global flag is off. Caches the system prompt and the
+        trailing turn, so the stable prefix (system + tools + history) is
+        reused while the breakpoint advances with the conversation. Returns []
+        (stand down) when neither flag is on, the provider does not consume
+        cache_control breakpoints (only anthropic / bedrock do), the model
+        lacks prompt-caching support, or the request already carries
+        client-supplied cache_control.
         """
         import litellm
 
-        if litellm.enable_anthropic_prompt_caching is not True:
+        if litellm.enable_anthropic_prompt_caching is not True and enable_prompt_caching is not True:
             return []
 
         provider = custom_llm_provider
@@ -433,6 +437,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         model: str,
         custom_llm_provider: str | None,
         tools: list | None = None,
+        enable_prompt_caching: bool | None = None,
     ) -> None:
         """For /chat/completions: resolve the injection points the request should carry.
 
@@ -458,6 +463,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
             model=model,
             custom_llm_provider=custom_llm_provider,
             tools=tools,
+            enable_prompt_caching=enable_prompt_caching,
         )
         if points:
             non_default_params["cache_control_injection_points"] = points
@@ -478,12 +484,17 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         judgment happens once per request; points a prior pass wrote back
         carry the judged stamp and are never re-judged (see
         ``_should_stand_down``). When none are configured but
-        ``litellm.enable_anthropic_prompt_caching`` is on, synthesize default
-        breakpoints for the native /v1/messages path. Pops the key from kwargs;
+        ``litellm.enable_anthropic_prompt_caching`` or the per-request
+        ``enable_prompt_caching`` kwarg (stamped from key metadata) is on,
+        synthesize default breakpoints for the native /v1/messages path. Pops
+        both keys from kwargs;
         if remaining (non-message) points exist they are written back so
         downstream transforms can handle them.
         """
         typed_messages = cast(list[AllMessageValues], messages)  # cast-ok: Anthropic-shaped dicts from v1/messages
+        enable_prompt_caching: Final = cast(  # cast-ok: kwargs is untyped; key stamped as bool by the proxy
+            bool | None, kwargs.pop("enable_prompt_caching", None)
+        )
         configured: Final = cast(  # cast-ok: kwargs is untyped; this key only holds the documented injection-point list
             list[CacheControlInjectionPoint] | None, kwargs.pop("cache_control_injection_points", None)
         )
@@ -497,6 +508,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
                 tools=tools,
                 model=model,
                 custom_llm_provider=custom_llm_provider,
+                enable_prompt_caching=enable_prompt_caching,
             )
         if not injection_points:
             return messages, system

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -504,6 +504,7 @@ async def acompletion(
         model=model,
         custom_llm_provider=cast(str | None, custom_llm_provider),  # cast-ok: read from untyped kwargs
         tools=tools,
+        enable_prompt_caching=cast(bool | None, kwargs.get("enable_prompt_caching")),  # cast-ok: untyped kwargs
     )
 
     if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and (
@@ -5105,6 +5106,7 @@ def completion(
         model=model,
         custom_llm_provider=cast(str | None, kwargs.get("custom_llm_provider")),  # cast-ok: untyped kwargs
         tools=tools,
+        enable_prompt_caching=cast(bool | None, kwargs.get("enable_prompt_caching")),  # cast-ok: untyped kwargs
     )
 
     if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and (

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1108,6 +1108,7 @@ class KeyRequestBase(GenerateRequestBase):
     budget_id: str | None = None
     tags: list[str] | None = None
     disable_global_guardrails: bool | None = None
+    enable_prompt_caching: bool | None = None
     throttle_on_budget_exceeded: bool | None = None
     enforced_params: list[str] | None = None
     allowed_routes: list | None = []
@@ -4123,6 +4124,7 @@ LiteLLM_ManagementEndpoint_MetadataFields: Final = [
     "enforced_batch_output_expires_after",
     "enforced_file_expires_after",
     "throttle_on_budget_exceeded",
+    "enable_prompt_caching",
 ]
 
 LiteLLM_ManagementEndpoint_MetadataFields_Premium: Final = [

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1317,9 +1317,8 @@ class LiteLLMProxyRequestSetup:
         if "disable_fallbacks" in key_metadata and isinstance(key_metadata["disable_fallbacks"], bool):
             data["disable_fallbacks"] = key_metadata["disable_fallbacks"]
 
-        ## KEY-LEVEL PROMPT CACHING AUTO-INJECTION
         if isinstance(key_metadata.get("enable_prompt_caching"), bool):
-            data["enable_prompt_caching"] = key_metadata["enable_prompt_caching"]
+            data["enable_prompt_caching"] = key_metadata["enable_prompt_caching"]  # rebind-ok: data is an out-param
 
         ## KEY-LEVEL METADATA
         data = LiteLLMProxyRequestSetup.add_management_endpoint_metadata_to_request_metadata(

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -201,6 +201,7 @@ _UNTRUSTED_ROOT_CONTROL_FIELDS: Final = (
     "mock_tool_calls",
     "disable_global_guardrails",
     "disable_global_guardrail",
+    "enable_prompt_caching",
     "opted_out_global_guardrails",
     "applied_guardrails",
     "applied_policies",
@@ -1315,6 +1316,10 @@ class LiteLLMProxyRequestSetup:
         ## KEY-LEVEL DISABLE FALLBACKS
         if "disable_fallbacks" in key_metadata and isinstance(key_metadata["disable_fallbacks"], bool):
             data["disable_fallbacks"] = key_metadata["disable_fallbacks"]
+
+        ## KEY-LEVEL PROMPT CACHING AUTO-INJECTION
+        if isinstance(key_metadata.get("enable_prompt_caching"), bool):
+            data["enable_prompt_caching"] = key_metadata["enable_prompt_caching"]
 
         ## KEY-LEVEL METADATA
         data = LiteLLMProxyRequestSetup.add_management_endpoint_metadata_to_request_metadata(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1589,6 +1589,7 @@ async def generate_key_fn(
     - policies: Optional[List[str]] - List of policy names to apply to the key. Policies define guardrails, conditions, and inheritance rules.
     - disable_global_guardrails: Optional[bool] - Whether to disable global guardrails for the key.
     - throttle_on_budget_exceeded: Optional[bool] - When the key exceeds its max_budget, throttle its tpm/rpm to the global budget_exceeded_throttle_percentage instead of blocking the key entirely.
+    - enable_prompt_caching: Optional[bool] - Auto-inject prompt caching breakpoints (Anthropic cache_control markers) on requests made with this key. Anthropic and Bedrock Claude models only.
     - permissions: Optional[dict] - key-specific permissions. Currently just used for turning off pii masking (if connected). Example - {"pii": false}
     - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}}. IF null or {} then no model specific budget.
     - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
@@ -2688,6 +2689,7 @@ async def update_key_fn(
     - policies: Optional[List[str]] - List of policy names to apply to the key. Policies define guardrails, conditions, and inheritance rules.
     - disable_global_guardrails: Optional[bool] - Whether to disable global guardrails for the key.
     - throttle_on_budget_exceeded: Optional[bool] - When the key exceeds its max_budget, throttle its tpm/rpm to the global budget_exceeded_throttle_percentage instead of blocking the key entirely.
+    - enable_prompt_caching: Optional[bool] - Auto-inject prompt caching breakpoints (Anthropic cache_control markers) on requests made with this key. Anthropic and Bedrock Claude models only.
     - prompts: Optional[List[str]] - List of prompts that the key is allowed to use.
     - blocked: Optional[bool] - Whether the key is blocked
     - aliases: Optional[dict] - Model aliases for the key - [Docs](https://litellm.vercel.app/docs/proxy/virtual_keys#model-aliases)

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3463,6 +3463,7 @@ all_litellm_params = (
         "caching_groups",
         "ttl",
         "cache",
+        "enable_prompt_caching",
         "no-log",
         "base_model",
         "stream_timeout",

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -1728,6 +1728,87 @@ class TestEnableAnthropicPromptCaching:
         assert result_msgs[-1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
         assert "cache_control" not in result_msgs[0]["content"][-1]
 
+
+class TestPerKeyEnablePromptCaching:
+    """Per-request enable_prompt_caching override (stamped from key metadata) with the global flag off."""
+
+    MESSAGES: List[AllMessageValues] = [
+        {"role": "system", "content": "a long system prompt"},
+        {"role": "user", "content": "latest turn"},
+    ]
+
+    def _points(self, enable_prompt_caching, model="claude-sonnet-4-5", provider="anthropic", messages=None):
+        return AnthropicCacheControlHook.get_default_injection_points(
+            messages=copy.deepcopy(self.MESSAGES) if messages is None else messages,
+            system=None,
+            model=model,
+            custom_llm_provider=provider,
+            enable_prompt_caching=enable_prompt_caching,
+        )
+
+    def test_true_injects_with_global_flag_off(self):
+        assert litellm.enable_anthropic_prompt_caching is False
+        assert self._points(True) == [
+            {"location": "message", "role": "system", "index": None, "control": {"type": "ephemeral"}},
+            {"location": "message", "role": None, "index": -1, "control": {"type": "ephemeral"}},
+        ]
+
+    @pytest.mark.parametrize("enable_prompt_caching", [False, None])
+    def test_false_and_none_fall_back_to_global_flag(self, enable_prompt_caching):
+        assert self._points(enable_prompt_caching) == []
+
+    def test_false_does_not_suppress_global_flag(self, monkeypatch):
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        assert [p["index"] for p in self._points(False)] == [None, -1]
+
+    def test_provider_gate_still_applies(self):
+        assert self._points(True, model="gpt-4o", provider="openai") == []
+
+    def test_unsupported_model_gate_still_applies(self):
+        assert self._points(True, model="anthropic.claude-3-5-sonnet-20240620-v1:0", provider="bedrock") == []
+
+    def test_client_markers_still_win(self):
+        messages = [
+            {"role": "system", "content": [{"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}]},
+            {"role": "user", "content": "latest turn"},
+        ]
+        assert self._points(True, messages=messages) == []
+
+    def test_seed_injects_with_global_flag_off(self):
+        params: dict = {}
+        AnthropicCacheControlHook.maybe_seed_default_injection_points(
+            non_default_params=params,
+            messages=copy.deepcopy(self.MESSAGES),
+            model="claude-sonnet-4-5",
+            custom_llm_provider="anthropic",
+            enable_prompt_caching=True,
+        )
+        assert [p["index"] for p in params["cache_control_injection_points"]] == [None, -1]
+
+    def test_v1_messages_injects_and_pops_flag_from_kwargs(self):
+        kwargs: dict = {"enable_prompt_caching": True}
+        result_msgs, result_sys = AnthropicCacheControlHook.maybe_inject_cache_control(
+            [{"role": "user", "content": [{"type": "text", "text": "latest"}]}],
+            "a system prompt",
+            kwargs,
+            model="claude-sonnet-4-5",
+            custom_llm_provider="anthropic",
+        )
+        assert result_sys == [{"type": "text", "text": "a system prompt", "cache_control": {"type": "ephemeral"}}]
+        assert result_msgs[-1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+        assert "enable_prompt_caching" not in kwargs
+
+    def test_v1_messages_pops_flag_even_when_noop(self):
+        kwargs: dict = {"enable_prompt_caching": True}
+        AnthropicCacheControlHook.maybe_inject_cache_control(
+            [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            None,
+            kwargs,
+            model="gpt-4o",
+            custom_llm_provider="openai",
+        )
+        assert "enable_prompt_caching" not in kwargs
+
     def test_v1_messages_is_noop_when_disabled(self):
         messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
         result_msgs, result_sys = AnthropicCacheControlHook.maybe_inject_cache_control(

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -1734,6 +1734,21 @@ async def test_update_service_account_works_with_team_id():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("flag_value", [True, False])
+async def test_update_key_enable_prompt_caching_folds_into_metadata(flag_value):
+    """Top-level enable_prompt_caching on /key/update lands in key metadata, including flipping back to False."""
+    data = UpdateKeyRequest(key="sk-1", enable_prompt_caching=flag_value)
+    existing_key = LiteLLM_VerificationToken(
+        token="hashed", metadata={"enable_prompt_caching": not flag_value}
+    )
+
+    updated = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert updated["metadata"]["enable_prompt_caching"] is flag_value
+    assert "enable_prompt_caching" not in {k for k in updated if k != "metadata"}
+
+
+@pytest.mark.asyncio
 async def test_update_preserves_service_account_id_when_metadata_replaced():
     """
     Regression: /key/update wholesale-replaced metadata, silently dropping

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -688,6 +688,7 @@ async def test_add_litellm_data_to_request_strips_user_control_fields():
         "mock_response": "free response",
         "mock_tool_calls": [{"id": "call_1"}],
         "disable_global_guardrails": True,
+        "enable_prompt_caching": True,
         "routing_decision": {"cause": "forged", "routed_model": "spoofed"},
         "metadata": copy.deepcopy(malicious_metadata),
         "litellm_metadata": copy.deepcopy(malicious_metadata),
@@ -705,6 +706,7 @@ async def test_add_litellm_data_to_request_strips_user_control_fields():
     assert "mock_response" not in updated
     assert "mock_tool_calls" not in updated
     assert "disable_global_guardrails" not in updated
+    assert "enable_prompt_caching" not in updated
     assert "routing_decision" not in updated
 
     stripped_keys = {
@@ -739,6 +741,42 @@ async def test_add_litellm_data_to_request_strips_user_control_fields():
     assert "mock_response" not in snapshot_body
     assert "mock_tool_calls" not in snapshot_body
     assert "pillar_response_headers" not in snapshot_body["metadata"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "key_value, expected",
+    [(True, True), (False, False), ("yes", None), (None, None)],
+)
+async def test_key_metadata_enable_prompt_caching_promoted_to_request_root(key_value, expected):
+    """Key metadata enable_prompt_caching is stamped onto the request root (bools only), even when the client spoofs it."""
+    request_mock = MagicMock(spec=Request)
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url = MagicMock()
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {"Content-Type": "application/json"}
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+
+    data = {
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "hello"}],
+        "enable_prompt_caching": "spoofed-by-client",
+    }
+    key_metadata = {} if key_value is None else {"enable_prompt_caching": key_value}
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=request_mock,
+        user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key", metadata=key_metadata),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated.get("enable_prompt_caching") == expected
 
 
 @pytest.mark.asyncio

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -1192,6 +1192,21 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                     <Switch checkedChildren="Yes" unCheckedChildren="No" />
                   </Form.Item>
                   <Form.Item
+                    className="mt-4"
+                    label={
+                      <span>
+                        Enable Prompt Caching{" "}
+                        <Tooltip title="Automatically add prompt caching breakpoints (cache_control markers) to requests made with this key, cutting input cost on repeated prompts. Applies to Anthropic and Bedrock Claude models; requests that already set their own cache_control markers are left untouched.">
+                          <InfoCircleOutlined style={{ marginLeft: "4px" }} />
+                        </Tooltip>
+                      </span>
+                    }
+                    name="enable_prompt_caching"
+                    valuePropName="checked"
+                  >
+                    <Switch checkedChildren="Yes" unCheckedChildren="No" />
+                  </Form.Item>
+                  <Form.Item
                     label={
                       <span>
                         Guardrails{" "}

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -410,6 +410,36 @@ describe("KeyEditView", () => {
     });
   });
 
+  it("should initialize and submit enable_prompt_caching from key metadata", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const keyDataWithPromptCaching = {
+      ...MOCK_KEY_DATA,
+      metadata: { ...MOCK_KEY_DATA.metadata, enable_prompt_caching: true },
+    };
+
+    renderWithProviders(
+      <KeyEditView
+        keyData={keyDataWithPromptCaching}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"admin"}
+        premiumUser={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Enable Prompt Caching")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalledWith(expect.objectContaining({ enable_prompt_caching: true }));
+    });
+  });
+
   it("should disable models field when management routes are selected", async () => {
     const keyDataWithManagementRoutes = {
       ...MOCK_KEY_DATA,

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -150,6 +150,7 @@ export function KeyEditView({
     guardrails: keyData.metadata?.guardrails,
     disable_global_guardrails: keyData.metadata?.disable_global_guardrails || false,
     throttle_on_budget_exceeded: keyData.metadata?.throttle_on_budget_exceeded || false,
+    enable_prompt_caching: keyData.metadata?.enable_prompt_caching || false,
     ...estimateFields(keyData.metadata),
     prompts: keyData.metadata?.prompts,
     tags: keyData.metadata?.tags,
@@ -178,36 +179,8 @@ export function KeyEditView({
   };
 
   useEffect(() => {
-    form.setFieldsValue({
-      ...keyData,
-      token: keyData.token || keyData.token_id,
-      budget_duration: canonicalBudgetDuration(keyData.budget_duration),
-      metadata: formatMetadataForDisplay(stripTagsFromMetadata(keyData.metadata)),
-      guardrails: keyData.metadata?.guardrails,
-      disable_global_guardrails: keyData.metadata?.disable_global_guardrails || false,
-      prompts: keyData.metadata?.prompts,
-      tags: keyData.metadata?.tags,
-      vector_stores: keyData.object_permission?.vector_stores || [],
-      mcp_servers_and_groups: {
-        servers: keyData.object_permission?.mcp_servers || [],
-        accessGroups: keyData.object_permission?.mcp_access_groups || [],
-        toolsets: keyData.object_permission?.mcp_toolsets || [],
-      },
-      mcp_tool_permissions: keyData.object_permission?.mcp_tool_permissions || {},
-      throttle_on_budget_exceeded: keyData.metadata?.throttle_on_budget_exceeded || false,
-      ...estimateFields(keyData.metadata),
-      logging_settings: extractLoggingSettings(keyData.metadata),
-      disabled_callbacks: Array.isArray(keyData.metadata?.litellm_disabled_callbacks)
-        ? mapInternalToDisplayNames(keyData.metadata.litellm_disabled_callbacks)
-        : [],
-      access_group_ids: keyData.access_group_ids || [],
-      auto_rotate: keyData.auto_rotate || false,
-      ...(keyData.rotation_interval && { rotation_interval: keyData.rotation_interval }),
-      allowed_routes:
-        Array.isArray(keyData.allowed_routes) && keyData.allowed_routes.length > 0
-          ? keyData.allowed_routes.join(", ")
-          : "",
-    });
+    form.setFieldsValue(initialValues);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- initialValues is rebuilt from keyData every render; depending on it would re-run each render
   }, [keyData, form]);
 
   // Sync auto-rotation state with form values
@@ -527,6 +500,21 @@ export function KeyEditView({
           </span>
         }
         name="throttle_on_budget_exceeded"
+        valuePropName="checked"
+      >
+        <Switch checkedChildren="Yes" unCheckedChildren="No" />
+      </Form.Item>
+
+      <Form.Item
+        label={
+          <span>
+            Enable Prompt Caching{" "}
+            <Tooltip title="Automatically add prompt caching breakpoints (cache_control markers) to requests made with this key, cutting input cost on repeated prompts. Applies to Anthropic and Bedrock Claude models; requests that already set their own cache_control markers are left untouched.">
+              <InfoCircleOutlined style={{ marginLeft: "4px" }} />
+            </Tooltip>
+          </span>
+        }
+        name="enable_prompt_caching"
         valuePropName="checked"
       >
         <Switch checkedChildren="Yes" unCheckedChildren="No" />

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -780,6 +780,13 @@ export default function KeyInfoView({
                     <Text>{currentKeyData.expires ? formatTimestamp(currentKeyData.expires) : "Never"}</Text>
                   </div>
 
+                  {Boolean(currentKeyData.metadata?.enable_prompt_caching) && (
+                    <div>
+                      <Text className="font-medium">Prompt Caching</Text>
+                      <Text>Enabled (auto-injects cache_control markers on Anthropic and Bedrock Claude requests)</Text>
+                    </div>
+                  )}
+
                   <AutoRotationView
                     autoRotate={currentKeyData.auto_rotate}
                     rotationInterval={currentKeyData.rotation_interval}

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -6781,6 +6781,7 @@ export interface paths {
          *     - policies: Optional[List[str]] - List of policy names to apply to the key. Policies define guardrails, conditions, and inheritance rules.
          *     - disable_global_guardrails: Optional[bool] - Whether to disable global guardrails for the key.
          *     - throttle_on_budget_exceeded: Optional[bool] - When the key exceeds its max_budget, throttle its tpm/rpm to the global budget_exceeded_throttle_percentage instead of blocking the key entirely.
+         *     - enable_prompt_caching: Optional[bool] - Auto-inject prompt caching breakpoints (Anthropic cache_control markers) on requests made with this key. Anthropic and Bedrock Claude models only.
          *     - permissions: Optional[dict] - key-specific permissions. Currently just used for turning off pii masking (if connected). Example - {"pii": false}
          *     - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}}. IF null or {} then no model specific budget.
          *     - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
@@ -7240,6 +7241,7 @@ export interface paths {
          *     - policies: Optional[List[str]] - List of policy names to apply to the key. Policies define guardrails, conditions, and inheritance rules.
          *     - disable_global_guardrails: Optional[bool] - Whether to disable global guardrails for the key.
          *     - throttle_on_budget_exceeded: Optional[bool] - When the key exceeds its max_budget, throttle its tpm/rpm to the global budget_exceeded_throttle_percentage instead of blocking the key entirely.
+         *     - enable_prompt_caching: Optional[bool] - Auto-inject prompt caching breakpoints (Anthropic cache_control markers) on requests made with this key. Anthropic and Bedrock Claude models only.
          *     - prompts: Optional[List[str]] - List of prompts that the key is allowed to use.
          *     - blocked: Optional[bool] - Whether the key is blocked
          *     - aliases: Optional[dict] - Model aliases for the key - [Docs](https://litellm.vercel.app/docs/proxy/virtual_keys#model-aliases)
@@ -24987,6 +24989,8 @@ export interface components {
             disable_global_guardrails?: boolean | null;
             /** Duration */
             duration?: string | null;
+            /** Enable Prompt Caching */
+            enable_prompt_caching?: boolean | null;
             /** Enforced Params */
             enforced_params?: string[] | null;
             /** Guardrails */
@@ -25147,6 +25151,8 @@ export interface components {
             disable_global_guardrails?: boolean | null;
             /** Duration */
             duration?: string | null;
+            /** Enable Prompt Caching */
+            enable_prompt_caching?: boolean | null;
             /** Enforced Params */
             enforced_params?: string[] | null;
             /** Expires */
@@ -29595,6 +29601,8 @@ export interface components {
             disable_global_guardrails?: boolean | null;
             /** Duration */
             duration?: string | null;
+            /** Enable Prompt Caching */
+            enable_prompt_caching?: boolean | null;
             /** Enforced Params */
             enforced_params?: string[] | null;
             /** Expires */
@@ -31440,6 +31448,8 @@ export interface components {
             disable_global_guardrails?: boolean | null;
             /** Duration */
             duration?: string | null;
+            /** Enable Prompt Caching */
+            enable_prompt_caching?: boolean | null;
             /** Enforced Params */
             enforced_params?: string[] | null;
             /** Grace Period */
@@ -33835,6 +33845,8 @@ export interface components {
             disable_global_guardrails?: boolean | null;
             /** Duration */
             duration?: string | null;
+            /** Enable Prompt Caching */
+            enable_prompt_caching?: boolean | null;
             /** Enforced Params */
             enforced_params?: string[] | null;
             /** Guardrails */


### PR DESCRIPTION
## TLDR

Problem this solves:

- Prompt caching auto-injection is all-or-nothing today (gateway-wide flag)
- Admins cannot turn caching on for one virtual key only

How it solves it:

- New `enable_prompt_caching` toggle on /key/generate and /key/update
- Flagged keys get cache_control breakpoints auto-injected per request
- Reuses all existing gates: Claude-only, client markers always win
- Admin UI switch on key create and key edit

## User Flow

Before: an admin wants prompt caching for one team's key, but the only knob caches for every key on the gateway

1. The admin opens http://localhost:4000/ui/?page=api-keys and creates a key for the team; the form has no prompt caching option
2. The team sends POST http://localhost:4000/v1/chat/completions with that key, a large stable system prompt, and no `cache_control` markers
3. The response `usage` shows plain `prompt_tokens` on every call: no `cache_creation_input_tokens`, `cached_tokens` stays 0, and the full prompt is billed at full price each time
4. The admin's only fix is asking the team to hand-edit every request, or flipping `enable_anthropic_prompt_caching: true`, which changes behavior for every key on the proxy

After: the admin flips one switch on that key and its requests start caching, with every other key untouched

1. The admin opens http://localhost:4000/ui/?page=api-keys, creates (or edits) the team's key, and turns on the new "Enable Prompt Caching" switch
2. The team sends the same POST http://localhost:4000/v1/chat/completions with no `cache_control` markers
3. The first response's `usage` now shows `cache_creation_input_tokens` > 0, and repeat calls within the cache TTL show `prompt_tokens_details.cached_tokens` > 0, cutting input cost on the stable prefix
4. Requests from every other key, and requests that already carry their own `cache_control` markers, behave exactly as before

## Relevant issues

## Linear ticket

Resolves LIT-4999

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Wire-level proof at c7ca26a8b8 against a live worktree proxy on :4999. The `anthropic/` deployment's api_base points at a local capture server so the exact outbound Anthropic request body is visible (this QA machine has no Anthropic credential; the paid runbook below reproduces the same thing against the real API)

```
KEY_ON=$(curl -s http://localhost:4999/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key_alias":"lit4999-wire-on","enable_prompt_caching":true}' | jq -r .key)
KEY_OFF=$(curl -s http://localhost:4999/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key_alias":"lit4999-wire-off"}' | jq -r .key)
BODY='{"model":"anthropic-sonnet-5","max_tokens":20,"messages":[{"role":"system","content":"a long stable system prompt"},{"role":"user","content":"Say pong."}]}'
curl -s http://localhost:4999/v1/chat/completions -H "Authorization: Bearer $KEY_ON" -H 'Content-Type: application/json' -d "$BODY"
curl -s http://localhost:4999/v1/chat/completions -H "Authorization: Bearer $KEY_OFF" -H 'Content-Type: application/json' -d "$BODY"
curl -s http://localhost:4999/v1/messages -H "Authorization: Bearer $KEY_ON" -H 'Content-Type: application/json' \
  -d '{"model":"anthropic-sonnet-5","max_tokens":20,"system":"a long stable system prompt","messages":[{"role":"user","content":"Say pong."}]}'
```

Captured outbound Anthropic request bodies, in call order (`system` lists each system block's cache_control; note the flagged key gets ephemeral breakpoints on the system prompt and the trailing turn on both endpoints, the control key gets none):

```
{"system": [{"type": "ephemeral"}], "last_message_content": [{"type": "text", "text": "Say pong.", "cache_control": {"type": "ephemeral"}}]}
{"system": [null], "last_message_content": [{"type": "text", "text": "Say pong."}]}
{"system": [{"type": "ephemeral"}], "last_message_content": [{"type": "text", "text": "Say pong.", "cache_control": {"type": "ephemeral"}}]}
```

UI flow at c7ca26a8b8 (dashboard dev server against the same live proxy). Creating a key with the new switch on:

![Create key form with Enable Prompt Caching switch on](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit4999_screenshots/create-key-toggle.png)

The created key's Settings tab shows the stored state:

![Key settings read-only view showing Prompt Caching enabled](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit4999_screenshots/key-settings-readonly.png)

Edit Settings loads the switch pre-checked from the key, so it can be flipped off again:

![Key edit view with the switch pre-checked](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit4999_screenshots/key-edit-toggle.png)

Paid reproduction against the real Anthropic API (run with `ANTHROPIC_API_KEY` set):

1. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
2. Create a key with the toggle: `curl -s http://localhost:4000/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"enable_prompt_caching":true}'`
3. Send the same /v1/chat/completions request twice with that key, using a system prompt over the model's minimum cacheable length (about 1,000 tokens for `anthropic-sonnet-5`)
4. Expect the first response's `usage.cache_creation_input_tokens` > 0 and the second's `usage.prompt_tokens_details.cached_tokens` > 0; a key without the toggle shows neither
5. UI: open http://localhost:3000/?page=api-keys, click Create Key, and see the "Enable Prompt Caching" switch under the rate limit fields; flip it, create, then open the key's Settings tab and see "Prompt Caching: Enabled"

## Type

🆕 New Feature

## Caveats (if any)

- Auto-injection applies to Anthropic and Bedrock Claude models only
- Toggle is on-or-inherit; no per-key force-off of the global flag
- Key-level only; team-level toggle left for a follow-up

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
