### PR TITLE
fix(bedrock): add text block to converse user messages carrying documents

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3967,6 +3967,36 @@ def _rename_duplicate_bedrock_document_names(
     return contents
 
 
+BEDROCK_DOCUMENT_PLACEHOLDER_TEXT: Final = "."
+
+
+def _with_text_when_document_only(message: BedrockMessageBlock) -> BedrockMessageBlock:
+    blocks: Final = message["content"]
+    needs_text: Final = (
+        message["role"] == "user"
+        and any("document" in block for block in blocks)
+        and all("text" not in block for block in blocks)
+    )
+    if not needs_text:
+        return message
+    placeholder: Final = BedrockContentBlock(text=BEDROCK_DOCUMENT_PLACEHOLDER_TEXT)
+    cut: Final = len(blocks) - 1 if "cachePoint" in blocks[-1] else len(blocks)
+    return BedrockMessageBlock(role="user", content=[*blocks[:cut], placeholder, *blocks[cut:]])
+
+
+def _ensure_document_messages_have_text(
+    contents: list[BedrockMessageBlock],
+) -> list[BedrockMessageBlock]:
+    """
+    Bedrock Converse rejects any user message that carries a document block
+    without a sibling text block ("A text block must be included when using
+    documents"), e.g. Claude Code sends the PDF as a document-only user turn.
+    Inject a placeholder text block, kept ahead of a trailing cachePoint so
+    the caller's cache boundary stays the final block.
+    """
+    return [_with_text_when_document_only(message) for message in contents]
+
+
 def _sort_bedrock_assistant_content_blocks(
     blocks: list[BedrockContentBlock],
 ) -> list[BedrockContentBlock]:
@@ -4535,7 +4565,7 @@ class BedrockConverseMessagesProcessor:
                     llm_provider=llm_provider,
                 )
 
-        return _rename_duplicate_bedrock_document_names(contents)
+        return _ensure_document_messages_have_text(_rename_duplicate_bedrock_document_names(contents))
 
     @staticmethod
     def translate_thinking_blocks_to_reasoning_content_blocks(
@@ -4911,7 +4941,7 @@ def _bedrock_converse_messages_pt(
                 llm_provider=llm_provider,
             )
 
-    return _rename_duplicate_bedrock_document_names(contents)
+    return _ensure_document_messages_have_text(_rename_duplicate_bedrock_document_names(contents))
 
 
 def make_valid_bedrock_tool_name(input_tool_name: str) -> str:

--- a/tests/e2e/claude_code/pdf_input/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/pdf_input/test_bedrock_converse.py
@@ -88,10 +88,6 @@ def _build_minimal_pdf(marker: str) -> bytes:
     return bytes(out)
 
 
-@pytest.mark.skip(
-    reason="product bug LIT-4523: Bedrock Converse requires a text block with document; "
-    "re-enable when document-only content is handled"
-)
 @pytest.mark.covers("llm.messages.bedrock_converse.pdf_input.nonstream.works")
 def test_pdf_input_bedrock_converse(compat_result, tmp_path):
     base_url, api_key = require_proxy(compat_result)

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -8,6 +8,7 @@ import pytest
 import litellm
 from litellm.litellm_core_utils.prompt_templates.factory import (
     BAD_MESSAGE_ERROR_STR,
+    BEDROCK_DOCUMENT_PLACEHOLDER_TEXT,
     BedrockConverseMessagesProcessor,
     BedrockImageProcessor,
     _bedrock_converse_messages_pt,
@@ -3269,3 +3270,140 @@ def test_group_tool_exchanges_is_linear_in_message_count():
 
     assert len(groups) == 100_000
     assert elapsed < 3.0, f"grouping 100k messages took {elapsed:.2f}s; suspect superlinear accumulation"
+
+
+_PDF_DATA_URI = "data:application/pdf;base64," + base64.b64encode(b"%PDF-1.4 regression fixture").decode()
+_PNG_DATA_URI = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+def _text_blocks(message):
+    return [block["text"] for block in message["content"] if "text" in block]
+
+
+def test_bedrock_converse_pdf_only_user_message_gets_text_block():
+    """
+    Regression for LIT-4523: Claude Code sends a PDF as a user turn whose only
+    content is the document (an image_url part with a pdf data URI after the
+    /v1/messages -> completion bridge). Bedrock Converse rejects any user
+    message carrying a document without a sibling text block, so the builder
+    must inject a placeholder text block.
+    """
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": _PDF_DATA_URI}}],
+        }
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-haiku-4-5", "bedrock"
+    )
+
+    assert len(result) == 1
+    assert any("document" in block for block in result[0]["content"])
+    assert _text_blocks(result[0]) == [BEDROCK_DOCUMENT_PLACEHOLDER_TEXT]
+
+
+def test_bedrock_converse_document_with_text_gets_no_extra_text_block():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": _PDF_DATA_URI}},
+                {"type": "text", "text": "summarize this"},
+            ],
+        }
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-haiku-4-5", "bedrock"
+    )
+
+    assert _text_blocks(result[0]) == ["summarize this"]
+
+
+def test_bedrock_converse_image_only_user_message_gets_no_text_block():
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": _PNG_DATA_URI}}],
+        }
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-haiku-4-5", "bedrock"
+    )
+
+    assert any("image" in block for block in result[0]["content"])
+    assert _text_blocks(result[0]) == []
+
+
+def test_bedrock_converse_tool_round_trip_document_injects_text_before_cache_point():
+    """
+    Claude Code shape: after a Read tool round trip, the document-only user
+    turn (with cache_control) merges into the toolResult message. The injected
+    text block must land before the trailing cachePoint so the cache boundary
+    stays the final block, and earlier turns must stay untouched.
+    """
+    messages = [
+        {"role": "user", "content": "read the pdf"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "tooluse_pdf1",
+                    "type": "function",
+                    "function": {"name": "Read", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "tooluse_pdf1", "content": "read ok"},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": "dGVzdA==",
+                    },
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-haiku-4-5", "bedrock"
+    )
+
+    assert _text_blocks(result[0]) == ["read the pdf"]
+    document_message = result[-1]
+    block_keys = [next(iter(block)) for block in document_message["content"]]
+    assert block_keys == ["toolResult", "document", "text", "cachePoint"]
+    assert _text_blocks(document_message) == [BEDROCK_DOCUMENT_PLACEHOLDER_TEXT]
+
+
+@pytest.mark.asyncio
+async def test_bedrock_converse_pdf_only_user_message_gets_text_block_async():
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": _PDF_DATA_URI}}],
+        }
+    ]
+
+    result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="anthropic.claude-haiku-4-5",
+        llm_provider="bedrock",
+    )
+
+    assert len(result) == 1
+    assert any("document" in block for block in result[0]["content"])
+    assert _text_blocks(result[0]) == [BEDROCK_DOCUMENT_PLACEHOLDER_TEXT]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Claude Code PDF reads fail on Bedrock Converse deployments
- AWS rejects user turns holding a document without text
- Fails the pdf_input x bedrock_converse compat matrix cell

