### PR TITLE
fix(e2e): assert on the gen-AI span that served the stream, not the span count

### DIFF
--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -150,13 +150,41 @@ def _tag(span: JaegerSpan, key: str) -> str | int | float | bool | None:
 #: chunk (stamped only for streaming; added in #32236).
 TTFT_TAG = "gen_ai.response.time_to_first_chunk"
 
+#: Jaeger's rendering of a span whose OTEL status is ERROR.
+ERROR_STATUS_TAG = "otel.status_code"
+
+
+def served_genai_spans(trace: JaegerTrace, genai_span: str) -> list[JaegerSpan]:
+    """The gen-AI spans for attempts that actually served the request.
+
+    The proxy opens one gen-AI span per upstream attempt, so a call the router
+    retried carries an error span for every failed attempt beside the one that
+    answered. Only the served attempt streams chunks, so only it records TTFT
+    or a streaming flag; asserting over the raw span list makes every one of
+    these tests fail whenever the upstream 429s, 529s, or hands back a stale
+    credential on the first try."""
+    return [
+        span
+        for span in trace.spans
+        if span.operation_name == genai_span and _tag(span, ERROR_STATUS_TAG) != "ERROR"
+    ]
+
+
+def one_served_genai_span(trace: JaegerTrace, genai_span: str) -> JaegerSpan:
+    served = served_genai_spans(trace, genai_span)
+    assert len(served) == 1, (
+        f"a streamed call must produce exactly ONE served gen-AI span, got {len(served)}; "
+        f"spans: {trace.span_names()}"
+    )
+    return served[0]
+
 
 def _assert_real_ttft(hits: list[JaegerTrace], *, genai_span: str) -> None:
-    """The enforced behavior: the streamed call's single gen-AI span records a
-    TTFT that is a real measurement - present, numeric, positive, and strictly
-    less than the span's own total duration. A TTFT of zero, or one at/above
-    the full span duration, is a clock artifact rather than first-token
-    latency."""
+    """The enforced behavior: the gen-AI span for the attempt that served the
+    stream records a TTFT that is a real measurement - present, numeric,
+    positive, and strictly less than that span's own total duration. A TTFT of
+    zero, or one at/above the span duration, is a clock artifact rather than
+    first-token latency."""
     assert hits, (
         "no trace for this call arrived at the destination within the deadline "
         "(nothing tagged with its call id was found)"
@@ -166,12 +194,7 @@ def _assert_real_ttft(hits: list[JaegerTrace], *, genai_span: str) -> None:
         f"{[(t.trace_id, t.span_names()) for t in hits]}"
     )
     trace = hits[0]
-    spans = [span for span in trace.spans if span.operation_name == genai_span]
-    assert len(spans) == 1, (
-        f"a streamed call must produce exactly ONE gen-AI span, got {len(spans)}; "
-        f"spans: {trace.span_names()}"
-    )
-    span = spans[0]
+    span = one_served_genai_span(trace, genai_span)
 
     value = _tag(span, TTFT_TAG)
     assert value is not None, (
@@ -412,12 +435,8 @@ class TestOtelTraceCompleteness:
         )
         _assert_complete_trace(hits, route=route, genai_span=genai_span)
 
-        genai_spans = [span for span in hits[0].spans if span.operation_name == genai_span]
-        assert len(genai_spans) == 1, (
-            f"a streamed call must produce exactly ONE gen-AI span, got {len(genai_spans)}; "
-            f"spans: {hits[0].span_names()}"
-        )
-        assert _tag(genai_spans[0], "litellm.request.streaming") is True, (
+        served = one_served_genai_span(hits[0], genai_span)
+        assert _tag(served, "litellm.request.streaming") is True, (
             "the gen-AI span must record litellm.request.streaming=true; its absence means "
             "the stream flag was dropped before the model call"
         )
@@ -468,12 +487,8 @@ class TestOtelTraceCompleteness:
         )
         _assert_complete_trace(hits, route=route, genai_span=genai_span)
 
