### PR TITLE
fix(proxy): inject streaming usage cost on openai passthrough streams

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -7,6 +7,7 @@ import traceback
 from collections.abc import AsyncGenerator, Callable, Mapping
 from datetime import datetime
 from functools import lru_cache
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal
 
 import anyio
@@ -3063,12 +3064,12 @@ class ProxyBaseLLMRequestProcessing:
                 if maybe_modified is not None:
                     return maybe_modified
             elif isinstance(chunk, (bytes, bytearray)):
-                # Decode to str, inject, and rebuild as bytes
                 try:
-                    s: Final = chunk.decode("utf-8", errors="ignore")
-                    maybe_mod = ProxyBaseLLMRequestProcessing._inject_cost_into_sse_frame_str(s, model_name)
-                    if maybe_mod is not None:
-                        return (maybe_mod + ("" if maybe_mod.endswith("\n\n") else "\n\n")).encode("utf-8")
+                    s: Final = chunk.decode("utf-8")
+                    if s.endswith("\n\n"):
+                        maybe_mod = ProxyBaseLLMRequestProcessing._inject_cost_into_sse_frame_str(s, model_name)
+                        if maybe_mod is not None:
+                            return maybe_mod.encode("utf-8")
                 except Exception:
                     pass
             elif isinstance(chunk, str):
@@ -3114,9 +3115,78 @@ class ProxyBaseLLMRequestProcessing:
             return None
 
     @staticmethod
+    def _anthropic_stream_usage_kwargs(usage: Mapping[str, Any]) -> Mapping[str, Any]:
+        prompt_tokens: Final = int(usage.get("input_tokens", 0) or 0)
+        completion_tokens: Final = int(usage.get("output_tokens", 0) or 0)
+        total_tokens: Final = int(
+            usage.get("total_tokens", prompt_tokens + completion_tokens) or (prompt_tokens + completion_tokens)
+        )
+        web_search_requests: Final = usage.get("web_search_requests")
+        server_tool_use: Final = (
+            ServerToolUse(web_search_requests=web_search_requests) if web_search_requests is not None else None
+        )
+        return MappingProxyType(
+            {
+                key: value
+                for key, value in (
+                    ("prompt_tokens", prompt_tokens),
+                    ("completion_tokens", completion_tokens),
+                    ("total_tokens", total_tokens),
+                    ("completion_tokens_details", usage.get("completion_tokens_details")),
+                    ("prompt_tokens_details", usage.get("prompt_tokens_details")),
+                    ("cache_creation_input_tokens", usage.get("cache_creation_input_tokens")),
+                    ("cache_read_input_tokens", usage.get("cache_read_input_tokens")),
+                    ("server_tool_use", server_tool_use),
+                )
+                if value is not None
+            }
+        )
+
+    @staticmethod
+    def _openai_stream_usage_kwargs(usage: Mapping[str, Any]) -> Mapping[str, Any]:
+        prompt_tokens: Final = int(usage.get("prompt_tokens", 0) or 0)
+        completion_tokens: Final = int(usage.get("completion_tokens", 0) or 0)
+        total_tokens: Final = int(
+            usage.get("total_tokens", prompt_tokens + completion_tokens) or (prompt_tokens + completion_tokens)
+        )
+        return MappingProxyType(
+            {
+                key: value
+                for key, value in (
+                    ("prompt_tokens", prompt_tokens),
+                    ("completion_tokens", completion_tokens),
+                    ("total_tokens", total_tokens),
+                    ("completion_tokens_details", usage.get("completion_tokens_details")),
+                    ("prompt_tokens_details", usage.get("prompt_tokens_details")),
+                )
+                if value is not None
+            }
+        )
+
+    @staticmethod
+    def _stream_usage_kwargs_for_event(obj: Mapping[str, object], usage: Mapping[str, Any]) -> Mapping[str, Any] | None:
+        if obj.get("type") == "message_delta":
+            return ProxyBaseLLMRequestProcessing._anthropic_stream_usage_kwargs(usage)
+        if obj.get("object") == "chat.completion.chunk":
+            return ProxyBaseLLMRequestProcessing._openai_stream_usage_kwargs(usage)
+        return None
+
+    @staticmethod
+    def _completion_cost_or_none(
+        model_response: ModelResponse, model_name: str, service_tier: str | None
+    ) -> float | None:
+        try:
+            return litellm.completion_cost(
+                completion_response=model_response, model=model_name, service_tier=service_tier
+            )
+        except Exception:
+            return None
+
+    @staticmethod
     def _inject_cost_into_usage_dict(obj: dict, model_name: str) -> dict | None:
         """
-        Inject cost information into a usage dictionary for message_delta events.
+        Inject cost information into the usage object of a streamed usage event
+        (Anthropic ``message_delta`` or OpenAI ``chat.completion.chunk``).
 
         Args:
             obj: Dictionary containing the SSE event data
@@ -3125,57 +3195,21 @@ class ProxyBaseLLMRequestProcessing:
         Returns:
             Modified dictionary with cost injected, or None if no modification needed
         """
