### PR TITLE
fix(otel): bound and shut down credential-scoped tracer providers

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1,5 +1,7 @@
 import os
-from collections.abc import Mapping
+import threading
+from collections import OrderedDict
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, TypedDict, cast
@@ -24,6 +26,7 @@ from litellm.litellm_core_utils.service_tier_utils import (
     get_requested_service_tier,
     get_served_service_tier,
 )
+from litellm.litellm_core_utils.thread_pool_executor import executor
 from litellm.secret_managers.main import get_secret_bool, str_to_bool
 from litellm.types.services import ServiceLoggerPayload
 from litellm.types.utils import (
@@ -82,6 +85,9 @@ class _UsageCompletionTokensView(TypedDict, total=False):
 class _ResponseWithUsageView(TypedDict, total=False):
     usage: "_UsageCompletionTokensView | None"
 
+
+# Cap on credential-scoped providers held at once; each one owns an exporter thread.
+_MAX_DYNAMIC_TRACER_PROVIDERS: Final = 256
 
 LITELLM_TRACER_NAME: Final = os.getenv("OTEL_TRACER_NAME", "litellm")
 LITELLM_METER_NAME: Final = os.getenv("LITELLM_METER_NAME", "litellm")
@@ -227,6 +233,26 @@ def _freeze_for_dedupe(value: object, _depth: int = 0) -> HashableScope:
     return repr(value)
 
 
+def _shutdown_tracer_provider(provider: "_SDKTracerProvider") -> None:
+    """Flush and stop a dropped provider so its exporter thread is reclaimed."""
+    try:
+        provider.shutdown()
+    except Exception as e:  # noqa: BLE001  # exporter shutdown must not fail the request that dropped it
+        verbose_logger.debug("OpenTelemetry: error shutting down dropped tracer provider: %s", e)
+
+
+def _provider_owns_exporter(exporter: "str | _SpanExporter") -> bool:
+    """Whether a provider built for ``exporter`` may be shut down when it is dropped.
+
+    ``_get_span_processor`` builds a fresh exporter for a named kind, but wraps a
+    caller-supplied ``SpanExporter`` instance as-is, and that instance is shared with the
+    logger's own provider. Shutting a dropped provider down would then stop exporting for
+    the whole process. The shared case also uses ``SimpleSpanProcessor``, so it owns no
+    thread and there is nothing to reclaim.
+    """
+    return not hasattr(exporter, "export")
+
+
 @dataclass
 class OpenTelemetryConfig:
     exporter: str | SpanExporter = "console"
@@ -322,6 +348,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         tracer_provider: object | None = None,
         logger_provider: object | None = None,
         meter_provider: object | None = None,
+        max_dynamic_tracer_providers: int = _MAX_DYNAMIC_TRACER_PROVIDERS,
         **kwargs,
     ):
         team_metadata_keys_override: Final = kwargs.pop("baggage_team_metadata_keys", None)
@@ -347,7 +374,9 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         self.OTEL_EXPORTER = self.config.exporter
         self.OTEL_ENDPOINT = self.config.endpoint
         self.OTEL_HEADERS = self.config.headers
-        self._tracer_provider_cache: dict[str, _SDKTracerProvider] = {}
+        self._tracer_provider_cache: OrderedDict[str, _SDKTracerProvider] = OrderedDict()
+        self._tracer_provider_cache_lock: Final = threading.Lock()
+        self._max_dynamic_tracer_providers: Final = max(1, max_dynamic_tracer_providers)
         self._init_tracing(tracer_provider)
 
         _debug_otel: Final = str(os.getenv("DEBUG_OTEL", "False")).lower()
@@ -1027,38 +1056,81 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
         return self.construct_dynamic_otel_config(standard_callback_dynamic_params=standard_callback_dynamic_params)
 
-    def _get_tracer_with_dynamic_config(self, dynamic_config: OpenTelemetryConfig):
+    def _insert_or_drop(
+        self, cache_key: str, built: "_SDKTracerProvider"
+    ) -> "tuple[_SDKTracerProvider, _SDKTracerProvider | None]":
+        """Cache ``built`` under ``cache_key``, returning the tracer to use and what to drop.
+
+        Caller holds ``_tracer_provider_cache_lock``. The drop is either the loser of a
+        concurrent build for this key or the LRU victim its insertion pushed out.
+        """
+        raced: Final = self._tracer_provider_cache.get(cache_key)
+        if raced is not None:
+            self._tracer_provider_cache.move_to_end(cache_key)
+            return raced, built
+
+        self._tracer_provider_cache[cache_key] = built
+        if len(self._tracer_provider_cache) > self._max_dynamic_tracer_providers:
+            return built, self._tracer_provider_cache.popitem(last=False)[1]
+        return built, None
+
+    def _cached_dynamic_tracer(
+        self,
+        cache_key: str,
+        build: Callable[[], "_SDKTracerProvider"],
+        shutdown_dropped: bool,
+    ) -> "_Tracer":
+        """Return the tracer for ``cache_key``, building and caching a provider on miss.
+
+        A provider that owns its exporter also owns a ``BatchSpanProcessor`` worker thread
+        that only stops on ``shutdown()``, so the cache is a bounded LRU and whatever it
+        drops is shut down. Without both, a proxy serving key-scoped credentials accumulates
+        one live thread per credential set for the life of the process.
+        """
+        with self._tracer_provider_cache_lock:
+            cached: Final = self._tracer_provider_cache.get(cache_key)
+            if cached is not None:
+                self._tracer_provider_cache.move_to_end(cache_key)
+                return cached.get_tracer(LITELLM_TRACER_NAME)
+
+        # Built outside the lock: constructing an exporter can block on DNS/TLS setup,
+        # which would otherwise stall every other tenant's spans.
+        built: Final = build()
+
+        with self._tracer_provider_cache_lock:
+            winner, dropped = self._insert_or_drop(cache_key, built)
+
+        if dropped is not None and shutdown_dropped:
+            # Off the caller's thread: shutdown joins the exporter worker, which flushes
+            # with the OTLP retry budget and would otherwise stall the event loop.
+            executor.submit(_shutdown_tracer_provider, dropped)
+        return winner.get_tracer(LITELLM_TRACER_NAME)
+
+    def _get_tracer_with_dynamic_config(self, dynamic_config: OpenTelemetryConfig) -> "_Tracer":
         """Create (or reuse) a tracer whose exporter target comes from a per-request config."""
         from opentelemetry.sdk.trace import TracerProvider
 
