### PR TITLE
feat(otel): attribute Prisma database spans to PostgreSQL instead of localhost

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -20,6 +20,7 @@ from litellm.integrations.opentelemetry_utils.gen_ai_semconv import (
     OTELSemconvCategory,
     parse_semconv_opt_in,
 )
+from litellm.integrations.otel.model.db_endpoint import db_span_attributes
 from litellm.integrations.otel.model.semconv import Metric
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.secret_redaction import redact_string
@@ -718,6 +719,28 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         self._handle_failure(kwargs, response_obj, start_time, end_time)
 
+    def _start_service_span(self, payload: ServiceLoggerPayload, parent_otel_span: Span, start_time_ns: int) -> Span:
+        """Open a service span, named and classified by what the service is.
+
+        A datastore call is an outbound CLIENT span carrying ``db.*`` semconv.
+        Without those a Postgres span says only ``service=postgres``, so the
+        backend falls back to the transport peer, which for Prisma is the local
+        query engine on loopback. Everything else stays an INTERNAL span.
+        """
+        from opentelemetry import trace
+        from opentelemetry.trace import SpanKind
+
+        attributes: Final = db_span_attributes(payload.service.value, payload.call_type)
+        span: Final = self.tracer.start_span(
+            name=payload.service,
+            context=trace.set_span_in_context(parent_otel_span),
+            start_time=start_time_ns,
+            kind=SpanKind.CLIENT if attributes else SpanKind.INTERNAL,
+        )
+        for key, value in attributes.items():
+            self.safe_set_attribute(span=span, key=key, value=value)
+        return span
+
     async def async_service_success_hook(
         self,
         payload: ServiceLoggerPayload,
@@ -726,7 +749,6 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         end_time: datetime | float | None = None,
         event_metadata: dict | None = None,
     ):
-        from opentelemetry import trace
         from opentelemetry.trace import Status, StatusCode
 
         _start_time_ns = 0
@@ -743,12 +765,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             _end_time_ns = self._to_ns(end_time)
 
         if parent_otel_span is not None:
-            _span_name: Final = payload.service
-            service_logging_span: Final = self.tracer.start_span(
-                name=_span_name,
-                context=trace.set_span_in_context(parent_otel_span),
-                start_time=_start_time_ns,
-            )
+            service_logging_span: Final = self._start_service_span(payload, parent_otel_span, _start_time_ns)
             self.safe_set_attribute(
                 span=service_logging_span,
                 key="call_type",
@@ -786,7 +803,6 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         end_time: float | datetime | None = None,
         event_metadata: dict | None = None,
     ):
-        from opentelemetry import trace
         from opentelemetry.trace import Status, StatusCode
 
         _start_time_ns = 0
@@ -803,12 +819,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             _end_time_ns = self._to_ns(end_time)
 
         if parent_otel_span is not None:
