### PR TITLE
fix(ui): scope Virtual Keys and Logs team lists to the caller

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.test.ts
@@ -913,8 +913,6 @@ describe("useAllTeams", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    // A scoped call that comes back empty is the failure this guards against: the
-    // 401 disappears but the page still shows no teams.
     expect(result.current.data).toEqual(mockTeams);
     expect(result.current.data?.length).toBeGreaterThan(0);
     expect(requestedUserId(fetchMock.mock.calls[0][0] as string)).toBe("member-7");

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.test.ts
@@ -820,6 +820,18 @@ describe("useAllTeams", () => {
   });
 
   const requestedPage = (url: string) => new URLSearchParams(url.split("?")[1]).get("page");
+  const requestedUserId = (url: string) => new URLSearchParams(url.split("?")[1]).get("user_id");
+  const asRole = (userRole: string, userId = "test-user-id") =>
+    mockUseAuthorized.mockReturnValue({
+      accessToken: "test-access-token",
+      userId,
+      userRole,
+      token: "test-token",
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
 
   it("paginates /v2/team/list to completion and concatenates every page", async () => {
     fetchMock.mockImplementation((url: string) =>
@@ -891,5 +903,66 @@ describe("useAllTeams", () => {
     rerender();
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("scopes the request to the caller for an internal user and returns their teams", async () => {
+    asRole("Internal User", "member-7");
+    fetchMock.mockResolvedValue(pageResponse(mockTeams, 1, 1));
+
+    const { result } = renderHook(() => useAllTeams(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // A scoped call that comes back empty is the failure this guards against: the
+    // 401 disappears but the page still shows no teams.
+    expect(result.current.data).toEqual(mockTeams);
+    expect(result.current.data?.length).toBeGreaterThan(0);
+    expect(requestedUserId(fetchMock.mock.calls[0][0] as string)).toBe("member-7");
+  });
+
+  it("carries user_id on every page of a scoped multi-page result", async () => {
+    asRole("Internal Viewer", "member-7");
+    fetchMock.mockImplementation((url: string) =>
+      Promise.resolve(
+        requestedPage(url) === "1" ? pageResponse([mockTeams[0]], 1, 2) : pageResponse([mockTeams[1]], 2, 2),
+      ),
+    );
+
+    const { result } = renderHook(() => useAllTeams(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const scopes = fetchMock.mock.calls.map((call) => requestedUserId(call[0] as string));
+    expect(scopes).toEqual(["member-7", "member-7"]);
+  });
+
+  it.each(["Admin", "Admin Viewer", "Org Admin"])(
+    "sends no user_id for %s so the broad list is left intact",
+    async (userRole) => {
+      asRole(userRole);
+      fetchMock.mockResolvedValue(pageResponse(mockTeams, 1, 1));
+
+      const { result } = renderHook(() => useAllTeams(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(requestedUserId(fetchMock.mock.calls[0][0] as string)).toBeNull();
+    },
+  );
+
+  it("refetches when the scope changes even though the access token has not", async () => {
+    asRole("Internal User", "member-7");
+    fetchMock.mockResolvedValue(pageResponse(mockTeams, 1, 1));
+
+    const { result, rerender } = renderHook(() => useAllTeams(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    asRole("Internal User", "member-8");
+    rerender();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(requestedUserId(fetchMock.mock.calls[1][0] as string)).toBe("member-8");
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.ts
@@ -5,6 +5,7 @@ import { fetchTeams } from "@/app/(dashboard)/networking";
 import { createQueryKeys } from "@/app/(dashboard)/hooks/common/queryKeysFactory";
 import { teamInfoCall } from "@/components/networking";
 import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage, handleError } from "@/components/networking";
+import { teamListScopeUserId } from "@/utils/roles";
 
 export interface TeamsResponse {
   teams: Team[];
@@ -116,24 +117,30 @@ export const useTeams = (): UseQueryResult<Team[]> => {
 
 const ALL_TEAMS_PAGE_SIZE = 100;
 
-const fetchAllTeamsPaged = async (accessToken: string): Promise<Team[]> => {
-  const firstPage: TeamsResponse = await teamListCall(accessToken, 1, ALL_TEAMS_PAGE_SIZE);
+const fetchAllTeamsPaged = async (accessToken: string, userID: string | null): Promise<Team[]> => {
+  const firstPage: TeamsResponse = await teamListCall(accessToken, 1, ALL_TEAMS_PAGE_SIZE, { userID });
   const totalPages = firstPage.total_pages ?? 1;
   if (totalPages <= 1) return firstPage.teams;
 
   const remainingPages: TeamsResponse[] = await Promise.all(
-    Array.from({ length: totalPages - 1 }, (_, i) => teamListCall(accessToken, i + 2, ALL_TEAMS_PAGE_SIZE)),
+    Array.from({ length: totalPages - 1 }, (_, i) => teamListCall(accessToken, i + 2, ALL_TEAMS_PAGE_SIZE, { userID })),
   );
   return [firstPage, ...remainingPages].flatMap((page) => page.teams);
 };
 
 export const useAllTeams = (): UseQueryResult<Team[]> => {
-  const { accessToken } = useAuthorized();
+  const { accessToken, userId, userRole } = useAuthorized();
+  const scopedUserID = teamListScopeUserId(userRole, userId);
   return useQuery<Team[]>({
     queryKey: teamKeys.list({
-      filters: { scope: "all", pageSize: ALL_TEAMS_PAGE_SIZE, accessToken: accessToken ?? "" },
+      filters: {
+        scope: "all",
+        pageSize: ALL_TEAMS_PAGE_SIZE,
+        accessToken: accessToken ?? "",
+        userID: scopedUserID ?? "",
+      },
     }),
-    queryFn: async () => await fetchAllTeamsPaged(accessToken!),
+    queryFn: async () => await fetchAllTeamsPaged(accessToken!, scopedUserID),
     enabled: Boolean(accessToken),
     staleTime: 30000,
   });

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_helpers.test.ts
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_helpers.test.ts
@@ -1,11 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
-import { fetchTeamFilterOptions } from "./filter_helpers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchAllTeams, fetchTeamFilterOptions } from "./filter_helpers";
 
 const mockKeyListCall = vi.fn();
+const mockTeamListCall = vi.fn();
 
 vi.mock("@/components/networking", () => ({
   keyListCall: (...args: unknown[]) => mockKeyListCall(...args),
-  teamListCall: vi.fn(),
+  teamListCall: (...args: unknown[]) => mockTeamListCall(...args),
   organizationListCall: vi.fn(),
 }));
 
@@ -76,5 +77,41 @@ describe("fetchTeamFilterOptions", () => {
     const result = await fetchTeamFilterOptions("tok-123", "team-1");
 
     expect(result).toEqual({ keyAliases: [], organizationIds: [], userIds: [] });
+  });
+});
+
+describe("fetchAllTeams", () => {
+  beforeEach(() => {
+    mockTeamListCall.mockReset();
+  });
+
+  it("forwards the scoping user id to /team/list and returns the rows it answers with", async () => {
+    mockTeamListCall.mockResolvedValue([{ team_id: "team-a" }, { team_id: "team-b" }]);
+
+    const teams = await fetchAllTeams("tok-123", null, "member-7");
+
+    expect(mockTeamListCall).toHaveBeenCalledWith("tok-123", null, "member-7");
+    expect(teams.map((team) => team.team_id)).toEqual(["team-a", "team-b"]);
+  });
+
+  it("sends no user id when the caller is entitled to the broad list", async () => {
+    mockTeamListCall.mockResolvedValue([]);
+
+    await fetchAllTeams("tok-123");
+
+    expect(mockTeamListCall).toHaveBeenCalledWith("tok-123", null, null);
+  });
+
+  it("keeps the organization filter independent of the scoping user id", async () => {
+    mockTeamListCall.mockResolvedValue([]);
+
+    await fetchAllTeams("tok-123", "org-1", "member-7");
+
+    expect(mockTeamListCall).toHaveBeenCalledWith("tok-123", "org-1", "member-7");
+  });
+
+  it("returns an empty list without calling the endpoint when there is no access token", async () => {
+    expect(await fetchAllTeams(null, null, "member-7")).toEqual([]);
+    expect(mockTeamListCall).not.toHaveBeenCalled();
   });
 });

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_helpers.ts
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_helpers.ts
@@ -114,9 +114,15 @@ export const fetchTeamFilterOptions = async (
  * Fetches all teams across all pages
  * @param accessToken The access token for API authentication
  * @param organizationId Optional organization ID to filter teams
+ * @param userID Scopes the list to that user's teams. Required for roles the endpoint
+ *   does not grant a broad list to; see `teamListScopeUserId`
  * @returns Array of all teams
  */
-export const fetchAllTeams = async (accessToken: string | null, organizationId?: string | null): Promise<Team[]> => {
+export const fetchAllTeams = async (
+  accessToken: string | null,
+  organizationId?: string | null,
+  userID?: string | null,
+): Promise<Team[]> => {
   if (!accessToken) return [];
 
   try {
@@ -125,7 +131,7 @@ export const fetchAllTeams = async (accessToken: string | null, organizationId?:
     let hasMorePages = true;
 
     while (hasMorePages) {
-      const response = await teamListCall(accessToken, organizationId || null, null);
+      const response = await teamListCall(accessToken, organizationId || null, userID ?? null);
 
       // Add teams from this page
       allTeams = [...allTeams, ...response];

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
@@ -26,6 +26,8 @@ vi.mock("@/components/key_team_helpers/filter_helpers", () => ({
 }));
 
 import { uiSpendLogsCall } from "../networking";
+import { fetchAllTeams } from "@/components/key_team_helpers/filter_helpers";
+import type { Team } from "../key_team_helpers/key_list";
 
 const emptyResponse: PaginatedResponse = {
   data: [],
@@ -196,6 +198,41 @@ describe("useLogFilterLogic", () => {
       await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalled());
       expect(lastCallParams()?.params).toMatchObject({ user_id: "someone-else" });
     });
+  });
+
+  describe("team filter list scope", () => {
+    const callerTeams = [{ team_id: "team-a" }, { team_id: "team-b" }] as Team[];
+
+    it("scopes /team/list to an internal user and still surfaces their teams", async () => {
+      vi.mocked(fetchAllTeams).mockResolvedValue(callerTeams);
+
+      const { result } = renderFilterHook({ userRole: "Internal User", userID: "member-7" });
+
+      await waitFor(() => expect(fetchAllTeams).toHaveBeenCalled());
+      expect(fetchAllTeams).toHaveBeenCalledWith("test-token", null, "member-7");
+      // Without the scope the request 401s and the filter falls back to an empty
+      // list, so the rows matter as much as the argument.
+      await waitFor(() => expect(result.current.allTeams).toEqual(callerTeams));
+    });
+
+    it("scopes /team/list for an internal viewer", async () => {
+      vi.mocked(fetchAllTeams).mockResolvedValue(callerTeams);
+
+      renderFilterHook({ userRole: "Internal Viewer", userID: "member-7" });
+
+      await waitFor(() => expect(fetchAllTeams).toHaveBeenCalledWith("test-token", null, "member-7"));
+    });
+
+    it.each(["Admin", "Admin Viewer", "Org Admin"])(
+      "leaves /team/list unscoped for %s so the broad list survives",
+      async (userRole) => {
+        vi.mocked(fetchAllTeams).mockResolvedValue(callerTeams);
+
+        renderFilterHook({ userRole, userID: "member-7" });
+
+        await waitFor(() => expect(fetchAllTeams).toHaveBeenCalledWith("test-token", null, null));
+      },
+    );
   });
 
   it("returns an empty payload and does not crash when the call fails", async () => {

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
@@ -210,8 +210,6 @@ describe("useLogFilterLogic", () => {
 
       await waitFor(() => expect(fetchAllTeams).toHaveBeenCalled());
       expect(fetchAllTeams).toHaveBeenCalledWith("test-token", null, "member-7");
-      // Without the scope the request 401s and the filter falls back to an empty
-      // list, so the rows matter as much as the argument.
       await waitFor(() => expect(result.current.allTeams).toEqual(callerTeams));
     });
 

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -4,6 +4,7 @@ import type { ColumnFiltersState, PaginationState, SortingState } from "@tanstac
 import { uiSpendLogsCall } from "../networking";
 import { Team } from "../key_team_helpers/key_list";
 import { fetchAllTeams } from "../../components/key_team_helpers/filter_helpers";
+import { teamListScopeUserId } from "../../utils/roles";
 import { defaultPageSize } from "../constants";
 import { LOGS_SORT_FIELD_MAP, type LogEntry, type LogsSortField } from "./columns";
 
@@ -194,11 +195,13 @@ export function useLogFilterLogic({
     total_pages: 0,
   };
 
+  const teamListUserID = teamListScopeUserId(userRole, userID);
+
   const allTeamsQueryOptions: UseQueryOptions<Team[], Error> = {
-    queryKey: ["allTeamsForLogFilters", accessToken],
+    queryKey: ["allTeamsForLogFilters", accessToken, teamListUserID],
     queryFn: async () => {
       if (!accessToken) return [];
-      const teamsData = await fetchAllTeams(accessToken);
+      const teamsData = await fetchAllTeams(accessToken, null, teamListUserID);
       return teamsData || [];
     },
     enabled: !!accessToken,

--- a/ui/litellm-dashboard/src/utils/roles.test.ts
+++ b/ui/litellm-dashboard/src/utils/roles.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  all_admin_roles,
   effectiveSessionRole,
   isAdminRole,
   isProxyAdminRole,
@@ -8,6 +9,7 @@ import {
   isViewOnlySessionRole,
   rolesAllowedToViewWriteScopedPages,
   rolesWithWriteAccess,
+  teamListScopeUserId,
 } from "./roles";
 import { Team } from "@/components/networking";
 
@@ -234,6 +236,44 @@ describe("roles", () => {
     it("stays true for proxy_admin_viewer even though its session role reads as Admin", () => {
       expect(effectiveSessionRole("proxy_admin_viewer")).toBe("Admin");
       expect(isViewOnlySessionRole("proxy_admin_viewer")).toBe(true);
+    });
+  });
+
+  describe("teamListScopeUserId", () => {
+    const SESSION_USER_ID = "user-1";
+
+    // The truth table is driven through effectiveSessionRole rather than hand-written
+    // labels, so it keeps holding if the raw -> display mapping ever moves.
+    it.each(["proxy_admin", "proxy_admin_viewer", "org_admin"])(
+      "leaves %s unscoped so the endpoint keeps returning its broad list",
+      (rawRole) => {
+        expect(teamListScopeUserId(effectiveSessionRole(rawRole), SESSION_USER_ID)).toBeNull();
+      },
+    );
+
+    it.each(["internal_user", "internal_user_viewer", "internal_viewer", "app_user"])(
+      "scopes %s to its own user id, which is what the endpoint authorizes on",
+      (rawRole) => {
+        expect(teamListScopeUserId(effectiveSessionRole(rawRole), SESSION_USER_ID)).toBe(SESSION_USER_ID);
+      },
+    );
+
+    it("also accepts the Admin Viewer label that formatUserRole emits", () => {
+      expect(teamListScopeUserId("Admin Viewer", SESSION_USER_ID)).toBeNull();
+    });
+
+    it("scopes an unknown or absent role rather than assuming a broad list", () => {
+      expect(teamListScopeUserId(null, SESSION_USER_ID)).toBe(SESSION_USER_ID);
+      expect(teamListScopeUserId("Undefined Role", SESSION_USER_ID)).toBe(SESSION_USER_ID);
+    });
+
+    it("keeps Org Admin broad even though all_admin_roles carries only the raw org_admin", () => {
+      // all_admin_roles mixes display labels with raw role names, so isAdminRole is
+      // false for the value useAuthorized actually supplies for an org admin. Relying
+      // on it here would scope org admins down to their direct memberships.
+      expect(all_admin_roles).not.toContain(effectiveSessionRole("org_admin"));
+      expect(isAdminRole(effectiveSessionRole("org_admin"))).toBe(false);
+      expect(teamListScopeUserId(effectiveSessionRole("org_admin"), SESSION_USER_ID)).toBeNull();
     });
   });
 });

--- a/ui/litellm-dashboard/src/utils/roles.test.ts
+++ b/ui/litellm-dashboard/src/utils/roles.test.ts
@@ -242,8 +242,6 @@ describe("roles", () => {
   describe("teamListScopeUserId", () => {
     const SESSION_USER_ID = "user-1";
 
-    // The truth table is driven through effectiveSessionRole rather than hand-written
-    // labels, so it keeps holding if the raw -> display mapping ever moves.
     it.each(["proxy_admin", "proxy_admin_viewer", "org_admin"])(
       "leaves %s unscoped so the endpoint keeps returning its broad list",
       (rawRole) => {
@@ -268,9 +266,6 @@ describe("roles", () => {
     });
 
     it("keeps Org Admin broad even though all_admin_roles carries only the raw org_admin", () => {
-      // all_admin_roles mixes display labels with raw role names, so isAdminRole is
-      // false for the value useAuthorized actually supplies for an org admin. Relying
-      // on it here would scope org admins down to their direct memberships.
       expect(all_admin_roles).not.toContain(effectiveSessionRole("org_admin"));
       expect(isAdminRole(effectiveSessionRole("org_admin"))).toBe(false);
       expect(teamListScopeUserId(effectiveSessionRole("org_admin"), SESSION_USER_ID)).toBeNull();

--- a/ui/litellm-dashboard/src/utils/roles.ts
+++ b/ui/litellm-dashboard/src/utils/roles.ts
@@ -77,3 +77,12 @@ export const effectiveSessionRole = (rawUserRole?: string): string => {
 
 export const isViewOnlySessionRole = (rawUserRole?: string): boolean =>
   viewOnlyRawRoles.includes(rawUserRole?.toLowerCase() ?? "");
+
+// Session roles (the value `useAuthorized().userRole` supplies) that /team/list and
+// /v2/team/list already answer with a broad list: proxy-wide for admins, org-wide for
+// org admins. Sending a user_id for those narrows the response to direct memberships,
+// so only the roles the endpoints would otherwise reject carry one.
+const sessionRolesWithBroadTeamList: string[] = ["Admin", "Admin Viewer", "Org Admin"];
+
+export const teamListScopeUserId = (userRole: string | null, userId: string | null): string | null =>
+  sessionRolesWithBroadTeamList.includes(userRole ?? "") ? null : userId;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Virtual Keys and Logs 401 for non-admin roles
- Both pages asked for every team on the proxy
- Non-admins may see their own teams, not none

How it solves it:

- Those two requests now carry the caller's user id
- Admins and org admins keep their broad, unscoped request
- One shared helper decides which roles get scoped

## User Flow

Before: an internal user who belongs to two teams opens Virtual Keys or Logs and the team data never arrives

1. They sign in at https://litellm-domain/ui/ as an internal user
2. They open https://litellm-domain/ui/?page=api-keys, and the browser network tab shows `GET /v2/team/list?page=1&page_size=100` coming back 401 with `Only admin users can query all teams/other teams. Your user role=internal_user`
3. The same page also sends `GET /v2/team/list?user_id=<their id>&page=1&page_size=100`, which returns 200 and their two teams, so a working request and a failing one sit side by side
4. They open https://litellm-domain/ui/?page=logs, and `GET /team/list` comes back with the same 401
5. The Team ID filter on the Logs page offers no teams to pick from
6. A proxy admin walking the same two pages sees every request return 200 and the full proxy-wide team list

After: the same user's two pages load their teams, and an admin sees no change at all

1. They sign in at https://litellm-domain/ui/ as an internal user
2. They open https://litellm-domain/ui/?page=api-keys, and the network tab shows only `GET /v2/team/list?user_id=<their id>&page=1&page_size=100`, returning 200 with both of their teams
3. There is no longer a second, failing team request on the page
4. They open https://litellm-domain/ui/?page=logs, and `GET /team/list?user_id=<their id>` returns 200 with the same two teams
5. The Team ID filter on the Logs page now lists both of their teams
6. A proxy admin walking the same two pages sends the exact same unscoped requests as before and still sees every team on the proxy

Neither list grows for anyone. An internal user still only receives the teams they belong to, which is the set the gateway was already willing to hand them when asked correctly

## Call sites

Every caller of the two team-list fetchers, and what happened to each

`GET /team/list`:

| Caller | Before | After | Reason |
| --- | --- | --- | --- |
| `key_team_helpers/filter_helpers.ts` `fetchAllTeams`, reached from the Logs page | unscoped | **scoped** | Logs is reachable by every role, so the unscoped call 401s for non-admins |
| `app/(dashboard)/networking.ts` `fetchTeams` | role-branched | unchanged | already sends the caller's id for non-admins |
| `common_components/fetch_teams.tsx` `fetchTeams` | role-branched | unchanged | already sends the caller's id for non-admins |
| `policies/_components/policy_test_panel.tsx` | always scoped | unchanged | already sends the caller's id |
| `policies/_components/add_attachment_form.tsx` | unscoped | unchanged | the Policies nav entry is gated to admin roles, so only callers the endpoint answers broadly reach it |
| `users/_components/view_users/user_info_view.tsx` | unscoped | unchanged | the Internal Users nav entry is gated to admins and org admins, both of which the endpoint answers without a user id |

`GET /v2/team/list`:

| Caller | Before | After | Reason |
| --- | --- | --- | --- |
| `hooks/teams/useTeams.ts` `useAllTeams`, reached from the Virtual Keys table | unscoped | **scoped** | Virtual Keys is reachable by every role, so the unscoped call 401s for non-admins |
| `api-keys/ApiKeysDashboard.tsx` | role-branched | unchanged | already sends the caller's id for non-admins |
| `hooks/teams/useTeams.ts` `useTeamsTable`, reached from the Teams table | role-branched | unchanged | already sends the caller's id for non-admins |
| `hooks/teams/useTeams.ts` `useInfiniteTeams` | role-branched | unchanged | already sends the caller's id for non-admins |
| `hooks/teams/useTeams.ts` `useDeletedTeams` | unscoped | unchanged | the Deleted Teams tab is gated to admin roles |

Scoping a caller that the gateway already answers broadly is not free, so the four unscoped callers above were left alone deliberately. Measured against a live gateway, a proxy admin who sends their own user id gets 0 teams back instead of 146, and an org admin who sends their own id on `/team/list` gets 0 instead of their 2 organization teams. Shrinking an admin's view would be a worse bug than the one being fixed here

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live gateway on `localhost:4000` started with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`, dashboard dev server on `localhost:3000` pointed at it. Fixture: an org with two teams, plus `tls-internal`, an `internal_user` who is a member of both and of nothing else. `INTERNAL_KEY` is that user's own key, and the master key is `dev_config.yaml`'s `sk-1234`

### The two endpoints, scoped and unscoped

Captured at `444b275ac3`. This PR changes no gateway code, so these responses are identical before and after it

```
# 1. non-admin, unscoped: what the two pages sent before this PR
$ curl -s -o /tmp/r.json -w 'HTTP %{http_code}\n' -H "Authorization: Bearer $INTERNAL_KEY" 'http://localhost:4000/team/list' && jq -c . /tmp/r.json
HTTP 401
{"detail":{"error":"Only admin users can query all teams/other teams. Your user role=internal_user"}}

$ curl -s -o /tmp/r.json -w 'HTTP %{http_code}\n' -H "Authorization: Bearer $INTERNAL_KEY" 'http://localhost:4000/v2/team/list?page=1&page_size=100' && jq -c . /tmp/r.json
HTTP 401
{"detail":{"error":"Only admin users can query all teams/other teams. Your user role=internal_user"}}

# 2. non-admin, scoped: what they send after
$ curl -s -o /tmp/r.json -w 'HTTP %{http_code}\n' -H "Authorization: Bearer $INTERNAL_KEY" 'http://localhost:4000/team/list?user_id=tls-internal' && jq -c '[.[].team_id]' /tmp/r.json
HTTP 200
["e6d82685-ef92-4633-9b6f-4b8282a1c4b8","cb5512db-7315-4165-9f76-6ca04656c517"]

$ curl -s -o /tmp/r.json -w 'HTTP %{http_code}\n' -H "Authorization: Bearer $INTERNAL_KEY" 'http://localhost:4000/v2/team/list?user_id=tls-internal&page=1&page_size=100' && jq -c '{teams: [.teams[].team_id], total}' /tmp/r.json
HTTP 200
{"teams":["cb5512db-7315-4165-9f76-6ca04656c517","e6d82685-ef92-4633-9b6f-4b8282a1c4b8"],"total":2}

# 3. master-key control: the proxy-wide list is untouched
$ curl -s -o /tmp/r.json -w 'HTTP %{http_code}\n' -H 'Authorization: Bearer sk-1234' 'http://localhost:4000/team/list' && jq -c '{total_teams: length}' /tmp/r.json
HTTP 200
{"total_teams":146}

$ curl -s -o /tmp/r.json -w 'HTTP %{http_code}\n' -H 'Authorization: Bearer sk-1234' 'http://localhost:4000/v2/team/list?page=1&page_size=100' && jq -c '{returned: (.teams|length), total}' /tmp/r.json
HTTP 200
{"returned":100,"total":146}
```

Sending `user_id` is what flips the authorization outcome, so the scoped variant is not working by accident. Both routes reject a non-admin who omits it and answer with that user's memberships when it is present

### Why org admins are left unscoped

```
$ curl -s -o /tmp/r.json -w 'HTTP %{http_code}\n' -H "Authorization: Bearer $ORGADMIN_KEY" 'http://localhost:4000/team/list' && jq -c '[.[].team_alias]' /tmp/r.json
HTTP 200
["tls-team1","tls-team2"]

$ curl -s -o /tmp/r.json -w 'HTTP %{http_code}\n' -H "Authorization: Bearer $ORGADMIN_KEY" 'http://localhost:4000/team/list?user_id=tls-orgadmin' && jq -c '[.[].team_alias]' /tmp/r.json
HTTP 200
[]
```

An org admin administers teams they are not a member of, so scoping their `/team/list` empties it. `/v2/team/list` nulls out a caller's own id and returns the same two teams either way, but `/team/list` does not, which is why org admins are treated as a broad-list role rather than a non-admin

### Full role matrix

Every role against both routes, scoped and unscoped, against the same fixture. `T1`/`T2` are the org's two teams and `T3` sits outside the org. The internal user and the internal viewer belong to `T1` and `T2`; the team admin belongs to `T1`, the org admin belongs to no team but administers the org, and the two proxy-admin users belong to no team

| Role | Route | Unscoped | Scoped to own id |
| --- | --- | --- | --- |
| master key | `/team/list` | 200, all 146 | n/a |
| master key | `/v2/team/list` | 200, all 146 | n/a |
| `proxy_admin` | `/team/list` | 200, all 146 | 200, 0 teams |
| `proxy_admin` | `/v2/team/list` | 200, all 146 | 200, 0 teams |
| `proxy_admin_viewer` | `/team/list` | 200, all 146 | 200, 0 teams |
| `proxy_admin_viewer` | `/v2/team/list` | 200, all 146 | 200, 0 teams |
| org admin | `/team/list` | 200, T1 T2 | 200, 0 teams |
| org admin | `/v2/team/list` | 200, T1 T2 | 200, T1 T2 |
| team admin | `/team/list` | **401** | 200, T1 |
| team admin | `/v2/team/list` | **401** | 200, T1 |
| `internal_user` | `/team/list` | **401** | 200, T1 T2 |
| `internal_user` | `/v2/team/list` | **401** | 200, T1 T2 |
| `internal_user_viewer` | `/team/list` | **401** | 200, T1 T2 |
| `internal_user_viewer` | `/v2/team/list` | **401** | 200, T1 T2 |

Every row that the dashboard sends after this PR lands in a 200 column, and every row it already sent stays exactly where it was. No role gains a team it could not see before

### Dashboard, before and after

Requests the pages actually issued, read out of the browser as `tls-internal`. Before was captured at `444b275ac3`, the commit this branch started from, with the change set reverted out of the working tree. After was captured at the same base with the change set restored, and that change set is byte-identical to what landed in `8f0644e63f` on top of the later merge with staging

Before, Virtual Keys:

```
200 /v2/team/list?user_id=tls-internal&page=1&page_size=100
401 /v2/team/list?page=1&page_size=100
```

Before, Logs:

```
200 /team/list?user_id=tls-internal
401 /team/list
```

After, Virtual Keys:

```
200 /v2/team/list?user_id=tls-internal&page=1&page_size=100
```

After, Logs:

```
200 /team/list?user_id=tls-internal
```

After, the same two pages as `tls-padmin`, a `proxy_admin`, showing the unscoped requests are still going out and still paginating the whole proxy:

```
200 /team/list
200 /v2/team/list?page=1&page_size=100
200 /v2/team/list?page=2&page_size=100
```

Screenshots to attach:

1. Sign in at http://localhost:3000 as the internal user, open http://localhost:3000/api-keys with the network tab open and filtered to `team/list`, screenshot the request list plus the page
2. Open http://localhost:3000/logs, screenshot the network tab, then open the Filters panel and screenshot the Team ID options showing both teams
3. Sign in as a proxy admin, repeat both pages, screenshot the network tab and the full team list on each

## Type

🐛 Bug Fix

## Caveats (if any)

- `v2TeamListCall` in `networking.tsx` now has no callers
- `all_admin_roles` mixes display labels with raw role names
- The new helper reads display labels only, avoiding that hazard

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
