### PR TITLE
fix(ui): filter the team list when adding models if user only has team admin rights on some teams

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
@@ -2,7 +2,7 @@ import { renderHook, screen, waitFor, renderWithProviders } from "../../../tests
 import userEvent from "@testing-library/user-event";
 import { Form } from "antd";
 import type { UploadProps } from "antd/es/upload";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { Team } from "../key_team_helpers/key_list";
 import type { CredentialItem } from "../networking";
 import { Providers } from "../provider_info_helpers";
@@ -65,25 +65,28 @@ vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: vi.fn(),
 }));
 
+const mockUseInfiniteTeams = vi.hoisted(() => vi.fn());
 vi.mock("@/app/(dashboard)/hooks/teams/useTeams", () => ({
-  useInfiniteTeams: () => ({
-    data: {
-      pages: [
-        {
-          teams: [{ team_id: "team-1", team_alias: "Test Team", organization_id: "org-1" }],
-          total: 1,
-          page: 1,
-          page_size: 20,
-          total_pages: 1,
-        },
-      ],
-    },
-    fetchNextPage: vi.fn(),
-    hasNextPage: false,
-    isFetchingNextPage: false,
-    isLoading: false,
-  }),
+  useInfiniteTeams: mockUseInfiniteTeams,
 }));
