### PR TITLE
fix(passthrough): carry the budget reservation into request metadata

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -565,6 +565,7 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
         # real parent span.
         _metadata["user_api_key"] = user_api_key_dict.api_key
         _metadata["litellm_parent_otel_span"] = user_api_key_dict.parent_otel_span
+        _metadata["user_api_key_budget_reservation"] = user_api_key_dict.budget_reservation
         _metadata.update(
             LiteLLMProxyRequestSetup.get_sanitized_user_information_from_key(user_api_key_dict=user_api_key_dict)
         )

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -4877,3 +4877,119 @@ async def test_unusable_upstream_cost_records_zero_not_the_flat_estimate():
     assert len(payloads) == 1
     assert payloads[0]["response_cost"] == 0.0
     assert payloads[0]["total_tokens"] == 1874
+
+
+def _passthrough_kwargs_for_reservation(
+    user_api_key_dict: UserAPIKeyAuth, parsed_body: Optional[dict] = None
+) -> dict:
+    mock_request = MagicMock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.url = (
+        "http://0.0.0.0:4000/gemini/v1beta/models/gemini-2.5-flash:generateContent"
+    )
+    mock_request.headers = Headers({})
+
+    return HttpPassThroughEndpointHelpers._init_kwargs_for_pass_through_endpoint(
+        request=mock_request,
+        user_api_key_dict=user_api_key_dict,
+        passthrough_logging_payload=MagicMock(),
+        logging_obj=MagicMock(),
+        _parsed_body=parsed_body if parsed_body is not None else {},
+        litellm_call_id="lit-5425-call-id",
+    )
+
+
+async def _track_cost_for_passthrough_kwargs(kwargs: dict) -> AsyncMock:
+    from datetime import datetime
+
+    from litellm.proxy.hooks.proxy_track_cost_callback import _ProxyDBLogger
+
+    callback_kwargs = {
+        **kwargs,
+        "stream": False,
+        "standard_logging_object": {
+            "response_cost": 0.002,
+            "request_tags": None,
+        },
+    }
+
+    increment_spend_counters = AsyncMock()
+    with (
+        patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging,
+        patch(
+            "litellm.proxy.proxy_server.increment_spend_counters",
+            increment_spend_counters,
+        ),
+        patch("litellm.proxy.proxy_server.update_cache", new_callable=AsyncMock),
+    ):
+        mock_proxy_logging.db_spend_update_writer.update_database = AsyncMock()
+        mock_proxy_logging.slack_alerting_instance.customer_spend_alert = AsyncMock()
+
+        await _ProxyDBLogger()._PROXY_track_cost_callback(
+            kwargs=callback_kwargs,
+            completion_response=None,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+        )
+
+    return increment_spend_counters
+
+
+@pytest.mark.asyncio
+async def test_passthrough_success_reconciles_budget_reservation():
+    """
+    A successful pass-through request must hand its pre-call budget reservation
+    to the spend-counter update so the reserved amount is reconciled down to the
+    actual cost. Without it the reservation stays in the shared Redis counter and
+    the actual cost is added on top, so the counter drifts above real spend until
+    the key falsely trips BudgetExceededError.
+    """
+    budget_reservation = {
+        "reserved_cost": 0.5,
+        "entries": [{"counter_key": "spend:key:hashed-token", "reserved_cost": 0.5}],
+    }
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="hashed-token",
+        user_id="u1",
+        budget_reservation=budget_reservation,
+    )
+
+    reservation = user_api_key_dict.budget_reservation
+    kwargs = _passthrough_kwargs_for_reservation(user_api_key_dict)
+    assert (
+        kwargs["litellm_params"]["metadata"]["user_api_key_budget_reservation"]
+        is reservation
+    )
+
+    increment_spend_counters = await _track_cost_for_passthrough_kwargs(kwargs)
+
+    increment_spend_counters.assert_awaited_once()
+    assert increment_spend_counters.await_args.kwargs["budget_reservation"] is reservation
+    assert increment_spend_counters.await_args.kwargs["budget_reservation"] == budget_reservation
+
+
+@pytest.mark.asyncio
+async def test_passthrough_body_cannot_forge_budget_reservation():
+    """
+    The reservation is an internal counter handle: a client-supplied metadata
+    field naming arbitrary counter keys must never reach the spend-counter
+    update, or a caller could decrement another entity's Redis counter.
+    """
+    forged = {
+        "reserved_cost": 99.0,
+        "entries": [{"counter_key": "spend:team:victim", "reserved_cost": 99.0}],
+    }
+    user_api_key_dict = UserAPIKeyAuth(api_key="hashed-token", user_id="u1")
+
+    kwargs = _passthrough_kwargs_for_reservation(
+        user_api_key_dict,
+        parsed_body={"litellm_metadata": {"user_api_key_budget_reservation": forged}},
+    )
+    assert (
+        kwargs["litellm_params"]["metadata"]["user_api_key_budget_reservation"] is None
+    )
+
+    increment_spend_counters = await _track_cost_for_passthrough_kwargs(kwargs)
+
+    increment_spend_counters.assert_awaited_once()
+    assert increment_spend_counters.await_args.kwargs["budget_reservation"] is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Successful passthrough requests leak budget reservations into Redis
- The shared spend counter drifts above real spend on every request
- Keys hit false BudgetExceededError while Postgres spend stays tiny

