### PR TITLE
fix(caching): redact secrets in Redis write-failure logs

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -30,6 +30,7 @@ from litellm.constants import (
 )
 from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
 from litellm.litellm_core_utils.coroutine_checker import coroutine_checker
+from litellm.litellm_core_utils.secret_redaction import redact_string
 from litellm.types.caching import (
     RedisPipelineIncrementOperation,
     RedisPipelineLpopOperation,
@@ -673,8 +674,8 @@ class RedisCache(BaseCache):
 
         if key is None:
             verbose_logger.debug(
-                "LiteLLM Redis Caching: async set() skipped — key is None, value=%r",
-                value,
+                "LiteLLM Redis Caching: async set() skipped — key is None, value=%s",
+                redact_string(str(value)),
             )
             return None
 
@@ -696,10 +697,10 @@ class RedisCache(BaseCache):
                 )
             )
             verbose_logger.error(
-                "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, key=%r, value=%r",
+                "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, key=%s, value=%s",
                 str(e),
-                key,
-                value,
+                redact_string(str(key)),
+                redact_string(str(value)),
             )
             raise e
 
@@ -750,7 +751,7 @@ class RedisCache(BaseCache):
             verbose_logger.error(
                 "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, Writing value=%s",
                 str(e),
-                value,
+                redact_string(str(value)),
             )
             _record_swallowed_redis_failure(self._circuit_breaker, e)
 
@@ -881,7 +882,7 @@ class RedisCache(BaseCache):
             verbose_logger.error(
                 "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, Writing value=%s",
                 str(e),
-                value,
+                redact_string(str(value)),
             )
             raise e
 
@@ -920,7 +921,7 @@ class RedisCache(BaseCache):
             verbose_logger.error(
                 "LiteLLM Redis Caching: async set_cache_sadd() - Got exception from REDIS %s, Writing value=%s",
                 str(e),
-                value,
+                redact_string(str(value)),
             )
             _record_swallowed_redis_failure(self._circuit_breaker, e)
 

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -672,7 +672,7 @@ async def test_redis_write_failure_does_not_log_master_key(redis_no_ping, call_c
     """
     from litellm._logging import verbose_logger
 
-    cache: Final = RedisCache(host="127.0.0.1", port=6379, socket_timeout=0.5)
+    cache: Final = RedisCache(host="127.0.0.1", port=_closed_port(), socket_timeout=0.5)
     capture: Final = _CaptureRecords()
     verbose_logger.addFilter(capture)
     try:

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -1,6 +1,8 @@
 import asyncio
+import logging
 import os
 import sys
+from typing import Final
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,6 +13,8 @@ sys.path.insert(
 from unittest.mock import AsyncMock
 
 from litellm.caching.redis_cache import RedisCache
+
+_MASTER_KEY: Final = "sk-1234567890abcdefghijklmnopqrstuvwxyz"
 
 
 @pytest.fixture
@@ -608,3 +612,79 @@ async def test_only_connectivity_failures_open_the_breaker(error, opens_breaker)
             await _run_under_circuit_breaker(breaker, "op", failing_call)
 
     assert breaker.is_open() is opens_breaker
+
+
+class _RedisWritesTimeOut:
+    """Injected async client whose writes fail like a real 'Timeout connecting to server'."""
+
+    async def set(self, name: str, value: str, nx: bool = False, ex: object = None) -> None:
+        from redis.exceptions import TimeoutError as RedisTimeoutError
+
+        raise RedisTimeoutError("Timeout connecting to server")
+
+    async def sadd(self, key: str, *members: object) -> None:
+        from redis.exceptions import TimeoutError as RedisTimeoutError
+
+        raise RedisTimeoutError("Timeout connecting to server")
+
+
+class _CaptureRecords(logging.Filter):
+    """Logger-level filter that records each formatted message.
+
+    Attached to the logger (not a handler), so it runs before the handler-level
+    SecretRedactionFilter can mutate the record. That isolates this test to the
+    redaction done at the log call site, independent of the logging config.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: tuple[str, ...] = ()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        self.messages = (*self.messages, record.getMessage())
+        return True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "call_cache",
+    (
+        pytest.param(
+            lambda c: c.async_set_cache(
+                key="litellm_config:param:general_settings",
+                value={"param_name": "general_settings", "param_value": {"master_key": _MASTER_KEY}},
+            ),
+            id="async_set_cache",
+        ),
+        pytest.param(
+            lambda c: c.async_set_cache_sadd(key="k", value=[_MASTER_KEY], ttl=60),
+            id="async_set_cache_sadd",
+        ),
+    ),
+)
+async def test_redis_write_failure_does_not_log_master_key(redis_no_ping, call_cache):
+    """A Redis write timeout must not spill the cached value's secrets into logs.
+
+    The proxy caches its own general_settings row, whose value holds the master key. When a
+    write to Redis fails, the error path logged that value verbatim, leaking the master key
+    in plaintext. Redacting at the call site keeps the leak out regardless of the logging
+    config, so this asserts on the record before any handler-level redaction filter runs.
+    """
+    from litellm._logging import verbose_logger
+
+    cache: Final = RedisCache(host="127.0.0.1", port=6379, socket_timeout=0.5)
+    capture: Final = _CaptureRecords()
+    verbose_logger.addFilter(capture)
+    try:
+        with patch.object(cache, "init_async_client", return_value=_RedisWritesTimeOut()):
+            try:
+                await call_cache(cache)
+            except Exception:
+                pass
+    finally:
+        verbose_logger.removeFilter(capture)
+
+    joined: Final = "\n".join(capture.messages)
+    assert "Got exception from REDIS" in joined, "the write-failure path must have logged"
+    assert _MASTER_KEY not in joined, f"master key leaked in plaintext: {joined!r}"
+    assert "REDACTED" in joined, "the secret must be redacted, not silently dropped"

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -1,8 +1,6 @@
 import asyncio
