### PR TITLE
refactor(ui): migrate cost-optimization to shadcn

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -199,11 +199,6 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/(dashboard)/cost-optimization/_components/PromptCompressionTab.tsx": {
     "no-restricted-imports": {
       "count": 1

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import React from "react";
-import { PiggyBank } from "lucide-react";
-import { Alert, Tabs } from "antd";
+import { Info, PiggyBank } from "lucide-react";
 
 import useCan from "@/app/(dashboard)/hooks/useCan";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import UsageTab from "./UsageTab";
 import PromptCompressionTab from "./PromptCompressionTab";
 import PromptCachingTab from "./PromptCachingTab";
@@ -20,39 +20,21 @@ interface CostOptimizationViewProps {
 const CostOptimizationView: React.FC<CostOptimizationViewProps> = ({ accessToken, userId, userRole }) => {
   const activity = useDailyActivityRange(accessToken, userId, userRole);
   const canViewProxyWideCostData = useCan("viewProxyWideCostData");
+  const [visitedTabs, setVisitedTabs] = React.useState<readonly string[]>(["usage"]);
 
-  const items = [
-    {
-      key: "usage",
-      label: "Overall",
-      children: <UsageTab accessToken={accessToken} activity={activity} />,
-    },
-    ...(canViewProxyWideCostData
-      ? [
-          {
-            key: "compression",
-            label: "Prompt Compression",
-            children: <PromptCompressionTab accessToken={accessToken} />,
-          },
-          {
-            key: "caching",
-            label: "Prompt Caching",
-            children: <PromptCachingTab accessToken={accessToken} activity={activity} />,
-          },
-          {
-            key: "autorouter-usage",
-            label: "Auto-Router",
-            children: <AutoRouterBenchmarksTab accessToken={accessToken} />,
-          },
-        ]
-      : []),
-  ];
+  const handleTabChange = (value: unknown) => {
+    if (typeof value !== "string") {
+      return;
+    }
+
+    setVisitedTabs((currentTabs) => (currentTabs.includes(value) ? currentTabs : [...currentTabs, value]));
+  };
 
   return (
     <div className="w-full space-y-6 p-6">
       <div>
         <div className="flex items-center gap-2">
-          <PiggyBank className="size-6 text-emerald-600" strokeWidth={1.75} />
+          <PiggyBank className="size-6 text-primary" strokeWidth={1.75} />
           <h1 className="text-xl font-semibold text-foreground">Cost Optimization</h1>
         </div>
         <p className="mt-1 text-sm text-muted-foreground">
@@ -61,26 +43,62 @@ const CostOptimizationView: React.FC<CostOptimizationViewProps> = ({ accessToken
         </p>
       </div>
 
-      <Alert
-        type="info"
-        showIcon
-        message="This is an experimental dashboard"
-        description={
-          <span>
-            Have feedback? Join the discussion{" "}
-            <a
-              href="https://github.com/BerriAI/litellm/discussions/32168"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 underline"
-            >
-              here
-            </a>
-          </span>
-        }
-      />
+      <div
+        role="alert"
+        className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 rounded-lg border border-border bg-muted/50 px-4 py-4"
+      >
+        <Info className="mt-0.5 size-5 text-primary" aria-hidden="true" />
+        <p className="font-medium text-foreground">This is an experimental dashboard</p>
+        <p className="col-start-2 text-sm text-muted-foreground">
+          Have feedback? Join the discussion{" "}
+          <a
+            href="https://github.com/BerriAI/litellm/discussions/32168"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline underline-offset-2"
+          >
+            here
+          </a>
+        </p>
+      </div>
 
-      <Tabs defaultActiveKey="usage" items={items} />
+      <Tabs defaultValue="usage" onValueChange={handleTabChange}>
+        <TabsList variant="line" className="h-auto w-full justify-start rounded-none border-b p-0">
+          <TabsTrigger value="usage" className="flex-none rounded-none px-4 py-2">
+            Overall
+          </TabsTrigger>
+          {canViewProxyWideCostData && (
+            <>
+              <TabsTrigger value="compression" className="flex-none rounded-none px-4 py-2">
+                Prompt Compression
+              </TabsTrigger>
+              <TabsTrigger value="caching" className="flex-none rounded-none px-4 py-2">
+                Prompt Caching
+              </TabsTrigger>
+              <TabsTrigger value="autorouter-usage" className="flex-none rounded-none px-4 py-2">
+                Auto-Router
+              </TabsTrigger>
+            </>
+          )}
+        </TabsList>
+
+        <TabsContent value="usage" keepMounted={visitedTabs.includes("usage")}>
+          <UsageTab accessToken={accessToken} activity={activity} />
+        </TabsContent>
+        {canViewProxyWideCostData && (
+          <>
+            <TabsContent value="compression" keepMounted={visitedTabs.includes("compression")}>
+              <PromptCompressionTab accessToken={accessToken} />
+            </TabsContent>
+            <TabsContent value="caching" keepMounted={visitedTabs.includes("caching")}>
+              <PromptCachingTab accessToken={accessToken} activity={activity} />
+            </TabsContent>
+            <TabsContent value="autorouter-usage" keepMounted={visitedTabs.includes("autorouter-usage")}>
+              <AutoRouterBenchmarksTab accessToken={accessToken} />
+            </TabsContent>
+          </>
+        )}
+      </Tabs>
     </div>
   );
 };


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cost Optimization still used legacy dashboard UI primitives

How it solves it:

- Moves the route shell to installed shadcn primitives
- Preserves permissions, tab behavior, and data flows

## User Flow

Before: a proxy admin can use Cost Optimization, but its route shell follows the legacy dashboard visual system

1. They open `http://localhost:4000/ui/?page=cost-optimization`
2. They see Overall, Prompt Compression, Prompt Caching, and Auto-Router tabs
3. They switch among tabs and see the corresponding data and configuration panels

After: the same flow uses the current dashboard visual system without behavior changes

1. They open `http://localhost:4000/ui/?page=cost-optimization`
2. They see Overall, Prompt Compression, Prompt Caching, and Auto-Router tabs
3. They switch among tabs and see the corresponding data and configuration panels

## Relevant issues

Part of the ShadCN migration tracker

## Linear ticket

## Changes

`CostOptimizationView.tsx` now uses the installed shadcn tabs and a tokenized informational callout, with the obsolete lint suppression removed

The analyzer reports `MIGRATE=0` after this change. Three `DEFERRED` form files and 23 `SHARED` files remain separate migration tracks. The route has no `TABLE` files

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Before, captured from `7e80e094c4`

![Cost Optimization before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_pr_proof_20260811/pr-proof/2026-08-11/cost-optimization-before.png)

After, captured from `5216397ca9`

![Cost Optimization after](https://raw.githubusercontent.com/BerriAI/litellm/litellm_pr_proof_20260811/pr-proof/2026-08-11/cost-optimization-after.png)

The clean-head calibration found 35 stable routes and zero unstable routes. The migrated route update passed 1/1, and the final zero-tolerance blast-radius gate passed 35/35 with every unaffected route pixel-identical

Live proxy-admin verification exercised all four tabs, keyboard activation, panel revisit persistence, relevant 200 API responses, and the 1280x600 viewport

## Type

Refactoring

## Caveats (if any)

- Form and shared-component migrations remain separate tracks
- Full Vitest retains 13 unrelated failures on current staging

## QA runbook

1. Open `http://localhost:4000/ui/?page=cost-optimization` as a proxy admin
2. Confirm Overall is selected and its savings cards render
3. Open Prompt Compression and confirm its configuration panel renders
4. Open Prompt Caching and confirm its configuration panel renders
5. Use the keyboard to select Auto-Router and confirm its usage panel renders
6. Return to Overall and confirm visited panels retain their state
7. Resize to 1280x600 and confirm tabs remain visible without horizontal overflow

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
