### PR TITLE
ci: retry transient network fetch failures in lint workflow

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -43,9 +43,10 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          MERGE_BASE=$(gh api "repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}?per_page=1" --jq '.merge_base_commit.sha')
+          retry() { "$@" || { sleep 15; "$@"; } || { sleep 30; "$@"; }; }
+          MERGE_BASE=$(retry gh api "repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}?per_page=1" --jq '.merge_base_commit.sha')
           test -n "$MERGE_BASE"
-          git fetch --no-tags --depth=1 origin "$MERGE_BASE"
+          retry git fetch --no-tags --depth=1 origin "$MERGE_BASE"
           echo "GATE_BASE_SHA=$MERGE_BASE" >> "$GITHUB_ENV"
 
       - name: Set up Python
@@ -161,7 +162,8 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          retry() { "$@" || { sleep 15; "$@"; } || { sleep 30; "$@"; }; }
+          retry git fetch --no-tags --depth=1 origin "$BASE_SHA"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -205,7 +207,8 @@ jobs:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
         run: |
           if [ -n "$GITGUARDIAN_API_KEY" ]; then
-            git fetch --no-tags --unshallow origin
+            retry() { "$@" || { sleep 15; "$@"; } || { sleep 30; "$@"; }; }
+            retry git fetch --no-tags --unshallow origin
             uv tool run --from 'ggshield==1.48.0' ggshield secret scan repo .
           else
             echo "GITGUARDIAN_API_KEY not set, skipping ggshield scan"


### PR DESCRIPTION
## TLDR

Problem this solves:

- One runner network blip fails the whole required lint check
- The job died in 12 seconds before linting anything
- A human had to notice and press re-run by hand

How it solves it:

- Wraps each network fetch step in a 3-attempt retry
- Backs off 15 then 30 seconds, like the uv setup retries

## User Flow

Before: one runner network blip fails the required lint check before any lint runs, and the PR stays blocked until someone re-runs the job by hand

1. They push a commit to their open PR and watch https://github.com/BerriAI/litellm/pull/{number}/checks
2. The required "LiteLLM Linting / lint" check turns red after about 12 seconds
3. The check's log ends at the very first fetch with "fatal: unable to access 'https://github.com/BerriAI/litellm/': server certificate verification failed", before any lint ran
4. Their code was never the problem, but the failing required check blocks merge
5. They press "Re-run failed jobs" and wait another 7 minutes for the same commit to pass

After: the same blip is absorbed inside the job and the check goes green in one run

1. They push a commit to their open PR and watch https://github.com/BerriAI/litellm/pull/{number}/checks
2. The same fetch hits the same certificate error, and the step log shows it pausing 15 seconds and trying again
3. The retry succeeds and the run continues into the actual lint gates
4. The required "LiteLLM Linting / lint" check turns green in one run, with no manual re-run

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduction, captured at d608948eef on PR #36543: https://github.com/BerriAI/litellm/actions/runs/31518654317/job/93869992555 is the real transient failure that motivated this. The required lint job died 12 seconds in, on its first network step

```
Fetch gate base (merge-base with target branch)
  git fetch --no-tags --depth=1 origin "$MERGE_BASE"
  fatal: unable to access 'https://github.com/BerriAI/litellm/': server certificate verification failed. CAfile: none CRLfile: none
  ##[error]Process completed with exit code 128.
```

Retry semantics, captured at e9156afdd0 with the exact helper line from the workflow: a command that fails once then succeeds is absorbed, and a command that always fails still fails the step after three attempts

```
$ bash -ec '
retry() { "$@" || { sleep 15; "$@"; } || { sleep 30; "$@"; }; }
attempts=/tmp/attempts; rm -f $attempts
flaky() { echo x >> $attempts; [ $(wc -l < $attempts) -ge 2 ] && echo SUCCESS-OUTPUT; [ $(wc -l < $attempts) -ge 2 ]; }
OUT=$(retry flaky)
echo "captured: $OUT after $(wc -l < $attempts) attempts"'
captured: SUCCESS-OUTPUT after 2 attempts

$ bash -ec 'retry() { "$@" || { "$@"; } || { "$@"; }; }; retry false; echo should-not-print'; echo "exit: $?"
exit: 1
```

This PR's own required lint check ran the retry-wrapped workflow at e9156afdd0 and passed in one run: https://github.com/BerriAI/litellm/actions/runs/31523584763. The happy path is unchanged with zero added latency, since the retries only engage after a failure

## Type

🚄 Infrastructure

## Caveats (if any)

- Only this workflow's fetch steps are covered
- actions/checkout's own network calls are not retried

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