-        if obj.get("type") == "message_delta" and isinstance(obj.get("usage"), dict):
-            _usage: Final = obj["usage"]
-            prompt_tokens: Final = int(_usage.get("input_tokens", 0) or 0)
-            completion_tokens: Final = int(_usage.get("output_tokens", 0) or 0)
-            total_tokens: Final = int(
-                _usage.get("total_tokens", prompt_tokens + completion_tokens) or (prompt_tokens + completion_tokens)
-            )
-
-            # Extract additional usage fields
-            cache_creation_input_tokens: Final = _usage.get("cache_creation_input_tokens")
-            cache_read_input_tokens: Final = _usage.get("cache_read_input_tokens")
-            web_search_requests: Final = _usage.get("web_search_requests")
-            completion_tokens_details: Final = _usage.get("completion_tokens_details")
-            prompt_tokens_details: Final = _usage.get("prompt_tokens_details")
-
-            usage_kwargs: Final[dict[str, Any]] = {
-                "prompt_tokens": prompt_tokens,
-                "completion_tokens": completion_tokens,
-                "total_tokens": total_tokens,
-            }
-
-            # Add optional named parameters
-            if completion_tokens_details is not None:
-                usage_kwargs["completion_tokens_details"] = completion_tokens_details
-            if prompt_tokens_details is not None:
-                usage_kwargs["prompt_tokens_details"] = prompt_tokens_details
-
-            # Handle web_search_requests by wrapping in ServerToolUse
-            if web_search_requests is not None:
-                usage_kwargs["server_tool_use"] = ServerToolUse(web_search_requests=web_search_requests)
-
-            # Add cache-related fields to **params (handled by Usage.__init__)
-            if cache_creation_input_tokens is not None:
-                usage_kwargs["cache_creation_input_tokens"] = cache_creation_input_tokens
-            if cache_read_input_tokens is not None:
-                usage_kwargs["cache_read_input_tokens"] = cache_read_input_tokens
-
-            _mr: Final = ModelResponse(usage=Usage(**usage_kwargs))
-
-            try:
-                cost_val = litellm.completion_cost(
-                    completion_response=_mr,
-                    model=model_name,
-                )
-            except Exception:
-                cost_val = None
-
-            if cost_val is not None:
-                obj.setdefault("usage", {})["cost"] = cost_val
-                return obj
-        return None
+        usage: Final = obj.get("usage")
+        if not isinstance(usage, dict):
+            return None
+        usage_kwargs: Final = ProxyBaseLLMRequestProcessing._stream_usage_kwargs_for_event(obj, usage)
+        if usage_kwargs is None:
+            return None
+        service_tier: Final = obj.get("service_tier")
+        cost_val: Final = ProxyBaseLLMRequestProcessing._completion_cost_or_none(
+            ModelResponse(usage=Usage(**usage_kwargs)),
+            model_name,
+            service_tier if isinstance(service_tier, str) else None,
+        )
+        if cost_val is None:
+            return None
+        return {**obj, "usage": {**usage, "cost": cost_val}}
 
     def maybe_get_model_id(self, _logging_obj: LiteLLMLoggingObj | None) -> str | None:
         """

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -3107,8 +3107,7 @@ class ProxyBaseLLMRequestProcessing:
                         obj = json.loads(json_part)
                         maybe_modified = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(obj, model_name)
                         if maybe_modified is not None:
-                            # Replace just this line with updated JSON using safe_dumps
-                            lines[idx] = f"data: {safe_dumps(maybe_modified)}"
+                            lines[idx] = "data: " + safe_dumps(maybe_modified) + ("\r" if ln.endswith("\r") else "")
                             return "\n".join(lines)
             return None
         except Exception:

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -3066,7 +3066,7 @@ class ProxyBaseLLMRequestProcessing:
             elif isinstance(chunk, (bytes, bytearray)):
                 try:
                     s: Final = chunk.decode("utf-8")
-                    if s.endswith("\n\n"):
+                    if s.endswith(("\n\n", "\r\n\r\n")):
                         maybe_mod = ProxyBaseLLMRequestProcessing._inject_cost_into_sse_frame_str(s, model_name)
                         if maybe_mod is not None:
                             return maybe_mod.encode("utf-8")

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -141,10 +141,12 @@ class PassThroughStreamingHandler:
 
     @staticmethod
     def _split_complete_sse_frames(pending: bytes) -> tuple[bytes, bytes]:
-        frame_boundary: Final = pending.rfind(b"\n\n")
-        if frame_boundary == -1:
+        lf_boundary_end: Final = pending.rfind(b"\n\n") + 2
+        crlf_boundary_end: Final = pending.rfind(b"\r\n\r\n") + 4
+        boundary_end: Final = max(lf_boundary_end if lf_boundary_end >= 2 else 0, crlf_boundary_end if crlf_boundary_end >= 4 else 0)
+        if boundary_end == 0:
             return b"", pending
-        return pending[: frame_boundary + 2], pending[frame_boundary + 2 :]
+        return pending[:boundary_end], pending[boundary_end:]
 
     @staticmethod
     async def _route_streaming_logging_to_handler(

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -1,5 +1,6 @@
+from collections.abc import Coroutine
 from datetime import datetime
-from typing import Final
+from typing import Final, Protocol
 
 import httpx
 
@@ -24,6 +25,21 @@ from .llm_provider_handlers.vertex_passthrough_logging_handler import (
 from .success_handler import PassThroughEndpointLogging
 
 
+class RouteStreamingLogging(Protocol):
+    def __call__(
+        self,
+        *,
+        litellm_logging_obj: LiteLLMLoggingObj,
+        passthrough_success_handler_obj: PassThroughEndpointLogging,
+        url_route: str,
+        request_body: dict,
+        endpoint_type: EndpointType,
+        start_time: datetime,
+        raw_bytes: list[bytes],
+        end_time: datetime,
+    ) -> Coroutine[None, None, None]: ...
+
+
 class PassThroughStreamingHandler:
     @staticmethod
     def _stamp_first_chunk_if_needed(litellm_logging_obj: LiteLLMLoggingObj) -> None:
@@ -39,7 +55,11 @@ class PassThroughStreamingHandler:
         start_time: datetime,
         passthrough_success_handler_obj: PassThroughEndpointLogging,
         url_route: str,
+        route_streaming_logging: RouteStreamingLogging | None = None,
     ):
+        resolved_route_streaming_logging: Final[RouteStreamingLogging] = (
+            route_streaming_logging or PassThroughStreamingHandler._route_streaming_logging_to_handler
+        )
         raw_bytes: Final[list[bytes]] = []
         logging_scheduled = False
         model_name: Final = PassThroughStreamingHandler._extract_model_for_cost_injection(
@@ -77,10 +97,19 @@ class PassThroughStreamingHandler:
                 # -> ``str`` for the per-chunk call site.
                 assert model_name is not None
                 resolved_model_name: Final[str] = model_name
+                pending = b""
                 async for chunk in response.aiter_bytes():
                     raw_bytes.append(chunk)
                     PassThroughStreamingHandler._stamp_first_chunk_if_needed(litellm_logging_obj)
-                    yield ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(chunk, resolved_model_name)
+                    complete_frames, pending = PassThroughStreamingHandler._split_complete_sse_frames(
+                        pending + chunk
+                    )  # rebind-ok: SSE frame reassembly buffer across transport chunks
+                    if complete_frames:
+                        yield ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(
+                            complete_frames, resolved_model_name
+                        )
+                if pending:
+                    yield pending
         except Exception as e:
             verbose_proxy_logger.error("Error in chunk_processor: %s", e)
             raise
@@ -96,7 +125,7 @@ class PassThroughStreamingHandler:
                 logging_scheduled = True
                 try:
                     GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
-                        async_coroutine=PassThroughStreamingHandler._route_streaming_logging_to_handler(
+                        async_coroutine=resolved_route_streaming_logging(
                             litellm_logging_obj=litellm_logging_obj,
                             passthrough_success_handler_obj=passthrough_success_handler_obj,
                             url_route=url_route,
@@ -109,6 +138,13 @@ class PassThroughStreamingHandler:
                     )
                 except Exception as e:
                     verbose_proxy_logger.error("Error scheduling chunk_processor logging: %s", e)
+
+    @staticmethod
+    def _split_complete_sse_frames(pending: bytes) -> tuple[bytes, bytes]:
+        frame_boundary: Final = pending.rfind(b"\n\n")
+        if frame_boundary == -1:
+            return b"", pending
+        return pending[: frame_boundary + 2], pending[frame_boundary + 2 :]
 
     @staticmethod
     async def _route_streaming_logging_to_handler(

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -56,7 +56,13 @@ class PassThroughStreamingHandler:
         cost_injection_active: Final = (
             bool(getattr(litellm, "include_cost_in_streaming_usage", False))
             and bool(model_name)
-            and endpoint_type in (EndpointType.VERTEX_AI, EndpointType.ANTHROPIC)
+            and (
+                endpoint_type in (EndpointType.ANTHROPIC, EndpointType.OPENAI)
+                or (
+                    endpoint_type == EndpointType.VERTEX_AI
+                    and ("streamRawPredict" in url_route or "rawPredict" in url_route)
+                )
+            )
         )
         try:
             if not cost_injection_active:
@@ -74,21 +80,7 @@ class PassThroughStreamingHandler:
                 async for chunk in response.aiter_bytes():
                     raw_bytes.append(chunk)
                     PassThroughStreamingHandler._stamp_first_chunk_if_needed(litellm_logging_obj)
-                    if endpoint_type == EndpointType.VERTEX_AI:
-                        if "streamRawPredict" in url_route or "rawPredict" in url_route:
-                            modified_chunk = ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(
-                                chunk, resolved_model_name
-                            )
-                            if modified_chunk is not None:
-                                chunk = modified_chunk
-                    else:  # EndpointType.ANTHROPIC
-                        modified_chunk = ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(
-                            chunk, resolved_model_name
-                        )
-                        if modified_chunk is not None:
-                            chunk = modified_chunk
-
-                    yield chunk
+                    yield ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(chunk, resolved_model_name)
         except Exception as e:
             verbose_proxy_logger.error("Error in chunk_processor: %s", e)
             raise

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -143,7 +143,9 @@ class PassThroughStreamingHandler:
     def _split_complete_sse_frames(pending: bytes) -> tuple[bytes, bytes]:
         lf_boundary_end: Final = pending.rfind(b"\n\n") + 2
         crlf_boundary_end: Final = pending.rfind(b"\r\n\r\n") + 4
-        boundary_end: Final = max(lf_boundary_end if lf_boundary_end >= 2 else 0, crlf_boundary_end if crlf_boundary_end >= 4 else 0)
+        boundary_end: Final = max(
+            lf_boundary_end if lf_boundary_end >= 2 else 0, crlf_boundary_end if crlf_boundary_end >= 4 else 0
+        )
         if boundary_end == 0:
             return b"", pending
         return pending[:boundary_end], pending[boundary_end:]

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
@@ -454,6 +454,9 @@ async def test_chunk_processor_streams_crlf_delimited_frames_live_and_injects_co
 
     assert len(received) == len(chunks)
     assert received[0] == chunks[0]
+    injected_usage_frame = received[2]
+    assert injected_usage_frame.endswith(b"\r\n\r\n")
+    assert b"\n" not in injected_usage_frame.replace(b"\r\n", b"")
     reassembled = b"".join(received).decode("utf-8")
     usage_lines = [ln for ln in reassembled.replace("\r\n", "\n").split("\n") if '"total_tokens"' in ln]
     assert len(usage_lines) == 1

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
@@ -383,23 +383,19 @@ def _openai_passthrough_stream_chunks():
 
 async def _collect_openai_passthrough_chunks(chunks, endpoint_type):
     response = _make_streaming_response(chunks)
-    with patch.object(
-        PassThroughStreamingHandler,
-        "_route_streaming_logging_to_handler",
-        new=AsyncMock(),
+    received = []
+    async for chunk in PassThroughStreamingHandler.chunk_processor(
+        response=response,
+        request_body={"model": "gpt-4o-mini", "stream": True},
+        litellm_logging_obj=MagicMock(),
+        endpoint_type=endpoint_type,
+        start_time=datetime.now(),
+        passthrough_success_handler_obj=MagicMock(),
+        url_route="/openai/v1/chat/completions",
+        route_streaming_logging=AsyncMock(),
     ):
-        received = []
-        async for chunk in PassThroughStreamingHandler.chunk_processor(
-            response=response,
-            request_body={"model": "gpt-4o-mini", "stream": True},
-            litellm_logging_obj=MagicMock(),
-            endpoint_type=endpoint_type,
-            start_time=datetime.now(),
-            passthrough_success_handler_obj=MagicMock(),
-            url_route="/openai/v1/chat/completions",
-        ):
-            received.append(chunk)
-        await asyncio.sleep(0)
+        received.append(chunk)
+    await asyncio.sleep(0)
     return received
 
 
@@ -424,6 +420,27 @@ async def test_chunk_processor_injects_cost_into_openai_passthrough_usage_frame(
     assert final_payload["usage"]["prompt_tokens"] == 11
     assert final_payload["usage"]["completion_tokens"] == 4
     assert final_payload["usage"]["total_tokens"] == 15
+
+
+@pytest.mark.asyncio
+async def test_chunk_processor_injects_cost_into_usage_frame_fragmented_across_chunks(monkeypatch):
+    """Regression: an SSE usage frame split across transport chunks must still get
+    cost injected once the frame completes, instead of passing through untouched."""
+    monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", True)
+    whole = _openai_passthrough_stream_chunks()
+    usage_frame = whole[2]
+    split_at = len(usage_frame) // 2
+    chunks = [whole[0], whole[1], usage_frame[:split_at], usage_frame[split_at:], whole[3]]
+
+    received = await _collect_openai_passthrough_chunks(chunks, EndpointType.OPENAI)
+
+    reassembled = b"".join(received).decode("utf-8")
+    usage_lines = [ln for ln in reassembled.split("\n") if '"total_tokens"' in ln]
+    assert len(usage_lines) == 1
+    final_payload = json.loads(usage_lines[0].split("data:", 1)[1].strip())
+    assert final_payload["usage"]["cost"] > 0
+    assert final_payload["usage"]["prompt_tokens"] == 11
+    assert reassembled.endswith("data: [DONE]\n\n")
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
@@ -444,6 +444,24 @@ async def test_chunk_processor_injects_cost_into_usage_frame_fragmented_across_c
 
 
 @pytest.mark.asyncio
+async def test_chunk_processor_streams_crlf_delimited_frames_live_and_injects_cost(monkeypatch):
+    """Regression: CRLF-delimited SSE frames must flow as they complete instead of
+    buffering until EOF, and the usage frame must still get cost injected."""
+    monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", True)
+    chunks = [chunk.replace(b"\n\n", b"\r\n\r\n") for chunk in _openai_passthrough_stream_chunks()]
+
+    received = await _collect_openai_passthrough_chunks(chunks, EndpointType.OPENAI)
+
+    assert len(received) == len(chunks)
+    assert received[0] == chunks[0]
+    reassembled = b"".join(received).decode("utf-8")
+    usage_lines = [ln for ln in reassembled.replace("\r\n", "\n").split("\n") if '"total_tokens"' in ln]
+    assert len(usage_lines) == 1
+    final_payload = json.loads(usage_lines[0].split("data:", 1)[1].strip())
+    assert final_payload["usage"]["cost"] > 0
+
+
+@pytest.mark.asyncio
 async def test_chunk_processor_flag_off_leaves_openai_passthrough_stream_byte_identical(monkeypatch):
     monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", False)
     chunks = _openai_passthrough_stream_chunks()

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
@@ -1,12 +1,14 @@
-"""Regression tests for LIT-2642 — interrupted pass-through streams must still log usage."""
+"""Regression tests for PassThroughStreamingHandler.chunk_processor."""
 
 import asyncio
+import json
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
+import litellm
 from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 from litellm.proxy.pass_through_endpoints.streaming_handler import (
     PassThroughStreamingHandler,
@@ -359,6 +361,107 @@ async def test_chunk_processor_stamps_completion_start_time_on_cost_injection_pa
         litellm_mod.include_cost_in_streaming_usage = original
 
     mock_logging_obj._update_completion_start_time.assert_called_once()
+
+
+def _openai_passthrough_stream_chunks():
+    return [
+        (
+            b'data: {"id":"chatcmpl-1","object":"chat.completion.chunk",'
+            b'"choices":[{"index":0,"delta":{"content":"Hi"}}],"usage":null}\n\n'
+        ),
+        b": keepalive\n\n",
+        (
+            b'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[],'
+            b'"usage":{"prompt_tokens":11,"completion_tokens":4,"total_tokens":15,'
+            b'"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},'
+            b'"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,'
+            b'"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}\n\n'
+        ),
+        b"data: [DONE]\n\n",
+    ]
+
+
+async def _collect_openai_passthrough_chunks(chunks, endpoint_type):
+    response = _make_streaming_response(chunks)
+    with patch.object(
+        PassThroughStreamingHandler,
+        "_route_streaming_logging_to_handler",
+        new=AsyncMock(),
+    ):
+        received = []
+        async for chunk in PassThroughStreamingHandler.chunk_processor(
+            response=response,
+            request_body={"model": "gpt-4o-mini", "stream": True},
+            litellm_logging_obj=MagicMock(),
+            endpoint_type=endpoint_type,
+            start_time=datetime.now(),
+            passthrough_success_handler_obj=MagicMock(),
+            url_route="/openai/v1/chat/completions",
+        ):
+            received.append(chunk)
+        await asyncio.sleep(0)
+    return received
+
+
+@pytest.mark.asyncio
+async def test_chunk_processor_injects_cost_into_openai_passthrough_usage_frame(monkeypatch):
+    """Regression: issue #36492 — with include_cost_in_streaming_usage on, the final
+    OpenAI passthrough chat.completion.chunk usage frame must carry usage.cost, like
+    every other streaming surface already does."""
+    monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", True)
+    chunks = _openai_passthrough_stream_chunks()
+
+    received = await _collect_openai_passthrough_chunks(chunks, EndpointType.OPENAI)
+
+    assert received[0] == chunks[0]
+    assert received[1] == chunks[1]
+    assert received[3] == chunks[3]
+    final_payload = json.loads(received[2].decode("utf-8").split("data:", 1)[1].strip())
+    pricing = litellm.model_cost["gpt-4o-mini"]
+    expected_cost = 11 * pricing["input_cost_per_token"] + 4 * pricing["output_cost_per_token"]
+    assert final_payload["usage"]["cost"] == pytest.approx(expected_cost)
+    assert final_payload["usage"]["cost"] > 0
+    assert final_payload["usage"]["prompt_tokens"] == 11
+    assert final_payload["usage"]["completion_tokens"] == 4
+    assert final_payload["usage"]["total_tokens"] == 15
+
+
+@pytest.mark.asyncio
+async def test_chunk_processor_flag_off_leaves_openai_passthrough_stream_byte_identical(monkeypatch):
+    monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", False)
+    chunks = _openai_passthrough_stream_chunks()
+
+    received = await _collect_openai_passthrough_chunks(chunks, EndpointType.OPENAI)
+
+    assert received == chunks
+
+
+@pytest.mark.asyncio
+async def test_chunk_processor_flag_on_leaves_openai_frames_without_usage_untouched(monkeypatch):
+    monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", True)
+    chunks = [
+        (
+            b'data: {"id":"chatcmpl-1","object":"chat.completion.chunk",'
+            b'"choices":[{"index":0,"delta":{"content":"Hi"}}],"usage":null}\n\n'
+        ),
+        b": keepalive\n\n",
+        b"not json at all\n\n",
+        b"data: [DONE]\n\n",
+    ]
+
+    received = await _collect_openai_passthrough_chunks(chunks, EndpointType.OPENAI)
+
+    assert received == chunks
+
+
+@pytest.mark.asyncio
+async def test_chunk_processor_flag_on_leaves_generic_passthrough_untouched(monkeypatch):
+    monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", True)
+    chunks = _openai_passthrough_stream_chunks()
+
+    received = await _collect_openai_passthrough_chunks(chunks, EndpointType.GENERIC)
+
+    assert received == chunks
 
 
 def test_convert_raw_bytes_survives_truncated_multibyte_sequence():

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import datetime
+import json
 from types import SimpleNamespace
 from typing import AsyncGenerator, Callable, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -5746,3 +5747,132 @@ class TestPerRequestModelGroupAlias:
         )
 
         assert merged_for == ["group-b"]
+
+
+class TestInjectCostIntoUsageDict:
+    @staticmethod
+    def _expected_cost(model, prompt_tokens, completion_tokens):
+        pricing = litellm.model_cost[model]
+        return prompt_tokens * pricing["input_cost_per_token"] + completion_tokens * pricing["output_cost_per_token"]
+
+    def test_openai_chat_completion_chunk_usage_gets_cost(self):
+        event = {
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 11,
+                "completion_tokens": 4,
+                "total_tokens": 15,
+                "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
+                "completion_tokens_details": {
+                    "reasoning_tokens": 0,
+                    "audio_tokens": 0,
+                    "accepted_prediction_tokens": 0,
+                    "rejected_prediction_tokens": 0,
+                },
+            },
+        }
+
+        result = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(event, "gpt-4o-mini")
+
+        assert result is not None
+        assert result["usage"]["cost"] == pytest.approx(self._expected_cost("gpt-4o-mini", 11, 4))
+        assert result["usage"]["cost"] > 0
+        assert result["usage"]["prompt_tokens"] == 11
+        assert result["id"] == "chatcmpl-1"
+        assert "cost" not in event["usage"]
+
+    def test_anthropic_message_delta_usage_still_gets_cost(self):
+        event = {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"input_tokens": 11, "output_tokens": 4},
+        }
+
+        result = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(event, "claude-haiku-4-5")
+
+        assert result is not None
+        assert result["usage"]["cost"] == pytest.approx(self._expected_cost("claude-haiku-4-5", 11, 4))
+        assert result["usage"]["cost"] > 0
+        assert result["usage"]["output_tokens"] == 4
+
+    def test_openai_chunk_with_flex_service_tier_uses_flex_pricing(self):
+        event = {
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "service_tier": "flex",
+            "choices": [],
+            "usage": {"prompt_tokens": 1000, "completion_tokens": 100, "total_tokens": 1100},
+        }
+
+        result = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(event, "gpt-5-mini")
+
+        assert result is not None
+        pricing = litellm.model_cost["gpt-5-mini"]
+        expected_flex_cost = 1000 * pricing["input_cost_per_token_flex"] + 100 * pricing["output_cost_per_token_flex"]
+        assert result["usage"]["cost"] == pytest.approx(expected_flex_cost)
+        assert result["usage"]["cost"] < self._expected_cost("gpt-5-mini", 1000, 100)
+
+    def test_openai_chunk_with_null_usage_is_not_modified(self):
+        event = {
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "choices": [{"index": 0, "delta": {"content": "Hi"}}],
+            "usage": None,
+        }
+
+        assert ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(event, "gpt-4o-mini") is None
+
+    def test_unrecognized_event_shape_with_usage_is_not_modified(self):
+        event = {"kind": "custom", "usage": {"prompt_tokens": 11, "completion_tokens": 4}}
+
+        assert ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(event, "gpt-4o-mini") is None
+
+    def test_sse_frame_with_coalesced_done_line_injects_into_usage_frame(self):
+        frame = (
+            'data: {"object":"chat.completion.chunk","choices":[],'
+            '"usage":{"prompt_tokens":11,"completion_tokens":4,"total_tokens":15}}\n\n'
+            "data: [DONE]\n\n"
+        )
+
+        result = ProxyBaseLLMRequestProcessing._inject_cost_into_sse_frame_str(frame, "gpt-4o-mini")
+
+        assert result is not None
+        assert "data: [DONE]" in result
+        injected = json.loads(result.split("\n")[0].split("data:", 1)[1].strip())
+        assert injected["usage"]["cost"] == pytest.approx(self._expected_cost("gpt-4o-mini", 11, 4))
+
+
+class TestProcessChunkWithCostInjection:
+    def test_complete_usage_frame_chunk_is_injected(self, monkeypatch):
+        monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", True)
+        chunk = (
+            b'data: {"object":"chat.completion.chunk","choices":[],'
+            b'"usage":{"prompt_tokens":11,"completion_tokens":4,"total_tokens":15}}\n\n'
+        )
+
+        result = ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(chunk, "gpt-4o-mini")
+
+        assert result != chunk
+        assert result.endswith(b"\n\n")
+        payload = json.loads(result.decode("utf-8").split("data:", 1)[1].strip())
+        assert payload["usage"]["cost"] > 0
+
+    def test_chunk_ending_in_partial_frame_passes_through_byte_identical(self, monkeypatch):
+        monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", True)
+        chunk = (
+            b'data: {"object":"chat.completion.chunk","choices":[],'
+            b'"usage":{"prompt_tokens":11,"completion_tokens":4,"total_tokens":15}}\n\ndata: [DO'
+        )
+
+        assert ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(chunk, "gpt-4o-mini") == chunk
+
+    def test_chunk_with_invalid_utf8_passes_through_byte_identical(self, monkeypatch):
+        monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", True)
+        chunk = (
+            b'\xa8data: {"object":"chat.completion.chunk","choices":[],'
+            b'"usage":{"prompt_tokens":11,"completion_tokens":4,"total_tokens":15}}\n\n'
+        )
+
+        assert ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(chunk, "gpt-4o-mini") == chunk


### PR DESCRIPTION
## TLDR

Problem this solves:

- With `include_cost_in_streaming_usage: true`, every streaming surface injects a LiteLLM-calculated `cost` into the streamed usage object except OpenAI passthrough, so clients relying on the flag silently get no cost on exactly one route family (#36492)

How it solves it:

- Widens the `cost_injection_active` gate in the passthrough streaming handler to include `EndpointType.OPENAI`, and narrows Vertex to the rawPredict routes whose frames are Anthropic-shaped
- Teaches the shared usage-injection helper to recognize OpenAI `chat.completion.chunk` usage frames alongside Anthropic `message_delta` events, keeping format detection in the one shared helper
- Passes `service_tier` through to cost calculation and only rewrites frames that decode cleanly and end with a complete SSE terminator
- Reassembles SSE frames that arrive fragmented across transport chunks before injection, recognizing both LF and CRLF frame boundaries and preserving the frame's original line endings on rewrite, so cost lands even when the usage frame is split by the network and CRLF-delimited streams keep flowing live and stay CRLF-clean
- The stream logging routine is injected into `chunk_processor` as a dependency, so tests pass a fake instead of patching class state

## User Flow

Before, the flow breaks at step 4 where the passthrough stream has no cost:

1. Proxy admin sets `include_cost_in_streaming_usage: true` in `litellm_settings` and restarts the proxy
2. A user streams `POST https://litellm-domain/v1/chat/completions` with `stream_options: {"include_usage": true}` and reads `usage.cost` off the final SSE chunk
3. The same user streams the same body through `POST https://litellm-domain/openai/v1/chat/completions`
4. The final usage frame has token counts but no `cost` field, so their per-request cost pipeline breaks on passthrough traffic only

After, the same flow succeeds end to end:

1. Proxy admin sets `include_cost_in_streaming_usage: true` in `litellm_settings` and restarts the proxy
2. A user streams `POST https://litellm-domain/v1/chat/completions` with `stream_options: {"include_usage": true}` and reads `usage.cost` off the final SSE chunk
3. The same user streams the same body through `POST https://litellm-domain/openai/v1/chat/completions`
4. The final usage frame carries `usage.cost` with the same value the control route reported for the same token counts

## Relevant issues

Fixes #36492

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Two live proxies with the issue's exact config (`include_cost_in_streaming_usage: true`, real OpenAI calls): a before leg at the merge base 3726bceb53 (port 27183) and an after leg at this PR's head e7c8cff3b7 (port 28467), each hit with the same two streaming curls

```bash
for route in /v1/chat/completions /openai/v1/chat/completions; do
  curl -sN http://localhost:$PORT$route \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.4-nano","messages":[{"role":"user","content":"Say hi in one word"}],"stream":true,"stream_options":{"include_usage":true}}' \
    | grep '"usage"' | tail -1
done
```

Before leg (merge base), the control route's final usage chunk carries cost but the passthrough route's does not:

```
data: {"id":"chatcmpl-EBccgrRmQg09MAcnW68uLqwRsVOUw",...,"usage":{"completion_tokens":4,"prompt_tokens":11,"total_tokens":15,...,"cost":7.2000000000000005e-6}}
data: {"id":"chatcmpl-EBccgzrdaX86PmxrOvo2PsHnGGFZR","object":"chat.completion.chunk",...,"usage":{"prompt_tokens":11,"completion_tokens":4,"total_tokens":15,"prompt_tokens_details":{...},"completion_tokens_details":{...}},"obfuscation":"PKTTU"}
```

After leg (this PR's head), both routes report the identical cost for identical token counts:

```
data: {"id":"chatcmpl-EBceXkQtqpEy19eEWFEBKPLDmMObh",...,"usage":{"completion_tokens":4,"prompt_tokens":11,"total_tokens":15,...,"cost":7.2000000000000005e-6}}
data: {"id": "chatcmpl-EBceXbTRpD9fHmfH2PUc6ACAQZers", "object": "chat.completion.chunk", ..., "usage": {"prompt_tokens": 11, "completion_tokens": 4, "total_tokens": 15, ..., "cost": 7.2000000000000005e-06}, "obfuscation": "5KVom"}
```

One observation from the after leg, caused by this PR and cosmetic only: the rewritten passthrough usage frame is re-serialized with spaces after JSON separators while untouched upstream frames have none; it stays valid JSON and only the usage frame is affected

## Type

🐛 Bug Fix

## Caveats (if any)

Cost injection on Vertex passthrough now only engages on `rawPredict`/`streamRawPredict` routes, since those are the Anthropic-shaped frames the helper understands; other Vertex streams were never modified successfully before, so behavior there is unchanged

## QA runbook

1. Start a proxy on this branch with the config from #36492 and `include_cost_in_streaming_usage: true`
2. Run the two curls above; assert the final usage frame on both routes carries `usage.cost` and the values match
3. Remove the flag, restart, rerun the passthrough curl, and assert the frame is byte-identical to upstream with no `cost` key

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
