### PR TITLE
fix(cerebras)!: add max_retries and extra_headers to get_supported_openai_params

### DIFF
--- a/litellm/llms/cerebras/chat.py
+++ b/litellm/llms/cerebras/chat.py
@@ -68,6 +68,8 @@ class CerebrasConfig(OpenAIGPTConfig):
             "tool_choice",
             "tools",
             "user",
+            "max_retries",
+            "extra_headers",
         ]
 
         # Only add reasoning_effort for models that support it

--- a/tests/test_litellm/llms/cerebras/test_cerebras_chat_transformation.py
+++ b/tests/test_litellm/llms/cerebras/test_cerebras_chat_transformation.py
@@ -1,0 +1,61 @@
+from litellm.llms.cerebras.chat import CerebrasConfig
+
+
+def test_max_retries_in_supported_params() -> None:
+    config = CerebrasConfig()
+    params = config.get_supported_openai_params(model="llama-3.3-70b")
+    assert "max_retries" in params, (
+        f"max_retries must be in CerebrasConfig.get_supported_openai_params(); got: {params!r}"
+    )
+
+
+def test_extra_headers_in_supported_params() -> None:
+    config = CerebrasConfig()
+    params = config.get_supported_openai_params(model="llama-3.3-70b")
+    assert "extra_headers" in params, (
+        f"extra_headers must be in CerebrasConfig.get_supported_openai_params(); got: {params!r}"
+    )
+
+
+def test_core_openai_params_still_supported() -> None:
+    config = CerebrasConfig()
+    params = config.get_supported_openai_params(model="llama-3.3-70b")
+    for expected in (
+        "max_tokens",
+        "max_completion_tokens",
+        "response_format",
+        "seed",
+        "stop",
+        "stream",
+        "temperature",
+        "top_p",
+        "tool_choice",
+        "tools",
+        "user",
+    ):
+        assert expected in params, f"{expected!r} unexpectedly missing from Cerebras supported params: {params!r}"
+
+
+def test_map_openai_params_preserves_max_retries() -> None:
+    config = CerebrasConfig()
+    result = config.map_openai_params(
+        non_default_params={"max_retries": 0, "temperature": 0.7},
+        optional_params={},
+        model="llama-3.3-70b",
+        drop_params=False,
+    )
+    assert result.get("max_retries") == 0, f"map_openai_params must preserve max_retries=0; got: {result!r}"
+    assert result.get("temperature") == 0.7
+
+
+def test_map_openai_params_preserves_max_retries_zero_falsy() -> None:
+    config = CerebrasConfig()
+    result = config.map_openai_params(
+        non_default_params={"max_retries": 0},
+        optional_params={},
+        model="llama-3.3-70b",
+        drop_params=False,
+    )
+    assert "max_retries" in result and result["max_retries"] == 0, (
+        f"max_retries=0 (falsy) must not be silently omitted; got: {result!r}"
+    )


### PR DESCRIPTION
## Relevant issues

Fixes #31872

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

Bug Fix

## Changes

`CerebrasConfig.get_supported_openai_params()` overrides the parent `OpenAIGPTConfig` with a hand-crafted list that was missing `max_retries` and `extra_headers`. Since `map_openai_params` only passes through params in this list, both were silently discarded — `max_retries` always fell back to the hardcoded default of 2 in `openai.py:653`, and custom `extra_headers` were dropped before reaching the HTTP handler.

Added both params to the supported list and added regression tests (including the `max_retries=0` falsy-value edge case) verifying `map_openai_params` passes them through unchanged.

## Behavior Changes

**max_retries:** Router's default `max_retries=0` now reaches the SDK for cerebras, where it was previously dropped. This aligns cerebras with OpenAI/Azure behavior when called through Router — the Router owns retry logic, so SDK-level retries are disabled by design. Existing calls that don't explicitly pass `max_retries` will now have SDK retries set to 0 instead of the default 2. Callers can override by passing `max_retries=2` (or any value) explicitly per request.

**extra_headers:** No behavior change — `extra_headers` was already being injected via `main.py:2437-2438` regardless of the supported-params list. Adding it to the list only updates documentation and the Model Hub UI.

## Screenshots / Proof of Fix

Verified against a local proxy with a real Cerebras API key:

```bash
curl -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-local-dev-master-key" \
  -d '{"model":"llama-cerebras","messages":[{"role":"user","content":"say hi"}],"max_retries":0,"extra_headers":{"X-Verify":"patch-05"}}'
# -> {"choices":[{"message":{"content":"Hi! How can I assist you today?"}}]}
```

Log evidence: `max_retries` now appears in `optional_params` (previously silently dropped), and `extra_headers` was forwarded in the outbound HTTP request.

Note: BerriAI/litellm#31885 and #30060 are also open against this same gap; this PR targets our internal staging branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow provider-config fix that restores intended passthrough of existing LiteLLM parameters; no new auth or API surface beyond fixing dropped options.
> 
> **Overview**
> **Cerebras chat** now advertises `max_retries` and `extra_headers` in `CerebrasConfig.get_supported_openai_params()`, matching the parent OpenAI config behavior.
> 
> Previously, `map_openai_params` only forwarded params on that list, so callers' `max_retries` (including `0`) never reached optional params and retry behavior defaulted elsewhere, and custom `extra_headers` were dropped before the HTTP layer.
> 
> Regression tests cover both params in the supported list, core params unchanged, and explicit preservation of `max_retries=0` through mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9315ebb5f0578eb80244a6e69e59f4855fb785b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->