### PR TITLE
fix(langfuse): record rerank output in OTEL spans

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -169,6 +169,13 @@ class LangfuseOtelLogger(OpenTelemetry):
                         safe_dumps(output_data),
                     )
 
+        results: Final = response_obj.get("results", [])
+        if results:
+            safe_set_attribute(
+                span,
+                LangfuseSpanAttributes.OBSERVATION_OUTPUT.value,
+                safe_dumps(results),
+            )
         output: Final = response_obj.get("output", [])
         if output:
             output_items_data: Final[list[dict]] = []

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -291,6 +291,33 @@ class TestLangfuseOtelIntegration:
                 actual == expect_output
             ), "Mismatch in observation input/output OTEL attributes."
 
+    def test_set_langfuse_specific_attributes_with_rerank_results(self):
+        from litellm.types.integrations.langfuse_otel import LangfuseSpanAttributes
+        from litellm.types.rerank import RerankResponse
+
+        response_obj = RerankResponse(
+            id="rerank-test",
+            results=[
+                {"index": 2, "relevance_score": 0.98},
+                {"index": 0, "relevance_score": 0.41},
+            ],
+        )
+
+        with patch(
+            "litellm.integrations.arize._utils.safe_set_attribute"
+        ) as mock_safe_set_attribute:
+            LangfuseOtelLogger._set_langfuse_specific_attributes(
+                MagicMock(), {}, response_obj
+            )
+
+        output_calls = [
+            call
+            for call in mock_safe_set_attribute.call_args_list
+            if call.args[1] == LangfuseSpanAttributes.OBSERVATION_OUTPUT.value
+        ]
+        assert len(output_calls) == 1
+        assert json.loads(output_calls[0].args[2]) == response_obj.results
+
     def test_set_langfuse_specific_attributes_with_tool_calls(self):
         """Test that _set_langfuse_specific_attributes correctly sets observation.output with tool calls in Langfuse format."""
         from litellm.types.integrations.langfuse_otel import LangfuseSpanAttributes


### PR DESCRIPTION
## TLDR

Problem this solves:

- Langfuse OTEL rerank observations have empty output

How it solves it:

- Serialize rerank results into the observation output attribute
- Add focused coverage for the complete ranking payload

## User Flow

Before: a developer traces rerank requests through Langfuse OTEL but cannot inspect the returned ranking

1. The proxy admin enables the `langfuse_otel` success callback
2. The developer sends POST https://litellm-domain/v1/rerank with a query and documents
3. They open the request in Langfuse and see Input populated but Output empty

After: the same rerank trace includes the ranking result in Langfuse

1. The proxy admin enables the `langfuse_otel` success callback
2. The developer sends POST https://litellm-domain/v1/rerank with a query and documents
3. They open the request in Langfuse and see each result index and relevance score in Output

## Relevant issues

Fixes #36537

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proof was not captured because it requires a configured rerank provider and Langfuse OTEL destination. The issue contains the complete live reproduction steps for commit `7c71f57`

## Type

Bug Fix

Test

## Caveats (if any)

- Live Langfuse verification still requires provider credentials

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