-        genai_spans = [span for span in hits[0].spans if span.operation_name == genai_span]
-        assert len(genai_spans) == 1, (
-            f"a streamed call must produce exactly ONE gen-AI span, got {len(genai_spans)}; "
-            f"spans: {hits[0].span_names()}"
-        )
-        assert _tag(genai_spans[0], "litellm.request.streaming") is True, (
+        served = one_served_genai_span(hits[0], genai_span)
+        assert _tag(served, "litellm.request.streaming") is True, (
             "the gen-AI span must record litellm.request.streaming=true; its absence means "
             "the stream flag was dropped before the model call"
         )
@@ -526,11 +541,7 @@ class TestOtelTraceCompleteness:
         )
         _assert_complete_trace(hits, route=route, genai_span=genai_span, require_cost_span=False)
 
-        genai_spans = [span for span in hits[0].spans if span.operation_name == genai_span]
-        assert len(genai_spans) == 1, (
-            f"a streamed call must produce exactly ONE gen-AI span, got {len(genai_spans)}; "
-            f"spans: {hits[0].span_names()}"
-        )
+        one_served_genai_span(hits[0], genai_span)
 
         spend_row = client.poll_proxy_spend_for_key(key)
         assert spend_row is not None and spend_row.spend is not None and spend_row.spend > 0, (

--- a/tests/e2e/logging/test_span_selection.py
+++ b/tests/e2e/logging/test_span_selection.py
@@ -1,0 +1,83 @@
+"""Harness coverage for the gen-AI span selection in `test_otel_trace_e2e`.
+
+Carries no `e2e` marker: this exercises the selection helper itself against
+Jaeger-shaped payloads, so it runs whether or not a proxy is up. The live
+assertions it protects are expensive to reproduce (they need an upstream that
+fails the first attempt), which is exactly why the helper is worth pinning
+here.
+"""
+
+from __future__ import annotations
+
+import pytest
+from otel_client import JaegerTrace
+from test_otel_trace_e2e import TTFT_TAG, one_served_genai_span, served_genai_spans
+
+GENAI_SPAN = "chat claude-haiku-4-5"
+
+
+def _span(name: str, *, failed: bool = False, ttft: float | None = None) -> dict[str, object]:
+    tags: list[dict[str, object]] = []
+    if failed:
+        tags.append({"key": "otel.status_code", "value": "ERROR"})
+        tags.append({"key": "error.type", "value": "AuthenticationError"})
+    if ttft is not None:
+        tags.append({"key": TTFT_TAG, "value": ttft})
+    return {"spanID": f"{name}-{len(tags)}-{failed}-{ttft}", "operationName": name, "tags": tags}
+
+
+def _trace(*spans: dict[str, object]) -> JaegerTrace:
+    return JaegerTrace.model_validate({"traceID": "t1", "spans": list(spans)})
+
+
+def test_served_span_is_the_only_one_when_nothing_was_retried() -> None:
+    trace = _trace(_span("POST /chat/completions"), _span(GENAI_SPAN, ttft=0.3))
+
+    assert [span.operation_name for span in served_genai_spans(trace, GENAI_SPAN)] == [GENAI_SPAN]
+
+
+def test_retried_attempt_span_is_excluded() -> None:
+    """The real shape from a stage trace: the first attempt 401s and records no
+    TTFT, the retry serves the stream. The served attempt is the one the TTFT
+    assertions must run against."""
+    trace = _trace(
+        _span(GENAI_SPAN, failed=True),
+        _span(GENAI_SPAN, ttft=0.52),
+    )
+
+    served = one_served_genai_span(trace, GENAI_SPAN)
+
+    assert [tag.value for tag in served.tags if tag.key == TTFT_TAG] == [0.52]
+
+
+def test_several_failed_attempts_still_leave_one_served_span() -> None:
+    trace = _trace(
+        _span(GENAI_SPAN, failed=True),
+        _span(GENAI_SPAN, failed=True),
+        _span(GENAI_SPAN, failed=True),
+        _span(GENAI_SPAN, ttft=0.1),
+    )
+
+    assert len(served_genai_spans(trace, GENAI_SPAN)) == 1
+
+
+def test_two_served_spans_still_fail() -> None:
+    """The regression the count assertion exists for: one streamed call must
+    not be logged as two served gen-AI spans."""
+    trace = _trace(_span(GENAI_SPAN, ttft=0.2), _span(GENAI_SPAN, ttft=0.4))
+
+    with pytest.raises(AssertionError, match="exactly ONE served gen-AI span, got 2"):
+        one_served_genai_span(trace, GENAI_SPAN)
+
+
+def test_all_attempts_failed_is_a_failure_not_a_pass() -> None:
+    trace = _trace(_span(GENAI_SPAN, failed=True), _span(GENAI_SPAN, failed=True))
+
+    with pytest.raises(AssertionError, match="exactly ONE served gen-AI span, got 0"):
+        one_served_genai_span(trace, GENAI_SPAN)
+
+
+def test_other_operations_are_not_counted() -> None:
+    trace = _trace(_span("chat gpt-5.5", ttft=0.3), _span(GENAI_SPAN, ttft=0.3))
+
+    assert len(served_genai_spans(trace, GENAI_SPAN)) == 1


### PR DESCRIPTION
## TLDR

Problem this solves:

- Four otel e2e tests fail whenever the router retries
- A retried call is a success, but the test calls it a failure
- Currently red in the nightly, intermittently

How it solves it:

- Assert on the attempt that served the stream
- Ignore the error span a failed attempt leaves behind
- Keep failing when one call logs two served spans

## User Flow

This PR changes only `tests/e2e`, so no end user's behavior changes. The flow below is the engineer reading the nightly e2e report.

Before: a nightly run goes red on a request the gateway served correctly, so the report says the otel integration is broken when it is not

1. The suite sends POST https://litellm-domain/v1/messages with `"stream": true` against `claude-haiku-4-5`
2. The gateway's first upstream attempt fails, it retries, and the second attempt streams the answer back with a 200
3. The suite reads the trace back from the trace store and finds two `chat claude-haiku-4-5` spans, one per attempt
4. The run fails with "a streamed call must produce exactly ONE gen-AI span, got 2", naming a request that actually succeeded

After: the same run is green, and still red for the problem these tests were written to catch

1. The suite sends the same POST https://litellm-domain/v1/messages with `"stream": true`
2. The gateway retries the same way and returns the same 200
3. The suite reads the trace back and looks at the attempt that served the stream, ignoring the failed attempt's error span
4. The run passes, and the time-to-first-token assertions run against the attempt that actually streamed chunks

## Relevant issues

## Linear ticket

Resolves LIT-5441

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs ran against the same live gateway from a pod built from the nightly's own e2e image, same four tests, same command, back to back.

**Before**, at base commit `bea31871fc` (the file straight out of `git show HEAD:...`, asserted to not contain the fix before running):

```
$ git show HEAD:tests/e2e/logging/test_otel_trace_e2e.py > base_otel_test.py
$ grep -c 'exactly ONE gen-AI span' base_otel_test.py
4
$ for i in 1 2 3; do pytest logging/test_otel_trace_e2e.py \
    -k "stream_exports_complete_trace or stream_records_real_ttft"; done

E  AssertionError: a streamed call must produce exactly ONE gen-AI span, got 2; spans:
   ['POST /v1/messages', 'auth /v1/messages', 'batch_write_to_db _PROXY_track_cost_callback',
    'chat claude-haiku-4-5', 'chat claude-haiku-4-5', 'postgres get_data', ...]
FAILED logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_messages_stream_records_real_ttft
1 failed, 5 passed, 4 deselected in 48.82s
6 passed, 4 deselected in 36.91s
6 passed, 4 deselected in 47.01s
```

That is the nightly's failure reproduced, and rounds 2 and 3 passing is the intermittency.

Reading that trace out of the trace store shows the two spans are one request, not a split trace:

```
op=chat claude-haiku-4-5  start=...176812  dur=150.0ms  status=ERROR  ttft=None
    error.type=AuthenticationError
    error.message=AnthropicException ... {"error":{"type":"authentication_error",
                  "message":"invalid x-api-key"}}
op=chat claude-haiku-4-5  start=...408760  dur=566.3ms  status=None   ttft=0.5199649333953857
    gen_ai.response.id=chatcmpl-be080786-4d5e-4b07-8d97-8af980ec6454
```

**After**, same gateway, same command, fifteen rounds: nine at `c7f9da4e5e` and six more at `c881b1426f`, which renamed two helpers so the harness type gate would accept the cross-module import and changed nothing else. The staged file is greped first so an after leg cannot silently be running the base code:

```
$ grep -c one_served_genai_span logging/test_otel_trace_e2e.py
5
$ for i in $(seq 9); do pytest logging/test_otel_trace_e2e.py \
    -k "stream_exports_complete_trace or stream_records_real_ttft"; done
6 passed, 4 deselected in 37.79s
6 passed, 4 deselected in 48.90s
6 passed, 4 deselected in 37.94s
6 passed, 4 deselected in 43.42s
6 passed, 4 deselected in 38.50s
6 passed, 4 deselected in 44.97s
6 passed, 4 deselected in 37.98s
6 passed, 4 deselected in 46.94s
6 passed, 4 deselected in 38.78s

# after the rename, at c881b1426f
6 passed, 4 deselected in 39.12s
6 passed, 4 deselected in 38.74s
6 passed, 4 deselected in 48.59s
6 passed, 4 deselected in 42.79s
6 passed, 4 deselected in 38.22s
6 passed, 4 deselected in 41.47s
```

90 passes with no failure, against a 17.5% per-call retry rate on this gateway.

**Mutation check** on the new selection logic, each mutant applied and run separately, every mutation step self-verifying that it changed the source:

```
M1: stop excluding failed attempts   -> 3 failed, 3 passed   KILLED
M2: weaken the count to at-least-one -> 1 failed, 5 passed   KILLED
M3: wrong-case error status          -> 3 failed, 3 passed   KILLED
restore                              -> 6 passed
```

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

- The retry is stochastic, so the before leg needs a few rounds
- Retries here come from broken leaked deployments, see LIT-5442
- A plain upstream 429 trips the same assertion, so this fix stands alone

## QA runbook

- tests/e2e/logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_messages_stream_records_real_ttft - a streamed /v1/messages call records a real time-to-first-token on the attempt that served it, even when an earlier attempt failed
  - [x] Point a proxy at two deployments of one model name, one with a valid provider key and one with a deliberately invalid key, and set `num_retries: 3`
  - [x] Send POST /v1/messages with `"stream": true`, repeating until the response 200s having burned an attempt on the bad deployment
  - [x] Read the trace for that call id back from the trace store and expect two `chat <model>` spans, one with `otel.status_code=ERROR` and no TTFT, one with a TTFT between 0 and its own duration
  - [x] Expect the test to pass against that trace, and to fail if the served span's TTFT is missing or exceeds the span duration
  - [x] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/logging/test_span_selection.py - the span selection itself, over trace payloads, with no proxy involved
  - [x] Run it with no proxy up and expect 6 passed, since it carries no e2e marker
  - [x] Delete the `otel.status_code` filter and expect 3 failures
  - [x] Change the survivor count from `== 1` to `>= 1` and expect test_two_served_spans_still_fail to fail
  - [x] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
