### PR TITLE
fix(proxy): apply DB max budget overrides on reload

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1556,6 +1556,7 @@ LITELLM_SETTINGS_SAFE_DB_OVERRIDES: Final = [
     "cost_discount_config",
     "cost_margin_config",
     "budget_exceeded_throttle_percentage",
+    "max_budget",
     # Every field editable from the Admin UI (proxy_server._GENERAL_SETTINGS_UI_LITELLM_FIELDS)
     # must be listed here so a DB write from one worker overrides the live litellm attribute on
     # the others when config reloads; otherwise peer workers stay on their startup value.

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6241,8 +6241,8 @@ class ProxyConfig:
             return current_config
         elif param_name == "litellm_settings" and isinstance(db_param_value, dict):
             for key, value in db_param_value.items():
-                if key in LITELLM_SETTINGS_SAFE_DB_OVERRIDES:  # params that are safe to override with db values
-                    setattr(litellm, key, value)
+                if key in LITELLM_SETTINGS_SAFE_DB_OVERRIDES and (key != "max_budget" or value is not None):
+                    setattr(litellm, key, float(value) if key == "max_budget" else value)
 
         # If param doesn't exist in config, add it
         if param_name not in current_config:

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9847,6 +9847,24 @@ def test_prompt_caching_settings_propagate_on_config_reload(monkeypatch, field_n
     assert getattr(litellm, field_name) == db_value
 
 
+@pytest.mark.parametrize(
+    "db_value, expected_value",
+    [(10.0, 10.0), ("10.0", 10.0), (None, 0.00001)],
+)
+def test_max_budget_propagates_on_config_reload(monkeypatch, db_value, expected_value):
+    import litellm.proxy.proxy_server as ps
+
+    monkeypatch.setattr(litellm, "max_budget", 0.00001)
+
+    ps.ProxyConfig()._update_config_fields(
+        current_config={"litellm_settings": {"max_budget": 0.00001}},
+        param_name="litellm_settings",
+        db_param_value={"max_budget": db_value},
+    )
+
+    assert litellm.max_budget == expected_value
+
+
 def test_get_config_list_marks_untouched_prompt_caching_flag_as_not_set(monkeypatch):
     """The flag defaults to False rather than None, so a plain 'is not None' check would
     report the default as 'In Config' and imply an admin had set it."""


### PR DESCRIPTION
## TLDR

DB-backed `litellm_settings.max_budget` values were not applied to the live proxy runtime after a configuration reload. Workers kept enforcing the value from the YAML file.

This change adds `max_budget` to the existing safe database override path and converts the value to `float`, matching startup config loading. A null database value leaves the current runtime value unchanged.

## User Flow

Before:

1. Start the proxy with `litellm_settings.max_budget: 0.00001` and `STORE_MODEL_IN_DB=True`
2. Update the proxy configuration with `{"litellm_settings": {"max_budget": 10}}`
3. The update succeeds, but the worker continues using the old YAML budget

After:

1. Start the proxy with the same file configuration and database setting
2. Update the proxy configuration with the same request
3. The worker applies the database-backed budget as `10.0`, and global budget checks use that value

## Relevant issues

Fixes #36533

## Validation

- Added regression coverage for numeric, string, and null database values
- `uv run --no-sync pytest tests/test_litellm/proxy/test_proxy_server.py -q` -> `311 passed, 24 warnings`
- Focused reload tests -> `6 passed`
- Ruff, formatting, strict-rule, and type-discipline checks passed

The repository's `make lint` target could not reach the lint stage in this checkout because its Prisma generation step invokes a broken Homebrew Node installation. Node could not load `libllhttp.9.3.dylib`. The corresponding CI check is still running.

## Type

Bug Fix

## Scope

The change is limited to the runtime database override allowlist, numeric conversion for `max_budget`, and its regression test.
