### PR TITLE
fix(utils): register_model with an empty payload silently turns unknown-model cost errors into $0.0

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3119,12 +3119,19 @@ def register_model(
                 existing_model.pop(_cost_field, None)
         ## override / add new keys to the existing model cost dictionary
         updated_dictionary = _update_dictionary(existing_model, value)
-        litellm.model_cost.setdefault(model_cost_key, {}).update(updated_dictionary)
+        # An empty payload for a model with no built-in entry carries no
+        # information — do not materialize a bare key for it. Key existence is
+        # what cost lookup treats as "mapped", so an empty entry flips
+        # ``completion_cost`` for an unmapped model from a loud "model isn't
+        # mapped" error to a silent $0.0 (``Router.__init__`` registers every
+        # deployment's backend key this way when no pricing is configured).
+        if updated_dictionary:
+            litellm.model_cost.setdefault(model_cost_key, {}).update(updated_dictionary)
 
-        # Invalidate case-insensitive lookup map since model_cost was modified
-        _invalidate_model_cost_lowercase_map()
+            # Invalidate case-insensitive lookup map since model_cost was modified
+            _invalidate_model_cost_lowercase_map()
 
-        verbose_logger.debug("added/updated model=%s in litellm.model_cost: %s", model_cost_key, model_cost_key)
+            verbose_logger.debug("added/updated model=%s in litellm.model_cost: %s", model_cost_key, model_cost_key)
         # add new model names to provider lists
         if value.get("litellm_provider") == "openai":
             if key not in litellm.open_ai_chat_completion_models:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3119,12 +3119,6 @@ def register_model(
                 existing_model.pop(_cost_field, None)
         ## override / add new keys to the existing model cost dictionary
         updated_dictionary = _update_dictionary(existing_model, value)
-        # An empty payload for a model with no built-in entry carries no
-        # information — do not materialize a bare key for it. Key existence is
-        # what cost lookup treats as "mapped", so an empty entry flips
-        # ``completion_cost`` for an unmapped model from a loud "model isn't
-        # mapped" error to a silent $0.0 (``Router.__init__`` registers every
-        # deployment's backend key this way when no pricing is configured).
         if updated_dictionary:
             litellm.model_cost.setdefault(model_cost_key, {}).update(updated_dictionary)
 

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1,6 +1,9 @@
 
 import json
+import os
+import sys
 from pathlib import Path
+from typing import Final
 
 import pytest
 
@@ -1072,10 +1075,11 @@ def test_tiered_pricing_only_deployment_selects_router_model_id():
     entry = litellm.model_cost[router_model_id]
     assert entry.get("input_cost_per_token") is None
     assert entry.get("tiered_pricing") is not None
-    # The stripped shared alias must not carry tiered pricing.
-    assert (
-        litellm.model_cost["dashscope/qwen-tier-only-test"].get("tiered_pricing") is None
-    )
+    # The stripped shared alias must not carry tiered pricing. After
+    # stripping, this deployment contributes nothing to the shared key, so
+    # ``register_model`` may not have materialized it at all.
+    shared_alias_entry: Final = litellm.model_cost.get("dashscope/qwen-tier-only-test")
+    assert shared_alias_entry is None or shared_alias_entry.get("tiered_pricing") is None
 
     selected = _select_model_name_for_cost_calc(
         model="dashscope/qwen-tier-only-test",

--- a/tests/test_litellm/test_register_model_custom_pricing.py
+++ b/tests/test_litellm/test_register_model_custom_pricing.py
@@ -11,6 +11,8 @@ calculations for DB-sourced models with prompt caching pricing.
 
 import copy
 import os
+import sys
+from typing import Final
 
 import pytest
 
@@ -993,3 +995,72 @@ def test_completion_cost_applies_off_peak_only_deployment_pricing():
     finally:
         _restore_model_cost_entries(original_entries)
         del router
+
+
+def test_register_model_empty_payload_does_not_materialize_entry():
+    """An empty payload for a model with no built-in entry carries no
+    information, and ``register_model`` must not create a bare key for it in
+    ``litellm.model_cost``. Key existence is what cost lookup treats as
+    "mapped", so an empty entry flips ``completion_cost`` for an unmapped
+    model from a loud "model isn't mapped" error to a silent $0.0.
+    """
+    from litellm.utils import _runtime_registered_model_cost
+
+    model_key: Final = "deepinfra/fake-unmapped-model-empty-registration"
+    assert model_key not in litellm.model_cost
+    with pytest.raises(Exception, match="isn't mapped"):
+        litellm.completion_cost(model=model_key, prompt="hi", completion="there")
+
+    try:
+        litellm.register_model({model_key: {}})  # mutable-ok: registration payload under test
+
+        assert model_key not in litellm.model_cost, (
+            "register_model materialized an empty model_cost entry for an "
+            "unmapped model registered with an empty payload"
+        )
+        with pytest.raises(Exception, match="isn't mapped"):
+            litellm.completion_cost(model=model_key, prompt="hi", completion="there")
+    finally:
+        litellm.model_cost.pop(model_key, None)
+        _runtime_registered_model_cost.pop(model_key, None)
+        _invalidate_model_cost_lowercase_map()
+
+
+def test_router_init_without_pricing_keeps_unmapped_model_cost_loud():
+    """``Router.__init__`` registers every deployment's backend key through
+    ``register_model`` (``_register_deployment_in_model_cost``, shared-backend
+    path). For a deployment whose model is not in the cost map and that
+    carries no pricing or ``model_info``, that registration used to
+    materialize an empty entry — after which ``litellm.completion_cost`` for
+    the unmapped model silently returned 0.0 process-wide instead of raising,
+    even for calls that never touch the router.
+    """
+    from litellm import Router
+
+    backend_model: Final = "deepinfra/fake-unmapped-router-model-empty-reg"
+    stripped_key: Final = backend_model.split("/", 1)[1]
+    assert backend_model not in litellm.model_cost
+
+    router: Final = Router(
+        model_list=[  # mutable-ok: Router constructor payload
+            {  # mutable-ok: deployment entry under test
+                "model_name": "my-unpriced-model",
+                "litellm_params": {"model": backend_model, "api_key": "fake-key"},  # mutable-ok: deployment params
+            }
+        ]
+    )
+
+    try:
+        assert backend_model not in litellm.model_cost, (
+            "Router.__init__ materialized an empty model_cost entry for an "
+            "unmapped deployment with no pricing"
+        )
+        with pytest.raises(Exception, match="isn't mapped"):
+            litellm.completion_cost(
+                model=backend_model, prompt="hi", completion="there"
+            )
+    finally:
+        del router
+        litellm.model_cost.pop(backend_model, None)
+        litellm.model_cost.pop(stripped_key, None)
+        _invalidate_model_cost_lowercase_map()

--- a/tests/test_litellm/test_router_model_cost_isolation.py
+++ b/tests/test_litellm/test_router_model_cost_isolation.py
@@ -1282,23 +1282,29 @@ def test_repointing_a_deployment_drops_its_previous_backend_key(monkeypatch):
         dict(litellm_utils._runtime_registered_model_cost),
     )
 
+    # ``mode`` is a cost-map schema field, so it flows through to the shared
+    # backend key. Without at least one such field the shared payload is empty
+    # and ``register_model`` (correctly) registers nothing for the backend key,
+    # which would leave this test nothing to observe.
     router = Router(
         model_list=[
             {
                 "model_name": "moving-target",
                 "litellm_params": {"model": "hosted_vllm/old-backend"},
-                "model_info": {"id": "moving-target-id"},
+                "model_info": {"id": "moving-target-id", "mode": "chat"},
             }
         ],
     )
 
     saved_model_cost = litellm.model_cost
     try:
+        assert "hosted_vllm/old-backend" in litellm.model_cost
+
         router.upsert_deployment(
             deployment=Deployment(
                 model_name="moving-target",
                 litellm_params=LiteLLM_Params(model="hosted_vllm/new-backend"),
-                model_info=ModelInfo(id="moving-target-id"),
+                model_info=ModelInfo(id="moving-target-id", mode="chat"),
             )
         )
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Unmapped models silently cost $0.00 instead of erroring
- Every Router deployment without pricing triggers it at startup
- Spend dashboards under-report, quietly, forever
- Budgets and rate limits keyed on spend never fire

How it solves it:

- Skip writing a cost-map entry when the payload is empty
- An unknown model stays unknown, so cost lookup still errors
- Models with real pricing are untouched

## User Flow

Before: a team routing to a model that isn't in the public price catalog sees every request logged at $0.00, and no error anywhere tells them why.

1. The proxy admin adds a deployment to `config.yaml` for `deepinfra/deepseek-ai/DeepSeek-V4-Flash-0731` with no pricing fields, and starts the proxy
2. A developer sends POST `https://litellm-domain/v1/chat/completions` with `"model": "my-deepseek"` and gets a normal completion back
3. They open `https://litellm-domain/ui/?page=logs` and the request is listed at **$0.00 spend**
4. They repeat this for a month; the monthly total stays $0.00 while the provider invoice shows real charges
5. A budget of $100/month set on that key never triggers, because recorded spend never rises

After: the same setup surfaces the missing price instead of inventing a zero.

1. The proxy admin adds the same deployment with no pricing fields, and starts the proxy
2. A developer sends the same POST `https://litellm-domain/v1/chat/completions` and gets the same completion back
3. `https://litellm-domain/ui/?page=logs` no longer reports a confident $0.00 for a model nobody priced — the unknown price is surfaced rather than silently recorded as free
4. The admin adds `input_cost_per_token` / `output_cost_per_token` for that deployment and restarts
5. `https://litellm-domain/ui/?page=logs` now shows real spend, and the $100/month budget enforces correctly

## Relevant issues

None filed — found while working in this code path. Reproduction below.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Captured at commit `09889e1986` (`litellm_internal_staging`).

This is a pure cost-arithmetic path — no provider call takes part in computing the cost — so the proof is a complete SDK transcript rather than a live LLM call. The proxy's spend logging sits directly on this function.

**Before the fix:**

```
>>> litellm.completion_cost(model="deepinfra/deepseek-ai/DeepSeek-V4-Flash-0731", prompt="hi", completion="there")
Exception: This model isn't mapped yet. model=deepinfra/deepseek-ai/DeepSeek-V4-Flash-0731

>>> from litellm import Router
>>> Router(model_list=[{"model_name": "my-deepseek",
...   "litellm_params": {"model": "deepinfra/deepseek-ai/DeepSeek-V4-Flash-0731", "api_key": "sk-redacted"}}])
>>> litellm.model_cost["deepinfra/deepseek-ai/DeepSeek-V4-Flash-0731"]
{}                                    # <- bare entry materialized by Router startup

>>> litellm.completion_cost(model="deepinfra/deepseek-ai/DeepSeek-V4-Flash-0731", prompt="hi", completion="there")
0.0                                   # <- silent, wrong, process-wide
```

**After the fix**, same commands:

```
>>> litellm.completion_cost(...)      # before Router
Exception: This model isn't mapped yet.

>>> Router(model_list=[...])          # same startup
>>> "deepinfra/deepseek-ai/DeepSeek-V4-Flash-0731" in litellm.model_cost
False                                 # <- nothing materialized

>>> litellm.completion_cost(...)
Exception: This model isn't mapped yet.   # <- stays loud
```

## Type

🐛 Bug Fix

## Caveats

- Metadata-only payloads (e.g. `{"mode": "chat"}`) still zero-cost; filed as #36999
- That variant needs a fix at cost synthesis, not registration

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
