### PR TITLE
fix(proxy): track streamed passthrough Responses cost

### DIFF
--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -356,7 +356,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
     @staticmethod
     def parse_terminal_response_from_stream_chunks(all_chunks: list[str]) -> ResponsesAPIResponse | None:
         for chunk_str in reversed(all_chunks):
-            for event_model in (ResponseCompletedEvent, ResponseIncompleteEvent):
+            for event_model in (ResponseCompletedEvent, ResponseIncompleteEvent, ResponseFailedEvent):
                 try:
                     return event_model.model_validate_json(chunk_str.removeprefix("data: ")).response
                 except ValueError:

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -354,6 +354,15 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
             return event_pydantic_model.model_construct(**parsed_chunk)
 
     @staticmethod
+    def parse_completed_response_from_stream_chunks(all_chunks: list[str]) -> ResponsesAPIResponse | None:
+        for chunk_str in reversed(all_chunks):
+            try:
+                return ResponseCompletedEvent.model_validate_json(chunk_str.removeprefix("data: ")).response
+            except ValueError:
+                continue
+        return None
+
+    @staticmethod
     def get_event_model_class(event_type: str) -> Any:
         """
         Returns the appropriate event model class based on the event type.

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -354,12 +354,13 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
             return event_pydantic_model.model_construct(**parsed_chunk)
 
     @staticmethod
-    def parse_completed_response_from_stream_chunks(all_chunks: list[str]) -> ResponsesAPIResponse | None:
+    def parse_terminal_response_from_stream_chunks(all_chunks: list[str]) -> ResponsesAPIResponse | None:
         for chunk_str in reversed(all_chunks):
-            try:
-                return ResponseCompletedEvent.model_validate_json(chunk_str.removeprefix("data: ")).response
-            except ValueError:
-                continue
+            for event_model in (ResponseCompletedEvent, ResponseIncompleteEvent):
+                try:
+                    return event_model.model_validate_json(chunk_str.removeprefix("data: ")).response
+                except ValueError:
+                    continue
         return None
 
     @staticmethod

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
@@ -542,7 +542,7 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             handler: Final = OpenAIPassthroughLoggingHandler()
             handler_instance: Final = handler
             complete_response: Final = (
-                OpenAIResponsesAPIConfig.parse_completed_response_from_stream_chunks(all_chunks=all_chunks)
+                OpenAIResponsesAPIConfig.parse_terminal_response_from_stream_chunks(all_chunks=all_chunks)
                 if is_responses
                 else handler._build_complete_streaming_response(
                     all_chunks=all_chunks,

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
@@ -583,6 +583,8 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
                 "response_cost": response_cost,
                 "model": model,
                 "custom_llm_provider": custom_llm_provider,
+                "call_type": litellm_logging_obj.call_type,
+                "messages": litellm_logging_obj.model_call_details.get("messages"),
                 "litellm_params": existing_litellm_params.copy(),
             }
 
@@ -599,8 +601,11 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
                         user
                     )
 
-            # Create standard logging object
-            get_standard_logging_object_payload(
+            # Attach the payload to kwargs so the success handler adopts it;
+            # its later rebuild runs on a copy whose Responses usage was
+            # coerced to chat shape and serializes as total_tokens only,
+            # zeroing the prompt/completion split in spend logs.
+            standard_logging_object: Final = get_standard_logging_object_payload(
                 kwargs=kwargs,
                 init_response_obj=complete_response,
                 start_time=start_time,
@@ -608,6 +613,8 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
                 logging_obj=litellm_logging_obj,
                 status="success",
             )
+            if standard_logging_object is not None:
+                kwargs["standard_logging_object"] = standard_logging_object
 
             # Update logging object with cost information
             litellm_logging_obj.model_call_details["model"] = model

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
@@ -26,7 +26,7 @@ from litellm.proxy.pass_through_endpoints.llm_provider_handlers.base_passthrough
 from litellm.proxy.pass_through_endpoints.success_handler import (
     PassThroughEndpointLogging,
 )
-from litellm.types.llms.openai import ResponsesAPIResponse
+from litellm.types.llms.openai import ResponseCompletedEvent, ResponsesAPIResponse
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     EndpointType,
     PassthroughStandardLoggingPayload,
@@ -464,7 +464,7 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
 
     def _build_complete_streaming_response(
         self,
-        all_chunks: list,
+        all_chunks: list[str],
         litellm_logging_obj: LiteLLMLoggingObj,
         model: str,
     ) -> ModelResponse | TextCompletionResponse | None:
@@ -519,6 +519,15 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             return None
 
     @staticmethod
+    def _build_complete_streaming_responses_response(all_chunks: list[str]) -> ResponsesAPIResponse | None:
+        for chunk_str in reversed(all_chunks):
+            try:
+                return ResponseCompletedEvent.model_validate_json(chunk_str.removeprefix("data: ")).response
+            except ValueError:
+                continue
+        return None
+
+    @staticmethod
     def _handle_logging_openai_collected_chunks(
         litellm_logging_obj: LiteLLMLoggingObj,
         passthrough_success_handler_obj: PassThroughEndpointLogging,
@@ -536,13 +545,19 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             # Extract model from request body
             model: Final = request_body.get("model", "gpt-4o")
 
+            is_responses: Final = OpenAIPassthroughLoggingHandler.is_openai_responses_route(url_route)
+
             # Build complete response from chunks using our streaming handler
             handler: Final = OpenAIPassthroughLoggingHandler()
             handler_instance: Final = handler
-            complete_response: Final = handler._build_complete_streaming_response(
-                all_chunks=all_chunks,
-                litellm_logging_obj=litellm_logging_obj,
-                model=model,
+            complete_response: Final = (
+                handler._build_complete_streaming_responses_response(all_chunks=all_chunks)
+                if is_responses
+                else handler._build_complete_streaming_response(
+                    all_chunks=all_chunks,
+                    litellm_logging_obj=litellm_logging_obj,
+                    model=model,
+                )
             )
 
             if complete_response is None:
@@ -554,10 +569,19 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
 
             custom_llm_provider: Final = litellm_logging_obj.model_call_details.get("custom_llm_provider", "openai")
             # Calculate cost using LiteLLM's cost calculator
-            response_cost: Final = litellm.completion_cost(
-                completion_response=complete_response,
-                model=model,
-                custom_llm_provider=custom_llm_provider,
+            response_cost: Final = (
+                litellm.completion_cost(
+                    completion_response=complete_response,
+                    model=model,
+                    custom_llm_provider=custom_llm_provider,
+                    call_type="responses",
+                )
+                if is_responses
+                else litellm.completion_cost(
+                    completion_response=complete_response,
+                    model=model,
+                    custom_llm_provider=custom_llm_provider,
+                )
             )
 
             # Preserve existing litellm_params to maintain metadata tags

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
@@ -26,7 +26,7 @@ from litellm.proxy.pass_through_endpoints.llm_provider_handlers.base_passthrough
 from litellm.proxy.pass_through_endpoints.success_handler import (
     PassThroughEndpointLogging,
 )
-from litellm.types.llms.openai import ResponseCompletedEvent, ResponsesAPIResponse
+from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     EndpointType,
     PassthroughStandardLoggingPayload,
@@ -519,15 +519,6 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             return None
 
     @staticmethod
-    def _build_complete_streaming_responses_response(all_chunks: list[str]) -> ResponsesAPIResponse | None:
-        for chunk_str in reversed(all_chunks):
-            try:
-                return ResponseCompletedEvent.model_validate_json(chunk_str.removeprefix("data: ")).response
-            except ValueError:
-                continue
-        return None
-
-    @staticmethod
     def _handle_logging_openai_collected_chunks(
         litellm_logging_obj: LiteLLMLoggingObj,
         passthrough_success_handler_obj: PassThroughEndpointLogging,
@@ -551,7 +542,7 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             handler: Final = OpenAIPassthroughLoggingHandler()
             handler_instance: Final = handler
             complete_response: Final = (
-                handler._build_complete_streaming_responses_response(all_chunks=all_chunks)
+                OpenAIResponsesAPIConfig.parse_completed_response_from_stream_chunks(all_chunks=all_chunks)
                 if is_responses
                 else handler._build_complete_streaming_response(
                     all_chunks=all_chunks,

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
@@ -586,6 +586,7 @@ class TestOpenAIPassthroughLoggingHandler:
         assert response.usage.input_tokens == 14
         assert response.usage.output_tokens == 2
         assert result["kwargs"]["response_cost"] == 3.3e-06
+        assert result["kwargs"]["standard_logging_object"] is mock_get_standard_logging.return_value
         mock_completion_cost.assert_called_once_with(
             completion_response=response,
             model="gpt-4o-mini",
@@ -657,6 +658,7 @@ class TestOpenAIPassthroughLoggingHandler:
         assert response.status == "incomplete"
         assert response.usage.output_tokens == 32
         assert result["kwargs"]["response_cost"] == 2.1e-06
+        assert result["kwargs"]["standard_logging_object"] is mock_get_standard_logging.return_value
         mock_completion_cost.assert_called_once_with(
             completion_response=response,
             model="gpt-4o-mini",
@@ -714,12 +716,60 @@ class TestOpenAIPassthroughLoggingHandler:
         assert response.status == "failed"
         assert response.usage.total_tokens == 21
         assert result["kwargs"]["response_cost"] == 1.4e-06
+        assert result["kwargs"]["standard_logging_object"] is mock_get_standard_logging.return_value
         mock_completion_cost.assert_called_once_with(
             completion_response=response,
             model="gpt-4o-mini",
             custom_llm_provider="openai",
             call_type="responses",
         )
+
+    @patch(f"{OpenAIPassthroughLoggingHandler.__module__}.get_standard_logging_object_payload", return_value=None)
+    @patch("litellm.completion_cost", return_value=3.3e-06)
+    def test_streaming_responses_none_payload_is_not_attached(self, mock_completion_cost, mock_get_standard_logging):
+        completed_event = {
+            "type": "response.completed",
+            "sequence_number": 8,
+            "response": {
+                "id": "resp_NONEPAYLOADSENTINEL0123456789",
+                "object": "response",
+                "created_at": 1786374786,
+                "status": "completed",
+                "model": "gpt-4o-mini-2024-07-18",
+                "output": [],
+                "usage": {
+                    "input_tokens": 14,
+                    "input_tokens_details": {"cached_tokens": 0},
+                    "output_tokens": 2,
+                    "output_tokens_details": {"reasoning_tokens": 0},
+                    "total_tokens": 16,
+                },
+                "error": None,
+                "incomplete_details": None,
+                "instructions": None,
+                "metadata": {},
+                "parallel_tool_calls": True,
+                "temperature": 1.0,
+                "tool_choice": "auto",
+                "tools": [],
+                "top_p": 1.0,
+            },
+        }
+        logging_obj = self._create_mock_logging_obj()
+
+        result = OpenAIPassthroughLoggingHandler._handle_logging_openai_collected_chunks(
+            litellm_logging_obj=logging_obj,
+            passthrough_success_handler_obj=MagicMock(),
+            url_route="https://api.openai.com/v1/responses",
+            request_body={"model": "gpt-4o-mini", "stream": True},
+            endpoint_type=MagicMock(),
+            start_time=self.start_time,
+            all_chunks=[f"data: {json.dumps(completed_event)}", "data: [DONE]"],
+            end_time=self.end_time,
+        )
+
+        assert "standard_logging_object" not in result["kwargs"]
+        assert result["kwargs"]["response_cost"] == 3.3e-06
 
     @patch(f"{OpenAIPassthroughLoggingHandler.__module__}.get_standard_logging_object_payload")
     @patch("litellm.completion_cost")

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
@@ -665,6 +665,63 @@ class TestOpenAIPassthroughLoggingHandler:
         )
 
     @patch(f"{OpenAIPassthroughLoggingHandler.__module__}.get_standard_logging_object_payload")
+    @patch("litellm.completion_cost", return_value=1.4e-06)
+    def test_streaming_responses_failed_event_is_billed(self, mock_completion_cost, mock_get_standard_logging):
+        response_id = "resp_FAILEDSENTINEL0123456789abcd"
+        failed_event = {
+            "type": "response.failed",
+            "sequence_number": 4,
+            "response": {
+                "id": response_id,
+                "object": "response",
+                "created_at": 1786374786,
+                "status": "failed",
+                "model": "gpt-4o-mini-2024-07-18",
+                "output": [],
+                "usage": {
+                    "input_tokens": 14,
+                    "input_tokens_details": {"cached_tokens": 0},
+                    "output_tokens": 7,
+                    "output_tokens_details": {"reasoning_tokens": 0},
+                    "total_tokens": 21,
+                },
+                "error": {"code": "server_error", "message": "The model failed to generate a response"},
+                "incomplete_details": None,
+                "instructions": None,
+                "metadata": {},
+                "parallel_tool_calls": True,
+                "temperature": 1.0,
+                "tool_choice": "auto",
+                "tools": [],
+                "top_p": 1.0,
+            },
+        }
+        logging_obj = self._create_mock_logging_obj()
+
+        result = OpenAIPassthroughLoggingHandler._handle_logging_openai_collected_chunks(
+            litellm_logging_obj=logging_obj,
+            passthrough_success_handler_obj=MagicMock(),
+            url_route="https://api.openai.com/v1/responses",
+            request_body={"model": "gpt-4o-mini", "stream": True},
+            endpoint_type=MagicMock(),
+            start_time=self.start_time,
+            all_chunks=[f"data: {json.dumps(failed_event)}"],
+            end_time=self.end_time,
+        )
+
+        response = result["result"]
+        assert response.id == response_id
+        assert response.status == "failed"
+        assert response.usage.total_tokens == 21
+        assert result["kwargs"]["response_cost"] == 1.4e-06
+        mock_completion_cost.assert_called_once_with(
+            completion_response=response,
+            model="gpt-4o-mini",
+            custom_llm_provider="openai",
+            call_type="responses",
+        )
+
+    @patch(f"{OpenAIPassthroughLoggingHandler.__module__}.get_standard_logging_object_payload")
     @patch("litellm.completion_cost")
     def test_streaming_responses_without_completed_event_returns_none(
         self, mock_completion_cost, mock_get_standard_logging

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
@@ -593,6 +593,30 @@ class TestOpenAIPassthroughLoggingHandler:
             call_type="responses",
         )
 
+    @patch(f"{OpenAIPassthroughLoggingHandler.__module__}.get_standard_logging_object_payload")
+    @patch("litellm.completion_cost")
+    def test_streaming_responses_without_completed_event_returns_none(
+        self, mock_completion_cost, mock_get_standard_logging
+    ):
+        logging_obj = self._create_mock_logging_obj()
+
+        result = OpenAIPassthroughLoggingHandler._handle_logging_openai_collected_chunks(
+            litellm_logging_obj=logging_obj,
+            passthrough_success_handler_obj=MagicMock(),
+            url_route="https://api.openai.com/v1/responses",
+            request_body={"model": "gpt-4o-mini", "stream": True},
+            endpoint_type=MagicMock(),
+            start_time=self.start_time,
+            all_chunks=[
+                'data: {"type": "response.created", "sequence_number": 0}',
+                'data: {"type": "response.output_text.delta", "sequence_number": 1, "delta": "OK"}',
+            ],
+            end_time=self.end_time,
+        )
+
+        assert result == {"result": None, "kwargs": {}}
+        mock_completion_cost.assert_not_called()
+
     @patch("litellm.completion_cost")
     @patch(
         "litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload"

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
@@ -519,6 +519,80 @@ class TestOpenAIPassthroughLoggingHandler:
 
         assert result is None  # Placeholder implementation
 
+    @patch(f"{OpenAIPassthroughLoggingHandler.__module__}.get_standard_logging_object_payload")
+    @patch("litellm.completion_cost", return_value=3.3e-06)
+    def test_streaming_responses_cost_uses_completed_response(
+        self, mock_completion_cost, mock_get_standard_logging
+    ):
+        response_id = "resp_PROOFSENTINEL0123456789abcdef"
+        completed_event = {
+            "type": "response.completed",
+            "sequence_number": 8,
+            "response": {
+                "id": response_id,
+                "object": "response",
+                "created_at": 1786374786,
+                "status": "completed",
+                "model": "gpt-4o-mini-2024-07-18",
+                "output": [
+                    {
+                        "id": "msg_abc",
+                        "type": "message",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "OK",
+                                "annotations": [],
+                            }
+                        ],
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 14,
+                    "input_tokens_details": {"cached_tokens": 0},
+                    "output_tokens": 2,
+                    "output_tokens_details": {"reasoning_tokens": 0},
+                    "total_tokens": 16,
+                },
+                "error": None,
+                "incomplete_details": None,
+                "instructions": None,
+                "metadata": {},
+                "parallel_tool_calls": True,
+                "temperature": 1.0,
+                "tool_choice": "auto",
+                "tools": [],
+                "top_p": 1.0,
+            },
+        }
+        logging_obj = self._create_mock_logging_obj()
+
+        result = OpenAIPassthroughLoggingHandler._handle_logging_openai_collected_chunks(
+            litellm_logging_obj=logging_obj,
+            passthrough_success_handler_obj=MagicMock(),
+            url_route="https://api.openai.com/v1/responses",
+            request_body={"model": "gpt-4o-mini", "stream": True},
+            endpoint_type=MagicMock(),
+            start_time=self.start_time,
+            all_chunks=[f"data: {json.dumps(completed_event)}", "data: [DONE]"],
+            end_time=self.end_time,
+        )
+
+        response = result["result"]
+        assert response.id == response_id
+        assert response.model == "gpt-4o-mini-2024-07-18"
+        assert response.usage.input_tokens == 14
+        assert response.usage.output_tokens == 2
+        assert result["kwargs"]["response_cost"] == 3.3e-06
+        mock_completion_cost.assert_called_once_with(
+            completion_response=response,
+            model="gpt-4o-mini",
+            custom_llm_provider="openai",
+            call_type="responses",
+        )
+
     @patch("litellm.completion_cost")
     @patch(
         "litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload"

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
@@ -594,6 +594,77 @@ class TestOpenAIPassthroughLoggingHandler:
         )
 
     @patch(f"{OpenAIPassthroughLoggingHandler.__module__}.get_standard_logging_object_payload")
+    @patch("litellm.completion_cost", return_value=2.1e-06)
+    def test_streaming_responses_incomplete_event_is_billed(self, mock_completion_cost, mock_get_standard_logging):
+        response_id = "resp_INCOMPLETESENTINEL0123456789ab"
+        incomplete_event = {
+            "type": "response.incomplete",
+            "sequence_number": 5,
+            "response": {
+                "id": response_id,
+                "object": "response",
+                "created_at": 1786374786,
+                "status": "incomplete",
+                "model": "gpt-4o-mini-2024-07-18",
+                "output": [
+                    {
+                        "id": "msg_abc",
+                        "type": "message",
+                        "status": "incomplete",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "OK",
+                                "annotations": [],
+                            }
+                        ],
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 14,
+                    "input_tokens_details": {"cached_tokens": 0},
+                    "output_tokens": 32,
+                    "output_tokens_details": {"reasoning_tokens": 0},
+                    "total_tokens": 46,
+                },
+                "error": None,
+                "incomplete_details": {"reason": "max_output_tokens"},
+                "instructions": None,
+                "metadata": {},
+                "parallel_tool_calls": True,
+                "temperature": 1.0,
+                "tool_choice": "auto",
+                "tools": [],
+                "top_p": 1.0,
+            },
+        }
+        logging_obj = self._create_mock_logging_obj()
+
+        result = OpenAIPassthroughLoggingHandler._handle_logging_openai_collected_chunks(
+            litellm_logging_obj=logging_obj,
+            passthrough_success_handler_obj=MagicMock(),
+            url_route="https://api.openai.com/v1/responses",
+            request_body={"model": "gpt-4o-mini", "stream": True},
+            endpoint_type=MagicMock(),
+            start_time=self.start_time,
+            all_chunks=[f"data: {json.dumps(incomplete_event)}"],
+            end_time=self.end_time,
+        )
+
+        response = result["result"]
+        assert response.id == response_id
+        assert response.status == "incomplete"
+        assert response.usage.output_tokens == 32
+        assert result["kwargs"]["response_cost"] == 2.1e-06
+        mock_completion_cost.assert_called_once_with(
+            completion_response=response,
+            model="gpt-4o-mini",
+            custom_llm_provider="openai",
+            call_type="responses",
+        )
+
+    @patch(f"{OpenAIPassthroughLoggingHandler.__module__}.get_standard_logging_object_payload")
     @patch("litellm.completion_cost")
     def test_streaming_responses_without_completed_event_returns_none(
         self, mock_completion_cost, mock_get_standard_logging


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed passthrough Responses calls log zero tokens and spend
- Logged response IDs cannot match provider response IDs

How it solves it:

- Reads the typed terminal `response.completed`, `response.incomplete`, or `response.failed` event
- Prices its response with Responses API semantics
- Attaches the built standard logging payload to the success handler kwargs, so the spend log keeps the exact prompt/completion token split instead of zeros

## User Flow

Before: a developer streams an OpenAI passthrough Responses call, but its cost record is empty and cannot be correlated

1. They send POST `https://litellm-domain/openai_passthrough/v1/responses` with `"stream": true`
2. The terminal SSE event contains a `resp_...` ID and nonzero usage
3. The logged response instead has a random `chatcmpl-...` ID, zero tokens, and zero spend

After: the same stream keeps the provider response identity and usage for cost logging

1. They send the same POST `https://litellm-domain/openai_passthrough/v1/responses` with `"stream": true`
2. The terminal SSE event contains a `resp_...` ID and nonzero usage
3. The spend log row carries that exact ID, the exact cost, and the full input/output token split

## Relevant issues

Fixes #36523

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks run locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Two live proxies against real OpenAI (`gpt-4o-mini`), each in its own worktree with its own fresh Postgres: the before leg at the merge base `b0fac57fe4`, the after leg at this PR's head `08a73740ec`. Both legs ran the exact same four curl scenarios; only the proxy commit differs

```bash
B="http://localhost:$PORT"; H1="Authorization: Bearer sk-1234"; H2="Content-Type: application/json"

# S1 buffered Responses passthrough
curl -s $B/openai_passthrough/v1/responses -H "$H1" -H "$H2" \
  -d '{"model": "gpt-4o-mini", "input": "Say OK and nothing else."}'

# S2 streamed Responses passthrough, ends in response.completed
curl -s $B/openai_passthrough/v1/responses -H "$H1" -H "$H2" \
  -d '{"model": "gpt-4o-mini", "input": "Say OK and nothing else.", "stream": true}'

# S3 streamed Responses passthrough, ends in response.incomplete (max_output_tokens hit)
curl -s $B/openai_passthrough/v1/responses -H "$H1" -H "$H2" \
  -d '{"model": "gpt-4o-mini", "input": "Write a 200 word story about clouds.", "stream": true, "max_output_tokens": 16}'

# S4 streamed chat completions passthrough with include_usage, control
curl -s $B/openai_passthrough/v1/chat/completions -H "$H1" -H "$H2" \
  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Say OK and nothing else."}], "stream": true, "stream_options": {"include_usage": true}}'
```

Response IDs the client saw on the before leg: S1 `resp_0c376049564efbbb006a7bf706990c819a9ea5fcceff92c2df`, S2 `resp_08cf858013c95cc8006a7bf7077b44819b84d58cabf3819b9f` (terminal SSE event), S3 `resp_0bae3331212d2ea9006a7bf70b4c7c819b8fb9fa29c09dfd57` (terminal SSE event), S4 `chatcmpl-EBuuKdf5JTEgu2EIlpEdhBRMCkBX2`

Before leg spend logs at `b0fac57fe4`: the two streamed Responses rows (S2, S3) are unbillable, a fabricated `chatcmpl-` UUID with zero spend and zero tokens, and their stored usage object is all zeros

```
                       request_id                        |  spend   | prompt_tokens | completion_tokens | total_tokens
---------------------------------------------------------+----------+---------------+-------------------+--------------
 resp_0c376049564efbbb006a7bf706990c819a9ea5fcceff92c2df | 3.15e-06 |            13 |                 2 |           15
 chatcmpl-378cf04c-5c4b-4cd5-bcd2-95bbb5ffdda7           |        0 |             0 |                 0 |            0
 chatcmpl-cf3eb03f-3840-4c26-99ec-3d2efc0662f9           |        0 |             0 |                 0 |            0
 chatcmpl-EBuuKdf5JTEgu2EIlpEdhBRMCkBX2                  | 2.55e-06 |            13 |                 1 |           14
(4 rows)
```

After leg spend logs at `08a73740ec`: every row matches the ID the client saw, spend is exact at gpt-4o-mini pricing (S2: 13 x 1.5e-07 + 2 x 6e-07 = 3.15e-06; S3: 16 x 1.5e-07 + 16 x 6e-07 = 1.2e-05), the token split is fully populated, and the stored usage object carries the same numbers

```
                       request_id                        |  spend   | prompt_tokens | completion_tokens | total_tokens
---------------------------------------------------------+----------+---------------+-------------------+--------------
 resp_014f704180278f52006a7bf70d268881999cdb9bf3459b2cf0 | 3.15e-06 |            13 |                 2 |           15
 resp_0a27c0379c4113e0006a7bf70dec00819ab3e3883cd6dfe713 | 3.15e-06 |            13 |                 2 |           15
 resp_01580b62d19157fb006a7bf70ea2088198b564916d8fc7225d |  1.2e-05 |            16 |                16 |           32
 chatcmpl-EBuuNghJMZM5bEBF4CWwS8q2x4lKS                  | 2.55e-06 |            13 |                 1 |           14
(4 rows)
```

Regression coverage lives in `tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py`, 32 tests: terminal-event parsing for all three event types, exact ID/model/usage/cost assertions, no-terminal-event streams logging nothing, and the standard logging payload being attached (and skipped when the builder returns None)

QA observations, none caused or worsened by this PR:

- Zero-spend chatcmpl ghost rows from before the fix stay unbilled
- model_group column empty on all passthrough rows; leaves alone
- SpendLogs call_type stays pass_through_endpoint everywhere; leaves alone
- Separately reported stored-response 403 unproven and unchanged; leaves alone

## Type

🐛 Bug Fix

## Caveats (if any)

- The separately reported stored-response 403 remains unproven and unchanged

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches spend/cost logging for streamed Responses passthrough, so incorrect parsing could under- or over-bill. Scope is limited to that path and covered by new terminal-event tests.
> 
> **Overview**
> Fixes **zero-token / zero-spend** logging for streamed OpenAI Responses passthrough calls, and keeps the provider `resp_...` ID instead of a fabricated `chatcmpl-...` ID.
> 
> Adds `parse_terminal_response_from_stream_chunks` to pull the typed terminal `response.completed`, `response.incomplete`, or `response.failed` event from collected SSE chunks. Streaming Responses logging now uses that response with `call_type="responses"` cost calculation, and attaches the built `standard_logging_object` to kwargs so spend logs keep the prompt/completion token split instead of zeros.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a73740ec3dba37d3109af6b1a9bdadb680781e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->