### PR TITLE
fix(deps): ship boto3 with the base SDK so bedrock works out of the box

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ proxy = [
     "cryptography>=49.0.0,<51.0",
     "pynacl>=1.6.2,<2.0",
     "websockets>=15.0.1,<16.0",
+    "boto3>=1.43.1,<2.0",
     "azure-identity>=1.25.2,<2.0",
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.28.1,<2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "pydantic>=2.10.0,<3.0.0",
     "pydantic-settings>=2.14.1,<3.0",
     "jsonschema>=4.0.0,<5.0",
+    "boto3>=1.43.1,<2.0",
 ]
 
 [project.urls]
@@ -62,7 +63,6 @@ proxy = [
     "cryptography>=49.0.0,<51.0",
     "pynacl>=1.6.2,<2.0",
     "websockets>=15.0.1,<16.0",
-    "boto3>=1.43.1,<2.0",
     "azure-identity>=1.25.2,<2.0",
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.28.1,<2.0",

--- a/tests/base_sdk_tests/check_base_sdk_install.py
+++ b/tests/base_sdk_tests/check_base_sdk_install.py
@@ -87,13 +87,18 @@ def check_token_counter() -> str:
 
 
 def check_bedrock_credential_resolution() -> str:
+    import os
+    from unittest import mock
+
     from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 
-    credentials = BaseAWSLLM().get_credentials(
-        aws_access_key_id="AKIA-fake-base-sdk-check",
-        aws_secret_access_key="fake-secret",
-        aws_region_name="us-east-1",
-    )
+    non_aws_environ = {k: v for k, v in os.environ.items() if not k.startswith("AWS_")}
+    with mock.patch.dict(os.environ, non_aws_environ, clear=True):
+        credentials = BaseAWSLLM().get_credentials(
+            aws_access_key_id="AKIA-fake-base-sdk-check",
+            aws_secret_access_key="fake-secret",
+            aws_region_name="us-east-1",
+        )
     _require(
         credentials.access_key == "AKIA-fake-base-sdk-check",
         f"get_credentials returned access_key={credentials.access_key!r}",

--- a/tests/base_sdk_tests/check_base_sdk_install.py
+++ b/tests/base_sdk_tests/check_base_sdk_install.py
@@ -11,7 +11,7 @@ import sys
 import traceback
 from collections.abc import Callable
 
-EXTRAS_ONLY_MODULES = ("fastapi", "boto3", "uvicorn")
+EXTRAS_ONLY_MODULES = ("fastapi", "uvicorn")
 
 
 def _require(condition: bool, message: str) -> None:
@@ -86,6 +86,21 @@ def check_token_counter() -> str:
     return f"token_counter returned {count}"
 
 
+def check_bedrock_credential_resolution() -> str:
+    from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+    credentials = BaseAWSLLM().get_credentials(
+        aws_access_key_id="AKIA-fake-base-sdk-check",
+        aws_secret_access_key="fake-secret",
+        aws_region_name="us-east-1",
+    )
+    _require(
+        credentials.access_key == "AKIA-fake-base-sdk-check",
+        f"get_credentials returned access_key={credentials.access_key!r}",
+    )
+    return "bedrock credential resolution works (boto3 ships with the base SDK)"
+
+
 CHECKS: tuple[tuple[str, Callable[[], str]], ...] = (
     ("environment is base-only", check_environment_is_base_only),
     ("import litellm", check_import),
@@ -93,6 +108,7 @@ CHECKS: tuple[tuple[str, Callable[[], str]], ...] = (
     ("embedding", check_embedding),
     ("bundled model metadata", check_bundled_model_metadata),
     ("token counter", check_token_counter),
+    ("bedrock credential resolution", check_bedrock_credential_resolution),
 )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-08T19:20:17.280437Z"
+exclude-newer = "2026-08-08T19:31:43.729157Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4250,6 +4250,7 @@ proxy = [
     { name = "azure-identity" },
     { name = "azure-storage-blob" },
     { name = "backoff" },
+    { name = "boto3" },
     { name = "cryptography" },
     { name = "expression" },
     { name = "fastapi" },
@@ -4419,6 +4420,7 @@ requires-dist = [
     { name = "azure-storage-file-datalake", marker = "extra == 'proxy-runtime'", specifier = ">=12.20.0,<13.0" },
     { name = "backoff", marker = "extra == 'proxy'", specifier = ">=2.2.1,<3.0" },
     { name = "boto3", specifier = ">=1.43.1,<2.0" },
+    { name = "boto3", marker = "extra == 'proxy'", specifier = ">=1.43.1,<2.0" },
     { name = "click", specifier = ">=8.0.0,<9.0" },
     { name = "cryptography", marker = "extra == 'proxy'", specifier = ">=49.0.0,<51.0" },
     { name = "ddtrace", marker = "extra == 'proxy-runtime'", specifier = ">=4.8.2,<5.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-06T13:09:00.574651711Z"
+exclude-newer = "2026-08-08T19:20:17.280437Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4198,6 +4198,7 @@ version = "1.97.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "boto3" },
     { name = "click" },
     { name = "fastuuid" },
     { name = "httpx" },
@@ -4249,7 +4250,6 @@ proxy = [
     { name = "azure-identity" },
     { name = "azure-storage-blob" },
     { name = "backoff" },
-    { name = "boto3" },
     { name = "cryptography" },
     { name = "expression" },
     { name = "fastapi" },
@@ -4418,7 +4418,7 @@ requires-dist = [
     { name = "azure-storage-blob", marker = "extra == 'proxy'", specifier = ">=12.28.0,<13.0" },
     { name = "azure-storage-file-datalake", marker = "extra == 'proxy-runtime'", specifier = ">=12.20.0,<13.0" },
     { name = "backoff", marker = "extra == 'proxy'", specifier = ">=2.2.1,<3.0" },
-    { name = "boto3", marker = "extra == 'proxy'", specifier = ">=1.43.1,<2.0" },
+    { name = "boto3", specifier = ">=1.43.1,<2.0" },
     { name = "click", specifier = ">=8.0.0,<9.0" },
     { name = "cryptography", marker = "extra == 'proxy'", specifier = ">=49.0.0,<51.0" },
     { name = "ddtrace", marker = "extra == 'proxy-runtime'", specifier = ">=4.8.2,<5.0" },


### PR DESCRIPTION
## TLDR

fixes #36550 

Problem this solves:

- Base `pip install litellm` cannot call Bedrock at all
- Every Bedrock call needs boto3, but only `[proxy]` shipped it

How it solves it:

- Adds boto3 to core dependencies (still listed in the proxy extra)
- Base SDK smoke check now exercises Bedrock credential resolution

## User Flow

Before: a developer installs the SDK and their first Bedrock call crashes

1. They run `pip install litellm` in a fresh environment
2. They call `litellm.completion(model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0", ...)` with AWS keys set
3. The call raises `APIConnectionError: No module named 'boto3'` instead of reaching AWS
4. They search the error, find they must also run `pip install boto3`, and retry

After: the same install works on the first try

1. They run `pip install litellm` in a fresh environment
2. They call `litellm.completion(model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0", ...)` with AWS keys set
3. The model responds and `litellm.completion_cost(...)` prices the call

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (published litellm 1.96.0, base install, no extras):

```
$ uv venv /tmp/litellm-before --python 3.11
$ uv pip install --python /tmp/litellm-before/bin/python litellm
$ /tmp/litellm-before/bin/python -c 'import litellm; litellm.completion(model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0", messages=[{"role": "user", "content": "hi"}], aws_region_name="us-east-1", max_tokens=10)'
APIConnectionError: litellm.APIConnectionError: No module named 'boto3'
  File ".../litellm/llms/bedrock/base_aws_llm.py", line 1294, in _auth_with_access_key_and_secret_key
    import boto3
ModuleNotFoundError: No module named 'boto3'
```

After (this branch at 09643687d3, base install from the repo, no extras, real Bedrock call against AWS):

```
$ uv venv /tmp/litellm-base-test --python 3.11
$ uv pip install --python /tmp/litellm-base-test/bin/python .
$ /tmp/litellm-base-test/bin/python -c '
import litellm
resp = litellm.completion(
    model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
    messages=[{"role": "user", "content": "In one sentence, what is Amazon Bedrock?"}],
    aws_region_name="us-east-1",
    max_tokens=100,
)
print(resp.choices[0].message.content)
print(f"cost: ${litellm.completion_cost(completion_response=resp):.6f}")'
Amazon Bedrock is a fully managed AWS service that provides access to foundation models from various AI providers through a single API, enabling developers to build generative AI applications without managing the underlying infrastructure.
cost: $0.000251
```

The base SDK smoke check also passes in that same venv at 09643687d3 and its new bedrock check fails against 1.96.0:

```
$ /tmp/litellm-base-test/bin/python tests/base_sdk_tests/check_base_sdk_install.py
PASS  bedrock credential resolution: bedrock credential resolution works (boto3 ships with the base SDK)
all 7 checks passed

$ /tmp/litellm-before/bin/python tests/base_sdk_tests/check_base_sdk_install.py
FAIL  bedrock credential resolution: ... ModuleNotFoundError: No module named 'boto3'
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Base install grows by roughly 80MB (boto3 plus botocore)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

