### PR TITLE
docs(terraform): describe the provider release as automatic

### DIFF
--- a/terraform/provider/RELEASING.md
+++ b/terraform/provider/RELEASING.md
@@ -106,19 +106,23 @@ Before creating a release:
 
 4. **Land the changes in BerriAI/litellm**
 
-   Open a PR to `BerriAI/litellm` updating `terraform/provider/CHANGELOG.md` (and any source changes) and merge it. Note the merge commit SHA; the release workflow takes it as `git_ref`
+   Open a PR to `BerriAI/litellm` updating `terraform/provider/CHANGELOG.md` (and any source changes) and merge it
 
 ### 2. Mirror and Tag via project-releaser
 
 The provider source lives at `terraform/provider/` in `BerriAI/litellm`; `BerriAI/terraform-provider-litellm` is a thin release mirror. Do not commit or tag the mirror directly
+
+Normally there is nothing to do here. `BerriAI/project-releaser`'s release pipeline runs the same check on every release except `adhoc`, nightly included: it reads the topmost released heading in `terraform/provider/CHANGELOG.md`, probes the mirror for `v<version>`, and dispatches `Publish Terraform provider` only when the changelog has moved ahead of what the mirror carries. Cutting the version heading in step 1 is therefore what releases the provider, and the next release picks it up, so the wait is a day rather than a week
+
+Dispatch by hand only for an out-of-band release, or to recover a run that failed:
 
 1. Go to `BerriAI/project-releaser` > **Actions** > `Publish Terraform provider`
 2. Click **Run workflow**:
    - `git_ref`: full 40-char commit SHA from `BerriAI/litellm` to release from
    - `provider_version`: the new version without the `v` prefix (e.g. `0.3.0`)
    - `dry_run`: optional; validates without pushing
-3. The workflow rsyncs `terraform/provider/` into the mirror repo, commits, and pushes tag `v<provider_version>`
-4. The tag push triggers the mirror's `Release` workflow (goreleaser), which is gated by the `production-release` environment approval
+
+Automatic or manual, the run waits on the `production-release` approval in `project-releaser`, then rsyncs `terraform/provider/` into the mirror repo, commits, and pushes tag `v<provider_version>`. That approval is the only one in the flow. The tag push triggers the mirror's `Release` workflow (goreleaser), which runs unattended
 
 **Important**:
 - Tags must follow the format: `v<MAJOR>.<MINOR>.<PATCH>` (e.g., `v0.1.2`, `v1.0.0`)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Provider runbook describes a flow that no longer exists
- It tells you to dispatch the publish by hand
- It promises a second approval in the mirror repo
- Both were removed; the docs still shipped to the registry

How it solves it:

- Says the publish is automatic once the changelog heading moves
- Keeps the manual dispatch as the out-of-band and recovery path
- Records that one approval remains, in project-releaser

## User Flow

Before: someone releasing the provider follows the runbook and does two manual steps that are no longer wired that way

1. They open `terraform/provider/RELEASING.md` and read step 1, which tells them to note the merge commit SHA because the release workflow takes it as `git_ref`
2. They merge the changelog PR, then go to `BerriAI/project-releaser` > Actions > Publish Terraform provider and run it by hand, pasting that SHA
3. They read step 2.4, which says the tag push triggers a `Release` workflow in `BerriAI/terraform-provider-litellm` gated by a `production-release` approval, so they open that repo's Actions tab and wait for a run to approve
4. Nobody is watching that second repo, so the run sits, and the registry keeps serving the previous version

After: the same person reads the same file and learns there is nothing to do after the merge

1. They open `terraform/provider/RELEASING.md` and read step 1, which asks only for a PR that moves the topmost `[Unreleased]` items under a new `## [X.Y.Z] - <date>` heading
2. They merge it
3. They read step 2, which says the pipeline runs this check on every release except `adhoc`, nightly included, and dispatches the publish itself once the changelog is ahead of the mirror's tags
4. They approve the one `production-release` gate in `BerriAI/project-releaser` when it appears, and the file tells them that is the only approval in the flow
5. https://registry.terraform.io/providers/BerriAI/litellm shows the new version, typically within a day of the merge instead of the next week

## Relevant issues

## Linear ticket

Resolves LIT-5282

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR edits one markdown file and changes no runtime behavior, so there is no proxy request to capture. The behavior it documents is verified in the two sibling PRs, where the workflow contract tests pin it.

## Type

📖 Documentation

## Caveats (if any)

- Behavior lands in BerriAI/project-releaser#163 and BerriAI/terraform-provider-litellm#49
- No tests here; the pinning tests live in project-releaser#163
- Mirror overwrites this file on every publish, so it belongs upstream
