### PR TITLE
fix(bedrock): preserve adaptive thinking effort through the /v1/messages bridge

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -976,6 +976,17 @@ class LiteLLMAnthropicMessagesAdapter:
         model: Final = new_kwargs.get("model", "")
         if self.is_anthropic_claude_model(model) or self.is_bedrock_arn_model(model):
             new_kwargs["thinking"] = thinking
+            # Adaptive thinking without its effort tier makes Bedrock Converse
+            # return zero reasoning blocks, so forward output_config (minus
+            # `format`, already translated to response_format) for Bedrock
+            # targets only: other bridged providers reject the raw param, and
+            # get_llm_provider strips the `bedrock/` prefix before this runs.
+            if model.startswith(("bedrock/", "converse/", "invoke/")) or self.is_bedrock_arn_model(model):
+                claude_output_config: Final = anthropic_message_request.get("output_config")
+                if isinstance(claude_output_config, dict):
+                    effort_config: Final = {k: v for k, v in claude_output_config.items() if k != "format"}
+                    if effort_config:
+                        new_kwargs["output_config"] = effort_config  # rebind-ok: out-param store like thinking above
             return
 
         reasoning_effort = self.translate_anthropic_thinking_to_reasoning_effort(cast(dict[str, Any], thinking))

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -80,6 +80,7 @@ from ..common_utils import (
     bedrock_converse_supports_parallel_tool_use_config,
     get_anthropic_beta_from_headers,
     get_bedrock_tool_name,
+    is_bedrock_application_inference_profile_arn,
     is_claude_4_5_on_bedrock,
     normalize_bedrock_opus_output_config_effort,
 )
@@ -1318,7 +1319,12 @@ class AmazonConverseConfig(BaseConfig):
         additional_request_params = filter_exceptions_from_params(additional_request_params)
 
         if anthropic_output_config is not None and isinstance(anthropic_output_config, dict):
-            if base_model.startswith("anthropic"):
+            # Application inference profile ARNs hide the underlying model, so the
+            # effort ceiling and capability gates below cannot run; forward
+            # verbatim (like ``thinking``) and let Bedrock enforce.
+            if is_bedrock_application_inference_profile_arn(model):
+                additional_request_params["output_config"] = anthropic_output_config
+            elif base_model.startswith("anthropic"):
                 if litellm.drop_params is True and not AnthropicConfig._model_supports_effort_param(model, "bedrock"):
                     litellm.verbose_logger.warning(
                         DROP_UNSUPPORTED_OUTPUT_CONFIG_WARNING,

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -514,6 +514,7 @@ class AmazonConverseConfig(BaseConfig):
             supported_params.append("tool_choice")
             supported_params.append("thinking")
             supported_params.append("reasoning_effort")
+            supported_params.append("output_config")
             # For nova imported models, also add web_search_options
             if "nova" in model.lower():
                 supported_params.append("web_search_options")
@@ -564,6 +565,7 @@ class AmazonConverseConfig(BaseConfig):
         ):
             supported_params.append("thinking")
             supported_params.append("reasoning_effort")
+            supported_params.append("output_config")
 
         if base_model.startswith("anthropic"):
             supported_params.append("context_management")
@@ -919,6 +921,10 @@ class AmazonConverseConfig(BaseConfig):
                 self._handle_reasoning_effort_parameter(
                     model=model, reasoning_effort=value, optional_params=optional_params
                 )
+            elif param == "output_config" and isinstance(value, dict):
+                mapped_output_config = dict(value)
+                normalize_bedrock_opus_output_config_effort(model=model, output_config=mapped_output_config)
+                optional_params["output_config"] = mapped_output_config  # rebind-ok: out-param store like siblings
             elif param == "context_management" and isinstance(value, (dict, list)):
                 self._map_context_management_param(value, optional_params)
             if param == "requestMetadata":

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -929,6 +929,7 @@ class ChatCompletionRequest(TypedDict, total=False):
     user: str
     metadata: dict  # litellm specific param
     reasoning_effort: str  # OpenAI o1/o3 reasoning parameter
+    output_config: Mapping[str, object]  # Anthropic adaptive-thinking effort, bridged for Bedrock Claude
 
 
 class ChatCompletionDeltaChunk(TypedDict, total=False):

--- a/tests/e2e/claude_code/thinking/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/thinking/test_bedrock_converse.py
@@ -54,10 +54,6 @@ def _has_thinking_block(events: Sequence[Mapping[str, Any]]) -> bool:
     return False
 
 
