### PR TITLE
test(ui): scope the role-gate assertions to each page's own endpoint

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/page.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/page.integration.test.tsx
@@ -46,7 +46,9 @@ describe("Guardrails Monitor page access by role", () => {
       renderAs(userRole);
 
       expect(await screen.findByText("Guardrails Monitor is only available to admin users.")).toBeInTheDocument();
-      await waitFor(() => expect(fetchMock).not.toHaveBeenCalled());
+      // Scoped to this page's own endpoint, not every request. Resolving whether a caller is an org
+      // admin goes through /organization/list for every role, so a blanket "no fetch at all" would
+      // fail on a request that has nothing to do with this page's gate.
       expect(requestedUrls().filter((url) => url.includes("/guardrails/usage"))).toEqual([]);
     },
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/memory/page.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/memory/page.integration.test.tsx
@@ -46,7 +46,9 @@ describe("Memory page access by role", () => {
       renderAs(userRole);
 
       expect(await screen.findByText("Memory is only available to admin users.")).toBeInTheDocument();
-      await waitFor(() => expect(fetchMock).not.toHaveBeenCalled());
+      // Scoped to this page's own endpoint, not every request. Resolving whether a caller is an org
+      // admin goes through /organization/list for every role, so a blanket "no fetch at all" would
+      // fail on a request that has nothing to do with this page's gate.
       expect(requestedUrls().filter((url) => url.includes("/v1/memory"))).toEqual([]);
     },
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/workflows/page.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/workflows/page.integration.test.tsx
@@ -46,7 +46,9 @@ describe("Workflows page access by role", () => {
       renderAs(userRole);
 
       expect(await screen.findByText("Workflow Runs is only available to admin users.")).toBeInTheDocument();
-      await waitFor(() => expect(fetchMock).not.toHaveBeenCalled());
+      // Scoped to this page's own endpoint, not every request. Resolving whether a caller is an org
+      // admin goes through /organization/list for every role, so a blanket "no fetch at all" would
+      // fail on a request that has nothing to do with this page's gate.
       expect(requestedUrls().filter((url) => url.includes("/v1/workflows"))).toEqual([]);
     },
   );


### PR DESCRIPTION
## TLDR

Problem this solves:

- Three page tests are red on `litellm_internal_staging`
- They assert a denied role fires no request at all
- Their names and next line say: no request for this page's data
- Resolving org-admin status legitimately fetches `/organization/list`
- That unrelated request fails the blanket assertion

How it solves it:

- Drops the blanket no-fetch assertion in all three files
- Keeps the scoped assertion that was already on the next line
- Adds a comment saying why other requests are legitimate
- No product code changes

## User Flow

Not user-facing. This changes three test files only; no route, response, or dashboard behaviour is touched.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

No proxy behaviour changes here, so the proof is the test run itself plus a mutation check that the narrowed assertion still catches a real regression.

Before, on `origin/litellm_internal_staging` with no changes:

```
$ npx vitest run "src/app/(dashboard)/memory/page.integration.test.tsx" \
    "src/app/(dashboard)/workflows/page.integration.test.tsx" \
    "src/app/(dashboard)/guardrails-monitor/page.integration.test.tsx"
 Test Files  3 failed (3)
      Tests  12 failed | 5 passed (17)

AssertionError: expected "spy" to not be called at all, but actually been called 1 times
  1st spy call:
  [ "http://localhost:3000/organization/list", { "method": "GET", ... } ]
```

The chain that fires it, for every role rather than only admins: the page calls `useCan`, which calls `useIsOrgAdmin`, which calls `useOrganizations`, whose query is `enabled: Boolean(accessToken && userId && userRole)`. Deciding org-admin-for-any-org needs the list, and `/organization/list` scopes rows per caller, so the request is correct.

After, same three files:

```
$ npx vitest run "src/app/(dashboard)/memory/page.integration.test.tsx" \
    "src/app/(dashboard)/workflows/page.integration.test.tsx" \
    "src/app/(dashboard)/guardrails-monitor/page.integration.test.tsx"
 Test Files  3 passed (3)
      Tests  17 passed (17)
```

The narrowed assertion is weaker, so here it is still failing when the gate it guards is actually broken. Bypassing the role gate in `memory/page.tsx`:

```
-  const canViewMemory = useCan("viewMemory");
+  const canViewMemory = true;

$ npx vitest run "src/app/(dashboard)/memory/page.integration.test.tsx"
      Tests  5 failed | 1 passed (6)
```

Reverted, back to 6 passed.

## Type

✅ Test

## Caveats (if any)

- Assertion is narrower: unrelated requests no longer fail these tests
- That is the point; the old one asserted the app made no network calls

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
