### PR TITLE
fix(guardrails): persist content filter evaluations

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -20,7 +20,7 @@ from fastapi import HTTPException
 from litellm import Router
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
-from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.integrations.custom_guardrail import CustomGuardrail, log_guardrail_information
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.utils import (
     CallTypes,
@@ -1864,6 +1864,7 @@ class ContentFilterGuardrail(CustomGuardrail):
             if filtered_arguments != arguments:
                 self._set_tool_call_arguments(tool_call, filtered_arguments)
 
+    @log_guardrail_information
     async def apply_guardrail(
         self,
         inputs: "GenericGuardrailAPIInputs",

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -5,6 +5,7 @@ Tests for the Content Filter Guardrail
 import json
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -231,6 +232,27 @@ class TestContentFilterGuardrail:
         assert len(result) == 1
         assert "[EMAIL_REDACTED]" in result[0]
         assert "test@example.com" not in result[0]
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_syncs_information_to_logging_obj(self):
+        guardrail = ContentFilterGuardrail(guardrail_name="test-logging-sync")
+        request_data = {"metadata": {}}
+        logging_obj = SimpleNamespace(
+            litellm_params={"metadata": {}},
+            model_call_details={},
+        )
+
+        await guardrail.apply_guardrail(
+            inputs={"texts": ["A normal request"]},
+            request_data=request_data,
+            input_type="request",
+            logging_obj=logging_obj,
+        )
+
+        entries = logging_obj.litellm_params["metadata"]["standard_logging_guardrail_information"]
+        assert len(entries) == 1
+        assert entries[0]["guardrail_name"] == "test-logging-sync"
+        assert entries[0]["guardrail_status"] == "success"
 
     @pytest.mark.asyncio
     async def test_apply_guardrail_blocked_word_mask(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Successful content-filter runs were missing from persisted guardrail logs
- Guardrails Monitor could not count individual content-filter evaluations

How it solves it:

- Reuses LiteLLM's logging wrapper around the content-filter entry point
- Preserves the existing detailed detection payload and syncs it to spend logs

## User Flow

Before: a request succeeds, but the content-filter evaluation is absent from its logs

1. An admin enables one or more global `litellm_content_filter` guardrails in `pre_call` mode
2. An application sends `POST http://localhost:4000/v1/chat/completions` with a normal chat request
3. The response returns `200`, but the request's `guardrail_information` omits the content-filter evaluation
4. The admin opens `http://localhost:4000/ui/?page=logs` and cannot find that guardrail's evaluation in the request details

After: the same request records the content-filter evaluation alongside the successful response

1. An admin enables one or more global `litellm_content_filter` guardrails in `pre_call` mode
2. An application sends `POST http://localhost:4000/v1/chat/completions` with a normal chat request
3. The response returns `200`, and the request's `guardrail_information` includes a successful content-filter evaluation
4. The admin opens `http://localhost:4000/ui/?page=logs` and sees that guardrail's evaluation in the request details

## Relevant issues

Fixes #36566

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The issue report documents successful requests where `applied_guardrails` contains the content filters but `guardrail_information` does not

Starting from base commit `b4f5e46a44`, I temporarily added the regression test before the implementation change. It failed because the logging object's metadata had no `standard_logging_guardrail_information` entry

After commit `06377b9047`, the focused content-filter suite passes with `83 passed`, and the related custom-guardrail suite passes with `89 passed`

The regression test exercises the real content-filter implementation and logging synchronization path without a provider mock. No provider credentials were available in this checkout, so I did not include a paid live-LLM capture or claim live e2e verification

## Type

Bug Fix

## Caveats (if any)

Live provider verification still needs to run with provider credentials

The change covers the unified `apply_guardrail` path; the existing streaming hook keeps its own detailed logging behavior

## Final Attestation

- [x] The tests check the relevant successful and intervention paths, including the logging regression

AI assistance: this patch was prepared and tested with AI coding assistance. The implementation and regression scope are included for maintainer review
