### PR TITLE
fix(responses): preserve Bedrock Mantle validation errors

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2308,7 +2308,7 @@ def exception_type(
                     exception_provider=exception_provider,
                     extra_information=extra_information,
                 )
-            elif custom_llm_provider == "bedrock":
+            elif custom_llm_provider in ("bedrock", "bedrock_mantle"):
                 _map_bedrock_exception(
                     model=model,
                     original_exception=mappable_exception,

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -680,3 +680,26 @@ def test_azure_404_with_invalid_request_error_type_maps_to_not_found():
 
     assert excinfo.value.status_code == 404
     assert "Response with id 'resp_abc' not found." in excinfo.value.message
+
+
+def test_bedrock_mantle_400_maps_to_bad_request():
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    original_exception = BaseLLMException(
+        status_code=400,
+        message=(
+            '{"error": {"code": "validation_error", "message": '
+            "\"invalid request body: Invalid 'input': value did not match any expected variant\", "
+            '"type": "invalid_request_error"}}'
+        ),
+    )
+
+    with pytest.raises(litellm.BadRequestError) as excinfo:
+        exception_type(
+            model="gpt-5.6-terra",
+            original_exception=original_exception,
+            custom_llm_provider="bedrock_mantle",
+        )
+
+    assert excinfo.value.status_code == 400
+    assert "Invalid 'input'" in excinfo.value.message


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Mantle validation failures reach callers as status 500
- The upstream 400 response is treated like a connection failure

How it solves it:

- Routes Bedrock Mantle through the existing Bedrock status mapping
- Preserves `BadRequestError`, status 400, and the upstream message

## User Flow

Before: a Responses API caller receives the wrong error class for an invalid request

1. They send `POST https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses` with a Responses request
2. Mantle rejects the request with HTTP 400 and an `invalid_request_error` body
3. The caller receives `APIConnectionError` with status 500 and cannot distinguish validation from connectivity

After: the same invalid request is reported as a client error

1. They send `POST https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses` with the same Responses request
2. Mantle rejects the request with HTTP 400 and an `invalid_request_error` body
3. The caller receives `BadRequestError` with status 400 and the upstream validation message

## Relevant issues

Addresses the error-classification portion of #36546

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

The before run was captured against commit `bea31871fc` with a mocked HTTP 400 response. Both sync and async `litellm.responses()` paths raised `APIConnectionError` with status 500

The after run was captured against commit `f6f6044e09` with the same mocked HTTP 400 response. Both paths raised `BadRequestError` with status 400 and preserved `Invalid 'input'`

Targeted regression tests passed:

`uv run --no-sync pytest tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py -q` -> 63 passed

`uv run --no-sync pytest tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py -q` -> 116 passed

No live Bedrock credentials were available in this environment, so I did not include a live provider run

## Type

Bug Fix

## Caveats (if any)

Live Bedrock verification still needs to run with provider credentials

This PR covers the 400-to-500 error masking. Input-item normalization remains a separate concern

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

AI assistance: this patch was prepared and tested with AI coding assistance. The implementation, reproduction, and test scope are included for maintainer review
