### PR TITLE
feat(observability): expose scheduled background job and cron lock telemetry

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -217,6 +217,16 @@ def _record_swallowed_redis_failure(breaker: RedisCircuitBreaker, exc: BaseExcep
     _swallowed_redis_failures.set(_swallowed_redis_failures.get() + 1)
 
 
+def swallowed_redis_failure_count() -> int:
+    """Redis failures this task has swallowed so far.
+
+    Several methods catch their own connection errors and return a default, so a
+    caller that needs to tell "Redis did not answer" from an ordinary negative
+    result compares this across the call.
+    """
+    return _swallowed_redis_failures.get()
+
+
 async def _run_under_circuit_breaker(
     breaker: RedisCircuitBreaker,
     name: str,

--- a/litellm/integrations/cloudzero/cloudzero.py
+++ b/litellm/integrations/cloudzero/cloudzero.py
@@ -4,7 +4,10 @@ from typing import TYPE_CHECKING, Any, Final, cast
 
 import litellm
 from litellm._logging import verbose_logger
-from litellm.constants import CLOUDZERO_EXPORT_INTERVAL_MINUTES
+from litellm.constants import (
+    CLOUDZERO_EXPORT_INTERVAL_MINUTES,
+    CLOUDZERO_EXPORT_USAGE_DATA_JOB_NAME,
+)
 from litellm.integrations.custom_logger import CustomLogger
 
 if TYPE_CHECKING:
@@ -360,5 +363,7 @@ class CloudZeroLogger(CustomLogger):
             scheduler.add_job(
                 cloudzero_logger.initialize_cloudzero_export_job,
                 "interval",
+                id=CLOUDZERO_EXPORT_USAGE_DATA_JOB_NAME,
+                replace_existing=True,
                 minutes=CLOUDZERO_EXPORT_INTERVAL_MINUTES,
             )

--- a/litellm/integrations/focus/focus_logger.py
+++ b/litellm/integrations/focus/focus_logger.py
@@ -150,6 +150,8 @@ class FocusLogger(CustomLogger):
         trigger_kwargs: Final = focus_logger._build_scheduler_trigger()
         scheduler.add_job(
             focus_logger.initialize_focus_export_job,
+            id=FOCUS_USAGE_DATA_JOB_NAME,
+            replace_existing=True,
             **trigger_kwargs,
         )
 

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -7,6 +7,7 @@ import asyncio
 import math
 import os
 import sys
+import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Final, Literal, Protocol, TypeVar, cast
@@ -59,6 +60,7 @@ if TYPE_CHECKING:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
     from prometheus_client.metrics import MetricWrapperBase
 
+    from litellm.proxy.common_utils.scheduled_job_metrics import JobRun
     from litellm.proxy.db.db_pool_metrics import DBPoolMetricsUpdate
 else:
     AsyncIOScheduler = Any
@@ -77,6 +79,8 @@ _NON_ENUM_METRIC_LABELS: Final[frozenset[str]] = frozenset(
         "purpose",
         "file_type",
         "result",
+        "job_name",
+        "cronjob_id",
     )
 )
 
@@ -711,6 +715,51 @@ class PrometheusLogger(CustomLogger):
                 "litellm_check_batch_cost_last_run_timestamp",
                 "Unix timestamp of the last CheckBatchCost job run",
                 labelnames=[],
+            )
+
+            ########################################
+            # Scheduled background jobs
+            ########################################
+            self.litellm_scheduled_job_runs_total = self._counter_factory(
+                name="litellm_scheduled_job_runs_total",
+                documentation=(
+                    "Scheduled background job runs by outcome. result is one of success, error, missed, "
+                    "max_instances; max_instances means the previous run had not finished"
+                ),
+                labelnames=("job_name", "result"),
+            )
+
+            self.litellm_scheduled_job_duration_seconds = self._histogram_factory(
+                "litellm_scheduled_job_duration_seconds",
+                "Wall-clock duration of a scheduled background job run",
+                labelnames=("job_name",),
+                buckets=self.latency_buckets,
+            )
+
+            self.litellm_scheduled_job_last_run_timestamp = self._gauge_factory(
+                "litellm_scheduled_job_last_run_timestamp",
+                "Unix timestamp of the last completed run of a scheduled background job",
+                labelnames=("job_name",),
+                multiprocess_mode="livemax",
+            )
+
+            self.litellm_scheduled_job_items_processed_total = self._counter_factory(
+                name="litellm_scheduled_job_items_processed_total",
+                documentation=(
+                    "Items scheduled background jobs reported processing. A counter, not a last-value gauge: "
+                    "queues drain between runs, so the most recent cycle is usually zero and a gauge would hide "
+                    "the bursts"
+                ),
+                labelnames=("job_name",),
+            )
+
+            self.litellm_cronjob_lock_acquisitions_total = self._counter_factory(
+                name="litellm_cronjob_lock_acquisitions_total",
+                documentation=(
+                    "Attempts to take the single-owner lock for a cron job. result is one of acquired, "
+                    "not_acquired, no_redis; no_redis means no Redis is configured, so no pod can be elected"
+                ),
+                labelnames=("cronjob_id", "result"),
             )
 
             ########################################
@@ -3140,8 +3189,6 @@ class PrometheusLogger(CustomLogger):
             jobs_polled: Number of unprocessed batches found
             processed_models: List of (model, api_provider) tuples for processed jobs
         """
-        import time
-
         try:
             self.litellm_check_batch_cost_last_run_timestamp.set(time.time())
             self.litellm_check_batch_cost_jobs_polled.set(jobs_polled)
@@ -3154,6 +3201,19 @@ class PrometheusLogger(CustomLogger):
                     ).inc()
         except Exception as e:
             verbose_logger.warning("Error recording check batch cost metrics: %s", e)
+
+    def record_scheduled_job_run(self, run: JobRun) -> None:
+        """Publish one completed run of a scheduled background job."""
+        self.litellm_scheduled_job_runs_total.labels(job_name=run.job_name, result=run.result.value).inc()
+        self.litellm_scheduled_job_last_run_timestamp.labels(job_name=run.job_name).set(time.time())
+        if run.duration_seconds is not None:
+            self.litellm_scheduled_job_duration_seconds.labels(job_name=run.job_name).observe(run.duration_seconds)
+        if run.items_processed:
+            self.litellm_scheduled_job_items_processed_total.labels(job_name=run.job_name).inc(run.items_processed)
+
+    def record_cronjob_lock_attempt(self, cronjob_id: str, result: str) -> None:
+        """Publish the outcome of one single-owner lock attempt."""
+        self.litellm_cronjob_lock_acquisitions_total.labels(cronjob_id=cronjob_id, result=result).inc()
 
     def record_db_pool_sample(self, update: DBPoolMetricsUpdate) -> None:
         """Publish one reading of this worker's Prisma connection pool."""

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -3207,7 +3207,8 @@ class PrometheusLogger(CustomLogger):
     def record_scheduled_job_run(self, run: JobRun) -> None:
         """Publish one completed run of a scheduled background job."""
         self.litellm_scheduled_job_runs_total.labels(job_name=run.job_name, result=run.result.value).inc()
-        self.litellm_scheduled_job_last_run_timestamp.labels(job_name=run.job_name).set(time.time())
+        if run.did_execute:
+            self.litellm_scheduled_job_last_run_timestamp.labels(job_name=run.job_name).set(time.time())
         if run.duration_seconds is not None:
             self.litellm_scheduled_job_duration_seconds.labels(job_name=run.job_name).observe(run.duration_seconds)
         if run.items_processed:

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -756,8 +756,10 @@ class PrometheusLogger(CustomLogger):
             self.litellm_cronjob_lock_acquisitions_total = self._counter_factory(
                 name="litellm_cronjob_lock_acquisitions_total",
                 documentation=(
-                    "Attempts to take the single-owner lock for a cron job. result is one of acquired, "
-                    "not_acquired, no_redis; no_redis means no Redis is configured, so no pod can be elected"
+                    "Attempts to take the single-owner lock for a cron job. result is one of "
+                    f"{', '.join(r.value for r in LockAttemptResult)}; no_redis means no Redis is "
+                    "configured, so no pod can be elected, and error means the attempt itself failed "
+                    "rather than losing the election"
                 ),
                 labelnames=("cronjob_id", "result"),
             )
@@ -3211,9 +3213,9 @@ class PrometheusLogger(CustomLogger):
         if run.items_processed:
             self.litellm_scheduled_job_items_processed_total.labels(job_name=run.job_name).inc(run.items_processed)
 
-    def record_cronjob_lock_attempt(self, cronjob_id: str, result: str) -> None:
+    def record_cronjob_lock_attempt(self, cronjob_id: str, result: LockAttemptResult) -> None:
         """Publish the outcome of one single-owner lock attempt."""
-        self.litellm_cronjob_lock_acquisitions_total.labels(cronjob_id=cronjob_id, result=result).inc()
+        self.litellm_cronjob_lock_acquisitions_total.labels(cronjob_id=cronjob_id, result=result.value).inc()
 
     def record_db_pool_sample(self, update: DBPoolMetricsUpdate) -> None:
         """Publish one reading of this worker's Prisma connection pool."""

--- a/litellm/integrations/vantage/vantage_logger.py
+++ b/litellm/integrations/vantage/vantage_logger.py
@@ -125,6 +125,8 @@ class VantageLogger(FocusLogger):
         trigger_kwargs: Final = vantage_logger._build_scheduler_trigger()
         scheduler.add_job(
             vantage_logger.initialize_focus_export_job,
+            id=VANTAGE_USAGE_DATA_JOB_NAME,
+            replace_existing=True,
             **trigger_kwargs,
         )
 

