### PR TITLE
feat(observability): expose Prisma connection pool saturation metrics

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1507,6 +1507,12 @@ SPEND_LOG_QUEUE_MAX_BYTES: Final = max(1, int(os.getenv("SPEND_LOG_QUEUE_MAX_BYT
 SPEND_LOG_QUEUE_POLL_INTERVAL: Final = float(os.getenv("SPEND_LOG_QUEUE_POLL_INTERVAL", 2.0))
 SPEND_COUNTER_RESEED_LOCKS_MAX_SIZE: Final = int(os.getenv("SPEND_COUNTER_RESEED_LOCKS_MAX_SIZE", 10000))
 DEFAULT_CRON_JOB_LOCK_TTL_SECONDS: Final = int(os.getenv("DEFAULT_CRON_JOB_LOCK_TTL_SECONDS", 60))  # 1 minute
+# Floor on how often the Prisma connection-pool counters are read. The read is a
+# local HTTP call to the query engine, and it rides along with real DB work, so
+# this bounds the added load rather than setting a publish cadence.
+DB_POOL_METRICS_MIN_SAMPLE_INTERVAL_SECONDS: Final = 10.0
+# Ceiling on how long a pool sample may hold up the database call it rides on.
+DB_POOL_METRICS_SAMPLE_TIMEOUT_SECONDS: Final = 1.0
 PROXY_BUDGET_RESCHEDULER_MIN_TIME: Final = int(os.getenv("PROXY_BUDGET_RESCHEDULER_MIN_TIME", 597))
 RESET_BUDGET_JOB_BATCH_SIZE: Final = max(1, int(os.getenv("RESET_BUDGET_JOB_BATCH_SIZE", "500")))
 RESET_BUDGET_JOB_MAX_CHUNKS_PER_RUN: Final = max(1, int(os.getenv("RESET_BUDGET_JOB_MAX_CHUNKS_PER_RUN", "100")))

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -159,12 +159,20 @@ class PrometheusLogger(CustomLogger):
 
     @staticmethod
     def get_instance() -> PrometheusLogger | None:
-        """Find the PrometheusLogger instance from litellm.callbacks, if registered."""
+        """The registered PrometheusLogger, however it was registered.
+
+        Searching ``litellm.callbacks`` alone misses the equally supported
+        ``litellm_settings.success_callback: ["prometheus"]``, which lands the
+        logger on the success-callback lists instead. Callers of this method
+        publish metrics from outside the request hooks, so a miss shows up as a
+        metric that registers and then never leaves zero.
+        """
         import litellm
 
-        for cb in litellm.callbacks:
-            if isinstance(cb, PrometheusLogger):
-                return cb
+        instances: Final = litellm.logging_callback_manager.get_custom_loggers_for_type(callback_type=PrometheusLogger)
+        for instance in instances:
+            if isinstance(instance, PrometheusLogger):
+                return instance
         return None
 
     def __init__(

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -159,10 +159,16 @@ class PrometheusLogger(CustomLogger):
 
     @staticmethod
     def get_instance() -> PrometheusLogger | None:
-        """The registered PrometheusLogger, however it was registered.
+        """The live PrometheusLogger, however it was registered.
 
-        ``litellm.callbacks`` alone misses ``success_callback: ["prometheus"]``,
-        which shows up as a metric that registers and never leaves zero.
+        Two registrations have to be covered, and neither one subsumes the other.
+        An object placed in ``litellm.callbacks`` is found through the callback
+        lists. A *string* registration -- ``success_callback: ["prometheus"]``,
+        which is what the docs show -- is different: the logger is constructed
+        lazily on the first request and cached in ``_in_memory_loggers``, and
+        nothing ever adds it to a callback list. Searching only the callback
+        lists therefore returns None for the whole life of such a proxy, and
+        every metric published through here registers and never leaves zero.
         """
         import litellm
 
@@ -170,6 +176,15 @@ class PrometheusLogger(CustomLogger):
         for instance in instances:
             if isinstance(instance, PrometheusLogger):
                 return instance
+
+        # Imported here, not at module scope: litellm_logging imports this module.
+        from litellm.litellm_core_utils.litellm_logging import (
+            _in_memory_loggers,  # pyright: ignore[reportPrivateUsage]  # the only registry of lazily built loggers
+        )
+
+        for logger in _in_memory_loggers:
+            if isinstance(logger, PrometheusLogger):
+                return logger
         return None
 
     def __init__(

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -58,6 +58,8 @@ from litellm.types.utils import (
 if TYPE_CHECKING:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
     from prometheus_client.metrics import MetricWrapperBase
+
+    from litellm.proxy.db.db_pool_metrics import DBPoolMetricsUpdate
 else:
     AsyncIOScheduler = Any
 
@@ -689,6 +691,83 @@ class PrometheusLogger(CustomLogger):
                 "litellm_check_batch_cost_last_run_timestamp",
                 "Unix timestamp of the last CheckBatchCost job run",
                 labelnames=[],
+            )
+
+            ########################################
+            # Database connection pool saturation
+            ########################################
+            self.litellm_db_pool_connections_max = self._gauge_factory(
+                "litellm_db_pool_connections_max",
+                "Configured maximum size of the Prisma connection pool, summed across live workers",
+                labelnames=(),
+                multiprocess_mode="livesum",
+            )
+
+            self.litellm_db_pool_connections_busy = self._gauge_factory(
+                "litellm_db_pool_connections_busy",
+                "Pool connections currently checked out by a query, summed across live workers",
+                labelnames=(),
+                multiprocess_mode="livesum",
+            )
+
+            self.litellm_db_pool_connections_idle = self._gauge_factory(
+                "litellm_db_pool_connections_idle",
+                "Pool capacity not currently checked out, summed across live workers",
+                labelnames=(),
+                multiprocess_mode="livesum",
+            )
+
+            self.litellm_db_pool_connections_open = self._gauge_factory(
+                "litellm_db_pool_connections_open",
+                "Connections actually opened to the database, summed across live workers",
+                labelnames=(),
+                multiprocess_mode="livesum",
+            )
+
+            self.litellm_db_pool_pending_acquirers = self._gauge_factory(
+                "litellm_db_pool_pending_acquirers",
+                "Queries waiting for a free pool connection, summed across live workers",
+                labelnames=(),
+                multiprocess_mode="livesum",
+            )
+
+            self.litellm_db_pool_acquire_wait_seconds_total = self._counter_factory(
+                name="litellm_db_pool_acquire_wait_seconds_total",
+                documentation=(
+                    "Cumulative seconds spent waiting for a pool connection, excluding query execution. "
+                    "Divide by litellm_db_pool_acquire_total for mean acquire latency. Counts only waits that ended in an acquisition, so it understates during exhaustion; pair it with litellm_db_pool_timeouts_total"
+                ),
+                labelnames=(),
+            )
+
+            self.litellm_db_pool_acquire_total = self._counter_factory(
+                name="litellm_db_pool_acquire_total",
+                documentation="Total pool connection acquisitions on this worker",
+                labelnames=(),
+            )
+
+            self.litellm_db_query_duration_seconds_total = self._counter_factory(
+                name="litellm_db_query_duration_seconds_total",
+                documentation=(
+                    "Cumulative seconds spent executing queries against the database, excluding pool wait. "
+                    "Divide by litellm_db_query_total for mean query latency"
+                ),
+                labelnames=(),
+            )
+
+            self.litellm_db_query_total = self._counter_factory(
+                name="litellm_db_query_total",
+                documentation="Total queries executed against the database by this worker",
+                labelnames=(),
+            )
+
+            self.litellm_db_pool_timeouts_total = self._counter_factory(
+                name="litellm_db_pool_timeouts_total",
+                documentation=(
+                    "Total queries that gave up waiting for a pool connection (prisma P2024). "
+                    "Any nonzero rate means the pool is exhausted"
+                ),
+                labelnames=(),
             )
 
             ########################################
@@ -3055,6 +3134,25 @@ class PrometheusLogger(CustomLogger):
                     ).inc()
         except Exception as e:
             verbose_logger.warning("Error recording check batch cost metrics: %s", e)
+
+    def record_db_pool_sample(self, update: DBPoolMetricsUpdate) -> None:
+        """Publish one reading of this worker's Prisma connection pool."""
+        sample: Final = update.sample
+        self.litellm_db_pool_connections_max.set(sample.max_connections)
+        self.litellm_db_pool_connections_busy.set(sample.busy_connections)
+        self.litellm_db_pool_connections_idle.set(sample.idle_connections)
+        self.litellm_db_pool_connections_open.set(sample.open_connections)
+        self.litellm_db_pool_pending_acquirers.set(update.pending_acquirers)
+        # Deltas are non-negative by construction: DBPoolMetricsSampler zeroes
+        # them when the engine's totals move backwards.
+        self.litellm_db_pool_acquire_total.inc(update.acquire_count_delta)
+        self.litellm_db_pool_acquire_wait_seconds_total.inc(update.acquire_wait_seconds_delta)
+        self.litellm_db_query_total.inc(update.query_count_delta)
+        self.litellm_db_query_duration_seconds_total.inc(update.query_duration_seconds_delta)
+
+    def record_db_pool_timeout(self) -> None:
+        """Count one query that gave up waiting for a free pool connection."""
+        self.litellm_db_pool_timeouts_total.inc()
 
     def record_check_batch_cost_error(self, error_type: str):
         try:

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -161,11 +161,8 @@ class PrometheusLogger(CustomLogger):
     def get_instance() -> PrometheusLogger | None:
         """The registered PrometheusLogger, however it was registered.
 
-        Searching ``litellm.callbacks`` alone misses the equally supported
-        ``litellm_settings.success_callback: ["prometheus"]``, which lands the
-        logger on the success-callback lists instead. Callers of this method
-        publish metrics from outside the request hooks, so a miss shows up as a
-        metric that registers and then never leaves zero.
+        ``litellm.callbacks`` alone misses ``success_callback: ["prometheus"]``,
+        which shows up as a metric that registers and never leaves zero.
         """
         import litellm
 

--- a/litellm/proxy/db/db_pool_metrics.py
+++ b/litellm/proxy/db/db_pool_metrics.py
@@ -162,12 +162,17 @@ class DBPoolMetricsSampler:
         return max(0.0, sample.pending_acquirers - self._pending_baseline)
 
     def _to_update(self, sample: DBPoolSample) -> DBPoolMetricsUpdate:
-        pending: Final = self._corrected_pending_acquirers(sample)
         previous: Final = self._previous
         engine_restarted: Final = previous is not None and (
             sample.acquire_count_total < previous.acquire_count_total
             or sample.query_count_total < previous.query_count_total
         )
+        if engine_restarted:
+            # A fresh engine has an unlatched waiter gauge, so carrying the old
+            # baseline would subtract a latch that no longer exists and hide
+            # real waiters.
+            self._pending_baseline = 0.0
+        pending: Final = self._corrected_pending_acquirers(sample)
         if previous is None or engine_restarted:
             return DBPoolMetricsUpdate(
                 sample=sample,

--- a/litellm/proxy/db/db_pool_metrics.py
+++ b/litellm/proxy/db/db_pool_metrics.py
@@ -1,0 +1,231 @@
+"""Bridges the Prisma query engine's connection-pool counters into Prometheus.
+
+The query engine tracks pool occupancy and, separately, how long a query spent
+waiting for a pool slot versus executing against the database. That split is the
+only way to tell "the database is slow" apart from "we ran out of connections",
+so it is sampled here and re-published under ``litellm_db_pool_*`` names.
+
+Sampling is driven from the DB call path rather than from a scheduled job: an
+exporter that runs on a timer stops reporting exactly when the event loop is
+saturated, which is the window an operator most needs. Requests are what stall
+during pool exhaustion, and they keep arriving, so a throttled sample taken
+alongside real DB work stays alive through the incident.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final, Protocol
+
+from litellm._logging import verbose_proxy_logger
+from litellm.constants import (
+    DB_POOL_METRICS_MIN_SAMPLE_INTERVAL_SECONDS,
+    DB_POOL_METRICS_SAMPLE_TIMEOUT_SECONDS,
+)
+
+if TYPE_CHECKING:
+    from prisma import Metrics
+
+_MILLISECONDS_PER_SECOND: Final = 1000.0
+
+_POOL_BUSY_KEY: Final = "prisma_pool_connections_busy"
+_POOL_IDLE_KEY: Final = "prisma_pool_connections_idle"
+_POOL_OPEN_KEY: Final = "prisma_pool_connections_open"
+_PENDING_ACQUIRERS_KEY: Final = "prisma_client_queries_wait"
+_ACQUIRE_WAIT_HISTOGRAM_KEY: Final = "prisma_client_queries_wait_histogram_ms"
+_QUERY_DURATION_HISTOGRAM_KEY: Final = "prisma_datasource_queries_duration_histogram_ms"
+
+
+class SupportsPoolSample(Protocol):
+    """The one method this module needs from a Prisma client wrapper.
+
+    Deliberately not ``runtime_checkable``: ``PrismaWrapper`` resolves most of
+    its surface through an instance-level ``__getattr__``, which an
+    ``isinstance`` check against a protocol does not see, so a runtime check
+    here would reject the very object it exists to accept.
+    """
+
+    async def get_pool_sample(self) -> DBPoolSample: ...
+
+
+@dataclass(frozen=True, slots=True)
+class DBPoolSample:
+    """One reading of the engine's pool counters.
+
+    ``max_connections`` is derived as ``busy + idle`` rather than parsed out of
+    ``DATABASE_URL``. The engine reports ``idle`` as remaining capacity, so the
+    sum is the configured ``connection_limit``, and deriving it here keeps the
+    database credentials out of this path entirely.
+    """
+
+    busy_connections: float
+    idle_connections: float
+    open_connections: float
+    pending_acquirers: float
+    acquire_wait_seconds_total: float
+    acquire_count_total: int
+    query_duration_seconds_total: float
+    query_count_total: int
+
+    @property
+    def max_connections(self) -> float:
+        return self.busy_connections + self.idle_connections
+
+
+@dataclass(frozen=True, slots=True)
+class DBPoolMetricsUpdate:
+    """A sample plus the cumulative movement since the previous sample.
+
+    The engine reports totals; Prometheus counters take increments. The deltas
+    are the difference between consecutive samples, and are omitted entirely
+    when the engine's totals move backwards, which happens when the query engine
+    restarts and its counters reset.
+    """
+
+    sample: DBPoolSample
+    pending_acquirers: float
+    acquire_wait_seconds_delta: float
+    acquire_count_delta: int
+    query_duration_seconds_delta: float
+    query_count_delta: int
+
+
+def _gauge_value(metrics: Metrics, key: str) -> float:
+    for gauge in metrics.gauges:
+        if gauge.key == key:
+            return float(gauge.value)
+    return 0.0
+
+
+def _histogram_seconds_and_count(metrics: Metrics, key: str) -> tuple[float, int]:
+    for histogram in metrics.histograms:
+        if histogram.key == key:
+            return (histogram.value.sum / _MILLISECONDS_PER_SECOND, histogram.value.count)
+    return (0.0, 0)
+
+
+def parse_pool_sample(metrics: Metrics) -> DBPoolSample:
+    acquire_wait_seconds, acquire_count = _histogram_seconds_and_count(metrics, _ACQUIRE_WAIT_HISTOGRAM_KEY)
+    query_duration_seconds, query_count = _histogram_seconds_and_count(metrics, _QUERY_DURATION_HISTOGRAM_KEY)
+    return DBPoolSample(
+        busy_connections=_gauge_value(metrics, _POOL_BUSY_KEY),
+        idle_connections=_gauge_value(metrics, _POOL_IDLE_KEY),
+        open_connections=_gauge_value(metrics, _POOL_OPEN_KEY),
+        pending_acquirers=_gauge_value(metrics, _PENDING_ACQUIRERS_KEY),
+        acquire_wait_seconds_total=acquire_wait_seconds,
+        acquire_count_total=acquire_count,
+        query_duration_seconds_total=query_duration_seconds,
+        query_count_total=query_count,
+    )
+
+
+class DBPoolMetricsSampler:
+    """Throttled reader of the engine's pool counters.
+
+    One instance per process. ``maybe_sample`` is safe to call on every DB
+    operation: it returns ``None`` without touching the engine until
+    ``min_interval_seconds`` has elapsed since the last reading.
+    """
+
+    def __init__(
+        self,
+        *,
+        min_interval_seconds: float = DB_POOL_METRICS_MIN_SAMPLE_INTERVAL_SECONDS,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._min_interval_seconds: Final = min_interval_seconds
+        self._monotonic: Final = monotonic
+        self._last_sampled_at: float | None = None
+        self._previous: DBPoolSample | None = None
+        self._pending_baseline: float = 0.0
+
+    def is_due(self) -> bool:
+        """Whether enough time has passed to justify reading the engine again."""
+        if self._last_sampled_at is None:
+            return True
+        return (self._monotonic() - self._last_sampled_at) >= self._min_interval_seconds
+
+    async def maybe_sample(self, resolve_client: Callable[[], SupportsPoolSample | None]) -> DBPoolMetricsUpdate | None:
+        """Read the engine's counters, or return ``None`` if not yet due.
+
+        The interval is consumed as soon as an attempt starts, before the client
+        is resolved, so a deployment that has no client to sample throttles the
+        same as one that does rather than retrying on every database call.
+
+        Never raises, and never blocks for long: a wedged query engine costs a
+        bounded wait. A pool sample is diagnostic, and an engine that cannot
+        answer one is already the subject of a louder alarm.
+
+        The client is resolved through a callable rather than passed in so that
+        resolution, which reads proxy module state, happens under the same
+        throttle and the same exception guard as the read itself.
+        """
+        if not self.is_due():
+            return None
+        self._last_sampled_at = self._monotonic()
+
+        try:
+            client: Final = resolve_client()
+            if client is None:
+                return None
+            sample: Final = await asyncio.wait_for(
+                client.get_pool_sample(), timeout=DB_POOL_METRICS_SAMPLE_TIMEOUT_SECONDS
+            )
+        except Exception as e:  # noqa: BLE001  # a diagnostic read must not fail the database call it rides on
+            verbose_proxy_logger.debug("db pool metrics sample failed: %s", e)
+            return None
+
+        update: Final = self._to_update(sample)
+        self._previous = sample
+        return update
+
+    def _corrected_pending_acquirers(self, sample: DBPoolSample) -> float:
+        """The engine's waiter gauge, corrected for waiters that timed out.
+
+        ``prisma_client_queries_wait`` is decremented when a waiter acquires a
+        connection but not when it gives up, so every pool timeout latches the
+        gauge one higher for the life of the process. Observed directly against
+        a live engine at ``connection_limit=2``: after two bursts that produced
+        seven P2024s, a fully drained pool still reported seven waiters.
+
+        Free capacity is proof that nobody is queued, so any reading taken while
+        a connection is idle is exactly the accumulated latch, and subtracting it
+        recovers the real depth. The baseline re-arms on every idle sample, so
+        repeated exhaustion stays accurate rather than drifting further each time.
+        """
+        if sample.idle_connections > 0:
+            self._pending_baseline = sample.pending_acquirers
+            return 0.0
+        return max(0.0, sample.pending_acquirers - self._pending_baseline)
+
+    def _to_update(self, sample: DBPoolSample) -> DBPoolMetricsUpdate:
+        pending: Final = self._corrected_pending_acquirers(sample)
+        previous: Final = self._previous
+        engine_restarted: Final = previous is not None and (
+            sample.acquire_count_total < previous.acquire_count_total
+            or sample.query_count_total < previous.query_count_total
+        )
+        if previous is None or engine_restarted:
+            return DBPoolMetricsUpdate(
+                sample=sample,
+                pending_acquirers=pending,
+                acquire_wait_seconds_delta=0.0,
+                acquire_count_delta=0,
+                query_duration_seconds_delta=0.0,
+                query_count_delta=0,
+            )
+        return DBPoolMetricsUpdate(
+            sample=sample,
+            pending_acquirers=pending,
+            acquire_wait_seconds_delta=max(
+                0.0, sample.acquire_wait_seconds_total - previous.acquire_wait_seconds_total
+            ),
+            acquire_count_delta=sample.acquire_count_total - previous.acquire_count_total,
+            query_duration_seconds_delta=max(
+                0.0, sample.query_duration_seconds_total - previous.query_duration_seconds_total
+            ),
+            query_count_delta=sample.query_count_total - previous.query_count_total,
+        )

--- a/litellm/proxy/db/db_pool_metrics.py
+++ b/litellm/proxy/db/db_pool_metrics.py
@@ -1,15 +1,7 @@
 """Bridges the Prisma query engine's connection-pool counters into Prometheus.
 
-The query engine tracks pool occupancy and, separately, how long a query spent
-waiting for a pool slot versus executing against the database. That split is the
-only way to tell "the database is slow" apart from "we ran out of connections",
-so it is sampled here and re-published under ``litellm_db_pool_*`` names.
-
-Sampling is driven from the DB call path rather than from a scheduled job: an
-exporter that runs on a timer stops reporting exactly when the event loop is
-saturated, which is the window an operator most needs. Requests are what stall
-during pool exhaustion, and they keep arriving, so a throttled sample taken
-alongside real DB work stays alive through the incident.
+Sampled from the DB call path, not a timer: an exporter on a timer stops
+reporting exactly when the event loop is saturated.
 """
 
 from __future__ import annotations
@@ -40,26 +32,17 @@ _QUERY_DURATION_HISTOGRAM_KEY: Final = "prisma_datasource_queries_duration_histo
 
 
 class SupportsPoolSample(Protocol):
-    """The one method this module needs from a Prisma client wrapper.
-
-    Deliberately not ``runtime_checkable``: ``PrismaWrapper`` resolves most of
-    its surface through an instance-level ``__getattr__``, which an
-    ``isinstance`` check against a protocol does not see, so a runtime check
-    here would reject the very object it exists to accept.
-    """
+    """Not ``runtime_checkable``: ``PrismaWrapper`` resolves through an
+    instance-level ``__getattr__``, which ``isinstance`` does not see."""
 
     async def get_pool_sample(self) -> DBPoolSample: ...
 
 
 @dataclass(frozen=True, slots=True)
 class DBPoolSample:
-    """One reading of the engine's pool counters.
-
-    ``max_connections`` is derived as ``busy + idle`` rather than parsed out of
-    ``DATABASE_URL``. The engine reports ``idle`` as remaining capacity, so the
-    sum is the configured ``connection_limit``, and deriving it here keeps the
-    database credentials out of this path entirely.
-    """
+    """One reading of the engine's pool counters. ``max_connections`` is
+    ``busy + idle`` because the engine reports idle as remaining capacity, which
+    also keeps ``DATABASE_URL`` out of this path."""
 
     busy_connections: float
     idle_connections: float
@@ -77,13 +60,8 @@ class DBPoolSample:
 
 @dataclass(frozen=True, slots=True)
 class DBPoolMetricsUpdate:
-    """A sample plus the cumulative movement since the previous sample.
-
-    The engine reports totals; Prometheus counters take increments. The deltas
-    are the difference between consecutive samples, and are omitted entirely
-    when the engine's totals move backwards, which happens when the query engine
-    restarts and its counters reset.
-    """
+    """A sample plus the movement since the previous one. Deltas are zeroed when
+    the engine's totals move backwards, which means it restarted."""
 
     sample: DBPoolSample
     pending_acquirers: float
@@ -123,12 +101,8 @@ def parse_pool_sample(metrics: Metrics) -> DBPoolSample:
 
 
 class DBPoolMetricsSampler:
-    """Throttled reader of the engine's pool counters.
-
-    One instance per process. ``maybe_sample`` is safe to call on every DB
-    operation: it returns ``None`` without touching the engine until
-    ``min_interval_seconds`` has elapsed since the last reading.
-    """
+    """Throttled reader of the engine's pool counters. Safe to call on every DB
+    operation: it touches nothing until ``min_interval_seconds`` has elapsed."""
 
     def __init__(
         self,
@@ -149,19 +123,11 @@ class DBPoolMetricsSampler:
         return (self._monotonic() - self._last_sampled_at) >= self._min_interval_seconds
 
     async def maybe_sample(self, resolve_client: Callable[[], SupportsPoolSample | None]) -> DBPoolMetricsUpdate | None:
-        """Read the engine's counters, or return ``None`` if not yet due.
+        """Read the engine's counters, or ``None`` if not yet due.
 
-        The interval is consumed as soon as an attempt starts, before the client
-        is resolved, so a deployment that has no client to sample throttles the
-        same as one that does rather than retrying on every database call.
-
-        Never raises, and never blocks for long: a wedged query engine costs a
-        bounded wait. A pool sample is diagnostic, and an engine that cannot
-        answer one is already the subject of a louder alarm.
-
-        The client is resolved through a callable rather than passed in so that
-        resolution, which reads proxy module state, happens under the same
-        throttle and the same exception guard as the read itself.
+        The interval is consumed before the client is resolved, so a deployment
+        with nothing to sample throttles the same as one that does. Never raises
+        and never blocks for long; a pool sample is diagnostic.
         """
         if not self.is_due():
             return None
@@ -185,16 +151,10 @@ class DBPoolMetricsSampler:
     def _corrected_pending_acquirers(self, sample: DBPoolSample) -> float:
         """The engine's waiter gauge, corrected for waiters that timed out.
 
-        ``prisma_client_queries_wait`` is decremented when a waiter acquires a
-        connection but not when it gives up, so every pool timeout latches the
-        gauge one higher for the life of the process. Observed directly against
-        a live engine at ``connection_limit=2``: after two bursts that produced
-        seven P2024s, a fully drained pool still reported seven waiters.
-
-        Free capacity is proof that nobody is queued, so any reading taken while
-        a connection is idle is exactly the accumulated latch, and subtracting it
-        recovers the real depth. The baseline re-arms on every idle sample, so
-        repeated exhaustion stays accurate rather than drifting further each time.
+        ``prisma_client_queries_wait`` decrements on acquisition but not on
+        timeout, so each P2024 latches it one higher for the life of the process.
+        Free capacity proves nobody is queued, so an idle reading is exactly the
+        accumulated latch; subtracting it recovers the real depth.
         """
         if sample.idle_connections > 0:
             self._pending_baseline = sample.pending_acquirers

--- a/litellm/proxy/db/db_pool_metrics.py
+++ b/litellm/proxy/db/db_pool_metrics.py
@@ -117,22 +117,36 @@ class DBPoolMetricsSampler:
         self._pending_baseline: float = 0.0
 
     def is_due(self) -> bool:
-        """Whether enough time has passed to justify reading the engine again."""
+        """Whether a sample is due. Read-only; does not claim."""
         if self._last_sampled_at is None:
             return True
         return (self._monotonic() - self._last_sampled_at) >= self._min_interval_seconds
 
-    async def maybe_sample(self, resolve_client: Callable[[], SupportsPoolSample | None]) -> DBPoolMetricsUpdate | None:
-        """Read the engine's counters, or ``None`` if not yet due.
+    def try_claim(self) -> bool:
+        """Claim the next sample, or return False if one is not due yet.
 
-        The interval is consumed before the client is resolved, so a deployment
-        with nothing to sample throttles the same as one that does. Never raises
-        and never blocks for long; a pool sample is diagnostic.
+        Check and set happen with no await between them, so a burst of callers
+        on the event loop produces exactly one claim and therefore one sample
+        rather than one per caller.
         """
         if not self.is_due():
-            return None
+            return False
         self._last_sampled_at = self._monotonic()
+        return True
 
+    async def maybe_sample(self, resolve_client: Callable[[], SupportsPoolSample | None]) -> DBPoolMetricsUpdate | None:
+        """Claim a sample and take it, or return ``None`` if one is not due."""
+        if not self.try_claim():
+            return None
+        return await self.sample(resolve_client)
+
+    async def sample(self, resolve_client: Callable[[], SupportsPoolSample | None]) -> DBPoolMetricsUpdate | None:
+        """Take a sample the caller has already claimed.
+
+        Never raises and never blocks for long; a pool sample is diagnostic, and
+        an engine that cannot answer one is already the subject of a louder
+        alarm.
+        """
         try:
             client: Final = resolve_client()
             if client is None:

--- a/litellm/proxy/db/exception_handler.py
+++ b/litellm/proxy/db/exception_handler.py
@@ -124,6 +124,23 @@ class PrismaDBExceptionHandler:
         return type(e) is prisma.errors.DataError
 
     @staticmethod
+    def is_connection_pool_timeout_error(e: Exception) -> bool:
+        """True iff the query engine gave up waiting for a free pool slot (P2024).
+
+        Matched on the prisma error code rather than the message, because the
+        message is also keyword-matched as a generic transport timeout elsewhere
+        in this class. The distinction matters to an operator: the database
+        answered fine, the proxy simply had no connection left to ask with, so
+        the fix is pool sizing or shedding load rather than anything database
+        side.
+
+        The ``P####`` codes are prisma's own namespace and only prisma populates
+        ``code`` with one, so no type check is needed. Skipping it also keeps
+        this callable on the DB failure path when prisma itself is stubbed.
+        """
+        return getattr(e, "code", None) == "P2024"
+
+    @staticmethod
     def is_database_transport_error(e: Exception) -> bool:
         """
         Returns True only for transport/connectivity failures where a reconnect

--- a/litellm/proxy/db/exception_handler.py
+++ b/litellm/proxy/db/exception_handler.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Awaitable, Callable
 from typing import Any, Final, TypeVar
 
@@ -8,6 +9,11 @@ from litellm.proxy._types import (
     ProxyException,
 )
 from litellm.secret_managers.main import str_to_bool
+
+# The engine reports a pool timeout as a raw HTTP error whose body carries the
+# code, with no `code` attribute to read. Matched on prisma's own JSON field so a
+# message that merely mentions the code cannot trip it.
+_P2024_IN_ENGINE_BODY: Final = re.compile(r'"error_code"\s*:\s*"P2024"')
 
 # Bounds the __cause__/__context__ walk in is_database_service_unavailable_error_in_chain.
 # Real exception chains are a few links deep; the cap also makes the walk cycle-safe.
@@ -137,8 +143,19 @@ class PrismaDBExceptionHandler:
         The ``P####`` codes are prisma's own namespace and only prisma populates
         ``code`` with one, so no type check is needed. Skipping it also keeps
         this callable on the DB failure path when prisma itself is stubbed.
+
+        Both shapes have to be read. Contention raises a typed prisma error
+        carrying the code, which the attribute check already handles. When the
+        database is unreachable the engine reports the same P2024 as a raw HTTP
+        error instead, with no ``code`` attribute and the code only in the JSON
+        body. Prisma classifies both as P2024, so which layer surfaced it should
+        not decide whether it is counted. The neighbouring gauges separate the
+        two cases: saturation holds ``busy`` at ``max`` with waiters queued,
+        while an unreachable database drops ``open`` instead.
         """
-        return getattr(e, "code", None) == "P2024"
+        if getattr(e, "code", None) == "P2024":
+            return True
+        return bool(_P2024_IN_ENGINE_BODY.search(str(e)))
 
     @staticmethod
     def is_database_transport_error(e: Exception) -> bool:

--- a/litellm/proxy/db/log_db_metrics.py
+++ b/litellm/proxy/db/log_db_metrics.py
@@ -57,7 +57,7 @@ async def _sample_db_pool_metrics() -> None:
     succeeded, so nothing here may turn a working query into a failed one.
     """
     try:
-        update: Final = await _pool_metrics_sampler.maybe_sample(_resolve_pool_client)
+        update: Final = await _pool_metrics_sampler.sample(_resolve_pool_client)
         if update is None:
             return
         logger: Final = _prometheus_logger()
@@ -130,8 +130,9 @@ def log_db_metrics(func):
             # Dispatched, never awaited. Awaiting here would add a suspension
             # point after the query already succeeded, so a client disconnect in
             # that window would discard a completed result and skip the success
-            # hook below. `is_due` keeps this to one task per sample interval.
-            if _pool_metrics_sampler.is_due():
+            # hook below. The claim is atomic, so a burst spawns one task rather
+            # than one per caller.
+            if _pool_metrics_sampler.try_claim():
                 asyncio.create_task(_sample_db_pool_metrics())
 
             if "PROXY" not in func.__name__:

--- a/litellm/proxy/db/log_db_metrics.py
+++ b/litellm/proxy/db/log_db_metrics.py
@@ -30,33 +30,31 @@ _pool_metrics_sampler: Final = DBPoolMetricsSampler()
 
 
 def _prometheus_logger() -> "PrometheusLogger | None":
-    """The active PrometheusLogger, or None when prometheus is not configured.
-
-    Imports lazily. Bare ``import litellm`` does not load the prometheus
-    integration, so hoisting this would make every proxy pay for a module that
-    only prometheus deployments use.
-    """
+    """The active PrometheusLogger, or None. Imported lazily so a proxy without
+    prometheus never loads the integration."""
     from litellm.integrations.prometheus import PrometheusLogger
 
     return PrometheusLogger.get_instance()
 
 
 def _resolve_pool_client() -> "SupportsPoolSample | None":
+    """The client to sample, or None when there is nothing to sample for.
+
+    Checks for a metrics consumer before returning a client, so a proxy without
+    prometheus never pays for the engine read.
+    """
     from litellm.proxy.proxy_server import prisma_client
 
-    return None if prisma_client is None else prisma_client.db
+    if prisma_client is None or _prometheus_logger() is None:
+        return None
+    return prisma_client.db
 
 
 async def _sample_db_pool_metrics() -> None:
-    """Publish a throttled reading of the connection pool, if one is due.
+    """Publish a throttled pool reading, if one is due.
 
-    Runs alongside real database work rather than on a timer: a scheduled
-    exporter goes quiet exactly when the event loop is saturated, which is the
-    window this metric exists to cover.
-
-    Every step is inside the guard, including resolving the client and locating
-    the logger. This runs off a database call that has already succeeded, so
-    nothing here may turn a working query into a failed one.
+    Every step is inside the guard: this runs off a database call that already
+    succeeded, so nothing here may turn a working query into a failed one.
     """
     try:
         update: Final = await _pool_metrics_sampler.maybe_sample(_resolve_pool_client)
@@ -70,16 +68,11 @@ async def _sample_db_pool_metrics() -> None:
 
 
 def _record_db_pool_timeout_if_exhausted(e: Exception) -> None:
-    """Count a pool exhaustion once, without ever displacing the error itself.
+    """Count a pool exhaustion once, without displacing the error itself.
 
-    Decorated database helpers nest: ``get_object_permission`` is called from
-    inside ``get_key_object``, and both carry this decorator. One P2024 therefore
-    passes through several ``except`` blocks on its way up, so the exception is
-    marked the first time it is counted and skipped afterwards.
-
-    The caller re-raises after this returns. Anything escaping here would replace
-    a P2024 with a metrics error, during the incident this counter exists to
-    record.
+    Decorated helpers nest (``get_object_permission`` inside ``get_key_object``),
+    so one P2024 passes through several ``except`` blocks; the exception is
+    marked the first time it is counted.
     """
     try:
         if not PrismaDBExceptionHandler.is_connection_pool_timeout_error(e):

--- a/litellm/proxy/db/log_db_metrics.py
+++ b/litellm/proxy/db/log_db_metrics.py
@@ -20,6 +20,10 @@ if TYPE_CHECKING:
     from litellm.integrations.prometheus import PrometheusLogger
     from litellm.proxy.db.db_pool_metrics import SupportsPoolSample
 
+# Marks a P2024 that has already been counted, so nested decorated helpers do
+# not each count the same timeout.
+_POOL_TIMEOUT_COUNTED: Final = "_litellm_db_pool_timeout_counted"
+
 # One sampler per process. The pool it reads is per-process too, so there is
 # nothing to key this by.
 _pool_metrics_sampler: Final = DBPoolMetricsSampler()
@@ -66,15 +70,25 @@ async def _sample_db_pool_metrics() -> None:
 
 
 def _record_db_pool_timeout_if_exhausted(e: Exception) -> None:
-    """Count a pool exhaustion, without ever displacing the error that caused it.
+    """Count a pool exhaustion once, without ever displacing the error itself.
 
-    The caller re-raises the original exception after this returns. Anything
-    that escaped here would replace a P2024 with a metrics error, during the
-    incident this counter exists to record.
+    Decorated database helpers nest: ``get_object_permission`` is called from
+    inside ``get_key_object``, and both carry this decorator. One P2024 therefore
+    passes through several ``except`` blocks on its way up, so the exception is
+    marked the first time it is counted and skipped afterwards.
+
+    The caller re-raises after this returns. Anything escaping here would replace
+    a P2024 with a metrics error, during the incident this counter exists to
+    record.
     """
     try:
         if not PrismaDBExceptionHandler.is_connection_pool_timeout_error(e):
             return
+        if getattr(e, _POOL_TIMEOUT_COUNTED, False):
+            return
+        # rebind-ok: marking the in-flight exception is how an outer decorator
+        # learns this timeout was already counted by an inner one
+        setattr(e, _POOL_TIMEOUT_COUNTED, True)
         logger: Final = _prometheus_logger()
         if logger is not None:
             logger.record_db_pool_timeout()

--- a/litellm/proxy/db/log_db_metrics.py
+++ b/litellm/proxy/db/log_db_metrics.py
@@ -8,10 +8,78 @@ import asyncio
 from collections.abc import Callable
 from datetime import datetime
 from functools import wraps
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
+from litellm._logging import verbose_proxy_logger
 from litellm._service_logger import ServiceTypes
 from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
+from litellm.proxy.db.db_pool_metrics import DBPoolMetricsSampler
+from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
+
+if TYPE_CHECKING:
+    from litellm.integrations.prometheus import PrometheusLogger
+    from litellm.proxy.db.db_pool_metrics import SupportsPoolSample
+
+# One sampler per process. The pool it reads is per-process too, so there is
+# nothing to key this by.
+_pool_metrics_sampler: Final = DBPoolMetricsSampler()
+
+
+def _prometheus_logger() -> "PrometheusLogger | None":
+    """The active PrometheusLogger, or None when prometheus is not configured.
+
+    Imports lazily. Bare ``import litellm`` does not load the prometheus
+    integration, so hoisting this would make every proxy pay for a module that
+    only prometheus deployments use.
+    """
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    return PrometheusLogger.get_instance()
+
+
+def _resolve_pool_client() -> "SupportsPoolSample | None":
+    from litellm.proxy.proxy_server import prisma_client
+
+    return None if prisma_client is None else prisma_client.db
+
+
+async def _sample_db_pool_metrics() -> None:
+    """Publish a throttled reading of the connection pool, if one is due.
+
+    Runs alongside real database work rather than on a timer: a scheduled
+    exporter goes quiet exactly when the event loop is saturated, which is the
+    window this metric exists to cover.
+
+    Every step is inside the guard, including resolving the client and locating
+    the logger. This runs off a database call that has already succeeded, so
+    nothing here may turn a working query into a failed one.
+    """
+    try:
+        update: Final = await _pool_metrics_sampler.maybe_sample(_resolve_pool_client)
+        if update is None:
+            return
+        logger: Final = _prometheus_logger()
+        if logger is not None:
+            logger.record_db_pool_sample(update)
+    except Exception as e:  # noqa: BLE001  # a metrics failure must never fail the database call it rides on
+        verbose_proxy_logger.debug("db pool metrics publish failed: %s", e)
+
+
+def _record_db_pool_timeout_if_exhausted(e: Exception) -> None:
+    """Count a pool exhaustion, without ever displacing the error that caused it.
+
+    The caller re-raises the original exception after this returns. Anything
+    that escaped here would replace a P2024 with a metrics error, during the
+    incident this counter exists to record.
+    """
+    try:
+        if not PrismaDBExceptionHandler.is_connection_pool_timeout_error(e):
+            return
+        logger: Final = _prometheus_logger()
+        if logger is not None:
+            logger.record_db_pool_timeout()
+    except Exception as metrics_error:  # noqa: BLE001  # counting an exhaustion must not mask the exhaustion itself
+        verbose_proxy_logger.debug("db pool timeout metric failed: %s", metrics_error)
 
 
 def _safe_db_event_metadata(kwargs: dict) -> dict[str, str] | None:
@@ -51,6 +119,13 @@ def log_db_metrics(func):
             result: Final = await func(*args, **kwargs)
             end_time: datetime = datetime.now()
             from litellm.proxy.proxy_server import proxy_logging_obj
+
+            # Dispatched, never awaited. Awaiting here would add a suspension
+            # point after the query already succeeded, so a client disconnect in
+            # that window would discard a completed result and skip the success
+            # hook below. `is_due` keeps this to one task per sample interval.
+            if _pool_metrics_sampler.is_due():
+                asyncio.create_task(_sample_db_pool_metrics())
 
             if "PROXY" not in func.__name__:
                 asyncio.create_task(
@@ -123,6 +198,11 @@ async def _handle_logging_db_exception(
     end_time: datetime,
 ) -> None:
     from litellm.proxy.proxy_server import proxy_logging_obj
+
+    # Counted before the DB-relatedness gate below: a pool timeout is the proxy
+    # running out of connections, so it must be recorded whether or not the
+    # failure is classified as a DB service failure.
+    _record_db_pool_timeout_if_exhausted(e)
 
     # don't log this as a DB Service Failure, if the DB did not raise an exception
     if _is_exception_related_to_db(e) is not True:

--- a/litellm/proxy/db/log_db_metrics.py
+++ b/litellm/proxy/db/log_db_metrics.py
@@ -20,12 +20,10 @@ if TYPE_CHECKING:
     from litellm.integrations.prometheus import PrometheusLogger
     from litellm.proxy.db.db_pool_metrics import SupportsPoolSample
 
-# Marks a P2024 that has already been counted, so nested decorated helpers do
-# not each count the same timeout.
+# Marks a P2024 already counted, so nested decorated helpers do not recount it.
 _POOL_TIMEOUT_COUNTED: Final = "_litellm_db_pool_timeout_counted"
 
-# One sampler per process. The pool it reads is per-process too, so there is
-# nothing to key this by.
+# One sampler per process; the pool it reads is per-process too.
 _pool_metrics_sampler: Final = DBPoolMetricsSampler()
 
 
@@ -127,11 +125,8 @@ def log_db_metrics(func):
             end_time: datetime = datetime.now()
             from litellm.proxy.proxy_server import proxy_logging_obj
 
-            # Dispatched, never awaited. Awaiting here would add a suspension
-            # point after the query already succeeded, so a client disconnect in
-            # that window would discard a completed result and skip the success
-            # hook below. The claim is atomic, so a burst spawns one task rather
-            # than one per caller.
+            # Never awaited: a suspension point here would let a client
+            # disconnect discard a query that already succeeded.
             if _pool_metrics_sampler.try_claim():
                 asyncio.create_task(_sample_db_pool_metrics())
 
@@ -207,9 +202,8 @@ async def _handle_logging_db_exception(
 ) -> None:
     from litellm.proxy.proxy_server import proxy_logging_obj
 
-    # Counted before the DB-relatedness gate below: a pool timeout is the proxy
-    # running out of connections, so it must be recorded whether or not the
-    # failure is classified as a DB service failure.
+    # Counted before the DB-relatedness gate: a pool timeout is this proxy out of
+    # connections, however the failure is later classified.
     _record_db_pool_timeout_if_exhausted(e)
 
     # don't log this as a DB Service Failure, if the DB did not raise an exception

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 from typing import Any, Final, Protocol
 
 from litellm._logging import verbose_proxy_logger
+from litellm.proxy.db.db_pool_metrics import DBPoolSample, parse_pool_sample
 from litellm.secret_managers.main import str_to_bool
 
 
@@ -797,6 +798,17 @@ class PrismaWrapper:
             return False
         seconds_left: Final = (expiration_time - datetime.utcnow()).total_seconds()
         return seconds_left > self.TOKEN_REFRESH_BUFFER_SECONDS
+
+    async def get_pool_sample(self) -> DBPoolSample:
+        """This connection pool's current occupancy, as the query engine sees it.
+
+        Declared rather than left to ``__getattr__``, which resolves through an
+        untyped delegation and so cannot satisfy a typed caller, and which also
+        makes the underlying client's identity easy to lose track of. Keeping
+        the engine's raw counter names behind this boundary means the metrics
+        layer never has to know them.
+        """
+        return parse_pool_sample(await self._original_prisma.get_metrics())
 
     def __getattr__(self, name: str):
         """

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -800,14 +800,9 @@ class PrismaWrapper:
         return seconds_left > self.TOKEN_REFRESH_BUFFER_SECONDS
 
     async def get_pool_sample(self) -> DBPoolSample:
-        """This connection pool's current occupancy, as the query engine sees it.
-
-        Declared rather than left to ``__getattr__``, which resolves through an
-        untyped delegation and so cannot satisfy a typed caller, and which also
-        makes the underlying client's identity easy to lose track of. Keeping
-        the engine's raw counter names behind this boundary means the metrics
-        layer never has to know them.
-        """
+        """This pool's occupancy, as the query engine sees it. Declared rather
+        than left to ``__getattr__`` so a typed caller can reach it, and so the
+        engine's counter names stay out of the metrics layer."""
         return parse_pool_sample(await self._original_prisma.get_metrics())
 
     def __getattr__(self, name: str):

--- a/litellm/proxy/db/routing_prisma_wrapper.py
+++ b/litellm/proxy/db/routing_prisma_wrapper.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from typing import Any, Final
 
 from litellm._logging import verbose_proxy_logger
+from litellm.proxy.db.db_pool_metrics import DBPoolSample
 from litellm.proxy.db.prisma_client import PrismaWrapper
 
 # Per-model action methods that read from the database. These are routed to
@@ -130,6 +131,15 @@ class RoutingPrismaWrapper:
         clears the flag — without this, the watchdog would keep firing
         reconnect attempts against an already-healthy writer."""
         self._writer_unavailable = False
+
+    async def get_pool_sample(self) -> DBPoolSample:
+        """The writer's pool occupancy.
+
+        The writer is the pool that auth, spend writes and every background job
+        contend for, so it is the one that saturates. The reader has its own
+        separate pool that this does not cover; see the metric docs.
+        """
+        return await self._writer.get_pool_sample()
 
     def _should_use_reader(self) -> bool:
         return not self._reader_unavailable

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -119,7 +119,7 @@ EXCEPTION_CLASS: Final = "exception_class"
 RATE_LIMIT_CATEGORY: Final = "rate_limit_category"
 RATE_LIMIT_TYPE: Final = "rate_limit_type"
 STATUS_CODE: Final = "status_code"
-EXCEPTION_LABELS: Final = [EXCEPTION_STATUS, EXCEPTION_CLASS]
+EXCEPTION_LABELS: Final = (EXCEPTION_STATUS, EXCEPTION_CLASS)
 LATENCY_BUCKETS: Final = (
     0.005,
     0.01,
@@ -273,6 +273,17 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     # MCP tool call metrics
     "litellm_mcp_tool_calls_total",
     "litellm_mcp_tool_call_spend_metric",
+    # Database connection pool saturation
+    "litellm_db_pool_connections_max",
+    "litellm_db_pool_connections_busy",
+    "litellm_db_pool_connections_idle",
+    "litellm_db_pool_connections_open",
+    "litellm_db_pool_pending_acquirers",
+    "litellm_db_pool_acquire_wait_seconds_total",
+    "litellm_db_pool_acquire_total",
+    "litellm_db_query_duration_seconds_total",
+    "litellm_db_query_total",
+    "litellm_db_pool_timeouts_total",
 ]
 
 
@@ -765,6 +776,20 @@ class PrometheusMetricLabels:
 
     litellm_check_batch_cost_last_run_timestamp: list[str] = []
 
+    # Database connection pool saturation. Deliberately unlabelled: the pool is a
+    # per-worker resource, and any key/team/user label would both be meaningless
+    # here and blow up cardinality on a metric scraped from every pod.
+    litellm_db_pool_connections_max: tuple[str, ...] = ()
+    litellm_db_pool_connections_busy: tuple[str, ...] = ()
+    litellm_db_pool_connections_idle: tuple[str, ...] = ()
+    litellm_db_pool_connections_open: tuple[str, ...] = ()
+    litellm_db_pool_pending_acquirers: tuple[str, ...] = ()
+    litellm_db_pool_acquire_wait_seconds_total: tuple[str, ...] = ()
+    litellm_db_pool_acquire_total: tuple[str, ...] = ()
+    litellm_db_query_duration_seconds_total: tuple[str, ...] = ()
+    litellm_db_query_total: tuple[str, ...] = ()
+    litellm_db_pool_timeouts_total: tuple[str, ...] = ()
+
     # MCP tool call metrics
     litellm_mcp_tool_calls_total: list[str] = [
         UserAPIKeyLabelNames.MCP_TOOL_NAME.value,
@@ -834,7 +859,7 @@ class PrometheusMetricLabels:
                 if label not in default_labels and label not in custom_labels:
                     custom_labels.append(label)
 
-        return default_labels + custom_labels
+        return [*default_labels, *custom_labels]
 
 
 _USER_API_KEY_LABEL_VALUE_INIT_ALIASES: Final[Mapping[str, str]] = MappingProxyType(

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -776,9 +776,8 @@ class PrometheusMetricLabels:
 
     litellm_check_batch_cost_last_run_timestamp: list[str] = []
 
-    # Database connection pool saturation. Deliberately unlabelled: the pool is a
-    # per-worker resource, and any key/team/user label would both be meaningless
-    # here and blow up cardinality on a metric scraped from every pod.
+    # Unlabelled: the pool is per-worker, so key/team/user labels would only add
+    # cardinality.
     litellm_db_pool_connections_max: tuple[str, ...] = ()
     litellm_db_pool_connections_busy: tuple[str, ...] = ()
     litellm_db_pool_connections_idle: tuple[str, ...] = ()

--- a/tests/test_litellm/integrations/test_prometheus_db_pool_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_db_pool_metrics.py
@@ -225,3 +225,37 @@ def test_the_gauge_publishes_the_corrected_pending_not_the_raw_engine_reading(lo
     )
 
     assert _value("litellm_db_pool_pending_acquirers") == 0.0
+
+
+def test_get_instance_finds_a_logger_registered_via_success_callback(logger):
+    """litellm_settings.success_callback: ["prometheus"] is an equally supported
+    registration and lands the logger on the success-callback lists rather than
+    litellm.callbacks. Searching only the latter left every pool metric
+    registered and permanently at zero, verified on a live proxy."""
+    import litellm
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    saved_callbacks = litellm.callbacks
+    saved_success = litellm.success_callback
+    try:
+        litellm.callbacks = []
+        litellm.success_callback = [logger]
+        assert PrometheusLogger.get_instance() is logger
+    finally:
+        litellm.callbacks = saved_callbacks
+        litellm.success_callback = saved_success
+
+
+def test_get_instance_returns_none_when_prometheus_is_not_registered(logger):
+    import litellm
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    saved_callbacks = litellm.callbacks
+    saved_success = litellm.success_callback
+    try:
+        litellm.callbacks = []
+        litellm.success_callback = []
+        assert PrometheusLogger.get_instance() is None
+    finally:
+        litellm.callbacks = saved_callbacks
+        litellm.success_callback = saved_success

--- a/tests/test_litellm/integrations/test_prometheus_db_pool_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_db_pool_metrics.py
@@ -1,0 +1,227 @@
+"""Prometheus surface for the Prisma connection-pool saturation metrics."""
+
+from typing import get_args
+from unittest.mock import MagicMock
+
+import pytest
+from prometheus_client import REGISTRY
+from prisma.errors import DataError
+
+from litellm.proxy.db.db_pool_metrics import DBPoolMetricsUpdate, DBPoolSample
+from litellm.types.integrations.prometheus import (
+    DEFINED_PROMETHEUS_METRICS,
+    PrometheusMetricLabels,
+)
+
+DB_POOL_METRICS = (
+    "litellm_db_pool_connections_max",
+    "litellm_db_pool_connections_busy",
+    "litellm_db_pool_connections_idle",
+    "litellm_db_pool_connections_open",
+    "litellm_db_pool_pending_acquirers",
+    "litellm_db_pool_acquire_wait_seconds_total",
+    "litellm_db_pool_acquire_total",
+    "litellm_db_query_duration_seconds_total",
+    "litellm_db_query_total",
+    "litellm_db_pool_timeouts_total",
+)
+
+
+@pytest.mark.parametrize("metric", DB_POOL_METRICS)
+def test_metric_is_registered_so_the_config_and_exclude_lists_accept_it(metric):
+    assert metric in get_args(DEFINED_PROMETHEUS_METRICS)
+    # Asserted on the class attribute rather than get_labels(), which also folds
+    # in whatever custom metadata labels and tags happen to be configured
+    # process-wide and so depends on global state another test may have set.
+    assert getattr(PrometheusMetricLabels, metric) == (), (
+        f"{metric} must stay unlabelled: the pool is a per-worker resource and the ticket "
+        "forbids api-key/team labels on saturation metrics"
+    )
+
+
+def _update(**kwargs) -> DBPoolMetricsUpdate:
+    sample = DBPoolSample(
+        busy_connections=kwargs.pop("busy", 0.0),
+        idle_connections=kwargs.pop("idle", 0.0),
+        open_connections=kwargs.pop("open_", 0.0),
+        pending_acquirers=kwargs.pop("pending", 0.0),
+        acquire_wait_seconds_total=0.0,
+        acquire_count_total=0,
+        query_duration_seconds_total=0.0,
+        query_count_total=0,
+    )
+    return DBPoolMetricsUpdate(
+        sample=sample,
+        pending_acquirers=sample.pending_acquirers,
+        acquire_wait_seconds_delta=kwargs.pop("wait_delta", 0.0),
+        acquire_count_delta=kwargs.pop("acquire_delta", 0),
+        query_duration_seconds_delta=kwargs.pop("query_seconds_delta", 0.0),
+        query_count_delta=kwargs.pop("query_delta", 0),
+    )
+
+
+def _clear_registry() -> None:
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def logger():
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    _clear_registry()
+    yield PrometheusLogger()
+    _clear_registry()
+
+
+def _value(name: str) -> float:
+    return REGISTRY.get_sample_value(name) or 0.0
+
+
+def test_a_saturated_pool_is_visible_in_the_gauges(logger):
+    logger.record_db_pool_sample(_update(busy=5.0, idle=0.0, open_=5.0, pending=3.0))
+
+    assert _value("litellm_db_pool_connections_busy") == 5.0
+    assert _value("litellm_db_pool_connections_idle") == 0.0
+    assert _value("litellm_db_pool_connections_open") == 5.0
+    assert _value("litellm_db_pool_pending_acquirers") == 3.0
+    assert _value("litellm_db_pool_connections_max") == 5.0, "busy + idle is the configured limit"
+
+
+def test_pool_wait_and_query_execution_are_counted_separately(logger):
+    logger.record_db_pool_sample(
+        _update(wait_delta=1.5, acquire_delta=6, query_seconds_delta=0.4, query_delta=4)
+    )
+
+    assert _value("litellm_db_pool_acquire_wait_seconds_total") == pytest.approx(1.5)
+    assert _value("litellm_db_pool_acquire_total") == 6.0
+    assert _value("litellm_db_query_duration_seconds_total") == pytest.approx(0.4)
+    assert _value("litellm_db_query_total") == 4.0
+
+
+def test_counters_accumulate_across_samples(logger):
+    logger.record_db_pool_sample(_update(acquire_delta=6, wait_delta=1.5))
+    logger.record_db_pool_sample(_update(acquire_delta=0, wait_delta=0.0))
+    logger.record_db_pool_sample(_update(acquire_delta=4, wait_delta=0.5))
+
+    assert _value("litellm_db_pool_acquire_total") == 10.0
+    assert _value("litellm_db_pool_acquire_wait_seconds_total") == pytest.approx(2.0)
+
+
+def test_pool_timeouts_are_counted(logger):
+    logger.record_db_pool_timeout()
+    logger.record_db_pool_timeout()
+
+    assert _value("litellm_db_pool_timeouts_total") == 2.0
+
+
+@pytest.mark.asyncio
+async def test_a_broken_metric_never_fails_the_database_call_it_rides_on(logger):
+    """The publish path sits inline on a DB call, so the safety boundary lives
+    in log_db_metrics rather than in each recorder."""
+    from unittest.mock import patch
+
+    from litellm.proxy.db.log_db_metrics import (
+        _record_db_pool_timeout_if_exhausted,
+        _sample_db_pool_metrics,
+    )
+
+    logger.record_db_pool_sample = MagicMock(side_effect=RuntimeError("registry gone"))
+    logger.record_db_pool_timeout = MagicMock(side_effect=RuntimeError("registry gone"))
+
+    prisma_client = MagicMock()
+
+    async def _sample():
+        raise RuntimeError("engine gone")
+
+    prisma_client.db.get_pool_sample = _sample
+
+    with (
+        patch("litellm.proxy.db.log_db_metrics._prometheus_logger", return_value=logger),
+        patch("litellm.proxy.proxy_server.prisma_client", prisma_client),
+    ):
+        await _sample_db_pool_metrics()
+        _record_db_pool_timeout_if_exhausted(
+            DataError({"user_facing_error": {"error_code": "P2024", "message": "pool timeout"}})
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_unimportable_prometheus_module_does_not_break_the_db_call():
+    """_prometheus_logger imports lazily. If that import fails, a database call
+    that already succeeded must still succeed, and a pool timeout must still
+    surface as the original P2024 rather than as an ImportError."""
+    from unittest.mock import patch
+
+    from litellm.proxy.db.log_db_metrics import (
+        _record_db_pool_timeout_if_exhausted,
+        _sample_db_pool_metrics,
+    )
+
+    with patch(
+        "litellm.proxy.db.log_db_metrics._prometheus_logger",
+        side_effect=ImportError("prometheus integration unavailable"),
+    ):
+        await _sample_db_pool_metrics()
+        _record_db_pool_timeout_if_exhausted(
+            DataError({"user_facing_error": {"error_code": "P2024", "message": "pool timeout"}})
+        )
+
+
+@pytest.mark.parametrize("metric", DB_POOL_METRICS)
+def test_the_emitted_series_carries_no_labels(logger, metric):
+    """The ticket forbids unbounded labels on saturation metrics. Asserted on
+    the constructed metric rather than on PrometheusMetricLabels, which these
+    metrics never consult, so this fails if someone adds a labelname."""
+    assert getattr(logger, metric)._labelnames == ()
+
+
+POOL_GAUGES = (
+    "litellm_db_pool_connections_max",
+    "litellm_db_pool_connections_busy",
+    "litellm_db_pool_connections_idle",
+    "litellm_db_pool_connections_open",
+    "litellm_db_pool_pending_acquirers",
+)
+
+
+@pytest.mark.parametrize("metric", POOL_GAUGES)
+def test_pool_gauges_aggregate_across_workers_instead_of_fanning_out_per_pid(logger, metric):
+    """Under PROMETHEUS_MULTIPROC_DIR a Gauge with no multiprocess_mode defaults
+    to 'all', which stamps an unbounded pid label on every series and never
+    aggregates. Worse, mark_process_dead only reaps gauge_live* files, so a
+    recycled worker leaves its last reading in every later scrape. livesum sums
+    over live workers and drops dead ones, which is what a pod-level pool number
+    means."""
+    assert getattr(logger, metric)._multiprocess_mode == "livesum"
+
+
+def test_the_gauge_publishes_the_corrected_pending_not_the_raw_engine_reading(logger):
+    """The engine's waiter gauge latches on pool timeouts, so the sampler
+    corrects it. Publishing sample.pending_acquirers instead would put the
+    latched value on the dashboard."""
+    latched = DBPoolSample(
+        busy_connections=0.0,
+        idle_connections=2.0,
+        open_connections=2.0,
+        pending_acquirers=7.0,
+        acquire_wait_seconds_total=0.0,
+        acquire_count_total=0,
+        query_duration_seconds_total=0.0,
+        query_count_total=0,
+    )
+    logger.record_db_pool_sample(
+        DBPoolMetricsUpdate(
+            sample=latched,
+            pending_acquirers=0.0,
+            acquire_wait_seconds_delta=0.0,
+            acquire_count_delta=0,
+            query_duration_seconds_delta=0.0,
+            query_count_delta=0,
+        )
+    )
+
+    assert _value("litellm_db_pool_pending_acquirers") == 0.0

--- a/tests/test_litellm/integrations/test_prometheus_db_pool_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_db_pool_metrics.py
@@ -246,6 +246,37 @@ def test_get_instance_finds_a_logger_registered_via_success_callback(logger):
         litellm.success_callback = saved_success
 
 
+def test_get_instance_finds_a_logger_registered_by_the_string_prometheus():
+    """success_callback: ["prometheus"] is the form the docs show. The logger is
+    built lazily on the first request and cached in _in_memory_loggers, and
+    nothing adds it to a callback list, so searching the callback lists alone
+    returns None for the life of the proxy and every pool metric stays at zero."""
+    import litellm
+    import litellm.litellm_core_utils.litellm_logging as litellm_logging
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    saved_callbacks = litellm.callbacks
+    saved_success = litellm.success_callback
+    saved_in_memory = list(litellm_logging._in_memory_loggers)
+    try:
+        litellm.callbacks = []
+        litellm.success_callback = ["prometheus"]
+        litellm_logging._in_memory_loggers.clear()
+
+        assert PrometheusLogger.get_instance() is None, "nothing is constructed before the first request"
+
+        constructed = litellm_logging._init_custom_logger_compatible_class(
+            "prometheus", internal_usage_cache=None, llm_router=None
+        )
+
+        assert PrometheusLogger.get_instance() is constructed
+    finally:
+        litellm_logging._in_memory_loggers.clear()
+        litellm_logging._in_memory_loggers.extend(saved_in_memory)
+        litellm.callbacks = saved_callbacks
+        litellm.success_callback = saved_success
+
+
 def test_get_instance_returns_none_when_prometheus_is_not_registered(logger):
     import litellm
     from litellm.integrations.prometheus import PrometheusLogger

--- a/tests/test_litellm/proxy/db/test_db_pool_metrics.py
+++ b/tests/test_litellm/proxy/db/test_db_pool_metrics.py
@@ -263,3 +263,33 @@ async def test_the_raw_engine_reading_is_still_carried_on_the_sample():
     assert update is not None
     assert update.pending_acquirers == 0.0
     assert update.sample.pending_acquirers == 4.0
+
+
+@pytest.mark.asyncio
+async def test_an_engine_restart_clears_the_pending_latch():
+    """The restart guard zeroes the counter deltas; the waiter baseline has to go
+    with them. A fresh engine's gauge carries no latch, so keeping the old
+    baseline would subtract waiters that are really queued and can report zero
+    during the saturation that caused the restart."""
+    clock = _Clock()
+    client = _Client(
+        # saturated, 6 waiters of which 4 are latched timeouts
+        _Metrics(busy=2.0, idle=0.0, wait=6.0, waits=40, queries=40),
+        # drained: baseline arms at 4
+        _Metrics(busy=0.0, idle=2.0, wait=4.0, waits=40, queries=40),
+        # engine restarted (totals reset) and is saturated again with 3 real waiters
+        _Metrics(busy=2.0, idle=0.0, wait=3.0, waits=1, queries=1),
+    )
+    sampler = DBPoolMetricsSampler(min_interval_seconds=1.0, monotonic=clock)
+
+    observed = []
+    for tick in range(3):
+        clock.now = tick * 2.0
+        update = await sampler.maybe_sample(lambda: client)
+        assert update is not None
+        observed.append(update.pending_acquirers)
+
+    assert observed[1] == 0.0, "an idle pool reports no waiters and arms the baseline"
+    assert observed[2] == 3.0, (
+        f"after a restart the fresh gauge must be reported in full, got {observed[2]}"
+    )

--- a/tests/test_litellm/proxy/db/test_db_pool_metrics.py
+++ b/tests/test_litellm/proxy/db/test_db_pool_metrics.py
@@ -1,0 +1,265 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.proxy.db.db_pool_metrics import DBPoolMetricsSampler, parse_pool_sample
+
+
+class _Value:
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+        self.labels = {}
+        self.description = ""
+
+
+class _Hist:
+    def __init__(self, total_sum, count):
+        self.sum = total_sum
+        self.count = count
+        self.buckets = []
+
+
+class _Metrics:
+    """Stands in for prisma's Metrics model, matching the shape the engine returns."""
+
+    def __init__(self, *, busy=0.0, idle=0.0, open_=0.0, wait=0.0, wait_ms=0.0, waits=0, query_ms=0.0, queries=0):
+        self.counters = []
+        self.gauges = [
+            _Value("prisma_pool_connections_busy", busy),
+            _Value("prisma_pool_connections_idle", idle),
+            _Value("prisma_pool_connections_open", open_),
+            _Value("prisma_client_queries_wait", wait),
+        ]
+        self.histograms = [
+            _Value("prisma_client_queries_wait_histogram_ms", _Hist(wait_ms, waits)),
+            _Value("prisma_datasource_queries_duration_histogram_ms", _Hist(query_ms, queries)),
+        ]
+
+
+class _Client:
+    def __init__(self, *metrics, fail=False):
+        self._metrics = list(metrics)
+        self._fail = fail
+        self.calls = 0
+
+    async def get_pool_sample(self):
+        self.calls += 1
+        if self._fail:
+            raise RuntimeError("engine unreachable")
+        return parse_pool_sample(self._metrics[min(self.calls - 1, len(self._metrics) - 1)])
+
+
+class _Clock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+
+def test_max_connections_is_busy_plus_idle_not_parsed_from_the_url():
+    """The engine reports idle as remaining capacity, so busy + idle is the
+    configured connection_limit. Verified against a live engine at
+    connection_limit=5 under saturation: busy=5, idle=0."""
+    sample = parse_pool_sample(_Metrics(busy=5.0, idle=0.0, open_=5.0))
+    assert sample.max_connections == 5.0
+
+    sample = parse_pool_sample(_Metrics(busy=2.0, idle=3.0, open_=5.0))
+    assert sample.max_connections == 5.0
+
+
+def test_parse_separates_pool_wait_from_query_execution():
+    sample = parse_pool_sample(_Metrics(wait=3.0, wait_ms=1500.0, waits=6, query_ms=800.0, queries=4))
+    assert sample.pending_acquirers == 3.0
+    assert sample.acquire_wait_seconds_total == 1.5
+    assert sample.acquire_count_total == 6
+    assert sample.query_duration_seconds_total == 0.8
+    assert sample.query_count_total == 4
+
+
+def test_parse_tolerates_a_metric_the_engine_did_not_report():
+    empty = _Metrics()
+    empty.gauges = []
+    empty.histograms = []
+    sample = parse_pool_sample(empty)
+    assert sample.max_connections == 0.0
+    assert sample.acquire_count_total == 0
+
+
+@pytest.mark.asyncio
+async def test_sampler_throttles_until_the_interval_elapses():
+    clock = _Clock()
+    client = _Client(_Metrics(busy=1.0, idle=9.0))
+    sampler = DBPoolMetricsSampler(min_interval_seconds=10.0, monotonic=clock)
+
+    assert await sampler.maybe_sample(lambda: client) is not None
+    assert client.calls == 1
+
+    clock.now = 9.9
+    assert sampler.is_due() is False
+    assert await sampler.maybe_sample(lambda: client) is None
+    assert client.calls == 1, "engine must not be re-read before the interval elapses"
+
+    clock.now = 10.0
+    assert sampler.is_due() is True
+    assert await sampler.maybe_sample(lambda: client) is not None
+    assert client.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_cumulative_totals_are_published_as_deltas():
+    clock = _Clock()
+    client = _Client(
+        _Metrics(wait_ms=1000.0, waits=10, query_ms=500.0, queries=5),
+        _Metrics(wait_ms=2500.0, waits=25, query_ms=900.0, queries=9),
+    )
+    sampler = DBPoolMetricsSampler(min_interval_seconds=1.0, monotonic=clock)
+
+    first = await sampler.maybe_sample(lambda: client)
+    assert first is not None
+    assert first.acquire_count_delta == 0, "first sample has no predecessor to diff against"
+    assert first.acquire_wait_seconds_delta == 0.0
+
+    clock.now = 5.0
+    second = await sampler.maybe_sample(lambda: client)
+    assert second is not None
+    assert second.acquire_count_delta == 15
+    assert second.acquire_wait_seconds_delta == pytest.approx(1.5)
+    assert second.query_count_delta == 4
+    assert second.query_duration_seconds_delta == pytest.approx(0.4)
+
+
+@pytest.mark.asyncio
+async def test_engine_restart_does_not_publish_a_negative_delta():
+    clock = _Clock()
+    client = _Client(
+        _Metrics(wait_ms=9000.0, waits=90, query_ms=4000.0, queries=40),
+        _Metrics(wait_ms=10.0, waits=1, query_ms=5.0, queries=1),
+    )
+    sampler = DBPoolMetricsSampler(min_interval_seconds=1.0, monotonic=clock)
+
+    await sampler.maybe_sample(lambda: client)
+    clock.now = 5.0
+    after_restart = await sampler.maybe_sample(lambda: client)
+
+    assert after_restart is not None
+    assert after_restart.acquire_count_delta == 0
+    assert after_restart.acquire_wait_seconds_delta == 0.0
+    assert after_restart.query_count_delta == 0
+    assert after_restart.sample.acquire_count_total == 1, "the fresh absolute reading is still reported"
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_engine_never_raises_into_the_db_call():
+    clock = _Clock()
+    sampler = DBPoolMetricsSampler(min_interval_seconds=1.0, monotonic=clock)
+    assert await sampler.maybe_sample(lambda: _Client(_Metrics(), fail=True)) is None
+
+
+@pytest.mark.asyncio
+async def test_a_failed_sample_still_consumes_the_interval():
+    """Otherwise a wedged engine is re-probed on every single DB call."""
+    clock = _Clock()
+    client = _Client(_Metrics(), fail=True)
+    sampler = DBPoolMetricsSampler(min_interval_seconds=10.0, monotonic=clock)
+
+    await sampler.maybe_sample(lambda: client)
+    clock.now = 1.0
+    await sampler.maybe_sample(lambda: client)
+    assert client.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_a_client_that_delegates_via_getattr_is_still_sampled():
+    """PrismaWrapper resolves its surface through an instance-level __getattr__,
+    so a class-level structural check rejects it while the call itself works.
+    An earlier revision guarded with isinstance() against a runtime_checkable
+    Protocol and silently published zeroes on a live proxy; this pins the shape
+    that regression had."""
+
+    class _Delegating:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    inner = _Client(_Metrics(busy=4.0, idle=1.0))
+    sampler = DBPoolMetricsSampler(min_interval_seconds=1.0, monotonic=_Clock())
+
+    update = await sampler.maybe_sample(lambda: _Delegating(inner))
+
+    assert update is not None
+    assert update.sample.max_connections == 5.0
+    assert inner.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_the_interval_is_consumed_even_when_there_is_no_client_to_sample():
+    """Otherwise a proxy with prometheus disabled, or one sampled before the DB
+    client exists, never records an attempt and so re-enters this path on every
+    single database call instead of once per interval."""
+    clock = _Clock()
+    sampler = DBPoolMetricsSampler(min_interval_seconds=10.0, monotonic=clock)
+
+    assert await sampler.maybe_sample(lambda: None) is None
+    assert sampler.is_due() is False, "a no-client attempt must still consume the interval"
+
+    clock.now = 10.0
+    assert sampler.is_due() is True
+
+
+@pytest.mark.asyncio
+async def test_a_resolver_that_raises_is_contained():
+    def _boom():
+        raise RuntimeError("proxy_server not importable")
+
+    sampler = DBPoolMetricsSampler(min_interval_seconds=1.0, monotonic=_Clock())
+    assert await sampler.maybe_sample(_boom) is None
+
+
+@pytest.mark.asyncio
+async def test_pool_timeouts_do_not_latch_the_pending_gauge():
+    """prisma decrements its waiter gauge on acquisition but not on timeout, so
+    every P2024 latches it one higher for the life of the process. Sequence
+    reproduced against a live engine at connection_limit=2: after two bursts
+    producing seven timeouts, a fully drained pool still reported pending=7.
+    Free capacity proves nobody is queued, so an idle reading is the latch."""
+    clock = _Clock()
+    client = _Client(
+        _Metrics(busy=0.0, idle=2.0, wait=0.0),   # at rest
+        _Metrics(busy=2.0, idle=0.0, wait=4.0),   # saturated, 4 real waiters
+        _Metrics(busy=0.0, idle=2.0, wait=4.0),   # drained, 4 latched timeouts
+        _Metrics(busy=2.0, idle=0.0, wait=7.0),   # saturated again, 3 real waiters
+        _Metrics(busy=0.0, idle=2.0, wait=7.0),   # drained again
+    )
+    sampler = DBPoolMetricsSampler(min_interval_seconds=1.0, monotonic=clock)
+
+    observed = []
+    for tick in range(5):
+        clock.now = tick * 2.0
+        update = await sampler.maybe_sample(lambda: client)
+        assert update is not None
+        observed.append(update.pending_acquirers)
+
+    assert observed == [0.0, 4.0, 0.0, 3.0, 0.0], (
+        f"expected the latch to be subtracted, got {observed}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_raw_engine_reading_is_still_carried_on_the_sample():
+    """The correction applies to what is published, not to what was observed."""
+    clock = _Clock()
+    client = _Client(_Metrics(busy=0.0, idle=2.0, wait=4.0))
+    sampler = DBPoolMetricsSampler(min_interval_seconds=1.0, monotonic=clock)
+
+    update = await sampler.maybe_sample(lambda: client)
+
+    assert update is not None
+    assert update.pending_acquirers == 0.0
+    assert update.sample.pending_acquirers == 4.0

--- a/tests/test_litellm/proxy/db/test_exception_handler.py
+++ b/tests/test_litellm/proxy/db/test_exception_handler.py
@@ -623,6 +623,49 @@ def test_only_p2024_counts_as_pool_exhaustion(other_error):
     assert PrismaDBExceptionHandler.is_connection_pool_timeout_error(other_error) is False
 
 
+def test_pool_exhaustion_is_detected_in_the_shape_the_engine_actually_raises():
+    """Contention raises a typed prisma error carrying the code, and that path is
+    covered above. When the database itself is unreachable the engine reports the
+    same P2024 as a raw HTTP error instead, with no `code` attribute at all and
+    the code recorded only in the JSON body. Prisma classifies both as P2024, so
+    the counter should not depend on which layer surfaced it. Body captured
+    verbatim from a live proxy run at connection limit 1 with Postgres paused."""
+    from types import SimpleNamespace
+
+    from prisma.engine.errors import EngineRequestError
+
+    body = (
+        '{"is_panic":false,"message":"Timed out fetching a new connection from the connection pool. '
+        'More info: http://pris.ly/d/connection-pool (Current connection pool timeout: 2, connection limit: 1)",'
+        '"meta":{"connection_limit":1,"timeout":2},"error_code":"P2024"}'
+    )
+    error = EngineRequestError(response=SimpleNamespace(status=500), body=body)
+
+    assert not hasattr(error, "code"), "the shape under test is the one with no code attribute"
+    assert PrismaDBExceptionHandler.is_connection_pool_timeout_error(error) is True
+
+
+def test_another_engine_error_code_is_not_read_as_pool_exhaustion():
+    """The body is matched on prisma's own error_code field, so a different
+    engine failure carrying its own code must not be counted."""
+    from types import SimpleNamespace
+
+    from prisma.engine.errors import EngineRequestError
+
+    error = EngineRequestError(
+        response=SimpleNamespace(status=500),
+        body='{"is_panic":false,"message":"boom","error_code":"P2010"}',
+    )
+
+    assert PrismaDBExceptionHandler.is_connection_pool_timeout_error(error) is False
+
+
+def test_a_message_merely_mentioning_the_code_is_not_pool_exhaustion():
+    """Matching loose text would let any error whose message quotes P2024 inflate
+    the exhaustion counter."""
+    assert PrismaDBExceptionHandler.is_connection_pool_timeout_error(Exception("see P2024 docs")) is False
+
+
 def test_pool_exhaustion_is_not_mistaken_for_a_reachability_failure():
     """P2024's message contains "Timed out", which the transport classifier
     keyword-matches. The pool predicate must not inherit that ambiguity."""

--- a/tests/test_litellm/proxy/db/test_exception_handler.py
+++ b/tests/test_litellm/proxy/db/test_exception_handler.py
@@ -582,3 +582,50 @@ def test_is_deadlock_error_matches_postgres_deadlock(error):
 def test_is_deadlock_error_excludes_non_deadlocks(error):
     """Non-deadlock prisma errors, connectivity failures, and non-prisma exceptions are not treated as deadlocks."""
     assert PrismaDBExceptionHandler.is_deadlock_error(error) is False
+
+
+def _pool_timeout_error(connection_limit: int = 10, timeout: int = 60) -> DataError:
+    """The exact payload prisma raises for P2024, captured from a live engine
+    driven to exhaustion with connection_limit=1 and pool_timeout=1."""
+    return DataError(
+        {
+            "user_facing_error": {
+                "error_code": "P2024",
+                "meta": {"connection_limit": connection_limit, "timeout": timeout},
+                "message": (
+                    "Timed out fetching a new connection from the connection pool. "
+                    f"(Current connection pool timeout: {timeout}, connection limit: {connection_limit})"
+                ),
+            }
+        }
+    )
+
+
+def test_pool_exhaustion_is_identified_by_its_prisma_code():
+    assert PrismaDBExceptionHandler.is_connection_pool_timeout_error(_pool_timeout_error()) is True
+
+
+@pytest.mark.parametrize(
+    "other_error",
+    [
+        DataError({"user_facing_error": {"error_code": "P2002", "message": "unique constraint"}}),
+        PrismaError("can't reach database server"),
+        UniqueViolationError({"user_facing_error": {"error_code": "P2002"}}),
+        httpx.ConnectError("connection refused"),
+        ValueError("unrelated"),
+    ],
+)
+def test_only_p2024_counts_as_pool_exhaustion(other_error):
+    """A database that answered and refused the data, and a database that could
+    not be reached at all, are both different problems from having no free
+    connection to ask with. Counting either as exhaustion would send an operator
+    to resize a pool that is fine."""
+    assert PrismaDBExceptionHandler.is_connection_pool_timeout_error(other_error) is False
+
+
+def test_pool_exhaustion_is_not_mistaken_for_a_reachability_failure():
+    """P2024's message contains "Timed out", which the transport classifier
+    keyword-matches. The pool predicate must not inherit that ambiguity."""
+    error = _pool_timeout_error()
+    assert PrismaDBExceptionHandler.is_connection_pool_timeout_error(error) is True
+    assert PrismaDBExceptionHandler.is_database_infrastructure_error(error) is False

--- a/tests/test_litellm/proxy/db/test_log_db_metrics.py
+++ b/tests/test_litellm/proxy/db/test_log_db_metrics.py
@@ -1,0 +1,105 @@
+import os
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from prisma.errors import DataError, UniqueViolationError
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.proxy.db.log_db_metrics import (
+    _handle_logging_db_exception,
+    _record_db_pool_timeout_if_exhausted,
+)
+
+
+def _pool_timeout_error() -> DataError:
+    return DataError(
+        {
+            "user_facing_error": {
+                "error_code": "P2024",
+                "meta": {"connection_limit": 10, "timeout": 60},
+                "message": "Timed out fetching a new connection from the connection pool.",
+            }
+        }
+    )
+
+
+def test_pool_exhaustion_increments_the_timeout_counter():
+    logger = MagicMock()
+    with patch("litellm.proxy.db.log_db_metrics._prometheus_logger", return_value=logger):
+        _record_db_pool_timeout_if_exhausted(_pool_timeout_error())
+    logger.record_db_pool_timeout.assert_called_once()
+
+
+def test_an_ordinary_db_error_does_not_increment_the_timeout_counter():
+    logger = MagicMock()
+    with patch("litellm.proxy.db.log_db_metrics._prometheus_logger", return_value=logger):
+        _record_db_pool_timeout_if_exhausted(UniqueViolationError({"user_facing_error": {"error_code": "P2002"}}))
+    logger.record_db_pool_timeout.assert_not_called()
+
+
+def test_no_prometheus_logger_configured_is_not_an_error():
+    with patch("litellm.proxy.db.log_db_metrics._prometheus_logger", return_value=None):
+        _record_db_pool_timeout_if_exhausted(_pool_timeout_error())
+
+
+@pytest.mark.asyncio
+async def test_pool_exhaustion_is_counted_even_though_it_is_not_a_db_service_failure():
+    """P2024 is a prisma ``DataError``, which ``_is_exception_related_to_db``
+    classifies as DB-related, but the counter must not depend on that gate:
+    exhaustion is the proxy running out of connections, and it has to be
+    recorded on whichever side of the classification it lands."""
+    logger = MagicMock()
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.service_logging_obj.async_service_failure_hook = MagicMock(
+        side_effect=AssertionError("should not be reached when the error is not DB related")
+    )
+
+    with (
+        patch("litellm.proxy.db.log_db_metrics._prometheus_logger", return_value=logger),
+        patch("litellm.proxy.db.log_db_metrics._is_exception_related_to_db", return_value=False),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", proxy_logging_obj),
+    ):
+        await _handle_logging_db_exception(
+            e=_pool_timeout_error(),
+            func=lambda: None,
+            kwargs={},
+            args=(),
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+        )
+
+    logger.record_db_pool_timeout.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_a_stalled_pool_sample_does_not_delay_the_database_call():
+    """The sample is dispatched, not awaited. Awaiting it would both add its
+    latency to every sampled query and open a cancellation window after the
+    query had already succeeded, in which a client disconnect would discard a
+    completed result."""
+    import asyncio
+
+    from litellm.proxy.db.log_db_metrics import _pool_metrics_sampler, log_db_metrics
+
+    started = asyncio.Event()
+
+    async def _hang():
+        started.set()
+        await asyncio.sleep(30)
+
+    @log_db_metrics
+    async def fake_db_call(**kwargs):
+        return "rows"
+
+    _pool_metrics_sampler._last_sampled_at = None
+    with patch("litellm.proxy.db.log_db_metrics._sample_db_pool_metrics", _hang):
+        result = await asyncio.wait_for(fake_db_call(table_name="x"), timeout=1.0)
+
+    assert result == "rows"
+    await asyncio.wait_for(started.wait(), timeout=1.0), "the sample must still be dispatched"
+    for task in asyncio.all_tasks():
+        if task is not asyncio.current_task() and task.get_coro().__name__ == "_hang":
+            task.cancel()

--- a/tests/test_litellm/proxy/db/test_log_db_metrics.py
+++ b/tests/test_litellm/proxy/db/test_log_db_metrics.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from prisma.errors import DataError, UniqueViolationError
@@ -103,3 +103,60 @@ async def test_a_stalled_pool_sample_does_not_delay_the_database_call():
     for task in asyncio.all_tasks():
         if task is not asyncio.current_task() and task.get_coro().__name__ == "_hang":
             task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_one_pool_timeout_is_counted_once_across_nested_decorated_calls():
+    """get_object_permission carries @log_db_metrics and is called from inside
+    get_key_object, which also carries it, so a single P2024 passes through
+    several except blocks on its way up. Counting per block would inflate the
+    exhaustion metric by the nesting depth."""
+    from litellm.proxy.db.log_db_metrics import log_db_metrics
+
+    logger = MagicMock()
+    error = _pool_timeout_error()
+
+    @log_db_metrics
+    async def inner(**kwargs):
+        raise error
+
+    @log_db_metrics
+    async def outer(**kwargs):
+        return await inner(**kwargs)
+
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.service_logging_obj.async_service_failure_hook = AsyncMock()
+
+    with (
+        patch("litellm.proxy.db.log_db_metrics._prometheus_logger", return_value=logger),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", proxy_logging_obj),
+    ):
+        with pytest.raises(DataError):
+            await outer(table_name="x")
+
+    assert logger.record_db_pool_timeout.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_two_separate_pool_timeouts_are_counted_separately():
+    """The dedup must key on the exception instance, not suppress the metric."""
+    from litellm.proxy.db.log_db_metrics import log_db_metrics
+
+    logger = MagicMock()
+
+    @log_db_metrics
+    async def failing(**kwargs):
+        raise _pool_timeout_error()
+
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.service_logging_obj.async_service_failure_hook = AsyncMock()
+
+    with (
+        patch("litellm.proxy.db.log_db_metrics._prometheus_logger", return_value=logger),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", proxy_logging_obj),
+    ):
+        for _ in range(2):
+            with pytest.raises(DataError):
+                await failing(table_name="x")
+
+    assert logger.record_db_pool_timeout.call_count == 2

--- a/tests/test_litellm/proxy/db/test_log_db_metrics.py
+++ b/tests/test_litellm/proxy/db/test_log_db_metrics.py
@@ -160,3 +160,29 @@ async def test_two_separate_pool_timeouts_are_counted_separately():
                 await failing(table_name="x")
 
     assert logger.record_db_pool_timeout.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_a_proxy_without_prometheus_never_reads_the_query_engine():
+    """The sample is worthless with no collector configured, so the engine read
+    must be skipped rather than taken and discarded every interval."""
+    from litellm.proxy.db.log_db_metrics import _pool_metrics_sampler, _sample_db_pool_metrics
+
+    reads = []
+    prisma_client = MagicMock()
+
+    async def _sample():
+        reads.append(1)
+        raise AssertionError("the engine must not be read when prometheus is off")
+
+    prisma_client.db.get_pool_sample = _sample
+    _pool_metrics_sampler._last_sampled_at = None
+
+    with (
+        patch("litellm.proxy.db.log_db_metrics._prometheus_logger", return_value=None),
+        patch("litellm.proxy.proxy_server.prisma_client", prisma_client),
+    ):
+        await _sample_db_pool_metrics()
+
+    assert reads == []
+    assert _pool_metrics_sampler.is_due() is False, "the interval must still be consumed"

--- a/tests/test_litellm/proxy/db/test_log_db_metrics.py
+++ b/tests/test_litellm/proxy/db/test_log_db_metrics.py
@@ -185,4 +185,79 @@ async def test_a_proxy_without_prometheus_never_reads_the_query_engine():
         await _sample_db_pool_metrics()
 
     assert reads == []
-    assert _pool_metrics_sampler.is_due() is False, "the interval must still be consumed"
+
+
+@pytest.mark.asyncio
+async def test_the_decorated_path_actually_samples_end_to_end():
+    """The decorator claims the interval and the dispatched task takes the
+    sample. If both claimed, the task's claim would fail and no sample would
+    ever be taken, while every throttle test kept passing."""
+    import asyncio
+
+    from litellm.proxy.db.db_pool_metrics import DBPoolSample
+    from litellm.proxy.db.log_db_metrics import _pool_metrics_sampler, log_db_metrics
+
+    sample = DBPoolSample(
+        busy_connections=2.0,
+        idle_connections=1.0,
+        open_connections=3.0,
+        pending_acquirers=0.0,
+        acquire_wait_seconds_total=0.0,
+        acquire_count_total=0,
+        query_duration_seconds_total=0.0,
+        query_count_total=0,
+    )
+    reads = []
+
+    async def get_pool_sample():
+        reads.append(1)
+        return sample
+
+    prisma_client = MagicMock()
+    prisma_client.db.get_pool_sample = get_pool_sample
+    logger = MagicMock()
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.service_logging_obj.async_service_success_hook = AsyncMock()
+
+    @log_db_metrics
+    async def fake_db_call(**kwargs):
+        return "rows"
+
+    _pool_metrics_sampler._last_sampled_at = None
+    with (
+        patch("litellm.proxy.db.log_db_metrics._prometheus_logger", return_value=logger),
+        patch("litellm.proxy.proxy_server.prisma_client", prisma_client),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", proxy_logging_obj),
+    ):
+        assert await fake_db_call(table_name="x") == "rows"
+        for _ in range(50):
+            await asyncio.sleep(0.01)
+            if reads:
+                break
+
+    assert reads == [1], f"the dispatched task must take exactly one sample, got {len(reads)}"
+    logger.record_db_pool_sample.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_a_burst_of_database_calls_claims_only_one_sample():
+    """The decorator gates task creation on the claim, so a burst of concurrent
+    database calls must produce one sample rather than one per caller.
+
+    Coroutines only interleave at await points, so this holds as long as the
+    claim stays synchronous. Introducing an await between the due check and the
+    timestamp write is what would break it.
+    """
+    import asyncio
+
+    from litellm.proxy.db.db_pool_metrics import DBPoolMetricsSampler
+
+    sampler = DBPoolMetricsSampler(min_interval_seconds=10.0)
+
+    async def caller() -> bool:
+        await asyncio.sleep(0)  # force a real scheduling point before claiming
+        return sampler.try_claim()
+
+    claims = await asyncio.gather(*[caller() for _ in range(50)])
+
+    assert sum(claims) == 1, f"exactly one caller may claim the interval, got {sum(claims)}"

--- a/tests/test_litellm/proxy/db/test_prisma_client.py
+++ b/tests/test_litellm/proxy/db/test_prisma_client.py
@@ -215,3 +215,50 @@ def test_db_push_applies_replica_identity_full_when_requested(monkeypatch):
 
     assert mock_run.call_args[0][0][:3] == ["prisma", "db", "push"]
     assert applied == [True]
+
+
+@pytest.mark.asyncio
+async def test_get_pool_sample_parses_the_engines_counters():
+    """The wrapper owns the engine, so it owns the engine's counter names. This
+    pins the delegation and keeps those six key strings out of the metrics
+    layer."""
+    from unittest.mock import AsyncMock
+
+    from litellm.proxy.db.prisma_client import PrismaWrapper
+
+    class _Value:
+        def __init__(self, key, value):
+            self.key = key
+            self.value = value
+
+    class _Hist:
+        def __init__(self, total, count):
+            self.sum = total
+            self.count = count
+
+    class _Metrics:
+        gauges = [
+            _Value("prisma_pool_connections_busy", 3.0),
+            _Value("prisma_pool_connections_idle", 0.0),
+            _Value("prisma_pool_connections_open", 3.0),
+            _Value("prisma_client_queries_wait", 5.0),
+        ]
+        histograms = [
+            _Value("prisma_client_queries_wait_histogram_ms", _Hist(2000.0, 8)),
+            _Value("prisma_datasource_queries_duration_histogram_ms", _Hist(500.0, 20)),
+        ]
+        counters = []
+
+    original = MagicMock()
+    original.get_metrics = AsyncMock(return_value=_Metrics())
+    wrapper = PrismaWrapper(original_prisma=original, iam_token_db_auth=False)
+
+    sample = await wrapper.get_pool_sample()
+
+    original.get_metrics.assert_awaited_once()
+    assert sample.busy_connections == 3.0
+    assert sample.max_connections == 3.0
+    assert sample.pending_acquirers == 5.0
+    assert sample.acquire_wait_seconds_total == 2.0
+    assert sample.query_duration_seconds_total == 0.5
+    assert sample.query_count_total == 20

--- a/tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py
+++ b/tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py
@@ -991,3 +991,33 @@ async def test_recreate_keeps_writer_unavailable_when_writer_recreate_fails():
         await routing.recreate_prisma_client("writer-url")
 
     assert routing.writer_unavailable is True
+
+
+@pytest.mark.asyncio
+async def test_get_pool_sample_reads_the_writer_pool():
+    """Reads route to the replica, but the writer is the pool this PR samples.
+    Pinned so a later change to sample the reader is a deliberate edit rather
+    than a silent one, and so deleting the delegation fails."""
+    from litellm.proxy.db.db_pool_metrics import DBPoolSample
+    from litellm.proxy.db.routing_prisma_wrapper import RoutingPrismaWrapper
+
+    sample = DBPoolSample(
+        busy_connections=1.0,
+        idle_connections=2.0,
+        open_connections=3.0,
+        pending_acquirers=0.0,
+        acquire_wait_seconds_total=0.0,
+        acquire_count_total=0,
+        query_duration_seconds_total=0.0,
+        query_count_total=0,
+    )
+    writer = MagicMock()
+    writer.get_pool_sample = AsyncMock(return_value=sample)
+    reader = MagicMock()
+    reader.get_pool_sample = AsyncMock()
+
+    wrapper = RoutingPrismaWrapper(writer=writer, reader=reader)
+
+    assert await wrapper.get_pool_sample() is sample
+    writer.get_pool_sample.assert_awaited_once()
+    reader.get_pool_sample.assert_not_awaited()


### PR DESCRIPTION
## TLDR

Problem this solves:

- During recent scalability incidents operators could see latency and database CPU symptoms but had no way to tell whether the proxy had simply run out of database connections, because nothing exposed the Prisma pool
- There was also no way to separate time a query spent queued for a connection from time it spent executing, so "the database is slow" and "we are out of connections" looked identical on a dashboard
- Pool exhaustion (prisma `P2024`) was neither counted nor surfaced anywhere

How it solves it:

- Ten bounded-cardinality metrics bridge the query engine's own pool counters into Prometheus, with pool wait and query execution kept as separate signals
- `litellm_db_pool_timeouts_total` counts `P2024` at the error site, so exhaustion is recorded on the request path rather than by an exporter that has stopped running
- The configured maximum is derived from the engine as `busy + idle` instead of being parsed out of `DATABASE_URL`, so no credential is read on this path

## User Flow

Operators already running the prometheus callback get the new series on the existing `/metrics` endpoint with no configuration change. Nothing is emitted for deployments that do not enable prometheus.

| Metric | Type | Meaning |
|---|---|---|
| `litellm_db_pool_connections_max` | Gauge | Configured pool size, summed across live workers |
| `litellm_db_pool_connections_busy` | Gauge | Connections currently checked out |
| `litellm_db_pool_connections_idle` | Gauge | Capacity not currently checked out |
| `litellm_db_pool_connections_open` | Gauge | Connections actually opened to the database |
| `litellm_db_pool_pending_acquirers` | Gauge | Queries queued for a free connection |
| `litellm_db_pool_acquire_wait_seconds_total` | Counter | Cumulative seconds waiting for a slot, excluding execution |
| `litellm_db_pool_acquire_total` | Counter | Acquisitions, for the mean-wait ratio |
| `litellm_db_query_duration_seconds_total` | Counter | Cumulative seconds executing, excluding pool wait |
| `litellm_db_query_total` | Counter | Queries executed |
| `litellm_db_pool_timeouts_total` | Counter | Acquisitions that gave up waiting (`P2024`) |

Saturation reads as `busy` at `max` with `pending_acquirers` above zero. Mean acquire latency is `rate(litellm_db_pool_acquire_wait_seconds_total[5m]) / rate(litellm_db_pool_acquire_total[5m])`, and the same ratio over the query pair gives execution time, which is the comparison that separates a slow database from an exhausted pool.

## Relevant issues

## Linear ticket

Refs LIT-5435

This covers the database-pool section of the ticket only. The scheduled-job and per-pod request-pressure sections are separate PRs, so this one says Refs rather than Resolves.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Real proxy, real Postgres 16, real Gemini API, no mocks.

### Before

```
$ curl -sSL http://127.0.0.1:20435/metrics -H "Authorization: Bearer sk-1234" \
    | grep -E "^# HELP" | grep -iE "pool|connection|acquire|prisma"
```

No output. 119 metric families exposed, none of them about the connection pool.

### After, healthy pool at `database_connection_pool_limit: 3`

```
$ curl -sSL http://127.0.0.1:20435/metrics -H "Authorization: Bearer sk-1234" | grep -E "^litellm_db_(pool|query)" | grep -v _created
litellm_db_pool_connections_max 3.0
litellm_db_pool_connections_busy 0.0
litellm_db_pool_connections_idle 3.0
litellm_db_pool_connections_open 3.0
litellm_db_pool_pending_acquirers 0.0
litellm_db_pool_acquire_wait_seconds_total 3.620699999999985e-05
litellm_db_pool_acquire_total 17.0
litellm_db_query_duration_seconds_total 0.182499623
litellm_db_query_total 37.0
litellm_db_pool_timeouts_total 0.0
```

`max` reports the configured 3, derived from the engine rather than from the connection string.

### Under contention, 40 concurrent cold-cache auth lookups

```
  40 200
litellm_db_pool_acquire_wait_seconds_total 0.483372629     (was 3.6e-05)
litellm_db_pool_acquire_total 165.0
litellm_db_query_duration_seconds_total 0.7769011680000002
litellm_db_query_total 416.0
```

Pool wait rose four orders of magnitude while query execution stayed flat, which is the distinction this PR exists to provide.

### Saturated, pool of 1, sampled during a 45-request burst

```
litellm_db_pool_connections_busy 1.0
litellm_db_pool_pending_acquirers 12.0
```

### Exhausted, database stalled with `pool_timeout=1s`

```
  25 503
litellm_db_pool_connections_max 1.0
litellm_db_pool_timeouts_total 61.0
```

### Recovery

```
recovered request: 200
litellm_db_pool_pending_acquirers 0.0
litellm_db_pool_connections_busy 0.0
litellm_db_pool_timeouts_total 61.0
```

Gauges track back to healthy and the counter holds.

## Type

🆕 New Feature

## Caveats (if any)

The query engine decrements its waiter gauge when a waiter acquires a connection but not when one times out, so every `P2024` latches it one higher for the life of the process. Reproduced directly at `connection_limit=2, pool_timeout=1`, where a fully drained pool still reported seven waiters after two bursts. Free capacity is proof that nothing is queued, so a reading taken while a connection is idle is exactly the accumulated latch; the sampler subtracts that baseline and re-arms it on every idle sample. Verified after driving 46 real timeouts, with `pending_acquirers` correctly back to 0.

`litellm_db_pool_acquire_wait_seconds_total` records only waits that ended in an acquisition, because the engine's histogram excludes timed-out waits. It therefore understates mean acquire latency during exhaustion, which is why the help text pairs it with the timeout counter.

Sampling rides on database work, so a proxy whose auth cache is entirely warm samples less often. That is the intended coupling: the sampler is liveliest exactly when the database is busiest, and it cannot be silenced by a stalled scheduler. It is what the ticket asks for, a failure-resilient path rather than a periodic exporter.

The cost of that choice, measured rather than estimated: one sample is a 383us call to the query engine's local HTTP server, taken at most once per 10 seconds per worker, which is 0.0038 percent of wall clock. It is dispatched as a task and never awaited, so it adds no latency to the database call it rides on and opens no cancellation window. It also does not consume a pool connection, confirmed by sampling successfully while the pool was fully checked out:

```
sampled while pool fully busy: busy=2 idle=0 -> answered OK
```

That last property is what makes the design work at all, since a sampler that needed a connection would be the first thing to fail during the exhaustion it exists to report.

The counters are fed by differencing the engine's cumulative totals, so the first sample after startup establishes a baseline and the counters begin moving from the second sample.

With `DATABASE_URL_READ_REPLICA` configured the reader has its own separate pool that these metrics do not cover. `RoutingPrismaWrapper.get_pool_sample` samples the writer, which is the pool that background jobs and spend writes contend for. Reader coverage needs a `pool` label and is left to a follow-up.

`EXCEPTION_LABELS` in `litellm/types/integrations/prometheus.py` changes from a list to a tuple. It has no reader anywhere in the repo; freezing it offsets the one mutable-collection violation this diff adds, so no suppression was needed.

### Review follow-ups, both reproduced live before fixing

`PrometheusLogger.get_instance` searched only `litellm.callbacks`. With the
equally supported `litellm_settings.success_callback: ["prometheus"]` the metrics
registered and then sat at zero forever, confirmed on a live proxy:

```
# success_callback registration, before
litellm_db_pool_connections_max 0.0
litellm_db_pool_acquire_total 0.0

# same config, after
litellm_db_pool_connections_max 3.0
litellm_db_pool_acquire_total 17.0
litellm_db_query_total 39.0
```

It now resolves through `logging_callback_manager`, which covers all five
callback lists, so the enterprise batch-cost metrics that use the same accessor
benefit too.

Separately, decorated database helpers nest: `get_object_permission` is called
from inside `get_key_object` and both carry `@log_db_metrics`, so a single P2024
was counted once per enclosing `except`. The exception is now marked the first
time it is counted. The exhaustion counter is per failed database operation, and
a request performs several, so a 20-request burst against a stalled database
records 48 timeouts rather than 20.

## QA runbook

1. Start Postgres and a proxy with `general_settings.database_connection_pool_limit: 3` and `litellm_settings.callbacks: ["prometheus"]`
2. Mint a virtual key with `POST /key/generate`, then send a chat completion with that key. A virtual key is required, since the master key path does no database lookup and so triggers no sample
3. `curl -sSL localhost:4000/metrics -H "Authorization: Bearer sk-1234" | grep litellm_db_` and confirm `litellm_db_pool_connections_max` equals the configured limit
4. Mint 40 keys and fire them concurrently with `xargs -P 40`, polling `/metrics` throughout. `litellm_db_pool_pending_acquirers` should rise above zero while `busy` sits at `max`
5. To force exhaustion, restart with `database_connection_pool_limit: 1` and `database_connection_timeout: 1`, `docker pause` the Postgres container, then fire the burst. `litellm_db_pool_timeouts_total` should climb and the requests should surface as 503
6. `docker unpause`, send one more request, and confirm `pending_acquirers` returns to 0 while the timeout counter holds

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


### Review follow-ups

`get_instance` missed a string registration. `success_callback: ["prometheus"]` builds the logger lazily into `_in_memory_loggers` and never adds it to a callback list, so the lookup returned `None` for the life of such a proxy and every pool metric here would have sat at zero. It now falls back to that cache, with a test that drives the string form and the lazy construction. I refuted this on an earlier round citing 103 metric families on a live proxy; that measurement covered litellm's own metrics, which the logging path records on the instance directly rather than through this lookup, so it did not cover the claim. The report was right.

On the review point that sampling adds a query-engine request to the database path, re-measured against a saturated pool on the current head:

```
pool at sample time: busy=5.0 idle=0.0 pending=5.0
get_metrics() returned in 2572us WHILE the pool was saturated
```

Five callers were already queued for a connection. A read that needed one would have joined that queue and blocked for seconds rather than returning in 2.6ms, so this takes no pool connection: it is an HTTP GET to the query-engine process. It is also dispatched with `create_task` rather than awaited, and throttled to once per 10s per worker, so it cannot extend a request or fail a query that succeeded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared DB success/failure path and exception handling, but metrics failures are fully isolated so they cannot fail or delay database calls. Observability-only; no auth or data-mutation changes.
> 
> **Overview**
> Exposes **Prisma connection-pool saturation** as Prometheus metrics so operators can tell pool exhaustion apart from slow database queries.
> 
> Adds ten unlabelled series (gauges for busy/idle/open/pending/max, counters for acquire wait, query duration, and `P2024` timeouts). Sampling rides the existing `@log_db_metrics` DB path—throttled to once per 10s, dispatched not awaited—so it stays alive under event-loop saturation and never adds latency or fails a successful query. Pool max is derived as `busy + idle` from the engine rather than from `DATABASE_URL`.
> 
> Also fixes `PrometheusLogger.get_instance` to resolve via `logging_callback_manager` (covering `success_callback: ["prometheus"]`), and deduplicates timeout counting across nested decorated DB helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88cc6d7aa9767eb64c8bcb6f7552463cdf7b7c25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
