### PR TITLE
fix(anthropic): preserve document blocks during guardrail write-back

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2438,9 +2438,7 @@ def anthropic_messages_pt(
                                     anthropic_content_element=_document_content_element,
                                     original_content_element=m,
                                 )
-                                user_content.append(
-                                    cast(AnthropicMessagesDocumentParam, _document_content_element)
-                                )  # cast-ok: same union narrowing as above
+                                user_content.append(_document_content_element)
                                 continue
                             # Bedrock invoke models have format: invoke/...
                             # Vertex AI Anthropic also doesn't support URL sources for images

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2422,17 +2422,21 @@ def anthropic_messages_pt(
                                 image_url_value.get("url") if isinstance(image_url_value, dict) else image_url_value
                             )
                             if isinstance(url_str, str) and _is_anthropic_document_data_uri(url_str):
-                                synth_file_message: ChatCompletionFileObject = {
-                                    "type": "file",
-                                    "file": {"file_data": url_str},
-                                }
-                                _document_content_element = anthropic_process_openai_file_message(synth_file_message)
-                                _document_content_element = add_cache_control_to_content(
-                                    anthropic_content_element=cast(
-                                        AnthropicMessagesDocumentParam,
-                                        _document_content_element,
+                                image_chunk: Final = convert_to_anthropic_image_obj(
+                                    openai_image_url=url_str,
+                                    format=None,
+                                )
+                                _document_content_element: Final = AnthropicMessagesDocumentParam(
+                                    type="document",
+                                    source=AnthropicContentParamSource(
+                                        type="base64",
+                                        media_type=image_chunk["media_type"],
+                                        data=image_chunk["data"],
                                     ),
-                                    original_content_element=dict(m),
+                                )
+                                add_cache_control_to_content(
+                                    anthropic_content_element=_document_content_element,
+                                    original_content_element=m,
                                 )
                                 user_content.append(cast(AnthropicMessagesDocumentParam, _document_content_element))
                                 continue

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2421,12 +2421,12 @@ def anthropic_messages_pt(
                             url_str = (
                                 image_url_value.get("url") if isinstance(image_url_value, dict) else image_url_value
                             )
-                            if isinstance(url_str, str) and _is_anthropic_document_data_uri(url_str):
-                                image_chunk: Final = convert_to_anthropic_image_obj(
+                            if isinstance(url_str, str) and _is_anthropic_document_data_uri(url_str):  # pyright: ignore[reportUnnecessaryIsInstance]  # malformed payloads can carry a non-str url
+                                image_chunk = convert_to_anthropic_image_obj(
                                     openai_image_url=url_str,
                                     format=None,
                                 )
-                                _document_content_element: Final = AnthropicMessagesDocumentParam(
+                                _document_content_element = AnthropicMessagesDocumentParam(
                                     type="document",
                                     source=AnthropicContentParamSource(
                                         type="base64",
@@ -2436,7 +2436,7 @@ def anthropic_messages_pt(
                                 )
                                 add_cache_control_to_content(
                                     anthropic_content_element=_document_content_element,
-                                    original_content_element=m,
+                                    original_content_element=m,  # pyright: ignore[reportArgumentType]  # cache_control lives on the block
                                 )
                                 user_content.append(_document_content_element)
                                 continue

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2438,7 +2438,9 @@ def anthropic_messages_pt(
                                     anthropic_content_element=_document_content_element,
                                     original_content_element=m,
                                 )
-                                user_content.append(cast(AnthropicMessagesDocumentParam, _document_content_element))  # cast-ok: same union narrowing as above
+                                user_content.append(
+                                    cast(AnthropicMessagesDocumentParam, _document_content_element)
+                                )  # cast-ok: same union narrowing as above
                                 continue
                             # Bedrock invoke models have format: invoke/...
                             # Vertex AI Anthropic also doesn't support URL sources for images

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2438,7 +2438,7 @@ def anthropic_messages_pt(
                                     anthropic_content_element=_document_content_element,
                                     original_content_element=m,
                                 )
-                                user_content.append(cast(AnthropicMessagesDocumentParam, _document_content_element))
+                                user_content.append(cast(AnthropicMessagesDocumentParam, _document_content_element))  # cast-ok: same union narrowing as above
                                 continue
                             # Bedrock invoke models have format: invoke/...
                             # Vertex AI Anthropic also doesn't support URL sources for images

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2418,6 +2418,24 @@ def anthropic_messages_pt(
                                     "url": image_url_value["url"],
                                     "format": image_url_value.get("format"),
                                 }
+                            url_str = (
+                                image_url_value.get("url") if isinstance(image_url_value, dict) else image_url_value
+                            )
+                            if isinstance(url_str, str) and _is_anthropic_document_data_uri(url_str):
+                                synth_file_message: ChatCompletionFileObject = {
+                                    "type": "file",
+                                    "file": {"file_data": url_str},
+                                }
+                                _document_content_element = anthropic_process_openai_file_message(synth_file_message)
+                                _document_content_element = add_cache_control_to_content(
+                                    anthropic_content_element=cast(
+                                        AnthropicMessagesDocumentParam,
+                                        _document_content_element,
+                                    ),
+                                    original_content_element=dict(m),
+                                )
+                                user_content.append(cast(AnthropicMessagesDocumentParam, _document_content_element))
+                                continue
                             # Bedrock invoke models have format: invoke/...
                             # Vertex AI Anthropic also doesn't support URL sources for images
                             is_bedrock_invoke = model.lower().startswith("invoke/")

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2163,6 +2163,34 @@ def test_anthropic_messages_pt_file_block_without_cache_control():
     assert "cache_control" not in file_block
 
 
+def test_anthropic_messages_pt_maps_pdf_data_uri_to_document_block():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:application/pdf;base64,AAAA"},
+                }
+            ],
+        }
+    ]
+
+    result = anthropic_messages_pt(
+        messages=messages,
+        model="claude-sonnet-4-5",
+        llm_provider="anthropic",
+    )
+
+    document = result[0]["content"][0]
+    assert document["type"] == "document"
+    assert document["source"] == {
+        "type": "base64",
+        "media_type": "application/pdf",
+        "data": "AAAA",
+    }
+
+
 # ── _convert_to_bedrock_tool_call_invoke tests ──
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Guardrail write-back turns PDF `document` blocks into invalid `image` blocks
- Anthropic rejects the request with a 400 for `application/pdf`

How it solves it:

- Route supported document data URIs through the existing file conversion path
- Keep ordinary image data URIs on the existing image conversion path

## User Flow

Before: a native Anthropic request containing a PDF fails after a message-mutating guardrail runs

1. The user sends `POST http://localhost:4000/v1/messages` with a base64 PDF `document` block
2. A configured pre-call guardrail modifies the structured messages
3. Anthropic receives the PDF as an `image` block with `application/pdf` and returns HTTP 400

After: the same request keeps its document type through guardrail write-back

1. The user sends `POST http://localhost:4000/v1/messages` with a base64 PDF `document` block
2. A configured pre-call guardrail modifies the structured messages
3. Anthropic receives the PDF as a `document` block with its original media type

## Relevant issues

Fixes #36524

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes the focused lint, format, and unit checks
- [x] My PR's scope is isolated to this document write-back bug
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

The pure conversion path does not require provider credentials. At the base commit `7e80e094c4d3447007d175ed72a5e85880bc62a4`, the reported PDF data URI produced `type: image` and the regression test failed

At commit `35912a2fb89e45dfdf2c045153131b005c0257b2`, the same conversion produced:

```text
{'type': 'document', 'source': {'type': 'base64', 'media_type': 'application/pdf', 'data': 'AAAA'}}
```

The same run kept `data:image/png;base64,AAAA` as an Anthropic `image` block

Focused checks:

```text
92 passed in 0.80s
5 passed in 2.06s
```

## Type

Bug Fix

## Caveats (if any)

The change covers base64 `application/pdf` and `text/plain` document data URIs. URL-backed documents are outside this write-back path

### Final Attestation

- [x] The regression test fails on the base revision and passes with this fix
