### PR TITLE
fix(passthrough): enable cost tracking and responses call_type for streamed /v1/responses (#36523)

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
@@ -115,7 +115,9 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
         if not url_route:
             return False
         parsed_url: Final = urlparse(url_route)
-        return _is_openai_compatible_host(parsed_url.hostname) and "/v1/chat/completions" in parsed_url.path
+        if parsed_url.hostname and not _is_openai_compatible_host(parsed_url.hostname):
+            return False
+        return "/v1/chat/completions" in parsed_url.path or "/chat/completions" in parsed_url.path
 
     @staticmethod
     def is_openai_image_generation_route(url_route: str) -> bool:
@@ -123,7 +125,9 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
         if not url_route:
             return False
         parsed_url: Final = urlparse(url_route)
-        return _is_openai_compatible_host(parsed_url.hostname) and "/v1/images/generations" in parsed_url.path
+        if parsed_url.hostname and not _is_openai_compatible_host(parsed_url.hostname):
+            return False
+        return "/v1/images/generations" in parsed_url.path or "/images/generations" in parsed_url.path
 
     @staticmethod
     def is_openai_image_editing_route(url_route: str) -> bool:
@@ -131,7 +135,9 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
         if not url_route:
             return False
         parsed_url: Final = urlparse(url_route)
-        return _is_openai_compatible_host(parsed_url.hostname) and "/v1/images/edits" in parsed_url.path
+        if parsed_url.hostname and not _is_openai_compatible_host(parsed_url.hostname):
+            return False
+        return "/v1/images/edits" in parsed_url.path or "/images/edits" in parsed_url.path
 
     @staticmethod
     def is_openai_responses_route(url_route: str) -> bool:
@@ -139,7 +145,9 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
         if not url_route:
             return False
         parsed_url: Final = urlparse(url_route)
-        return _is_openai_compatible_host(parsed_url.hostname) and (
+        if parsed_url.hostname and not _is_openai_compatible_host(parsed_url.hostname):
+            return False
+        return (
             "/v1/responses" in parsed_url.path or "/responses" in parsed_url.path
         )
 
@@ -467,7 +475,8 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
         all_chunks: list,
         litellm_logging_obj: LiteLLMLoggingObj,
         model: str,
-    ) -> ModelResponse | TextCompletionResponse | None:
+        is_responses: bool = False,
+    ) -> ModelResponse | TextCompletionResponse | ResponsesAPIResponse | None:
         """
         Builds complete response from raw chunks for OpenAI streaming responses.
 
@@ -476,6 +485,44 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
         - Builds complete response from litellm chunks
         """
         try:
+            from litellm.llms.base_llm.base_model_iterator import (
+                BaseModelResponseIterator,
+            )
+
+            if is_responses:
+                for chunk_str in all_chunks:
+                    try:
+                        stripped_json_chunk = BaseModelResponseIterator._string_to_dict_parser(str_line=chunk_str)
+                        if isinstance(stripped_json_chunk, dict):
+                            response_data = None
+                            if (
+                                stripped_json_chunk.get("type") in ("response.completed", "response.done")
+                                and "response" in stripped_json_chunk
+                            ):
+                                response_data = stripped_json_chunk["response"]
+                            elif (
+                                stripped_json_chunk.get("object") == "response"
+                                and "usage" in stripped_json_chunk
+                            ):
+                                response_data = stripped_json_chunk
+                            elif (
+                                "response" in stripped_json_chunk
+                                and isinstance(stripped_json_chunk["response"], dict)
+                                and "usage" in stripped_json_chunk["response"]
+                            ):
+                                response_data = stripped_json_chunk["response"]
+
+                            if response_data and isinstance(response_data, dict):
+                                resp_dict = dict(response_data)
+                                resp_dict.setdefault("model", model)
+                                resp_dict.setdefault("created_at", int(datetime.now().timestamp()))
+                                resp_dict.setdefault("output", [])
+                                resp_dict.setdefault("object", "response")
+                                return ResponsesAPIResponse.model_validate(resp_dict)
+                    except Exception as e:
+                        verbose_proxy_logger.debug("Error parsing responses streaming chunk: %s", e)
+                        continue
+
             # OpenAI's response iterator to parse chunks
             from litellm.llms.openai.openai import OpenAIChatCompletionResponseIterator
 
@@ -487,11 +534,6 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             all_openai_chunks: Final = []
             for chunk_str in all_chunks:
                 try:
-                    # Parse the string chunk using the base iterator's string parser
-                    from litellm.llms.base_llm.base_model_iterator import (
-                        BaseModelResponseIterator,
-                    )
-
                     # Convert string chunk to dict
                     stripped_json_chunk = BaseModelResponseIterator._string_to_dict_parser(str_line=chunk_str)
 
@@ -536,6 +578,9 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             # Extract model from request body
             model: Final = request_body.get("model", "gpt-4o")
 
+            # Check if this is a responses API route
+            is_responses: Final = OpenAIPassthroughLoggingHandler.is_openai_responses_route(url_route)
+
             # Build complete response from chunks using our streaming handler
             handler: Final = OpenAIPassthroughLoggingHandler()
             handler_instance: Final = handler
@@ -543,6 +588,7 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
                 all_chunks=all_chunks,
                 litellm_logging_obj=litellm_logging_obj,
                 model=model,
