### PR TITLE
fix(bedrock): reject Anthropic server-side web_search tool with actionable error

### DIFF
--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -67,6 +67,8 @@ class AmazonAnthropicClaudeMessagesConfig(
 
     DEFAULT_BEDROCK_ANTHROPIC_API_VERSION = "bedrock-2023-05-31"
 
+    WEBSEARCH_INTERCEPTION_DOCS_URL = "https://docs.litellm.ai/docs/integrations/websearch_interception"
+
     @property
     def custom_llm_provider(self) -> str | None:
         return "bedrock"
@@ -572,6 +574,45 @@ class AmazonAnthropicClaudeMessagesConfig(
 
         return filtered_betas
 
+    @staticmethod
+    def _reject_unsupported_web_search_tools(anthropic_messages_request: dict, model: str) -> None:
+        """
+        Bedrock's Anthropic endpoints cannot execute Anthropic's server-side
+        ``web_search_*`` tool; forwarding it returns an opaque
+        "The provided request is not valid" 400 from Bedrock. Fail fast with an
+        error that names the problem and the fix instead.
+
+        When web search interception is enabled
+        (``litellm_settings.callbacks: ["websearch_interception"]``), the tool
+        is converted to a regular function tool before this transform runs, so
+        this guard never fires.
+        """
+        from litellm.integrations.websearch_interception.tools import (
+            is_anthropic_native_web_search_tool,
+        )
+
+        tools: Final = anthropic_messages_request.get("tools")
+        if not isinstance(tools, list):
+            return
+        web_search_tool: Final = next(
+            (t for t in tools if isinstance(t, dict) and is_anthropic_native_web_search_tool(t)),
+            None,
+        )
+        if web_search_tool is None:
+            return
+        raise litellm.BadRequestError(
+            message=(
+                f"Bedrock does not support Anthropic's server-side web search tool "
+                f"(tool type '{web_search_tool.get('type')}', model '{model}'). "
+                "To use web search with this model, enable LiteLLM's web search interception "
+                "so the proxy executes the search instead: "
+                f"{AmazonAnthropicClaudeMessagesConfig.WEBSEARCH_INTERCEPTION_DOCS_URL}. "
+                "Alternatively, remove the web_search tool from the request."
+            ),
+            model=model,
+            llm_provider="bedrock",
+        )
+
     def _strip_unsupported_bedrock_invoke_fields(
         self,
         anthropic_messages_request: dict,
@@ -629,6 +670,10 @@ class AmazonAnthropicClaudeMessagesConfig(
         #########################################################
         ############## BEDROCK Invoke SPECIFIC TRANSFORMATION ###
         #########################################################
+
+        # 0. Server-side web_search tools are unsupported on Bedrock — reject
+        # with an actionable error before Bedrock 400s opaquely.
+        self._reject_unsupported_web_search_tools(anthropic_messages_request=anthropic_messages_request, model=model)
 
         # 1. anthropic_version is required for all claude models
         if "anthropic_version" not in anthropic_messages_request:

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -575,7 +575,7 @@ class AmazonAnthropicClaudeMessagesConfig(
         return filtered_betas
 
     @staticmethod
-    def _reject_unsupported_web_search_tools(anthropic_messages_request: dict, model: str) -> None:
+    def _reject_unsupported_web_search_tools(anthropic_messages_request: dict[str, object], model: str) -> None:
         """
         Bedrock's Anthropic endpoints cannot execute Anthropic's server-side
         ``web_search_*`` tool; forwarding it returns an opaque
@@ -671,8 +671,6 @@ class AmazonAnthropicClaudeMessagesConfig(
         ############## BEDROCK Invoke SPECIFIC TRANSFORMATION ###
         #########################################################
 
-        # 0. Server-side web_search tools are unsupported on Bedrock — reject
-        # with an actionable error before Bedrock 400s opaquely.
         self._reject_unsupported_web_search_tools(anthropic_messages_request=anthropic_messages_request, model=model)
 
         # 1. anthropic_version is required for all claude models

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -2583,7 +2583,7 @@ def test_replayed_intercepted_search_turn_leaves_no_unsupported_block_for_bedroc
 
 
 @pytest.mark.parametrize("tool_type", ["web_search_20250305", "web_search_20260209"])
-def test_bedrock_invoke_messages_rejects_server_web_search_tool(tool_type):
+def test_bedrock_invoke_messages_rejects_server_web_search_tool(tool_type: str):
     """Bedrock can't execute Anthropic's server-side web search; the transform
     must raise an actionable 400 pointing at the interception docs instead of
     letting Bedrock return an opaque "provided request is not valid"."""

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -2580,3 +2580,52 @@ def test_replayed_intercepted_search_turn_leaves_no_unsupported_block_for_bedroc
     assert "server_tool_use" not in serialized
     assert expected_evidence in serialized
     assert "Rome was founded in 753 BC." in serialized
+
+
+@pytest.mark.parametrize("tool_type", ["web_search_20250305", "web_search_20260209"])
+def test_bedrock_invoke_messages_rejects_server_web_search_tool(tool_type):
+    """Bedrock can't execute Anthropic's server-side web search; the transform
+    must raise an actionable 400 pointing at the interception docs instead of
+    letting Bedrock return an opaque "provided request is not valid"."""
+    import litellm
+    from litellm.types.router import GenericLiteLLMParams
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        cfg.transform_anthropic_messages_request(
+            model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            messages=[{"role": "user", "content": "search the web for litellm"}],
+            anthropic_messages_optional_request_params={
+                "max_tokens": 128,
+                "tools": [{"type": tool_type, "name": "web_search", "max_uses": 5}],
+            },
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+    assert "https://docs.litellm.ai/docs/integrations/websearch_interception" in str(exc_info.value)
+    assert "us.anthropic.claude-haiku-4-5-20251001-v1:0" in str(exc_info.value)
+
+
+def test_bedrock_invoke_messages_allows_converted_websearch_function_tool():
+    """The interception hook rewrites web_search into a plain custom tool
+    (litellm_web_search); that converted shape must pass through untouched."""
+    from litellm.types.router import GenericLiteLLMParams
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    result = cfg.transform_anthropic_messages_request(
+        model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        messages=[{"role": "user", "content": "search the web for litellm"}],
+        anthropic_messages_optional_request_params={
+            "max_tokens": 128,
+            "tools": [
+                {
+                    "name": "litellm_web_search",
+                    "description": "Search the web",
+                    "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                }
+            ],
+        },
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+    assert result["tools"][0]["name"] == "litellm_web_search"


### PR DESCRIPTION
## TLDR

Problem this solves:

- web_search tool on Bedrock claude models returns an opaque 400
- Bedrock's raw "The provided request is not valid" gives users no clue

How it solves it:

- reject the tool before calling Bedrock with an actionable error
- error names the tool, the model, and links the interception docs

## User Flow

Before: a developer calling claude-haiku-4-5 on Bedrock with the web_search tool gets an unexplained 400

1. They send POST https://litellm-domain/v1/messages with a Bedrock claude model and `"tools": [{"type": "web_search_20250305", "name": "web_search"}]`
2. The response is 400 `{"message":"The provided request is not valid"}` with no hint about what is wrong or how to fix it
3. They tweak prompts and models and keep hitting the same opaque error

After: the same request fails fast with an error that names the unsupported tool and links the fix

1. They send the same POST https://litellm-domain/v1/messages with the same web_search tool
2. The response is a 400 saying Bedrock does not support Anthropic's server-side web search tool, naming the tool type and model, and linking https://docs.litellm.ai/docs/integrations/websearch_interception
3. They enable web search interception per the linked docs (or drop the tool) and their requests go through

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (from the customer report, reproduced against Bedrock passthrough with claude-haiku-4-5 plus the web_search tool):

```
400 {"message":"The provided request is not valid"}
```

After (captured at 803c077eef against a live proxy running this branch; the rejection fires before any Bedrock call, exactly what an end user sees):

```
curl -s http://localhost:4187/v1/messages \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"bedrock-invoke-haiku-4-5","max_tokens":256,
       "messages":[{"role":"user","content":"What is the latest LiteLLM release?"}],
       "tools":[{"type":"web_search_20250305","name":"web_search","max_uses":3}]}'

{"error":{"message":"litellm.BadRequestError: Bedrock does not support Anthropic's server-side web search tool (tool type 'web_search_20250305', model 'us.anthropic.claude-haiku-4-5-20251001-v1:0'). To use web search with this model, enable LiteLLM's web search interception so the proxy executes the search instead: https://docs.litellm.ai/docs/integrations/websearch_interception. Alternatively, remove the web_search tool from the request.. Received Model Group=bedrock-invoke-haiku-4-5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
```

The "before" curl could not be re-run on this machine (no AWS credentials available), but the error above is verbatim from the report. The unit tests additionally pin that the converted `litellm_web_search` function tool (what the interception hook emits) still passes through, so enabling interception keeps working

## Type

🐛 Bug Fix

## Caveats (if any)

- guard covers /v1/messages Bedrock invoke and mantle routes only
- claude_platform and converse adapter paths are unchanged
- when interception is enabled the tool is converted first, guard never fires

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