How it solves it:

- Converse message builders inject a placeholder text block
- Only for user turns with a document and no text
- Placeholder lands before a trailing cachePoint block

## User Flow

Before: a developer using Claude Code against the gateway with a Bedrock Converse claude model cannot have it read any PDF

1. They point Claude Code at the gateway, pick a Bedrock Converse claude model, and ask it to read a PDF on disk
2. The CLI reads the file and sends POST http://litellm-domain/v1/messages with a user turn whose only content is the PDF document
3. They see the session die with API Error 400 saying "A text block must be included when using documents. Add a text block and retry your request."

After: the same session reads the PDF and answers from its contents

1. They point Claude Code at the gateway, pick a Bedrock Converse claude model, and ask it to read a PDF on disk
2. The CLI reads the file and sends POST http://litellm-domain/v1/messages with a user turn whose only content is the PDF document
3. The reply comes back 200 and the assistant reports what the PDF says

## Relevant issues

RCA doc: https://app.notion.com/p/3b943b8acdab815f9d41f1c2897dab5e

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on 127.0.0.1:4120 running `tests/e2e/claude_code/test_config.yaml` with real AWS Bedrock traffic. The request is the exact shape Claude Code emits after its Read tool round trip: a user turn whose content is only the Anthropic document block

Before, at parent commit d8762bf4db:

