### PR TITLE
feat(observability): expose per-pod request pressure and the enforced concurrency ceiling

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -718,6 +718,29 @@ class PrometheusLogger(CustomLogger):
             )
 
             ########################################
+            # Per-pod request pressure
+            ########################################
+            self.litellm_requests_shed_total = self._counter_factory(
+                name="litellm_requests_shed_total",
+                documentation=(
+                    "Responses where the proxy declined to serve rather than failed to, by status. "
+                    "429 is a rate or concurrency limit, 503 is the database being unavailable"
+                ),
+                labelnames=("status",),
+            )
+
+            self.litellm_global_max_parallel_requests_limit = self._gauge_factory(
+                "litellm_global_max_parallel_requests_limit",
+                (
+                    "Concurrency ceiling actually applied on this worker. +Inf means nothing bounds "
+                    "concurrency, either because global_max_parallel_requests is unset or because the "
+                    "active limiter does not enforce it"
+                ),
+                labelnames=(),
+                multiprocess_mode="livemax",
+            )
+
+            ########################################
             # Scheduled background jobs
             ########################################
             self.litellm_scheduled_job_runs_total = self._counter_factory(
@@ -3203,6 +3226,14 @@ class PrometheusLogger(CustomLogger):
                     ).inc()
         except Exception as e:
             verbose_logger.warning("Error recording check batch cost metrics: %s", e)
+
+    def record_request_shed(self, status: int) -> None:
+        """Count one response where the proxy declined to serve."""
+        self.litellm_requests_shed_total.labels(status=str(status)).inc()
+
+    def set_global_max_parallel_requests_limit(self, limit: float) -> None:
+        """Publish the per-pod concurrency ceiling actually in force."""
+        self.litellm_global_max_parallel_requests_limit.set(limit)
 
     def record_scheduled_job_run(self, run: JobRun) -> None:
         """Publish one completed run of a scheduled background job."""

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -885,6 +885,30 @@ class PrometheusLogger(CustomLogger):
             print_verbose(f"Got exception on init prometheus client {e}")
             raise e
 
+        self._restore_effective_concurrency_ceiling()
+
+    def _restore_effective_concurrency_ceiling(self) -> None:
+        """Set the ceiling gauge to the value already in force.
+
+        Startup publishes the ceiling, but ``success_callback: ["prometheus"]``
+        builds this logger lazily on the first request, long after that ran with
+        no logger to publish to. The gauge would then register at its zero
+        default and stay there, reading as "no requests allowed" on a proxy
+        serving everything, which is the reading ``+Inf`` exists to prevent.
+
+        Set directly rather than through the module helper, because during
+        ``__init__`` this instance is not yet reachable by the logger lookup.
+        """
+        try:
+            from litellm.proxy.common_utils.request_pressure_metrics import effective_global_limit
+            from litellm.proxy.proxy_server import general_settings
+
+            self.set_global_max_parallel_requests_limit(
+                effective_global_limit(general_settings.get("global_max_parallel_requests"))
+            )
+        except Exception as e:  # noqa: BLE001  # a logger that cannot read proxy config must still start
+            print_verbose(f"could not publish the concurrency ceiling on init: {e}")
+
     def _parse_prometheus_config(self) -> dict[str, list[str]]:
         """Parse prometheus metrics configuration for label filtering and enabled metrics"""
         import litellm

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -723,8 +723,10 @@ class PrometheusLogger(CustomLogger):
             self.litellm_requests_shed_total = self._counter_factory(
                 name="litellm_requests_shed_total",
                 documentation=(
-                    "Responses where the proxy declined to serve rather than failed to, by status. "
-                    "429 is a rate or concurrency limit, 503 is the database being unavailable"
+                    "Responses where this proxy declined to serve rather than failed to, by status. "
+                    "status is one of 429; upstream rate limits are forwarded with the same status and "
+                    "are excluded, as are the 503s raised when a budget cannot be verified, which mean "
+                    "a dependency is unreachable rather than this pod being at capacity"
                 ),
                 labelnames=("status",),
             )

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1834,6 +1834,10 @@ class ProxyBaseLLMRequestProcessing:
         llm_router: Router | None,
     ) -> tuple[dict, LiteLLMLoggingObj]:
         from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