-        cache_key = f"dynamic_config:{dynamic_config.exporter}:{dynamic_config.endpoint}:{dynamic_config.headers}"
-        if cache_key in self._tracer_provider_cache:
-            return self._tracer_provider_cache[cache_key].get_tracer(LITELLM_TRACER_NAME)
+        def _build() -> "_SDKTracerProvider":
+            provider: Final = TracerProvider(resource=self._get_litellm_resource(self.config))
+            provider.add_span_processor(self._get_span_processor(config_override=dynamic_config))
+            return provider
 
-        temp_provider: Final = TracerProvider(resource=self._get_litellm_resource(self.config))
-        temp_provider.add_span_processor(self._get_span_processor(config_override=dynamic_config))
+        cache_key: Final = (
+            f"dynamic_config:{dynamic_config.exporter}:{dynamic_config.endpoint}:{dynamic_config.headers}"
+        )
+        return self._cached_dynamic_tracer(cache_key, _build, _provider_owns_exporter(dynamic_config.exporter))
 
-        self._tracer_provider_cache[cache_key] = temp_provider
-
-        return temp_provider.get_tracer(LITELLM_TRACER_NAME)
-
-    def _get_tracer_with_dynamic_headers(self, dynamic_headers: dict):
-        """Create a temporary tracer with dynamic headers for this request only."""
+    def _get_tracer_with_dynamic_headers(self, dynamic_headers: Mapping[str, str]) -> "_Tracer":
+        """Create (or reuse) a tracer whose OTLP headers come from a per-request credential set."""
         from opentelemetry.sdk.trace import TracerProvider
 
-        # Prevents thread exhaustion by reusing providers for the same credential sets (e.g. per-team keys)
+        def _build() -> "_SDKTracerProvider":
+            provider: Final = TracerProvider(resource=self._get_litellm_resource(self.config))
+            provider.add_span_processor(self._get_span_processor(dynamic_headers=dict(dynamic_headers)))
+            return provider
+
         cache_key: Final = str(sorted(dynamic_headers.items()))
