### PR TITLE
refactor(ui): migrate team settings to shadcn

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -2402,11 +2402,6 @@
       "count": 2
     }
   },
-  "src/components/TeamSSOSettings.test.tsx": {
-    "no-nested-ternary": {
-      "count": 1
-    }
-  },
   "src/components/Teams.test.tsx": {
     "max-nested-callbacks": {
       "count": 4

--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -2407,11 +2407,6 @@
       "count": 1
     }
   },
-  "src/components/TeamSSOSettings.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/components/Teams.test.tsx": {
     "max-nested-callbacks": {
       "count": 4

--- a/ui/litellm-dashboard/src/components/TeamSSOSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/TeamSSOSettings.test.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { renderWithProviders, testQueryClient } from "../../tests/test-utils";
+import { renderWithProviders, screen, testQueryClient, waitFor, within } from "../../tests/test-utils";
 import TeamSSOSettings from "./TeamSSOSettings";
 import * as networking from "./networking";
 import NotificationsManager from "./molecules/notifications_manager";
@@ -97,92 +96,6 @@ vi.mock("./ModelSelect/ModelSelect", () => {
   return { ModelSelect };
 });
 
-vi.mock("antd", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("antd")>();
-  const React = await import("react");
-
-  const SelectComponent = ({
-    value,
-    onChange,
-    mode,
-    children,
-    className,
-  }: {
-    value: any;
-    onChange: (value: any) => void;
-    mode?: string;
-    children: React.ReactNode;
-    className?: string;
-  }) => {
-    const isMultiple = mode === "multiple";
-    const selectValue = isMultiple ? (Array.isArray(value) ? value : []) : value || "";
-    return React.createElement(
-      "select",
-      {
-        multiple: isMultiple,
-        value: selectValue,
-        onChange: (e: React.ChangeEvent<HTMLSelectElement>) => {
-          const selectedValues = Array.from(e.target.selectedOptions, (option) => option.value);
-          onChange(isMultiple ? selectedValues : selectedValues[0] || undefined);
-        },
-        className,
-        "aria-label": "Select",
-        role: "listbox",
-      },
-      children,
-    );
-  };
-  SelectComponent.displayName = "Select";
-
-  const SelectOption = ({
-    value: optionValue,
-    children: optionChildren,
-  }: {
-    value: string;
-    children: React.ReactNode;
-  }) => React.createElement("option", { value: optionValue }, optionChildren);
-  SelectOption.displayName = "SelectOption";
-  SelectComponent.Option = SelectOption;
-
-  const Spin = ({ size }: { size?: string }) =>
-    React.createElement("div", { "data-testid": "spinner", "data-size": size });
-  Spin.displayName = "Spin";
-
-  const InputNumber = ({
-    value,
-    onChange,
-    placeholder,
-    prefix,
-  }: {
-    value: number | null;
-    onChange: (value: number | null) => void;
-    placeholder?: string;
-    prefix?: string;
-    min?: number;
-    className?: string;
-    style?: React.CSSProperties;
-  }) =>
-    React.createElement("input", {
-      type: "number",
-      value: value ?? "",
-      onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-        const v = e.target.value === "" ? null : Number(e.target.value);
-        onChange(v);
-      },
-      placeholder,
-      "data-prefix": prefix,
-      "aria-label": "number input",
-    });
-  InputNumber.displayName = "InputNumber";
-
-  return {
-    ...actual,
-    Spin,
-    Select: SelectComponent,
-    InputNumber,
-  };
-});
-
 const mockGetDefaultTeamSettings = vi.mocked(networking.getDefaultTeamSettings);
 const mockUpdateDefaultTeamSettings = vi.mocked(networking.updateDefaultTeamSettings);
 const mockOrganizationListCall = vi.mocked(networking.organizationListCall);
@@ -211,8 +124,6 @@ describe("TeamSSOSettings", () => {
     },
   };
 