-@pytest.mark.skip(
-    reason="product bug LIT-4524: Bedrock Converse streaming Content block is not a text block; "
-    "re-enable when empty/mismatched content_block_delta is fixed"
-)
 @pytest.mark.covers("llm.messages.bedrock_converse.thinking.nonstream.works")
 def test_thinking_bedrock_converse(compat_result):
     """Drive the `claude` CLI against the LiteLLM proxy with thinking

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1610,6 +1610,88 @@ def test_thinking_disabled_stays_plain_string_when_auto_summary_enabled():
     assert new_kwargs["reasoning_effort"] == "none"
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        # SDK-style model with the provider prefix intact
+        "bedrock/converse/us.anthropic.claude-opus-4-7",
+        # what the bridge actually sees in the proxy: get_llm_provider has
+        # already stripped the `bedrock/` prefix by the time it translates
+        "converse/us.anthropic.claude-opus-4-7",
+    ],
+)
+def test_adaptive_thinking_output_config_effort_preserved_for_claude_model(model):
+    """
+    Regression: Claude Code drives adaptive thinking as `thinking: {"type": "adaptive"}`
+    plus `output_config: {"effort": "max"}`. The Claude branch of the thinking translator
+    forwarded `thinking` verbatim but returned early without reading `output_config`, and
+    the handler strips the raw key from extra_kwargs, so the effort tier never reached the
+    backend. On Bedrock Converse, adaptive thinking without effort streams zero reasoning
+    blocks. The `format` subkey must still be excluded (it is translated to
+    `response_format` separately).
+    """
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+    anthropic_request = AnthropicMessagesRequest(
+        model=model,
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "hi"}],
+        thinking={"type": "adaptive"},
+        output_config={
+            "effort": "max",
+            "format": {"type": "json_schema", "schema": {"type": "object", "properties": {}}},
+        },
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(anthropic_message_request=anthropic_request)
+
+    assert openai_request["thinking"] == {"type": "adaptive"}
+    assert openai_request["output_config"] == {"effort": "max"}
+    assert "response_format" in openai_request
+
+
+def test_adaptive_thinking_format_only_output_config_not_forwarded_for_claude_model():
+    """When `output_config` carries only `format`, nothing effort-bearing remains, so the
+    translator must not forward an empty `output_config` dict."""
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+    anthropic_request = AnthropicMessagesRequest(
+        model="bedrock/converse/us.anthropic.claude-opus-4-7",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "hi"}],
+        thinking={"type": "adaptive"},
+        output_config={"format": {"type": "json_schema", "schema": {"type": "object", "properties": {}}}},
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(anthropic_message_request=anthropic_request)
+
+    assert openai_request["thinking"] == {"type": "adaptive"}
+    assert "output_config" not in openai_request
+
+
+def test_adaptive_thinking_output_config_not_forwarded_for_non_bedrock_claude_model():
+    """`output_config` is forwarded only for Bedrock-destined Claude models. Other
+    Claude-through-bridge providers (e.g. openrouter) accept `thinking` but reject a raw
+    `output_config` param with UnsupportedParamsError when drop_params is off."""
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+    anthropic_request = AnthropicMessagesRequest(
+        model="openrouter/anthropic/claude-opus-4-7",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "hi"}],
+        thinking={"type": "adaptive"},
+        output_config={"effort": "max"},
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(anthropic_message_request=anthropic_request)
+
+    assert openai_request["thinking"] == {"type": "adaptive"}
+    assert "output_config" not in openai_request
+
+
 def test_stop_sequences_translated_to_stop_for_non_claude_model():
     from litellm.types.llms.anthropic import AnthropicMessagesRequest
 

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -410,6 +410,33 @@ def test_output_config_supported_param_for_arn_models_converse():
     assert "output_config" in config.get_supported_openai_params(arn_model)
 
 
+def test_output_config_effort_forwarded_for_application_inference_profile_arn():
+    """Regression: opaque application inference profile ARNs cannot resolve a
+    base model, so the anthropic-only serialization gate dropped ``output_config``
+    while still sending ``thinking``: adaptive thinking with no effort tier, and
+    Bedrock streams zero ``reasoningContent`` blocks. The effort must be forwarded
+    verbatim (ceilings and capability gates are unknowable behind the alias) for
+    Bedrock to enforce."""
+    config = AmazonConverseConfig()
+    arn_model = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdef123456"
+
+    result = config._transform_request(
+        model=arn_model,
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={
+            "maxTokens": 256,
+            "thinking": {"type": "adaptive"},
+            "output_config": {"effort": "max"},
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    additional = result.get("additionalModelRequestFields", {})
+    assert additional.get("thinking") == {"type": "adaptive"}
+    assert additional.get("output_config") == {"effort": "max"}
+
+
 def test_output_config_format_translated_to_native_output_config_converse():
     """``output_config.format`` becomes Bedrock ``outputConfig`` and is not forwarded raw."""
     config = AmazonConverseConfig()

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -370,6 +370,46 @@ def test_output_config_effort_forwarded_into_additional_request_fields(model):
     assert additional.get("output_config") == {"effort": "high"}
 
 
+@pytest.mark.parametrize(
+    "model,effort,expected_effort",
+    [
+        ("bedrock/converse/us.anthropic.claude-opus-4-7", "max", "max"),
+        ("bedrock/converse/us.anthropic.claude-opus-4-6-v1", "xhigh", "max"),
+    ],
+)
+def test_explicit_output_config_effort_mapped_for_adaptive_thinking_converse(model, effort, expected_effort):
+    """Regression: Claude Code drives adaptive thinking as ``thinking: {"type":
+    "adaptive"}`` plus ``output_config: {"effort": ...}``. ``output_config`` must
+    be a supported openai param and survive ``map_openai_params`` (clamped to the
+    model's Bedrock effort ceiling), otherwise the Converse request carries
+    adaptive thinking without an effort tier and Bedrock streams zero
+    ``reasoningContent`` blocks."""
+    config = AmazonConverseConfig()
+
+    assert "output_config" in config.get_supported_openai_params(model)
+
+    optional_params = config.map_openai_params(
+        non_default_params={
+            "thinking": {"type": "adaptive"},
+            "output_config": {"effort": effort},
+        },
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    assert optional_params["thinking"] == {"type": "adaptive"}
+    assert optional_params["output_config"] == {"effort": expected_effort}
+
+
+def test_output_config_supported_param_for_arn_models_converse():
+    """ARN model ids hide the underlying Claude model, so ``output_config`` must
+    be in the blanket ARN supported-params list too."""
+    config = AmazonConverseConfig()
+    arn_model = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdef123456"
+    assert "output_config" in config.get_supported_openai_params(arn_model)
+
+
 def test_output_config_format_translated_to_native_output_config_converse():
     """``output_config.format`` becomes Bedrock ``outputConfig`` and is not forwarded raw."""
     config = AmazonConverseConfig()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Claude Code thinking on Bedrock Converse Opus 4.7 streamed zero thinking blocks
- The /v1/messages bridge forwarded `thinking: {"type": "adaptive"}` but dropped `output_config: {"effort": ...}`
- Bedrock Converse returns no `reasoningContent` for adaptive thinking without an effort tier

How it solves it:

- The bridge's thinking translator now forwards the effort part of `output_config` for Bedrock targets
- `output_config` becomes a supported openai param for reasoning Claude and ARN models on Converse
- `map_openai_params` carries it through with the model's Bedrock effort ceiling applied
- Application inference profile ARNs forward the effort verbatim, since the alias hides the model from the ceiling and capability gates
- Re-enables the skipped e2e compat cell that catches this

RCA doc: https://app.notion.com/p/3b943b8acdab8197b710e0da01ce3773

## User Flow

Before: a Claude Code user on Opus 4.7 via Bedrock (Converse) never sees extended thinking

1. Claude Code sends POST http://localhost:4000/v1/messages with model `claude-opus-4-7-bedrock-converse`, `thinking: {"type": "adaptive"}` and `output_config: {"effort": "max"}` (what `--effort max` produces)
2. The stream contains a single `content_block_start` of type `text` and no thinking block at all, so the CLI renders a plain answer with no reasoning
3. The compat matrix cell fails with `no thinking content block observed in stream-json events`

After: the same request streams a thinking block before the text

1. Claude Code sends the identical request
2. The stream opens with `content_block_start` index 0 of type `thinking` (with its signature), then the text block at index 1
3. The compat cell passes for all three Bedrock Converse tiers

## Relevant issues

RCA doc: https://app.notion.com/p/3b943b8acdab8197b710e0da01ce3773

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against real AWS Bedrock in us-east-1, booted with `litellm --config tests/e2e/claude_code/test_config.yaml --host 127.0.0.1 --port 4110`. Same curl before and after

```
$ curl -sN http://127.0.0.1:4110/v1/messages \
  -H "Authorization: Bearer sk-local-rca" -H "content-type: application/json" \
  -d '{"model": "claude-opus-4-7-bedrock-converse", "max_tokens": 2048, "stream": true,
       "thinking": {"type": "adaptive"}, "output_config": {"effort": "max"},
       "messages": [{"role": "user", "content": "I have a 3-gallon jug and a 5-gallon jug. How can I measure exactly 4 gallons of water? Think through the steps carefully."}]}'
```

Before, at commit d8762bf4db (base), the stream has no thinking block:

```
data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
...
data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"input_tokens": 60, "output_tokens": 701}}
```

After, at commit 929ee52b87 (this PR), identical request:

```
data: {"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": "", "signature": "Er8MCnMIEBABGAIqQBFiVd4S...[redacted]"}}
data: {"type": "content_block_delta", "index": 0, "delta": {"type": "signature_delta", "signature": "Er8MCnMIEBABGAIqQBFiVd4S...[redacted]"}}
data: {"type": "content_block_stop", "index": 0}
data: {"type": "content_block_start", "index": 1, "content_block": {"type": "text", "text": ""}}
...
data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"input_tokens": 60, "output_tokens": 1311}}
```

The e2e compat cell this PR re-enables, driving the real `claude` CLI with `--effort max` against that same proxy, goes from `[claude-opus-4-7-bedrock-converse] no thinking content block observed in stream-json events` at d8762bf4db to all green at 929ee52b87:

```
$ LITELLM_PROXY_URL=http://127.0.0.1:4110 LITELLM_MASTER_KEY=*** \
    pytest tests/e2e/claude_code/thinking/test_bedrock_converse.py -q
[compat] per-provider breakdown:
  bedrock_converse     pass=3
1 passed in 15.89s
```

The regression tests were verified in both directions: with the `litellm/` changes stashed, the adapter effort-preservation test (both model shapes), both converse param-mapping cases, and the ARN supported-param test fail; with them restored, all 276 tests across the two touched files pass

Commit 0f41365c34 extends this to opaque application inference profile ARNs, which passed the new param mapping but were still dropped at request serialization because the alias cannot resolve to an anthropic base model. The new serialization test (thinking plus effort both landing in `additionalModelRequestFields` for a profile ARN) fails at 929ee52b87 and passes with the commit

**QA run at head 0f41365c34** (2026-08-11). Real Claude Code CLI v2.1.227 driven interactively under tmux, before leg proxied at the merge base d8762bf4db and after leg at 0f41365c34, each with its own worktree, venv, env file, and port, real AWS Bedrock traffic throughout. Both legs ran the identical session, differing only in the proxy's commit:

```
ANTHROPIC_BASE_URL=http://127.0.0.1:<port> ANTHROPIC_AUTH_TOKEN=sk-local-qa \
  claude --model claude-opus-4-7-bedrock-converse --effort max
> I have a 3-gallon jug and a 5-gallon jug. How can I measure exactly 4 gallons
  of water? Think through the steps carefully.
```

Before, proxy at d8762bf4db (port 24576): the answer streams with no thinking block anywhere. The client's own session transcript records the assistant message as a single text block

```
assistant blocks: {'text': 1}    (zero blocks of type "thinking", output in 9s)
```

After, proxy at 0f41365c34 (port 35886): the thinking block arrives with its signature ahead of the text, on both turns of the session

```
assistant#1  model=converse/us.anthropic.claude-opus-4-7  blocks=[('thinking', 0 chars, signature)]  output_tokens=1314
assistant#2  blocks=[('text', 927 chars)]
```

Control on the already-green invoke cell (claude-opus-4-7-bedrock-invoke, same proxy build, port 44637), pinning what parity means for a real user:

```
block 1: type=thinking, thinking="" (0 chars), signature present (1116 chars)
block 2: type=text, 688 chars       output_tokens=710, both requests 200
```

QA caveats, all observed live and none caused or worsened by this PR: on both Bedrock routes Opus 4.7 adaptive thinking arrives signature-only, so the interactive TUI shows no visible reasoning text on Converse or on the reference-good Invoke column, and billed output_tokens exceed the delivered text on both; this PR brings Converse to exact parity with Invoke, which is what the matrix cell measures. Separately, every Converse turn produced a hidden 400 before the 200 (Bedrock rejects `output_config.format` on Claude Code's structured-output side request) identically at base and at head, and not at all on Invoke; that is the pre-existing follow-up already listed under Caveats

## Type

🐛 Bug Fix

## Caveats (if any)

- `output_config` forwarding is scoped to Bedrock-destined models: other bridged providers (e.g. openrouter) accept `thinking` but reject the raw param when drop_params is off
- For profile ARNs the effort ships unvalidated and Bedrock enforces it, matching how `thinking` already flows for them; a profile fronting a non-Anthropic model would get a loud provider error instead of a silent drop
- Follow-up, not bundled here: Bedrock Converse rejects `output_config.format` on Claude Code's title-generation side request

## QA runbook

- tests/e2e/claude_code/thinking/test_bedrock_converse.py::test_thinking_bedrock_converse - the proxy preserves the adaptive-thinking effort tier so Bedrock Converse streams a thinking block on every probed Claude tier (needs AWS Bedrock credentials in env)
  - [ ] Boot the proxy: `litellm --config tests/e2e/claude_code/test_config.yaml --port 4000`
  - [ ] POST /v1/messages with model `claude-opus-4-7-bedrock-converse`, `thinking: {"type": "adaptive"}` and `output_config: {"effort": "max"}` (exact body in Proof of Fix above)
  - [ ] Expect the stream to open with a `content_block_start` of type `thinking` before the text block
  - [ ] Run the e2e cell above with the claude CLI installed, expect `bedrock_converse pass=3`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