```
curl -s -w "\nHTTP %{http_code}\n" http://127.0.0.1:4120/v1/messages \
  -H "x-api-key: sk-local-rca" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
  -d '{"model":"claude-haiku-4-5-bedrock-converse","max_tokens":256,"messages":[{"role":"user","content":[{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCAyMDAgMjAwXSAvQ29udGVudHMgNCAwIFIgL1Jlc291cmNlcyA8PCAvRm9udCA8PCAvRjEgNSAwIFIgPj4gPj4gPj4KZW5kb2JqCjQgMCBvYmoKPDwgL0xlbmd0aCAzNSA+PgpzdHJlYW0KQlQgL0YxIDI0IFRmIDUwIDEwMCBUZCAoUE9ORykgVGogRVQKZW5kc3RyZWFtCmVuZG9iago1IDAgb2JqCjw8IC9UeXBlIC9Gb250IC9TdWJ0eXBlIC9UeXBlMSAvQmFzZUZvbnQgL0hlbHZldGljYSA+PgplbmRvYmoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDA5IDAwMDAwIG4gCjAwMDAwMDAwNTggMDAwMDAgbiAKMDAwMDAwMDExNSAwMDAwMCBuIAowMDAwMDAwMjQxIDAwMDAwIG4gCjAwMDAwMDAzMjYgMDAwMDAgbiAKdHJhaWxlcgo8PCAvU2l6ZSA2IC9Sb290IDEgMCBSID4+CnN0YXJ0eHJlZgozOTYKJSVFT0YK"}}]}]}'

{"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"A text block must be included when using documents. Add a text block and retry your request.\"}. Received Model Group=claude-haiku-4-5-bedrock-converse\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
HTTP 400
```

The matrix-faithful CLI run fails the same way at d8762bf4db (marker.pdf is a tiny one page PDF whose only text is PONG, the same fixture the e2e cell builds):

```
ANTHROPIC_BASE_URL=http://127.0.0.1:4120 ANTHROPIC_AUTH_TOKEN=sk-local-rca claude --print \
  --output-format stream-json --verbose --model claude-haiku-4-5-bedrock-converse --allowed-tools Read \
  -- "Use the Read tool to read the file at $PWD/marker.pdf. Report the single word that appears in the document."

is_error: True
result: API Error: 400 litellm.BadRequestError: BedrockException - {"message":"A text block must be included when using documents. Add a text block and retry your request."}. Received Model Group=claude-haiku-4-5-bedrock-converse
```

After, at 79accda090, the identical curl succeeds and the model reads the document:

```
HTTP 200
content: [{"type": "text", "text": "# PONG\n\nThis is the title screen for **Pong**, the iconic arcade video game. ..."}]
stop_reason: end_turn
```

The identical CLI run also succeeds at 79accda090:

```
is_error: False
result: The single word that appears in the document is **PONG**.
```

The three new injection tests in `tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py` fail on the parent commit and pass with the fix; the two no-injection guards pass on both, as intended

## Type

🐛 Bug Fix

## Caveats (if any)

- Injected placeholder "." is visible to the model
- Injection is unconditional, not gated on modify_params: a Converse user turn with a document and no text can never succeed, matching the unconditional blank text sanitization precedent

## QA runbook

- tests/e2e/claude_code/pdf_input/test_bedrock_converse.py::test_pdf_input_bedrock_converse - the claude CLI reads a PDF through each Bedrock Converse claude deployment and reports the marker word it contains (skip removed by this PR so the cell gates the fix)
  - [ ] Boot the proxy with AWS Bedrock creds in env: `litellm --config tests/e2e/claude_code/test_config.yaml --port 4000`
  - [ ] Write a small one page PDF whose only text is PONG to disk
  - [ ] For each of claude-haiku-4-5-bedrock-converse, claude-sonnet-4-5-bedrock-converse, claude-opus-4-7-bedrock-converse run: `ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_AUTH_TOKEN=<key> claude --print --model <alias> --allowed-tools Read -- "Use the Read tool to read the file at <path>/marker.pdf. Report the single word that appears in the document."`
  - [ ] Expect exit 0 and a reply mentioning PONG for every alias
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Bedrock Converse message shaping with clear guards (document-only user turns); well-covered by unit and e2e tests, with only a visible "." placeholder as a behavioral caveat.
> 
> **Overview**
> Fixes **Bedrock Converse 400** when a user turn includes a **document** (e.g. Claude Code PDF via `/v1/messages`) but **no text block**, which AWS rejects.
> 
> The Bedrock Converse message builders now run **`_ensure_document_messages_have_text`** after duplicate document renaming on both sync and async paths. For **user** messages that contain a document and no text, they inject a placeholder text block (`"."`), inserted **before** a trailing **`cachePoint`** so prompt-cache boundaries stay last.
> 
> Unit tests cover PDF-only injection, no-op when text or image-only, tool-round-trip + cache ordering, and async parity. The **pdf_input × bedrock_converse** e2e test skip for LIT-4523 is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79accda0900ce2dbe3de9da5f6e7290eda360e03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->