+                is_responses=is_responses,
             )
 
             if complete_response is None:
@@ -553,11 +599,13 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
                 }
 
             custom_llm_provider: Final = litellm_logging_obj.model_call_details.get("custom_llm_provider", "openai")
+            call_type: Final = "responses" if is_responses else None
             # Calculate cost using LiteLLM's cost calculator
             response_cost: Final = litellm.completion_cost(
                 completion_response=complete_response,
                 model=model,
                 custom_llm_provider=custom_llm_provider,
+                call_type=call_type,
             )
 
             # Preserve existing litellm_params to maintain metadata tags
@@ -570,6 +618,9 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
                 "custom_llm_provider": custom_llm_provider,
                 "litellm_params": existing_litellm_params.copy(),
             }
+            if is_responses:
+                kwargs["call_type"] = "responses"
+                litellm_logging_obj.model_call_details["call_type"] = "responses"
 
             # Extract user information for tracking
             passthrough_logging_payload: Final[PassthroughStandardLoggingPayload | None] = (

--- a/tests/pass_through_unit_tests/test_openai_passthrough_responses_streaming.py
+++ b/tests/pass_through_unit_tests/test_openai_passthrough_responses_streaming.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+import litellm
+from litellm.proxy.pass_through_endpoints.llm_provider_handlers.openai_passthrough_logging_handler import (
+    OpenAIPassthroughLoggingHandler,
+)
+from litellm.types.llms.openai import ResponsesAPIResponse
+from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointType
+
+
+def test_is_openai_responses_route():
+    """Verify is_openai_responses_route works for both full URLs and relative path url_route."""
+    assert OpenAIPassthroughLoggingHandler.is_openai_responses_route("/openai_passthrough/v1/responses")
+    assert OpenAIPassthroughLoggingHandler.is_openai_responses_route("/v1/responses")
+    assert OpenAIPassthroughLoggingHandler.is_openai_responses_route("https://api.openai.com/v1/responses")
+    assert OpenAIPassthroughLoggingHandler.is_openai_responses_route("https://api.openai.com/openai_passthrough/v1/responses")
+    assert not OpenAIPassthroughLoggingHandler.is_openai_responses_route("/v1/chat/completions")
+
+
+def test_handle_logging_openai_collected_chunks_responses():
+    """Verify streaming passthrough handler for /v1/responses calculates cost and sets call_type='responses'."""
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {"custom_llm_provider": "openai", "litellm_params": {}}
+
+    all_chunks = [
+        'data: {"type":"response.created","response":{"id":"resp_0c72","object":"response","status":"in_progress"}}',
+        'data: {"type":"response.completed","response":{"id":"resp_0c72","object":"response","created_at":1723360000,"output":[],"model":"gpt-4o-mini-2024-07-18","usage":{"input_tokens":14,"output_tokens":2,"total_tokens":16}}}',
+    ]
+
+    res = OpenAIPassthroughLoggingHandler._handle_logging_openai_collected_chunks(
+        litellm_logging_obj=logging_obj,
+        passthrough_success_handler_obj=MagicMock(),
+        url_route="/openai_passthrough/v1/responses",
+        request_body={"model": "gpt-4o-mini", "stream": True},
+        endpoint_type=EndpointType.OPENAI,
+        start_time=datetime.now(),
+        all_chunks=all_chunks,
+        end_time=datetime.now(),
+    )
+
+    assert isinstance(res["result"], ResponsesAPIResponse)
+    assert res["kwargs"]["call_type"] == "responses"
+    assert logging_obj.model_call_details["call_type"] == "responses"
+    assert pytest.approx(res["kwargs"]["response_cost"], 1e-8) == 3.3e-06


### PR DESCRIPTION
## Description

Fixes #36523.

Currently, streamed requests to OpenAI passthrough `/v1/responses` (or `/openai_passthrough/v1/responses`) fail to calculate cost ($0 with 0 tokens logged). This was caused by several issues in `OpenAIPassthroughLoggingHandler`:

1. `_handle_logging_openai_collected_chunks` accepted `url_route`, but never checked `is_openai_responses_route(url_route)` or passed `is_responses` to `_build_complete_streaming_response`.
2. `_build_complete_streaming_response` parsed all streaming chunks assuming OpenAI Chat Completion SSE format (`choices`), failing to parse Responses API SSE chunks (`type: response.completed` / `response.done`).
3. `litellm.completion_cost` was called without `call_type="responses"`, causing cost calculation to fail for Responses API objects.
4. Route helper methods (`is_openai_*_route`) failed to match relative path `url_route` strings because `urlparse(url_route).hostname` returned `None`.

### Changes
- Updated route helper methods in `OpenAIPassthroughLoggingHandler` to handle relative path `url_route` inputs.
- Extended `_build_complete_streaming_response` to parse `response.completed` and `response.done` SSE events into `ResponsesAPIResponse` when `is_responses` is True.
- Set `call_type="responses"` for `litellm.completion_cost` and logging metadata when handling Responses API streaming routes.

## Related Issue

Fixes #36523

## Tests

- Added unit tests in `tests/pass_through_unit_tests/test_openai_passthrough_responses_streaming.py` verifying `is_openai_responses_route` matching for relative routes and `_handle_logging_openai_collected_chunks` cost calculation for streamed `/v1/responses`.
