### PR TITLE
fix(proxy): allow trailing slash and sub-paths on MCP inference routes

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -472,7 +472,7 @@ class LiteLLMRoutes(enum.Enum):
     mcp_inference_routes = [
         "/mcp",
         "/mcp/",
-        "/mcp/{subpath}",
+        "/mcp/{subpath:path}",
         "/mcp/tools",
         "/mcp/tools/list",
         "/mcp/tools/call",

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -462,6 +462,8 @@ def test_virtual_key_llm_api_routes_rejects_mcp_multi_segment_admin_subpaths(
         ("/mcp", "POST"),
         ("/mcp/", "POST"),
         ("/mcp/my-server", "POST"),  # matches the /mcp/{subpath} pattern
+        ("/mcp/my-server/", "POST"),  # same server, trailing slash
+        ("/mcp/my-server/mcp", "POST"),  # streamable-http transport sub-path
         ("/mcp/tools", "GET"),
         ("/mcp/tools/list", "POST"),
         ("/mcp/tools/call", "POST"),


### PR DESCRIPTION
## Title

fix(proxy): allow trailing slash and sub-paths on MCP inference routes

## Relevant issues

Fixes #36531

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory — the parametrized
      case list in `tests/test_litellm/proxy/auth/test_route_checks.py` gains the two
      shapes that currently fail.

## Type

🐛 Bug Fix

## Changes

`LiteLLMRoutes.mcp_inference_routes` declares the placeholder as `"/mcp/{subpath}"`.
`RouteChecks._route_matches_pattern` expands a placeholder to `[^:]+` only when it ends
in `:path`, otherwise to `[^/]+`. So the entry compiles to `^/mcp/[^/]+$`, which does
not match a trailing slash nor a multi-segment sub-path:

```
route                  is_llm_api_route
/mcp/my-server         True
/mcp/my-server/        False   <-- falls through to the admin-only branch
/mcp/my-server/mcp     False   <-- streamable-http transport sub-path
```

`is_llm_api_route()` returning `False` sends the request to
`non_proxy_admin_allowed_routes_check()`, which ends in
`_raise_admin_only_route_exception()` — so a non-admin virtual key calling an MCP
server with a trailing slash gets:

```
Only proxy admin can be used to generate, delete, update info for new
keys/users/teams. Route=/mcp/gitlab_mcp/. Your role=internal_user
```

which points at RBAC config instead of at route matching.

The fix is the `:path` placeholder, the same idiom `mcp_management_routes` already uses
twelve lines below (`"/v1/mcp/server/{path:path}"`), so it introduces no new convention.

**It does not widen admin surface.** Everything admin-only under MCP lives under the
`/v1/mcp/` prefix, which `^/mcp/...` never matches, and multi-segment paths under
`/mcp/` are already inference routes (`/mcp/tools/list`, `/mcp/tools/call` are explicit
entries in the same list). `test_virtual_key_llm_api_routes_rejects_mcp_multi_segment_admin_subpaths`
targets `/v1/mcp/server/...` and is unaffected.

Verified by patching the route list in-process and re-running the classifier:

```
route                            before   after
/mcp/my-server/                  False    True    <- fixed
/mcp/my-server/mcp               False    True    <- fixed
/mcp, /mcp/, /mcp/my-server      True     True    (unchanged)
/mcp/tools{,/list,/call}         True     True    (unchanged)
/v1/mcp/server/abc-123/approve   False    False   (guard holds)
/v1/mcp/server/oauth/session     False    False   (guard holds)
/key/generate, /user/new         False    False   (guard holds)
```

### Why CI is green today

The existing parametrized test covers `("/mcp/my-server", "POST")` — the shape that
works. The broken shapes were never exercised. This PR adds them.