How it solves it:

- Passthrough metadata now carries the pre-call budget reservation
- The success cost callback can reconcile it instead of double counting
- Set after the client metadata merge, so a body cannot forge one

## User Flow

Before: a developer sending passthrough traffic through a budgeted key gets 429s after a handful of requests, and the spend page says they have spent almost nothing

1. An admin creates a key with `"max_budget": 0.30` via POST http://localhost:4000/key/generate
2. The developer sends POST http://localhost:4000/openai/v1/chat/completions with that key, `"model": "gpt-5"` and `"max_completion_tokens": 8000`, and gets a normal 200 with a completion
3. They repeat it three more times, all 200
4. The fifth identical request comes back HTTP 429 `Budget has been exceeded! ... Current cost: 0.30011, Max budget: 0.3`
5. They check their spend and it reads $0.00108 of $0.30, so the gateway is refusing a key that is 0.4% used
6. Every later request on that key keeps failing until the counter happens to expire, then the same thing happens again

After: the same key serves traffic until its real spend actually reaches the budget

1. An admin creates a key with `"max_budget": 0.30` via POST http://localhost:4000/key/generate
2. The developer sends POST http://localhost:4000/openai/v1/chat/completions with that key, `"model": "gpt-5"` and `"max_completion_tokens": 8000`, and gets a normal 200 with a completion
3. They repeat it three more times, all 200
4. The fifth identical request comes back 200 with a completion
5. Their spend reads $0.00055 of $0.30, matching what the gateway is enforcing against
6. A sixth request also returns 200, and the key keeps working until real spend reaches $0.30

A caller also cannot put a `user_api_key_budget_reservation` in the request body to make the gateway subtract from another key's or team's counter

## Relevant issues

## Linear ticket

Resolves LIT-5425

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on port 4425 against real Postgres, real Redis, and the real OpenAI API. Same commands, same key budget, same request body on both legs. Only the proxy's code differs

### Before, at `bea31871fc` (the base commit, without this fix)

