### PR TITLE
bump: version 1.96.1 → 1.96.2 (1.96.1 burned by the PyPI storage failure)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.96.1"
+version = "1.96.2"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.15"
@@ -303,7 +303,7 @@ members = ["enterprise", "litellm-proxy-extras"]
 profile = "black"
 
 [tool.commitizen]
-version = "1.96.1"
+version = "1.96.2"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-08T02:01:05.094812Z"
+exclude-newer = "2026-08-08T20:21:09.567144Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4116,7 +4116,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.96.1"
+version = "1.96.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bumps `stable/1.96.x` from **1.96.1 → 1.96.2**. No code changes — version only.

## Why

The `v1.96.1` release run exhausted the PyPI project storage quota partway
through the upload, so `1.96.1` is now a permanently incomplete release:

| Surface | State |
|---|---|
| PyPI `litellm==1.96.1` | **4 of 36 files** (only `cp310` × 4 platforms, uploaded 2026-08-11 02:31–02:32Z) — no sdist, no cp311–cp314 |
| PyPI `litellm==1.96.0` (reference) | 36 files |
| DockerHub `litellm/litellm:v1.96.1` | absent (404) |
| GHCR `ghcr.io/berriai/litellm:v1.96.1` | absent |
| git tag `v1.96.1` | absent |
| branch `release/v1.96.1` | absent |

PyPI filenames are immutable — the 4 uploaded files can never be replaced. Strictly
speaking the 32 *missing* files could still be pushed under `1.96.1` (the publish
steps run `skip-existing: true`, so a re-run would fill the gaps rather than error),
but that would ship a stable version whose artifacts come from two different builds
days apart, with no guarantee the rebuilt wheels match the four already on the index.
That's not something to do to a stable release. Treating `1.96.1` as burned and
moving to `1.96.2` is the clean call.

Nothing downstream consumed `1.96.1` (no image, no tag, no release branch), so the
bump skips nothing and strands nothing.

## What's in here

Same two-commit shape as the `1.96.1` bump on this line:

- `bump: version 1.96.1 → 1.96.2` — `pyproject.toml` only (`[project].version` +
  `[tool.commitizen].version`), produced by `cz bump --increment PATCH`
- `chore: refresh uv.lock for 1.96.2` — `uv lock` run with the line's own uv pin
  (`0.11.7`, per `Dockerfile` `UV_IMAGE`)

Total diff: 4 lines across 2 files. The lock refresh moved **only** the project's
own entry (`litellm 1.96.1 → 1.96.2`) plus the rolling `exclude-newer` timestamp
— no third-party package version moved, and `revision = 3` / format fields are
unchanged. No git tag was created (tagging is `release.yml`'s job).

## Subpackages: not bumped, and that's correct

`litellm-enterprise` (0.1.53) and `litellm-proxy-extras` (0.4.81) are unchanged
on this line and are already fully published on PyPI (2 files each, from
2026-08-03 and 2026-07-29 respectively — i.e. before the failed run, not casualties
of it). The publish workflows use `skip-existing: true`, so re-publishing them at
`1.96.2` is a no-op rather than an error.

## Before re-running the release

The storage quota that killed the run is not addressed by this PR. If the PyPI
project limit is still exhausted, `1.96.2` will fail exactly the same way and burn
another version — confirm the quota has been raised before dispatching.