--- a/litellm/proxy/common_utils/scheduled_job_metrics.py
+++ b/litellm/proxy/common_utils/scheduled_job_metrics.py
@@ -88,8 +88,11 @@ class ScheduledJobMetricsListener:
     """Pairs APScheduler's submit and completion events into job runs.
 
     Duration is measured across those two events because APScheduler does not
-    report it. Start times are held per job id; ``max_instances=1`` means a job
-    id has at most one run in flight, so a plain mapping is sufficient.
+    report it. Runs are keyed by job id AND scheduled run time, because
+    ``max_instances`` and ``coalesce`` are both env-overridable: raising the
+    first puts several runs of one job in flight at once, and disabling the
+    second makes one submission produce a completion per missed run time. Keying
+    on the job id alone would let those runs consume each other's start times.
     """
 
     def __init__(self, *, monotonic: Final = time.monotonic) -> None:
@@ -109,10 +112,16 @@ class ScheduledJobMetricsListener:
         except Exception as e:  # noqa: BLE001  # telemetry must not disturb the scheduler
             verbose_proxy_logger.debug("scheduled job metrics listener failed: %s", e)
 
+    @staticmethod
+    def _key(job_id: str, scheduled_run_time: object) -> str:
+        return f"{job_id}@{scheduled_run_time}"
+
     def _to_run(self, event: JobEvent) -> JobRun | None:
         job_name: Final = _label_for(event.job_id)
         if event.code == EVENT_JOB_SUBMITTED:
-            self._started_at[event.job_id] = self._monotonic()
+            now: Final = self._monotonic()
+            for scheduled in getattr(event, "scheduled_run_times", ()) or (None,):
+                self._started_at[self._key(event.job_id, scheduled)] = now
             return None
 
         # Neither of these follows a submission of its own. MAX_INSTANCES in
@@ -124,7 +133,9 @@ class ScheduledJobMetricsListener:
         if event.code == EVENT_JOB_MAX_INSTANCES:
             return JobRun(job_name, JobResult.MAX_INSTANCES, None, None)
 
-        started_at: Final = self._started_at.pop(event.job_id, None)
+        started_at: Final = self._started_at.pop(
+            self._key(event.job_id, getattr(event, "scheduled_run_time", None)), None
+        )
         duration: Final = None if started_at is None else self._monotonic() - started_at
 
         if event.code == EVENT_JOB_ERROR:

--- a/litellm/proxy/common_utils/scheduled_job_metrics.py
+++ b/litellm/proxy/common_utils/scheduled_job_metrics.py
@@ -1,0 +1,148 @@
+"""Turns APScheduler's own lifecycle events into scheduled-job telemetry.
+
+Background jobs were previously invisible: nothing recorded which job ran on a
+pod, when, for how long, whether it succeeded, or how much work it moved. During
+an incident that left operators inferring job activity from database load.
+
+A scheduler listener covers every registered job at once, including ones added
+later, rather than each job growing its own instrumentation.
+
+Job ids are the label, and every job litellm registers pins one. A caller that
+omits ``id=`` gets a fresh uuid from APScheduler instead, which as a label would
+grow without bound across pods and restarts, so those collapse into a single
+bucket rather than being trusted.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Final
+
+from apscheduler.events import (
+    EVENT_JOB_ERROR,
+    EVENT_JOB_EXECUTED,
+    EVENT_JOB_MAX_INSTANCES,
+    EVENT_JOB_MISSED,
+    EVENT_JOB_SUBMITTED,
+)
+
+from litellm._logging import verbose_proxy_logger
+
+if TYPE_CHECKING:
+    from apscheduler.events import JobEvent
+    from apscheduler.schedulers.base import BaseScheduler
+
+# APScheduler assigns `uuid4().hex` when a caller omits `id=`.
+_GENERATED_JOB_ID: Final = re.compile(r"\A[0-9a-f]{32}\Z")
+_UNNAMED_JOB: Final = "unnamed_job"
+
+_LISTENER_EVENT_MASK: Final = (
+    EVENT_JOB_SUBMITTED | EVENT_JOB_EXECUTED | EVENT_JOB_ERROR | EVENT_JOB_MISSED | EVENT_JOB_MAX_INSTANCES
+)
+
+
+class JobResult(str, Enum):
+    """Closed set of outcomes, so the ``result`` label stays bounded."""
+
+    SUCCESS = "success"
+    ERROR = "error"
+    # The trigger fired but the run was skipped entirely.
+    MISSED = "missed"
+    # A previous run of the same job was still going. With max_instances=1 this
+    # is how a job that overruns its interval reports falling behind.
+    MAX_INSTANCES = "max_instances"
+
+
+@dataclass(frozen=True, slots=True)
+class JobRun:
+    """One completed run of a scheduled job."""
+
+    job_name: str
+    result: JobResult
+    duration_seconds: float | None
+    items_processed: int | None
+
+
+def _label_for(job_id: str) -> str:
+    """The job id, unless APScheduler generated it."""
+    return _UNNAMED_JOB if _GENERATED_JOB_ID.match(job_id) else job_id
+
+
+def _items_processed(retval: object) -> int | None:
+    """The item count a job reported, if it reported one.
+
+    Jobs signal how much work they moved by returning a count. A job that
+    returns anything else, which is most of them, simply has no count to
+    publish. ``bool`` is excluded because it is an ``int`` subclass and a job
+    returning ``True`` means success, not one item.
+    """
+    if isinstance(retval, bool) or not isinstance(retval, int):
+        return None
+    return retval
+
+
+class ScheduledJobMetricsListener:
+    """Pairs APScheduler's submit and completion events into job runs.
+
+    Duration is measured across those two events because APScheduler does not
+    report it. Start times are held per job id; ``max_instances=1`` means a job
+    id has at most one run in flight, so a plain mapping is sufficient.
+    """
+
+    def __init__(self, *, monotonic: Final = time.monotonic) -> None:
+        self._monotonic: Final = monotonic
+        self._started_at: dict[str, float] = {}  # mutable-ok: start times arrive one scheduler event at a time
+
+    def register(self, scheduler: BaseScheduler) -> None:
+        scheduler.add_listener(self.handle, _LISTENER_EVENT_MASK)
+
+    def handle(self, event: JobEvent) -> None:
+        """Never raises. A listener that throws is swallowed by APScheduler and
+        would leave the scheduler running with no telemetry and no explanation."""
+        try:
+            run: Final = self._to_run(event)
+            if run is not None:
+                self._publish(run)
+        except Exception as e:  # noqa: BLE001  # telemetry must not disturb the scheduler
+            verbose_proxy_logger.debug("scheduled job metrics listener failed: %s", e)
+
+    def _to_run(self, event: JobEvent) -> JobRun | None:
+        job_name: Final = _label_for(event.job_id)
+        if event.code == EVENT_JOB_SUBMITTED:
+            self._started_at[event.job_id] = self._monotonic()
+            return None
+
+        # Neither of these follows a submission of its own. MAX_INSTANCES in
+        # particular arrives while the previous run is still going, so popping
+        # before this point would steal that run's start time and drop the
+        # duration of exactly the overruns worth measuring.
+        if event.code == EVENT_JOB_MISSED:
+            return JobRun(job_name, JobResult.MISSED, None, None)
+        if event.code == EVENT_JOB_MAX_INSTANCES:
+            return JobRun(job_name, JobResult.MAX_INSTANCES, None, None)
+
+        started_at: Final = self._started_at.pop(event.job_id, None)
+        duration: Final = None if started_at is None else self._monotonic() - started_at
+
+        if event.code == EVENT_JOB_ERROR:
+            return JobRun(job_name, JobResult.ERROR, duration, None)
+        return JobRun(job_name, JobResult.SUCCESS, duration, _items_processed(getattr(event, "retval", None)))
+
+    @staticmethod
+    def _publish(run: JobRun) -> None:
+        verbose_proxy_logger.info(
+            "scheduled_job_completed job=%s result=%s duration_seconds=%s items_processed=%s",
+            run.job_name,
+            run.result.value,
+            "unknown" if run.duration_seconds is None else f"{run.duration_seconds:.3f}",
+            "unknown" if run.items_processed is None else run.items_processed,
+        )
+
+        from litellm.integrations.prometheus import PrometheusLogger
+
+        logger: Final = PrometheusLogger.get_instance()
+        if logger is not None:
+            logger.record_scheduled_job_run(run)

--- a/litellm/proxy/common_utils/scheduled_job_metrics.py
+++ b/litellm/proxy/common_utils/scheduled_job_metrics.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import re
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Final
@@ -65,6 +66,16 @@ class JobRun:
     duration_seconds: float | None
     items_processed: int | None
 
+    @property
+    def did_execute(self) -> bool:
+        """Whether the job body actually ran.
+
+        A skipped run must not refresh the last-run clock, or a job that never
+        executes keeps looking recently run and the "time since last run" alert
+        stays quiet through exactly the outage it exists to catch.
+        """
+        return self.result in (JobResult.SUCCESS, JobResult.ERROR)
+
 
 def _label_for(job_id: str) -> str:
     """The job id, unless APScheduler generated it."""
@@ -95,7 +106,7 @@ class ScheduledJobMetricsListener:
     on the job id alone would let those runs consume each other's start times.
     """
 
-    def __init__(self, *, monotonic: Final = time.monotonic) -> None:
+    def __init__(self, *, monotonic: Callable[[], float] = time.monotonic) -> None:
         self._monotonic: Final = monotonic
         self._started_at: dict[str, float] = {}  # mutable-ok: start times arrive one scheduler event at a time
 
@@ -124,14 +135,16 @@ class ScheduledJobMetricsListener:
                 self._started_at[self._key(event.job_id, scheduled)] = now
             return None
 
