### PR TITLE
fix(proxy): allow public pass-through routes for virtual keys

### DIFF
--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -12,6 +12,9 @@ from litellm.proxy._types import (
     LitellmUserRoles,
     UserAPIKeyAuth,
 )
+from litellm.types.passthrough_endpoints.pass_through_endpoints import (
+    LITELLM_PASS_THROUGH_ENDPOINT_MARKER,
+)
 
 from .auth_checks_organization import _user_is_org_admin
 
@@ -249,7 +252,9 @@ class RouteChecks:
         ):
             RouteChecks._require_auth_pass_through_access(route=route, valid_token=valid_token)
         elif RouteChecks.is_llm_api_route(route=route) or RouteChecks.is_public_pass_through_route(
-            route=route, method=RouteChecks._get_request_method(request=request)
+            route=route,
+            method=RouteChecks._get_request_method(request=request),
+            request=request,
         ):
             pass
         elif RouteChecks.is_info_route(route=route):
@@ -632,14 +637,25 @@ class RouteChecks:
         return route_info.get("auth") is True
 
     @staticmethod
-    def is_public_pass_through_route(route: str, method: str | None = None) -> bool:
+    def is_public_pass_through_route(
+        route: str,
+        method: str | None = None,
+        request: Request | None = None,
+    ) -> bool:
+        if request is None:
+            return False
+        scope: Final = getattr(request, "scope", None)
+        if not isinstance(scope, dict):
+            return False
+        endpoint: Final = scope.get("endpoint")
+        if getattr(endpoint, LITELLM_PASS_THROUGH_ENDPOINT_MARKER, False) is not True:
+            return False
+
         from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
             InitPassThroughEndpointHelpers,
         )
 
-        route_info: Final = InitPassThroughEndpointHelpers.get_registered_pass_through_route(
-            route=route, method=method
-        )
+        route_info: Final = InitPassThroughEndpointHelpers.get_registered_pass_through_route(route=route, method=method)
         if route_info is None:
             return False
         return route_info.get("auth") is False

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -248,7 +248,9 @@ class RouteChecks:
             method=RouteChecks._get_request_method(request=request),
         ):
             RouteChecks._require_auth_pass_through_access(route=route, valid_token=valid_token)
-        elif RouteChecks.is_llm_api_route(route=route):
+        elif RouteChecks.is_llm_api_route(route=route) or RouteChecks.is_public_pass_through_route(
+            route=route, method=RouteChecks._get_request_method(request=request)
+        ):
             pass
         elif RouteChecks.is_info_route(route=route):
             # check if user allowed to call an info route
@@ -628,6 +630,19 @@ class RouteChecks:
         if route_info is None:
             return False
         return route_info.get("auth") is True
+
+    @staticmethod
+    def is_public_pass_through_route(route: str, method: str | None = None) -> bool:
+        from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+            InitPassThroughEndpointHelpers,
+        )
+
+        route_info: Final = InitPassThroughEndpointHelpers.get_registered_pass_through_route(
+            route=route, method=method
+        )
+        if route_info is None:
+            return False
+        return route_info.get("auth") is False
 
     @staticmethod
     def _auth_pass_through_denied_exception(route: str) -> HTTPException:

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -1200,9 +1200,22 @@ def test_non_proxy_admin_allows_non_auth_pass_through_with_llm_api_routes(
         user_role=LitellmUserRoles.INTERNAL_USER.value,
         allowed_routes=["llm_api_routes"],
     )
-    request = MagicMock(spec=Request)
-    request.method = "GET"
-    request.query_params = {}
+    from litellm.types.passthrough_endpoints.pass_through_endpoints import (
+        LITELLM_PASS_THROUGH_ENDPOINT_MARKER,
+    )
+
+    def pass_through_endpoint(): ...
+
+    setattr(pass_through_endpoint, LITELLM_PASS_THROUGH_ENDPOINT_MARKER, True)
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [],
+            "method": "GET",
+            "query_string": b"",
+            "endpoint": pass_through_endpoint,
+        }
+    )
 
     with (
         patch(
@@ -1230,6 +1243,72 @@ def test_non_proxy_admin_allows_non_auth_pass_through_with_llm_api_routes(
             valid_token=valid_token,
             request_data={},
         )
+
+
+@pytest.mark.parametrize(
+    "registered_path,registered_type",
+    [
+        ("/config/update", "exact"),
+        ("/config", "subpath"),
+    ],
+)
+def test_public_pass_through_registration_does_not_bypass_builtin_route_auth(
+    registered_path, registered_type
+):
+    mock_registered_routes = {
+        f"test-uuid-1:{registered_type}:{registered_path}:GET": {
+            "endpoint_id": "test-uuid-1",
+            "path": registered_path,
+            "type": registered_type,
+            "methods": ["GET"],
+            "auth": False,
+        },
+    }
+    valid_token = UserAPIKeyAuth(
+        user_id="test_user",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        allowed_routes=["llm_api_routes"],
+    )
+
+    def builtin_config_update(): ...
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [],
+            "method": "GET",
+            "query_string": b"",
+            "endpoint": builtin_config_update,
+        }
+    )
+
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints._registered_pass_through_routes",
+            mock_registered_routes,
+        ),
+        patch(
+            "litellm.proxy.utils.get_server_root_path",
+            return_value="/",
+        ),
+    ):
+        assert (
+            RouteChecks.is_virtual_key_allowed_to_call_route(
+                route="/config/update",
+                valid_token=valid_token,
+                request=request,
+            )
+            is True
+        )
+        with pytest.raises(Exception, match="Only proxy admin"):
+            RouteChecks.non_proxy_admin_allowed_routes_check(
+                user_obj=None,
+                _user_role=LitellmUserRoles.INTERNAL_USER.value,
+                route="/config/update",
+                request=request,
+                valid_token=valid_token,
+                request_data={},
+            )
 
 
 def test_virtual_key_without_llm_api_routes_cannot_access_pass_through():

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -1176,6 +1176,62 @@ def test_non_proxy_admin_allows_auth_pass_through_with_team_allowlist():
         )
 
 
