### PR TITLE
feat(ui) add option to allow test admins to create models for that team

### DIFF
--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -202,6 +202,11 @@ class UISettings(BaseModel):
         description="If true, internal users cannot add models from the UI",
     )
 
+    allow_model_add_for_team_admins: bool = Field(
+        default=False,
+        description="If true, team admins can add models (scoped to their team) from the UI, even when disable_model_add_for_internal_users is true.",
+    )
+
     disable_team_admin_delete_team_user: bool = Field(
         default=False,
         description="Prevents Team Admins from deleting users from the teams they manage. Useful for SCIM provisioning where team membership is defined externally.",
@@ -292,6 +297,7 @@ class UISettingsResponse(SettingsResponse):
 # Allowlist of UI settings that can be stored
 ALLOWED_UI_SETTINGS_FIELDS: Final = {
     "disable_model_add_for_internal_users",
+    "allow_model_add_for_team_admins",
     "disable_team_admin_delete_team_user",
     "enabled_ui_pages_internal_users",
     "require_auth_for_public_ai_hub",

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -1403,6 +1403,57 @@ class TestProxySettingEndpoints:
         stored_settings = json.loads(create_data["ui_settings"])
         assert stored_settings["disable_model_add_for_internal_users"] is True
 
+    def test_update_ui_settings_allow_model_add_for_team_admins(self, mock_auth, monkeypatch):
+        """allow_model_add_for_team_admins is allowlisted and round-trips through GET"""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+        mock_user_auth = UserAPIKeyAuth(
+            user_id="test-user-123",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+        app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_uisettings.upsert = AsyncMock()
+        mock_prisma.db.litellm_uisettings.find_unique = AsyncMock(return_value=None)
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+        payload = {
+            "disable_model_add_for_internal_users": True,
+            "allow_model_add_for_team_admins": True,
+        }
+
+        try:
+            response = client.patch("/update/ui_settings", json=payload)
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["settings"]["allow_model_add_for_team_admins"] is True
+
+        call_args = mock_prisma.db.litellm_uisettings.upsert.call_args
+        stored_settings = json.loads(call_args.kwargs["data"]["create"]["ui_settings"])
+        assert stored_settings["allow_model_add_for_team_admins"] is True
+
+        mock_prisma.db.litellm_uisettings.find_unique = AsyncMock(
+            return_value=MagicMock(ui_settings=stored_settings)
+        )
+        app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+        try:
+            get_response = client.get("/get/ui_settings")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert get_response.status_code == 200
+        get_data = get_response.json()
+        assert "allow_model_add_for_team_admins" in get_data["field_schema"]["properties"]
+        assert get_data["values"]["allow_model_add_for_team_admins"] is True
+
     def test_update_ui_settings_ignores_non_allowlisted_value(
         self, mock_auth, monkeypatch
     ):

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.tsx
@@ -91,6 +91,7 @@ export default function ModelsAndEndpointsPage() {
       teams: teams ?? null,
       disabledForInternalUsers:
         isInternalUser === true && uiSettings?.values?.disable_model_add_for_internal_users === true,
+      allowTeamAdmins: uiSettings?.values?.allow_model_add_for_team_admins === true,
     },
   );
   const isAdmin = all_admin_roles.includes(userRole);

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/panels/AutoRoutersTabPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/panels/AutoRoutersTabPanel.tsx
@@ -25,6 +25,7 @@ export default function AutoRoutersTabPanel() {
     {
       teams: teams ?? null,
       disabledForInternalUsers: isInternalUser && uiSettings?.values?.disable_model_add_for_internal_users === true,
+      allowTeamAdmins: uiSettings?.values?.allow_model_add_for_team_admins === true,
     },
   );
 

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.test.tsx
@@ -35,6 +35,9 @@ const buildSettingsResponse = (overrides?: Partial<Record<string, unknown>>) => 
         disable_model_add_for_internal_users: {
           description: "Disable model add for internal users",
         },
+        allow_model_add_for_team_admins: {
+          description: "Allow model add for team admins",
+        },
         disable_team_admin_delete_team_user: {
           description: "Disable team admin delete team user",
         },
@@ -45,6 +48,7 @@ const buildSettingsResponse = (overrides?: Partial<Record<string, unknown>>) => 
     },
     values: {
       disable_model_add_for_internal_users: false,
+      allow_model_add_for_team_admins: false,
       disable_team_admin_delete_team_user: false,
       require_auth_for_public_ai_hub: false,
     },
@@ -72,6 +76,7 @@ describe("UISettings", () => {
 
     expect(screen.getByText("UI Settings")).toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "Disable model add for internal users" })).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Allow model add for team admins" })).toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "Disable team admin delete team user" })).toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "Require authentication for public AI Hub" })).toBeInTheDocument();
   });