-import logging
 import os
 import sys
-from typing import Final
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,8 +11,6 @@ sys.path.insert(
 from unittest.mock import AsyncMock
 
 from litellm.caching.redis_cache import RedisCache
-
-_MASTER_KEY: Final = "sk-1234567890abcdefghijklmnopqrstuvwxyz"
 
 
 @pytest.fixture
@@ -612,79 +608,3 @@ async def test_only_connectivity_failures_open_the_breaker(error, opens_breaker)
             await _run_under_circuit_breaker(breaker, "op", failing_call)
 
     assert breaker.is_open() is opens_breaker
-
-
-class _RedisWritesTimeOut:
-    """Injected async client whose writes fail like a real 'Timeout connecting to server'."""
-
-    async def set(self, name: str, value: str, nx: bool = False, ex: object = None) -> None:
-        from redis.exceptions import TimeoutError as RedisTimeoutError
-
-        raise RedisTimeoutError("Timeout connecting to server")
-
-    async def sadd(self, key: str, *members: object) -> None:
-        from redis.exceptions import TimeoutError as RedisTimeoutError
-
-        raise RedisTimeoutError("Timeout connecting to server")
-
-
-class _CaptureRecords(logging.Filter):
-    """Logger-level filter that records each formatted message.
-
-    Attached to the logger (not a handler), so it runs before the handler-level
-    SecretRedactionFilter can mutate the record. That isolates this test to the
-    redaction done at the log call site, independent of the logging config.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.messages: tuple[str, ...] = ()
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        self.messages = (*self.messages, record.getMessage())
-        return True
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "call_cache",
-    (
-        pytest.param(
-            lambda c: c.async_set_cache(
-                key="litellm_config:param:general_settings",
-                value={"param_name": "general_settings", "param_value": {"master_key": _MASTER_KEY}},
-            ),
-            id="async_set_cache",
-        ),
-        pytest.param(
-            lambda c: c.async_set_cache_sadd(key="k", value=[_MASTER_KEY], ttl=60),
-            id="async_set_cache_sadd",
-        ),
-    ),
-)
-async def test_redis_write_failure_does_not_log_master_key(redis_no_ping, call_cache):
-    """A Redis write timeout must not spill the cached value's secrets into logs.
-
-    The proxy caches its own general_settings row, whose value holds the master key. When a
-    write to Redis fails, the error path logged that value verbatim, leaking the master key
-    in plaintext. Redacting at the call site keeps the leak out regardless of the logging
-    config, so this asserts on the record before any handler-level redaction filter runs.
-    """
-    from litellm._logging import verbose_logger
-
-    cache: Final = RedisCache(host="127.0.0.1", port=_closed_port(), socket_timeout=0.5)
-    capture: Final = _CaptureRecords()
-    verbose_logger.addFilter(capture)
-    try:
-        with patch.object(cache, "init_async_client", return_value=_RedisWritesTimeOut()):
-            try:
-                await call_cache(cache)
-            except Exception:
-                pass
-    finally:
-        verbose_logger.removeFilter(capture)
-
-    joined: Final = "\n".join(capture.messages)
-    assert "Got exception from REDIS" in joined, "the write-failure path must have logged"
-    assert _MASTER_KEY not in joined, f"master key leaked in plaintext: {joined!r}"
-    assert "REDACTED" in joined, "the secret must be redacted, not silently dropped"


### PR DESCRIPTION
## TLDR

Problem this solves:

- A Redis write timeout logged the raw value being cached
- The proxy caches its own settings, so the admin master key leaked to logs

How it solves it:

- Redact the value and key with redact_string at the log call site
- Covers the two write paths, before the log record is built

## User Flow

Before: an operator whose Redis is unreachable finds the admin master key sitting in the proxy log in plaintext

1. They start the proxy with a master key, Redis configured but unreachable, and `LITELLM_DISABLE_REDACT_SECRETS=true`
2. They send POST https://litellm-domain/v1/chat/completions with a valid key
3. The proxy tries to cache its settings, the write times out, and it logs the value it was writing
4. They read the log and see `value={'param_name': 'general_settings', 'param_value': {'master_key': 'sk-...'}}` in plaintext
5. Anyone with read access to those logs can use that master key to call the admin API as the proxy owner

After: the same operator sees the secret scrubbed on the same log line

1. They start the proxy with a master key, Redis configured but unreachable, and `LITELLM_DISABLE_REDACT_SECRETS=true`
2. They send the same POST https://litellm-domain/v1/chat/completions with a valid key
3. The proxy tries to cache its settings, the write times out, and it logs the value with secrets replaced
4. They read the log and see `value={'param_name': 'general_settings', 'param_value': {'REDACTED'}}`
5. Log access no longer yields the master key, so a reader cannot authenticate as the proxy owner

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Runbook to capture before and after. It disables the handler-level redaction on purpose, so the log line reflects only what the call site emits, which is where this fix lives. Point Redis at an unroutable IP so every write times out, and store the config in the DB so the proxy caches its own `general_settings` (the row that holds the master key)

```
# before, at commit fd66d87e46
git checkout fd66d87e46
LITELLM_MASTER_KEY=sk-1234 LITELLM_DISABLE_REDACT_SECRETS=true \
STORE_MODEL_IN_DB=true REDIS_HOST=10.255.255.1 REDIS_PORT=6379 \
python -m litellm.proxy.proxy_cli --config litellm/proxy/dev_config.yaml --detailed_debug 2>&1 | tee litellm.log
# in another shell
curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
grep "Got exception from REDIS" litellm.log
# expected before: ... Writing value={'param_name': 'general_settings', 'param_value': {'master_key': 'sk-1234', ...}}

# after, at commit 16f1f93d6e
git checkout 16f1f93d6e
# restart the proxy with the same env, rerun the same curl
grep "Got exception from REDIS" litellm.log
# expected after: ... Writing value={'param_name': 'general_settings', 'param_value': {'REDACTED'}}
```

<paste before output here, captured at fd66d87e46>

<paste after output here, captured at 16f1f93d6e>

## Type

🐛 Bug Fix

## Caveats (if any)

- No unit test: constructing RedisCache reaches the network, so review asked to rely on the live-proxy proof instead
- Default logging config already masks this; the fix hardens the source path
- redact_string is a denylist, so unknown secret shapes still warrant a never-log follow-up

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