```
$ curl -s -X POST http://127.0.0.1:4425/key/generate \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"max_budget": 0.30, "key_alias": "lit5425-BEFORE"}'
hashed token: 1b92628a116b7e82dc7f14e0614e34e7c8888746b1b2fee7e925f3fe138c547c

$ for i in 1 2 3 4 5; do
    curl -s -X POST http://127.0.0.1:4425/openai/v1/chat/completions \
      -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
      -d '{"model": "gpt-5", "max_completion_tokens": 8000, "messages": [{"role": "user", "content": "Say OK"}]}'
    sleep 2
  done
  request 1 -> id= chatcmpl-EBrbmGuLTVST1T5916mluhYHUsQjY  total_tokens= 82
  request 2 -> id= chatcmpl-EBrbpyqPrx74Q7ArjQLQWfgnERHHV  total_tokens= 18
  request 3 -> id= chatcmpl-EBrbssjLeEFKDcyvgiW9V5YEVfHh6  total_tokens= 18
  request 4 -> id= chatcmpl-EBrbwrjWZdDJx34Mw0GRH5k33iHxP  total_tokens= 18
  request 5 -> id= None  {"message": "Budget has been exceeded! Key=lit5425-BEFORE (sk-...i17w) Current cost: 0.30011, Max budget: 0.3", "type": "budget_exceeded"}

$ docker exec lit5425-pg psql -U lit5425 -d lit5425 -t -A -c \
    "SELECT spend, max_budget FROM \"LiteLLM_VerificationToken\" WHERE token='1b92628a...'"
db_spend=0.00108000 | max_budget=0.3

$ docker exec lit5425-redis redis-cli GET "spend:key:1b92628a..."
0.30010999999999999

$ curl -s -X POST http://127.0.0.1:4425/openai/v1/chat/completions -H "Authorization: Bearer $KEY" ... -w "HTTP %{http_code}"
{"error":{"message":"Budget has been exceeded! Key=lit5425-BEFORE (sk-...i17w) Current cost: 0.30011, Max budget: 0.3","type":"budget_exceeded","param":null,"code":"429"}}
  HTTP 429
```

4 successful requests cost $0.00108, and the counter the gateway enforces against reads $0.30011, so a key that is 0.4% used is refused

### After, at `9db6b900e2` (this PR)

```
$ curl -s -X POST http://127.0.0.1:4425/key/generate \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"max_budget": 0.30, "key_alias": "lit5425-AFTER"}'
hashed token: 0205e4a1d4673e27f44373d5280f502e126817bd6f2fd5e4197abf4cfc674b57

$ for i in 1 2 3 4 5; do ...same request body... done
  request 1 -> id= chatcmpl-EBrcZMsa2oH4m7UwptX3MlbJcenao  total_tokens= 18
  request 2 -> id= chatcmpl-EBrcc3GdILoeXypdxhJ1fMnsebKgo  total_tokens= 18
  request 3 -> id= chatcmpl-EBrcgNCCrLW48im0xGaepJ1W9Ecjk  total_tokens= 18
  request 4 -> id= chatcmpl-EBrckgUQ3RixLqS2dhnnle37gmGjY  total_tokens= 18
  request 5 -> id= chatcmpl-EBrcnWogvuF8mMKgUKnpivCfjuqdz  total_tokens= 18

$ docker exec lit5425-pg psql -U lit5425 -d lit5425 -t -A -c \
    "SELECT spend, max_budget FROM \"LiteLLM_VerificationToken\" WHERE token='0205e4a1...'"
db_spend=0.00055000 | max_budget=0.3

$ docker exec lit5425-redis redis-cli GET "spend:key:0205e4a1..."
0.00054999999999995

$ curl -s -X POST http://127.0.0.1:4425/openai/v1/chat/completions -H "Authorization: Bearer $KEY" ... -w "HTTP %{http_code}"
{
  "id": "chatcmpl-EBrd02ERzwLj5Mw1ULuaIsbuovVfc",
  "model": "gpt-5-2025-08-07",
  "choices": [{"index": 0, "message": {"role": "assistant", "content": "OK"}, "finish_reason": "stop"}],
  "usage": {"prompt_tokens": 8, "completion_tokens": 10, "total_tokens": 18}
}
  HTTP 200
```

