### PR TITLE
fix(ui): stub useIsOrgAdmin in UsageTab tests so useCan needs no QueryClient

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
@@ -13,6 +13,12 @@ vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: useAuthorizedMock,
 }));
 
+// useCan reaches useOrganizations (react-query) through useIsOrgAdmin; stub the
+// org-admin leg so role gating flows through hasCapability without a QueryClient
+vi.mock("@/app/(dashboard)/hooks/useIsOrgAdmin", () => ({
+  default: () => false,
+}));
+
 vi.mock("@/components/networking", () => ({
   getToolSpend: (...args: unknown[]) => mockGetToolSpend(...args),
 }));


### PR DESCRIPTION
## TLDR

Problem this solves:

- ui-unit-tests is red on litellm_internal_staging itself
- All 18 UsageTab tests fail with "No QueryClient set"
- Every open PR inherits the red check from the base

How it solves it:

- Stub useIsOrgAdmin, the leg of useCan that needs react-query
- Role gating still runs through the real hasCapability

## User Flow

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Commit 255d65192e added useCan to UsageTab. useCan calls useIsOrgAdmin, which calls useOrganizations, a react-query hook, and the test renders UsageTab without a QueryClientProvider, so the whole suite throws before asserting anything

On origin/litellm_internal_staging (cbf85a015f):

```
npx vitest run "src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx"
# -> Tests  18 failed (18), every case: "No QueryClient set, use QueryClientProvider to set one"
```

With this fix:

```
npx vitest run "src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx"
# -> Tests  18 passed (18)
```

The stub returns false, the value a non org admin gets, so the role-varied cases the gating commit added (Admin vs Internal User on the spend-by-tool card) still exercise the real hasCapability path

## Type

✅ Test

## Caveats (if any)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