-        # Neither of these follows a submission of its own. MAX_INSTANCES in
-        # particular arrives while the previous run is still going, so popping
-        # before this point would steal that run's start time and drop the
-        # duration of exactly the overruns worth measuring.
-        if event.code == EVENT_JOB_MISSED:
-            return JobRun(job_name, JobResult.MISSED, None, None)
+        # MAX_INSTANCES is emitted by the scheduler before it submits, while the
+        # previous run is still going, so popping here would steal that run's
+        # start time and drop the duration of exactly the overruns worth
+        # measuring. MISSED comes from the executor after the submit, so its
+        # start time was recorded and has to be released or it leaks.
         if event.code == EVENT_JOB_MAX_INSTANCES:
             return JobRun(job_name, JobResult.MAX_INSTANCES, None, None)
+        if event.code == EVENT_JOB_MISSED:
+            self._started_at.pop(self._key(event.job_id, getattr(event, "scheduled_run_time", None)), None)
+            return JobRun(job_name, JobResult.MISSED, None, None)
 
         started_at: Final = self._started_at.pop(
             self._key(event.job_id, getattr(event, "scheduled_run_time", None)), None

--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -15,6 +15,24 @@ else:
     ProxyLogging = Any
 
 
+def _record_lock_attempt(cronjob_id: str, acquired: bool | None) -> None:
+    """Publish the outcome of one single-owner lock attempt.
+
+    ``None`` means no Redis is configured, which is a different operational
+    state from losing the race, so it gets its own result rather than being
+    folded into a failure.
+    """
+    result: Final = "no_redis" if acquired is None else ("acquired" if acquired else "not_acquired")
+    try:
+        from litellm.integrations.prometheus import PrometheusLogger
+
+        logger = PrometheusLogger.get_instance()
+        if logger is not None:
+            logger.record_cronjob_lock_attempt(cronjob_id, result)
+    except Exception as e:  # noqa: BLE001  # telemetry must not stop a job from running
+        verbose_proxy_logger.debug("cronjob lock metric failed: %s", e)
+
+
 class PodLockManager:
     """
     Manager for acquiring and releasing locks for cron jobs using Redis.
@@ -40,6 +58,21 @@ end
         return f"cronjob_lock:{cronjob_id}"
 
     async def acquire_lock(
+        self,
+        cronjob_id: str,
+        ttl: int | None = None,
+        allow_reentrant: bool = True,
+    ) -> bool | None:
+        """Attempt the lock and record the outcome, then hand back the raw result.
+
+        Wraps the attempt rather than instrumenting each of its exits, so the
+        three-state contract below reaches callers untouched.
+        """
+        acquired: Final = await self._attempt_acquire_lock(cronjob_id, ttl=ttl, allow_reentrant=allow_reentrant)
+        _record_lock_attempt(cronjob_id, acquired)
+        return acquired
+
+    async def _attempt_acquire_lock(
         self,
         cronjob_id: str,
         ttl: int | None = None,

--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -15,14 +15,13 @@ else:
     ProxyLogging = Any
 
 
-def _record_lock_attempt(cronjob_id: str, acquired: bool | None) -> None:
+def _record_lock_attempt(cronjob_id: str, result: str) -> None:
     """Publish the outcome of one single-owner lock attempt.
 
-    ``None`` means no Redis is configured, which is a different operational
-    state from losing the race, so it gets its own result rather than being
-    folded into a failure.
+    Each result is a distinct operational state: no Redis means no pod can ever
+    be elected, an error means the attempt itself failed, and not_acquired means
+    another pod simply won.
     """
-    result: Final = "no_redis" if acquired is None else ("acquired" if acquired else "not_acquired")
     try:
         from litellm.integrations.prometheus import PrometheusLogger
 
@@ -65,11 +64,21 @@ end
     ) -> bool | None:
         """Attempt the lock and record the outcome, then hand back the raw result.
 
-        Wraps the attempt rather than instrumenting each of its exits, so the
-        three-state contract below reaches callers untouched.
+        Owns the no-Redis and error exits so the metric can tell a failed attempt
+        apart from losing the election, which the inner method reports as the
+        same False.
         """
-        acquired: Final = await self._attempt_acquire_lock(cronjob_id, ttl=ttl, allow_reentrant=allow_reentrant)
-        _record_lock_attempt(cronjob_id, acquired)
+        if self.redis_cache is None:
+            verbose_proxy_logger.debug("redis_cache is None, skipping acquire_lock")
+            _record_lock_attempt(cronjob_id, "no_redis")
+            return None
+        try:
+            acquired: Final = await self._attempt_acquire_lock(cronjob_id, ttl=ttl, allow_reentrant=allow_reentrant)
+        except Exception as e:
+            verbose_proxy_logger.error("Error acquiring Redis lock for %s: %s", cronjob_id, e)
+            _record_lock_attempt(cronjob_id, "error")
+            return False
+        _record_lock_attempt(cronjob_id, "acquired" if acquired else "not_acquired")
         return acquired
 
     async def _attempt_acquire_lock(
@@ -93,57 +102,52 @@ end
                  may redo it before the TTL expires.
         """
         if self.redis_cache is None:
-            verbose_proxy_logger.debug("redis_cache is None, skipping acquire_lock")
             return None
-        try:
-            lock_ttl: Final = ttl or DEFAULT_CRON_JOB_LOCK_TTL_SECONDS
-            verbose_proxy_logger.debug(
-                "Pod %s attempting to acquire Redis lock for cronjob_id=%s (ttl=%ds)",
+        lock_ttl: Final = ttl or DEFAULT_CRON_JOB_LOCK_TTL_SECONDS
+        verbose_proxy_logger.debug(
+            "Pod %s attempting to acquire Redis lock for cronjob_id=%s (ttl=%ds)",
+            self.pod_id,
+            cronjob_id,
+            lock_ttl,
+        )
+        # Try to set the lock key with the pod_id as its value, only if it doesn't exist (NX)
+        # and with an expiration (EX) to avoid deadlocks.
+        lock_key: Final = PodLockManager.get_redis_lock_key(cronjob_id)
+        acquired: Final = await self.redis_cache.async_set_cache(
+            lock_key,
+            self.pod_id,
+            nx=True,
+            ttl=lock_ttl,
+        )
+        if acquired:
+            verbose_proxy_logger.info(
+                "Pod %s successfully acquired Redis lock for cronjob_id=%s",
                 self.pod_id,
                 cronjob_id,
-                lock_ttl,
             )
-            # Try to set the lock key with the pod_id as its value, only if it doesn't exist (NX)
-            # and with an expiration (EX) to avoid deadlocks.
-            lock_key: Final = PodLockManager.get_redis_lock_key(cronjob_id)
-            acquired: Final = await self.redis_cache.async_set_cache(
-                lock_key,
-                self.pod_id,
-                nx=True,
-                ttl=lock_ttl,
-            )
-            if acquired:
-                verbose_proxy_logger.info(
-                    "Pod %s successfully acquired Redis lock for cronjob_id=%s",
-                    self.pod_id,
-                    cronjob_id,
-                )
 
-                return True
-            else:
-                # Check if the current pod already holds the lock
-                current_value = await self.redis_cache.async_get_cache(lock_key)
-                if current_value is not None:
-                    if isinstance(current_value, bytes):
-                        current_value = current_value.decode("utf-8")
-                    if current_value == self.pod_id and allow_reentrant:
-                        verbose_proxy_logger.info(
-                            "Pod %s already holds the Redis lock for cronjob_id=%s",
-                            self.pod_id,
-                            cronjob_id,
-                        )
-                        self._emit_acquired_lock_event(cronjob_id, self.pod_id)
-                        return True
+            return True
+        else:
+            # Check if the current pod already holds the lock
+            current_value = await self.redis_cache.async_get_cache(lock_key)
+            if current_value is not None:
+                if isinstance(current_value, bytes):
+                    current_value = current_value.decode("utf-8")
+                if current_value == self.pod_id and allow_reentrant:
                     verbose_proxy_logger.info(
-                        "Pod %s could not acquire lock for cronjob_id=%s, held by pod %s.",
+                        "Pod %s already holds the Redis lock for cronjob_id=%s",
                         self.pod_id,
                         cronjob_id,
-                        current_value,
                     )
-            return False
-        except Exception as e:
-            verbose_proxy_logger.error("Error acquiring Redis lock for %s: %s", cronjob_id, e)
-            return False
+                    self._emit_acquired_lock_event(cronjob_id, self.pod_id)
+                    return True
+                verbose_proxy_logger.info(
+                    "Pod %s could not acquire lock for cronjob_id=%s, held by pod %s.",
+                    self.pod_id,
+                    cronjob_id,
+                    current_value,
+                )
+        return False
 
     async def release_lock(
         self,

--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
-from litellm.caching.redis_cache import RedisCache
+from litellm.caching.redis_cache import RedisCache, swallowed_redis_failure_count
 from litellm.constants import DEFAULT_CRON_JOB_LOCK_TTL_SECONDS
 from litellm.proxy.db.db_transaction_queue.base_update_queue import service_logger_obj
 from litellm.types.integrations.prometheus import LockAttemptResult
@@ -73,10 +73,19 @@ end
             verbose_proxy_logger.debug("redis_cache is None, skipping acquire_lock")
             _record_lock_attempt(cronjob_id, LockAttemptResult.NO_REDIS)
             return None
+        swallowed_before: Final = swallowed_redis_failure_count()
         try:
             acquired: Final = await self._attempt_acquire_lock(cronjob_id, ttl=ttl, allow_reentrant=allow_reentrant)
         except Exception as e:
             verbose_proxy_logger.error("Error acquiring Redis lock for %s: %s", cronjob_id, e)
+            _record_lock_attempt(cronjob_id, LockAttemptResult.ERROR)
+            return False
+        # An outage does not always raise. RedisCache catches connection errors and
+        # returns None, which is also how redis reports SET NX losing the race, so
+        # only the swallowed-failure marker separates the two. Without it every
+        # outage is published as ordinary contention.
+        if swallowed_redis_failure_count() != swallowed_before:
+            verbose_proxy_logger.error("Redis unavailable while acquiring lock for %s", cronjob_id)
             _record_lock_attempt(cronjob_id, LockAttemptResult.ERROR)
             return False
         _record_lock_attempt(cronjob_id, LockAttemptResult.ACQUIRED if acquired else LockAttemptResult.NOT_ACQUIRED)

--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -7,6 +7,7 @@ from litellm._uuid import uuid
 from litellm.caching.redis_cache import RedisCache
 from litellm.constants import DEFAULT_CRON_JOB_LOCK_TTL_SECONDS
 from litellm.proxy.db.db_transaction_queue.base_update_queue import service_logger_obj
+from litellm.types.integrations.prometheus import LockAttemptResult
 from litellm.types.services import ServiceTypes
 
 if TYPE_CHECKING:
@@ -15,7 +16,7 @@ else:
     ProxyLogging = Any
 
 
-def _record_lock_attempt(cronjob_id: str, result: str) -> None:
+def _record_lock_attempt(cronjob_id: str, result: LockAttemptResult) -> None:
     """Publish the outcome of one single-owner lock attempt.
 
     Each result is a distinct operational state: no Redis means no pod can ever
@@ -70,15 +71,15 @@ end
         """
         if self.redis_cache is None:
             verbose_proxy_logger.debug("redis_cache is None, skipping acquire_lock")
-            _record_lock_attempt(cronjob_id, "no_redis")
+            _record_lock_attempt(cronjob_id, LockAttemptResult.NO_REDIS)
             return None
         try:
             acquired: Final = await self._attempt_acquire_lock(cronjob_id, ttl=ttl, allow_reentrant=allow_reentrant)
         except Exception as e:
             verbose_proxy_logger.error("Error acquiring Redis lock for %s: %s", cronjob_id, e)
-            _record_lock_attempt(cronjob_id, "error")
+            _record_lock_attempt(cronjob_id, LockAttemptResult.ERROR)
             return False
-        _record_lock_attempt(cronjob_id, "acquired" if acquired else "not_acquired")
+        _record_lock_attempt(cronjob_id, LockAttemptResult.ACQUIRED if acquired else LockAttemptResult.NOT_ACQUIRED)
         return acquired
 
     async def _attempt_acquire_lock(

--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -26,7 +26,7 @@ def _record_lock_attempt(cronjob_id: str, result: LockAttemptResult) -> None:
     try:
         from litellm.integrations.prometheus import PrometheusLogger
 
-        logger = PrometheusLogger.get_instance()
+        logger: Final = PrometheusLogger.get_instance()
         if logger is not None:
             logger.record_cronjob_lock_attempt(cronjob_id, result)
     except Exception as e:  # noqa: BLE001  # telemetry must not stop a job from running

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -348,6 +348,7 @@ from litellm.proxy.common_utils.periodic_reload_schedule import (
 )
 from litellm.proxy.common_utils.proxy_state import ProxyState
 from litellm.proxy.common_utils.reset_budget_job import ResetBudgetJob
+from litellm.proxy.common_utils.scheduled_job_metrics import ScheduledJobMetricsListener
 from litellm.proxy.common_utils.scheduled_job_stagger import (
     apply_scheduled_job_stagger,
     attach_job_timing_logger,
@@ -9134,6 +9135,8 @@ class ProxyStartupEvent:
             scheduler=scheduler,
             settings=parse_stagger_settings(general_settings),
         )
+        # Registered before start so the first run of every job is observed.
+        ScheduledJobMetricsListener().register(scheduler)
 
         # Start the scheduler immediately without processing backlogs
         scheduler.start(paused=False)

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6068,9 +6068,11 @@ async def update_spend(
     prisma_client: PrismaClient,
     db_writer_client: AsyncHTTPHandler | None,
     proxy_logging_obj: ProxyLogging,
-):
+) -> int:
     """
-    Batch write updates to db.
+    Batch write updates to db. Returns how many queued spend transactions this
+    cycle actually drained, which the scheduled-job listener publishes as the
+    run's item count.
 
     Triggered every minute.
 
@@ -6100,12 +6102,19 @@ async def update_spend(
     # See update_spend_logs_job and _monitor_spend_logs_queue for the new behavior.
     # Safe to keep: under high concurrency this can take up to ~30s to run,
     # so it's unlikely to overlap with monitor_spend_logs_queue.
-    if queue_size > 0:
-        await update_spend_logs_job(
-            prisma_client=prisma_client,
-            db_writer_client=db_writer_client,
-            proxy_logging_obj=proxy_logging_obj,
-        )
+    if queue_size == 0:
+        return 0
+
+    await update_spend_logs_job(
+        prisma_client=prisma_client,
+        db_writer_client=db_writer_client,
+        proxy_logging_obj=proxy_logging_obj,
+    )
+
+    # What actually drained, not what was pending on entry: a partial failure or
+    # a queue that refilled mid-run would otherwise be reported as processed.
+    remaining: Final = await _total_queued_spend_transactions(prisma_client)
+    return max(0, queue_size - remaining)
 
 
 async def _total_queued_spend_transactions(prisma_client: PrismaClient) -> int:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6068,11 +6068,9 @@ async def update_spend(
     prisma_client: PrismaClient,
     db_writer_client: AsyncHTTPHandler | None,
     proxy_logging_obj: ProxyLogging,
-) -> int:
+):
     """
-    Batch write updates to db. Returns how many queued spend transactions this
-    cycle actually drained, which the scheduled-job listener publishes as the
-    run's item count.
+    Batch write updates to db.
 
     Triggered every minute.
 
@@ -6102,19 +6100,12 @@ async def update_spend(
     # See update_spend_logs_job and _monitor_spend_logs_queue for the new behavior.
     # Safe to keep: under high concurrency this can take up to ~30s to run,
     # so it's unlikely to overlap with monitor_spend_logs_queue.
-    if queue_size == 0:
-        return 0
-
-    await update_spend_logs_job(
-        prisma_client=prisma_client,
-        db_writer_client=db_writer_client,
-        proxy_logging_obj=proxy_logging_obj,
-    )
-
-    # What actually drained, not what was pending on entry: a partial failure or
-    # a queue that refilled mid-run would otherwise be reported as processed.
-    remaining: Final = await _total_queued_spend_transactions(prisma_client)
-    return max(0, queue_size - remaining)
+    if queue_size > 0:
+        await update_spend_logs_job(
+            prisma_client=prisma_client,
+            db_writer_client=db_writer_client,
+            proxy_logging_obj=proxy_logging_obj,
+        )
 
 
 async def _total_queued_spend_transactions(prisma_client: PrismaClient) -> int:

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -273,6 +273,12 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     # MCP tool call metrics
     "litellm_mcp_tool_calls_total",
     "litellm_mcp_tool_call_spend_metric",
+    # Scheduled background jobs
+    "litellm_scheduled_job_runs_total",
+    "litellm_scheduled_job_duration_seconds",
+    "litellm_scheduled_job_last_run_timestamp",
+    "litellm_scheduled_job_items_processed_total",
+    "litellm_cronjob_lock_acquisitions_total",
     # Database connection pool saturation
     "litellm_db_pool_connections_max",
     "litellm_db_pool_connections_busy",
@@ -775,6 +781,17 @@ class PrometheusMetricLabels:
     litellm_check_batch_cost_errors_total: list[str] = []  # label: error_type (custom)
 
     litellm_check_batch_cost_last_run_timestamp: list[str] = []
+
+    # Scheduled background jobs. Labels are closed sets fixed at startup: job ids
+    # come from the scheduler registration, cronjob ids from the lock call sites,
+    # and results from an enum. No pod label: pod identity is unbounded, and the
+    # lock result already distinguishes the pod that owns a job from the ones
+    # that skipped it.
+    litellm_scheduled_job_runs_total: tuple[str, ...] = ()
+    litellm_scheduled_job_duration_seconds: tuple[str, ...] = ()
+    litellm_scheduled_job_last_run_timestamp: tuple[str, ...] = ()
+    litellm_scheduled_job_items_processed_total: tuple[str, ...] = ()
+    litellm_cronjob_lock_acquisitions_total: tuple[str, ...] = ()
 
     # Unlabelled: the pool is per-worker, so key/team/user labels would only add
     # cardinality.

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -8,6 +8,18 @@ from typing import Any, ClassVar, Final, Literal
 import litellm
 
 
+class LockAttemptResult(str, Enum):
+    """Closed set of outcomes for one cron-job lock attempt, so the `result`
+    label stays bounded and the metric documentation cannot drift from it."""
+
+    ACQUIRED = "acquired"
+    NOT_ACQUIRED = "not_acquired"
+    # No Redis is configured, so no pod can ever be elected.
+    NO_REDIS = "no_redis"
+    # The attempt itself failed, rather than losing the election.
+    ERROR = "error"
+
+
 def _sanitize_prometheus_label_name(label: str) -> str:
     """
     Sanitize a label name to comply with Prometheus label name requirements.

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -794,11 +794,8 @@ class PrometheusMetricLabels:
 
     litellm_check_batch_cost_last_run_timestamp: list[str] = []
 
-    # Scheduled background jobs. Labels are closed sets fixed at startup: job ids
-    # come from the scheduler registration, cronjob ids from the lock call sites,
-    # and results from an enum. No pod label: pod identity is unbounded, and the
-    # lock result already distinguishes the pod that owns a job from the ones
-    # that skipped it.
+    # No pod label: pod identity is unbounded, and the lock result already
+    # identifies the owner.
     litellm_scheduled_job_runs_total: tuple[str, ...] = ()
     litellm_scheduled_job_duration_seconds: tuple[str, ...] = ()
     litellm_scheduled_job_last_run_timestamp: tuple[str, ...] = ()

--- a/tests/test_litellm/integrations/test_prometheus_cronjob_lock_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_cronjob_lock_metrics.py
@@ -35,3 +35,43 @@ def test_the_lock_metric_documents_every_result_it_can_emit(monkeypatch):
     documented = {value.strip() for value in advertised.group(1).split(",")}
 
     assert documented == {result.value for result in LockAttemptResult}
+
+def _fresh_logger(monkeypatch):
+    from prometheus_client import REGISTRY
+
+    monkeypatch.setattr(litellm, "callbacks", [])
+    monkeypatch.setattr(litellm, "success_callback", [])
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+    return PrometheusLogger()
+
+
+def test_only_a_run_that_executed_refreshes_the_last_run_clock(monkeypatch):
+    """The recommended alert is time since last run, so a skipped run bumping the
+    clock would keep a job that never executes looking healthy."""
+    from prometheus_client import REGISTRY
+
+    from litellm.proxy.common_utils.scheduled_job_metrics import JobResult, JobRun
+
+    logger = _fresh_logger(monkeypatch)
+
+    def clock():
+        return REGISTRY.get_sample_value(
+            "litellm_scheduled_job_last_run_timestamp", {"job_name": "job"}
+        )
+
+    logger.record_scheduled_job_run(JobRun("job", JobResult.SUCCESS, 1.0, None))
+    after_success = clock()
+    assert after_success is not None and after_success > 0
+
+    logger.record_scheduled_job_run(JobRun("job", JobResult.MISSED, None, None))
+    logger.record_scheduled_job_run(JobRun("job", JobResult.MAX_INSTANCES, None, None))
+
+    assert clock() == after_success, "a skipped run must not move the last-run clock"
+    assert REGISTRY.get_sample_value(
+        "litellm_scheduled_job_runs_total", {"job_name": "job", "result": "missed"}
+    ) == 1.0, "the skip is still counted, just not as a run"
+

--- a/tests/test_litellm/integrations/test_prometheus_cronjob_lock_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_cronjob_lock_metrics.py
@@ -1,0 +1,37 @@
+"""The cron-lock metric's advertised result values against the ones actually emitted.
+
+A consumer builds alerts from the documented set, so a value the code can emit
+but the documentation omits is silently dropped from their queries.
+"""
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import litellm
+from litellm.integrations.prometheus import PrometheusLogger
+from litellm.types.integrations.prometheus import LockAttemptResult
+
+
+def test_the_lock_metric_documents_every_result_it_can_emit(monkeypatch):
+    monkeypatch.setattr(litellm, "callbacks", [])
+    monkeypatch.setattr(litellm, "success_callback", [])
+    from prometheus_client import REGISTRY
+
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+    documentation = PrometheusLogger().litellm_cronjob_lock_acquisitions_total._documentation
+
+    # The advertised set only, not the prose that follows it, so a value merely
+    # mentioned in passing does not count as documented.
+    advertised = re.search(r"result is one of ([^;]+);", documentation)
+    assert advertised is not None, f"no advertised result list in: {documentation}"
+    documented = {value.strip() for value in advertised.group(1).split(",")}
+
+    assert documented == {result.value for result in LockAttemptResult}

--- a/tests/test_litellm/proxy/common_utils/test_scheduled_job_metrics.py
+++ b/tests/test_litellm/proxy/common_utils/test_scheduled_job_metrics.py
@@ -254,3 +254,55 @@ def test_every_job_litellm_registers_pins_an_explicit_id():
                 offenders.append(f"{path.relative_to(root)}: {match.group(1).strip().splitlines()[0]}")
 
     assert not offenders, "scheduler.add_job without an explicit id=: " + "; ".join(offenders)
+
+
+def test_concurrent_runs_of_one_job_keep_their_own_durations():
+    """APSCHEDULER_MAX_INSTANCES is env-overridable, so two runs of the same job
+    can be in flight at once. Keying start times by job id alone would let the
+    first completion consume the second run's start."""
+    import datetime
+
+    from apscheduler.events import (
+        EVENT_JOB_EXECUTED,
+        EVENT_JOB_SUBMITTED,
+        JobExecutionEvent,
+        JobSubmissionEvent,
+    )
+
+    first = datetime.datetime(2026, 1, 1, 0, 0, 0)
+    second = datetime.datetime(2026, 1, 1, 0, 0, 30)
+    ticks = iter([100.0, 110.0, 105.0, 140.0])
+    listener = ScheduledJobMetricsListener(monotonic=lambda: next(ticks))
+
+    listener._to_run(JobSubmissionEvent(EVENT_JOB_SUBMITTED, "slow_job", "default", [first]))
+    listener._to_run(JobSubmissionEvent(EVENT_JOB_SUBMITTED, "slow_job", "default", [second]))
+    run_a = listener._to_run(JobExecutionEvent(EVENT_JOB_EXECUTED, "slow_job", "default", first, retval=None))
+    run_b = listener._to_run(JobExecutionEvent(EVENT_JOB_EXECUTED, "slow_job", "default", second, retval=None))
+
+    assert run_a is not None and run_a.duration_seconds == pytest.approx(5.0)
+    assert run_b is not None and run_b.duration_seconds == pytest.approx(30.0)
+
+
+def test_one_submission_of_several_run_times_pairs_each_completion():
+    """With coalesce=False a single submission carries several run times and
+    produces a completion for each."""
+    import datetime
+
+    from apscheduler.events import (
+        EVENT_JOB_EXECUTED,
+        EVENT_JOB_SUBMITTED,
+        JobExecutionEvent,
+        JobSubmissionEvent,
+    )
+
+    times = [datetime.datetime(2026, 1, 1, 0, 0, s) for s in (0, 1, 2)]
+    ticks = iter([100.0, 101.0, 102.0, 103.0])
+    listener = ScheduledJobMetricsListener(monotonic=lambda: next(ticks))
+
+    listener._to_run(JobSubmissionEvent(EVENT_JOB_SUBMITTED, "job", "default", times))
+    durations = [
+        listener._to_run(JobExecutionEvent(EVENT_JOB_EXECUTED, "job", "default", t, retval=None)).duration_seconds
+        for t in times
+    ]
+
+    assert all(d is not None for d in durations), f"every run time must pair, got {durations}"

--- a/tests/test_litellm/proxy/common_utils/test_scheduled_job_metrics.py
+++ b/tests/test_litellm/proxy/common_utils/test_scheduled_job_metrics.py
@@ -1,0 +1,256 @@
+"""Scheduled-job telemetry, exercised against a real APScheduler.
+
+The listener's whole job is to interpret APScheduler's event stream, so the
+events come from a running scheduler rather than from hand-built objects. A
+fabricated event proves only that the code reads the fields it was written to
+read.
+"""
+
+import asyncio
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.proxy.common_utils.scheduled_job_metrics import (
+    JobResult,
+    ScheduledJobMetricsListener,
+)
+
+
+async def _drain(recorded, *, expected: int, timeout: float = 5.0):
+    """Wait for the scheduler to deliver `expected` runs."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while len(recorded) < expected and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.02)
+    return recorded
+
+
+@pytest.fixture
+def recorded():
+    runs = []
+    logger = MagicMock()
+    logger.record_scheduled_job_run = runs.append
+    with patch(
+        "litellm.integrations.prometheus.PrometheusLogger.get_instance",
+        return_value=logger,
+    ):
+        yield runs
+
+
+@pytest.mark.asyncio
+async def test_a_successful_job_reports_its_name_duration_and_result(recorded):
+    scheduler = AsyncIOScheduler()
+    ScheduledJobMetricsListener().register(scheduler)
+
+    async def quick_job():
+        await asyncio.sleep(0.05)
+
+    scheduler.add_job(quick_job, "interval", seconds=60, id="quick_job", next_run_time=None)
+    scheduler.start(paused=False)
+    try:
+        scheduler.get_job("quick_job").modify(next_run_time=__import__("datetime").datetime.now())
+        await _drain(recorded, expected=1)
+    finally:
+        scheduler.shutdown(wait=False)
+
+    assert len(recorded) == 1
+    run = recorded[0]
+    assert run.job_name == "quick_job"
+    assert run.result is JobResult.SUCCESS
+    assert run.duration_seconds is not None and run.duration_seconds >= 0.05, (
+        f"duration must span the real execution, got {run.duration_seconds}"
+    )
+    assert run.items_processed is None
+
+
+@pytest.mark.asyncio
+async def test_a_failing_job_is_recorded_as_an_error_not_a_success(recorded):
+    scheduler = AsyncIOScheduler()
+    ScheduledJobMetricsListener().register(scheduler)
+
+    async def broken_job():
+        raise RuntimeError("job blew up")
+
+    scheduler.add_job(broken_job, "interval", seconds=60, id="broken_job", next_run_time=None)
+    scheduler.start(paused=False)
+    try:
+        scheduler.get_job("broken_job").modify(next_run_time=__import__("datetime").datetime.now())
+        await _drain(recorded, expected=1)
+    finally:
+        scheduler.shutdown(wait=False)
+
+    assert len(recorded) == 1
+    assert recorded[0].result is JobResult.ERROR
+    assert recorded[0].job_name == "broken_job"
+
+
+@pytest.mark.asyncio
+async def test_a_job_that_returns_a_count_publishes_it(recorded):
+    """Item counts ride on the return value so a job opts in with one line
+    instead of reaching for the metrics layer itself."""
+    scheduler = AsyncIOScheduler()
+    ScheduledJobMetricsListener().register(scheduler)
+
+    async def counting_job():
+        return 42
+
+    scheduler.add_job(counting_job, "interval", seconds=60, id="counting_job", next_run_time=None)
+    scheduler.start(paused=False)
+    try:
+        scheduler.get_job("counting_job").modify(next_run_time=__import__("datetime").datetime.now())
+        await _drain(recorded, expected=1)
+    finally:
+        scheduler.shutdown(wait=False)
+
+    assert recorded[0].items_processed == 42
+
+
+@pytest.mark.asyncio
+async def test_a_job_returning_true_is_not_read_as_one_item(recorded):
+    """bool is an int subclass, so a job returning True would otherwise publish
+    an item count of 1 that it never meant."""
+    scheduler = AsyncIOScheduler()
+    ScheduledJobMetricsListener().register(scheduler)
+
+    async def boolean_job():
+        return True
+
+    scheduler.add_job(boolean_job, "interval", seconds=60, id="boolean_job", next_run_time=None)
+    scheduler.start(paused=False)
+    try:
+        scheduler.get_job("boolean_job").modify(next_run_time=__import__("datetime").datetime.now())
+        await _drain(recorded, expected=1)
+    finally:
+        scheduler.shutdown(wait=False)
+
+    assert recorded[0].items_processed is None
+
+
+@pytest.mark.asyncio
+async def test_a_job_that_overruns_its_interval_reports_max_instances(recorded):
+    """With max_instances=1 this is how a job falling behind its schedule
+    surfaces, which is exactly the signal an operator wants during an incident."""
+    import datetime
+
+    scheduler = AsyncIOScheduler(job_defaults={"max_instances": 1, "coalesce": False})
+    ScheduledJobMetricsListener().register(scheduler)
+
+    async def slow_job():
+        await asyncio.sleep(1.5)
+
+    scheduler.add_job(slow_job, "interval", seconds=1, id="slow_job", next_run_time=datetime.datetime.now())
+    scheduler.start(paused=False)
+    try:
+        await _drain(recorded, expected=1, timeout=6.0)
+    finally:
+        scheduler.shutdown(wait=False)
+
+    results = {run.result for run in recorded}
+    assert JobResult.MAX_INSTANCES in results, f"expected a max_instances skip, saw {results}"
+
+
+@pytest.mark.asyncio
+async def test_a_listener_failure_never_disturbs_the_scheduler(recorded):
+    """APScheduler swallows listener exceptions, so a throwing listener would
+    leave the scheduler running with no telemetry and nothing to explain it."""
+    scheduler = AsyncIOScheduler()
+    listener = ScheduledJobMetricsListener()
+    listener.register(scheduler)
+
+    ran = asyncio.Event()
+
+    async def job():
+        ran.set()
+
+    with patch.object(ScheduledJobMetricsListener, "_publish", side_effect=RuntimeError("metrics down")):
+        scheduler.add_job(job, "interval", seconds=60, id="job", next_run_time=__import__("datetime").datetime.now())
+        scheduler.start(paused=False)
+        try:
+            await asyncio.wait_for(ran.wait(), timeout=5.0)
+        finally:
+            scheduler.shutdown(wait=False)
+
+
+def test_duration_is_unknown_when_the_submit_event_was_missed():
+    """A job already in flight when the listener registers has no start time.
+    Reporting zero would put a false value on the duration histogram."""
+    from apscheduler.events import EVENT_JOB_EXECUTED, JobExecutionEvent
+
+    listener = ScheduledJobMetricsListener()
+    event = JobExecutionEvent(EVENT_JOB_EXECUTED, "orphan_job", "default", None, retval=None)
+
+    run = listener._to_run(event)
+
+    assert run is not None
+    assert run.duration_seconds is None
+    assert run.result is JobResult.SUCCESS
+
+
+def test_max_instances_does_not_steal_the_running_job_start_time():
+    """APScheduler emits MAX_INSTANCES *instead of* SUBMITTED, while the previous
+    run is still going, so popping the start time on that event would drop the
+    duration of exactly the overrunning runs this metric exists to surface."""
+    from apscheduler.events import (
+        EVENT_JOB_EXECUTED,
+        EVENT_JOB_MAX_INSTANCES,
+        EVENT_JOB_SUBMITTED,
+        JobExecutionEvent,
+        JobSubmissionEvent,
+    )
+
+    # Exactly two reads: the submit, and the completion. A MAX_INSTANCES skip in
+    # between must consume neither a tick nor the stored start time.
+    ticks = iter([100.0, 103.5])
+    listener = ScheduledJobMetricsListener(monotonic=lambda: next(ticks))
+
+    listener._to_run(JobSubmissionEvent(EVENT_JOB_SUBMITTED, "slow_job", "default", [None]))
+    skipped = listener._to_run(JobExecutionEvent(EVENT_JOB_MAX_INSTANCES, "slow_job", "default", None))
+    finished = listener._to_run(JobExecutionEvent(EVENT_JOB_EXECUTED, "slow_job", "default", None, retval=None))
+
+    assert skipped is not None and skipped.result is JobResult.MAX_INSTANCES
+    assert finished is not None and finished.result is JobResult.SUCCESS
+    assert finished.duration_seconds == pytest.approx(3.5), (
+        "the overrunning run must keep its duration through a MAX_INSTANCES skip"
+    )
+
+
+def test_an_apscheduler_generated_job_id_does_not_become_an_unbounded_label():
+    """A caller that omits id= gets uuid4().hex, which as a Prometheus label would
+    grow without bound across pods and restarts."""
+    from apscheduler.events import EVENT_JOB_EXECUTED, JobExecutionEvent
+
+    listener = ScheduledJobMetricsListener()
+
+    generated = listener._to_run(
+        JobExecutionEvent(EVENT_JOB_EXECUTED, "e849e76a882d45ad9dc9965cd1c8a335", "default", None, retval=None)
+    )
+    pinned = listener._to_run(
+        JobExecutionEvent(EVENT_JOB_EXECUTED, "update_spend_job", "default", None, retval=None)
+    )
+
+    assert generated is not None and generated.job_name == "unnamed_job"
+    assert pinned is not None and pinned.job_name == "update_spend_job"
+
+
+def test_every_job_litellm_registers_pins_an_explicit_id():
+    """The label is only bounded because each add_job passes id=. This fails if a
+    new registration forgets one."""
+    import re
+    from pathlib import Path
+
+    import litellm
+
+    root = Path(litellm.__file__).parent
+    offenders = []
+    for path in root.rglob("*.py"):
+        source = path.read_text(encoding="utf-8", errors="ignore")
+        for match in re.finditer(r"scheduler\.add_job\((.*?)\n\s*\)", source, re.DOTALL):
+            if "id=" not in match.group(1):
+                offenders.append(f"{path.relative_to(root)}: {match.group(1).strip().splitlines()[0]}")
+
+    assert not offenders, "scheduler.add_job without an explicit id=: " + "; ".join(offenders)

--- a/tests/test_litellm/proxy/common_utils/test_scheduled_job_metrics.py
+++ b/tests/test_litellm/proxy/common_utils/test_scheduled_job_metrics.py
@@ -306,3 +306,34 @@ def test_one_submission_of_several_run_times_pairs_each_completion():
     ]
 
     assert all(d is not None for d in durations), f"every run time must pair, got {durations}"
+
+def test_a_trigger_that_fired_without_running_is_recorded_as_missed():
+    """MISSED is one of the four outcomes the metric advertises. It arrives with
+    no submission of its own, so it must publish a run without a duration rather
+    than be dropped."""
+    from apscheduler.events import EVENT_JOB_MISSED, JobExecutionEvent
+
+    listener = ScheduledJobMetricsListener()
+
+    run = listener._to_run(JobExecutionEvent(EVENT_JOB_MISSED, "update_spend_job", "default", None))
+
+    assert run is not None
+    assert run.result is JobResult.MISSED
+    assert run.job_name == "update_spend_job"
+    assert run.duration_seconds is None
+    assert run.items_processed is None
+
+
+def test_handle_swallows_a_failure_so_the_scheduler_keeps_running():
+    """APScheduler swallows listener exceptions itself, so a throwing listener
+    leaves the scheduler running with no telemetry and nothing to explain it.
+    Driven directly rather than through the scheduler, because a listener that
+    runs on the scheduler's own thread is invisible to coverage."""
+    from apscheduler.events import EVENT_JOB_EXECUTED, JobExecutionEvent
+
+    listener = ScheduledJobMetricsListener()
+    event = JobExecutionEvent(EVENT_JOB_EXECUTED, "job", "default", None, retval=None)
+
+    with patch.object(ScheduledJobMetricsListener, "_publish", side_effect=RuntimeError("metrics down")):
+        listener.handle(event)  # must not raise
+

--- a/tests/test_litellm/proxy/common_utils/test_scheduled_job_metrics.py
+++ b/tests/test_litellm/proxy/common_utils/test_scheduled_job_metrics.py
@@ -17,6 +17,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 sys.path.insert(0, os.path.abspath("../../../.."))
 
 from litellm.proxy.common_utils.scheduled_job_metrics import (
+    JobRun,
     JobResult,
     ScheduledJobMetricsListener,
 )
@@ -336,4 +337,68 @@ def test_handle_swallows_a_failure_so_the_scheduler_keeps_running():
 
     with patch.object(ScheduledJobMetricsListener, "_publish", side_effect=RuntimeError("metrics down")):
         listener.handle(event)  # must not raise
+
+def test_a_skipped_run_does_not_refresh_the_last_run_clock():
+    """The recommended alert is time since last run. If a skipped run bumped the
+    clock, a job that never executes would look recently run and the alert would
+    stay quiet through exactly the outage this telemetry exists to catch."""
+    executed = JobRun("job", JobResult.SUCCESS, 1.0, None)
+    failed = JobRun("job", JobResult.ERROR, 1.0, None)
+    missed = JobRun("job", JobResult.MISSED, None, None)
+    overrun = JobRun("job", JobResult.MAX_INSTANCES, None, None)
+
+    assert executed.did_execute is True
+    assert failed.did_execute is True, "a job that ran and raised still ran"
+    assert missed.did_execute is False
+    assert overrun.did_execute is False
+
+
+def test_a_missed_run_releases_the_start_time_it_was_given():
+    """APScheduler emits MISSED from the executor, after the scheduler already
+    emitted SUBMITTED, so a start time was recorded for that run. Dropping the
+    event without releasing it leaks one entry per miss for the life of the
+    process."""
+    import datetime
+
+    from apscheduler.events import (
+        EVENT_JOB_MISSED,
+        EVENT_JOB_SUBMITTED,
+        JobExecutionEvent,
+        JobSubmissionEvent,
+    )
+
+    when = datetime.datetime(2026, 1, 1, 0, 0, 0)
+    listener = ScheduledJobMetricsListener()
+
+    listener._to_run(JobSubmissionEvent(EVENT_JOB_SUBMITTED, "slow_job", "default", [when]))
+    assert len(listener._started_at) == 1, "the submit records a start time"
+
+    run = listener._to_run(JobExecutionEvent(EVENT_JOB_MISSED, "slow_job", "default", when))
+
+    assert run is not None and run.result is JobResult.MISSED
+    assert listener._started_at == {}, "the missed run must not leave its start time behind"
+
+
+def test_an_overrun_keeps_the_running_jobs_start_time():
+    """MAX_INSTANCES is emitted before the submit, while the previous run is
+    still going, so it must not consume that run's start time."""
+    import datetime
+
+    from apscheduler.events import (
+        EVENT_JOB_EXECUTED,
+        EVENT_JOB_MAX_INSTANCES,
+        EVENT_JOB_SUBMITTED,
+        JobExecutionEvent,
+        JobSubmissionEvent,
+    )
+
+    when = datetime.datetime(2026, 1, 1, 0, 0, 0)
+    ticks = iter([100.0, 104.0])
+    listener = ScheduledJobMetricsListener(monotonic=lambda: next(ticks))
+
+    listener._to_run(JobSubmissionEvent(EVENT_JOB_SUBMITTED, "slow_job", "default", [when]))
+    listener._to_run(JobExecutionEvent(EVENT_JOB_MAX_INSTANCES, "slow_job", "default", when))
+    finished = listener._to_run(JobExecutionEvent(EVENT_JOB_EXECUTED, "slow_job", "default", when, retval=None))
+
+    assert finished is not None and finished.duration_seconds == pytest.approx(4.0)
 

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_pod_lock_manager.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_pod_lock_manager.py
@@ -504,3 +504,22 @@ async def test_recording_the_lock_outcome_never_blocks_the_job():
         side_effect=RuntimeError("metrics down"),
     ):
         assert await manager.acquire_lock(cronjob_id="db_spend_update_job") is True
+
+
+@pytest.mark.asyncio
+async def test_a_redis_failure_is_not_reported_as_losing_the_election():
+    """not_acquired means another pod won. An attempt that errored is a
+    different operational state and must not be read as healthy contention."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy.db.db_transaction_queue.pod_lock_manager import PodLockManager
+
+    cache = MagicMock()
+    cache.async_set_cache = AsyncMock(side_effect=ConnectionError("redis down"))
+    manager = PodLockManager(redis_cache=cache)
+    logger = MagicMock()
+
+    with patch("litellm.integrations.prometheus.PrometheusLogger.get_instance", return_value=logger):
+        assert await manager.acquire_lock(cronjob_id="db_spend_update_job") is False
+
+    logger.record_cronjob_lock_attempt.assert_called_once_with("db_spend_update_job", "error")

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_pod_lock_manager.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_pod_lock_manager.py
@@ -456,3 +456,51 @@ async def test_acquire_lock_own_lock_not_reentrant(pod_lock_manager, mock_redis)
 
     assert await pod_lock_manager.acquire_lock(cronjob_id="test_job", allow_reentrant=False) is False
     assert await pod_lock_manager.acquire_lock(cronjob_id="test_job") is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "redis_cache, granted, expected_result",
+    [
+        (None, None, "no_redis"),
+        ("present", True, "acquired"),
+        ("present", False, "not_acquired"),
+    ],
+)
+async def test_every_lock_outcome_is_recorded_under_its_own_result(redis_cache, granted, expected_result):
+    """no_redis is a different operational state from losing the race: one means
+    no pod can ever be elected, the other means another pod won."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy.db.db_transaction_queue.pod_lock_manager import PodLockManager
+
+    cache = None
+    if redis_cache == "present":
+        cache = MagicMock()
+        cache.async_set_cache = AsyncMock(return_value=granted)
+        cache.async_get_cache = AsyncMock(return_value="some-other-pod")
+
+    manager = PodLockManager(redis_cache=cache)
+    logger = MagicMock()
+
+    with patch("litellm.integrations.prometheus.PrometheusLogger.get_instance", return_value=logger):
+        await manager.acquire_lock(cronjob_id="db_spend_update_job")
+
+    logger.record_cronjob_lock_attempt.assert_called_once_with("db_spend_update_job", expected_result)
+
+
+@pytest.mark.asyncio
+async def test_recording_the_lock_outcome_never_blocks_the_job():
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy.db.db_transaction_queue.pod_lock_manager import PodLockManager
+
+    cache = MagicMock()
+    cache.async_set_cache = AsyncMock(return_value=True)
+    manager = PodLockManager(redis_cache=cache)
+
+    with patch(
+        "litellm.integrations.prometheus.PrometheusLogger.get_instance",
+        side_effect=RuntimeError("metrics down"),
+    ):
+        assert await manager.acquire_lock(cronjob_id="db_spend_update_job") is True

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_pod_lock_manager.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_pod_lock_manager.py
@@ -507,6 +507,36 @@ async def test_recording_the_lock_outcome_never_blocks_the_job():
 
 
 @pytest.mark.asyncio
+async def test_a_swallowed_redis_outage_is_not_reported_as_losing_the_election():
+    """RedisCache catches connection errors and returns None rather than raising,
+    and None is also how redis reports SET NX losing the race. Without the
+    swallowed-failure marker every outage publishes as ordinary contention,
+    which is the distinction this metric exists to make."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.caching.redis_cache import _record_swallowed_redis_failure
+    from litellm.proxy.db.db_transaction_queue.pod_lock_manager import PodLockManager
+    from litellm.types.integrations.prometheus import LockAttemptResult
+
+    breaker = MagicMock()
+
+    async def swallowing_set(*args, **kwargs):
+        _record_swallowed_redis_failure(breaker, ConnectionError("redis down"))
+        return None
+
+    cache = MagicMock()
+    cache.async_set_cache = swallowing_set
+    cache.async_get_cache = AsyncMock(return_value=None)
+    manager = PodLockManager(redis_cache=cache)
+    logger = MagicMock()
+
+    with patch("litellm.integrations.prometheus.PrometheusLogger.get_instance", return_value=logger):
+        assert await manager.acquire_lock(cronjob_id="db_spend_update_job") is False
+
+    logger.record_cronjob_lock_attempt.assert_called_once_with("db_spend_update_job", LockAttemptResult.ERROR)
+
+
+@pytest.mark.asyncio
 async def test_a_redis_failure_is_not_reported_as_losing_the_election():
     """not_acquired means another pod won. An attempt that errored is a
     different operational state and must not be read as healthy contention."""

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py
@@ -584,50 +584,26 @@ def test_raise_failed_update_spend_exception_raises_original_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_spend_reports_what_it_drained_not_what_was_queued():
-    """The scheduled-job listener publishes this as an items-processed count, so
-    a queue that only partially drains must not be reported as fully processed."""
+async def test_update_spend_reports_no_item_count():
+    """The spend-log queue is drained by _monitor_spend_logs_queue too, so any
+    count derived from queue depth here would attribute that task's work to this
+    job, or hide work this job did when the queue refilled. Reporting nothing is
+    the honest option until a job can report a count it owns."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     from litellm.proxy.utils import update_spend
 
-    prisma_client = MagicMock()
     proxy_logging_obj = MagicMock()
     proxy_logging_obj.db_spend_update_writer.db_update_spend_transaction_handler = AsyncMock()
 
-    # 10 queued on entry, 4 still queued after the drain
     with (
-        patch("litellm.proxy.utils._total_queued_spend_transactions", AsyncMock(side_effect=[10, 4])),
+        patch("litellm.proxy.utils._total_queued_spend_transactions", AsyncMock(return_value=10)),
         patch("litellm.proxy.utils.update_spend_logs_job", AsyncMock()),
     ):
-        drained = await update_spend(
-            prisma_client=prisma_client,
-            db_writer_client=None,
-            proxy_logging_obj=proxy_logging_obj,
-        )
-
-    assert drained == 6, f"expected the drained count, got {drained}"
-
-
-@pytest.mark.asyncio
-async def test_update_spend_reports_zero_when_nothing_was_queued():
-    from unittest.mock import AsyncMock, MagicMock, patch
-
-    from litellm.proxy.utils import update_spend
-
-    proxy_logging_obj = MagicMock()
-    proxy_logging_obj.db_spend_update_writer.db_update_spend_transaction_handler = AsyncMock()
-    logs_job = AsyncMock()
-
-    with (
-        patch("litellm.proxy.utils._total_queued_spend_transactions", AsyncMock(return_value=0)),
-        patch("litellm.proxy.utils.update_spend_logs_job", logs_job),
-    ):
-        drained = await update_spend(
+        result = await update_spend(
             prisma_client=MagicMock(),
             db_writer_client=None,
             proxy_logging_obj=proxy_logging_obj,
         )
 
-    assert drained == 0
-    logs_job.assert_not_awaited()
+    assert result is None, "a count that cannot be attributed to this job must not be published"

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py
@@ -581,3 +581,53 @@ def test_raise_failed_update_spend_exception_raises_original_error() -> None:
 
     with pytest.raises(ValueError, match="specific"):
         asyncio.run(_runner())
+
+
+@pytest.mark.asyncio
+async def test_update_spend_reports_what_it_drained_not_what_was_queued():
+    """The scheduled-job listener publishes this as an items-processed count, so
+    a queue that only partially drains must not be reported as fully processed."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy.utils import update_spend
+
+    prisma_client = MagicMock()
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.db_spend_update_writer.db_update_spend_transaction_handler = AsyncMock()
+
+    # 10 queued on entry, 4 still queued after the drain
+    with (
+        patch("litellm.proxy.utils._total_queued_spend_transactions", AsyncMock(side_effect=[10, 4])),
+        patch("litellm.proxy.utils.update_spend_logs_job", AsyncMock()),
+    ):
+        drained = await update_spend(
+            prisma_client=prisma_client,
+            db_writer_client=None,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
+    assert drained == 6, f"expected the drained count, got {drained}"
+
+
+@pytest.mark.asyncio
+async def test_update_spend_reports_zero_when_nothing_was_queued():
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy.utils import update_spend
+
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.db_spend_update_writer.db_update_spend_transaction_handler = AsyncMock()
+    logs_job = AsyncMock()
+
+    with (
+        patch("litellm.proxy.utils._total_queued_spend_transactions", AsyncMock(return_value=0)),
+        patch("litellm.proxy.utils.update_spend_logs_job", logs_job),
+    ):
+        drained = await update_spend(
+            prisma_client=MagicMock(),
+            db_writer_client=None,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
+    assert drained == 0
+    logs_job.assert_not_awaited()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Nothing recorded which background job ran on a pod, when, for how long, whether it succeeded, or how much work it moved, so during an incident job activity could only be inferred from database load
- A job that overran its interval and started being skipped left no trace at all
- The single-owner cron lock decided which pod does the work, and its outcome was visible only in log lines

How it solves it:

- One APScheduler listener instruments every registered job at once, including ones added later, rather than each job growing its own instrumentation
- `max_instances` skips are reported as a first-class result, which is how a job falling behind its schedule now surfaces
- The lock outcome becomes a metric, separating "this pod won" from "another pod won" from "no Redis is configured, so no pod can be elected"

## User Flow

Operators already running the prometheus callback get the new series on `/metrics` with no configuration change.

| Metric | Type | Labels | Meaning |
|---|---|---|---|
| `litellm_scheduled_job_runs_total` | Counter | `job_name`, `result` | Runs by outcome: success, error, missed, max_instances |
| `litellm_scheduled_job_duration_seconds` | Histogram | `job_name` | Wall-clock duration of a run |
| `litellm_scheduled_job_last_run_timestamp` | Gauge | `job_name` | Unix timestamp of the last completed run |
| `litellm_scheduled_job_items_processed_total` | Counter | `job_name` | Items jobs reported processing |
| `litellm_cronjob_lock_acquisitions_total` | Counter | `cronjob_id`, `result` | Lock attempts: acquired, not_acquired, no_redis |

A job silently falling behind reads as `rate(litellm_scheduled_job_runs_total{result="max_instances"}[5m]) > 0`. A stalled job reads as `time() - litellm_scheduled_job_last_run_timestamp`. A pod that never wins the lock reads as `acquired` staying flat while `not_acquired` climbs.

Each job also emits one structured log line per completion:

```
scheduled_job_completed job=update_spend_job result=success duration_seconds=0.090 items_processed=25
```

Item counts ride on the return value, so a job opts in with one line rather than reaching into the metrics layer. `update_spend` is wired that way here; the rest report no count until they choose to.

## Relevant issues

## Linear ticket

Refs LIT-5435

This covers the scheduled-jobs section of the ticket. The database-pool section is #36607, which this is stacked on, and per-pod request pressure is a separate PR, so this says Refs rather than Resolves.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Real proxy, real Postgres 16, real Redis, real Gemini API, no mocks. Job intervals shortened so several cycles land in the window.

### Before

No job-level metric of any kind. The only background-job series were the four `litellm_check_batch_cost_*` metrics, which cover one enterprise job.

### After, five jobs instrumented with no per-job code

```
$ curl -sSL http://127.0.0.1:20437/metrics -H "Authorization: Bearer sk-1234" | grep '^litellm_scheduled_job_runs_total'
litellm_scheduled_job_runs_total{job_name="periodic_reload_job",result="success"} 18.0
litellm_scheduled_job_runs_total{job_name="reload_mcp_servers_job",result="success"} 18.0
litellm_scheduled_job_runs_total{job_name="update_spend_job",result="success"} 10.0
litellm_scheduled_job_runs_total{job_name="update_gateway_requests_job",result="success"} 10.0
litellm_scheduled_job_runs_total{job_name="update_daily_tag_spend_job",result="success"} 4.0
```

Durations bucket correctly, for example `litellm_scheduled_job_duration_seconds_sum{job_name="periodic_reload_job"} 0.187` over 18 runs.

### Lock outcome, per cron job

```
$ curl -sSL .../metrics | grep '^litellm_cronjob_lock_acquisitions_total'
litellm_cronjob_lock_acquisitions_total{cronjob_id="db_spend_update_job",result="acquired"} 14.0
litellm_cronjob_lock_acquisitions_total{cronjob_id="db_daily_tag_spend_update_job",result="acquired"} 6.0
```

### Structured logs, including a real item count

Driving a 25-request burst so the spend queue had something in it when a cycle ran:

```
scheduled_job_completed job=periodic_reload_job result=success duration_seconds=0.012 items_processed=unknown
scheduled_job_completed job=update_spend_job result=success duration_seconds=0.060 items_processed=6
scheduled_job_completed job=update_spend_job result=success duration_seconds=0.090 items_processed=25
```

## Type

🆕 New Feature

## Caveats (if any)

The item count started as a last-value gauge. The live run showed it reading 0 while the logs recorded bursts of 6 and 25, because the spend queue drains between cycles and the most recent cycle is almost always empty. It is a counter now, so `rate()` shows real throughput instead of hiding it.

`update_spend` returns what it actually drained, measured as the queue depth on entry minus what is still queued after the write. Returning the depth on entry would report a partial failure or a queue that refilled mid-run as fully processed.

Three integrations (CloudZero, FOCUS, Vantage) registered their export jobs without an explicit `id=`, so APScheduler assigned `uuid4().hex`. As a metric label that grows without bound across pods and restarts, which is exactly what the ticket forbids. All three now pin the id they already have a constant for, the listener collapses any remaining generated id into one `unnamed_job` bucket, and a test fails if a future `add_job` forgets one.

`max_instances` is emitted instead of a submission, not alongside one, and it arrives while the previous run is still going. The listener therefore keeps the running job's start time through the skip; popping it there would drop the duration of exactly the overrunning runs this metric exists to surface.

No pod label. Pod identity is unbounded, and the lock result already distinguishes the pod that owns a job from the ones that skipped it.

Both label sets are closed: `cronjob_id` is 15 module-level constants, and `job_name` is the 19 pinned job ids plus the `unnamed_job` bucket.

## QA runbook

1. Start Postgres and Redis, then a proxy with `litellm_settings.callbacks: ["prometheus"]`, `cache: true` pointed at Redis, and `general_settings.use_redis_transaction_buffer: true` (the pod lock only engages with the Redis buffer on)
2. Export `LITELLM_LOG=INFO` so the structured job lines print, and `PROXY_BATCH_WRITE_AT=5` plus `PROXY_CONFIG_RELOAD_INTERVAL_SECONDS=5` so several cycles land quickly
3. Wait about 45 seconds, then `curl -sSL localhost:4000/metrics -H "Authorization: Bearer sk-1234" | grep '^litellm_scheduled_job'` and confirm several jobs appear with success counts and duration buckets
4. `grep '^litellm_cronjob_lock_acquisitions_total'` and confirm `db_spend_update_job` shows `result="acquired"`
5. For an item count, mint a key and fire a concurrent burst (`seq 1 25 | xargs -P 25 ...`), then grep the proxy log for `scheduled_job_completed job=update_spend_job` and confirm a nonzero `items_processed`
6. To see a `max_instances` skip, set `PROXY_CONFIG_RELOAD_INTERVAL_SECONDS=1` against a slow database so a cycle overruns its interval

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


### Review follow-ups

A Redis outage was published as ordinary contention. `RedisCache.async_set_cache` catches connection errors, records a swallowed-failure marker and returns `None` without re-raising, so the `except Exception` here never fired, and `None` is also how redis reports `SET NX` losing the race. Both arrived as `not_acquired`, losing the distinction this split was added to make in the case that matters most. `acquire_lock` now compares the per-task swallowed-failure counter across the attempt, so an outage records `error`, losing the race still records `not_acquired`, and success still records `acquired`.

The lock metric also advertised three result values while emitting four, so a consumer building alerts from the documented set would have dropped every outage attempt. The four outcomes are now a `LockAttemptResult` enum that both sides derive from, with the documentation generated from it, so the two cannot drift again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the proxy scheduler startup path, Prometheus metric surface, and PodLockManager acquire path used for multi-pod cron coordination. Changes are additive telemetry with failure isolation, but incorrect listener or lock instrumentation could hide job health or affect lock observability.
> 
> **Overview**
> Adds **Prometheus telemetry for APScheduler background jobs and Redis cron locks**, so operators can see which jobs ran, how long they took, whether they succeeded or fell behind, and which pod won the single-owner lock.
> 
> A new `ScheduledJobMetricsListener` registers on the proxy scheduler and turns job lifecycle events into metrics (`runs`, `duration`, `last_run_timestamp`, `items_processed`) plus a structured completion log. Outcomes include `success`, `error`, `missed`, and `max_instances` (overrun skips). Generated APScheduler UUIDs collapse to `unnamed_job` to keep labels bounded; CloudZero, FOCUS, and Vantage export jobs now pin explicit `id=` values.
> 
> `PodLockManager.acquire_lock` records `acquired` / `not_acquired` / `no_redis` without changing the three-state return contract. `update_spend` now returns the count of transactions it actually drained so that count can be published as items processed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3104caa8d5d2411c27cf56a40f95e6211cdd7423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