-        if cache_key in self._tracer_provider_cache:
-            return self._tracer_provider_cache[cache_key].get_tracer(LITELLM_TRACER_NAME)
-
-        # Create a temporary tracer provider with dynamic headers
-        temp_provider: Final = TracerProvider(resource=self._get_litellm_resource(self.config))
-        temp_provider.add_span_processor(self._get_span_processor(dynamic_headers=dynamic_headers))
-
-        # Store in cache for reuse
-        self._tracer_provider_cache[cache_key] = temp_provider
-
-        return temp_provider.get_tracer(LITELLM_TRACER_NAME)
+        return self._cached_dynamic_tracer(cache_key, _build, _provider_owns_exporter(self.OTEL_EXPORTER))
 
     def construct_dynamic_otel_headers(
         self, standard_callback_dynamic_params: StandardCallbackDynamicParams

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -2,6 +2,7 @@ import os
 import threading
 from collections import OrderedDict
 from collections.abc import Callable, Mapping
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, TypedDict, cast
@@ -26,7 +27,6 @@ from litellm.litellm_core_utils.service_tier_utils import (
     get_requested_service_tier,
     get_served_service_tier,
 )
-from litellm.litellm_core_utils.thread_pool_executor import executor
 from litellm.secret_managers.main import get_secret_bool, str_to_bool
 from litellm.types.services import ServiceLoggerPayload
 from litellm.types.utils import (
@@ -88,6 +88,11 @@ class _ResponseWithUsageView(TypedDict, total=False):
 
 # Cap on credential-scoped providers held at once; each one owns an exporter thread.
 _MAX_DYNAMIC_TRACER_PROVIDERS: Final = 256
+
+# Dedicated so a dropped provider whose endpoint is unreachable, whose shutdown blocks for
+# the OTLP retry budget, cannot starve the shared executor that serves unrelated logging.
+# Threads spawn lazily, so a proxy that never evicts a provider never pays for this.
+_PROVIDER_SHUTDOWN_EXECUTOR: Final = ThreadPoolExecutor(max_workers=4, thread_name_prefix="OtelProviderShutdown")
 
 LITELLM_TRACER_NAME: Final = os.getenv("OTEL_TRACER_NAME", "litellm")
 LITELLM_METER_NAME: Final = os.getenv("LITELLM_METER_NAME", "litellm")
@@ -1103,7 +1108,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         if dropped is not None and shutdown_dropped:
             # Off the caller's thread: shutdown joins the exporter worker, which flushes
             # with the OTLP retry budget and would otherwise stall the event loop.
-            executor.submit(_shutdown_tracer_provider, dropped)
+            _PROVIDER_SHUTDOWN_EXECUTOR.submit(_shutdown_tracer_provider, dropped)
         return winner.get_tracer(LITELLM_TRACER_NAME)
 
     def _get_tracer_with_dynamic_config(self, dynamic_config: OpenTelemetryConfig) -> "_Tracer":

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -3248,8 +3248,8 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                 for part in parts:
                     key, value = part.split("=", 1)
                     _split_otel_headers[key] = value
-            elif isinstance(headers, dict):
-                _split_otel_headers = headers
+            elif isinstance(headers, Mapping):
+                _split_otel_headers.update(headers)
         return _split_otel_headers
 
     async def async_management_endpoint_success_hook(

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -246,6 +246,14 @@ def _shutdown_tracer_provider(provider: "_SDKTracerProvider") -> None:
         verbose_logger.debug("OpenTelemetry: error shutting down dropped tracer provider: %s", e)
 
 
+@dataclass(frozen=True, slots=True)
+class _CachedTracerProvider:
+    """A cached credential-scoped provider plus whether it may be shut down when dropped."""
+
+    provider: "_SDKTracerProvider"
+    owns_exporter: bool
+
+
 def _provider_owns_exporter(exporter: "str | _SpanExporter") -> bool:
     """Whether a provider built for ``exporter`` may be shut down when it is dropped.
 
@@ -379,7 +387,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         self.OTEL_EXPORTER = self.config.exporter
         self.OTEL_ENDPOINT = self.config.endpoint
         self.OTEL_HEADERS = self.config.headers
-        self._tracer_provider_cache: OrderedDict[str, _SDKTracerProvider] = OrderedDict()
+        self._tracer_provider_cache: OrderedDict[str, _CachedTracerProvider] = OrderedDict()
         self._tracer_provider_cache_lock: Final = threading.Lock()
         self._max_dynamic_tracer_providers: Final = max(1, max_dynamic_tracer_providers)
         self._init_tracing(tracer_provider)
@@ -1062,9 +1070,9 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         return self.construct_dynamic_otel_config(standard_callback_dynamic_params=standard_callback_dynamic_params)
 
     def _insert_or_drop(
-        self, cache_key: str, built: "_SDKTracerProvider"
-    ) -> "tuple[_SDKTracerProvider, _SDKTracerProvider | None]":
-        """Cache ``built`` under ``cache_key``, returning the tracer to use and what to drop.
+        self, cache_key: str, built: "_CachedTracerProvider"
+    ) -> "tuple[_CachedTracerProvider, _CachedTracerProvider | None]":
+        """Cache ``built`` under ``cache_key``, returning the entry to use and what to drop.
 
         Caller holds ``_tracer_provider_cache_lock``. The drop is either the loser of a
         concurrent build for this key or the LRU victim its insertion pushed out.
@@ -1083,7 +1091,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         self,
         cache_key: str,
         build: Callable[[], "_SDKTracerProvider"],
-        shutdown_dropped: bool,
+        owns_exporter: bool,
     ) -> "_Tracer":
         """Return the tracer for ``cache_key``, building and caching a provider on miss.
 
@@ -1091,25 +1099,30 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         that only stops on ``shutdown()``, so the cache is a bounded LRU and whatever it
         drops is shut down. Without both, a proxy serving key-scoped credentials accumulates
         one live thread per credential set for the life of the process.
+
+        ``owns_exporter`` describes the provider being built, and is cached with it, because
+        the two dynamic entry points share this cache and can disagree: whether the LRU
+        victim may be shut down is a property of the victim, never of the request that
+        happened to evict it.
         """
         with self._tracer_provider_cache_lock:
             cached: Final = self._tracer_provider_cache.get(cache_key)
             if cached is not None:
                 self._tracer_provider_cache.move_to_end(cache_key)
-                return cached.get_tracer(LITELLM_TRACER_NAME)
+                return cached.provider.get_tracer(LITELLM_TRACER_NAME)
 
         # Built outside the lock: constructing an exporter can block on DNS/TLS setup,
         # which would otherwise stall every other tenant's spans.
-        built: Final = build()
+        built: Final = _CachedTracerProvider(provider=build(), owns_exporter=owns_exporter)
 
         with self._tracer_provider_cache_lock:
             winner, dropped = self._insert_or_drop(cache_key, built)
 
-        if dropped is not None and shutdown_dropped:
+        if dropped is not None and dropped.owns_exporter:
             # Off the caller's thread: shutdown joins the exporter worker, which flushes
             # with the OTLP retry budget and would otherwise stall the event loop.
-            _PROVIDER_SHUTDOWN_EXECUTOR.submit(_shutdown_tracer_provider, dropped)
-        return winner.get_tracer(LITELLM_TRACER_NAME)
+            _PROVIDER_SHUTDOWN_EXECUTOR.submit(_shutdown_tracer_provider, dropped.provider)
+        return winner.provider.get_tracer(LITELLM_TRACER_NAME)
 
     def _get_tracer_with_dynamic_config(self, dynamic_config: OpenTelemetryConfig) -> "_Tracer":
         """Create (or reuse) a tracer whose exporter target comes from a per-request config."""
@@ -1131,7 +1144,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
         def _build() -> "_SDKTracerProvider":
             provider: Final = TracerProvider(resource=self._get_litellm_resource(self.config))
-            provider.add_span_processor(self._get_span_processor(dynamic_headers=dict(dynamic_headers)))
+            provider.add_span_processor(self._get_span_processor(dynamic_headers=dynamic_headers))
             return provider
 
         cache_key: Final = str(sorted(dynamic_headers.items()))
@@ -2909,7 +2922,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
     def _get_span_processor(
         self,
-        dynamic_headers: dict | None = None,
+        dynamic_headers: Mapping[str, str] | None = None,
         config_override: OpenTelemetryConfig | None = None,
     ):
         from opentelemetry.sdk.trace.export import (
@@ -3221,7 +3234,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
     @staticmethod
     def _get_headers_dictionary(
-        headers: str | dict | None,
+        headers: "str | Mapping[str, str] | None",
     ) -> dict[str, str]:
         """
         Convert a string or dictionary of headers into a dictionary of headers.

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -89,9 +89,7 @@ class _ResponseWithUsageView(TypedDict, total=False):
 # Cap on credential-scoped providers held at once; each one owns an exporter thread.
 _MAX_DYNAMIC_TRACER_PROVIDERS: Final = 256
 
-# Dedicated so a dropped provider whose endpoint is unreachable, whose shutdown blocks for
-# the OTLP retry budget, cannot starve the shared executor that serves unrelated logging.
-# Threads spawn lazily, so a proxy that never evicts a provider never pays for this.
+# Dedicated so a slow exporter shutdown cannot starve the shared logging executor.
 _PROVIDER_SHUTDOWN_EXECUTOR: Final = ThreadPoolExecutor(max_workers=4, thread_name_prefix="OtelProviderShutdown")
 
 LITELLM_TRACER_NAME: Final = os.getenv("OTEL_TRACER_NAME", "litellm")
@@ -1100,6 +1098,12 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         drops is shut down. Without both, a proxy serving key-scoped credentials accumulates
         one live thread per credential set for the life of the process.
 
+        ``owns_exporter`` also decides ``shutdown_on_exit`` at build time: a provider we may
+        never shut down must not hold an interpreter-exit hook, which would both pin it in
+        memory for the life of the process and stop the shared exporter at exit. Those
+        providers use ``SimpleSpanProcessor``, which buffers nothing, so the hook costs them
+        no flush.
+
         ``owns_exporter`` describes the provider being built, and is cached with it, because
         the two dynamic entry points share this cache and can disagree: whether the LRU
         victim may be shut down is a property of the victim, never of the request that
@@ -1111,16 +1115,14 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                 self._tracer_provider_cache.move_to_end(cache_key)
                 return cached.provider.get_tracer(LITELLM_TRACER_NAME)
 
-        # Built outside the lock: constructing an exporter can block on DNS/TLS setup,
-        # which would otherwise stall every other tenant's spans.
+        # Built outside the lock: exporter construction can block on DNS/TLS.
         built: Final = _CachedTracerProvider(provider=build(), owns_exporter=owns_exporter)
 
         with self._tracer_provider_cache_lock:
             winner, dropped = self._insert_or_drop(cache_key, built)
 
         if dropped is not None and dropped.owns_exporter:
-            # Off the caller's thread: shutdown joins the exporter worker, which flushes
-            # with the OTLP retry budget and would otherwise stall the event loop.
+            # Off the caller's thread: shutdown joins the exporter worker.
             _PROVIDER_SHUTDOWN_EXECUTOR.submit(_shutdown_tracer_provider, dropped.provider)
         return winner.provider.get_tracer(LITELLM_TRACER_NAME)
 
@@ -1128,27 +1130,35 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         """Create (or reuse) a tracer whose exporter target comes from a per-request config."""
         from opentelemetry.sdk.trace import TracerProvider
 
+        owns_exporter: Final = _provider_owns_exporter(dynamic_config.exporter)
+
         def _build() -> "_SDKTracerProvider":
-            provider: Final = TracerProvider(resource=self._get_litellm_resource(self.config))
+            provider: Final = TracerProvider(
+                resource=self._get_litellm_resource(self.config), shutdown_on_exit=owns_exporter
+            )
             provider.add_span_processor(self._get_span_processor(config_override=dynamic_config))
             return provider
 
         cache_key: Final = (
             f"dynamic_config:{dynamic_config.exporter}:{dynamic_config.endpoint}:{dynamic_config.headers}"
         )
-        return self._cached_dynamic_tracer(cache_key, _build, _provider_owns_exporter(dynamic_config.exporter))
+        return self._cached_dynamic_tracer(cache_key, _build, owns_exporter)
 
     def _get_tracer_with_dynamic_headers(self, dynamic_headers: Mapping[str, str]) -> "_Tracer":
         """Create (or reuse) a tracer whose OTLP headers come from a per-request credential set."""
         from opentelemetry.sdk.trace import TracerProvider
 
+        owns_exporter: Final = _provider_owns_exporter(self.OTEL_EXPORTER)
+
         def _build() -> "_SDKTracerProvider":
-            provider: Final = TracerProvider(resource=self._get_litellm_resource(self.config))
+            provider: Final = TracerProvider(
+                resource=self._get_litellm_resource(self.config), shutdown_on_exit=owns_exporter
+            )
             provider.add_span_processor(self._get_span_processor(dynamic_headers=dynamic_headers))
             return provider
 
         cache_key: Final = str(sorted(dynamic_headers.items()))
-        return self._cached_dynamic_tracer(cache_key, _build, _provider_owns_exporter(self.OTEL_EXPORTER))
+        return self._cached_dynamic_tracer(cache_key, _build, owns_exporter)
 
     def construct_dynamic_otel_headers(
         self, standard_callback_dynamic_params: StandardCallbackDynamicParams

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -554,7 +554,7 @@ class TestLangfuseOtelKeyDynamicConfig:
         assert tracer is not logger.tracer
         assert len(logger._tracer_provider_cache) == 1
 
-        provider = next(iter(logger._tracer_provider_cache.values()))
+        provider = next(iter(logger._tracer_provider_cache.values())).provider
         span_processors = provider._active_span_processor._span_processors
         assert len(span_processors) == 1
         assert isinstance(span_processors[0], BatchSpanProcessor)
@@ -619,7 +619,7 @@ class TestLangfuseOtelKeyDynamicConfig:
         assert secret not in logged
         assert f"Basic {secret}" not in logged
 
-        provider = next(iter(logger._tracer_provider_cache.values()))
+        provider = next(iter(logger._tracer_provider_cache.values())).provider
         exporter = provider._active_span_processor._span_processors[0].span_exporter
         assert isinstance(exporter, OTLPSpanExporter)
         assert exporter._headers == {

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -7,6 +7,7 @@ import threading
 import time
 import unittest
 from datetime import datetime, timedelta, timezone
+from types import MappingProxyType
 from parameterized import parameterized
 from unittest.mock import MagicMock, patch
 
@@ -1842,6 +1843,22 @@ class TestOpenTelemetryHeaderSplitting(unittest.TestCase):
         self.assertEqual(
             result, {"api-key": "value1=part2", "config": "setting=enabled"}
         )
+
+    def test_accepts_any_mapping_not_only_dict(self):
+        """The parameter is typed Mapping, so a non-dict Mapping must not silently drop
+        every header and leave the exporter unauthenticated."""
+        otel = OpenTelemetry()
+        headers = MappingProxyType({"authorization": "Basic abc"})
+        self.assertEqual(otel._get_headers_dictionary(headers), {"authorization": "Basic abc"})
+
+    def test_returns_a_copy_so_the_exporter_never_aliases_the_caller(self):
+        """The result is handed to a long-lived exporter, so it must not be the caller's
+        own dict."""
+        otel = OpenTelemetry()
+        headers = {"authorization": "Basic abc"}
+        result = otel._get_headers_dictionary(headers)
+        self.assertIsNot(result, headers)
+        self.assertEqual(result, headers)
 
 
 class TestOpenTelemetryEndpointNormalization(unittest.TestCase):

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -6030,8 +6030,8 @@ class TestDynamicTracerProviderCache(unittest.TestCase):
         return logger
 
     def _drain(self, logger):
-        for provider in list(logger._tracer_provider_cache.values()):
-            provider.shutdown()
+        for entry in list(logger._tracer_provider_cache.values()):
+            entry.provider.shutdown()
         logger._tracer_provider_cache.clear()
 
     def _live_exporter_threads(self):
@@ -6073,7 +6073,7 @@ class TestDynamicTracerProviderCache(unittest.TestCase):
 
             self.assertNotIn(evicted, logger._tracer_provider_cache.values())
             self._wait_for_call(mock_shutdown)
-            mock_shutdown.assert_called_once_with(evicted)
+            mock_shutdown.assert_called_once_with(evicted.provider)
 
     def _wait_for_call(self, mock_fn, timeout=10.0):
         """The shutdown runs on a worker thread, so give it a moment to land."""
@@ -6116,3 +6116,45 @@ class TestDynamicTracerProviderCache(unittest.TestCase):
         self.assertEqual(
             [span.name for span in shared.get_finished_spans()], ["before", "after"]
         )
+
+    def test_mixed_ownership_cache_shuts_down_only_the_victims_that_own_their_exporter(self):
+        """Both dynamic entry points share one cache, so it can hold providers of mixed
+        ownership. Whether an evicted provider may be shut down is a property of that
+        provider, not of the request that evicted it."""
+        shared = InMemorySpanExporter()
+        logger = self._logger(cap=1, exporter=shared)
+        with logger.tracer.start_as_current_span("before"):
+            pass
+
+        # Cached by the headers path, so its processor wraps the SHARED exporter.
+        logger._get_tracer_with_dynamic_headers({"authorization": "Basic shared-owner"})
+        # Evicted by the config path, which builds its OWN exporter from a named kind.
+        logger._get_tracer_with_dynamic_config(
+            OpenTelemetryConfig(exporter="console", skip_set_global=True)
+        )
+
+        with logger.tracer.start_as_current_span("after"):
+            pass
+
+        self.assertFalse(shared._stopped)
+        self.assertEqual(
+            [span.name for span in shared.get_finished_spans()], ["before", "after"]
+        )
+
+    def test_mixed_ownership_cache_still_reclaims_a_thread_owning_victim(self):
+        """The other direction of the same defect: a victim that owns a real exporter
+        thread must still be shut down even when the evicting request does not."""
+        shared = InMemorySpanExporter()
+        logger = self._logger(cap=1, exporter=shared)
+        before = len(self._live_exporter_threads())
+
+        # Cached by the config path with a named kind, so it owns a BatchSpanProcessor thread.
+        logger._get_tracer_with_dynamic_config(
+            OpenTelemetryConfig(exporter="console", skip_set_global=True)
+        )
+        self.assertEqual(len(self._live_exporter_threads()) - before, 1)
+
+        # Evicted by the headers path, whose own exporter is the shared instance.
+        logger._get_tracer_with_dynamic_headers({"authorization": "Basic shared-owner"})
+
+        self.assertEqual(self._wait_for_exporter_threads(before) - before, 0)

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -1,7 +1,9 @@
 import asyncio
+import concurrent.futures
 import json
 import os
 import sys
+import threading
 import time
 import unittest
 from datetime import datetime, timedelta, timezone
@@ -20,6 +22,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 import litellm
+from litellm.integrations import opentelemetry as otel_module
 from litellm.integrations.opentelemetry import (
     OpenTelemetry,
     OpenTelemetryConfig,
@@ -6007,3 +6010,109 @@ class TestOTELServiceTierAttributes(unittest.TestCase):
             response_obj,
         )
         self.assertEqual(attributes[self.RESPONSE_KEY], "tier-added-by-provider-later")
+
+
+class TestDynamicTracerProviderCache(unittest.TestCase):
+    """Every credential-scoped TracerProvider that owns its exporter also owns a
+    BatchSpanProcessor worker thread that only stops on shutdown, so the cache holding them
+    must be bounded and must shut down whatever it drops (LIT-5437: threads accumulated
+    until pods were OOMKilled)."""
+
+    BSP_THREAD_NAME = "OtelBatchSpanProcessor"
+
+    def _logger(self, cap=3, exporter="console"):
+        logger = OpenTelemetry(
+            config=OpenTelemetryConfig(exporter=exporter, skip_set_global=True),
+            max_dynamic_tracer_providers=cap,
+        )
+        self.addCleanup(logger._tracer_provider.shutdown)
+        self.addCleanup(self._drain, logger)
+        return logger
+
+    def _drain(self, logger):
+        for provider in list(logger._tracer_provider_cache.values()):
+            provider.shutdown()
+        logger._tracer_provider_cache.clear()
+
+    def _live_exporter_threads(self):
+        return [t for t in threading.enumerate() if t.name == self.BSP_THREAD_NAME]
+
+    def _wait_for_exporter_threads(self, expected, timeout=10.0):
+        """Dropped providers are shut down off-thread, so poll instead of sleeping."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            count = len(self._live_exporter_threads())
+            if count <= expected:
+                return count
+            time.sleep(0.05)
+        return len(self._live_exporter_threads())
+
+    def test_distinct_credential_sets_stay_bounded(self):
+        """One tenant per credential set must not mean one live thread per credential set."""
+        logger = self._logger(cap=3)
+        before = len(self._live_exporter_threads())
+
+        for i in range(25):
+            logger._get_tracer_with_dynamic_headers({"authorization": f"Basic tenant-{i}"})
+
+        self.assertEqual(len(logger._tracer_provider_cache), 3)
+        # Guards the thread-name constant: a rename upstream would make this read 0 and the
+        # bound assertion below would pass while measuring nothing.
+        self.assertGreaterEqual(len(self._live_exporter_threads()), 1)
+        self.assertLessEqual(self._wait_for_exporter_threads(before + 3) - before, 3)
+
+    def test_evicted_provider_is_shut_down(self):
+        """An evicted provider is stopped, not silently dropped with its thread running."""
+        logger = self._logger(cap=3)
+        with patch.object(otel_module, "_shutdown_tracer_provider") as mock_shutdown:
+            logger._get_tracer_with_dynamic_headers({"authorization": "Basic evict-me"})
+            evicted = next(iter(logger._tracer_provider_cache.values()))
+
+            for i in range(3):
+                logger._get_tracer_with_dynamic_headers({"authorization": f"Basic keep-{i}"})
+
+            self.assertNotIn(evicted, logger._tracer_provider_cache.values())
+            self._wait_for_call(mock_shutdown)
+            mock_shutdown.assert_called_once_with(evicted)
+
+    def _wait_for_call(self, mock_fn, timeout=10.0):
+        """The shutdown runs on a worker thread, so give it a moment to land."""
+        deadline = time.time() + timeout
+        while time.time() < deadline and not mock_fn.call_args_list:
+            time.sleep(0.05)
+
+    def test_concurrent_first_requests_build_one_provider(self):
+        """Concurrent misses on one credential set race to build; only the winner may survive,
+        and the losers must be shut down rather than orphaned with their threads running."""
+        logger = self._logger(cap=3)
+        before = len(self._live_exporter_threads())
+        headers = {"authorization": "Basic same-tenant"}
+        barrier = threading.Barrier(16)
+
+        def _request_tracer(_):
+            barrier.wait()
+            return logger._get_tracer_with_dynamic_headers(headers)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+            list(pool.map(_request_tracer, range(16)))
+
+        self.assertEqual(len(logger._tracer_provider_cache), 1)
+        self.assertEqual(self._wait_for_exporter_threads(before + 1) - before, 1)
+
+    def test_shared_exporter_instance_survives_dropped_providers(self):
+        """A caller-supplied SpanExporter is shared with the logger's own provider, so a
+        dropped provider must not shut it down and silence the whole process."""
+        shared = InMemorySpanExporter()
+        logger = self._logger(cap=1, exporter=shared)
+        with logger.tracer.start_as_current_span("before"):
+            pass
+
+        for i in range(4):
+            logger._get_tracer_with_dynamic_headers({"authorization": f"Basic tenant-{i}"})
+
+        with logger.tracer.start_as_current_span("after"):
+            pass
+
+        self.assertEqual(
+            [span.name for span in shared.get_finished_spans()], ["before", "after"]
+        )

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -1,11 +1,13 @@
 import asyncio
 import concurrent.futures
+import gc
 import json
 import os
 import sys
 import threading
 import time
 import unittest
+import weakref
 from datetime import datetime, timedelta, timezone
 from types import MappingProxyType
 from parameterized import parameterized
@@ -6081,6 +6083,7 @@ class TestDynamicTracerProviderCache(unittest.TestCase):
     def test_evicted_provider_is_shut_down(self):
         """An evicted provider is stopped, not silently dropped with its thread running."""
         logger = self._logger(cap=3)
+        before = len(self._live_exporter_threads())
         with patch.object(otel_module, "_shutdown_tracer_provider") as mock_shutdown:
             logger._get_tracer_with_dynamic_headers({"authorization": "Basic evict-me"})
             evicted = next(iter(logger._tracer_provider_cache.values()))
@@ -6091,6 +6094,12 @@ class TestDynamicTracerProviderCache(unittest.TestCase):
             self.assertNotIn(evicted, logger._tracer_provider_cache.values())
             self._wait_for_call(mock_shutdown)
             mock_shutdown.assert_called_once_with(evicted.provider)
+
+        # The patch stopped the real shutdown, so stop the victim here; leaving its
+        # exporter thread alive would perturb the thread-census assertions elsewhere.
+        evicted.provider.shutdown()
+        still_cached = len(logger._tracer_provider_cache)
+        self.assertEqual(self._wait_for_exporter_threads(before + still_cached), before + still_cached)
 
     def _wait_for_call(self, mock_fn, timeout=10.0):
         """The shutdown runs on a worker thread, so give it a moment to land."""
@@ -6175,3 +6184,31 @@ class TestDynamicTracerProviderCache(unittest.TestCase):
         logger._get_tracer_with_dynamic_headers({"authorization": "Basic shared-owner"})
 
         self.assertEqual(self._wait_for_exporter_threads(before) - before, 0)
+
+    def test_dropped_shared_exporter_provider_is_not_retained_by_an_exit_hook(self):
+        """A provider we may never shut down must not register an interpreter-exit hook.
+        The hook holds a strong reference, so the provider would be pinned for the life of
+        the process (the very leak this fixes) and would stop the shared exporter at exit."""
+        shared = InMemorySpanExporter()
+        logger = self._logger(cap=1, exporter=shared)
+
+        logger._get_tracer_with_dynamic_headers({"authorization": "Basic a"})
+        entry = next(iter(logger._tracer_provider_cache.values()))
+        self.assertFalse(entry.owns_exporter)
+        victim = weakref.ref(entry.provider)
+
+        logger._get_tracer_with_dynamic_headers({"authorization": "Basic b"})
+        del entry
+        gc.collect()
+
+        self.assertIsNone(victim(), "evicted shared-exporter provider is still referenced")
+
+    def test_provider_that_owns_its_exporter_keeps_its_exit_flush(self):
+        """The counterpart: a provider that owns a buffering processor must keep its exit
+        hook so its last batch still flushes when the process stops."""
+        logger = self._logger(cap=3)
+        logger._get_tracer_with_dynamic_headers({"authorization": "Basic owned"})
+        entry = next(iter(logger._tracer_provider_cache.values()))
+
+        self.assertTrue(entry.owns_exporter)
+        self.assertIsNotNone(entry.provider._atexit_handler)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `OpenTelemetry._tracer_provider_cache` (the v1 OTEL logger's per-credential-set `TracerProvider` cache) was an unbounded, unsynchronized dict that never shut anything down. Each entry owns a `BatchSpanProcessor` worker thread that only stops on `shutdown()`, so every distinct team or key scoped credential set added one live thread for the life of the process. Idle threads park in `futex_wait`, and a Python thread stack is the dominant per-thread RSS cost, which is what turns this into linear memory growth and eventual OOMKills
- The check-then-insert had no lock, so concurrent first-requests for the same credential set each built a provider. Only one landed in the dict; the losers were orphaned immediately, unreachable and still running their exporter thread
- `TracerProvider.shutdown()` also unregisters the provider's `atexit` handler, so the old code leaked those too

How it solves it:

- The cache is now a lock-guarded bounded LRU (256 providers). The least-recently-used provider is flushed and stopped when a 257th credential set arrives, and the loser of a concurrent build is stopped instead of orphaned. This matches what `litellm/integrations/otel/plumbing/routing.py` already does for OTel v2
- Providers that wrap a caller-supplied `SpanExporter` instance are dropped without shutdown. That exporter object is shared with the logger's own provider, so shutting it down would stop exporting for the whole process; those providers use `SimpleSpanProcessor` and own no thread, so there is nothing to reclaim
- Shutdown runs on a dedicated 4-worker executor rather than inline. `BatchSpanProcessor.shutdown()` joins its worker, whose final flush carries the OTLP retry budget, and the call site is inside the async success handler. The pool is dedicated so a tenant whose endpoint is unreachable cannot queue behind, or starve, the shared executor that serves unrelated logging; its threads spawn lazily, so a proxy that never evicts a provider never pays for it

## User Flow

No user-visible change for a proxy under 256 concurrently active credential sets, which is every deployment that does not use team or key scoped observability credentials at that scale. Past that, the least-recently-used tenant's provider is rebuilt on its next request

## Relevant issues

## Linear ticket

Refs LIT-5437

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical on both sides: one proxy per side against its own Postgres, `store_model_in_db: true`, `litellm_settings.callbacks: ["langfuse_otel"]`, real Gemini calls, real Langfuse credentials from the environment. Each proxy prints `litellm.__file__` and a fix-symbol probe at startup so the side is proven, and thread names are read from inside the process (`threading.enumerate()`), which is the py-spy equivalent the ticket asks for.

```
$ cat config.yaml
model_list:
  - model_name: gemini-flash
    litellm_params:
      model: gemini/gemini-3.6-flash
      api_key: os.environ/GEMINI_API_KEY
general_settings:
  master_key: sk-lit5437
  store_model_in_db: true
litellm_settings:
  callbacks: ["langfuse_otel"]
  drop_params: true
```

The credential-churn driver, used verbatim on both sides:

```
$ one() {
    K=$(curl -s -X POST http://127.0.0.1:$PORT/key/generate -H "Authorization: Bearer sk-lit5437" -H "Content-Type: application/json" \
      -d "{\"metadata\": {\"logging\": [{\"callback_name\": \"langfuse_otel\", \"callback_type\": \"success\", \"callback_vars\": {\"langfuse_public_key\": \"pk-$TAG-$1\", \"langfuse_secret_key\": \"sk-$TAG-$1\"}}]}}" | jq -r .key)
    curl -s -X POST http://127.0.0.1:$PORT/v1/chat/completions -H "Authorization: Bearer $K" -H "Content-Type: application/json" \
      -d '{"model":"gemini-flash","messages":[{"role":"user","content":"hi"}],"max_tokens":5}' -o /dev/null
  }
$ seq 1 300 | xargs -P 8 -I{} bash -c 'one {}'
```

### Before (e75b4b1c2a)

#### Exporter threads under credential churn

1. Start the proxy and confirm the side

   ```
   $ ./launch_base.sh
   TREE /Users/yucheng/litellm-wt/lit5437_base/litellm/__init__.py
   HAS_FIX False
   ```

2. Read the thread census before any traffic

   ```
   $ tail -1 census_base.txt
   15:31:09 total=4 MainThread=1 OtelBatchSpanProcessor=1 lit5437-census=1 prisma-engine-waitpid-65476=1
   ```

3. Drive 300 distinct key-scoped Langfuse credential sets, one real completion each

   ```
   $ seq 1 300 | xargs -P 8 -I{} bash -c 'one {}'
   [qa4438] 300 credential sets driven
   ```

4. Read the census again: one exporter thread per credential set, none of them ever exit

   ```
   $ tail -1 census_base.txt | tr ' ' '\n' | grep -E "^total|OtelBatch"
   total=309
   OtelBatchSpanProcessor=301
   ```

#### Export delivery to Langfuse

1. Send a marked completion through the proxy

   ```
   $ curl -s -X POST http://127.0.0.1:4438/v1/chat/completions -H "Authorization: Bearer sk-lit5437" -H "Content-Type: application/json" \
       -d '{"model":"gemini-flash","messages":[{"role":"user","content":"reply with exactly: lit5437-qa-BEFORE-1787092378"}],"max_tokens":2000}' | jq -r .choices[0].message.content
   lit5437-qa-BEFORE-1787092378
   ```

2. Read the trace back through the Langfuse API

   ```
   $ curl -s -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" "$LANGFUSE_HOST/api/public/traces?limit=6"
   2026-08-18T22:32:58.608Z litellm_request [{'role': 'user', 'content': 'reply with exactly: lit5437-qa-BEFORE-1787092378'}]
   ```

### After (21d144e5dd)

#### Exporter threads under credential churn

1. Start the proxy and confirm the side

   ```
   $ ./launch_head.sh
   TREE /Users/yucheng/litellm-wt/lit5437/litellm/__init__.py
   HAS_FIX True
   ```

2. Read the thread census before any traffic

   ```
   $ tail -1 census_head.txt
   15:31:05 total=2 MainThread=1 lit5437-census=1
   ```

3. Drive 300 distinct key-scoped Langfuse credential sets, one real completion each

   ```
   $ seq 1 300 | xargs -P 8 -I{} bash -c 'one {}'
   [qa4437] 300 credential sets driven
   ```

4. Read the census again: capped at the 256 bound plus the logger's own provider, with the bounded cleanup pool visible

   ```
   $ tail -1 census_head.txt | tr ' ' '\n' | grep -E "^total|OtelBatch|OtelProviderShutdown"
   total=266
   OtelBatchSpanProcessor=257
   OtelProviderShutdown_0=1
   ```

#### Export delivery to Langfuse

1. Send a marked completion through the proxy

   ```
   $ curl -s -X POST http://127.0.0.1:4437/v1/chat/completions -H "Authorization: Bearer sk-lit5437" -H "Content-Type: application/json" \
       -d '{"model":"gemini-flash","messages":[{"role":"user","content":"reply with exactly: lit5437-qa-AFTER-1787092380"}],"max_tokens":2000}' | jq -r .choices[0].message.content
   lit5437-qa-AFTER-1787092380
   ```

2. Read the trace back through the Langfuse API

   ```
   $ curl -s -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" "$LANGFUSE_HOST/api/public/traces?limit=6"
   2026-08-18T22:33:00.133Z litellm_request [{'role': 'user', 'content': 'reply with exactly: lit5437-qa-AFTER-1787092380'}]
   ```

## Type

🐛 Bug Fix

## Design notes

### Residual bound on the cleanup pool

The cleanup pool's pending queue is not itself bounded, so it is worth stating what the drain actually costs. Measured on the pinned `opentelemetry-sdk`, against a stub that accepts the connection and never answers:

```
connection refused                                    shutdown took   0.01s
accepts, never responds                               shutdown took  10.01s
evicted immediately after a span (buffer still full)  shutdown took  10.01s
evicted as an LRU victim (idle 20s, buffer drained)   shutdown took   0.00s
```

The worst case is the exporter's 10s read timeout, not the 64s retry budget; `_export_batch` gives up rather than retrying on the shutdown flush. More to the point, the provider that gets evicted is by definition the least recently used one, so the `BatchSpanProcessor` schedule delay of 5s has already drained its buffer and its shutdown returns immediately. Reaching the 10s path requires evicting a provider that emitted a span within the last five seconds, which means 256 distinct credential sets all active inside a five second window, with that tenant's endpoint accepting TCP and never responding

A bounded queue would have to drop shutdowns to stay bounded, which puts the leak straight back. The honest statement is that this trades a permanent unbounded leak for a drain that is rate limited under one specific pathology, and that the pool is dedicated so the pathology cannot spread to unrelated logging

### Mixed-ownership eviction

The first cut of this decided whether a dropped provider could be shut down from the exporter of the request doing the evicting. Both dynamic entry points write the same cache, so it can hold providers of mixed exporter ownership, and that flag then described the wrong provider in both directions: a shared caller-supplied exporter got stopped, silencing telemetry process wide, and a provider owning a real `BatchSpanProcessor` thread got dropped without shutdown, which is the original leak surviving the fix. Ownership is now cached with the provider, so the decision reads the victim's own flag

Reproduced on a live proxy through the custom-callback extension point (`callbacks: ["my_module.logger_instance"]`), real Gemini calls, span counts read back over `GET /otel-spans`:

```
                                        merge-base   before this commit   after
spans after master-key request                   2                    2       2
spans after a key-scoped request evicts it       4                    2       4
```

### Header mapping type

Widening the dynamic-header parameter to `Mapping[str, str]` left `_get_headers_dictionary` matching on `isinstance(headers, dict)`, so a non-dict `Mapping` returned no headers at all. On the OTLP path that is an exporter with no credentials and no traces, with nothing raised. The same branch returned the caller's own object rather than a copy, and dropping the defensive copy at the call site let that alias reach a long-lived exporter. It now matches on `Mapping` and copies

```
                    before        after
plain dict          {...}         {...}
MappingProxyType    {}            {...}
OrderedDict         OrderedDict   {...}
returns caller obj  True          False
```

No first-party caller passes a non-dict mapping today, so nothing was live-broken; the contract this PR introduced was simply not honored

### Interpreter-exit hooks

Every `TracerProvider` registers an `atexit` hook by default, and that hook holds a strong reference. Providers wrapping a caller-supplied exporter are dropped without shutdown, so they stayed pinned for the life of the process and then stopped the shared exporter at exit. Measured before the fix: two extra `atexit` callbacks and the evicted provider surviving `gc.collect()`. `shutdown_on_exit` is now tied to ownership, so those providers register no hook and are collectable, while a provider that owns its exporter keeps the hook and its exit flush. The non-owning case uses `SimpleSpanProcessor`, which buffers nothing, so it loses no flush

## Caveats (if any)

The ticket reports growth on idle pods. That did not reproduce here: with the DB config reload accelerated to 1s (roughly 30x production cadence, verified live by inserting a model row straight into `LiteLLM_ProxyModelTable` and watching `/v1/models` pick it up), the thread census stayed flat. What does reproduce is the cache above, which needs request traffic carrying team or key scoped credentials. So this is filed as `Refs`, not `Resolves`, and the ticket should stay open until the reporter's key and team logging configuration confirms it is the same path

Two related findings from the same sweep are deliberately left out of this diff and are worth their own tickets:

- `_init_custom_logger_compatible_class` swallows a constructor exception and returns `None` without appending to `_in_memory_loggers`. `OpenTelemetry.__init__` starts its exporter thread in `_init_tracing` before `_init_metrics` and `_init_logs` run, so a raise in either leaves a live orphan thread and the next config poll builds another
- `OpenTelemetryConfig.exporter` defaults to `"console"`, and `_get_span_processor` also falls back to `BatchSpanProcessor(ConsoleSpanExporter())` for any unrecognized kind. `LangfuseOtelLogger` reaches that default whenever `LANGFUSE_PUBLIC_KEY` or `LANGFUSE_SECRET_KEY` is unset, which writes full prompts to stdout for an operator who configured `langfuse_otel` and nothing else. That is acceptance criterion 5 on the ticket, still open

## QA runbook

1. Run a proxy with `store_model_in_db: true` and `litellm_settings.callbacks: ["langfuse_otel"]`
2. Create more than 256 virtual keys, each with distinct `metadata.logging[].callback_vars.langfuse_public_key` / `langfuse_secret_key`, and send one completion through each
3. Confirm the process holds at most 257 threads named `OtelBatchSpanProcessor` and that the count does not grow with further traffic
4. Confirm spans for the most recent keys still arrive in their Langfuse projects

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

## Behavior changes

- A logger holds at most 256 credential-scoped tracer providers. Past that, the least-recently-used one is flushed and shut down; a span started on that tracer and ended after the eviction is dropped by the stopped processor. The tenant gets a fresh provider on its next request. `arize_phoenix` documents the same hazard as its reason for not shutting down evicted providers, but its providers share one span processor and own no thread, so it has nothing to reclaim and this one does
- `OpenTelemetry.__init__` takes a new `max_dynamic_tracer_providers` injection point, defaulting to the module constant
- A process that evicts a provider gains up to 4 threads named `OtelProviderShutdown_*`, which is the bounded cost of reclaiming an unbounded one
- `_tracer_provider_cache` is now an `OrderedDict`. It has no non-test readers, and `OrderedDict() == {}` still holds for the existing assertion in `test_langfuse_otel.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ce1956741c8d849d0eddd91c8378c18f01a23347. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
