### PR TITLE
fix(bedrock): explain why Anthropic's web_search server tool is rejected

### DIFF
--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from typing import TYPE_CHECKING, Any, Final, cast
 
 import httpx
@@ -54,6 +54,9 @@ if TYPE_CHECKING:
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
     LiteLLMLoggingObj = Any
+
+
+UNSUPPORTED_BEDROCK_SERVER_TOOL_PREFIX: Final = "web_search_"
 
 
 class AmazonAnthropicClaudeMessagesConfig(
@@ -605,6 +608,39 @@ class AmazonAnthropicClaudeMessagesConfig(
         normalize_bedrock_opus_output_config_effort(model=model, output_config=clamped)
         optional_params["reasoning_effort"] = clamped["effort"]
 
+    def _reject_unsupported_server_tools(self, anthropic_messages_request: Mapping[str, object], model: str) -> None:
+        """Bedrock hosts none of Anthropic's ``web_search_*`` server tools, so
+        forwarding one earns an opaque ``The provided request is not valid`` from
+        AWS that names neither the tool nor a way forward. Web-search
+        interception rewrites the tool before this point, so reaching here means
+        it is not configured for this request.
+        """
+        tools: Final = anthropic_messages_request.get("tools")
+        if not isinstance(tools, list):
+            return
+        entries: Final = cast(list[Mapping[str, object]], tools)  # cast-ok: request body is untyped upstream
+        unsupported: Final = sorted(
+            {
+                tool_type
+                for tool in entries
+                if isinstance(tool_type := tool.get("type"), str)
+                if tool_type.startswith(UNSUPPORTED_BEDROCK_SERVER_TOOL_PREFIX)
+            }
+        )
+        if not unsupported:
+            return
+        raise litellm.BadRequestError(
+            message=(
+                f"Amazon Bedrock does not support the Anthropic server tool(s) {unsupported}. "
+                "Enable LiteLLM's web-search interception to serve them, by adding "
+                '`websearch_interception` to `litellm_settings.callbacks`, listing "bedrock" under '
+                "`litellm_settings.websearch_interception_params.enabled_providers`, and declaring a "
+                "`search_tools` entry. Otherwise remove the tool from the request."
+            ),
+            model=model,
+            llm_provider="bedrock",
+        )
+
     def transform_anthropic_messages_request(
         self,
         model: str,
@@ -626,6 +662,8 @@ class AmazonAnthropicClaudeMessagesConfig(
             headers=headers,
         )
         self._normalize_system_role_messages(anthropic_messages_request, model=model)
+        request_view: Final = cast(Mapping[str, object], anthropic_messages_request)  # cast-ok: body is untyped here
+        self._reject_unsupported_server_tools(request_view, model=model)
         #########################################################
         ############## BEDROCK Invoke SPECIFIC TRANSFORMATION ###
         #########################################################

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -29,6 +29,8 @@ from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_tran
     AmazonAnthropicClaudeMessagesConfig,
     AmazonAnthropicClaudeMessagesStreamDecoder,
 )
+import litellm
+from litellm.types.router import GenericLiteLLMParams
 
 
 @pytest.fixture
@@ -2580,3 +2582,50 @@ def test_replayed_intercepted_search_turn_leaves_no_unsupported_block_for_bedroc
     assert "server_tool_use" not in serialized
     assert expected_evidence in serialized
     assert "Rome was founded in 753 BC." in serialized
+
+
+def test_bedrock_messages_rejects_anthropic_web_search_server_tool():
+    """Bedrock hosts none of Anthropic's web_search server tools. Forwarding one
+    earns an opaque 'The provided request is not valid' from AWS that names
+    neither the tool nor a way forward, so reject it here with a message that
+    does both."""
+    with pytest.raises(litellm.BadRequestError) as excinfo:
+        AmazonAnthropicClaudeMessagesConfig().transform_anthropic_messages_request(
+            model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            messages=[{"role": "user", "content": "Anthropic Claude news"}],
+            anthropic_messages_optional_request_params={
+                "max_tokens": 64,
+                "tools": [{"type": "web_search_20250305", "name": "web_search", "max_uses": 3}],
+            },
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+    message = str(excinfo.value)
+    assert "web_search_20250305" in message
+    assert "websearch_interception" in message
+
+
+def test_bedrock_messages_allows_the_tool_interception_rewrites_it_into():
+    """Web-search interception rewrites the native tool into LiteLLM's own search
+    tool before this transform runs, and that rewritten tool carries an
+    input_schema like any custom tool. Rejecting the native type must not touch
+    it, or enabling interception would break the very path that serves search."""
+    body = AmazonAnthropicClaudeMessagesConfig().transform_anthropic_messages_request(
+        model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        messages=[{"role": "user", "content": "Anthropic Claude news"}],
+        anthropic_messages_optional_request_params={
+            "max_tokens": 64,
+            "tools": [
+                {
+                    "name": "litellm_web_search",
+                    "description": "Search the web",
+                    "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                }
+            ],
+        },
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert [tool["name"] for tool in body["tools"]] == ["litellm_web_search"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock rejects Anthropic's `web_search` tool with an opaque 400
- The error names neither the tool nor a way forward
- Every Claude model fails alike, reading as a broken deployment

How it solves it:

- Reject it in the Bedrock Invoke transform with an actionable message
- Name the tool and the interception settings that do serve it
- Guard only fires when interception is off, so the working path is untouched

## User Flow

Before: a developer using Claude on Bedrock adds web search and gets an error that tells them nothing

1. They send POST https://litellm-domain/v1/messages with `"model": "<their bedrock claude alias>"` and `"tools": [{"type": "web_search_20250305", "name": "web_search", "max_uses": 3}]`
2. They get back 400 `{"message":"The provided request is not valid"}`
3. Nothing names the tool, so they try the other Claude models and get the same 400 from each
4. Dropping the tool makes the request succeed, which is the only hint that the tool is the cause, and there is still nothing pointing at the setting that would make it work

After: the same request explains itself and says what to turn on

1. The developer sends the same POST https://litellm-domain/v1/messages with the same tool
2. They get back a 400 reading `Amazon Bedrock does not support the Anthropic server tool(s) ['web_search_20250305']. Enable LiteLLM's web-search interception to serve them, by adding` `websearch_interception` `to litellm_settings.callbacks, listing "bedrock" under litellm_settings.websearch_interception_params.enabled_providers, and declaring a search_tools entry. Otherwise remove the tool from the request.`
3. They switch interception on, resend, and get a 200 carrying `server_tool_use`, `web_search_tool_result`, and a summary over those results

## Relevant issues

Related to #26252

## Linear ticket

Resolves LIT-5391

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against real Bedrock (`us.anthropic.claude-haiku-4-5-20251001-v1:0`, us-east-1, real credentials and real spend). Before at `ea6c18baa5`, after at `2f5e4c5ae4`. The same request on both legs

```bash
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://127.0.0.1:4391/v1/messages \
  -H 'Authorization: Bearer sk-lit5391' -H 'content-type: application/json' \
  -d '{"model":"bedrock-haiku","max_tokens":512,
       "messages":[{"role":"user","content":"Anthropic Claude news"}],
       "tools":[{"type":"web_search_20250305","name":"web_search","max_uses":3}]}'
```

Before, AWS answers and says nothing useful:

```
{"error":{"message":"{\"message\":\"The provided request is not valid\"}.
  Received Model Group=bedrock-haiku ...","code":"400"}}
HTTP_STATUS:400
```

After, the same 400 status carries an actionable reason:

```
{"error":{"message":"litellm.BadRequestError: Amazon Bedrock does not support the
  Anthropic server tool(s) ['web_search_20250305']. Enable LiteLLM's web-search
  interception to serve them, by adding `websearch_interception` to
  `litellm_settings.callbacks`, listing \"bedrock\" under
  `litellm_settings.websearch_interception_params.enabled_providers`, and declaring
  a `search_tools` entry. Otherwise remove the tool from the request.. Received
  Model Group=bedrock-haiku ...","code":"400"}}
HTTP_STATUS:400
```

The control, the same deployment and key without the tool, is 200 on both legs, so the 400 is the tool and not the deployment

The path that already works must keep working, since interception rewrites the tool before this guard. Same build as the after leg, with interception switched on:

```
id: msg_bdrk_01JRFnKJp5GqMDJDoDqF4tJ1
blocks: ['server_tool_use', 'web_search_tool_result', 'text']
```

That is a real Bedrock message id with native citation blocks, identical to what staging returns, so the guard does not touch it

Local gates: full `tests/test_litellm/llms/bedrock/` is 1148 passed 1 skipped, `ruff format --check` and `ruff check` clean, the ruff-strict and type-discipline gates are within ceiling, and basedpyright on the changed file is 206 errors against 206 for the same file at base, so zero delta

Mutation checks, one site at a time. Removing the guard call fails the reject test. Matching on the tool's `name` instead of its `type` fails the reject test. A substring match on `name`, which would swallow the rewritten `litellm_web_search` tool, fails the allow test. Widening the prefix to the empty string fails a pre-existing custom-tool test rather than one of mine, which I mention because it is the one mutant my own tests did not kill

## Type

🐛 Bug Fix

## Caveats (if any)

- Turns an opaque 400 into a clear one; it does not add the capability
- Bedrock Invoke messages path only, Converse still drops silently
- If AWS ever hosts the tool, this guard must be removed
- The intermittent 401 in the same ticket is not addressed here

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