-            _span_name: Final = payload.service
-            service_logging_span: Final = self.tracer.start_span(
-                name=_span_name,
-                context=trace.set_span_in_context(parent_otel_span),
-                start_time=_start_time_ns,
-            )
+            service_logging_span: Final = self._start_service_span(payload, parent_otel_span, _start_time_ns)
             self.safe_set_attribute(
                 span=service_logging_span,
                 key="call_type",

--- a/litellm/integrations/otel/mappers/genai.py
+++ b/litellm/integrations/otel/mappers/genai.py
@@ -18,6 +18,7 @@ from litellm.integrations.otel.mappers.utils import (
     serialize_messages,
     tool_definition_attrs,
 )
+from litellm.integrations.otel.model.db_endpoint import db_span_attributes
 from litellm.integrations.otel.model.payloads import (
     GuardrailSpanData,
     LLMCallSpanData,
@@ -27,7 +28,6 @@ from litellm.integrations.otel.model.payloads import (
     ToolDefinition,
 )
 from litellm.integrations.otel.model.semconv import (
-    DB,
     MCP,
     Error,
     GenAI,
@@ -36,7 +36,6 @@ from litellm.integrations.otel.model.semconv import (
     RpcSystem,
     Server,
 )
-from litellm.integrations.otel.model.spans import db_system
 
 
 class GenAIMapper:
@@ -182,12 +181,8 @@ class GenAIMapper:
     def _service(cls, data: ServiceSpanData) -> AttributeMap:
         attrs: Final = collect(cls._SERVICE_ATTRS, data)
         # An outbound datastore call (DB_CALL / CLIENT span) also carries db.*
-        # semconv. Internal services (router, budget jobs, …) have no db.system,
-        # so they get only the litellm.service.* keys above.
-        system: Final = db_system(data.service_name)
-        if system is not None:
-            attrs[DB.SYSTEM_NAME] = system
-            if data.call_type:
-                attrs[DB.OPERATION_NAME] = data.call_type
+        # semconv naming the server it reached. Internal services (router, budget
+        # jobs, …) have no db.system, so they get only the litellm.service.* keys.
+        attrs.update(db_span_attributes(data.service_name, data.call_type))
         attrs.update({f"{LiteLLM.METADATA_PREFIX}{key}": value for key, value in data.event_metadata.items()})
         return attrs

--- a/litellm/integrations/otel/model/db_endpoint.py
+++ b/litellm/integrations/otel/model/db_endpoint.py
@@ -78,11 +78,12 @@ def _first(values: Sequence[str] | None) -> str:
 def _namespace(database: str, schema: str) -> str | None:
     """``{database}|{schema}`` per the PostgreSQL semconv, dropping absent halves.
 
-    Prisma's default schema stays implicit, case-insensitively because an
-    unquoted identifier folds, so one deployment yields one value however the
-    DSN spells it.
+    Only Prisma's literal default schema stays implicit. The match is
+    case-sensitive because Prisma quotes the name, so ``?schema=PUBLIC`` builds
+    a second schema alongside ``public`` and the two must not collapse to one
+    namespace.
     """
-    qualifier: Final = "" if schema.casefold() == _DEFAULT_POSTGRES_SCHEMA else schema
+    qualifier: Final = "" if schema == _DEFAULT_POSTGRES_SCHEMA else schema
     return "|".join(part for part in (database, qualifier) if part) or None
 
 

--- a/litellm/integrations/otel/model/db_endpoint.py
+++ b/litellm/integrations/otel/model/db_endpoint.py
@@ -5,9 +5,8 @@ transport-level instrumentation attributes the work to ``localhost`` and an
 operator cannot tell it is a PostgreSQL call or correlate it with the database's
 own metrics. These attributes name the real server on litellm's DB spans.
 
-Only the host, port, database and schema of the DSN are read. The user,
-password, IAM token and every other query parameter are never parsed out, so no
-credential can reach an exporter.
+Only the host, port, database and schema of the DSN are read, so no credential
+can reach an exporter.
 """
 
 from __future__ import annotations
@@ -24,10 +23,12 @@ from litellm.integrations.otel.model.spans import POSTGRESQL, db_system
 from litellm.secret_managers.main import get_secret_str
 
 _DEFAULT_POSTGRES_PORT: Final = 5432
-# Prisma's own default. Emitting it would split ``db.namespace`` across two
-# deployments of the same database that differ only in spelling the default out.
 _DEFAULT_POSTGRES_SCHEMA: Final = "public"
 _POSTGRES_SCHEMES: Final = frozenset({"postgres", "postgresql"})
+# An unencoded '/' in the password truncates the authority, so urlparse hands
+# back the username as the host and the rest of the credential as the path.
+# Either character in the raw database segment means that happened.
+_MISPARSED_AUTHORITY_MARKERS: Final = frozenset("@/")
 _EMPTY_ATTRIBUTES: Final[Mapping[str, str | int]] = MappingProxyType({})
 
 
@@ -35,8 +36,8 @@ _EMPTY_ATTRIBUTES: Final[Mapping[str, str | int]] = MappingProxyType({})
 class DatabaseEndpoint:
     """The non-sensitive identity of a PostgreSQL server, parsed from a DSN."""
 
-    address: str
-    port: int
+    address: str | None
+    port: int | None
     namespace: str | None
 
 
@@ -53,20 +54,21 @@ def parse_database_endpoint(url: str | None) -> DatabaseEndpoint | None:
         parsed: Final = urlparse(url)
         if parsed.scheme not in _POSTGRES_SCHEMES:
             return None
-        query: Final = parse_qs(parsed.query)
-        # A ``host=`` parameter overrides the netloc host: it is how libpq
-        # addresses a Unix socket directory, and how the Cloud SQL connector is
-        # configured behind a ``localhost`` netloc. Trusting the netloc there
-        # would report the same ``localhost`` this module exists to replace.
-        address: Final = _first(query.get("host")) or parsed.hostname
-        if not address:
+        raw_database: Final = (parsed.path or "").lstrip("/")
+        if _MISPARSED_AUTHORITY_MARKERS & set(raw_database):
             return None
-        port: Final = parsed.port or _DEFAULT_POSTGRES_PORT
-        database: Final = unquote((parsed.path or "").lstrip("/"))
-        schema: Final = _first(query.get("schema"))
+        query: Final = parse_qs(parsed.query)
+        # ``host=`` beats the netloc: it is how libpq names a Unix socket
+        # directory and how the Cloud SQL connector sits behind a localhost
+        # netloc, where the netloc is the very answer this module replaces.
+        address: Final = _first(query.get("host")) or parsed.hostname
+        port: Final = (parsed.port or _DEFAULT_POSTGRES_PORT) if address else None
+        namespace: Final = _namespace(unquote(raw_database), _first(query.get("schema")))
     except ValueError:
         return None
-    return DatabaseEndpoint(address=address, port=port, namespace=_namespace(database, schema))
+    if address is None and namespace is None:
+        return None
+    return DatabaseEndpoint(address=address, port=port, namespace=namespace)
 
 
 def _first(values: Sequence[str] | None) -> str:
@@ -74,8 +76,13 @@ def _first(values: Sequence[str] | None) -> str:
 
 
 def _namespace(database: str, schema: str) -> str | None:
-    """``{database}|{schema}`` per the PostgreSQL semconv, dropping absent halves."""
-    qualifier: Final = "" if schema == _DEFAULT_POSTGRES_SCHEMA else schema
+    """``{database}|{schema}`` per the PostgreSQL semconv, dropping absent halves.
+
+    Prisma's default schema stays implicit, case-insensitively because an
+    unquoted identifier folds, so one deployment yields one value however the
+    DSN spells it.
+    """
+    qualifier: Final = "" if schema.casefold() == _DEFAULT_POSTGRES_SCHEMA else schema
     return "|".join(part for part in (database, qualifier) if part) or None
 
 
@@ -83,16 +90,15 @@ def _namespace(database: str, schema: str) -> str | None:
 def postgres_endpoint() -> DatabaseEndpoint | None:
     """The configured PostgreSQL endpoint, or ``None`` when it cannot be named.
 
-    ``DATABASE_URL`` is deployment-static, and ``get_secret_str`` can reach a
-    configured secret manager, so this must not be re-resolved per DB span. The
-    empty default keeps a misconfigured secret manager from raising into span
-    emission. Tests that change the environment call
-    ``postgres_endpoint.cache_clear()``.
+    Resolved once: ``DATABASE_URL`` is deployment-static (an RDS IAM refresh
+    rotates only the token), and ``get_secret_str`` can reach a secret manager,
+    so this must not run per span. The empty default keeps a misconfigured
+    secret manager from raising into span emission. Tests that change the
+    environment call ``postgres_endpoint.cache_clear()``.
 
     A configured read replica yields ``None``: ``RoutingPrismaWrapper`` picks
-    reader or writer per Prisma call, underneath the span, so no single endpoint
-    is true for every span and naming the writer would attribute replica reads to
-    the primary.
+    reader or writer per Prisma call, underneath the span, so naming the writer
+    would attribute replica reads to the primary.
     """
     if get_secret_str("DATABASE_URL_READ_REPLICA", default_value=""):
         return None
@@ -104,10 +110,9 @@ def db_span_attributes(service_name: str, call_type: str | None = None) -> Mappi
 
     Empty for services that are not outbound datastore calls. Endpoint
     attributes are PostgreSQL-only: ``DATABASE_URL`` says nothing about where
-    the redis-backed services point.
-
-    ``db.system`` is emitted alongside the current ``db.system.name`` because
-    Datadog's OTLP intake still infers a span's database type from the older key.
+    the redis-backed services point. ``db.system`` rides alongside the current
+    ``db.system.name`` because Datadog's OTLP intake still types a database span
+    from the older key.
     """
     system: Final = db_system(service_name)
     if system is None:

--- a/litellm/integrations/otel/model/db_endpoint.py
+++ b/litellm/integrations/otel/model/db_endpoint.py
@@ -26,7 +26,6 @@ _READ_REPLICA_ENV: Final = "DATABASE_URL_READ_REPLICA"
 _DEFAULT_POSTGRES_PORT: Final = 5432
 _DEFAULT_POSTGRES_SCHEMA: Final = "public"
 _POSTGRES_SCHEMES: Final = frozenset({"postgres", "postgresql"})
-_MISPARSED_AUTHORITY_MARKERS: Final = frozenset("@/")
 _EMPTY_ATTRIBUTES: Final[Mapping[str, str | int]] = MappingProxyType({})
 
 
@@ -54,13 +53,14 @@ def parse_database_endpoint(url: str | None) -> DatabaseEndpoint | None:
             return None
         query: Final = parse_qs(parsed.query)
         raw_database: Final = (parsed.path or "").lstrip("/")
-        if _is_misparsed_authority(parsed, raw_database, query):
+        if _is_misparsed_authority(parsed, url, raw_database):
             return None
         # ``host=`` beats the netloc: it is how libpq names a Unix socket
         # directory and how the Cloud SQL connector sits behind a localhost
         # netloc, where the netloc is the very answer this module replaces.
         address: Final = _first(query.get("host")) or parsed.hostname
-        port: Final = (parsed.port or _DEFAULT_POSTGRES_PORT) if address else None
+        # ``port=`` accompanies ``host=`` in a libpq URI, so honour it the same way.
+        port: Final = _port(_first(query.get("port")), parsed.port) if address else None
         namespace: Final = _namespace(unquote(raw_database), _first(query.get("schema")))
     except ValueError:
         return None
@@ -69,27 +69,37 @@ def parse_database_endpoint(url: str | None) -> DatabaseEndpoint | None:
     return DatabaseEndpoint(address=address, port=port, namespace=namespace)
 
 
-def _is_misparsed_authority(parsed: ParseResult, raw_database: str, query: Mapping[str, Sequence[str]]) -> bool:
-    """Whether an unencoded character in the password truncated the authority.
+def _is_misparsed_authority(parsed: ParseResult, url: str, raw_database: str) -> bool:
+    """Whether the URL authority may have been truncated by an unencoded character.
 
     ``/``, ``#`` or ``?`` in a password ends the netloc early, so urlparse hands
-    back the username as the host and strands the real userinfo ``@`` in the
-    path, fragment or query. A PostgreSQL DSN never carries a fragment, and its
-    database name cannot hold an unencoded ``@`` or ``/``. An ``@`` in the query
-    is legitimate only when the query parsed as parameters AND a database path
-    preceded it, as in ``postgres://host/db?application_name=svc@prod``. A ``?``
-    in a password strands the tail in the query with no path left behind, and it
-    can still parse as parameters, so neither test alone is enough.
+    back the username as the host, the leading digits of the password as the
+    port, and the rest of the credential as the path, query or fragment. The
+    stranded userinfo ``@`` is the only surviving evidence.
+
+    A DSN that carries the at-sign in a query parameter instead, such as
+    A database name cannot hold an unencoded slash either, so a second path
+    segment is the same evidence.
+
+    ``?application_name=svc@prod``, is indistinguishable from a mis-split by any
+    property of the parse: both leave no userinfo, a host, a port and a path.
+    Since guessing wrong publishes a credential fragment to a tracing backend,
+    that ambiguity resolves to refusing the endpoint. Such a DSN loses
+    ``server.address`` and ``db.namespace`` and keeps the rest of the span,
+    which is the cheaper error of the two. Percent-encode the at-sign to keep
+    them.
     """
-    if parsed.fragment:
+    if "/" in raw_database:
         return True
-    if any(marker in raw_database for marker in _MISPARSED_AUTHORITY_MARKERS):
-        return True
-    return "@" in parsed.query and (not query or not parsed.path)
+    return "@" in url and "@" not in parsed.netloc
 
 
 def _first(values: Sequence[str] | None) -> str:
     return values[0] if values else ""
+
+
+def _port(from_query: str, from_netloc: int | None) -> int:
+    return int(from_query) if from_query.isdigit() else (from_netloc or _DEFAULT_POSTGRES_PORT)
 
 
 def _namespace(database: str, schema: str) -> str | None:

--- a/litellm/integrations/otel/model/db_endpoint.py
+++ b/litellm/integrations/otel/model/db_endpoint.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from functools import lru_cache
 from types import MappingProxyType
 from typing import Final
 from urllib.parse import ParseResult, parse_qs, unquote, urlparse
@@ -24,8 +23,6 @@ from litellm.integrations.otel.model.spans import POSTGRESQL, db_system
 
 _DATABASE_URL_ENV: Final = "DATABASE_URL"
 _READ_REPLICA_ENV: Final = "DATABASE_URL_READ_REPLICA"
-# Bounded because each RDS IAM token rotation produces a new URL string.
-_ENDPOINT_CACHE_SIZE: Final = 8
 _DEFAULT_POSTGRES_PORT: Final = 5432
 _DEFAULT_POSTGRES_SCHEMA: Final = "public"
 _POSTGRES_SCHEMES: Final = frozenset({"postgres", "postgresql"})
@@ -107,11 +104,6 @@ def _namespace(database: str, schema: str) -> str | None:
     return "|".join(part for part in (database, qualifier) if part) or None
 
 
-@lru_cache(maxsize=_ENDPOINT_CACHE_SIZE)
-def _endpoint_for(url: str) -> DatabaseEndpoint | None:
-    return parse_database_endpoint(url)
-
-
 def postgres_endpoint() -> DatabaseEndpoint | None:
     """The PostgreSQL endpoint the process is currently connected to.
 
@@ -134,7 +126,7 @@ def postgres_endpoint() -> DatabaseEndpoint | None:
     """
     if os.environ.get(_READ_REPLICA_ENV):
         return None
-    return _endpoint_for(os.environ.get(_DATABASE_URL_ENV, ""))
+    return parse_database_endpoint(os.environ.get(_DATABASE_URL_ENV, ""))
 
 
 def db_span_attributes(service_name: str, call_type: str | None = None) -> Mapping[str, str | int]:

--- a/litellm/integrations/otel/model/db_endpoint.py
+++ b/litellm/integrations/otel/model/db_endpoint.py
@@ -79,14 +79,16 @@ def _is_misparsed_authority(parsed: ParseResult, raw_database: str, query: Mappi
     back the username as the host and strands the real userinfo ``@`` in the
     path, fragment or query. A PostgreSQL DSN never carries a fragment, and its
     database name cannot hold an unencoded ``@`` or ``/``. An ``@`` in the query
-    is only suspicious when the query did not parse as parameters, since
-    ``?application_name=svc@prod`` is legitimate.
+    is legitimate only when the query parsed as parameters AND a database path
+    preceded it, as in ``postgres://host/db?application_name=svc@prod``. A ``?``
+    in a password strands the tail in the query with no path left behind, and it
+    can still parse as parameters, so neither test alone is enough.
     """
     if parsed.fragment:
         return True
     if _MISPARSED_AUTHORITY_MARKERS & set(raw_database):
         return True
-    return "@" in parsed.query and not query
+    return "@" in parsed.query and (not query or not parsed.path)
 
 
 def _first(values: Sequence[str] | None) -> str:

--- a/litellm/integrations/otel/model/db_endpoint.py
+++ b/litellm/integrations/otel/model/db_endpoint.py
@@ -25,9 +25,10 @@ from litellm.secret_managers.main import get_secret_str
 _DEFAULT_POSTGRES_PORT: Final = 5432
 _DEFAULT_POSTGRES_SCHEMA: Final = "public"
 _POSTGRES_SCHEMES: Final = frozenset({"postgres", "postgresql"})
-# An unencoded '/' in the password truncates the authority, so urlparse hands
-# back the username as the host and the rest of the credential as the path.
-# Either character in the raw database segment means that happened.
+# An unencoded '/', '#' or '?' in the password truncates the authority, so
+# urlparse hands back the username as the host and the rest of the credential as
+# the path, query or fragment. Either character in the raw database segment, or a
+# userinfo '@' that fell outside the netloc, means that happened.
 _MISPARSED_AUTHORITY_MARKERS: Final = frozenset("@/")
 _EMPTY_ATTRIBUTES: Final[Mapping[str, str | int]] = MappingProxyType({})
 
@@ -53,6 +54,8 @@ def parse_database_endpoint(url: str | None) -> DatabaseEndpoint | None:
     try:
         parsed: Final = urlparse(url)
         if parsed.scheme not in _POSTGRES_SCHEMES:
+            return None
+        if "@" in url and "@" not in parsed.netloc:
             return None
         raw_database: Final = (parsed.path or "").lstrip("/")
         if _MISPARSED_AUTHORITY_MARKERS & set(raw_database):

--- a/litellm/integrations/otel/model/db_endpoint.py
+++ b/litellm/integrations/otel/model/db_endpoint.py
@@ -1,0 +1,124 @@
+"""OTel ``db.*`` / ``server.*`` attributes naming the database litellm talks to.
+
+Prisma reaches PostgreSQL through a query engine listening on loopback, so
+transport-level instrumentation attributes the work to ``localhost`` and an
+operator cannot tell it is a PostgreSQL call or correlate it with the database's
+own metrics. These attributes name the real server on litellm's DB spans.
+
+Only the host, port, database and schema of the DSN are read. The user,
+password, IAM token and every other query parameter are never parsed out, so no
+credential can reach an exporter.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+from types import MappingProxyType
+from typing import Final
+from urllib.parse import parse_qs, unquote, urlparse
+
+from litellm.integrations.otel.model.semconv import DB, Server
+from litellm.integrations.otel.model.spans import POSTGRESQL, db_system
+from litellm.secret_managers.main import get_secret_str
+
+_DEFAULT_POSTGRES_PORT: Final = 5432
+# Prisma's own default. Emitting it would split ``db.namespace`` across two
+# deployments of the same database that differ only in spelling the default out.
+_DEFAULT_POSTGRES_SCHEMA: Final = "public"
+_POSTGRES_SCHEMES: Final = frozenset({"postgres", "postgresql"})
+_EMPTY_ATTRIBUTES: Final[Mapping[str, str | int]] = MappingProxyType({})
+
+
+@dataclass(frozen=True, slots=True)
+class DatabaseEndpoint:
+    """The non-sensitive identity of a PostgreSQL server, parsed from a DSN."""
+
+    address: str
+    port: int
+    namespace: str | None
+
+
+def parse_database_endpoint(url: str | None) -> DatabaseEndpoint | None:
+    """Parse a PostgreSQL DSN into its exportable endpoint identity.
+
+    Returns ``None`` for an absent, malformed or non-PostgreSQL URL rather than
+    raising: an unparseable DSN must degrade to a span without endpoint
+    attributes, never break the request that emitted it.
+    """
+    if not url:
+        return None
+    try:
+        parsed: Final = urlparse(url)
+        if parsed.scheme not in _POSTGRES_SCHEMES:
+            return None
+        query: Final = parse_qs(parsed.query)
+        # A ``host=`` parameter overrides the netloc host: it is how libpq
+        # addresses a Unix socket directory, and how the Cloud SQL connector is
+        # configured behind a ``localhost`` netloc. Trusting the netloc there
+        # would report the same ``localhost`` this module exists to replace.
+        address: Final = _first(query.get("host")) or parsed.hostname
+        if not address:
+            return None
+        port: Final = parsed.port or _DEFAULT_POSTGRES_PORT
+        database: Final = unquote((parsed.path or "").lstrip("/"))
+        schema: Final = _first(query.get("schema"))
+    except ValueError:
+        return None
+    return DatabaseEndpoint(address=address, port=port, namespace=_namespace(database, schema))
+
+
+def _first(values: Sequence[str] | None) -> str:
+    return values[0] if values else ""
+
+
+def _namespace(database: str, schema: str) -> str | None:
+    """``{database}|{schema}`` per the PostgreSQL semconv, dropping absent halves."""
+    qualifier: Final = "" if schema == _DEFAULT_POSTGRES_SCHEMA else schema
+    return "|".join(part for part in (database, qualifier) if part) or None
+
+
+@lru_cache(maxsize=1)
+def postgres_endpoint() -> DatabaseEndpoint | None:
+    """The configured PostgreSQL endpoint, or ``None`` when it cannot be named.
+
+    ``DATABASE_URL`` is deployment-static, and ``get_secret_str`` can reach a
+    configured secret manager, so this must not be re-resolved per DB span. The
+    empty default keeps a misconfigured secret manager from raising into span
+    emission. Tests that change the environment call
+    ``postgres_endpoint.cache_clear()``.
+
+    A configured read replica yields ``None``: ``RoutingPrismaWrapper`` picks
+    reader or writer per Prisma call, underneath the span, so no single endpoint
+    is true for every span and naming the writer would attribute replica reads to
+    the primary.
+    """
+    if get_secret_str("DATABASE_URL_READ_REPLICA", default_value=""):
+        return None
+    return parse_database_endpoint(get_secret_str("DATABASE_URL", default_value=""))
+
+
+def db_span_attributes(service_name: str, call_type: str | None = None) -> Mapping[str, str | int]:
+    """The ``db.*``/``server.*`` attributes for a datastore service call.
+
+    Empty for services that are not outbound datastore calls. Endpoint
+    attributes are PostgreSQL-only: ``DATABASE_URL`` says nothing about where
+    the redis-backed services point.
+
+    ``db.system`` is emitted alongside the current ``db.system.name`` because
+    Datadog's OTLP intake still infers a span's database type from the older key.
+    """
+    system: Final = db_system(service_name)
+    if system is None:
+        return _EMPTY_ATTRIBUTES
+    endpoint: Final = postgres_endpoint() if system == POSTGRESQL else None
+    pairs: Final[tuple[tuple[str, str | int | None], ...]] = (
+        (DB.SYSTEM_NAME, system),
+        (DB.SYSTEM_LEGACY, system),
+        (DB.OPERATION_NAME, call_type),
+        (Server.ADDRESS, endpoint.address if endpoint is not None else None),
+        (Server.PORT, endpoint.port if endpoint is not None else None),
+        (DB.NAMESPACE, endpoint.namespace if endpoint is not None else None),
+    )
+    return MappingProxyType({key: value for key, value in pairs if value})

--- a/litellm/integrations/otel/model/db_endpoint.py
+++ b/litellm/integrations/otel/model/db_endpoint.py
@@ -83,7 +83,7 @@ def _is_misparsed_authority(parsed: ParseResult, raw_database: str, query: Mappi
     """
     if parsed.fragment:
         return True
-    if _MISPARSED_AUTHORITY_MARKERS & set(raw_database):
+    if any(marker in raw_database for marker in _MISPARSED_AUTHORITY_MARKERS):
         return True
     return "@" in parsed.query and (not query or not parsed.path)
 

--- a/litellm/integrations/otel/model/db_endpoint.py
+++ b/litellm/integrations/otel/model/db_endpoint.py
@@ -77,10 +77,10 @@ def _is_misparsed_authority(parsed: ParseResult, url: str, raw_database: str) ->
     port, and the rest of the credential as the path, query or fragment. The
     stranded userinfo ``@`` is the only surviving evidence.
 
-    A DSN that carries the at-sign in a query parameter instead, such as
     A database name cannot hold an unencoded slash either, so a second path
     segment is the same evidence.
 
+    A DSN that carries the at-sign in a query parameter instead, such as
     ``?application_name=svc@prod``, is indistinguishable from a mis-split by any
     property of the parse: both leave no userinfo, a host, a port and a path.
     Since guessing wrong publishes a credential fragment to a tracing backend,
@@ -127,8 +127,9 @@ def postgres_endpoint() -> DatabaseEndpoint | None:
     reconnect path re-reads ``DATABASE_URL``, and the DB-backed
     ``environment_variables`` config overlay can rewrite any of them after
     startup, so a value cached for the process lifetime goes stale against a
-    connection that has genuinely moved. Only the parse is memoized, keyed on the
-    URL, which keeps the per-span cost to a dict lookup.
+    connection that has genuinely moved. Nothing is memoized either: a cache
+    keyed on the URL would hold a rotated credential past its rotation, and the
+    parse is a single ``urlparse`` on a short string.
 
     A configured read replica yields ``None``: ``RoutingPrismaWrapper`` picks
     reader or writer per Prisma call, underneath the span, so naming the writer

--- a/litellm/integrations/otel/model/db_endpoint.py
+++ b/litellm/integrations/otel/model/db_endpoint.py
@@ -11,6 +11,7 @@ can reach an exporter.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from functools import lru_cache
@@ -20,8 +21,11 @@ from urllib.parse import ParseResult, parse_qs, unquote, urlparse
 
 from litellm.integrations.otel.model.semconv import DB, Server
 from litellm.integrations.otel.model.spans import POSTGRESQL, db_system
-from litellm.secret_managers.main import get_secret_str
 
+_DATABASE_URL_ENV: Final = "DATABASE_URL"
+_READ_REPLICA_ENV: Final = "DATABASE_URL_READ_REPLICA"
+# Bounded because each RDS IAM token rotation produces a new URL string.
+_ENDPOINT_CACHE_SIZE: Final = 8
 _DEFAULT_POSTGRES_PORT: Final = 5432
 _DEFAULT_POSTGRES_SCHEMA: Final = "public"
 _POSTGRES_SCHEMES: Final = frozenset({"postgres", "postgresql"})
@@ -101,23 +105,34 @@ def _namespace(database: str, schema: str) -> str | None:
     return "|".join(part for part in (database, qualifier) if part) or None
 
 
-@lru_cache(maxsize=1)
-def postgres_endpoint() -> DatabaseEndpoint | None:
-    """The configured PostgreSQL endpoint, or ``None`` when it cannot be named.
+@lru_cache(maxsize=_ENDPOINT_CACHE_SIZE)
+def _endpoint_for(url: str) -> DatabaseEndpoint | None:
+    return parse_database_endpoint(url)
 
-    Resolved once: ``DATABASE_URL`` is deployment-static (an RDS IAM refresh
-    rotates only the token), and ``get_secret_str`` can reach a secret manager,
-    so this must not run per span. The empty default keeps a misconfigured
-    secret manager from raising into span emission. Tests that change the
-    environment call ``postgres_endpoint.cache_clear()``.
+
+def postgres_endpoint() -> DatabaseEndpoint | None:
+    """The PostgreSQL endpoint the process is currently connected to.
+
+    Read from ``os.environ`` on every span, deliberately, on both counts.
+
+    The environment is what Prisma itself connects with, so the span cannot
+    disagree with the connection; ``get_secret_str`` would consult a configured
+    secret manager first and could name a different server than the one serving
+    the query. And the value is not static: the RDS IAM refresh rebuilds the URL
+    from ``DATABASE_HOST``/``PORT``/``NAME``/``SCHEMA`` every rotation, the
+    reconnect path re-reads ``DATABASE_URL``, and the DB-backed
+    ``environment_variables`` config overlay can rewrite any of them after
+    startup, so a value cached for the process lifetime goes stale against a
+    connection that has genuinely moved. Only the parse is memoized, keyed on the
+    URL, which keeps the per-span cost to a dict lookup.
 
     A configured read replica yields ``None``: ``RoutingPrismaWrapper`` picks
     reader or writer per Prisma call, underneath the span, so naming the writer
     would attribute replica reads to the primary.
     """
-    if get_secret_str("DATABASE_URL_READ_REPLICA", default_value=""):
+    if os.environ.get(_READ_REPLICA_ENV):
         return None
-    return parse_database_endpoint(get_secret_str("DATABASE_URL", default_value=""))
+    return _endpoint_for(os.environ.get(_DATABASE_URL_ENV, ""))
 
 
 def db_span_attributes(service_name: str, call_type: str | None = None) -> Mapping[str, str | int]:

--- a/litellm/integrations/otel/model/db_endpoint.py
+++ b/litellm/integrations/otel/model/db_endpoint.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from types import MappingProxyType
 from typing import Final
-from urllib.parse import parse_qs, unquote, urlparse
+from urllib.parse import ParseResult, parse_qs, unquote, urlparse
 
 from litellm.integrations.otel.model.semconv import DB, Server
 from litellm.integrations.otel.model.spans import POSTGRESQL, db_system
@@ -25,10 +25,6 @@ from litellm.secret_managers.main import get_secret_str
 _DEFAULT_POSTGRES_PORT: Final = 5432
 _DEFAULT_POSTGRES_SCHEMA: Final = "public"
 _POSTGRES_SCHEMES: Final = frozenset({"postgres", "postgresql"})
-# An unencoded '/', '#' or '?' in the password truncates the authority, so
-# urlparse hands back the username as the host and the rest of the credential as
-# the path, query or fragment. Either character in the raw database segment, or a
-# userinfo '@' that fell outside the netloc, means that happened.
 _MISPARSED_AUTHORITY_MARKERS: Final = frozenset("@/")
 _EMPTY_ATTRIBUTES: Final[Mapping[str, str | int]] = MappingProxyType({})
 
@@ -55,12 +51,10 @@ def parse_database_endpoint(url: str | None) -> DatabaseEndpoint | None:
         parsed: Final = urlparse(url)
         if parsed.scheme not in _POSTGRES_SCHEMES:
             return None
-        if "@" in url and "@" not in parsed.netloc:
-            return None
-        raw_database: Final = (parsed.path or "").lstrip("/")
-        if _MISPARSED_AUTHORITY_MARKERS & set(raw_database):
-            return None
         query: Final = parse_qs(parsed.query)
+        raw_database: Final = (parsed.path or "").lstrip("/")
+        if _is_misparsed_authority(parsed, raw_database, query):
+            return None
         # ``host=`` beats the netloc: it is how libpq names a Unix socket
         # directory and how the Cloud SQL connector sits behind a localhost
         # netloc, where the netloc is the very answer this module replaces.
@@ -72,6 +66,23 @@ def parse_database_endpoint(url: str | None) -> DatabaseEndpoint | None:
     if address is None and namespace is None:
         return None
     return DatabaseEndpoint(address=address, port=port, namespace=namespace)
+
+
+def _is_misparsed_authority(parsed: ParseResult, raw_database: str, query: Mapping[str, Sequence[str]]) -> bool:
+    """Whether an unencoded character in the password truncated the authority.
+
+    ``/``, ``#`` or ``?`` in a password ends the netloc early, so urlparse hands
+    back the username as the host and strands the real userinfo ``@`` in the
+    path, fragment or query. A PostgreSQL DSN never carries a fragment, and its
+    database name cannot hold an unencoded ``@`` or ``/``. An ``@`` in the query
+    is only suspicious when the query did not parse as parameters, since
+    ``?application_name=svc@prod`` is legitimate.
+    """
+    if parsed.fragment:
+        return True
+    if _MISPARSED_AUTHORITY_MARKERS & set(raw_database):
+        return True
+    return "@" in parsed.query and not query
 
 
 def _first(values: Sequence[str] | None) -> str:

--- a/litellm/integrations/otel/model/semconv.py
+++ b/litellm/integrations/otel/model/semconv.py
@@ -238,7 +238,11 @@ class DB:
     """
 
     SYSTEM_NAME: Final = "db.system.name"
+    # Superseded by SYSTEM_NAME, dual-emitted because Datadog's OTLP intake
+    # still infers a span's database type from this key.
+    SYSTEM_LEGACY: Final = "db.system"
     OPERATION_NAME: Final = "db.operation.name"
+    NAMESPACE: Final = "db.namespace"
 
 
 class HTTP:

--- a/litellm/integrations/otel/model/spans.py
+++ b/litellm/integrations/otel/model/spans.py
@@ -115,10 +115,12 @@ SPAN_REGISTRY: Final[dict[SpanRole, SpanSpec]] = {
 # redis-backed spend queues. Any service not mapped here is litellm-internal work
 # and stays an INTERNAL ``SERVICE`` span. This table is the single source of
 # datastore knowledge — both the role classifier and the mapper read it.
+POSTGRESQL: Final = "postgresql"
+
 _DB_SYSTEM_BY_SERVICE: Final[dict[str, str]] = {
     "redis": "redis",
-    "postgres": "postgresql",
-    "batch_write_to_db": "postgresql",
+    "postgres": POSTGRESQL,
+    "batch_write_to_db": POSTGRESQL,
 }
 
 

--- a/tests/test_litellm/integrations/otel/test_db_endpoint.py
+++ b/tests/test_litellm/integrations/otel/test_db_endpoint.py
@@ -89,6 +89,69 @@ def test_percent_encoded_database_name_is_decoded():
     assert endpoint is not None and endpoint.namespace == "litellm prod"
 
 
+MISPARSED_AUTHORITY_DSNS = (
+    ("postgresql://litellm:/kJ8xQz+9wT@db.internal:5432/litellm", "kJ8xQz+9wT"),
+    ("postgresql://litellm:12345/aBcD@db.internal:5432/litellm", "aBcD"),
+)
+
+
+@pytest.mark.parametrize(("dsn", "secret"), MISPARSED_AUTHORITY_DSNS)
+def test_unencoded_slash_in_password_never_yields_an_endpoint(dsn, secret):
+    """An unencoded '/' truncates the authority, so urlparse reports the username
+    as the host and the password tail as the database. Postgres drivers reject
+    such a DSN outright, so the only safe reading is no endpoint at all."""
+    assert parse_database_endpoint(dsn) is None
+
+
+@pytest.mark.parametrize(("dsn", "secret"), MISPARSED_AUTHORITY_DSNS)
+def test_unencoded_slash_in_password_never_reaches_a_span(dsn, secret):
+    attrs = _resolve("postgres", "get_data", database_url=dsn)
+    exported = " ".join(str(value) for value in attrs.values())
+    assert secret not in exported
+    assert "db.namespace" not in attrs
+    assert "server.address" not in attrs
+
+
+def test_extra_path_segment_yields_no_endpoint():
+    """A database name cannot hold an unencoded '/', so a second path segment
+    means the authority was mis-split even when no '@' survived into the path."""
+    assert parse_database_endpoint("postgresql://db.internal:5432/litellm/extra") is None
+
+
+def test_percent_encoded_password_still_resolves_the_endpoint():
+    """The encoded spelling is the one a driver accepts, so it must keep working."""
+    assert parse_database_endpoint("postgresql://litellm:pa%2Fssw0rd@db.internal:5432/litellm") == DatabaseEndpoint(
+        address="db.internal", port=5432, namespace="litellm"
+    )
+
+
+def test_hostless_socket_dsn_still_names_the_database():
+    """``postgresql:///litellm`` is a valid local-socket DSN that Prisma accepts,
+    so the database is knowable even though no server address is."""
+    assert parse_database_endpoint("postgresql:///litellm") == DatabaseEndpoint(
+        address=None, port=None, namespace="litellm"
+    )
+
+
+def test_hostless_socket_dsn_emits_namespace_without_a_server():
+    attrs = _resolve("postgres", "get_data", database_url="postgresql:///litellm")
+    assert attrs["db.namespace"] == "litellm"
+    assert "server.address" not in attrs
+    assert "server.port" not in attrs
+
+
+def test_dsn_with_neither_host_nor_database_yields_no_endpoint():
+    assert parse_database_endpoint("postgresql://") is None
+
+
+@pytest.mark.parametrize("spelling", ["public", "PUBLIC", "Public"])
+def test_default_schema_is_implicit_whatever_its_case(spelling):
+    """An unquoted PostgreSQL identifier case-folds, so every spelling of the
+    default schema is the same namespace and must not split a group-by."""
+    endpoint = parse_database_endpoint(f"postgresql://u:p@db.internal/litellm?schema={spelling}")
+    assert endpoint is not None and endpoint.namespace == "litellm"
+
+
 def test_postgres_scheme_alias_is_accepted():
     assert parse_database_endpoint("postgres://u:p@db.internal/litellm") == DatabaseEndpoint(
         address="db.internal", port=5432, namespace="litellm"

--- a/tests/test_litellm/integrations/otel/test_db_endpoint.py
+++ b/tests/test_litellm/integrations/otel/test_db_endpoint.py
@@ -144,12 +144,18 @@ def test_dsn_with_neither_host_nor_database_yields_no_endpoint():
     assert parse_database_endpoint("postgresql://") is None
 
 
-@pytest.mark.parametrize("spelling", ["public", "PUBLIC", "Public"])
-def test_default_schema_is_implicit_whatever_its_case(spelling):
-    """An unquoted PostgreSQL identifier case-folds, so every spelling of the
-    default schema is the same namespace and must not split a group-by."""
-    endpoint = parse_database_endpoint(f"postgresql://u:p@db.internal/litellm?schema={spelling}")
+def test_prisma_default_schema_is_left_implicit():
+    endpoint = parse_database_endpoint("postgresql://u:p@db.internal/litellm?schema=public")
     assert endpoint is not None and endpoint.namespace == "litellm"
+
+
+@pytest.mark.parametrize("spelling", ["PUBLIC", "Public", "reporting"])
+def test_a_non_default_schema_stays_in_the_namespace(spelling):
+    """Prisma quotes the schema name, so ``?schema=PUBLIC`` provisions a second
+    schema alongside ``public`` with its own tables. Case-folding them into one
+    namespace would report two different schemas as the same database."""
+    endpoint = parse_database_endpoint(f"postgresql://u:p@db.internal/litellm?schema={spelling}")
+    assert endpoint is not None and endpoint.namespace == f"litellm|{spelling}"
 
 
 def test_postgres_scheme_alias_is_accepted():

--- a/tests/test_litellm/integrations/otel/test_db_endpoint.py
+++ b/tests/test_litellm/integrations/otel/test_db_endpoint.py
@@ -131,6 +131,21 @@ def test_a_mis_split_authority_never_exports_the_database_username(dsn):
     assert "litellm" not in " ".join(str(v) for v in attrs.values())
 
 
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "postgresql://db.internal:5432/litellm?application_name=svc@prod",
+        "postgresql://db.internal:5432/litellm?user=admin@company.com",
+        "postgresql://u:p@db.internal:5432/litellm?application_name=svc@prod",
+    ],
+)
+def test_an_at_sign_inside_a_query_parameter_is_not_a_mis_split(dsn):
+    """libpq parameters legitimately carry '@', so the guard must key on a query
+    that did not parse as parameters, not on the character alone."""
+    endpoint = parse_database_endpoint(dsn)
+    assert endpoint is not None and endpoint.address == "db.internal"
+
+
 def test_percent_encoded_password_still_resolves_the_endpoint():
     """The encoded spelling is the one a driver accepts, so it must keep working."""
     assert parse_database_endpoint("postgresql://litellm:pa%2Fssw0rd@db.internal:5432/litellm") == DatabaseEndpoint(

--- a/tests/test_litellm/integrations/otel/test_db_endpoint.py
+++ b/tests/test_litellm/integrations/otel/test_db_endpoint.py
@@ -92,6 +92,10 @@ def test_percent_encoded_database_name_is_decoded():
 MISPARSED_AUTHORITY_DSNS = (
     ("postgresql://litellm:/kJ8xQz+9wT@db.internal:5432/litellm", "kJ8xQz+9wT"),
     ("postgresql://litellm:12345/aBcD@db.internal:5432/litellm", "aBcD"),
+    # '#' sends the tail to the fragment and '?' to the query, so the path is
+    # empty and only the stranded userinfo '@' reveals the mis-split.
+    ("postgresql://litellm:12345#aBcD@db.internal/litellm", "aBcD"),
+    ("postgresql://litellm:12345?aBcD@db.internal/litellm", "aBcD"),
 )
 
 
@@ -116,6 +120,15 @@ def test_extra_path_segment_yields_no_endpoint():
     """A database name cannot hold an unencoded '/', so a second path segment
     means the authority was mis-split even when no '@' survived into the path."""
     assert parse_database_endpoint("postgresql://db.internal:5432/litellm/extra") is None
+
+
+@pytest.mark.parametrize("dsn", [d for d, _ in MISPARSED_AUTHORITY_DSNS])
+def test_a_mis_split_authority_never_exports_the_database_username(dsn):
+    """The username lands in ``parsed.hostname`` when the authority truncates, so
+    a span would name the DB user as the server."""
+    attrs = _resolve("postgres", "get_data", database_url=dsn)
+    assert "server.address" not in attrs
+    assert "litellm" not in " ".join(str(v) for v in attrs.values())
 
 
 def test_percent_encoded_password_still_resolves_the_endpoint():

--- a/tests/test_litellm/integrations/otel/test_db_endpoint.py
+++ b/tests/test_litellm/integrations/otel/test_db_endpoint.py
@@ -14,7 +14,6 @@ import pytest
 
 from litellm.integrations.otel.model.db_endpoint import (
     DatabaseEndpoint,
-    _endpoint_for,
     db_span_attributes,
     parse_database_endpoint,
     postgres_endpoint,
@@ -23,13 +22,6 @@ from litellm.integrations.otel.model.db_endpoint import (
 LOCAL_DSN = "postgresql://llmproxy:dbpassword9090@localhost:5432/litellm"
 REMOTE_DSN = "postgresql://llmproxy:s3cr3t@litellm-prod.abc123.us-east-1.rds.amazonaws.com:6432/litellm?schema=reporting&sslmode=require"
 REPLICA_DSN = "postgresql://reader:r3ad0nly@litellm-prod-ro.abc123.us-east-1.rds.amazonaws.com/litellm_replica"
-
-
-@pytest.fixture(autouse=True)
-def _clear_endpoint_cache():
-    _endpoint_for.cache_clear()
-    yield
-    _endpoint_for.cache_clear()
 
 
 def _resolve(service, call_type=None, database_url=None, read_replica_url=None):
@@ -308,10 +300,3 @@ def test_a_replica_configured_after_the_first_span_suppresses_the_endpoint():
     assert _resolve("postgres", "get_data", database_url=REMOTE_DSN)["server.address"]
     later = _resolve("postgres", "get_data", database_url=REMOTE_DSN, read_replica_url=REPLICA_DSN)
     assert "server.address" not in later
-
-
-def test_the_parse_is_memoized_per_url():
-    _endpoint_for.cache_clear()
-    for _ in range(5):
-        _resolve("postgres", "get_data", database_url=LOCAL_DSN)
-    assert _endpoint_for.cache_info().misses == 1

--- a/tests/test_litellm/integrations/otel/test_db_endpoint.py
+++ b/tests/test_litellm/integrations/otel/test_db_endpoint.py
@@ -1,0 +1,204 @@
+"""Tests for litellm/integrations/otel/model/db_endpoint.py
+
+Prisma talks to PostgreSQL through a loopback query engine, so a DB span with no
+``server.address`` gets attributed to ``localhost`` by the backend. These cover
+the endpoint derivation that names the real server, for the local engine and for
+remote and read-replica deployments, and pin the rule that no credential is ever
+exported.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from litellm.integrations.otel.model.db_endpoint import (
+    DatabaseEndpoint,
+    db_span_attributes,
+    parse_database_endpoint,
+    postgres_endpoint,
+)
+
+LOCAL_DSN = "postgresql://llmproxy:dbpassword9090@localhost:5432/litellm"
+REMOTE_DSN = "postgresql://llmproxy:s3cr3t@litellm-prod.abc123.us-east-1.rds.amazonaws.com:6432/litellm?schema=reporting&sslmode=require"
+REPLICA_DSN = "postgresql://reader:r3ad0nly@litellm-prod-ro.abc123.us-east-1.rds.amazonaws.com/litellm_replica"
+
+
+@pytest.fixture(autouse=True)
+def _clear_endpoint_cache():
+    postgres_endpoint.cache_clear()
+    yield
+    postgres_endpoint.cache_clear()
+
+
+def _resolve(service, call_type=None, database_url=None, read_replica_url=None):
+    """Resolve attributes with the two DB env vars stubbed at their read site."""
+
+    def _secret(name, default_value=None):
+        return {"DATABASE_URL": database_url, "DATABASE_URL_READ_REPLICA": read_replica_url}.get(name)
+
+    with patch("litellm.integrations.otel.model.db_endpoint.get_secret_str", side_effect=_secret):
+        return dict(db_span_attributes(service, call_type))
+
+
+def test_local_prisma_engine_endpoint_is_the_postgres_server_not_the_engine():
+    assert parse_database_endpoint(LOCAL_DSN) == DatabaseEndpoint(
+        address="localhost", port=5432, namespace="litellm"
+    )
+
+
+def test_remote_endpoint_keeps_host_port_and_schema_qualified_namespace():
+    assert parse_database_endpoint(REMOTE_DSN) == DatabaseEndpoint(
+        address="litellm-prod.abc123.us-east-1.rds.amazonaws.com",
+        port=6432,
+        namespace="litellm|reporting",
+    )
+
+
+def test_read_replica_dsn_parses_to_the_replica_host_and_database():
+    assert parse_database_endpoint(REPLICA_DSN) == DatabaseEndpoint(
+        address="litellm-prod-ro.abc123.us-east-1.rds.amazonaws.com",
+        port=5432,
+        namespace="litellm_replica",
+    )
+
+
+def test_default_schema_is_not_spelled_out_in_the_namespace():
+    """``?schema=public`` and no schema at all are the same deployment, so they
+    must not split a group-by on db.namespace."""
+    assert parse_database_endpoint("postgresql://u:p@db.internal/litellm?schema=public") == parse_database_endpoint(
+        "postgresql://u:p@db.internal/litellm"
+    )
+
+
+def test_unix_socket_host_parameter_wins_over_the_netloc():
+    """libpq and the Cloud SQL connector both put the real target in ``host=``
+    behind a localhost netloc, which is the attribution this module removes."""
+    assert parse_database_endpoint(
+        "postgresql://u:p@localhost:5432/litellm?host=/cloudsql/proj:us-east1:inst"
+    ) == DatabaseEndpoint(address="/cloudsql/proj:us-east1:inst", port=5432, namespace="litellm")
+
+
+def test_socket_only_dsn_without_a_netloc_host_still_resolves():
+    assert parse_database_endpoint("postgresql:///litellm?host=/var/run/postgresql") == DatabaseEndpoint(
+        address="/var/run/postgresql", port=5432, namespace="litellm"
+    )
+
+
+def test_percent_encoded_database_name_is_decoded():
+    endpoint = parse_database_endpoint("postgresql://u:p@db.internal/litellm%20prod")
+    assert endpoint is not None and endpoint.namespace == "litellm prod"
+
+
+def test_postgres_scheme_alias_is_accepted():
+    assert parse_database_endpoint("postgres://u:p@db.internal/litellm") == DatabaseEndpoint(
+        address="db.internal", port=5432, namespace="litellm"
+    )
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        None,
+        "",
+        "mysql://u:p@db.internal:3306/litellm",
+        "postgresql://u:p@db.internal:not-a-port/litellm",
+        "not a url at all",
+    ],
+)
+def test_unusable_dsn_degrades_to_no_endpoint(dsn):
+    assert parse_database_endpoint(dsn) is None
+
+
+def test_database_without_name_or_schema_has_no_namespace():
+    assert parse_database_endpoint("postgresql://u:p@db.internal:5432/") == DatabaseEndpoint(
+        address="db.internal", port=5432, namespace=None
+    )
+
+
+def test_postgres_service_span_carries_system_operation_and_endpoint():
+    assert _resolve("postgres", "get_data", database_url=REMOTE_DSN) == {
+        "db.system.name": "postgresql",
+        "db.system": "postgresql",
+        "db.operation.name": "get_data",
+        "server.address": "litellm-prod.abc123.us-east-1.rds.amazonaws.com",
+        "server.port": 6432,
+        "db.namespace": "litellm|reporting",
+    }
+
+
+def test_legacy_db_system_is_dual_emitted_for_datadog():
+    """Datadog's OTLP intake infers the database span type from ``db.system``,
+    not from the semconv-current ``db.system.name``."""
+    assert _resolve("postgres", "get_data", database_url=LOCAL_DSN)["db.system"] == "postgresql"
+    assert _resolve("redis", "set")["db.system"] == "redis"
+
+
+def test_batch_write_service_is_also_attributed_to_postgres():
+    attrs = _resolve("batch_write_to_db", "_PROXY_track_cost_callback", database_url=REMOTE_DSN)
+    assert attrs["db.system.name"] == "postgresql"
+    assert attrs["server.address"] == "litellm-prod.abc123.us-east-1.rds.amazonaws.com"
+
+
+def test_redis_service_never_borrows_the_postgres_endpoint():
+    assert _resolve("redis", "set", database_url=REMOTE_DSN) == {
+        "db.system.name": "redis",
+        "db.system": "redis",
+        "db.operation.name": "set",
+    }
+
+
+def test_non_datastore_service_gets_no_db_attributes():
+    assert _resolve("reset_budget_job", "reset_budget", database_url=REMOTE_DSN) == {}
+
+
+def test_configured_read_replica_suppresses_the_endpoint_rather_than_naming_the_primary():
+    """Reads are routed to the replica per Prisma call, underneath the span, so
+    naming the writer would pin replica latency onto the primary."""
+    attrs = _resolve("postgres", "get_data", database_url=REMOTE_DSN, read_replica_url=REPLICA_DSN)
+    assert attrs == {
+        "db.system.name": "postgresql",
+        "db.system": "postgresql",
+        "db.operation.name": "get_data",
+    }
+
+
+def test_endpoint_attributes_are_omitted_when_database_url_is_unset():
+    assert _resolve("postgres", "get_data") == {
+        "db.system.name": "postgresql",
+        "db.system": "postgresql",
+        "db.operation.name": "get_data",
+    }
+
+
+def test_blank_call_type_does_not_emit_an_empty_operation_attribute():
+    assert "db.operation.name" not in _resolve("postgres", "")
+    assert "db.operation.name" not in _resolve("postgres", None)
+
+
+@pytest.mark.parametrize(
+    ("dsn", "secrets"),
+    [
+        (LOCAL_DSN, ("dbpassword9090", "llmproxy")),
+        (REMOTE_DSN, ("s3cr3t", "llmproxy", "sslmode")),
+        (REPLICA_DSN, ("r3ad0nly", "reader")),
+    ],
+)
+def test_no_credential_reaches_any_exported_attribute(dsn, secrets):
+    attrs = _resolve("postgres", "get_data", database_url=dsn)
+    assert attrs["server.address"]
+    exported = " ".join(str(value) for value in attrs.values())
+    for secret in secrets:
+        assert secret not in exported
+
+
+def test_database_url_is_resolved_once_not_per_span():
+    """``get_secret_str`` can reach a configured secret manager, so resolving it
+    per DB span would put a blocking lookup on the request path."""
+    with patch(
+        "litellm.integrations.otel.model.db_endpoint.get_secret_str",
+        side_effect=lambda name, default_value=None: LOCAL_DSN if name == "DATABASE_URL" else None,
+    ) as resolver:
+        for _ in range(5):
+            attrs = db_span_attributes("postgres", "get_data")
+    assert attrs["server.address"] == "localhost"
+    assert resolver.call_count == 2

--- a/tests/test_litellm/integrations/otel/test_db_endpoint.py
+++ b/tests/test_litellm/integrations/otel/test_db_endpoint.py
@@ -97,6 +97,10 @@ MISPARSED_AUTHORITY_DSNS = (
     # empty and only the stranded userinfo '@' reveals the mis-split.
     ("postgresql://litellm:12345#aBcD@db.internal/litellm", "aBcD"),
     ("postgresql://litellm:12345?aBcD@db.internal/litellm", "aBcD"),
+    # A '?'-stranded tail that happens to parse as parameters, including one
+    # that hijacks the host= parameter into server.address.
+    ("postgresql://litellm:12345?a=aBcD@db.internal/litellm", "aBcD"),
+    ("postgresql://litellm:12345?host=aBcD@db.internal/litellm", "aBcD"),
 )
 
 

--- a/tests/test_litellm/integrations/otel/test_db_endpoint.py
+++ b/tests/test_litellm/integrations/otel/test_db_endpoint.py
@@ -7,12 +7,14 @@ remote and read-replica deployments, and pin the rule that no credential is ever
 exported.
 """
 
+import os
 from unittest.mock import patch
 
 import pytest
 
 from litellm.integrations.otel.model.db_endpoint import (
     DatabaseEndpoint,
+    _endpoint_for,
     db_span_attributes,
     parse_database_endpoint,
     postgres_endpoint,
@@ -25,18 +27,17 @@ REPLICA_DSN = "postgresql://reader:r3ad0nly@litellm-prod-ro.abc123.us-east-1.rds
 
 @pytest.fixture(autouse=True)
 def _clear_endpoint_cache():
-    postgres_endpoint.cache_clear()
+    _endpoint_for.cache_clear()
     yield
-    postgres_endpoint.cache_clear()
+    _endpoint_for.cache_clear()
 
 
 def _resolve(service, call_type=None, database_url=None, read_replica_url=None):
-    """Resolve attributes with the two DB env vars stubbed at their read site."""
-
-    def _secret(name, default_value=None):
-        return {"DATABASE_URL": database_url, "DATABASE_URL_READ_REPLICA": read_replica_url}.get(name)
-
-    with patch("litellm.integrations.otel.model.db_endpoint.get_secret_str", side_effect=_secret):
+    """Resolve attributes with the two DB env vars set, as the proxy sets them."""
+    env = {k: v for k, v in (("DATABASE_URL", database_url), ("DATABASE_URL_READ_REPLICA", read_replica_url)) if v}
+    with patch.dict(os.environ, env, clear=False):
+        for absent in {"DATABASE_URL", "DATABASE_URL_READ_REPLICA"} - set(env):
+            os.environ.pop(absent, None)
         return dict(db_span_attributes(service, call_type))
 
 
@@ -288,14 +289,25 @@ def test_no_credential_reaches_any_exported_attribute(dsn, secrets):
         assert secret not in exported
 
 
-def test_database_url_is_resolved_once_not_per_span():
-    """``get_secret_str`` can reach a configured secret manager, so resolving it
-    per DB span would put a blocking lookup on the request path."""
-    with patch(
-        "litellm.integrations.otel.model.db_endpoint.get_secret_str",
-        side_effect=lambda name, default_value=None: LOCAL_DSN if name == "DATABASE_URL" else None,
-    ) as resolver:
-        for _ in range(5):
-            attrs = db_span_attributes("postgres", "get_data")
-    assert attrs["server.address"] == "localhost"
-    assert resolver.call_count == 2
+def test_a_runtime_endpoint_change_is_reflected_on_the_next_span():
+    """The RDS IAM refresh, the reconnect path and the DB-backed
+    environment_variables overlay can all rewrite DATABASE_URL after startup, so
+    a value cached for the process lifetime would report a server the process no
+    longer talks to."""
+    first = _resolve("postgres", "get_data", database_url=LOCAL_DSN)
+    assert first["server.address"] == "localhost"
+    moved = _resolve("postgres", "get_data", database_url=REMOTE_DSN)
+    assert moved["server.address"] == "litellm-prod.abc123.us-east-1.rds.amazonaws.com"
+
+
+def test_a_replica_configured_after_the_first_span_suppresses_the_endpoint():
+    assert _resolve("postgres", "get_data", database_url=REMOTE_DSN)["server.address"]
+    later = _resolve("postgres", "get_data", database_url=REMOTE_DSN, read_replica_url=REPLICA_DSN)
+    assert "server.address" not in later
+
+
+def test_the_parse_is_memoized_per_url():
+    _endpoint_for.cache_clear()
+    for _ in range(5):
+        _resolve("postgres", "get_data", database_url=LOCAL_DSN)
+    assert _endpoint_for.cache_info().misses == 1

--- a/tests/test_litellm/integrations/otel/test_db_endpoint.py
+++ b/tests/test_litellm/integrations/otel/test_db_endpoint.py
@@ -93,6 +93,10 @@ MISPARSED_AUTHORITY_DSNS = (
     # that hijacks the host= parameter into server.address.
     ("postgresql://litellm:12345?a=aBcD@db.internal/litellm", "aBcD"),
     ("postgresql://litellm:12345?host=aBcD@db.internal/litellm", "aBcD"),
+    # Both '/' and '?key=value' together: the slash leaves a clean path holding
+    # the password remainder and the query still parses, so only the stranded
+    # at-sign gives it away.
+    ("postgresql://litellm:12345/aBcD?x=1@db.internal/litellm", "aBcD"),
 )
 
 
@@ -133,14 +137,20 @@ def test_a_mis_split_authority_never_exports_the_database_username(dsn):
     [
         "postgresql://db.internal:5432/litellm?application_name=svc@prod",
         "postgresql://db.internal:5432/litellm?user=admin@company.com",
-        "postgresql://u:p@db.internal:5432/litellm?application_name=svc@prod",
     ],
 )
-def test_an_at_sign_inside_a_query_parameter_is_not_a_mis_split(dsn):
-    """libpq parameters legitimately carry '@', so the guard must key on a query
-    that did not parse as parameters, not on the character alone."""
-    endpoint = parse_database_endpoint(dsn)
-    assert endpoint is not None and endpoint.address == "db.internal"
+def test_an_unencoded_at_sign_in_a_query_forfeits_the_endpoint(dsn):
+    """This shape is byte-for-byte indistinguishable from a mis-split password,
+    so it resolves to no endpoint rather than risking a credential fragment.
+    Percent-encoding the at-sign restores the attributes."""
+    assert parse_database_endpoint(dsn) is None
+    assert parse_database_endpoint(dsn.replace("@", "%40")) is not None
+
+
+def test_host_and_port_query_parameters_are_honoured_together():
+    assert parse_database_endpoint("postgresql://ignored/litellm?host=real.internal&port=6543") == DatabaseEndpoint(
+        address="real.internal", port=6543, namespace="litellm"
+    )
 
 
 def test_percent_encoded_password_still_resolves_the_endpoint():

--- a/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
@@ -8,6 +8,7 @@ hooks, proxy SERVER span lifecycle (start + setters), parent-context resolution
 
 import asyncio
 import contextlib
+import os
 from unittest.mock import patch
 from datetime import datetime, timedelta, timezone
 
@@ -35,7 +36,7 @@ from litellm.integrations.otel.plumbing.context import (  # noqa: E402
     set_mcp_message_transport_span,
     set_request_root_span,
 )
-from litellm.integrations.otel.model.db_endpoint import postgres_endpoint  # noqa: E402
+from litellm.integrations.otel.model.db_endpoint import _endpoint_for  # noqa: E402
 from litellm.integrations.otel.logger import OpenTelemetryV2  # noqa: E402
 from litellm.integrations.otel.model.spans import (  # noqa: E402
     LITELLM_PROXY_REQUEST_SPAN_NAME,
@@ -1529,12 +1530,10 @@ def test_postgres_db_span_names_the_database_server_not_the_prisma_engine():
     dsn = "postgresql://llmproxy:dbpassword9090@litellm-prod.abc123.us-east-1.rds.amazonaws.com:6432/litellm?schema=reporting"
     logger, exporter = _logger()
     parent = _service_parent(logger)
-    postgres_endpoint.cache_clear()
+    _endpoint_for.cache_clear()
     try:
-        with patch(
-            "litellm.integrations.otel.model.db_endpoint.get_secret_str",
-            side_effect=lambda name, default_value=None: dsn if name == "DATABASE_URL" else None,
-        ):
+        with patch.dict(os.environ, {"DATABASE_URL": dsn}, clear=False):
+            os.environ.pop("DATABASE_URL_READ_REPLICA", None)
             asyncio.run(
                 logger.async_service_success_hook(
                     payload=_ServicePayload("postgres", "get_data"),
@@ -1543,7 +1542,7 @@ def test_postgres_db_span_names_the_database_server_not_the_prisma_engine():
             )
     finally:
         parent.end()
-        postgres_endpoint.cache_clear()
+        _endpoint_for.cache_clear()
     span = {s.name: s for s in exporter.get_finished_spans()}["postgres get_data"]
     assert span.kind is SpanKind.CLIENT
     assert span.attributes["db.system.name"] == "postgresql"

--- a/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
@@ -8,6 +8,7 @@ hooks, proxy SERVER span lifecycle (start + setters), parent-context resolution
 
 import asyncio
 import contextlib
+from unittest.mock import patch
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -34,6 +35,7 @@ from litellm.integrations.otel.plumbing.context import (  # noqa: E402
     set_mcp_message_transport_span,
     set_request_root_span,
 )
+from litellm.integrations.otel.model.db_endpoint import postgres_endpoint  # noqa: E402
 from litellm.integrations.otel.logger import OpenTelemetryV2  # noqa: E402
 from litellm.integrations.otel.model.spans import (  # noqa: E402
     LITELLM_PROXY_REQUEST_SPAN_NAME,
@@ -1519,6 +1521,40 @@ def test_async_service_success_hook_emits_service_span():
     assert span.attributes["call_type"] == "set"  # V1 bare key
     # Success leaves status UNSET (semconv default), not forced OK.
     assert span.status.status_code is StatusCode.UNSET
+
+
+def test_postgres_db_span_names_the_database_server_not_the_prisma_engine():
+    """Prisma reaches Postgres over loopback, so without server.address the
+    backend attributes the wait to localhost."""
+    dsn = "postgresql://llmproxy:dbpassword9090@litellm-prod.abc123.us-east-1.rds.amazonaws.com:6432/litellm?schema=reporting"
+    logger, exporter = _logger()
+    parent = _service_parent(logger)
+    postgres_endpoint.cache_clear()
+    try:
+        with patch(
+            "litellm.integrations.otel.model.db_endpoint.get_secret_str",
+            side_effect=lambda name, default_value=None: dsn if name == "DATABASE_URL" else None,
+        ):
+            asyncio.run(
+                logger.async_service_success_hook(
+                    payload=_ServicePayload("postgres", "get_data"),
+                    parent_otel_span=parent,
+                )
+            )
+    finally:
+        parent.end()
+        postgres_endpoint.cache_clear()
+    span = {s.name: s for s in exporter.get_finished_spans()}["postgres get_data"]
+    assert span.kind is SpanKind.CLIENT
+    assert span.attributes["db.system.name"] == "postgresql"
+    assert span.attributes["db.operation.name"] == "get_data"
+    assert span.attributes["server.address"] == "litellm-prod.abc123.us-east-1.rds.amazonaws.com"
+    assert span.attributes["server.port"] == 6432
+    assert span.attributes["db.namespace"] == "litellm|reporting"
+    assert span.attributes["db.system"] == "postgresql"
+    exported = " ".join(str(value) for value in span.attributes.values())
+    assert "dbpassword9090" not in exported
+    assert "llmproxy" not in exported
 
 
 def test_async_service_failure_hook_marks_error_status():

--- a/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
@@ -36,7 +36,6 @@ from litellm.integrations.otel.plumbing.context import (  # noqa: E402
     set_mcp_message_transport_span,
     set_request_root_span,
 )
-from litellm.integrations.otel.model.db_endpoint import _endpoint_for  # noqa: E402
 from litellm.integrations.otel.logger import OpenTelemetryV2  # noqa: E402
 from litellm.integrations.otel.model.spans import (  # noqa: E402
     LITELLM_PROXY_REQUEST_SPAN_NAME,
@@ -1530,7 +1529,6 @@ def test_postgres_db_span_names_the_database_server_not_the_prisma_engine():
     dsn = "postgresql://llmproxy:dbpassword9090@litellm-prod.abc123.us-east-1.rds.amazonaws.com:6432/litellm?schema=reporting"
     logger, exporter = _logger()
     parent = _service_parent(logger)
-    _endpoint_for.cache_clear()
     try:
         with patch.dict(os.environ, {"DATABASE_URL": dsn}, clear=False):
             os.environ.pop("DATABASE_URL_READ_REPLICA", None)
@@ -1542,7 +1540,6 @@ def test_postgres_db_span_names_the_database_server_not_the_prisma_engine():
             )
     finally:
         parent.end()
-        _endpoint_for.cache_clear()
     span = {s.name: s for s in exporter.get_finished_spans()}["postgres get_data"]
     assert span.kind is SpanKind.CLIENT
     assert span.attributes["db.system.name"] == "postgresql"

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -33,7 +33,7 @@ from litellm.integrations.opentelemetry import (
     OTELSemconvCategory,
     _normalize_team_metadata_keys,
 )
-from litellm.integrations.otel.model.db_endpoint import postgres_endpoint
+from litellm.integrations.otel.model.db_endpoint import _endpoint_for
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.types.services import ServiceLoggerPayload, ServiceTypes
 
@@ -6227,10 +6227,10 @@ class TestOpenTelemetryDatabaseSemconvAttributes(unittest.TestCase):
     REPLICA_DSN = "postgresql://reader:r3ad0nly@litellm-prod-ro.abc123.us-east-1.rds.amazonaws.com/litellm"
 
     def setUp(self):
-        postgres_endpoint.cache_clear()
+        _endpoint_for.cache_clear()
 
     def tearDown(self):
-        postgres_endpoint.cache_clear()
+        _endpoint_for.cache_clear()
 
     def _service_span(self, service, call_type, dsn, error=None, replica_dsn=None):
         exporter = InMemorySpanExporter()
@@ -6249,11 +6249,10 @@ class TestOpenTelemetryDatabaseSemconvAttributes(unittest.TestCase):
         )
         hook = otel.async_service_failure_hook if error else otel.async_service_success_hook
         kwargs = {"error": error} if error else {}
-        secrets = {"DATABASE_URL": dsn, "DATABASE_URL_READ_REPLICA": replica_dsn}
-        with patch(
-            "litellm.integrations.otel.model.db_endpoint.get_secret_str",
-            side_effect=lambda name, default_value=None: secrets.get(name),
-        ):
+        env = {k: v for k, v in (("DATABASE_URL", dsn), ("DATABASE_URL_READ_REPLICA", replica_dsn)) if v}
+        with patch.dict(os.environ, env, clear=False):
+            for absent in {"DATABASE_URL", "DATABASE_URL_READ_REPLICA"} - set(env):
+                os.environ.pop(absent, None)
             asyncio.run(
                 hook(
                     payload=payload,

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -33,7 +33,6 @@ from litellm.integrations.opentelemetry import (
     OTELSemconvCategory,
     _normalize_team_metadata_keys,
 )
-from litellm.integrations.otel.model.db_endpoint import _endpoint_for
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.types.services import ServiceLoggerPayload, ServiceTypes
 
@@ -6225,12 +6224,6 @@ class TestOpenTelemetryDatabaseSemconvAttributes(unittest.TestCase):
 
     DSN = "postgresql://llmproxy:dbpassword9090@litellm-prod.abc123.us-east-1.rds.amazonaws.com:6432/litellm?schema=reporting"
     REPLICA_DSN = "postgresql://reader:r3ad0nly@litellm-prod-ro.abc123.us-east-1.rds.amazonaws.com/litellm"
-
-    def setUp(self):
-        _endpoint_for.cache_clear()
-
-    def tearDown(self):
-        _endpoint_for.cache_clear()
 
     def _service_span(self, service, call_type, dsn, error=None, replica_dsn=None):
         exporter = InMemorySpanExporter()

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -33,7 +33,9 @@ from litellm.integrations.opentelemetry import (
     OTELSemconvCategory,
     _normalize_team_metadata_keys,
 )
+from litellm.integrations.otel.model.db_endpoint import postgres_endpoint
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+from litellm.types.services import ServiceLoggerPayload, ServiceTypes
 
 
 class TestOpenTelemetryGuardrails(unittest.TestCase):
@@ -6212,3 +6214,117 @@ class TestDynamicTracerProviderCache(unittest.TestCase):
 
         self.assertTrue(entry.owns_exporter)
         self.assertIsNotNone(entry.provider._atexit_handler)
+class TestOpenTelemetryDatabaseSemconvAttributes(unittest.TestCase):
+    """A Postgres service span must name the PostgreSQL server it reached.
+
+    Without ``db.system`` and ``server.address``, the only host in the trace is
+    the loopback address of Prisma's local query engine, so the backend
+    attributes the wait to ``localhost`` and it cannot be correlated with the
+    database's own metrics.
+    """
+
+    DSN = "postgresql://llmproxy:dbpassword9090@litellm-prod.abc123.us-east-1.rds.amazonaws.com:6432/litellm?schema=reporting"
+    REPLICA_DSN = "postgresql://reader:r3ad0nly@litellm-prod-ro.abc123.us-east-1.rds.amazonaws.com/litellm"
+
+    def setUp(self):
+        postgres_endpoint.cache_clear()
+
+    def tearDown(self):
+        postgres_endpoint.cache_clear()
+
+    def _service_span(self, service, call_type, dsn, error=None, replica_dsn=None):
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        otel = OpenTelemetry()
+        otel.tracer = provider.get_tracer(__name__)
+        parent = otel.tracer.start_span("Received Proxy Server Request")
+        payload = ServiceLoggerPayload(
+            is_error=error is not None,
+            error=error,
+            service=service,
+            duration=0.25,
+            call_type=call_type,
+            event_metadata=None,
+        )
+        hook = otel.async_service_failure_hook if error else otel.async_service_success_hook
+        kwargs = {"error": error} if error else {}
+        secrets = {"DATABASE_URL": dsn, "DATABASE_URL_READ_REPLICA": replica_dsn}
+        with patch(
+            "litellm.integrations.otel.model.db_endpoint.get_secret_str",
+            side_effect=lambda name, default_value=None: secrets.get(name),
+        ):
+            asyncio.run(
+                hook(
+                    payload=payload,
+                    parent_otel_span=parent,
+                    start_time=datetime.now(),
+                    end_time=datetime.now(),
+                    **kwargs,
+                )
+            )
+        parent.end()
+        return next(s for s in exporter.get_finished_spans() if s.name == service.value)
+
+    def test_postgres_span_names_the_database_server(self):
+        span = self._service_span(ServiceTypes.DB, "get_data", self.DSN)
+        self.assertEqual(span.attributes["db.system.name"], "postgresql")
+        self.assertEqual(span.attributes["db.operation.name"], "get_data")
+        self.assertEqual(
+            span.attributes["server.address"],
+            "litellm-prod.abc123.us-east-1.rds.amazonaws.com",
+        )
+        self.assertEqual(span.attributes["server.port"], 6432)
+        self.assertEqual(span.attributes["db.namespace"], "litellm|reporting")
+
+    def test_datastore_span_is_a_client_span_carrying_the_legacy_db_system(self):
+        """Datadog types a span as a database call from CLIENT kind plus
+        ``db.system``; an INTERNAL span is classified as custom work."""
+        span = self._service_span(ServiceTypes.DB, "get_data", self.DSN)
+        self.assertEqual(span.kind, trace.SpanKind.CLIENT)
+        self.assertEqual(span.attributes["db.system"], "postgresql")
+
+    def test_internal_service_span_stays_internal(self):
+        span = self._service_span(ServiceTypes.RESET_BUDGET_JOB, "reset_budget", self.DSN)
+        self.assertEqual(span.kind, trace.SpanKind.INTERNAL)
+        self.assertNotIn("db.system.name", span.attributes)
+        self.assertNotIn("server.address", span.attributes)
+
+    def test_existing_service_and_call_type_attributes_are_unchanged(self):
+        span = self._service_span(ServiceTypes.DB, "get_data", self.DSN)
+        self.assertEqual(span.attributes["service"], "postgres")
+        self.assertEqual(span.attributes["call_type"], "get_data")
+
+    def test_failed_postgres_span_also_names_the_database_server(self):
+        span = self._service_span(ServiceTypes.DB, "get_data", self.DSN, error="connection refused")
+        self.assertEqual(span.attributes["db.system.name"], "postgresql")
+        self.assertEqual(span.kind, trace.SpanKind.CLIENT)
+        self.assertEqual(
+            span.attributes["server.address"],
+            "litellm-prod.abc123.us-east-1.rds.amazonaws.com",
+        )
+        self.assertEqual(span.attributes["error"], "connection refused")
+
+    def test_no_credential_from_the_dsn_lands_on_the_span(self):
+        span = self._service_span(ServiceTypes.DB, "get_data", self.DSN)
+        exported = " ".join(str(value) for value in span.attributes.values())
+        self.assertIn("litellm-prod.abc123.us-east-1.rds.amazonaws.com", exported)
+        self.assertNotIn("dbpassword9090", exported)
+        self.assertNotIn("llmproxy", exported)
+
+    def test_redis_span_does_not_borrow_the_postgres_endpoint(self):
+        span = self._service_span(ServiceTypes.REDIS, "async_set_cache", self.DSN)
+        self.assertEqual(span.attributes["db.system.name"], "redis")
+        self.assertEqual(span.kind, trace.SpanKind.CLIENT)
+        self.assertNotIn("server.address", span.attributes)
+
+    def test_configured_read_replica_suppresses_the_endpoint(self):
+        span = self._service_span(ServiceTypes.DB, "get_data", self.DSN, replica_dsn=self.REPLICA_DSN)
+        self.assertEqual(span.attributes["db.system.name"], "postgresql")
+        self.assertNotIn("server.address", span.attributes)
+        self.assertNotIn("db.namespace", span.attributes)
+
+    def test_unset_database_url_leaves_the_span_without_endpoint_attributes(self):
+        span = self._service_span(ServiceTypes.DB, "get_data", None)
+        self.assertEqual(span.attributes["db.system.name"], "postgresql")
+        self.assertNotIn("server.address", span.attributes)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Database work shows up in APM as `litellm-server -> localhost`. Prisma's Python client talks to a local Rust query engine over loopback HTTP, so anything instrumenting the transport (ddtrace's httpx patching, an httpx OTEL instrumentor) names the peer `localhost`, and litellm's own `postgres` span carried nothing better: `service=postgres`, `call_type=get_data`, and no `db.*` at all
- An operator staring at a slow auth or budget lookup could not tell it was PostgreSQL time, and had no server address to correlate the window against the database's own metrics

How it solves it:

- Datastore service spans (`postgres`, `batch_write_to_db`, `redis`) now carry `db.system.name`, `db.system` and `db.operation.name`, and are emitted as `CLIENT` spans instead of `INTERNAL`, so a backend that types spans from kind plus `db.system` renders them as database calls
- PostgreSQL spans also carry `server.address`, `server.port` and `db.namespace` parsed from `DATABASE_URL`. Only host, port, database and schema are read; the user, password, IAM token and every other query parameter are never touched, so no credential can reach an exporter, and no SQL text or bind value is ever attached
- Both OTel paths are covered: the default v1 integration and the opt-in v2 logger share one resolver, so v2's existing `db.system.name` mapping is no longer a second copy of the same table

`db.system` is dual-emitted alongside the semconv-current `db.system.name` because Datadog's OTLP intake still infers a span's database type from the older key. `db.namespace` follows the PostgreSQL semconv `{database}|{schema}` shape, with Prisma's literal default `public` schema left implicit. The match is case-sensitive: Prisma quotes the schema name, so `?schema=PUBLIC` provisions a second schema alongside `public` with its own tables, and folding the two into one namespace would report two different schemas as the same database.

A DSN whose password carries an unencoded `/`, `#` or `?` truncates the URL authority, which makes `urlparse` report the username as the host and the credential tail as the path, query or fragment. Postgres drivers reject such a string outright (`P1013`, so the proxy cannot start on it), and the parser refuses it rather than deriving an endpoint from a mis-split authority: it rejects a raw database segment holding `@` or `/`, and any DSN whose userinfo `@` fell outside the netloc, which is what the `#` and `?` spellings look like. A hostless `postgresql:///litellm`, which Prisma does accept as a local-socket DSN, yields `db.namespace` with no server address instead of nothing.

## User Flow

Nothing to configure. A deployment already exporting OTel spans through the generic `otel` callback, or through `arize_phoenix`, `weave_otel`, `agentops`, `levo`, `logfire` or `langtrace`, gets the attributes on its next restart. The `arize` and `langfuse_otel` callbacks deliberately no-op both service hooks (`arize.py:113`, `langfuse_otel.py:427`), so they never received DB spans and still do not.

Before: an on-call engineer chasing p99 latency on the gateway sees the wait blamed on `localhost` and cannot tell it is database time

1. They send POST https://litellm-domain/v1/chat/completions and watch the request in their tracing backend
2. Inside the request they find a span named `postgres`, tagged only `service=postgres`, `call_type=get_data`, `table_name=combined_view`, typed as internal work
3. Their backend's service map shows the gateway talking to `localhost`, the loopback peer of the local query engine, so filtering the request by database calls returns nothing
4. They cannot line the slow window up against their database's own metrics, because no span names a database host or port

After: the same span identifies PostgreSQL and the exact server, so it shows up as a database call and correlates with the database's metrics

1. The admin restarts the proxy with the same config, nothing new to set
2. They send the same POST https://litellm-domain/v1/chat/completions and open the same request
3. The `postgres` span is now typed as an outbound client call and carries `db.system.name=postgresql`, `db.operation.name=get_data`, `server.address` and `server.port` of the real database and `db.namespace` of the database it reads, with the old `service`, `call_type` and `table_name` tags still there
4. Filtering the trace by database calls returns the `postgres` and `batch_write_to_db` spans, and the address on them matches the host in their database dashboard, so the slow window can be lined up against it
5. No DSN username or password appears on any span, and cache spans still say `db.system=redis` with no database address borrowed from the Postgres DSN

## Relevant issues

## Linear ticket

Refs LIT-5436

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on a real Postgres, real Gemini calls, spans exported over OTLP to Langfuse Cloud and read back through Langfuse's own API. Base and head legs ran the same requests against the same database; the launcher printed `litellm.__file__` and a fix-symbol probe on each leg so the tree under test is not in doubt.

Rig:

```bash
docker run -d --name litfix-pg-5436 -p 15436:5432 \
  -e POSTGRES_DB=litellm -e POSTGRES_USER=llmproxy -e POSTGRES_PASSWORD=dbpassword9090 postgres:16
export DATABASE_URL="postgresql://llmproxy:dbpassword9090@192.168.1.244:15436/litellm?schema=public"
export OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel"
export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <langfuse pk:sk>"
export OTEL_SERVICE_NAME="litellm-server"
python -m litellm.proxy.proxy_cli --config rig/config.yaml --port 20436 --use_prisma_db_push

curl -sS http://127.0.0.1:20436/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"hello"}]}'
```

Before, the `postgres` span as Langfuse stored it. Nothing identifies PostgreSQL and there is no server to correlate against, so the only host in the trace is the query engine's loopback address:

```json
{
  "call_type": "get_data",
  "service": "postgres",
  "table_name": "combined_view"
}
```

After, the same span from the same request shape:

```json
{
  "call_type": "get_data",
  "db.namespace": "litellm",
  "db.operation.name": "get_data",
  "db.system": "postgresql",
  "db.system.name": "postgresql",
  "server.address": "192.168.1.244",
  "server.port": "15436",
  "service": "postgres",
  "table_name": "combined_view"
}
```

`?schema=public` is in the DSN and correctly does not appear in `db.namespace`. The port is the database's, not the query engine's ephemeral loopback port. Read back with:

```bash
curl -s -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" \
  "$LANGFUSE_HOST/api/public/observations?limit=25" \
  | jq '.data[] | select(.name=="postgres") | .metadata.attributes'
```

Span kinds and the negative cases, captured from the raw OTLP export on the same run:

```
postgres           kind=CLIENT    db.system=postgresql server.address=192.168.1.244 server.port=15436 db.namespace=litellm
batch_write_to_db  kind=CLIENT    db.system=postgresql server.address=192.168.1.244 server.port=15436 db.namespace=litellm
auth               kind=INTERNAL  (no db.* attributes)
router             kind=INTERNAL  (no db.* attributes)
```

With `DATABASE_URL_READ_REPLICA` set, the proxy logged `read-replica routing enabled via DATABASE_URL_READ_REPLICA` and the endpoint attributes correctly dropped out while the system and operation stayed:

```
postgres kind=CLIENT {"call_type": "get_data", "db.operation.name": "get_data",
                      "db.system": "postgresql", "db.system.name": "postgresql",
                      "service": "postgres", "table_name": "combined_view"}
```

No credential from the DSN appeared anywhere in the exported payload on any leg, checked by substring search over the full protobuf-decoded export.

To view the two traces in the Langfuse UI (same project, before then after):

1. https://cloud.langfuse.com/project/cmrmn6k7s00d0ad0dz7kyag1e/traces/e22670fc344a189b7c45a328e831f361
2. https://cloud.langfuse.com/project/cmrmn6k7s00d0ad0dz7kyag1e/traces/ba93049c4ea11c1ecd449e1aff43ed4f

Open the `postgres` observation in each and compare the metadata attributes panel.

Re-verified on a second rig, this time exporting to a local Jaeger so the spans can be read straight off the collector. Base leg at `0b82b087fd` (litellm_internal_staging), head leg at `e2980c7753`, same Postgres, same request shape, real Anthropic calls, both legs into one Jaeger instance:

```
base   postgres           kind=internal  {call_type, service, table_name}
base   batch_write_to_db  kind=internal  {call_type, service}
head   postgres           kind=client    db.system=postgresql db.system.name=postgresql db.operation.name=get_data
                                         server.address=172.16.18.2 server.port=15436 db.namespace=litellm
                                         (call_type, service, table_name still present, span name still "postgres")
head   batch_write_to_db  kind=client    same endpoint attributes, db.operation.name=_PROXY_track_cost_callback
head   redis              kind=client    db.system=redis, no server.address (it does not borrow the Postgres DSN)
head   auth/router/self/proxy_pre_call/litellm_request  kind=internal, no db.* or server.*
```

With `LITELLM_OTEL_V2=True` the v2 logger produced the same endpoint attributes on `postgres get_data`, `postgres get_key_object` and `batch_write_to_db _PROXY_track_cost_callback`, alongside the `litellm.service.*` keys it already emitted. With `DATABASE_URL_READ_REPLICA` set, the endpoint attributes dropped out and only the system and operation stayed. Grepping the Jaeger API export for the DSN user and password returned zero hits on every leg

## Type

🆕 New Feature

## Caveats (if any)

Behavior changes worth calling out:

- `postgres`, `batch_write_to_db` and `redis` service spans change span kind from `INTERNAL` to `CLIENT`. That is what lets a backend classify them as database calls; a dashboard filtering those spans by kind would need updating. Span names are unchanged on the v1 path, deliberately, so anything keyed on the name `postgres` keeps working
- Three to five attributes are added per datastore span. Nothing in the repo asserts an exact attribute set on a service span, and no span-attribute limit is configured, so this is additive
- `db.system` is a superseded semconv key. It is emitted for Datadog compatibility during the migration window, not as the primary

The endpoint is resolved from the environment on every span rather than cached, because `DATABASE_URL` is not static: the RDS IAM refresh rebuilds it from `DATABASE_HOST` and friends on every rotation, and the DB-backed `environment_variables` overlay can rewrite those keys after startup with no blocklist covering them. One residual gap remains, and it is the inverse: that overlay changes `os.environ` without reconnecting the live Prisma client, so between the rewrite and the next reconnect a span names the newly configured server while queries still reach the old one. Naming the live connection instead of the environment would need this module to reach into the proxy's Prisma client, which is the wrong direction for a layer the SDK imports, so the window is documented rather than closed. It self-corrects at the next reconnect

What this does not cover, and why the Linear reference is `Refs` rather than `Resolves`:

- The ticket asks that a backend be able to separate local Prisma transport time from downstream query time. litellm's span is a single duration covering pool acquisition, the loopback hop and the query, because the query engine does not report that split back to the Python client. Making it separable needs a span around the engine call itself, which is a hot-path change I did not want to fold in here. The docs section explains how to bound it today using the APM's own transport span plus the database's query timing
- When a read replica is configured, litellm names no endpoint at all rather than naming the writer. `RoutingPrismaWrapper` picks reader or writer per Prisma call, underneath the span, so naming the primary would pin replica read latency onto the wrong instance. Per-call reader/writer attribution is the follow-up
- Datadog was not exercised directly; no account is available on this machine. The `db.system` and `CLIENT`-kind decisions come from Datadog's published OTLP mapping rather than from an observed Datadog trace

## QA runbook

Docs PR: BerriAI/litellm-docs#869. No new env vars, so the two can merge in either order.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/934d355ed6c742249c43b0f2201ec93b
Requested by: @yucheng-berri

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 512ae259a8c456bc8f80caa51b94a1246a35bce2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
