### PR TITLE
fix(redaction): redact MCP tool arguments and results

### DIFF
--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -860,7 +860,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
             if "messages" not in (excluded_fields or []) and standard_logging_object_copy.get("messages") is not None:
                 standard_logging_object_copy["messages"] = [Message(content=redacted_str).model_dump()]
 
-            if "metadata" not in (excluded_fields or []):
+            if not excluded_fields or "metadata" not in excluded_fields:
                 metadata: Final = standard_logging_object_copy.get("metadata")
                 redacted_metadata: Final = redacted_mcp_tool_call_metadata(metadata, redacted_str)
                 if redacted_metadata is not metadata:

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -828,6 +828,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
 
         import litellm
         from litellm import Choices, Message, ModelResponse
+        from litellm.litellm_core_utils.redact_messages import redacted_mcp_tool_call_metadata
 
         turn_off_message_logging: Final[bool] = getattr(self, "turn_off_message_logging", False)
         excluded_fields: Final[list[str] | None] = getattr(litellm, "standard_logging_payload_excluded_fields", None)
@@ -858,6 +859,12 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
 
             if "messages" not in (excluded_fields or []) and standard_logging_object_copy.get("messages") is not None:
                 standard_logging_object_copy["messages"] = [Message(content=redacted_str).model_dump()]
+
+            if "metadata" not in (excluded_fields or []):
+                metadata: Final = standard_logging_object_copy.get("metadata")
+                redacted_metadata: Final = redacted_mcp_tool_call_metadata(metadata, redacted_str)
+                if redacted_metadata is not metadata:
+                    standard_logging_object_copy["metadata"] = redacted_metadata
 
             if "response" not in (excluded_fields or []) and standard_logging_object_copy.get("response") is not None:
                 response: Final = standard_logging_object_copy["response"]

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -171,8 +171,8 @@ def redacted_mcp_tool_call_metadata(metadata: object, redacted_str: str) -> obje
         return metadata
 
     redacted_call: Final = {
-        **mcp_tool_call,
-        **{key: redacted_str for key in ("arguments", "result") if mcp_tool_call.get(key) is not None},
+        key: (redacted_str if key in ("arguments", "result") and value is not None else value)
+        for key, value in mcp_tool_call.items()
     }
     return {**metadata, "mcp_tool_call_metadata": redacted_call}
 

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -22,7 +22,7 @@ from litellm.llms.vertex_ai.common_utils import (
     redact_vertex_ai_metadata_from_logged_object,
 )
 from litellm.secret_managers.main import str_to_bool