+@pytest.mark.parametrize(
+    "route,registered_type",
+    [
+        ("/myprefix", "exact"),
+        ("/myprefix/models", "subpath"),
+    ],
+)
+def test_non_proxy_admin_allows_non_auth_pass_through_with_llm_api_routes(
+    route, registered_type
+):
+    mock_registered_routes = {
+        f"test-uuid-1:{registered_type}:/myprefix:GET": {
+            "endpoint_id": "test-uuid-1",
+            "path": "/myprefix",
+            "type": registered_type,
+            "methods": ["GET"],
+            "auth": False,
+        },
+    }
+    valid_token = UserAPIKeyAuth(
+        user_id="test_user",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        allowed_routes=["llm_api_routes"],
+    )
+    request = MagicMock(spec=Request)
+    request.method = "GET"
+    request.query_params = {}
+
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints._registered_pass_through_routes",
+            mock_registered_routes,
+        ),
+        patch(
+            "litellm.proxy.utils.get_server_root_path",
+            return_value="/",
+        ),
+    ):
+        assert (
+            RouteChecks.is_virtual_key_allowed_to_call_route(
+                route=route,
+                valid_token=valid_token,
+                request=request,
+            )
+            is True
+        )
+        RouteChecks.non_proxy_admin_allowed_routes_check(
+            user_obj=None,
+            _user_role=LitellmUserRoles.INTERNAL_USER.value,
+            route=route,
+            request=request,
+            valid_token=valid_token,
+            request_data={},
+        )
+
+
 def test_virtual_key_without_llm_api_routes_cannot_access_pass_through():
     """
     Test that virtual keys without llm_api_routes permission cannot access registered pass-through endpoints.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Public pass-through routes fail a second non-admin RBAC check.
- Valid virtual keys receive a misleading proxy-admin error.

How it solves it:

- Recognizes method-matched `auth: false` pass-through routes as public.
- Covers exact and subpath registrations with regression tests.

## User Flow

Before: a developer cannot call a public pass-through with a scoped virtual key

1. The proxy admin configures `GET /myprefix` with `auth: false` and subpaths enabled.
2. The developer gets a non-admin key with `allowed_routes: ["llm_api_routes"]`.
3. They send `GET https://litellm-domain/myprefix/models` with that key.
4. They receive a 401 claiming the route requires the proxy admin.

After: the same scoped key reaches the configured public pass-through

1. The proxy admin configures `GET /myprefix` with `auth: false` and subpaths enabled.
2. The developer gets a non-admin key with `allowed_routes: ["llm_api_routes"]`.
3. They send `GET https://litellm-domain/myprefix/models` with that key.
4. The request reaches the configured upstream instead of failing RBAC.

## Relevant issues

Fixes #36508

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

No live-proxy proof was captured in this environment. The regression was reproduced against `b0fac57` with both exact and subpath registrations failing the second RBAC check; the same two cases pass after this change. This is unit-test evidence, not an end-to-end proxy run.

## Type

Bug Fix

## Caveats (if any)

- Live proxy and upstream integration were not exercised locally.

## QA runbook

- `tests/test_litellm/proxy/auth/test_route_checks.py::test_non_proxy_admin_allows_non_auth_pass_through_with_llm_api_routes` - a scoped non-admin key reaches exact and subpath public pass-through routes
  - [ ] Configure a `GET /myprefix` pass-through with `auth: false` and `include_subpath: true`
  - [ ] Generate a non-admin key with `allowed_routes: ["llm_api_routes"]`
  - [ ] Send `GET /myprefix` and `GET /myprefix/models` with that key
  - [ ] Expect both requests to reach the configured upstream rather than return the proxy-admin 401
  - [ ] Sanity check that an `auth: true` route without `allowed_passthrough_routes` still returns 403

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
