### PR TITLE
chore(release): backport proxy request-handling maintenance and refresh runtime deps for 1.96.1

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -20,6 +20,7 @@ from litellm.litellm_core_utils.url_utils import (
     validate_url,
 )
 from litellm.proxy._types import *
+from litellm.proxy.common_utils.http_parsing_utils import extract_nested_form_metadata
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_ENDPOINT_MARKER,
 )
@@ -440,6 +441,13 @@ def is_request_body_safe(request_body: dict, general_settings: dict, llm_router:
         metadata = _coerce_metadata_to_dict(request_body.get(metadata_key))
         if metadata is not None:
             _check_banned_params(metadata, general_settings, llm_router, model)
+        if any(isinstance(key, str) and key.startswith(f"{metadata_key}[") for key in request_body):
+            _check_banned_params(
+                extract_nested_form_metadata(form_data=request_body, prefix=f"{metadata_key}["),
+                general_settings,
+                llm_router,
+                model,
+            )
     for target in iter_request_fallback_targets(request_body):
         if isinstance(target, dict):
             _check_banned_params(target, general_settings, llm_router, model)

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -68,7 +68,10 @@ if TYPE_CHECKING:
     ProxyConfig = _ProxyConfig
 else:
     ProxyConfig = Any
-from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+from litellm.proxy.litellm_pre_call_utils import (
+    add_litellm_data_to_request,
+    reject_url_valued_destination,
+)
 from litellm.types.utils import (
     ModelResponse,
     ModelResponseStream,
@@ -1252,6 +1255,9 @@ class ProxyBaseLLMRequestProcessing:
             if not isinstance(self.data[_metadata_variable_name], dict):
                 self.data[_metadata_variable_name] = {}
             self.data[_metadata_variable_name]["queue_time_seconds"] = queue_time_seconds
+
+        if isinstance(model, str):
+            reject_url_valued_destination("model", model)
 
         self.data["model"] = (
             general_settings.get("completion_model", None)  # server default

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -5,9 +5,9 @@ import os
 import secrets
 import time
 import traceback
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timedelta
-from typing import Any, Literal, TypedDict, Union, cast
+from typing import Any, Final, Literal, TypedDict, Union, cast
 
 import fastapi
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
@@ -29,6 +29,9 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
     WebhookEvent,
 )
+from litellm.proxy.auth.auth_utils import (
+    _BANNED_REQUEST_BODY_PARAMS,  # pyright: ignore[reportPrivateUsage]  # one canonical list, shared with the request-body check
+)
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.proxy.health_check import (
@@ -43,6 +46,10 @@ from litellm.proxy.middleware.in_flight_requests_middleware import (
     get_in_flight_requests,
 )
 from litellm.proxy.shutdown.graceful_shutdown_manager import GracefulShutdownManager
+from litellm.router_utils.clientside_credential_handler import (
+    _ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE,  # pyright: ignore[reportPrivateUsage]  # one canonical list, shared with the router path
+    clientside_credential_keys,
+)
 
 #### Health ENDPOINTS ####
 
@@ -78,6 +85,45 @@ def _reject_os_environ_references(params: dict) -> None:
             if isinstance(value, (dict, list)) and id(value) not in seen:
                 seen.add(id(value))
                 stack.append(value)
+
+
+_CONFIG_CONNECTION_FIELDS: Final[frozenset[str]] = frozenset(
+    (
+        *_ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE,
+        *clientside_credential_keys,
+        "litellm_credential_name",
+    )
+)
+
+
+def _config_base_for_health_check(
+    config_params: Mapping[str, object],
+    request_params: Mapping[str, object],
+    allow_client_side_credentials: bool = False,
+) -> dict[str, object]:
+    """Return the configured parameters to merge under a connection-test request.
+
+    A request that sets its own connection fields describes a connection of its
+    own, so the configuration's credentials are not carried into it: they belong
+    to the endpoint the configuration names. Anything the request does not set
+    still comes from the configuration, which is what lets a request name a
+    configured model and test it as configured.
+
+    ``litellm_credential_name`` is dropped alongside the literal credential
+    fields: it names a stored credential that ``load_credentials_from_list``
+    resolves into the same secrets further down the call, so leaving it in place
+    would reintroduce them by reference.
+
+    ``general_settings.allow_client_side_credentials`` is the existing proxy-wide
+    opt-in for callers supplying their own connection parameters. Where an admin
+    has enabled it, a request may pair its own endpoint with the configured
+    credentials, as it could before.
+    """
+    if allow_client_side_credentials:
+        return dict(config_params)
+    if not any(param in request_params for param in _BANNED_REQUEST_BODY_PARAMS):
+        return dict(config_params)
+    return {key: value for key, value in config_params.items() if key not in _CONFIG_CONNECTION_FIELDS}
 
 
 def get_callback_identifier(callback):
@@ -1785,7 +1831,12 @@ async def test_model_connection(
     from litellm.proxy.management_endpoints.model_management_endpoints import (
         ModelManagementAuthChecks,
     )
-    from litellm.proxy.proxy_server import llm_router, premium_user, prisma_client
+    from litellm.proxy.proxy_server import (
+        general_settings,
+        llm_router,
+        premium_user,
+        prisma_client,
+    )
     from litellm.types.router import Deployment, LiteLLM_Params
 
     try:
@@ -1854,8 +1905,14 @@ async def test_model_connection(
                 )
 
         # Merge: config params (from proxy config) as base, request params override
-        # This allows users to override specific params while using config for credentials
-        litellm_params = {**config_litellm_params, **request_litellm_params}
+        litellm_params = {
+            **_config_base_for_health_check(
+                config_litellm_params,
+                request_litellm_params,
+                allow_client_side_credentials=general_settings.get("allow_client_side_credentials") is True,
+            ),
+            **request_litellm_params,
+        }
 
         ## Auth check
         auth_model_info = loaded_model_info if loaded_model_info is not None else model_info

--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -69,6 +69,7 @@ async def image_generation(
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     model: str | None = None,
 ):
+    from litellm.proxy.litellm_pre_call_utils import reject_url_valued_destination
     from litellm.proxy.proxy_server import (
         add_litellm_data_to_request,
         general_settings,
@@ -94,6 +95,9 @@ async def image_generation(
             version=version,
             proxy_config=proxy_config,
         )
+
+        if isinstance(model, str):
+            reject_url_valued_destination("model", model)
 
         data["model"] = (
             model

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -4,7 +4,7 @@ import json
 import re
 import time
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from fastapi import HTTPException, Request
 from pydantic import ValidationError as PydanticValidationError
@@ -253,29 +253,37 @@ def _reject_url_valued_destinations(data: dict[str, Any]) -> None:
     are unaffected, while admins can opt specific hosts back in via
     ``litellm.provider_url_destination_allowed_hosts``.
     """
-    allowed_hosts = getattr(litellm, "provider_url_destination_allowed_hosts", []) or []
     for field in _URL_DESTINATION_REQUEST_FIELDS:
         value = data.get(field)
-        if not isinstance(value, str):
+        if isinstance(value, str):
+            reject_url_valued_destination(field, value)
+
+
+def reject_url_valued_destination(field: str, value: str) -> None:
+    """Reject a URL-valued destination identifier unless admin-allowlisted.
+
+    Operates on one field/value pair. ``_reject_url_valued_destinations`` applies
+    it across ``_URL_DESTINATION_REQUEST_FIELDS`` for a request body.
+    """
+    allowed_hosts: Final = getattr(litellm, "provider_url_destination_allowed_hosts", []) or []
+    for candidate in provider_url_destination_candidates(value):
+        if not candidate.lower().startswith(("http://", "https://")):
             continue
-        for candidate in provider_url_destination_candidates(value):
-            if not candidate.lower().startswith(("http://", "https://")):
-                continue
-            if is_url_destination_allowed_by_host(candidate, allowed_hosts):
-                continue
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "invalid_request",
-                    "param": field,
-                    "message": (
-                        f"URL-valued '{field}' is not allowed. Configure custom "
-                        "endpoints with api_base instead, or add the destination "
-                        "host to `provider_url_destination_allowed_hosts` in "
-                        "litellm_settings."
-                    ),
-                },
-            )
+        if is_url_destination_allowed_by_host(candidate, allowed_hosts):
+            continue
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_request",
+                "param": field,
+                "message": (
+                    f"URL-valued '{field}' is not allowed. Configure custom "
+                    "endpoints with api_base instead, or add the destination "
+                    "host to `provider_url_destination_allowed_hosts` in "
+                    "litellm_settings."
+                ),
+            },
+        )
 
 
 def _strip_untrusted_request_header_controls(

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,14 +1,4 @@
 [[IgnoredVulns]]
-id = "GHSA-fwg2-594c-jp42"
-ignoreUntil = 2026-08-12
-reason = "pypdf 6.15.0 (the fix) published 2026-08-06 and is still inside the P3D exclude-newer window, so uv cannot lock it yet; bump and drop this entry from 2026-08-09"
-
-[[IgnoredVulns]]
-id = "GHSA-fp3f-mc75-235c"
-ignoreUntil = 2026-08-12
-reason = "second pypdf advisory with the same 6.15.0 fix, published 2026-08-07 after the first; drop alongside GHSA-fwg2-594c-jp42 in the same bump"
-
-[[IgnoredVulns]]
 id = "GHSA-w8v5-vhqr-4h9v"
 ignoreUntil = 2026-09-09
 reason = "diskcache has no fixed release published; remove this entry once one exists"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.96.0"
+version = "1.96.1"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.15"
@@ -303,7 +303,7 @@ members = ["enterprise", "litellm-proxy-extras"]
 profile = "black"
 
 [tool.commitizen]
-version = "1.96.0"
+version = "1.96.1"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -3010,3 +3010,80 @@ class TestGetKeyTagRateLimits:
     def test_returns_none_when_unset(self):
         key = UserAPIKeyAuth(api_key="sk-123")
         assert get_key_tag_rpm_limit(key) is None
+
+
+class TestIsRequestBodySafeChecksBracketNotationMetadata:
+    """Bracket notation is how multipart callers express nested metadata; it is
+    validated the same way the dict form is."""
+
+    @pytest.mark.parametrize("metadata_key", ["metadata", "litellm_metadata"])
+    def test_bracket_notation_banned_param_is_rejected(self, metadata_key):
+        with pytest.raises(ValueError, match="langfuse_host"):
+            is_request_body_safe(
+                request_body={
+                    "purpose": "assistants",
+                    f"{metadata_key}[langfuse_host]": "https://example.invalid",
+                },
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+
+    def test_bracket_notation_api_base_is_rejected(self):
+        with pytest.raises(ValueError, match="api_base"):
+            is_request_body_safe(
+                request_body={"litellm_metadata[api_base]": "https://example.invalid"},
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+
+    def test_bracket_notation_allowed_under_proxy_wide_opt_in(self):
+        assert (
+            is_request_body_safe(
+                request_body={"litellm_metadata[langfuse_host]": "https://byok.example"},
+                general_settings={"allow_client_side_credentials": True},
+                llm_router=None,
+                model="gpt-4",
+            )
+            is True
+        )
+
+    def test_benign_bracket_notation_metadata_is_allowed(self):
+        assert (
+            is_request_body_safe(
+                request_body={
+                    "purpose": "assistants",
+                    "litellm_metadata[spend_logs_metadata][owner]": "john",
+                    "litellm_metadata[tags]": "production",
+                },
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+            is True
+        )
+
+    def test_bracket_notation_matches_json_encoding_for_deeper_nesting(self):
+        """A value nested below the first level is treated the same either way:
+        the check descends one level into metadata, for both encodings."""
+        deep_bracket = {
+            "litellm_metadata[spend_logs_metadata][langfuse_host]": "https://example.invalid"
+        }
+        deep_json = {
+            "litellm_metadata": {"spend_logs_metadata": {"langfuse_host": "https://example.invalid"}}
+        }
+        kwargs = dict(general_settings={}, llm_router=None, model="gpt-4")
+        assert is_request_body_safe(request_body=deep_bracket, **kwargs) is True
+        assert is_request_body_safe(request_body=deep_json, **kwargs) is True
+
+    def test_body_without_bracket_keys_is_unaffected(self):
+        assert (
+            is_request_body_safe(
+                request_body={"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+            is True
+        )

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -2364,3 +2364,96 @@ def test_clean_endpoint_data_strips_credentials_keeps_routing_fields():
     assert "aws_access_key_id" not in cleaned
     assert cleaned.get("api_base") == "https://example.test/v1"
     assert cleaned.get("api_version") == "2024-10-21"
+
+
+class TestConfigBaseForHealthCheck:
+    """A request that sets its own connection fields gets a base without the
+    configuration's credentials; anything it leaves unset still comes from
+    the configuration."""
+
+    CONFIG = {
+        "model": "openai/gpt-4o",
+        "api_key": "sk-configured",
+        "api_base": "https://configured.example/v1",
+        "vertex_credentials": "configured-creds",
+        "rpm": 100,
+    }
+
+    def _base(self, config, request, allow_client_side_credentials=False):
+        from litellm.proxy.health_endpoints._health_endpoints import (
+            _config_base_for_health_check,
+        )
+
+        return _config_base_for_health_check(
+            config, request, allow_client_side_credentials=allow_client_side_credentials
+        )
+
+    def test_request_without_connection_fields_inherits_config(self):
+        base = self._base(self.CONFIG, {"model": "openai/gpt-4o"})
+        assert base["api_key"] == "sk-configured"
+        assert base["api_base"] == "https://configured.example/v1"
+
+    def test_request_setting_api_base_does_not_inherit_config_credentials(self):
+        base = self._base(self.CONFIG, {"api_base": "https://caller.example/v1"})
+        assert "api_key" not in base
+        assert "api_base" not in base
+        assert "vertex_credentials" not in base
+        assert base["rpm"] == 100
+
+    def test_add_model_flow_keeps_its_own_credentials(self):
+        """Adding a second deployment for an already-configured name sends a
+        complete connection; it is tested as sent, not as configured."""
+        request = {
+            "model": "openai/gpt-4o",
+            "api_base": "https://new-deployment.example/v1",
+            "api_key": "sk-new-deployment",
+        }
+        merged = {**self._base(self.CONFIG, request), **request}
+        assert merged["api_base"] == "https://new-deployment.example/v1"
+        assert merged["api_key"] == "sk-new-deployment"
+        assert "sk-configured" not in str(merged)
+
+    def test_destination_override_without_own_key_inherits_no_credential(self):
+        """A request that redirects the destination but supplies no credential
+        of its own gets none from the configuration."""
+        request = {"api_base": "https://elsewhere.example"}
+        merged = {**self._base(self.CONFIG, request), **request}
+        assert "api_key" not in merged
+        assert "sk-configured" not in str(merged)
+
+    def test_non_api_base_destination_field_also_drops_credentials(self):
+        base = self._base(
+            {**self.CONFIG, "aws_secret_access_key": "configured-secret"},
+            {"aws_bedrock_runtime_endpoint": "https://caller.example"},
+        )
+        assert "api_key" not in base
+        assert "aws_secret_access_key" not in base
+
+    def test_opt_in_restores_configured_credentials_under_a_request_endpoint(self):
+        """With general_settings.allow_client_side_credentials enabled, a request
+        may pair its own endpoint with the configured credentials, as before."""
+        base = self._base(
+            self.CONFIG,
+            {"api_base": "https://caller.example/v1"},
+            allow_client_side_credentials=True,
+        )
+        assert base["api_key"] == "sk-configured"
+
+    def test_stored_credential_reference_is_dropped_with_the_credentials(self):
+        """A stored-credential name resolves to the same secrets downstream, so a
+        request that redirects the destination must not keep it either."""
+        config = {**self.CONFIG, "litellm_credential_name": "OpenAI-prod"}
+        base = self._base(config, {"api_base": "https://caller.example/v1"})
+        assert "litellm_credential_name" not in base
+        assert "api_key" not in base
+
+    def test_stored_credential_reference_kept_when_request_sets_no_connection(self):
+        """The Admin UI tests a configured model by naming it plus its stored
+        credential and nothing else; that keeps working."""
+        config = {**self.CONFIG, "litellm_credential_name": "OpenAI-prod"}
+        base = self._base(
+            config,
+            {"model": "openai/gpt-4o", "litellm_credential_name": "OpenAI-prod", "custom_llm_provider": "openai"},
+        )
+        assert base["litellm_credential_name"] == "OpenAI-prod"
+        assert base["api_key"] == "sk-configured"

--- a/tests/test_litellm/proxy/image_endpoints/test_azure_routes.py
+++ b/tests/test_litellm/proxy/image_endpoints/test_azure_routes.py
@@ -120,3 +120,28 @@ def test_azure_image_edit_route(client_no_auth):
     assert called_kwargs["prompt"] == "A cute baby sea otter"
     assert response.status_code == 200
     assert response.json()["data"]
+
+
+def test_azure_image_generation_route_rejects_url_valued_path_model(client_no_auth):
+    """A URL-valued deployment segment is refused before any provider call."""
+    client, mock_aimage_generation, _ = client_no_auth
+    response = client.post(
+        "/openai/deployments/oobabooga/https://example.invalid/images/generations",
+        json={"prompt": "A cute baby sea otter", "n": 1, "size": "1024x1024"},
+    )
+
+    assert response.status_code == 400
+    assert "URL-valued" in response.text
+    mock_aimage_generation.assert_not_called()
+
+
+def test_azure_image_generation_route_allows_ordinary_path_model(client_no_auth):
+    """A deployment name that merely contains a provider prefix still routes."""
+    client, mock_aimage_generation, _ = client_no_auth
+    response = client.post(
+        "/openai/deployments/dall-e-3/images/generations",
+        json={"prompt": "A cute baby sea otter", "n": 1, "size": "1024x1024"},
+    )
+
+    assert response.status_code == 200
+    mock_aimage_generation.assert_called_once()

--- a/tests/test_litellm/proxy/test_provider_url_destination_guard.py
+++ b/tests/test_litellm/proxy/test_provider_url_destination_guard.py
@@ -177,3 +177,16 @@ async def test_add_litellm_data_to_request_rejects_url_valued_model():
         )
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail["param"] == "model"
+
+
+class TestNonStringDestinationValues:
+    """Only string identifiers are inspected. Anything else is left alone for the
+    request's normal validation to handle."""
+
+    @pytest.mark.parametrize("value", [123, None, True, {"a": 1}, ["x"], 1.5])
+    def test_non_string_model_is_ignored(self, value):
+        _reject_url_valued_destinations({"model": value})
+
+    @pytest.mark.parametrize("value", [123, None, True, {"a": 1}, ["x"]])
+    def test_non_string_file_id_is_ignored(self, value):
+        _reject_url_valued_destinations({"file_id": value})

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-05T19:22:00.656947Z"
+exclude-newer = "2026-08-08T01:55:57.525718Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -7418,14 +7418,14 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.14.2"
+version = "6.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-08T01:55:57.525718Z"
+exclude-newer = "2026-08-08T02:01:05.094812Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4116,7 +4116,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.96.0"
+version = "1.96.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## TLDR

Problem this solves:

- 1.96.x lacks a request-handling change every older stable line carries
- Upgrading from a patched 1.95.1 to 1.96.0 would silently lose it
- Two pypdf lockfile exceptions on this line expire 2026-08-12

How it solves it:

- Cherry-picks #36011 onto stable/1.96.x, adapting only import plumbing
- Bumps pypdf to 6.15.0 and drops the exceptions it clears
- Cuts 1.96.1, the first release on this line carrying both

## Relevant issues

Patch release `1.96.1` on top of `v1.96.0`. The code commit is a `cherry-pick -x` of a commit already merged to `litellm_internal_staging`, so nothing here is new work written against the stable line

`#36011` reached `litellm_internal_staging` on 2026-08-05 and has been applied to every stable line from 1.88.x through 1.95.x. The 1.96.0 release branched before it arrived, so 1.96.x is the only line missing it. That ordering is the reason this PR exists: once 1.95.1 ships, a deployment upgrading to 1.96.0 would move from a line that has this change to one that does not, which is the opposite of what a version bump should mean

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests, carried in with the cherry-pick; see Verification
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests), leaving the full suite for CI
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

🧹 Refactoring
🚄 Infrastructure

## Changes

| Backported | Staging commit | Notes |
|---|---|---|
| `fix(proxy)!: apply request-parameter checks consistently across body, path and form inputs (#36011)` | `c898d341c0` | adapted, import plumbing only |

### Adaptation notes

`#36011` diverges from staging in exactly two lines, both the same cause. Every other added and removed line is byte-identical to the staging commit, verified by diffing the two patches line by line rather than by reading the range-diff

The commit annotates with `Final`, which neither `_health_endpoints.py` nor `litellm_pre_call_utils.py` imported on this line. `Final` joins each file's existing `typing` import rather than arriving on a second import line, matching how both files already source their generics. Unlike the 1.95.x backport, no `Mapping` or `Iterable` adaptation was needed; this line already imports those from `collections.abc`

The `_health_endpoints.py` half is load-bearing rather than cosmetic. That file gains a module-level `_CONFIG_CONNECTION_FIELDS: Final[frozenset[str]]`, and module-level annotations are evaluated at import, so a missing `Final` would be an import-time failure at proxy startup rather than a lint finding. The `litellm_pre_call_utils.py` half annotates a function-local, which Python does not evaluate, so there the same omission would surface only as a lint failure

One conflict resolved, in `litellm_pre_call_utils.py`. The commit extracts the per-field logic into `reject_url_valued_destination`, which computes `allowed_hosts` itself, leaving the local in `_reject_url_valued_destinations` dead. Both sides delete that local; they differ only because this line's copy of the pre-image lacked the `Final` annotation staging had already added. The post-image is identical

## Known behavior change

`#36011` is marked a breaking change upstream, so it is worth stating plainly what changes here

**`/health/test_connection` merges differently.** Previously the proxy config was the base and request parameters layered on top, so a request could name a configured model, override one field, and still inherit the configured connection details. Now, if the request carries any of the request-parameter list, the configured connection fields are not carried into it

A rough edge rides along unchanged from the upstream commit: the trigger is the full request-parameter list, but the fields dropped are the narrower connection set. So a request including a non-connection field such as `input_cost_per_token` also loses the configured `api_base` and `api_key`, leaving the probe with no endpoint and reporting a failed connection for a model that is fine. `general_settings.allow_client_side_credentials` restores the previous merge. This reproduces identically on `litellm_internal_staging`, so it is not introduced by this backport; flagging it so any follow-up lands in the right place

The other two changes are the intended effect of the commit. A URL-valued `model` supplied through the URL path or query string is now handled the same way a URL-valued `model` in the JSON body already was, and bracket-notation form fields such as `metadata[...]` are now inspected the same way the equivalent JSON object already was. Every bracket payload now rejected was already rejected in its JSON form on 1.96.0

## Dependency refreshes

Routine maintenance of the image lockfile, moving to the smallest version that satisfies this line's ranges

| Package | 1.96.0 | 1.96.1 | Kind |
|---|---|---|---|
| `pypdf` | 6.14.2 | 6.15.0 | lock-only |

The regeneration moved nothing but its target, checked by parsing both locks rather than reading the diff. `pypdf>=6.12.0,<7.0` already admits 6.15.0, so no manifest change is needed. The lock's `exclude-newer` stamp also advances, which is inherent to re-resolving the relative `P3D` span and is what makes 6.15.0 reachable at all

`osv-scanner.toml` loses its two `pypdf` entries in the same change. Both were written to expire on 2026-08-12 and both say to drop them alongside this bump, so leaving them would leave a stale claim in the tree. The file now matches `litellm_internal_staging` byte for byte

The remaining `diskcache` entry stays. No fixed release exists upstream, and `litellm_internal_staging` resolves the same version, so this line is not behind staging on it

After this patch the line resolves every package at or below `litellm_internal_staging`, checked by parsing both locks: 426 packages identical, 7 behind, none ahead. So upgrading from `1.96.1` to a later release never walks a dependency backwards, and the resulting lock carries the same residual scanner findings as staging itself

## Verification

Run on a worktree cut from `stable/1.96.x`, judged against a baseline captured on the untouched tip

- **The four mapped test files go 345 passed to 373 passed, with zero new failures.** The baseline was clean, so every one of the 28 added tests is signal rather than something argued against pre-existing noise
- **A revert check confirms the tests bind to this line's behavior.** Restoring the five source files to their pre-pick state while keeping the new tests drops the run to 12 failed / 361 passed, spanning all three of the commit's claims. Without it, green could mean the tests never exercised the new code
- **The path-supplied `model` check has no test of its own and was exercised directly rather than assumed.** It is reached from `common_processing_pre_call_logic`, which takes `model` as a parameter and is called with it from two call sites, behind the `/engines/{model:path}/...` and `/openai/deployments/{model:path}/...` routes. Driven directly, ordinary names such as `gpt-4o` and `azure/my-deployment` pass through, URL-valued ones return 400, and the `provider_url_destination_allowed_hosts` escape hatch both admits an allowlisted host and rejects it again once the allowlist is cleared, so the passing case is not vacuous
- **Import integrity.** All five modified modules import cleanly, and `_CONFIG_CONNECTION_FIELDS` evaluates to a 36-entry frozenset, which proves the module-level annotation resolves at runtime rather than merely satisfying the linter
- **Format and lint.** `ruff format --check` reports all five touched files already formatted, and `ruff check` is clean on them
- **`uv lock --check` passes**, so the lock is not stale against the manifest

The gauntlet and a live-proxy replay were deliberately skipped for this line. The same commit has landed cleanly on eight other lines, so the open question here was cherry-pick fidelity rather than behavioral correctness, and that is what the divergence audit, symbol closure, and the revert check address

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