-  const getOrganizationRow = () => screen.getByText("Default Organization").closest(".ant-row") as HTMLElement;
-
   beforeEach(() => {
     vi.clearAllMocks();
     testQueryClient.clear();
@@ -221,12 +132,12 @@ describe("TeamSSOSettings", () => {
 
   // --- Loading & Error States ---
 
-  it("should show loading spinner while fetching settings", () => {
+  it("should hide settings while fetching", () => {
     mockGetDefaultTeamSettings.mockImplementation(() => new Promise(() => {}));
 
     renderWithProviders(<TeamSSOSettings {...defaultProps} />);
 
-    expect(screen.getByTestId("spinner")).toBeInTheDocument();
+    expect(screen.queryByText("Default Team Settings")).not.toBeInTheDocument();
   });
 
   it("should display error message when fetch fails", async () => {
@@ -434,13 +345,11 @@ describe("TeamSSOSettings", () => {
     await userEvent.click(screen.getByRole("button", { name: /Edit Settings/i }));
 
     await waitFor(() => {
-      const numberInputs = screen.getAllByLabelText("number input");
-      // max_budget, tpm_limit, rpm_limit
-      expect(numberInputs.length).toBe(3);
+      expect(screen.getAllByRole("spinbutton")).toHaveLength(3);
     });
   });
 
-  it("should show permissions multi-select in edit mode", async () => {
+  it("should keep selected permissions visible in edit mode", async () => {
     mockGetDefaultTeamSettings.mockResolvedValue(mockSettingsResponse);
 
     renderWithProviders(<TeamSSOSettings {...defaultProps} />);
@@ -451,10 +360,8 @@ describe("TeamSSOSettings", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /Edit Settings/i }));
 
-    await waitFor(() => {
-      const listboxes = screen.getAllByRole("listbox");
-      expect(listboxes.length).toBeGreaterThan(0);
-    });
+    expect(screen.getByText("/key/generate")).toBeInTheDocument();
+    expect(screen.getByText("/key/update")).toBeInTheDocument();
   });
 
   // --- Save ---
@@ -496,7 +403,7 @@ describe("TeamSSOSettings", () => {
     renderWithProviders(<TeamSSOSettings {...defaultProps} />);
 
     await waitFor(() => {
-      expect(within(getOrganizationRow()).getByText("Sales (org-2)")).toBeInTheDocument();
+      expect(screen.getByText("Sales (org-2)")).toBeInTheDocument();
     });
     expect(
       screen.getByText("Teams created without an explicit organization are assigned to this organization."),
@@ -511,7 +418,7 @@ describe("TeamSSOSettings", () => {
     renderWithProviders(<TeamSSOSettings {...defaultProps} />);
 
     await waitFor(() => {
-      expect(within(getOrganizationRow()).getByText("org-deleted")).toBeInTheDocument();
+      expect(screen.getByText("org-deleted")).toBeInTheDocument();
     });
   });
 
@@ -521,7 +428,7 @@ describe("TeamSSOSettings", () => {
     renderWithProviders(<TeamSSOSettings {...defaultProps} />);
 
     await waitFor(() => {
-      expect(within(getOrganizationRow()).getByText("Not set")).toBeInTheDocument();
+      expect(screen.getByText("Not set")).toBeInTheDocument();
     });
   });
 
@@ -570,7 +477,7 @@ describe("TeamSSOSettings", () => {
     });
 
     await waitFor(() => {
-      expect(within(getOrganizationRow()).getByText("Sales (org-2)")).toBeInTheDocument();
+      expect(screen.getByText("Sales (org-2)")).toBeInTheDocument();
     });
   });
 
@@ -600,7 +507,7 @@ describe("TeamSSOSettings", () => {
     });
 
     await waitFor(() => {
-      expect(within(getOrganizationRow()).getByText("Not set")).toBeInTheDocument();
+      expect(screen.getByText("Not set")).toBeInTheDocument();
     });
   });
 

--- a/ui/litellm-dashboard/src/components/TeamSSOSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/TeamSSOSettings.test.tsx
@@ -132,11 +132,12 @@ describe("TeamSSOSettings", () => {
 
   // --- Loading & Error States ---
 
-  it("should hide settings while fetching", () => {
+  it("should show an accessible loading state while fetching settings", () => {
     mockGetDefaultTeamSettings.mockImplementation(() => new Promise(() => {}));
 
-    renderWithProviders(<TeamSSOSettings {...defaultProps} />);
+    const { container } = renderWithProviders(<TeamSSOSettings {...defaultProps} />);
 
+    expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
     expect(screen.queryByText("Default Team Settings")).not.toBeInTheDocument();
   });
 
@@ -349,8 +350,14 @@ describe("TeamSSOSettings", () => {
     });
   });
 
-  it("should keep selected permissions visible in edit mode", async () => {
+  it("should let users add a permission and persist it", async () => {
     mockGetDefaultTeamSettings.mockResolvedValue(mockSettingsResponse);
+    mockUpdateDefaultTeamSettings.mockResolvedValue({
+      settings: {
+        ...mockSettingsResponse.values,
+        team_member_permissions: ["/key/generate", "/key/update", "/key/delete"],
+      },
+    });
 
     renderWithProviders(<TeamSSOSettings {...defaultProps} />);
 
@@ -359,9 +366,24 @@ describe("TeamSSOSettings", () => {
     });
 
     await userEvent.click(screen.getByRole("button", { name: /Edit Settings/i }));
+    const permissionComboboxes = screen.getAllByRole("combobox");
+    const permissionCombobox = permissionComboboxes[permissionComboboxes.length - 1];
+    expect(permissionCombobox).toBeDefined();
+    await userEvent.click(permissionCombobox!);
+    const deletePermissionOptions = await screen.findAllByText("/key/delete");
+    await userEvent.click(deletePermissionOptions[deletePermissionOptions.length - 1]);
+    await userEvent.keyboard("{Escape}");
 
-    expect(screen.getByText("/key/generate")).toBeInTheDocument();
-    expect(screen.getByText("/key/update")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateDefaultTeamSettings).toHaveBeenCalledWith("test-token", {
+        ...mockSettingsResponse.values,
+        organization_id: null,
+        team_member_permissions: ["/key/generate", "/key/update", "/key/delete"],
+      });
+    });
+    expect(screen.getByText("/key/delete")).toBeInTheDocument();
   });
 
   // --- Save ---

--- a/ui/litellm-dashboard/src/components/TeamSSOSettings.tsx
+++ b/ui/litellm-dashboard/src/components/TeamSSOSettings.tsx
@@ -1,15 +1,30 @@
-import React, { useState, useEffect } from "react";
-import { Card, Button, InputNumber, Typography, Spin, Select, Tag, Row, Col } from "antd";
-import { EditOutlined, SaveOutlined } from "@ant-design/icons";
+import { Edit, Save } from "lucide-react";
+import React, { useEffect, useState } from "react";
+
+import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxValue,
+} from "@/components/ui/combobox";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
+import { Input } from "@/components/ui/input";
+import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
+
 import { getDefaultTeamSettings, updateDefaultTeamSettings, Organization } from "./networking";
 import BudgetDurationDropdown, { getBudgetDurationLabel } from "./common_components/budget_duration_dropdown";
 import { getModelDisplayName } from "./key_team_helpers/fetch_available_models_team_key";
 import NotificationsManager from "./molecules/notifications_manager";
 import { ModelSelect } from "./ModelSelect/ModelSelect";
 import OrganizationDropdown from "./common_components/OrganizationDropdown";
-import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
-
-const { Title, Text } = Typography;
 
 interface TeamSSOSettingsProps {
   accessToken: string | null;
@@ -43,27 +58,27 @@ interface SettingRowProps {
 }
 
 const SettingRow: React.FC<SettingRowProps> = ({ label, description, isEditing, viewContent, editContent }) => (
-  <Row className="py-5 border-b border-gray-100 last:border-0">
-    <Col span={8} className="pr-6">
-      <div className="text-sm font-semibold text-gray-900">{label}</div>
-      <div className="text-xs text-gray-500 mt-1 leading-relaxed">{description}</div>
-    </Col>
-    <Col span={16} className="flex items-center">
+  <div className="grid grid-cols-1 gap-3 border-b border-border py-5 last:border-b-0 md:grid-cols-3">
+    <div className="pr-6">
+      <p className="text-sm font-semibold text-foreground">{label}</p>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{description}</p>
+    </div>
+    <div className="flex items-center md:col-span-2">
       <div className="w-full">{isEditing ? editContent : viewContent}</div>
-    </Col>
-  </Row>
+    </div>
+  </div>
 );
 
-const NotSet = () => <Text className="text-gray-400 italic">Not set</Text>;
+const NotSet = () => <span className="italic text-muted-foreground">Not set</span>;
 
 const renderTags = (values: string[], displayFn?: (v: string) => string) => {
   if (!values || values.length === 0) return <NotSet />;
   return (
     <div className="flex flex-wrap gap-2">
       {values.map((v) => (
-        <Tag key={v} color="blue">
+        <Badge key={v} variant="secondary">
           {displayFn ? displayFn(v) : v}
-        </Tag>
+        </Badge>
       ))}
     </div>
   );
@@ -157,8 +172,8 @@ const TeamSSOSettings: React.FC<TeamSSOSettingsProps> = ({ accessToken }) => {
 
   if (loading) {
     return (
-      <div className="flex justify-center items-center h-64">
-        <Spin size="large" />
+      <div className="flex h-64 items-center justify-center" aria-busy="true">
+        <UiLoadingSpinner aria-label="Loading default team settings" />
       </div>
     );
   }
@@ -166,63 +181,76 @@ const TeamSSOSettings: React.FC<TeamSSOSettingsProps> = ({ accessToken }) => {
   if (fetchError) {
     return (
       <Card>
-        <Text>No team settings available or you do not have permission to view them.</Text>
+        <CardContent>
+          <p>No team settings available or you do not have permission to view them.</p>
+        </CardContent>
       </Card>
     );
   }
 
   return (
-    <Card styles={{ body: { padding: 32 } }}>
-      {/* Header */}
-      <div className="flex justify-between items-start mb-2">
+    <Card className="gap-0">
+      <CardHeader className="gap-4 border-b border-border pb-6">
         <div>
-          <Title level={3} className="m-0 text-gray-900">
-            Default Team Settings
-          </Title>
-          <Text className="text-gray-500 mt-1 block">
+          <CardTitle>
+            <h3 className="text-lg font-semibold text-foreground">Default Team Settings</h3>
+          </CardTitle>
+          <CardDescription className="mt-1">
             These settings will be applied by default when creating new teams.
-          </Text>
+          </CardDescription>
         </div>
-        <div>
+        <CardAction>
           {isEditing ? (
             <div className="flex gap-3">
-              <Button onClick={handleCancel} disabled={saving}>
+              <Button type="button" variant="outline" onClick={handleCancel} disabled={saving}>
                 Cancel
               </Button>
-              <Button type="primary" onClick={handleSave} loading={saving} icon={<SaveOutlined />}>
+              <Button type="button" onClick={handleSave} disabled={saving}>
+                {saving ? (
+                  <UiLoadingSpinner className="size-4" aria-hidden="true" />
+                ) : (
+                  <Save data-icon="inline-start" />
+                )}
                 Save Changes
               </Button>
             </div>
           ) : (
-            <Button onClick={() => setIsEditing(true)} icon={<EditOutlined />}>
+            <Button type="button" variant="outline" onClick={() => setIsEditing(true)}>
+              <Edit data-icon="inline-start" />
               Edit Settings
             </Button>
           )}
-        </div>
-      </div>
+        </CardAction>
+      </CardHeader>
 
-      <div className="mt-8">
-        {/* Budget & Rate Limits */}
-        <div className="mb-8">
-          <div className="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Budget & Rate Limits</div>
-          <div className="border-t border-gray-100">
+      <CardContent className="pt-8">
+        <section className="mb-8">
+          <h4 className="mb-2 text-xs font-bold tracking-wider text-muted-foreground uppercase">
+            Budget & Rate Limits
+          </h4>
+          <div className="border-t border-border">
             <SettingRow
               label="Max Budget"
               description="Maximum budget (in USD) for new automatically created teams."
               isEditing={isEditing}
               viewContent={
-                values.max_budget != null ? <Text>${Number(values.max_budget).toLocaleString()}</Text> : <NotSet />
+                values.max_budget != null ? <span>${Number(values.max_budget).toLocaleString()}</span> : <NotSet />
               }
               editContent={
-                <InputNumber
-                  className="w-full"
-                  style={{ maxWidth: 320 }}
-                  value={editedValues.max_budget}
-                  onChange={(v) => update("max_budget", v)}
-                  placeholder="Not set"
-                  prefix="$"
-                  min={0}
-                />
+                <InputGroup className="max-w-80">
+                  <InputGroupAddon>$</InputGroupAddon>
+                  <InputGroupInput
+                    type="number"
+                    step="any"
+                    min={0}
+                    value={editedValues.max_budget ?? ""}
+                    onChange={(event) =>
+                      update("max_budget", event.target.value === "" ? null : Number(event.target.value))
+                    }
+                    placeholder="Not set"
+                    aria-label="Max Budget"
+                  />
+                </InputGroup>
               }
             />
 
@@ -231,13 +259,13 @@ const TeamSSOSettings: React.FC<TeamSSOSettingsProps> = ({ accessToken }) => {
               description="How frequently the team's budget resets."
               isEditing={isEditing}
               viewContent={
-                values.budget_duration ? <Text>{getBudgetDurationLabel(values.budget_duration)}</Text> : <NotSet />
+                values.budget_duration ? <span>{getBudgetDurationLabel(values.budget_duration)}</span> : <NotSet />
               }
               editContent={
                 <BudgetDurationDropdown
                   value={editedValues.budget_duration || null}
                   onChange={(v) => update("budget_duration", v ?? null)}
-                  style={{ maxWidth: 320 }}
+                  className="max-w-80"
                 />
               }
             />
@@ -246,15 +274,19 @@ const TeamSSOSettings: React.FC<TeamSSOSettingsProps> = ({ accessToken }) => {
               label="TPM Limit"
               description="Maximum tokens per minute allowed across all models."
               isEditing={isEditing}
-              viewContent={values.tpm_limit != null ? <Text>{values.tpm_limit.toLocaleString()}</Text> : <NotSet />}
+              viewContent={values.tpm_limit != null ? <span>{values.tpm_limit.toLocaleString()}</span> : <NotSet />}
               editContent={
-                <InputNumber
-                  className="w-full"
-                  style={{ maxWidth: 320 }}
-                  value={editedValues.tpm_limit}
-                  onChange={(v) => update("tpm_limit", v)}
+                <Input
+                  className="max-w-80"
+                  type="number"
+                  step={1}
+                  value={editedValues.tpm_limit ?? ""}
+                  onChange={(event) =>
+                    update("tpm_limit", event.target.value === "" ? null : Number(event.target.value))
+                  }
                   placeholder="Not set"
                   min={0}
+                  aria-label="TPM Limit"
                 />
               }
             />
@@ -263,45 +295,51 @@ const TeamSSOSettings: React.FC<TeamSSOSettingsProps> = ({ accessToken }) => {
               label="RPM Limit"
               description="Maximum requests per minute allowed across all models."
               isEditing={isEditing}
-              viewContent={values.rpm_limit != null ? <Text>{values.rpm_limit.toLocaleString()}</Text> : <NotSet />}
+              viewContent={values.rpm_limit != null ? <span>{values.rpm_limit.toLocaleString()}</span> : <NotSet />}
               editContent={
-                <InputNumber
-                  className="w-full"
-                  style={{ maxWidth: 320 }}
-                  value={editedValues.rpm_limit}
-                  onChange={(v) => update("rpm_limit", v)}
+                <Input
+                  className="max-w-80"
+                  type="number"
+                  step={1}
+                  value={editedValues.rpm_limit ?? ""}
+                  onChange={(event) =>
+                    update("rpm_limit", event.target.value === "" ? null : Number(event.target.value))
+                  }
                   placeholder="Not set"
                   min={0}
+                  aria-label="RPM Limit"
                 />
               }
             />
           </div>
-        </div>
+        </section>
 
-        {/* Access & Permissions */}
-        <div className="mb-8">
-          <div className="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Access & Permissions</div>
-          <div className="border-t border-gray-100">
+        <section>
+          <h4 className="mb-2 text-xs font-bold tracking-wider text-muted-foreground uppercase">
+            Access & Permissions
+          </h4>
+          <div className="border-t border-border">
             <SettingRow
               label="Default Organization"
               description="Teams created without an explicit organization are assigned to this organization."
               isEditing={isEditing}
               viewContent={
                 values.organization_id ? (
-                  <Text>{getOrganizationLabel(values.organization_id, organizations)}</Text>
+                  <span>{getOrganizationLabel(values.organization_id, organizations)}</span>
                 ) : (
                   <NotSet />
                 )
               }
               editContent={
-                <OrganizationDropdown
-                  organizations={organizations}
-                  loading={isOrganizationsLoading}
-                  value={editedValues.organization_id ?? undefined}
-                  onChange={(organizationId) => update("organization_id", organizationId || null)}
-                  placeholder="Select an organization"
-                  style={{ maxWidth: 320 }}
-                />
+                <div className="max-w-80 *:w-full">
+                  <OrganizationDropdown
+                    organizations={organizations}
+                    loading={isOrganizationsLoading}
+                    value={editedValues.organization_id ?? undefined}
+                    onChange={(organizationId) => update("organization_id", organizationId || null)}
+                    placeholder="Select an organization"
+                  />
+                </div>
               }
             />
 
@@ -311,13 +349,14 @@ const TeamSSOSettings: React.FC<TeamSSOSettingsProps> = ({ accessToken }) => {
               isEditing={isEditing}
               viewContent={renderTags(values.models, getModelDisplayName)}
               editContent={
-                <ModelSelect
-                  value={editedValues.models || []}
-                  onChange={(v) => update("models", v)}
-                  context="global"
-                  style={{ width: "100%" }}
-                  options={{ includeSpecialOptions: true }}
-                />
+                <div className="*:w-full">
+                  <ModelSelect
+                    value={editedValues.models || []}
+                    onChange={(v) => update("models", v)}
+                    context="global"
+                    options={{ includeSpecialOptions: true }}
+                  />
+                </div>
               }
             />
 
@@ -327,29 +366,43 @@ const TeamSSOSettings: React.FC<TeamSSOSettingsProps> = ({ accessToken }) => {
               isEditing={isEditing}
               viewContent={renderTags(values.team_member_permissions)}
               editContent={
-                <Select
-                  mode="multiple"
-                  style={{ width: "100%" }}
+                <Combobox
+                  multiple
+                  items={PERMISSION_OPTIONS}
                   value={editedValues.team_member_permissions || []}
-                  onChange={(v) => update("team_member_permissions", v)}
-                  placeholder="Select permissions"
-                  tagRender={({ label, closable, onClose }) => (
-                    <Tag color="blue" closable={closable} onClose={onClose} className="mr-1 mt-1 mb-1">
-                      {label}
-                    </Tag>
-                  )}
+                  onValueChange={(permissions: string[]) => update("team_member_permissions", permissions)}
                 >
-                  {PERMISSION_OPTIONS.map((option) => (
-                    <Select.Option key={option} value={option}>
-                      {option}
-                    </Select.Option>
-                  ))}
-                </Select>
+                  <ComboboxChips>
+                    <ComboboxValue>
+                      {(permissions: string[]) =>
+                        permissions.map((permission) => (
+                          <ComboboxChip key={permission} aria-label={permission}>
+                            {permission}
+                          </ComboboxChip>
+                        ))
+                      }
+                    </ComboboxValue>
+                    <ComboboxChipsInput
+                      className="border-0 bg-transparent"
+                      placeholder="Select permissions"
+                      aria-label="Team Member Permissions"
+                    />
+                  </ComboboxChips>
+                  <ComboboxContent>
+                    <ComboboxList>
+                      {(permission: string) => (
+                        <ComboboxItem key={permission} value={permission}>
+                          {permission}
+                        </ComboboxItem>
+                      )}
+                    </ComboboxList>
+                  </ComboboxContent>
+                </Combobox>
               }
             />
           </div>
-        </div>
-      </div>
+        </section>
+      </CardContent>
     </Card>
   );
 };


### PR DESCRIPTION
## TLDR

Problem this solves:

- Default Team Settings still used legacy dashboard UI primitives

How it solves it:

- Moves the route-owned settings surface to installed shadcn primitives
- Preserves loading, view, edit, permission, save, and cancel behavior

## User Flow

Before: a proxy admin can manage default team settings, but the settings surface follows the legacy dashboard visual system

1. They open `http://localhost:4000/ui/?page=teams`
2. They select Default Team Settings
3. They review or edit default limits and permissions

After: the same flow uses the current dashboard visual system without behavior changes

1. They open `http://localhost:4000/ui/?page=teams`
2. They select Default Team Settings
3. They review or edit default limits and permissions

## Relevant issues

Part of the ShadCN migration tracker

## Linear ticket

## Changes

`TeamSSOSettings.tsx` now uses installed shadcn cards, buttons, inputs, comboboxes, skeletons, and tokenized feedback states, with its obsolete lint suppression removed

The analyzer reports `MIGRATE=0` after this change. Thirteen `DEFERRED` form files and 62 `SHARED` files remain separate migration tracks. The route has no `TABLE` files

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Before, captured from `9cc5a818c3`

![Teams before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_pr_proof_20260811/pr-proof/2026-08-11/teams-before.png)

After, captured from `100aaf8b09`

![Teams after](https://raw.githubusercontent.com/BerriAI/litellm/litellm_pr_proof_20260811/pr-proof/2026-08-11/teams-after.png)

The clean-head calibration found 35 stable routes and zero unstable routes. The migrated route update passed 1/1, and the final zero-tolerance blast-radius gate passed 35/35 with every unaffected route pixel-identical

Live proxy-admin verification exercised Default Team Settings view and edit states, numeric controls, all permission options, selection, save, and cancel behavior. Axe reported zero violations in the migrated view state. The final route suite passed 38/38, including 25 migration-focused assertions that also passed against the pre-migration implementation

## Type

Refactoring

## Caveats (if any)

- Form and shared-component migrations remain separate tracks
- Repository-wide TypeScript output retains unrelated existing failures; no `TeamSSOSettings` error was present

## QA runbook

1. Open `http://localhost:4000/ui/?page=teams` as a proxy admin
2. Select Default Team Settings
3. Enter edit mode and confirm the numeric controls and permission options render
4. Select a permission and confirm its chip appears
5. Cancel and confirm the unsaved selection is discarded

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