@@ -132,6 +137,75 @@ describe("UISettings", () => {
       }),
     );
     expect(NotificationManager.success).toHaveBeenCalledWith("UI settings updated successfully");
+  });
+
+  it("should toggle allow model add for team admins setting and call update", () => {
+    const mutateMock = vi.fn((_settings, options) => {
+      options?.onSuccess?.();
+    });
+
+    mockUseUpdateUISettings.mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+      error: null,
+    });
+    mockUseUISettings.mockReturnValue(
+      buildSettingsResponse({
+        data: {
+          field_schema: buildSettingsResponse().data.field_schema,
+          values: {
+            ...buildSettingsResponse().data.values,
+            disable_model_add_for_internal_users: true,
+          },
+        },
+      }),
+    );
+
+    render(<UISettings />);
+
+    const toggle = screen.getByRole("switch", { name: "Allow model add for team admins" });
+
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      { allow_model_add_for_team_admins: true },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+    expect(NotificationManager.success).toHaveBeenCalledWith("UI settings updated successfully");
+  });
+
+  // The exemption only matters once the kill switch is on, so the control stays disabled until then.
+  it("should disable the team-admin exemption toggle until the kill switch is on", () => {
+    render(<UISettings />);
+
+    const toggle = screen.getByRole("switch", { name: "Allow model add for team admins" });
+
+    expect(toggle).toBeDisabled();
+  });
+
+  it("should enable the team-admin exemption toggle once the kill switch is on", () => {
+    mockUseUISettings.mockReturnValue(
+      buildSettingsResponse({
+        data: {
+          field_schema: buildSettingsResponse().data.field_schema,
+          values: {
+            ...buildSettingsResponse().data.values,
+            disable_model_add_for_internal_users: true,
+          },
+        },
+      }),
+    );
+
+    render(<UISettings />);
+
+    const toggle = screen.getByRole("switch", { name: "Allow model add for team admins" });
+
+    expect(toggle).not.toBeDisabled();
   });
 
   it("should toggle require auth for public AI Hub setting and call update", () => {

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.tsx
@@ -14,6 +14,7 @@ export default function UISettings() {
 
   const schema = data?.field_schema;
   const property = schema?.properties?.disable_model_add_for_internal_users;
+  const allowModelAddTeamAdminsProperty = schema?.properties?.allow_model_add_for_team_admins;
   const disableTeamAdminDeleteProperty = schema?.properties?.disable_team_admin_delete_team_user;
   const requireAuthForPublicAIHubProperty = schema?.properties?.require_auth_for_public_ai_hub;
   const forwardClientHeadersProperty = schema?.properties?.forward_client_headers_to_llm_api;
@@ -36,6 +37,20 @@ export default function UISettings() {
   const handleToggle = (checked: boolean) => {
     updateSettings(
       { disable_model_add_for_internal_users: checked },
+      {
+        onSuccess: () => {
+          NotificationManager.success("UI settings updated successfully");
+        },
+        onError: (error) => {
+          NotificationManager.fromBackend(error);
+        },
+      },
+    );
+  };
+
+  const handleToggleAllowModelAddTeamAdmins = (checked: boolean) => {
+    updateSettings(
+      { allow_model_add_for_team_admins: checked },
       {
         onSuccess: () => {
           NotificationManager.success("UI settings updated successfully");
@@ -263,6 +278,24 @@ export default function UISettings() {
             <Space direction="vertical" size={4}>
               <Typography.Text strong>Disable model add for internal users</Typography.Text>
               {property?.description && <Typography.Text type="secondary">{property.description}</Typography.Text>}
+            </Space>
+          </Space>
+
+          <Space align="start" size="middle" style={{ marginLeft: 32 }}>
+            <Switch
+              checked={Boolean(values.allow_model_add_for_team_admins)}
+              disabled={isUpdating || !isDisabledForInternalUsers}
+              loading={isUpdating}
+              onChange={handleToggleAllowModelAddTeamAdmins}
+              aria-label={allowModelAddTeamAdminsProperty?.description ?? "Allow model add for team admins"}
+            />
+            <Space direction="vertical" size={4}>
+              <Typography.Text strong type={!isDisabledForInternalUsers ? "secondary" : undefined}>
+                Allow model add for team admins
+              </Typography.Text>
+              {allowModelAddTeamAdminsProperty?.description && (
+                <Typography.Text type="secondary">{allowModelAddTeamAdminsProperty.description}</Typography.Text>
+              )}
             </Space>
           </Space>
 

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
@@ -2,7 +2,7 @@ import { renderHook, screen, waitFor, renderWithProviders } from "../../../tests
 import userEvent from "@testing-library/user-event";
 import { Form } from "antd";
 import type { UploadProps } from "antd/es/upload";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Team } from "../key_team_helpers/key_list";
 import type { CredentialItem } from "../networking";
 import { Providers } from "../provider_info_helpers";
@@ -65,25 +65,28 @@ vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: vi.fn(),
 }));
 
+const mockUseInfiniteTeams = vi.hoisted(() => vi.fn());
 vi.mock("@/app/(dashboard)/hooks/teams/useTeams", () => ({
-  useInfiniteTeams: () => ({
-    data: {
-      pages: [
-        {
-          teams: [{ team_id: "team-1", team_alias: "Test Team", organization_id: "org-1" }],
-          total: 1,
-          page: 1,
-          page_size: 20,
-          total_pages: 1,
-        },
-      ],
-    },
-    fetchNextPage: vi.fn(),
-    hasNextPage: false,
-    isFetchingNextPage: false,
-    isLoading: false,
-  }),
+  useInfiniteTeams: mockUseInfiniteTeams,
 }));
+
+const buildInfiniteTeamsResult = (teams: Array<Record<string, unknown>>) => ({
+  data: {
+    pages: [
+      {
+        teams,
+        total: teams.length,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      },
+    ],
+  },
+  fetchNextPage: vi.fn(),
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  isLoading: false,
+});
 
 vi.mock("@/app/(dashboard)/hooks/guardrails/useGuardrails", () => ({
   useGuardrails: vi.fn().mockReturnValue({
@@ -176,6 +179,19 @@ const createTestProps = (userRole = "proxy_admin", userId = "user-1", isTeamAdmi
 };
 
 describe("AddModelForm", () => {
+  beforeEach(() => {
+    mockUseInfiniteTeams.mockReturnValue(
+      buildInfiniteTeamsResult([
+        {
+          team_id: "team-1",
+          team_alias: "Test Team",
+          organization_id: "org-1",
+          members_with_roles: [{ user_id: "user-1", role: "admin" }],
+        },
+      ]),
+    );
+  });
+
   it("should render", async () => {
     const mockUseAuthorized = vi.mocked(await import("@/app/(dashboard)/hooks/useAuthorized"));
     mockUseAuthorized.default.mockReturnValue(mockAuthorizedUser("proxy_admin", "user-1", true));
@@ -277,6 +293,37 @@ describe("AddModelForm", () => {
     });
 
     expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+  });
+
+  it("should only list teams the team admin administers, not every team they belong to", async () => {
+    const mockUseAuthorized = vi.mocked(await import("@/app/(dashboard)/hooks/useAuthorized"));
+    mockUseAuthorized.default.mockReturnValue(mockAuthorizedUser("team_member", "user-1", true));
+    mockUseInfiniteTeams.mockReturnValue(
+      buildInfiniteTeamsResult([
+        {
+          team_id: "team-1",
+          team_alias: "Admin Team",
+          organization_id: "org-1",
+          members_with_roles: [{ user_id: "user-1", role: "admin" }],
+        },
+        {
+          team_id: "team-2",
+          team_alias: "Member-Only Team",
+          organization_id: "org-1",
+          members_with_roles: [{ user_id: "user-1", role: "user" }],
+        },
+      ]),
+    );
+
+    const props = createTestProps("team_member", "user-1", true);
+
+    renderWithProviders(<AddModelForm {...props} />);
+
+    const teamSelect = await screen.findByRole("combobox");
+    await userEvent.click(teamSelect);
+
+    expect(await screen.findByText("Admin Team")).toBeInTheDocument();
+    expect(screen.queryByText("Member-Only Team")).not.toBeInTheDocument();
   });
 
   it("should handle non-admin, non-team-admin users - should not see team selection or switch", async () => {

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -104,7 +104,10 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
   const isTeamAdmin = isUserTeamAdminForAnyTeam(teams, userId);
   // Same owner the Auto-Routers tab uses, so the two creation forms cannot disagree about
   // who has to name a team. This form is only reachable when creation is allowed at all.
-  const createScope = modelCreationScope({ userRole, userID: userId }, { teams, disabledForInternalUsers: false });
+  const createScope = modelCreationScope(
+    { userRole, userID: userId },
+    { teams, disabledForInternalUsers: false, allowTeamAdmins: false },
+  );
   const requiresTeamScope = createScope === "team-required";
 
   return (

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -137,6 +137,7 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
                   tooltip="Select the team for which you want to add this model"
                 >
                   <TeamDropdown
+                    adminOnly
                     onChange={(value) => {
                       setTeamAdminSelectedTeam(value);
                     }}

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -493,7 +493,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
               labelCol={{ span: 10 }}
               labelAlign="left"
             >
-              <TeamDropdown />
+              <TeamDropdown adminOnly />
             </Form.Item>
           )}
 

--- a/ui/litellm-dashboard/src/components/common_components/team_dropdown.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/team_dropdown.tsx
@@ -3,7 +3,9 @@ import { Select, Typography } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
 import { useDebouncedState } from "@tanstack/react-pacer/debouncer";
 import { useInfiniteTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
+import { isUserTeamAdminForSingleTeam } from "@/utils/roles";
 import { Team } from "../key_team_helpers/key_list";
 
 const { Text } = Typography;
@@ -17,6 +19,8 @@ interface TeamDropdownProps {
   /** Filter teams by organization. */
   organizationId?: string | null;
   pageSize?: number;
+  /** Only list teams the current user administers, e.g. for team-scoped model creation. */
+  adminOnly?: boolean;
 }
 
 const SCROLL_THRESHOLD = 0.8;
@@ -28,7 +32,9 @@ const TeamDropdown: React.FC<TeamDropdownProps> = ({
   disabled,
   organizationId,
   pageSize = 20,
+  adminOnly = false,
 }) => {
+  const { userId } = useAuthorized();
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useDebouncedState("", {
     wait: DEBOUNCE_WAIT_MS,
@@ -47,12 +53,13 @@ const TeamDropdown: React.FC<TeamDropdownProps> = ({
     for (const page of data.pages) {
       for (const team of page.teams) {
         if (seen.has(team.team_id)) continue;
+        if (adminOnly && !isUserTeamAdminForSingleTeam(team.members_with_roles, userId ?? "")) continue;
         seen.add(team.team_id);
         result.push(team);
       }
     }
     return result;
-  }, [data]);
+  }, [data, adminOnly, userId]);
 
   const handlePopupScroll = (e: UIEvent<HTMLDivElement>) => {
     const target = e.currentTarget;

--- a/ui/litellm-dashboard/src/utils/modelPermissions.test.ts
+++ b/ui/litellm-dashboard/src/utils/modelPermissions.test.ts
@@ -10,7 +10,7 @@ const PROXY_ADMIN = { userRole: "Admin", userID: "u-admin" };
 const TEAM_ADMIN = { userRole: "Internal User", userID: "u-team-admin" };
 const MEMBER = { userRole: "Internal User", userID: "u-member" };
 
-const noLimits = { disabledForInternalUsers: false };
+const noLimits = { disabledForInternalUsers: false, allowTeamAdmins: false };
 
 describe("modelCreationScope", () => {
   it("lets a proxy admin create without naming a team", () => {
@@ -31,9 +31,32 @@ describe("modelCreationScope", () => {
 
   // The admin setting is scoped to internal users and must never lock out a proxy admin.
   it("honours the internal-user kill switch without touching proxy admins", () => {
-    const limits = { teams: teamWhere("u-team-admin", "admin"), disabledForInternalUsers: true };
+    const limits = { teams: teamWhere("u-team-admin", "admin"), disabledForInternalUsers: true, allowTeamAdmins: false };
     expect(modelCreationScope(TEAM_ADMIN, limits)).toBe("forbidden");
     expect(modelCreationScope(PROXY_ADMIN, limits)).toBe("unscoped-ok");
+  });
+
+  // allow_model_add_for_team_admins exempts team admins from the internal-user kill switch,
+  // but leaves a plain member forbidden and never grants an unscoped create.
+  it("lets a team admin through the kill switch when the team-admin exemption is on", () => {
+    const limits = { teams: teamWhere("u-team-admin", "admin"), disabledForInternalUsers: true, allowTeamAdmins: true };
+    expect(modelCreationScope(TEAM_ADMIN, limits)).toBe("team-required");
+  });
+
+  it("still forbids a plain member when the team-admin exemption is on", () => {
+    const limits = { teams: teamWhere("u-member", "user"), disabledForInternalUsers: true, allowTeamAdmins: true };
+    expect(modelCreationScope(MEMBER, limits)).toBe("forbidden");
+  });
+
+  it("does not change a proxy admin's unscoped create when the team-admin exemption is on", () => {
+    const limits = { teams: teamWhere("u-team-admin", "admin"), disabledForInternalUsers: true, allowTeamAdmins: true };
+    expect(modelCreationScope(PROXY_ADMIN, limits)).toBe("unscoped-ok");
+  });
+
+  // With the kill switch off, the exemption is a no-op: a team admin already gets team-required.
+  it("leaves team admin access unchanged when the exemption is on but the kill switch is off", () => {
+    const limits = { teams: teamWhere("u-team-admin", "admin"), disabledForInternalUsers: false, allowTeamAdmins: true };
+    expect(modelCreationScope(TEAM_ADMIN, limits)).toBe("team-required");
   });
 
   // org_admin and Admin Viewer are in all_admin_roles but are not PROXY_ADMIN to the API, so

--- a/ui/litellm-dashboard/src/utils/modelPermissions.ts
+++ b/ui/litellm-dashboard/src/utils/modelPermissions.ts
@@ -24,6 +24,8 @@ export interface ModelCreationLimits {
   teams: Team[] | null;
   /** The admin setting that withdraws model creation from internal users. */
   disabledForInternalUsers: boolean;
+  /** The admin setting that exempts team admins from disabledForInternalUsers. */
+  allowTeamAdmins: boolean;
 }
 
 const isTeamAdminOf = (teams: Team[] | null, userID: string, teamId: string): boolean => {
@@ -38,15 +40,13 @@ const isTeamAdminOf = (teams: Team[] | null, userID: string, teamId: string): bo
  */
 export const modelCreationScope = (
   { userRole, userID }: ModelActor,
-  { teams, disabledForInternalUsers }: ModelCreationLimits,
+  { teams, disabledForInternalUsers, allowTeamAdmins }: ModelCreationLimits,
 ): ModelWriteScope => {
   if (userRole != null && isProxyAdminRole(userRole)) {
     return "unscoped-ok";
   }
-  if (disabledForInternalUsers) {
-    return "forbidden";
-  }
-  if (userID != null && isUserTeamAdminForAnyTeam(teams, userID)) {
+  const isTeamAdmin = userID != null && isUserTeamAdminForAnyTeam(teams, userID);
+  if (isTeamAdmin && (!disabledForInternalUsers || allowTeamAdmins)) {
     return "team-required";
   }
   return "forbidden";


### PR DESCRIPTION
## TLDR

Problem this solves:

- LiteLLM allows Teams to have their own models. However, in the current environment, either the system admin must create the models, or the system must be configured to allow *any* user to create models
- In our enterprise environment we don't want most users to be able to create models, but some teams should have that ability. 

How it solves it:

- Adds a new "team admins can add models" checkbox in the UI settings. 
- The model creation endpoint was already unprotected so this was just a UI change
- Scopes the add model "team" dropdown to only show teams you're an admin of

## User Flow

Before: a team admin who wishes to add a model must contact a system admin

After: 

1. Team admin goes to "models" tab
2. Team admin clicks "add model" tab
3. Team admin can now add a model within that team

## Relevant issues


## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

<img width="1040" height="419" alt="Screenshot 2026-08-11 at 11 06 58 AM" src="https://github.com/user-attachments/assets/c2c2e5ab-a412-42f2-b3d3-9d3a083c50cf" />
<img width="1451" height="742" alt="Screenshot 2026-08-11 at 11 07 48 AM" src="https://github.com/user-attachments/assets/ac3cdf7b-a02b-4979-8b07-7b5ac1529b80" />


## Type
🆕 New Feature



### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