+
+const buildInfiniteTeamsResult = (teams: Array<Record<string, unknown>>) => ({
+  data: {
+    pages: [
+      {
+        teams,
+        total: teams.length,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      },
+    ],
+  },
+  fetchNextPage: vi.fn(),
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  isLoading: false,
+});
 
 vi.mock("@/app/(dashboard)/hooks/guardrails/useGuardrails", () => ({
   useGuardrails: vi.fn().mockReturnValue({
@@ -176,6 +179,19 @@ const createTestProps = (userRole = "proxy_admin", userId = "user-1", isTeamAdmi
 };
 
 describe("AddModelForm", () => {
+  beforeEach(() => {
+    mockUseInfiniteTeams.mockReturnValue(
+      buildInfiniteTeamsResult([
+        {
+          team_id: "team-1",
+          team_alias: "Test Team",
+          organization_id: "org-1",
+          members_with_roles: [{ user_id: "user-1", role: "admin" }],
+        },
+      ]),
+    );
+  });
+
   it("should render", async () => {
     const mockUseAuthorized = vi.mocked(await import("@/app/(dashboard)/hooks/useAuthorized"));
     mockUseAuthorized.default.mockReturnValue(mockAuthorizedUser("proxy_admin", "user-1", true));
@@ -277,6 +293,37 @@ describe("AddModelForm", () => {
     });
 
     expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+  });
+
+  it("should only list teams the team admin administers, not every team they belong to", async () => {
+    const mockUseAuthorized = vi.mocked(await import("@/app/(dashboard)/hooks/useAuthorized"));
+    mockUseAuthorized.default.mockReturnValue(mockAuthorizedUser("team_member", "user-1", true));
+    mockUseInfiniteTeams.mockReturnValue(
+      buildInfiniteTeamsResult([
+        {
+          team_id: "team-1",
+          team_alias: "Admin Team",
+          organization_id: "org-1",
+          members_with_roles: [{ user_id: "user-1", role: "admin" }],
+        },
+        {
+          team_id: "team-2",
+          team_alias: "Member-Only Team",
+          organization_id: "org-1",
+          members_with_roles: [{ user_id: "user-1", role: "user" }],
+        },
+      ]),
+    );
+
+    const props = createTestProps("team_member", "user-1", true);
+
+    renderWithProviders(<AddModelForm {...props} />);
+
+    const teamSelect = await screen.findByRole("combobox");
+    await userEvent.click(teamSelect);
+
+    expect(await screen.findByText("Admin Team")).toBeInTheDocument();
+    expect(screen.queryByText("Member-Only Team")).not.toBeInTheDocument();
   });
 
   it("should handle non-admin, non-team-admin users - should not see team selection or switch", async () => {

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
@@ -2,6 +2,7 @@ import { renderHook, screen, waitFor, renderWithProviders } from "../../../tests
 import userEvent from "@testing-library/user-event";
 import { Form } from "antd";
 import type { UploadProps } from "antd/es/upload";
+import { useState } from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { Team } from "../key_team_helpers/key_list";
 import type { CredentialItem } from "../networking";
@@ -314,6 +315,52 @@ describe("AddModelForm", () => {
         },
       ]),
     );
+
+    const props = createTestProps("team_member", "user-1", true);
+
+    renderWithProviders(<AddModelForm {...props} />);
+
+    const teamSelect = await screen.findByRole("combobox");
+    await userEvent.click(teamSelect);
+
+    expect(await screen.findByText("Admin Team")).toBeInTheDocument();
+    expect(screen.queryByText("Member-Only Team")).not.toBeInTheDocument();
+  });
+
+  // Regression: the filter runs client-side over whatever page already loaded. A first page of
+  // entirely non-admin teams used to render an empty, unscrollable "No teams found" popup with no
+  // way to reach the next page, hiding an admin team that existed one page later.
+  it("should page past a leading page of non-admin teams to reach the admin team", async () => {
+    const mockUseAuthorized = vi.mocked(await import("@/app/(dashboard)/hooks/useAuthorized"));
+    mockUseAuthorized.default.mockReturnValue(mockAuthorizedUser("team_member", "user-1", true));
+
+    const PAGE_ONE = buildInfiniteTeamsResult([
+      {
+        team_id: "team-2",
+        team_alias: "Member-Only Team",
+        organization_id: "org-1",
+        members_with_roles: [{ user_id: "user-1", role: "user" }],
+      },
+    ]).data.pages[0];
+    const PAGE_TWO = buildInfiniteTeamsResult([
+      {
+        team_id: "team-1",
+        team_alias: "Admin Team",
+        organization_id: "org-1",
+        members_with_roles: [{ user_id: "user-1", role: "admin" }],
+      },
+    ]).data.pages[0];
+
+    mockUseInfiniteTeams.mockImplementation(() => {
+      const [pages, setPages] = useState([PAGE_ONE]);
+      return {
+        data: { pages },
+        fetchNextPage: () => setPages((prev) => (prev.length < 2 ? [...prev, PAGE_TWO] : prev)),
+        hasNextPage: pages.length < 2,
+        isFetchingNextPage: false,
+        isLoading: false,
+      };
+    });
 
     const props = createTestProps("team_member", "user-1", true);
 

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -134,6 +134,7 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
                   tooltip="Select the team for which you want to add this model"
                 >
                   <TeamDropdown
+                    adminOnly
                     onChange={(value) => {
                       setTeamAdminSelectedTeam(value);
                     }}

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -493,7 +493,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
               labelCol={{ span: 10 }}
               labelAlign="left"
             >
-              <TeamDropdown />
+              <TeamDropdown adminOnly />
             </Form.Item>
           )}
 

--- a/ui/litellm-dashboard/src/components/common_components/team_dropdown.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/team_dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, type UIEvent } from "react";
+import React, { useEffect, useMemo, useState, type UIEvent } from "react";
 import { Select, Typography } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
 import { useDebouncedState } from "@tanstack/react-pacer/debouncer";
@@ -61,6 +61,17 @@ const TeamDropdown: React.FC<TeamDropdownProps> = ({
     return result;
   }, [data, adminOnly, userId]);
 
+  // adminOnly filters client-side, so a page of entirely non-admin teams renders an empty,
+  // unscrollable popup that can never reach the next page through onPopupScroll. Keep paging
+  // automatically until a match turns up or there is nothing left to fetch.
+  useEffect(() => {
+    const foundNothingYet = teams.length === 0 && hasNextPage;
+    const idle = !isFetchingNextPage && !isLoading;
+    if (adminOnly && foundNothingYet && idle) {
+      fetchNextPage();
+    }
+  }, [adminOnly, teams.length, hasNextPage, isFetchingNextPage, isLoading, fetchNextPage]);
+
   const handlePopupScroll = (e: UIEvent<HTMLDivElement>) => {
     const target = e.currentTarget;
     const scrollRatio = (target.scrollTop + target.clientHeight) / target.scrollHeight;
@@ -82,6 +93,11 @@ const TeamDropdown: React.FC<TeamDropdownProps> = ({
     }
   };
 
+  // True while a match could still turn up on a later page, so "No teams found" is deferred
+  // until every page has actually been checked instead of flashing between page fetches.
+  const foundNothingYet = teams.length === 0 && hasNextPage;
+  const stillSearchingForMatch = foundNothingYet && (isFetchingNextPage || adminOnly);
+
   return (
     <Select
       showSearch
@@ -95,7 +111,7 @@ const TeamDropdown: React.FC<TeamDropdownProps> = ({
       searchValue={searchInput}
       onPopupScroll={handlePopupScroll}
       loading={isLoading}
-      notFoundContent={isLoading ? <LoadingOutlined spin /> : "No teams found"}
+      notFoundContent={isLoading || stillSearchingForMatch ? <LoadingOutlined spin /> : "No teams found"}
       data-testid="team-dropdown"
       popupRender={(menu) => (
         <>

--- a/ui/litellm-dashboard/src/components/common_components/team_dropdown.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/team_dropdown.tsx
@@ -3,7 +3,9 @@ import { Select, Typography } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
 import { useDebouncedState } from "@tanstack/react-pacer/debouncer";
 import { useInfiniteTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
+import { isUserTeamAdminForSingleTeam } from "@/utils/roles";
 import { Team } from "../key_team_helpers/key_list";
 
 const { Text } = Typography;
@@ -17,6 +19,8 @@ interface TeamDropdownProps {
   /** Filter teams by organization. */
   organizationId?: string | null;
   pageSize?: number;
+  /** Only list teams the current user administers, e.g. for team-scoped model creation. */
+  adminOnly?: boolean;
 }
 
 const SCROLL_THRESHOLD = 0.8;
@@ -28,7 +32,9 @@ const TeamDropdown: React.FC<TeamDropdownProps> = ({
   disabled,
   organizationId,
   pageSize = 20,
+  adminOnly = false,
 }) => {
+  const { userId } = useAuthorized();
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useDebouncedState("", {
     wait: DEBOUNCE_WAIT_MS,
@@ -47,12 +53,13 @@ const TeamDropdown: React.FC<TeamDropdownProps> = ({
     for (const page of data.pages) {
       for (const team of page.teams) {
         if (seen.has(team.team_id)) continue;
+        if (adminOnly && !isUserTeamAdminForSingleTeam(team.members_with_roles, userId ?? "")) continue;
         seen.add(team.team_id);
         result.push(team);
       }
     }
     return result;
-  }, [data]);
+  }, [data, adminOnly, userId]);
 
   const handlePopupScroll = (e: UIEvent<HTMLDivElement>) => {
     const target = e.currentTarget;


### PR DESCRIPTION
## TLDR

When "disable_model_add_for_internal_users" is false, team admins can create models in teams they have admin power over. But right now, the UI shows all of their teams. If they actually try to add a model in these teams, it'll throw a 403. 
Problem this solves:

- 403 error when adding a model to a team you're not an admin of

How it solves it:

- New "adminOnly" flag on team selector
- check for user admin status when populating team selector

## User Flow
Before: 

1. Team Admin goes to "add model" tab and selects a team they aren't admin of
2. Person enters all of the necessary info for the model
3. Person hits save - 403 error

After: 

1. Team Admin goes to the "add model" tab and only sees teams they're admins of
2. Successfully adds model


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)


## Screenshots / Proof of Fix

Before:
<img width="412" height="241" alt="Screenshot 2026-08-11 at 12 20 28 PM" src="https://github.com/user-attachments/assets/6809cdb3-2002-403d-b714-7ea48c1be5f7" />
<img width="1444" height="775" alt="Screenshot 2026-08-11 at 12 20 18 PM" src="https://github.com/user-attachments/assets/fc52bbc1-0b69-4fd9-a7a5-a3d932295f9b" />


After:
<img width="1406" height="744" alt="Screenshot 2026-08-11 at 12 18 39 PM" src="https://github.com/user-attachments/assets/dcab5dbd-9323-4e8b-b145-307d80815f75" />



## Type

🐛 Bug Fix


### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
