### PR TITLE
fix(websearch): stop leaking interception control fields to providers

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3385,6 +3385,8 @@ agentic_loop_internal_litellm_params: Final = [
     "_code_interpreter_interception_sandbox_key",
     "_code_interpreter_interception_session_scoped",
     "_code_interpreter_interception_converted_stream",
+    "_websearch_interception_emit_native_blocks",
+    "_websearch_interception_converted_stream",
 ]
 
 # Proxy-owned callback credentials, stamped from admin-configured team/key callback

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -29,6 +29,7 @@ from litellm.types.utils import (
     StreamingChoices,
     Usage,
 )
+from litellm.types.utils import all_litellm_params
 from litellm.utils import (
     ProviderConfigManager,
     TextCompletionStreamWrapper,
@@ -36,6 +37,7 @@ from litellm.utils import (
     _is_streaming_request,
     get_api_key,
     get_llm_provider,
+    get_non_default_completion_params,
     get_optional_params_image_gen,
     get_prompt_cache_min_tokens,
     is_cached_message,
@@ -5254,3 +5256,33 @@ def test_function_setup_failure_log_line_shows_outer_not_doomed_ids(monkeypatch)
         verbose_logger.removeHandler(cap)
         trace_id_var.set("")
         session_id_var.set("")
+
+
+WEBSEARCH_INTERNAL_CONTROL_FIELDS = (
+    "_websearch_interception_emit_native_blocks",
+    "_websearch_interception_converted_stream",
+)
+
+
+def test_websearch_interception_control_fields_never_reach_the_provider():
+    """The web-search interception hooks stamp these onto kwargs to carry state
+    across the agentic loop. Anything the param builder does not recognize is
+    swept into the provider request, and a provider that validates its body
+    rejects the whole call: Bedrock Converse answers
+    `_websearch_interception_emit_native_blocks: Extra inputs are not permitted`
+    with a 400, so enabling interception breaks every request it touches.
+
+    Their code-interpreter counterparts are already registered; these were not.
+    """
+    kwargs = {
+        "a_real_provider_specific_param": 1,
+        **{field: True for field in WEBSEARCH_INTERNAL_CONTROL_FIELDS},
+    }
+
+    non_default = get_non_default_completion_params(kwargs)
+
+    assert non_default == {"a_real_provider_specific_param": 1}, (
+        "web-search interception control fields leaked into the provider params: "
+        f"{sorted(set(non_default) - {'a_real_provider_specific_param'})}"
+    )
+    assert set(WEBSEARCH_INTERNAL_CONTROL_FIELDS) <= set(all_litellm_params)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Web-search interception leaks two internal kwargs to providers
- Bedrock Converse rejects them, 400 on every intercepted request
- Their code-interpreter counterparts were already registered

How it solves it:

- Register both keys in `all_litellm_params`
- The param builder then keeps them out of the request body

## User Flow

Before: a developer turns on web-search interception and every affected request starts failing

1. The proxy admin enables interception with `litellm_settings.callbacks: ["websearch_interception"]` plus a search backend
2. The developer sends POST https://litellm-domain/v1/chat/completions to a Bedrock Converse model with `"tools": [{"type": "web_search_20250305", "name": "web_search", "max_uses": 3}]`
3. They get back 400 `BedrockException - {"message":"The model returned the following errors: _websearch_interception_emit_native_blocks: Extra inputs are not permitted"}`
4. The name in the error belongs to LiteLLM, not to anything they sent, so there is nothing in their request to change

After: the same request is answered with a search-grounded reply

1. Same setup, same POST https://litellm-domain/v1/chat/completions with the same tool
2. The response is a 200 whose message summarizes real search results
3. Turning interception off and on no longer changes whether the route works

## Relevant issues

Related to #26252

## Linear ticket

Resolves LIT-5391

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against real Bedrock (`bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0`, us-east-1, real credentials and real spend) with interception on and a real searxng backend. Before at `05943b47a3` (staging tip), after at `88a5c93b63`. Same request both legs

```bash
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://127.0.0.1:4391/v1/chat/completions \
  -H 'Authorization: Bearer sk-lit5391' -H 'content-type: application/json' \
  -d '{"model":"bedrock-haiku-converse","max_tokens":300,
       "messages":[{"role":"user","content":"Search the web: what did Anthropic announce most recently?"}],
       "tools":[{"type":"web_search_20250305","name":"web_search","max_uses":3}]}'
```

Before, LiteLLM's own control field reaches Bedrock and Bedrock rejects the body:

```
{"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"The model
  returned the following errors: _websearch_interception_emit_native_blocks: Extra inputs
  are not permitted\"}. Received Model Group=bedrock-haiku-converse ...","code":"400"}}
HTTP_STATUS:400
```

After, the same request is answered from real search results:

```
{"id":"chatcmpl-e5c1b9d3-089b-4b01-9f27-9e2a5898ebe9","model":"bedrock-haiku-converse",
 "object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{
 "content":"Based on the search results, here are Anthropic's most recent announcements:
 **Most Recent Announcements (July-August 2026):** 1. **Mariano-Florentino (Tino) Cuellar
 Joins as Chief Global Affairs Officer** (July 30, 2026) ... 2. **Cybersecurity Evaluation
 Incidents** (July 27-30, 2026) ..."}}]}
HTTP_STATUS:200
```

Local gates: `tests/test_litellm/test_utils.py` plus `tests/test_litellm/litellm_core_utils/test_chat_completion_agentic_loop.py` are 269 passed, `ruff format --check` and `ruff check` clean, the ruff-strict and type-discipline gates are within ceiling, and basedpyright on the changed file is 0 errors

Mutation checks, one key at a time. Dropping `_websearch_interception_emit_native_blocks` from the list fails the new test; dropping `_websearch_interception_converted_stream` fails it independently

## Type

🐛 Bug Fix

## Caveats (if any)

- Only providers that validate their request body surfaced this
- A permissive provider silently accepted the extra field before
- Found while auditing what #36473 left uncovered on Converse

## Changes

`litellm/types/utils.py` adds the two keys to `agentic_loop_internal_litellm_params`, whose existing comment already describes this exact failure mode for the code-interpreter fields

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
