### PR TITLE
chore: bump litellm-enterprise 0.1.54 -> 0.1.55, litellm-proxy-extras 0.4.84 -> 0.4.85, litellm 1.97.0 -> 1.98.0

### DIFF
--- a/enterprise/pyproject.toml
+++ b/enterprise/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-enterprise"
-version = "0.1.54"
+version = "0.1.55"
 description = "Package for LiteLLM Enterprise features"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.1.54"
+version = "0.1.55"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-enterprise==",

--- a/litellm-proxy-extras/pyproject.toml
+++ b/litellm-proxy-extras/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-proxy-extras"
-version = "0.4.84"
+version = "0.4.85"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.4.84"
+version = "0.4.85"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-proxy-extras==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.97.0"
+version = "1.98.0"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.15"
@@ -67,8 +67,8 @@ proxy = [
     "azure-identity>=1.25.2,<2.0",
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.28.1,<2.0",
-    "litellm-proxy-extras==0.4.84",
-    "litellm-enterprise==0.1.54",
+    "litellm-proxy-extras==0.4.85",
+    "litellm-enterprise==0.1.55",
     "RestrictedPython>=8.1,<9.0",
     "rich>=13.9.4,<14.0",
     "InquirerPy>=0.3.4,<1.0",
@@ -306,7 +306,7 @@ members = ["enterprise", "litellm-proxy-extras"]
 profile = "black"
 
 [tool.commitizen]
-version = "1.97.0"
+version = "1.98.0"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-08T19:31:43.729157Z"
+exclude-newer = "2026-08-08T22:14:09.01009Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4194,7 +4194,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.97.0"
+version = "1.98.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -4585,12 +4585,12 @@ proxy-dev = [
 
 [[package]]
 name = "litellm-enterprise"
-version = "0.1.54"
+version = "0.1.55"
 source = { editable = "enterprise" }
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.84"
+version = "0.4.85"
 source = { editable = "litellm-proxy-extras" }
 
 [[package]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- enterprise/ changed since main but its version did not
- litellm-proxy-extras/ changed since main but its version did not
- 1.97.0 already shipped an rc, so a new line opens

How it solves it:

- PATCH bump litellm-enterprise 0.1.54 -> 0.1.55
- PATCH bump litellm-proxy-extras 0.4.84 -> 0.4.85
- MINOR bump litellm 1.97.0 -> 1.98.0
- Refresh uv.lock against the bumped versions

## User Flow

Before: someone installing the published packages after this promotion gets contents that no longer match the version they asked for

1. They run `pip install litellm-enterprise==0.1.54` and get code built from main
2. Staging carries different enterprise code under that same 0.1.54 version
3. The same mismatch applies to `litellm-proxy-extras==0.4.84`

After: every package whose contents changed carries a version that reflects those contents

1. They run `pip install litellm-enterprise==0.1.55` and get the promoted code
2. `pip install litellm-proxy-extras==0.4.85` likewise resolves to the promoted code
3. `pip install litellm==1.98.0` pulls both of those pinned versions, opening the 1.98.0 line

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

There is no runtime behavior to demonstrate here. This PR only moves version strings and the matching lock entries, so a live proxy call would look identical before and after. The verifiable output is `uv lock`, which reported exactly the three bumped editable packages and nothing else:

```
Resolved 445 packages in 784ms
Updated litellm v1.97.0 -> v1.98.0
Updated litellm-enterprise v0.1.54 -> v0.1.55
Updated litellm-proxy-extras v0.4.84 -> v0.4.85
```

## Type

🚄 Infrastructure

## Caveats (if any)

- `uv.lock` `exclude-newer` moves with its rolling P3D window
- No third-party dependency versions moved

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
