### PR TITLE
refactor(ui): migrate users dashboard to shadcn

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1894,9 +1894,6 @@
     "local/filename-pascal-case": {
       "count": 1
     },
-    "no-restricted-imports": {
-      "count": 3
-    },
     "prefer-const": {
       "count": 1
     },

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.test.tsx
@@ -39,7 +39,15 @@ vi.mock("./view_users/user_info_view", () => ({
 
 vi.mock("./default-user-settings/DefaultUserSettingsForm", () => ({
   DefaultUserSettingsForm: function DefaultUserSettingsFormMock() {
-    return <section aria-label="Default user settings panel">Default settings content</section>;
+    const [value, setValue] = React.useState("");
+    return (
+      <section aria-label="Default user settings panel">
+        <label>
+          Default setting
+          <input value={value} onChange={(event) => setValue(event.target.value)} />
+        </label>
+      </section>
+    );
   },
 }));
 
@@ -128,11 +136,16 @@ describe("ViewUserDashboard", () => {
     expect(settingsTab).toHaveAttribute("aria-selected", "true");
     expect(usersTab).toHaveAttribute("aria-selected", "false");
     expect(screen.getByRole("region", { name: "Default user settings panel" })).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox", { name: "Default setting" }), "unsaved change");
 
     await user.click(usersTab);
 
     expect(usersTab).toHaveAttribute("aria-selected", "true");
     expect(settingsTab).toHaveAttribute("aria-selected", "false");
+
+    await user.click(settingsTab);
+
+    expect(screen.getByRole("textbox", { name: "Default setting" })).toHaveValue("unsaved change");
   });
 
   it("shows the users table without admin controls for non-proxy admins", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.test.tsx
@@ -37,6 +37,12 @@ vi.mock("./view_users/user_info_view", () => ({
   },
 }));
 
+vi.mock("./default-user-settings/DefaultUserSettingsForm", () => ({
+  DefaultUserSettingsForm: function DefaultUserSettingsFormMock() {
+    return <section aria-label="Default user settings panel">Default settings content</section>;
+  },
+}));
+
 // Mock NotificationsManager
 vi.mock("@/components/molecules/notifications_manager", () => ({
   default: {
@@ -78,10 +84,10 @@ const defaultProps = {
   teams: [],
 };
 
-const renderDashboard = () =>
+const renderDashboard = (overrides: Partial<typeof defaultProps> = {}) =>
   renderWithProviders(
     <QueryClientProvider client={createQueryClient()}>
-      <ViewUserDashboard {...defaultProps} />
+      <ViewUserDashboard {...defaultProps} {...overrides} />
     </QueryClientProvider>,
   );
 
@@ -105,6 +111,46 @@ describe("ViewUserDashboard", () => {
     });
 
     expect(screen.getAllByText("Default User Settings").length).toBeGreaterThan(0);
+  });
+
+  it("switches between the users table and default settings tabs for proxy admins", async () => {
+    const user = userEvent.setup();
+    renderDashboard();
+
+    expect(await screen.findByText("test@example.com")).toBeInTheDocument();
+
+    const usersTab = screen.getByRole("tab", { name: "Users" });
+    const settingsTab = screen.getByRole("tab", { name: "Default User Settings" });
+    expect(usersTab).toHaveAttribute("aria-selected", "true");
+
+    await user.click(settingsTab);
+
+    expect(settingsTab).toHaveAttribute("aria-selected", "true");
+    expect(usersTab).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByRole("region", { name: "Default user settings panel" })).toBeInTheDocument();
+
+    await user.click(usersTab);
+
+    expect(usersTab).toHaveAttribute("aria-selected", "true");
+    expect(settingsTab).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("shows the users table without admin controls for non-proxy admins", async () => {
+    renderDashboard({ userRole: "Internal User" });
+
+    expect(await screen.findByText("test@example.com")).toBeInTheDocument();
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("toggle-user-selection")).not.toBeInTheDocument();
+  });
+
+  it("keeps actions unavailable while the user list is loading", () => {
+    userListCall.mockReturnValue(new Promise(() => undefined));
+
+    renderDashboard();
+
+    expect(screen.getByText("Loading users…")).toBeInTheDocument();
+    expect(screen.queryByTestId("toggle-user-selection")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("bulk-edit-users")).not.toBeInTheDocument();
   });
 
   it("should show delete modal after choosing delete from the row actions menu", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.tsx
@@ -1,10 +1,11 @@
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@tremor/react";
 import { parseAsString, useQueryState } from "nuqs";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
-import { Button } from "antd";
 import BulkEditUserModal from "./BulkEditUsers";
 import { CreateUserButton } from "@/components/CreateUserButton";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import EditUserModal from "./edit_user";
 import {
   getPossibleUserRoles,
@@ -35,7 +36,6 @@ import { DefaultUserSettingsForm } from "./default-user-settings/DefaultUserSett
 import { UsersTable } from "./view_users/UsersTable";
 import UserInfoView from "./view_users/user_info_view";
 import { UserInfo } from "@/components/networking";
-import { Skeleton } from "antd";
 
 interface ViewUserDashboardProps {
   accessToken: string | null;
@@ -352,14 +352,14 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({
   );
 
   return (
-    <div className="w-full p-8 overflow-hidden">
-      <div className="flex items-center justify-between mb-4">
+    <div className="w-full overflow-hidden p-8">
+      <div className="mb-4 flex items-center justify-between">
         <div className="flex space-x-3">
           {userListQuery.isLoading && (
             <>
-              <Skeleton.Button active size="default" shape="default" style={{ width: 110, height: 36 }} />
-              <Skeleton.Button active size="default" shape="default" style={{ width: 145, height: 36 }} />
-              <Skeleton.Button active size="default" shape="default" style={{ width: 110, height: 36 }} />
+              <Skeleton className="h-9 w-28" />
+              <Skeleton className="h-9 w-36" />
+              <Skeleton className="h-9 w-28" />
             </>
           )}
           {!userListQuery.isLoading && userID && accessToken && (
@@ -375,9 +375,9 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({
 
               {isProxyAdmin && (
                 <Button
+                  type="button"
                   onClick={handleToggleSelectionMode}
-                  type={selectionMode ? "primary" : "default"}
-                  className="flex items-center"
+                  variant={selectionMode ? "default" : "outline"}
                   data-testid="toggle-user-selection"
                 >
                   {selectionMode ? "Cancel Selection" : "Select Users"}
@@ -386,10 +386,9 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({
 
               {isProxyAdmin && selectionMode && (
                 <Button
-                  type="primary"
+                  type="button"
                   onClick={() => setIsBulkEditModalVisible(true)}
                   disabled={selectedUsers.length === 0}
-                  className="flex items-center"
                   data-testid="bulk-edit-users"
                 >
                   Bulk Edit ({selectedUsers.length} selected)
@@ -401,26 +400,37 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({
       </div>
 
       {isProxyAdmin ? (
-        <TabGroup defaultIndex={0}>
-          <TabList className="mb-4">
-            <Tab>Users</Tab>
-            <Tab>Default User Settings</Tab>
-          </TabList>
+        <Tabs defaultValue="users" className="gap-0">
+          <TabsList variant="line" className="mb-4">
+            <TabsTrigger value="users" className="flex-none data-active:text-primary after:bg-primary">
+              Users
+            </TabsTrigger>
+            <TabsTrigger value="default-settings" className="flex-none data-active:text-primary after:bg-primary">
+              Default User Settings
+            </TabsTrigger>
+          </TabsList>
 
-          <TabPanels>
-            <TabPanel>{usersTable}</TabPanel>
+          <TabsContent value="users">{usersTable}</TabsContent>
 
-            <TabPanel>
-              {!userID || !userRole || !accessToken ? (
-                <div className="flex justify-center items-center h-64">
-                  <Skeleton active paragraph={{ rows: 4 }} />
+          <TabsContent value="default-settings">
+            {!userID || !userRole || !accessToken ? (
+              <div
+                className="flex h-64 items-center justify-center"
+                role="status"
+                aria-label="Loading default user settings"
+              >
+                <div className="w-full max-w-lg space-y-3">
+                  <Skeleton className="h-5 w-1/3" />
+                  <Skeleton className="h-5 w-full" />
+                  <Skeleton className="h-5 w-full" />
+                  <Skeleton className="h-5 w-2/3" />
                 </div>
-              ) : (
-                <DefaultUserSettingsForm possibleUIRoles={possibleUIRoles} />
-              )}
-            </TabPanel>
-          </TabPanels>
-        </TabGroup>
+              </div>
+            ) : (
+              <DefaultUserSettingsForm possibleUIRoles={possibleUIRoles} />
+            )}
+          </TabsContent>
+        </Tabs>
       ) : (
         usersTable
       )}

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.tsx
@@ -410,9 +410,11 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({
             </TabsTrigger>
           </TabsList>
 
-          <TabsContent value="users">{usersTable}</TabsContent>
+          <TabsContent value="users" keepMounted>
+            {usersTable}
+          </TabsContent>
 
-          <TabsContent value="default-settings">
+          <TabsContent value="default-settings" keepMounted>
             {!userID || !userRole || !accessToken ? (
               <div
                 className="flex h-64 items-center justify-center"


### PR DESCRIPTION
## TLDR

Problem this solves:

- The Internal Users route shell still used legacy dashboard UI primitives

How it solves it:

- Moves the form-free route shell to installed shadcn primitives
- Preserves proxy-admin tabs, table actions, loading, selection, and tab-panel state

## User Flow

Before: a proxy admin can manage internal users, but the route shell follows the legacy dashboard visual system

1. They open `http://localhost:4000/ui/?page=users`
2. They browse, select, edit, or delete users
3. They switch to Default User Settings when needed

After: the same flow uses the current dashboard visual system without behavior changes

1. They open `http://localhost:4000/ui/?page=users`
2. They browse, select, edit, or delete users
3. They switch to Default User Settings without losing unsaved tab state

## Relevant issues

Part of the ShadCN migration tracker

## Linear ticket

## Changes

`view_users.tsx` now uses installed shadcn buttons, skeletons, and tabs. Both tab panels remain mounted to preserve the legacy lifecycle and unsaved settings state. The obsolete lint suppression is removed

The analyzer reports `MIGRATE=0` after this change. One `TABLE` file, five `DEFERRED` form files, and 19 `SHARED` files remain separate migration tracks

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Before, captured from `9cc5a818c3`

![Users before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_pr_proof_20260811/pr-proof/2026-08-11/users-before.png)

After, captured from `f1fd4ee963`

![Users after](https://raw.githubusercontent.com/BerriAI/litellm/litellm_pr_proof_20260811/pr-proof/2026-08-11/users-after.png)

The clean-head calibration found 35 stable routes and zero unstable routes. The migrated route update passed 1/1, and the final zero-tolerance blast-radius gate passed 35/35 with every unaffected route pixel-identical

The Users route suite passed 136/136. A stateful tab round-trip test enters an unsaved Default User Settings value, switches away, returns, and verifies that the value remains

## Type

Refactoring

## Caveats (if any)

- Form, table, and shared-component migrations remain separate tracks
- Repository-wide ESLint retains an unrelated existing error in unchanged Models + Endpoints code; focused lint and staged `make check` pass

## QA runbook

1. Open `http://localhost:4000/ui/?page=users` as a proxy admin
2. Confirm the Users table and route actions render
3. Enable selection mode and select a user
4. Open Default User Settings and make an unsaved edit
5. Switch to Users and back, then confirm the unsaved edit remains

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