+        from litellm.proxy.common_utils.request_pressure_metrics import (
+            clear_request_shed_marker,
+            mark_request_shed_by_proxy,
+        )
 
         try:
             return await self.common_processing_pre_call_logic(
@@ -1876,6 +1880,11 @@ class ProxyBaseLLMRequestProcessing:
                     if fallback_model == original_model:
                         continue
                     self.data["model"] = fallback_model
+                    # This rejection is being recovered from, not returned, so it
+                    # must not leave the request marked as shed by this proxy. A
+                    # provider 429 on the fallback would otherwise be counted as
+                    # this pod shedding load.
+                    clear_request_shed_marker()
                     try:
                         return await self.common_processing_pre_call_logic(
                             request=request,
@@ -1900,6 +1909,9 @@ class ProxyBaseLLMRequestProcessing:
                 raise
 
             self.data["model"] = original_model
+            # Every fallback was rate limited too, so the original rejection is
+            # what the client gets and the mark has to be restored.
+            mark_request_shed_by_proxy()
             raise original_exc
 
     def _resolve_fallback_models(

--- a/litellm/proxy/common_utils/proxy_rate_limit_error.py
+++ b/litellm/proxy/common_utils/proxy_rate_limit_error.py
@@ -98,6 +98,9 @@ def _coerce_message(detail: Any) -> str:
 # Both narrowings are intentional and handled at construction time — every
 # instance always has status_code == 429 and a Dict-typed headers — so we
 # silence the ATTR-overlap check rather than relax the annotations.
+from litellm.proxy.common_utils.request_pressure_metrics import mark_request_shed_by_proxy
+
+
 class ProxyRateLimitError(HTTPException, RateLimitError):
     """
     A 429 raised by litellm's proxy-side rate limiting hooks.
@@ -155,6 +158,7 @@ class ProxyRateLimitError(HTTPException, RateLimitError):
         # instance whose `.llm_provider` attribute is `None` — that would
         # break Prometheus' `_get_exception_class_name` (it calls
         # `.capitalize()` on the provider string).
+        mark_request_shed_by_proxy()
         model = model or ""
         llm_provider = llm_provider or "litellm_proxy"
         message: Final = _coerce_message(detail)

--- a/litellm/proxy/common_utils/request_pressure_metrics.py
+++ b/litellm/proxy/common_utils/request_pressure_metrics.py
@@ -1,0 +1,58 @@
+"""Publishes the per-pod concurrency ceiling that is actually in force.
+
+``global_max_parallel_requests`` is only read by the v1 parallel-request
+limiter, which is off unless ``LEGACY_MULTI_INSTANCE_RATE_LIMITING`` is set. The
+default v3 limiter never looks at it, so publishing the configured number
+regardless would hand operators a ceiling that nothing applies.
+
+A registered Prometheus gauge always exposes a value, so simply declining to set
+it renders as ``0``, which reads as "no requests allowed". The gauge therefore
+reports the effective ceiling in every state: the configured number when it is
+enforced, and ``+Inf`` when nothing bounds concurrency.
+
+See LIT-5460 for the enforcement gap itself.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from litellm._logging import verbose_proxy_logger
+
+UNBOUNDED: Final = float("inf")
+
+
+def is_global_limit_enforced() -> bool:
+    """Whether the registered limiter reads ``global_max_parallel_requests``."""
+    from litellm.proxy.hooks import PROXY_HOOKS
+    from litellm.proxy.hooks.parallel_request_limiter import (
+        _PROXY_MaxParallelRequestsHandler,
+    )
+
+    return PROXY_HOOKS.get("parallel_request_limiter") is _PROXY_MaxParallelRequestsHandler
+
+
+def effective_global_limit(limit: int | None) -> float:
+    """The ceiling actually applied to this worker's concurrency."""
+    if limit is None:
+        return UNBOUNDED
+    if not is_global_limit_enforced():
+        verbose_proxy_logger.warning(
+            "global_max_parallel_requests=%s is set but the active rate limiter does not enforce it, so the "
+            "limit metric reports unbounded. Set LEGACY_MULTI_INSTANCE_RATE_LIMITING=true to enforce it",
+            limit,
+        )
+        return UNBOUNDED
+    return float(limit)
+
+
+def publish_global_max_parallel_requests(limit: int | None) -> None:
+    """Publish the effective ceiling, whatever it turns out to be."""
+    try:
+        from litellm.integrations.prometheus import PrometheusLogger
+
+        logger: Final = PrometheusLogger.get_instance()
+        if logger is not None:
+            logger.set_global_max_parallel_requests_limit(effective_global_limit(limit))
+    except Exception as e:  # noqa: BLE001  # telemetry must not block startup
+        verbose_proxy_logger.debug("global max parallel requests metric failed: %s", e)

--- a/litellm/proxy/common_utils/request_pressure_metrics.py
+++ b/litellm/proxy/common_utils/request_pressure_metrics.py
@@ -15,11 +15,27 @@ See LIT-5460 for the enforcement gap itself.
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 from typing import Final
 
 from litellm._logging import verbose_proxy_logger
 
 UNBOUNDED: Final = float("inf")
+
+# Set where the proxy itself declines a request. litellm forwards upstream
+# rate limits with the same 429 the proxy uses for its own, so response status
+# alone cannot tell "this pod shed load" from "the provider throttled us", and
+# only the former should count toward a decision to throttle or scale out.
+proxy_shed_request: Final[ContextVar[bool]] = ContextVar("litellm_proxy_shed_request", default=False)
+
+
+def mark_request_shed_by_proxy() -> None:
+    """Record that this proxy, not an upstream, declined the current request."""
+    proxy_shed_request.set(True)
+
+
+def was_request_shed_by_proxy() -> bool:
+    return proxy_shed_request.get()
 
 
 def is_global_limit_enforced() -> bool:

--- a/litellm/proxy/common_utils/request_pressure_metrics.py
+++ b/litellm/proxy/common_utils/request_pressure_metrics.py
@@ -39,10 +39,17 @@ def was_request_shed_by_proxy() -> bool:
 
 
 def is_global_limit_enforced() -> bool:
-    """Whether the registered limiter reads ``global_max_parallel_requests``."""
+    """Whether the registered limiter reads ``global_max_parallel_requests``.
+
+    Only the v1 handler does. Identity against v1 rather than "anything but v3"
+    so an unrecognised limiter reports unbounded instead of claiming a ceiling
+    it may not apply.
+    """
+    # The limiter class is private by naming convention only: it is what the hook
+    # registry is built from, and proxy/utils.py imports it the same way.
     from litellm.proxy.hooks import PROXY_HOOKS
     from litellm.proxy.hooks.parallel_request_limiter import (
-        _PROXY_MaxParallelRequestsHandler,
+        _PROXY_MaxParallelRequestsHandler,  # pyright: ignore[reportPrivateUsage]  # the registry's own hook class, imported this way across the proxy
     )
 
     return PROXY_HOOKS.get("parallel_request_limiter") is _PROXY_MaxParallelRequestsHandler

--- a/litellm/proxy/common_utils/request_pressure_metrics.py
+++ b/litellm/proxy/common_utils/request_pressure_metrics.py
@@ -16,6 +16,7 @@ See LIT-5460 for the enforcement gap itself.
 from __future__ import annotations
 
 from contextvars import ContextVar
+from functools import lru_cache
 from typing import Final
 
 from litellm._logging import verbose_proxy_logger
@@ -66,16 +67,27 @@ def is_global_limit_enforced() -> bool:
     return PROXY_HOOKS.get("parallel_request_limiter") is _PROXY_MaxParallelRequestsHandler
 
 
+@lru_cache(maxsize=8)
+def _warn_limit_not_enforced(limit: int) -> None:
+    """Say this once per configured value, not once per settings reload.
+
+    Settings refresh on a timer, so warning per call repeats the same line for
+    the life of the process and drowns out real output. The cached return is
+    what makes it once.
+    """
+    verbose_proxy_logger.warning(
+        "global_max_parallel_requests=%s is set but the active rate limiter does not enforce it, so "
+        "the limit metric reports unbounded. Set LEGACY_MULTI_INSTANCE_RATE_LIMITING=true to enforce it",
+        limit,
+    )
+
+
 def effective_global_limit(limit: int | None) -> float:
     """The ceiling actually applied to this worker's concurrency."""
     if limit is None:
         return UNBOUNDED
     if not is_global_limit_enforced():
-        verbose_proxy_logger.warning(
-            "global_max_parallel_requests=%s is set but the active rate limiter does not enforce it, so the "
-            "limit metric reports unbounded. Set LEGACY_MULTI_INSTANCE_RATE_LIMITING=true to enforce it",
-            limit,
-        )
+        _warn_limit_not_enforced(limit)
         return UNBOUNDED
     return float(limit)
 

--- a/litellm/proxy/common_utils/request_pressure_metrics.py
+++ b/litellm/proxy/common_utils/request_pressure_metrics.py
@@ -34,6 +34,17 @@ def mark_request_shed_by_proxy() -> None:
     proxy_shed_request.set(True)
 
 
+def clear_request_shed_marker() -> None:
+    """Undo the mark because the rejection is being recovered from, not returned.
+
+    The mark is set when the error is constructed, which is the only point every
+    raise site passes through. A caught rejection that falls back to another
+    model would otherwise leave the request marked, and a provider 429 on that
+    fallback would be counted as this pod shedding load.
+    """
+    proxy_shed_request.set(False)
+
+
 def was_request_shed_by_proxy() -> bool:
     return proxy_shed_request.get()
 

--- a/litellm/proxy/hooks/__init__.py
+++ b/litellm/proxy/hooks/__init__.py
@@ -1,6 +1,8 @@
 import os
 from typing import Final, Literal
 
+from litellm.integrations.custom_logger import CustomLogger
+
 from . import *
 from .cache_control_check import _PROXY_CacheControlCheck
 from .litellm_skills import SkillsInjectionHook
@@ -16,7 +18,11 @@ from .sensitive_data_routing import _PROXY_SensitiveDataRoutingHandler
 # Defined before the enterprise import below so that any module re-imported
 # transitively through `enterprise.enterprise_hooks` can resolve `PROXY_HOOKS`
 # and `get_proxy_hook` from this partially-initialized module without circling.
-PROXY_HOOKS: Final = {
+# Annotated rather than inferred: the literal below is not the whole mapping.
+# The v1 parallel-request limiter replaces its entry under
+# LEGACY_MULTI_INSTANCE_RATE_LIMITING, and ENTERPRISE_PROXY_HOOKS is merged in
+# at the bottom of this module, so the value type is any CustomLogger subclass.
+PROXY_HOOKS: Final[dict[str, type[CustomLogger]]] = {  # mutable-ok: the swap and merge below
     "max_budget_limiter": _PROXY_MaxBudgetLimiter,
     "parallel_request_limiter": _PROXY_MaxParallelRequestsHandler_v3,
     "cache_control_check": _PROXY_CacheControlCheck,

--- a/litellm/proxy/middleware/in_flight_requests_middleware.py
+++ b/litellm/proxy/middleware/in_flight_requests_middleware.py
@@ -83,13 +83,18 @@ class InFlightRequestsMiddleware:
         return InFlightRequestsMiddleware._gauge
 
 
-# Statuses that mean the proxy declined to serve rather than failed to. Kept to
-# a fixed set so the metric label cannot grow.
+# Statuses the proxy uses when it declines to serve. A response only counts once
+# the request is also marked as shed by this proxy, since litellm forwards
+# upstream 429s with the same status.
 _SHED_STATUSES: Final = frozenset({429, 503})
 
 
 def _record_shed_response(status: int) -> None:
     if status not in _SHED_STATUSES:
+        return
+    from litellm.proxy.common_utils.request_pressure_metrics import was_request_shed_by_proxy
+
+    if not was_request_shed_by_proxy():
         return
     try:
         from litellm.integrations.prometheus import PrometheusLogger

--- a/litellm/proxy/middleware/in_flight_requests_middleware.py
+++ b/litellm/proxy/middleware/in_flight_requests_middleware.py
@@ -1,14 +1,18 @@
 """
-Tracks the number of HTTP requests currently in-flight on this uvicorn worker.
+Tracks per-worker request pressure: how many HTTP requests are in flight, and
+how many the proxy shed rather than served.
 
-Used by /health/backlog to expose per-pod queue depth, and emitted as the
-Prometheus gauge `litellm_in_flight_requests`.
+Counting shed responses here rather than at each limiter means no rejection path
+can be missed, and the count is per worker for the same reason the in-flight
+gauge is.
 """
 
 import os
 from typing import Any, Final
 
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from litellm._logging import verbose_proxy_logger
 
 
 class InFlightRequestsMiddleware:
@@ -43,7 +47,7 @@ class InFlightRequestsMiddleware:
         if gauge is not None:
             gauge.inc()
         try:
-            await self.app(scope, receive, send)
+            await self.app(scope, receive, send=_counting_send(send))
         finally:
             InFlightRequestsMiddleware._in_flight -= 1
             if gauge is not None:
@@ -77,6 +81,33 @@ class InFlightRequestsMiddleware:
         except Exception:
             InFlightRequestsMiddleware._gauge = None
         return InFlightRequestsMiddleware._gauge
+
+
+# Statuses that mean the proxy declined to serve rather than failed to. Kept to
+# a fixed set so the metric label cannot grow.
+_SHED_STATUSES: Final = frozenset({429, 503})
+
+
+def _record_shed_response(status: int) -> None:
+    if status not in _SHED_STATUSES:
+        return
+    try:
+        from litellm.integrations.prometheus import PrometheusLogger
+
+        logger = PrometheusLogger.get_instance()
+        if logger is not None:
+            logger.record_request_shed(status)
+    except Exception as e:  # noqa: BLE001  # counting a shed response must not break the response
+        verbose_proxy_logger.debug("request shed metric failed: %s", e)
+
+
+def _counting_send(send: Send) -> Send:
+    async def wrapped(message: Message) -> None:
+        if message["type"] == "http.response.start":
+            _record_shed_response(int(message["status"]))
+        await send(message)
+
+    return wrapped
 
 
 def get_in_flight_requests() -> int:

--- a/litellm/proxy/middleware/in_flight_requests_middleware.py
+++ b/litellm/proxy/middleware/in_flight_requests_middleware.py
@@ -83,10 +83,12 @@ class InFlightRequestsMiddleware:
         return InFlightRequestsMiddleware._gauge
 
 
-# Statuses the proxy uses when it declines to serve. A response only counts once
-# the request is also marked as shed by this proxy, since litellm forwards
-# upstream 429s with the same status.
-_SHED_STATUSES: Final = frozenset({429, 503})
+# The status this proxy uses when it declines load, and only counted once the
+# request is also marked as shed here, since litellm forwards upstream 429s with
+# the same status. The proxy's 503s are fail-closed budget rejections, a
+# dependency being unreachable rather than this pod at capacity, so counting
+# them would blur the throttle-vs-scale signal the metric exists to give.
+_SHED_STATUSES: Final = frozenset({429})
 
 
 def _record_shed_response(status: int) -> None:

--- a/litellm/proxy/middleware/in_flight_requests_middleware.py
+++ b/litellm/proxy/middleware/in_flight_requests_middleware.py
@@ -101,7 +101,7 @@ def _record_shed_response(status: int) -> None:
     try:
         from litellm.integrations.prometheus import PrometheusLogger
 
-        logger = PrometheusLogger.get_instance()
+        logger: Final = PrometheusLogger.get_instance()
         if logger is not None:
             logger.record_request_shed(status)
     except Exception as e:  # noqa: BLE001  # counting a shed response must not break the response

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1217,6 +1217,10 @@ async def proxy_startup_event(app: FastAPI) -> AsyncGenerator[None, None]:
         prisma_client=prisma_client,
     )
 
+    # Not gated on the database: concurrency is bounded per worker regardless, and
+    # a registered gauge always exposes a value, so skipping this would publish 0.
+    publish_global_max_parallel_requests(general_settings.get("global_max_parallel_requests"))
+
     ### START BATCH WRITING DB + CHECKING NEW MODELS###
     worker_heartbeat: Final = (
         await ProxyStartupEvent.initialize_scheduled_background_jobs(
@@ -6326,6 +6330,7 @@ class ProxyConfig:
 
         if "global_max_parallel_requests" in _general_settings:
             general_settings["global_max_parallel_requests"] = _general_settings["global_max_parallel_requests"]
+            publish_global_max_parallel_requests(general_settings["global_max_parallel_requests"])
 
         if "max_batch_file_size_mb" not in self._yaml_general_settings_keys:
             general_settings["max_batch_file_size_mb"] = _general_settings.get("max_batch_file_size_mb")
@@ -9138,7 +9143,6 @@ class ProxyStartupEvent:
         )
         # Registered before start so the first run of every job is observed.
         ScheduledJobMetricsListener().register(scheduler)
-        publish_global_max_parallel_requests(general_settings.get("global_max_parallel_requests"))
 
         # Start the scheduler immediately without processing backlogs
         scheduler.start(paused=False)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -347,6 +347,7 @@ from litellm.proxy.common_utils.periodic_reload_schedule import (
     write_reload_interval,
 )
 from litellm.proxy.common_utils.proxy_state import ProxyState
+from litellm.proxy.common_utils.request_pressure_metrics import publish_global_max_parallel_requests
 from litellm.proxy.common_utils.reset_budget_job import ResetBudgetJob
 from litellm.proxy.common_utils.scheduled_job_metrics import ScheduledJobMetricsListener
 from litellm.proxy.common_utils.scheduled_job_stagger import (
@@ -9137,6 +9138,7 @@ class ProxyStartupEvent:
         )
         # Registered before start so the first run of every job is observed.
         ScheduledJobMetricsListener().register(scheduler)
+        publish_global_max_parallel_requests(general_settings.get("global_max_parallel_requests"))
 
         # Start the scheduler immediately without processing backlogs
         scheduler.start(paused=False)

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -797,16 +797,12 @@ class PrometheusMetricLabels:
 
     litellm_check_batch_cost_last_run_timestamp: list[str] = []
 
-    # Per-pod request pressure. status is a fixed set of shed codes; the limit
-    # gauge is unlabelled because it describes this worker.
+    # Unlabelled: the limit describes this worker.
     litellm_requests_shed_total: tuple[str, ...] = ()
     litellm_global_max_parallel_requests_limit: tuple[str, ...] = ()
 
-    # Scheduled background jobs. Labels are closed sets fixed at startup: job ids
-    # come from the scheduler registration, cronjob ids from the lock call sites,
-    # and results from an enum. No pod label: pod identity is unbounded, and the
-    # lock result already distinguishes the pod that owns a job from the ones
-    # that skipped it.
+    # No pod label: pod identity is unbounded, and the lock result already
+    # identifies the owner.
     litellm_scheduled_job_runs_total: tuple[str, ...] = ()
     litellm_scheduled_job_duration_seconds: tuple[str, ...] = ()
     litellm_scheduled_job_last_run_timestamp: tuple[str, ...] = ()

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -285,6 +285,9 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     # MCP tool call metrics
     "litellm_mcp_tool_calls_total",
     "litellm_mcp_tool_call_spend_metric",
+    # Per-pod request pressure
+    "litellm_requests_shed_total",
+    "litellm_global_max_parallel_requests_limit",
     # Scheduled background jobs
     "litellm_scheduled_job_runs_total",
     "litellm_scheduled_job_duration_seconds",
@@ -794,8 +797,16 @@ class PrometheusMetricLabels:
 
     litellm_check_batch_cost_last_run_timestamp: list[str] = []
 
-    # No pod label: pod identity is unbounded, and the lock result already
-    # identifies the owner.
+    # Per-pod request pressure. status is a fixed set of shed codes; the limit
+    # gauge is unlabelled because it describes this worker.
+    litellm_requests_shed_total: tuple[str, ...] = ()
+    litellm_global_max_parallel_requests_limit: tuple[str, ...] = ()
+
+    # Scheduled background jobs. Labels are closed sets fixed at startup: job ids
+    # come from the scheduler registration, cronjob ids from the lock call sites,
+    # and results from an enum. No pod label: pod identity is unbounded, and the
+    # lock result already distinguishes the pod that owns a job from the ones
+    # that skipped it.
     litellm_scheduled_job_runs_total: tuple[str, ...] = ()
     litellm_scheduled_job_duration_seconds: tuple[str, ...] = ()
     litellm_scheduled_job_last_run_timestamp: tuple[str, ...] = ()

--- a/tests/test_litellm/proxy/common_utils/test_request_pressure_metrics.py
+++ b/tests/test_litellm/proxy/common_utils/test_request_pressure_metrics.py
@@ -1,0 +1,106 @@
+"""The concurrency-ceiling gauge must never claim a limit nothing enforces."""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.proxy.common_utils.request_pressure_metrics import (
+    UNBOUNDED,
+    effective_global_limit,
+    is_global_limit_enforced,
+    publish_global_max_parallel_requests,
+)
+
+
+def _with_limiter(handler):
+    from litellm.proxy import hooks
+
+    return patch.dict(hooks.PROXY_HOOKS, {"parallel_request_limiter": handler})
+
+
+def test_the_v1_limiter_is_the_one_that_enforces_the_global_limit():
+    from litellm.proxy.hooks.parallel_request_limiter import (
+        _PROXY_MaxParallelRequestsHandler,
+    )
+
+    with _with_limiter(_PROXY_MaxParallelRequestsHandler):
+        assert is_global_limit_enforced() is True
+
+
+def test_the_default_v3_limiter_does_not_enforce_the_global_limit():
+    """Verified live: with global_max_parallel_requests=3 and 20 concurrent
+    requests, the v3 limiter returned 20x 200 and zero rejections. Tracked as
+    LIT-5460."""
+    from litellm.proxy.hooks.parallel_request_limiter_v3 import (
+        _PROXY_MaxParallelRequestsHandler_v3,
+    )
+
+    with _with_limiter(_PROXY_MaxParallelRequestsHandler_v3):
+        assert is_global_limit_enforced() is False
+
+
+def test_an_enforced_limit_is_reported_as_the_configured_number():
+    from litellm.proxy.hooks.parallel_request_limiter import (
+        _PROXY_MaxParallelRequestsHandler,
+    )
+
+    logger = MagicMock()
+    with (
+        _with_limiter(_PROXY_MaxParallelRequestsHandler),
+        patch("litellm.integrations.prometheus.PrometheusLogger.get_instance", return_value=logger),
+    ):
+        publish_global_max_parallel_requests(3)
+
+    logger.set_global_max_parallel_requests_limit.assert_called_once_with(3.0)
+
+
+@pytest.mark.parametrize("configured", [3, None])
+def test_an_unenforced_limit_is_reported_as_unbounded(configured):
+    """A registered gauge always exposes a value, so declining to set it renders
+    as 0, which reads as "no requests allowed". Reporting +Inf says what is
+    actually true: nothing bounds concurrency."""
+    from litellm.proxy.hooks.parallel_request_limiter_v3 import (
+        _PROXY_MaxParallelRequestsHandler_v3,
+    )
+
+    with _with_limiter(_PROXY_MaxParallelRequestsHandler_v3):
+        assert effective_global_limit(configured) == UNBOUNDED
+
+
+def test_no_configured_limit_is_unbounded_even_when_enforcement_is_on():
+    from litellm.proxy.hooks.parallel_request_limiter import (
+        _PROXY_MaxParallelRequestsHandler,
+    )
+
+    with _with_limiter(_PROXY_MaxParallelRequestsHandler):
+        assert effective_global_limit(None) == UNBOUNDED
+
+
+def test_the_gauge_is_never_left_at_a_bare_zero():
+    """0 would be indistinguishable from a real ceiling of zero."""
+    from litellm.proxy.hooks.parallel_request_limiter_v3 import (
+        _PROXY_MaxParallelRequestsHandler_v3,
+    )
+
+    with _with_limiter(_PROXY_MaxParallelRequestsHandler_v3):
+        assert effective_global_limit(3) != 0.0
+        assert effective_global_limit(None) != 0.0
+
+
+def test_publishing_never_blocks_startup():
+    from litellm.proxy.hooks.parallel_request_limiter import (
+        _PROXY_MaxParallelRequestsHandler,
+    )
+
+    with (
+        _with_limiter(_PROXY_MaxParallelRequestsHandler),
+        patch(
+            "litellm.integrations.prometheus.PrometheusLogger.get_instance",
+            side_effect=RuntimeError("metrics down"),
+        ),
+    ):
+        publish_global_max_parallel_requests(3)

--- a/tests/test_litellm/proxy/common_utils/test_request_pressure_metrics.py
+++ b/tests/test_litellm/proxy/common_utils/test_request_pressure_metrics.py
@@ -133,3 +133,24 @@ def test_a_lazily_built_logger_publishes_the_ceiling_already_in_force(monkeypatc
 
     assert REGISTRY.get_sample_value("litellm_global_max_parallel_requests_limit") == 7.0
 
+def test_the_inert_limit_warning_is_not_repeated_on_every_reload(monkeypatch, caplog):
+    """Settings reload on a timer, so warning per call would repeat the same line
+    for the life of the process and drown out real output."""
+    import logging
+
+    from litellm.proxy.common_utils import request_pressure_metrics as rpm
+
+    monkeypatch.setattr(rpm, "is_global_limit_enforced", lambda: False)
+    rpm._warn_limit_not_enforced.cache_clear()
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(5):
+            assert rpm.effective_global_limit(3) == rpm.UNBOUNDED
+        first_round = [r for r in caplog.records if "does not enforce it" in r.getMessage()]
+
+        rpm.effective_global_limit(9)
+        after_change = [r for r in caplog.records if "does not enforce it" in r.getMessage()]
+
+    assert len(first_round) == 1, f"five reloads of the same limit warned {len(first_round)} times"
+    assert len(after_change) == 2, "a changed limit is worth saying again"
+

--- a/tests/test_litellm/proxy/common_utils/test_request_pressure_metrics.py
+++ b/tests/test_litellm/proxy/common_utils/test_request_pressure_metrics.py
@@ -104,3 +104,32 @@ def test_publishing_never_blocks_startup():
         ),
     ):
         publish_global_max_parallel_requests(3)
+
+def test_a_lazily_built_logger_publishes_the_ceiling_already_in_force(monkeypatch):
+    """success_callback: ["prometheus"] builds the logger on the first request,
+    long after startup published the ceiling with no logger to publish to. The
+    gauge would register at its zero default and stay there, reading as "no
+    requests allowed" on a proxy serving everything."""
+    from prometheus_client import REGISTRY
+
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    monkeypatch.setattr(litellm, "callbacks", [])
+    monkeypatch.setattr(litellm, "success_callback", [])
+    monkeypatch.setitem(proxy_server.general_settings, "global_max_parallel_requests", 7)
+    monkeypatch.setattr(
+        "litellm.proxy.common_utils.request_pressure_metrics.is_global_limit_enforced",
+        lambda: True,
+    )
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+    PrometheusLogger()
+
+    assert REGISTRY.get_sample_value("litellm_global_max_parallel_requests_limit") == 7.0
+

--- a/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
@@ -95,3 +95,66 @@ def test_non_http_scopes_not_counted():
 
     asyncio.run(mw({"type": "lifespan"}, None, None))  # type: ignore[arg-type]
     assert get_in_flight_requests() == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status, expected_calls", [(429, 1), (503, 1), (200, 0), (400, 0), (500, 0)])
+async def test_only_shed_responses_are_counted(status, expected_calls):
+    """A 500 is the proxy failing, not declining. Counting it here would blur the
+    signal an operator uses to decide between throttling and scaling out."""
+    from unittest.mock import MagicMock, patch
+
+    from litellm.proxy.middleware.in_flight_requests_middleware import (
+        InFlightRequestsMiddleware,
+    )
+
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def app(scope, receive, send):
+        await send({"type": "http.response.start", "status": status, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    logger = MagicMock()
+    with patch("litellm.integrations.prometheus.PrometheusLogger.get_instance", return_value=logger):
+        await InFlightRequestsMiddleware(app)({"type": "http"}, receive, send)
+
+    assert logger.record_request_shed.call_count == expected_calls
+    if expected_calls:
+        logger.record_request_shed.assert_called_once_with(status)
+    assert [m["type"] for m in sent] == ["http.response.start", "http.response.body"], (
+        "the wrapped send must still forward every message downstream"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_broken_metric_never_breaks_the_response():
+    from unittest.mock import patch
+
+    from litellm.proxy.middleware.in_flight_requests_middleware import (
+        InFlightRequestsMiddleware,
+    )
+
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 429, "headers": []})
+
+    with patch(
+        "litellm.integrations.prometheus.PrometheusLogger.get_instance",
+        side_effect=RuntimeError("metrics down"),
+    ):
+        await InFlightRequestsMiddleware(app)({"type": "http"}, receive, send)
+
+    assert len(sent) == 1

--- a/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
@@ -99,11 +99,12 @@ def test_non_http_scopes_not_counted():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("status, expected_calls", [(429, 1), (503, 1), (200, 0), (400, 0), (500, 0)])
-async def test_only_shed_responses_are_counted(status, expected_calls):
-    """A 500 is the proxy failing, not declining. Counting it here would blur the
+async def test_only_shed_responses_the_proxy_itself_produced_are_counted(status, expected_calls):
+    """A 500 is the proxy failing, not declining. Counting it would blur the
     signal an operator uses to decide between throttling and scaling out."""
     from unittest.mock import MagicMock, patch
 
+    from litellm.proxy.common_utils.request_pressure_metrics import mark_request_shed_by_proxy
     from litellm.proxy.middleware.in_flight_requests_middleware import (
         InFlightRequestsMiddleware,
     )
@@ -117,6 +118,7 @@ async def test_only_shed_responses_are_counted(status, expected_calls):
         return {"type": "http.request"}
 
     async def app(scope, receive, send):
+        mark_request_shed_by_proxy()
         await send({"type": "http.response.start", "status": status, "headers": []})
         await send({"type": "http.response.body", "body": b""})
 
@@ -125,36 +127,53 @@ async def test_only_shed_responses_are_counted(status, expected_calls):
         await InFlightRequestsMiddleware(app)({"type": "http"}, receive, send)
 
     assert logger.record_request_shed.call_count == expected_calls
-    if expected_calls:
-        logger.record_request_shed.assert_called_once_with(status)
     assert [m["type"] for m in sent] == ["http.response.start", "http.response.body"], (
         "the wrapped send must still forward every message downstream"
     )
 
 
 @pytest.mark.asyncio
-async def test_a_broken_metric_never_breaks_the_response():
-    from unittest.mock import patch
+async def test_a_provider_rate_limit_is_not_counted_as_this_pod_shedding():
+    """litellm forwards an upstream 429 with the same status the proxy uses for
+    its own limits. Counting it would tell an operator to scale out when the
+    bottleneck is the provider."""
+    from unittest.mock import MagicMock, patch
 
     from litellm.proxy.middleware.in_flight_requests_middleware import (
         InFlightRequestsMiddleware,
     )
 
-    sent = []
-
     async def send(message):
-        sent.append(message)
+        return None
 
     async def receive():
         return {"type": "http.request"}
 
     async def app(scope, receive, send):
+        # no mark: the 429 came back from the provider, not from a proxy limiter
         await send({"type": "http.response.start", "status": 429, "headers": []})
 
-    with patch(
-        "litellm.integrations.prometheus.PrometheusLogger.get_instance",
-        side_effect=RuntimeError("metrics down"),
-    ):
+    logger = MagicMock()
+    with patch("litellm.integrations.prometheus.PrometheusLogger.get_instance", return_value=logger):
         await InFlightRequestsMiddleware(app)({"type": "http"}, receive, send)
 
-    assert len(sent) == 1
+    logger.record_request_shed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_the_proxys_own_rate_limit_error_marks_the_request():
+    """ProxyRateLimitError is the one class litellm raises for its own 429s, so
+    constructing it is what distinguishes the two cases."""
+    from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
+    from litellm.proxy.common_utils.request_pressure_metrics import (
+        proxy_shed_request,
+        was_request_shed_by_proxy,
+    )
+
+    token = proxy_shed_request.set(False)
+    try:
+        assert was_request_shed_by_proxy() is False
+        ProxyRateLimitError(detail={"error": "limit"})
+        assert was_request_shed_by_proxy() is True
+    finally:
+        proxy_shed_request.reset(token)

--- a/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
@@ -178,3 +178,30 @@ async def test_the_proxys_own_rate_limit_error_marks_the_request():
         assert was_request_shed_by_proxy() is True
     finally:
         proxy_shed_request.reset(token)
+
+def test_the_shed_metric_documents_exactly_the_statuses_it_counts(monkeypatch):
+    """The advertised status set is what a consumer writes alerts against, so a
+    status the metric names but never counts inflates their view of shedding."""
+    import re
+
+    import litellm
+    from litellm.integrations.prometheus import PrometheusLogger
+    from litellm.proxy.middleware.in_flight_requests_middleware import _SHED_STATUSES
+
+    monkeypatch.setattr(litellm, "callbacks", [])
+    monkeypatch.setattr(litellm, "success_callback", [])
+    from prometheus_client import REGISTRY
+
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+    documentation = PrometheusLogger().litellm_requests_shed_total._documentation
+
+    advertised = re.search(r"status is one of ([^;]+);", documentation)
+    assert advertised is not None, f"no advertised status list in: {documentation}"
+    documented = {int(value.strip()) for value in advertised.group(1).split(",")}
+
+    assert documented == set(_SHED_STATUSES)

--- a/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
@@ -98,10 +98,11 @@ def test_non_http_scopes_not_counted():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("status, expected_calls", [(429, 1), (503, 1), (200, 0), (400, 0), (500, 0)])
+@pytest.mark.parametrize("status, expected_calls", [(429, 1), (503, 0), (200, 0), (400, 0), (500, 0)])
 async def test_only_shed_responses_the_proxy_itself_produced_are_counted(status, expected_calls):
-    """A 500 is the proxy failing, not declining. Counting it would blur the
-    signal an operator uses to decide between throttling and scaling out."""
+    """A 500 is the proxy failing, not declining, and the proxy's 503s are
+    fail-closed budget rejections raised when a dependency is unreachable.
+    Counting either would blur the throttle-vs-scale signal."""
     from unittest.mock import MagicMock, patch
 
     from litellm.proxy.common_utils.request_pressure_metrics import mark_request_shed_by_proxy

--- a/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
@@ -205,3 +205,37 @@ def test_the_shed_metric_documents_exactly_the_statuses_it_counts(monkeypatch):
     documented = {int(value.strip()) for value in advertised.group(1).split(",")}
 
     assert documented == set(_SHED_STATUSES)
+
+@pytest.mark.asyncio
+async def test_a_failure_counting_a_shed_response_still_returns_the_response():
+    """The counting rides the response boundary, so a metrics failure there would
+    otherwise turn a served 429 into no response at all."""
+    from unittest.mock import patch
+
+    from litellm.proxy.common_utils.request_pressure_metrics import mark_request_shed_by_proxy
+    from litellm.proxy.middleware.in_flight_requests_middleware import (
+        InFlightRequestsMiddleware,
+    )
+
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def app(scope, receive, send):
+        mark_request_shed_by_proxy()
+        await send({"type": "http.response.start", "status": 429, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    with patch(
+        "litellm.integrations.prometheus.PrometheusLogger.get_instance",
+        side_effect=RuntimeError("metrics down"),
+    ):
+        await InFlightRequestsMiddleware(app)({"type": "http"}, receive, send)
+
+    assert [m["type"] for m in sent] == ["http.response.start", "http.response.body"]
+    assert sent[0]["status"] == 429
+

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -4956,6 +4956,93 @@ class TestPreCallWithFallbacksOnLocalRateLimit:
         assert call_count == 2
 
     @pytest.mark.asyncio
+    async def test_a_recovered_rate_limit_does_not_leave_the_request_marked_as_shed(self):
+        """The mark is set when the error is constructed, so a rejection that is
+        recovered from by falling back would otherwise stay marked and make a
+        provider 429 on the fallback count as this pod shedding load."""
+        from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+        from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
+        from litellm.proxy.common_utils.request_pressure_metrics import (
+            clear_request_shed_marker,
+            was_request_shed_by_proxy,
+        )
+
+        clear_request_shed_marker()
+        processor = ProxyBaseLLMRequestProcessing(data={"model": "gpt-4"})
+        marked_during_fallback = []
+
+        async def mock_pre_call_logic(**kwargs):
+            if processor.data.get("model") == "gpt-4":
+                raise ProxyRateLimitError(detail="TPM limit exceeded for gpt-4")
+            marked_during_fallback.append(was_request_shed_by_proxy())
+            return processor.data, MagicMock()
+
+        mock_router = MagicMock()
+        mock_router.fallbacks = [{"gpt-4": ["gpt-3.5-turbo"]}]
+
+        with patch.object(processor, "common_processing_pre_call_logic", side_effect=mock_pre_call_logic):
+            await processor._pre_call_with_fallbacks(
+                request=MagicMock(),
+                general_settings={},
+                proxy_logging_obj=MagicMock(),
+                user_api_key_dict=MagicMock(router_settings=None),
+                version=None,
+                proxy_config=MagicMock(),
+                user_model=None,
+                user_temperature=None,
+                user_request_timeout=None,
+                user_max_tokens=None,
+                user_api_base=None,
+                model="gpt-4",
+                route_type="acompletion",
+                llm_router=mock_router,
+            )
+
+        assert marked_during_fallback == [False], "the fallback attempt must not inherit the recovered rejection's mark"
+        assert not was_request_shed_by_proxy()
+
+    @pytest.mark.asyncio
+    async def test_a_rejection_returned_to_the_client_stays_marked_as_shed(self):
+        """When every fallback is rate limited too, the original rejection is what
+        the client gets, so it must still count as this pod shedding."""
+        from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+        from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
+        from litellm.proxy.common_utils.request_pressure_metrics import (
+            clear_request_shed_marker,
+            was_request_shed_by_proxy,
+        )
+
+        clear_request_shed_marker()
+        processor = ProxyBaseLLMRequestProcessing(data={"model": "gpt-4"})
+
+        async def mock_pre_call_logic(**kwargs):
+            raise ProxyRateLimitError(detail="TPM limit exceeded")
+
+        mock_router = MagicMock()
+        mock_router.fallbacks = [{"gpt-4": ["gpt-3.5-turbo"]}]
+
+        with patch.object(processor, "common_processing_pre_call_logic", side_effect=mock_pre_call_logic):
+            with pytest.raises(ProxyRateLimitError):
+                await processor._pre_call_with_fallbacks(
+                    request=MagicMock(),
+                    general_settings={},
+                    proxy_logging_obj=MagicMock(),
+                    user_api_key_dict=MagicMock(router_settings=None),
+                    version=None,
+                    proxy_config=MagicMock(),
+                    user_model=None,
+                    user_temperature=None,
+                    user_request_timeout=None,
+                    user_max_tokens=None,
+                    user_api_base=None,
+                    model="gpt-4",
+                    route_type="acompletion",
+                    llm_router=mock_router,
+                )
+
+        assert was_request_shed_by_proxy()
+
+    @pytest.mark.asyncio
     async def test_raises_when_no_fallbacks_configured(self):
         from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
         from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing


### PR DESCRIPTION
## TLDR

Problem this solves:

- Operators could see how many requests were in flight on a pod but not how many the proxy was shedding, so there was no way to tell "throttle upstream" apart from "add pods"
- The configured concurrency ceiling was invisible, and worse, the setting most operators reach for is not enforced on a default install

How it solves it:

- Shed responses are counted at the ASGI layer, so no rejection path can be missed and the count is per worker for the same reason the in-flight gauge is
- The ceiling gauge reports what is actually in force, reporting unbounded rather than echoing a number no limiter applies

## User Flow

| Metric | Type | Labels | Meaning |
|---|---|---|---|
| `litellm_requests_shed_total` | Counter | `status` | Responses where the proxy declined to serve: 429 for a limit, 503 for the database being unavailable |
| `litellm_global_max_parallel_requests_limit` | Gauge | none | Concurrency ceiling actually applied on this worker; `+Inf` means nothing bounds it |

Together with the existing `litellm_in_flight_requests`, saturation reads as in-flight approaching the limit while the shed counter climbs. In-flight climbing while the limit stays `+Inf` says nothing is protecting the pod at all.

## Relevant issues

## Linear ticket

Refs LIT-5435

This covers the per-pod request pressure section. The database-pool section is #36607 and scheduled jobs is #36636, which this is stacked on, so this says Refs rather than Resolves.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Real proxy, real Postgres, real Gemini API, no mocks. `general_settings.global_max_parallel_requests: 3` in both legs.

### With the limiter that enforces it

```
$ curl -sSL localhost:20438/metrics -H "Authorization: Bearer sk-1234" | grep '^litellm_global_max_parallel_requests_limit'
litellm_global_max_parallel_requests_limit 3.0

$ seq 1 20 | xargs -P 20 -I{} curl -sS -o /dev/null -w "%{http_code}\n" localhost:20438/v1/chat/completions ... | sort | uniq -c
  11 200
   9 429

$ curl -sSL localhost:20438/metrics ... | grep '^litellm_requests_shed_total'
litellm_requests_shed_total{status="429"} 9.0
```

The shed count matches the rejections exactly.

### With the default limiter, same config

```
$ curl -sSL localhost:20438/metrics ... | grep '^litellm_global_max_parallel_requests_limit'
litellm_global_max_parallel_requests_limit +Inf

$ seq 1 20 | xargs -P 20 -I{} curl ... | sort | uniq -c
  20 200
```

Twenty concurrent requests against a configured limit of 3 all succeed, and the gauge says so.

Startup also names the reason:

```
global_max_parallel_requests=3 is set but the active rate limiter does not enforce it, so the limit
metric reports unbounded. Set LEGACY_MULTI_INSTANCE_RATE_LIMITING=true to enforce it
```

### Review follow-ups, all four cases re-verified on a live proxy

The ceiling gauge was published inside the database-gated startup branch, so a
DB-less prometheus proxy rendered `litellm_global_max_parallel_requests_limit 0.0`
while serving every request. Found by an adversarial pass over the stack and then
confirmed with curl before fixing.

```
# DB-less proxy, BEFORE
litellm_global_max_parallel_requests_limit 0.0
  20 concurrent -> 20 x 200          # serving everything while claiming a ceiling of zero

# DB-less proxy, AFTER
litellm_global_max_parallel_requests_limit +Inf
  20 concurrent -> 20 x 200          # gauge now agrees with reality
  litellm_requests_shed_total        # no series, correct: nothing was shed

# DB-backed + LEGACY_MULTI_INSTANCE_RATE_LIMITING=true, limit 3, AFTER
litellm_global_max_parallel_requests_limit 3.0
  20 concurrent -> 11 x 200, 9 x 429
litellm_requests_shed_total{status="429"} 9.0
```

The shed counter also counted upstream 429s. litellm forwards a provider rate
limit with the same status the proxy uses for its own, so a provider throttling
us was recorded as this pod shedding load, which inverts the throttle-or-scale
decision. Requests the proxy declines are now marked at `ProxyRateLimitError`,
the single class litellm raises for that, and only marked responses count. A
provider 429 with no marker is pinned by its own regression test.

The gauge is republished on `general_settings` reload; it previously went stale
for the life of the process.

## Type

🆕 New Feature

## Caveats (if any)

`global_max_parallel_requests` is only read by the v1 parallel-request limiter, which is off unless `LEGACY_MULTI_INSTANCE_RATE_LIMITING` is set. The default v3 limiter never looks at it. That gap is tracked separately as LIT-5460 and is not fixed here, because this PR is about observing pressure rather than enforcing it. The gauge is built so it cannot mislead in the meantime.

Reporting `+Inf` rather than leaving the gauge unset is deliberate. A registered Prometheus gauge always exposes a value, so declining to set it renders as `0`, which reads as "no requests allowed". This was caught on the live rig, where the first implementation published `litellm_global_max_parallel_requests_limit 0.0` for a proxy that was in fact serving every request.

500s are not counted as shed. A server error is the proxy failing rather than declining, and folding it in would blur the signal an operator uses to decide between throttling and scaling out.

The `status` label is a fixed two-value set, so it cannot grow.

## QA runbook

1. Start Postgres, then a proxy with `litellm_settings.callbacks: ["prometheus"]` and `general_settings.global_max_parallel_requests: 3`
2. `curl -sSL localhost:4000/metrics -H "Authorization: Bearer sk-1234" | grep global_max_parallel` and confirm it reports `+Inf`, since the default limiter does not enforce the setting
3. Fire 20 concurrent chat completions with `seq 1 20 | xargs -P 20 ...` and confirm all 20 return 200, matching the `+Inf`
4. Restart with `LEGACY_MULTI_INSTANCE_RATE_LIMITING=true`, confirm the gauge now reports `3.0`, re-run the burst, and confirm a mix of 200 and 429
5. `grep '^litellm_requests_shed_total'` and confirm the 429 count equals the number of rejected requests

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


### Review follow-ups

The shed mark leaked through fallback recovery. It is set when `ProxyRateLimitError` is constructed, which is the one point every raise site passes through, so a rejection that `_pre_call_with_fallbacks` catches and retries left the request marked, and a provider 429 on the fallback counted as this pod shedding. That is the conflation the mark exists to prevent, so it is now cleared before each fallback attempt.

503 left the counted set. Nothing ever marked a 503, so the entry was unreachable, and marking the paths that raise one would be wrong: both are fail-closed budget rejections raised when spend cannot be verified against Redis or the database, which means a dependency is unreachable rather than this pod being at capacity. The two call for opposite responses. The metric documentation now names only the status actually counted.

On the review point that deleting `global_max_parallel_requests` at runtime leaves the gauge stale, the stale value is genuinely still enforced, so the gauge is reporting the truth:

```
configured ceiling                 : 3
in-memory value after key deleted  : 3
value the request path enforces    : 3
```

`_update_general_settings` merges keys that are present and never clears ones that vanish, which is how it treats every setting it handles, `max_parallel_requests` included. `litellm_pre_call_utils` then reads `general_settings` per request and hands that value to the limiter. Publishing `+Inf` on deletion would understate a ceiling that is still applied to every request. Clearing absent keys is the real fix and belongs with that helper rather than here.


On the review point that other runtime configuration endpoints can change the enforced ceiling without republishing the gauge, only two functions mutate the module-level `general_settings` that the request path reads. `_update_general_settings` is one, and it publishes. The other is the UI-settings sync, which copies a fixed allowlist:

```
UI-settings writer allowlist: 8 keys
includes global_max_parallel_requests? False
```

The config endpoints build a local copy from the database row and write it back, so they change the stored value rather than the in-memory one, and the reload path that applies it is the publishing one. There is no path that changes the enforced ceiling in memory while leaving the gauge behind.


On the follow-up that the field update and delete endpoints mutate the in-memory settings, they do not. Both rebind `general_settings` to a local copy of the database row and upsert that back, with no `global` declaration, so the module dict the request path reads is untouched:

```
field UPDATE endpoint: update_config_general_settings()
   declares global: False | rebinds locally at: [15815, 15817]
   -> LOCAL COPY (module dict untouched)
field DELETE endpoint: delete_config_general_settings()
   declares global: False | rebinds locally at: [16396]
   -> LOCAL COPY (module dict untouched)
```

Scanning the whole repository rather than one file, every writer that does reach the module dict touches a different key: the UI settings sync copies a fixed eight-flag allowlist, and the rest set `allowed_ips`, `alerting`, `alert_types`, `alert_to_webhook_url`, `plugins`, `role_permissions`, `store_model_in_db` or `email_settings`. `_update_general_settings` remains the only writer that can change the enforced ceiling in memory, and it publishes the gauge on the next line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f4801f113fdeabed21cfff650c08a67560f66b43. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