-from litellm.types.utils import StandardCallbackDynamicParams
+from litellm.types.utils import StandardCallbackDynamicParams, StandardLoggingMetadata
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import (
@@ -158,7 +158,9 @@ def _redact_responses_api_output_dict(output_items, redacted_str: str):
             output_item["arguments"] = redacted_str
 
 
-def redacted_mcp_tool_call_metadata(metadata: object, redacted_str: str) -> object:
+def redacted_mcp_tool_call_metadata(
+    metadata: StandardLoggingMetadata | None, redacted_str: str
+) -> StandardLoggingMetadata | None:
     """MCP tool arguments and results are user content, and they ride in
     `metadata.mcp_tool_call_metadata` rather than in `messages` / `response`,
     so every integration that logs metadata exports them unless redacted here.

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -177,22 +177,6 @@ def redacted_mcp_tool_call_metadata(metadata: object, redacted_str: str) -> obje
     return {**metadata, "mcp_tool_call_metadata": redacted_call}
 
 
-def _redact_mcp_tool_call_in_place(model_call_details: dict) -> None:
-    """Redact the raw `mcp_tool_call_metadata` the MCP server stamped onto the
-    call details, so callbacks reading it off `kwargs` see the same redaction
-    the standard logging payload gets.
-    """
-    mcp_tool_call: Final = model_call_details.get("mcp_tool_call_metadata")
-    if not isinstance(mcp_tool_call, dict):
-        return
-
-    for key in ("arguments", "result"):
-        if mcp_tool_call.get(key) is not None:
-            # mutable-ok: redacting the shared call details in place is the point; a copy would leave
-            # callbacks that read mcp_tool_call_metadata off kwargs holding the unredacted values
-            mcp_tool_call[key] = "redacted-by-litellm"
-
-
 def _redact_standard_logging_object(model_call_details: dict):
     """Redact messages and response inside standard_logging_object if present."""
     standard_logging_object: Final = model_call_details.get("standard_logging_object")
@@ -278,7 +262,6 @@ def perform_redaction(model_call_details: dict, result, redact_streaming_respons
     model_call_details["messages"] = [{"role": "user", "content": "redacted-by-litellm"}]
     model_call_details["prompt"] = ""
     model_call_details["input"] = ""
-    _redact_mcp_tool_call_in_place(model_call_details)
     _redact_standard_logging_object(model_call_details)
     redact_vertex_ai_metadata_from_litellm_params(model_call_details)
 

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -158,6 +158,41 @@ def _redact_responses_api_output_dict(output_items, redacted_str: str):
             output_item["arguments"] = redacted_str
 
 
+def redacted_mcp_tool_call_metadata(metadata: object, redacted_str: str) -> object:
+    """MCP tool arguments and results are user content, and they ride in
+    `metadata.mcp_tool_call_metadata` rather than in `messages` / `response`,
+    so every integration that logs metadata exports them unless redacted here.
+    """
+    if not isinstance(metadata, dict):
+        return metadata
+
+    mcp_tool_call: Final = metadata.get("mcp_tool_call_metadata")
+    if not isinstance(mcp_tool_call, dict):
+        return metadata
+
+    redacted_call: Final = {
+        **mcp_tool_call,
+        **{key: redacted_str for key in ("arguments", "result") if mcp_tool_call.get(key) is not None},
+    }
+    return {**metadata, "mcp_tool_call_metadata": redacted_call}
+
+
+def _redact_mcp_tool_call_in_place(model_call_details: dict) -> None:
+    """Redact the raw `mcp_tool_call_metadata` the MCP server stamped onto the
+    call details, so callbacks reading it off `kwargs` see the same redaction
+    the standard logging payload gets.
+    """
+    mcp_tool_call: Final = model_call_details.get("mcp_tool_call_metadata")
+    if not isinstance(mcp_tool_call, dict):
+        return
+
+    for key in ("arguments", "result"):
+        if mcp_tool_call.get(key) is not None:
+            # mutable-ok: redacting the shared call details in place is the point; a copy would leave
+            # callbacks that read mcp_tool_call_metadata off kwargs holding the unredacted values
+            mcp_tool_call[key] = "redacted-by-litellm"
+
+
 def _redact_standard_logging_object(model_call_details: dict):
     """Redact messages and response inside standard_logging_object if present."""
     standard_logging_object: Final = model_call_details.get("standard_logging_object")
@@ -168,6 +203,11 @@ def _redact_standard_logging_object(model_call_details: dict):
 
     if standard_logging_object.get("messages") is not None:
         standard_logging_object["messages"] = [{"role": "user", "content": redacted_str}]
+
+    metadata: Final = standard_logging_object.get("metadata")
+    redacted_metadata: Final = redacted_mcp_tool_call_metadata(metadata, redacted_str)
+    if redacted_metadata is not metadata:
+        standard_logging_object["metadata"] = redacted_metadata
 
     response: Final = standard_logging_object.get("response")
     if response is not None:
@@ -238,6 +278,7 @@ def perform_redaction(model_call_details: dict, result, redact_streaming_respons
     model_call_details["messages"] = [{"role": "user", "content": "redacted-by-litellm"}]
     model_call_details["prompt"] = ""
     model_call_details["input"] = ""
+    _redact_mcp_tool_call_in_place(model_call_details)
     _redact_standard_logging_object(model_call_details)
     redact_vertex_ai_metadata_from_litellm_params(model_call_details)
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2637,13 +2637,13 @@ class StandardLoggingMCPToolCall(TypedDict, total=False):
     """
     Name of the tool to call
     """
-    arguments: dict
+    arguments: dict | str
     """
-    Arguments to pass to the tool
+    Arguments to pass to the tool, or the redaction marker when message logging is off
     """
-    result: dict
+    result: dict | str
     """
-    Result of the tool call
+    Result of the tool call, or the redaction marker when message logging is off
     """
 
     mcp_server_name: str | None

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -720,3 +720,102 @@ class TestRedactStreamingResponsesForCustomLogger:
 
         assert result_details is model_call_details
         assert response_obj.choices[0].message.content == "secret content"
+
+
+class TestRedactMcpToolCallMetadata:
+    """MCP tool arguments and results ride in metadata rather than in
+    messages/response, so they need their own redaction pass."""
+
+    def _slp(self):
+        return {
+            "standard_logging_object": {
+                "messages": [{"role": "user", "content": "secret prompt"}],
+                "metadata": {
+                    "user_api_key_hash": "abc",
+                    "mcp_tool_call_metadata": {
+                        "name": "get_weather",
+                        "arguments": {"city": "TOPSECRETCITY"},
+                        "result": {"text": "sensitive"},
+                    },
+                },
+            }
+        }
+
+    def test_global_redaction_strips_mcp_arguments_and_result(self):
+        from litellm.litellm_core_utils.redact_messages import _redact_standard_logging_object
+
+        model_call_details = self._slp()
+        _redact_standard_logging_object(model_call_details)
+
+        mcp_meta = model_call_details["standard_logging_object"]["metadata"]["mcp_tool_call_metadata"]
+        assert mcp_meta["arguments"] == "redacted-by-litellm"
+        assert mcp_meta["result"] == "redacted-by-litellm"
+        assert mcp_meta["name"] == "get_weather"
+        assert model_call_details["standard_logging_object"]["metadata"]["user_api_key_hash"] == "abc"
+
+    def test_callback_level_redaction_strips_mcp_arguments(self):
+        opted_out_logger = CustomLogger(turn_off_message_logging=True)
+
+        redacted = opted_out_logger.redact_standard_logging_payload_from_model_call_details(self._slp())
+
+        mcp_meta = redacted["standard_logging_object"]["metadata"]["mcp_tool_call_metadata"]
+        assert mcp_meta["arguments"] == "redacted-by-litellm"
+        assert mcp_meta["result"] == "redacted-by-litellm"
+
+    def test_callback_level_redaction_does_not_mutate_the_original(self):
+        model_call_details = self._slp()
+        opted_out_logger = CustomLogger(turn_off_message_logging=True)
+
+        opted_out_logger.redact_standard_logging_payload_from_model_call_details(model_call_details)
+
+        original = model_call_details["standard_logging_object"]["metadata"]["mcp_tool_call_metadata"]
+        assert original["arguments"] == {"city": "TOPSECRETCITY"}
+
+    def test_metadata_without_mcp_tool_call_is_untouched(self):
+        from litellm.litellm_core_utils.redact_messages import redacted_mcp_tool_call_metadata
+
+        metadata = {"user_api_key_hash": "abc"}
+
+        assert redacted_mcp_tool_call_metadata(metadata, "redacted-by-litellm") is metadata
+
+    def test_global_redaction_also_strips_the_raw_call_details_copy(self):
+        from litellm.litellm_core_utils.redact_messages import perform_redaction
+
+        model_call_details = {
+            "messages": [{"role": "user", "content": "secret prompt"}],
+            "mcp_tool_call_metadata": {
+                "name": "get_weather",
+                "arguments": {"city": "TOPSECRETCITY"},
+                "result": {"text": "sensitive"},
+            },
+            "standard_logging_object": {"messages": [], "metadata": {}},
+        }
+
+        perform_redaction(model_call_details, result=None)
+
+        raw = model_call_details["mcp_tool_call_metadata"]
+        assert raw["arguments"] == "redacted-by-litellm"
+        assert raw["result"] == "redacted-by-litellm"
+        assert raw["name"] == "get_weather"
+
+    def test_payload_without_metadata_does_not_gain_a_metadata_key(self):
+        """The callback-logs replay endpoint seeds a payload from an unvalidated
+        POST body, so `metadata` can legitimately be absent. Consumers that do
+        `payload.get("metadata", {}).get(...)` break on an explicit None."""
+        from litellm.litellm_core_utils.redact_messages import _redact_standard_logging_object
+
+        model_call_details = {"standard_logging_object": {"messages": [{"role": "user", "content": "x"}]}}
+
+        _redact_standard_logging_object(model_call_details)
+
+        assert "metadata" not in model_call_details["standard_logging_object"]
+
+    def test_metadata_without_mcp_tool_call_keeps_its_identity(self):
+        from litellm.litellm_core_utils.redact_messages import _redact_standard_logging_object
+
+        metadata = {"user_api_key_hash": "abc"}
+        model_call_details = {"standard_logging_object": {"messages": [], "metadata": metadata}}
+
+        _redact_standard_logging_object(model_call_details)
+
+        assert model_call_details["standard_logging_object"]["metadata"] is metadata

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -778,7 +778,11 @@ class TestRedactMcpToolCallMetadata:
 
         assert redacted_mcp_tool_call_metadata(metadata, "redacted-by-litellm") is metadata
 
-    def test_global_redaction_also_strips_the_raw_call_details_copy(self):
+    def test_global_redaction_leaves_the_raw_call_details_for_post_call_scanning(self):
+        """`Logging.post_call` redacts before `async_post_mcp_tool_call_hook` runs, and that
+        hook is what post_mcp_call guardrails scan. Redacting the shared call details there
+        would hand the scanner a placeholder instead of the arguments the user actually sent,
+        so enforcement must keep reading the originals."""
         from litellm.litellm_core_utils.redact_messages import perform_redaction
 
         model_call_details = {
@@ -788,15 +792,25 @@ class TestRedactMcpToolCallMetadata:
                 "arguments": {"city": "TOPSECRETCITY"},
                 "result": {"text": "sensitive"},
             },
-            "standard_logging_object": {"messages": [], "metadata": {}},
+            "standard_logging_object": {
+                "messages": [],
+                "metadata": {
+                    "mcp_tool_call_metadata": {
+                        "name": "get_weather",
+                        "arguments": {"city": "TOPSECRETCITY"},
+                    }
+                },
+            },
         }
 
         perform_redaction(model_call_details, result=None)
 
         raw = model_call_details["mcp_tool_call_metadata"]
-        assert raw["arguments"] == "redacted-by-litellm"
-        assert raw["result"] == "redacted-by-litellm"
-        assert raw["name"] == "get_weather"
+        assert raw["arguments"] == {"city": "TOPSECRETCITY"}
+        assert raw["result"] == {"text": "sensitive"}
+
+        exported = model_call_details["standard_logging_object"]["metadata"]["mcp_tool_call_metadata"]
+        assert exported["arguments"] == "redacted-by-litellm"
 
     def test_payload_without_metadata_does_not_gain_a_metadata_key(self):
         """The callback-logs replay endpoint seeds a payload from an unvalidated


### PR DESCRIPTION
## TLDR

Problem this solves:

- MCP tool arguments and results reach logging backends with message logging off
- They ride in metadata, so the message and response redaction never saw them
- Every integration that logs the standard payload exported them verbatim

How it solves it:

- Redact them in the global and the per-callback redaction paths
- Leave the raw call details intact so post-call tool scanning still works
- Widen the two typed fields so the marker is visible to type checkers

## User Flow

Before: an operator turns message logging off, and MCP tool arguments still leave the process

1. The proxy admin sets `turn_off_message_logging: true` and attaches any logging integration
2. A developer calls an MCP tool with sensitive arguments
3. Prompts and responses are redacted as expected
4. The tool arguments and result are exported anyway, because they live in `metadata.mcp_tool_call_metadata`; they land in the spend logs `metadata` column and, with content capture on, in the OTel `gen_ai.tool.call.arguments` span attribute

After: the same call redacts the tool content along with everything else

1. Same configuration
2. Same call
3. Prompts and responses are redacted as before
4. The tool arguments and result now read `redacted-by-litellm` everywhere, while the tool name, the namespaced tool name and the MCP server fields are untouched so spend tracking and cost attribution keep working

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Type

🐛 Bug Fix

## Changes

`_redact_standard_logging_object` rewrites `messages` and `response`, and `perform_redaction` rewrites `model_call_details["messages"]` in place. Neither touched `metadata`. MCP tool calls put their arguments and their result in `metadata.mcp_tool_call_metadata`, so redaction never reached them and every consumer of the standard payload metadata exported them.

`redacted_mcp_tool_call_metadata` replaces the `arguments` and `result` fields with the existing marker, building a new dict rather than mutating the caller's payload. It is applied in `_redact_standard_logging_object` for the global and request-level paths, and in `CustomLogger.redact_standard_logging_payload_from_model_call_details` so the per-callback opt-out is honored.

The shared `model_call_details` is deliberately left alone. `Logging.post_call` runs redaction before `async_post_mcp_tool_call_hook`, and that hook is what `post_mcp_call` guardrails scan, so redacting `mcp_tool_call_metadata` there would hand a security scanner the placeholder instead of the arguments the caller actually sent. An earlier revision of this PR did exactly that; it is removed, and a test pins the invariant. The consequence is that a callback reading `mcp_tool_call_metadata` straight off `kwargs` still sees the originals, which matches the behavior before this PR.

The payload metadata is only reassigned when redaction actually changed it. A payload with no `metadata` key previously gained `metadata: None`, and several consumers do `payload.get("metadata", {}).get(...)`, which raises on an explicit `None`. The replay endpoint at `/v1/rust_control_plane/logs` seeds a payload straight from a POST body, so that shape is reachable.

Redacting `arguments` to a plain string matches how this module already redacts every other `arguments` field. `StandardLoggingMCPToolCall` typed both fields as `dict`, so they are widened to `dict | str` rather than leaving the annotation contradicting what redaction writes.

## Screenshots / Proof of Fix

Re-run in full on the current head against a local proxy with real Postgres, a real MCP server over streamable HTTP, real OTel export, and `turn_off_message_logging: true`. Base is current `litellm_internal_staging`. No mocks, no stubs, no recorded fixtures; every number below was read out of the destination after the request.

Spend logs, out of Postgres. Row counts and the set of recorded tools match; `arguments` is the only field that differs:

```
head  rows=4  arguments=redacted-by-litellm       distinct_tools=2
base  rows=4  arguments={"city":"FINAL012659"}    distinct_tools=2
```

OTel v2 with `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only`, read off the exported spans:

```
head  gen_ai.tool.call.arguments = 'redacted-by-litellm'
base  gen_ai.tool.call.arguments = '{"city": "OTL013004"}'
      gen_ai.tool.name           = get_weather      (both sides)
```

The `post_mcp_call` hook that guardrails scan is unaffected, which is the property that must hold: a logging setting must not change what a security check inspects. A callback implementing `async_post_mcp_tool_call_hook` recorded, with redaction on:

```
head  arguments = {'city': 'FINAL012659'}
base  arguments = {'city': 'FINAL012659'}
```

Prometheus `litellm_mcp_tool_calls_total` is identical on both sides, labels and value:

```
both  mcp_tool_name="get_weather",team="None",user="default_user_id" 1.0
```

Zero errors or exceptions in either proxy log across the run. A chat completion on each side returned 200, so the non-MCP path is unchanged.

## Behavior changes

When message redaction is on, `LiteLLM_SpendLogs.metadata` stores `"arguments": "redacted-by-litellm"` where it previously stored an object. A query reading `metadata->'mcp_tool_call_metadata'->'arguments'->>'<key>'` returns NULL instead of a value. Nothing errors; the shape inside that JSON column changes. Redaction off is unaffected.

Out-of-tree `CustomLogger` implementations that call `mcp_meta["arguments"].get(...)` will see a string. No first-party consumer does; every in-repo reader either guards with `isinstance`, reads only the name fields, or serializes the value.

## Notes

Stacked on #36453, which fixes the Arize MCP span rendering. This PR is the redaction half, split out so the shared logging change is reviewed on its own.