All 5 requests succeed, the Redis counter tracks the recorded spend to the cent, and the 6th request is served

### Streaming, both legs, same rig

The metadata is built at one shared site, so streaming passthrough leaked the same way. Four streaming requests (`"stream": true`) on a fresh $0.30 key, each returning 4 SSE chunks

```
BEFORE, at bea31871fc            AFTER, at 9db6b900e2
  db_spend  = 0.00004000           db_spend  = 0.00004000
  redis     = 0.30000999999999999  redis     = 0.00003999999999996
  5th request HTTP 429             5th request HTTP 200
```

### Which routes could leak at all

A reservation is only minted when the route is an LLM API route and a model resolves from it, so this is the exact population that was leaking and is now covered by the one shared site

```
MINTS  /gemini/v1beta/models/gemini-2.5-flash:generateContent          est. max cost 0.3555328
MINTS  /gemini/v1beta/models/gemini-2.5-flash:streamGenerateContent    est. max cost 0.3555328
MINTS  /vertex_ai/.../models/gemini-2.5-flash:generateContent          est. max cost 0.3555328
MINTS  /anthropic/v1/messages                                          est. max cost 0.001509
MINTS  /openai/v1/chat/completions                                     est. max cost 0.08000375
MINTS  /cohere/v2/chat                                                 est. max cost 0.0409675
no     /assemblyai/v2/transcript      model=None
no     /langfuse/api/public/ingestion  model=None
no     /bedrock/model/.../converse     model=None
```

The two routes whose success handling returns early without dispatching the cost callback, assemblyai and langfuse, are also the two that mint no reservation, so nothing is left uncovered

## Review notes

Two P2 review-bot findings on the test file, both kept as written, with the reasoning here since a GitHub comment cannot carry it

On the helper dict types: the two helpers wrap `_init_kwargs_for_pass_through_endpoint`, whose own production signature is `_parsed_body: dict | None = None` and `-> dict` (pass_through_endpoints.py:532,534). The value really is a heterogeneous kwargs mapping carrying `litellm_params`, `call_type`, `litellm_call_id` and `passthrough_logging_payload`, so a narrower annotation on the test helper would describe something the production function does not return. Mirroring the wrapped signature is the honest type here, and the alternative is inventing a TypedDict for a shape production does not declare

On the docstrings: they record why each test exists, which the names and assertions do not carry. `test_passthrough_success_reconciles_budget_reservation` does not say that the counter drifts above real spend and falsely trips BudgetExceededError, and `test_passthrough_body_cannot_forge_budget_reservation` does not say that a forged value would decrement another entity's counter. That is the customer-visible failure each test pins, and it is the convention in this file already: 146 of its tests carry the same kind of docstring

## Type

🐛 Bug Fix

## Caveats (if any)

- Only routes whose model resolves get a reservation; the rest were never affected
- Fix lands at the shared metadata site, covering streaming, non-streaming and websocket passthrough
- `/vllm` and the `/azure` router-model branch leak the same way from a different site; scoped out below

The two router-model branches at `llm_passthrough_endpoints.py:328` and `:1282` call `llm_router.allm_passthrough_route(...)` directly, so they never reach `pass_through_request` and thread no metadata at all. They do mint a reservation, since both prefixes are LLM API routes and the branch condition is that the body's `model` names a router model, so it always resolves in the cost map:

```
MINTS  /vllm/v1/chat/completions      is_llm=True model='gpt-5' est_max_cost=0.08000375
MINTS  /azure/v1/chat/completions     is_llm=True model='gpt-5' est_max_cost=0.08000375
MINTS  /azure_ai/v1/chat/completions  is_llm=True model='gpt-5' est_max_cost=0.08000375
```

That is the same leak from a different site, and it carries no `user_api_key` either, so it is a wider defect than this one. Kept out of this PR to hold it to one problem, and filed as LIT-5470

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
