### PR TITLE
feat(ui): add tags column to the model table

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/ModelsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/ModelsTableColumns.tsx
@@ -22,6 +22,7 @@ export const UPDATED_AT_COLUMN_ID = "model_info_updated_at";
 export const COSTS_COLUMN_ID = "input_cost";
 export const TEAM_ID_COLUMN_ID = "model_info_team_id";
 export const ACCESS_GROUPS_COLUMN_ID = "model_info_access_groups";
+export const TAGS_COLUMN_ID = "model_info_tags";
 export const STATUS_COLUMN_ID = "model_info_db_model";
 
 const COLUMN_ID_TO_SERVER_SORT_FIELD: Record<string, string> = {
@@ -243,6 +244,38 @@ function AccessGroupsCell({ accessGroups }: { accessGroups: string[] | null }) {
   );
 }
 
+function TagsCell({ tags }: { tags: string[] | null }) {
+  if (!tags || tags.length === 0) {
+    return <span className="text-sm text-muted-foreground">-</span>;
+  }
+
+  const [first, ...overflow] = tags;
+
+  return (
+    <div className="flex min-w-0 items-center gap-1">
+      <Badge variant="outline" className="max-w-36 truncate border-purple-200 bg-purple-50 font-normal text-purple-600">
+        {first}
+      </Badge>
+      {overflow.length > 0 && (
+        <CellTooltip
+          content={
+            <div className="flex max-w-[280px] flex-col gap-0.5">
+              {overflow.map((tag) => (
+                <span key={tag}>{tag}</span>
+              ))}
+            </div>
+          }
+          trigger={
+            <Badge variant="outline" className="shrink-0 cursor-default font-normal">
+              +{overflow.length} more
+            </Badge>
+          }
+        />
+      )}
+    </div>
+  );
+}
+
 interface ModelRowActionsProps {
   model: ModelData;
   userRole: string;
@@ -449,6 +482,16 @@ export const getModelsTableColumns = ({
     size: 200,
     minSize: 120,
     cell: ({ row }) => <AccessGroupsCell accessGroups={row.original.model_info.access_groups} />,
+  },
+  {
+    id: TAGS_COLUMN_ID,
+    accessorFn: (row) => row.tags ?? [],
+    meta: { title: "Tags", skeleton: "chips" },
+    header: "Tags",
+    enableSorting: false,
+    size: 200,
+    minSize: 120,
+    cell: ({ row }) => <TagsCell tags={row.original.tags} />,
   },
   {
     id: STATUS_COLUMN_ID,

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/utils/modelDataTransformer.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/utils/modelDataTransformer.ts
@@ -70,6 +70,7 @@ export const transformModelData = (rawModelData: any, getProviderFromModel: (mod
     transformedData[i].max_input_tokens = max_input_tokens;
     transformedData[i].api_base = curr_model?.litellm_params?.api_base;
     transformedData[i].cleanedLitellmParams = cleanedLitellmParams;
+    transformedData[i].tags = curr_model?.litellm_params?.tags ?? null;
   }
 
   return { data: transformedData };

--- a/ui/litellm-dashboard/src/components/model_dashboard/types.ts
+++ b/ui/litellm-dashboard/src/components/model_dashboard/types.ts
@@ -33,6 +33,7 @@ export interface ModelData {
   litellm_params: LiteLLMParams;
   cleanedLitellmParams: Record<string, any>;
   accessToken?: string;
+  tags: string[] | null;
 }
 
 export interface ModelDashboardProps {


### PR DESCRIPTION
## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- Users couldn't see tags in the model table UI.

How it solves it:

- Adds a dedicated tags column to the models and endpoints table.
- Renders tags cleanly as badges with tooltips for overflow.

## User Flow

<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision

Example:

Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request comes back with real token counts, so the dashboard shows real spend

1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
-->

Before: an admin viewing the models page cannot see tag metadata for configured deployments

1. They open https://litellm-domain/ui/models-and-endpoints
2. They view the model table and notice there is no column showing assigned tags
3. They must inspect the detailed model page to see the tags

After: the same admin sees a dedicated tags column displaying model tags as badges

1. They open https://litellm-domain/ui/models-and-endpoints
2. They view the model table and see a new "Tags" column displaying the first tag as a purple badge
3. They hover over any `+N more` badge to see the full list of remaining tags in a tooltip

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests (No tests were added as this is a straightforward UI update, following the precedent of ACCESS_GROUPS_COLUMN_ID, which also lacks tests)
- [X] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [X] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

<img width="1324" height="469" alt="image" src="https://github.com/user-attachments/assets/7929e431-06ea-4e75-a347-d755bab7e191" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Caveats (if any)

<!-- Short bullet points, just like the TLDR: one line per bullet, roughly 10 words max
     Call out known limitations, follow-up work, or anything a reviewer should watch out for
     Leave this section empty if there are none -->

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [X] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
