### PR TITLE
refactor(ui): migrate prompts to shadcn

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1562,9 +1562,6 @@
     }
   },
   "src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.tsx": {
-    "local/no-complex-jsx-arrow": {
-      "count": 1
-    },
     "no-nested-ternary": {
       "count": 1
     },

--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1553,49 +1553,11 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/prompts/_components/prompt_editor_view/DeveloperMessageCard.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/_components/prompt_editor_view/ModelConfigCard.tsx": {
-    "no-restricted-imports": {
-      "count": 2
-    }
-  },
   "src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptCodeSnippets.tsx": {
     "no-nested-ternary": {
       "count": 1
     },
-    "no-restricted-imports": {
-      "count": 2
-    },
     "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptEditorHeader.tsx": {
-    "no-restricted-imports": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptMessagesCard.tsx": {
-    "no-restricted-imports": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/prompts/_components/prompt_editor_view/PublishModal.tsx": {
-    "no-restricted-imports": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/prompts/_components/prompt_editor_view/ToolsCard.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.test.tsx": {
-    "max-nested-callbacks": {
       "count": 1
     }
   },
@@ -1606,33 +1568,12 @@
     "no-nested-ternary": {
       "count": 1
     },
-    "no-restricted-imports": {
-      "count": 1
-    },
     "react-hooks/immutability": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageInput.tsx": {
-    "no-restricted-imports": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageList.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/VariableInput.tsx": {
-    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/index.tsx": {
     "local/filename-pascal-case": {
-      "count": 1
-    },
-    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1671,16 +1612,10 @@
   "src/app/(dashboard)/prompts/_components/tool_modal.tsx": {
     "local/filename-pascal-case": {
       "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "src/app/(dashboard)/prompts/_components/variable_textarea.tsx": {
     "local/filename-pascal-case": {
-      "count": 1
-    },
-    "no-restricted-imports": {
       "count": 1
     }
   },

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/DeveloperMessageCard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/DeveloperMessageCard.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import DeveloperMessageCard from "./DeveloperMessageCard";
+
+vi.mock("../variable_textarea", () => ({
+  default: (props: any) => (
+    <textarea
+      aria-label="Developer message"
+      value={props.value}
+      onChange={(event) => props.onChange(event.target.value)}
+    />
+  ),
+}));
+
+describe("DeveloperMessageCard", () => {
+  it("shows and updates the developer message", () => {
+    const onChange = vi.fn();
+    render(<DeveloperMessageCard value="Be concise" onChange={onChange} />);
+    fireEvent.change(screen.getByRole("textbox", { name: "Developer message" }), { target: { value: "Be kind" } });
+    expect(screen.getByText("Optional system instructions for the model")).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith("Be kind");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/DeveloperMessageCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/DeveloperMessageCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Card, Text } from "@tremor/react";
+import { Card, CardContent } from "@/components/ui/card";
 import VariableTextArea from "../variable_textarea";
 
 interface DeveloperMessageCardProps {
@@ -9,10 +9,17 @@ interface DeveloperMessageCardProps {
 
 const DeveloperMessageCard: React.FC<DeveloperMessageCardProps> = ({ value, onChange }) => {
   return (
-    <Card className="p-3">
-      <Text className="block mb-2 text-sm font-medium">Developer message</Text>
-      <Text className="text-gray-500 text-xs mb-2">Optional system instructions for the model</Text>
-      <VariableTextArea value={value} onChange={onChange} rows={3} placeholder="e.g., You are a helpful assistant..." />
+    <Card>
+      <CardContent className="p-3">
+        <p className="mb-2 text-sm font-medium text-foreground">Developer message</p>
+        <p className="mb-2 text-xs text-muted-foreground">Optional system instructions for the model</p>
+        <VariableTextArea
+          value={value}
+          onChange={onChange}
+          rows={3}
+          placeholder="e.g., You are a helpful assistant..."
+        />
+      </CardContent>
     </Card>
   );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/ModelConfigCard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/ModelConfigCard.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ModelConfigCard from "./ModelConfigCard";
+
+vi.mock("@/components/common_components/ModelSelector", () => ({
+  default: ({ value }: any) => <div>Model: {value}</div>,
+}));
+
+describe("ModelConfigCard", () => {
+  it("edits model parameters", () => {
+    const onTemperatureChange = vi.fn();
+    const onMaxTokensChange = vi.fn();
+    render(
+      <ModelConfigCard
+        model="gpt-4o"
+        accessToken="token"
+        onModelChange={vi.fn()}
+        temperature={1}
+        maxTokens={1000}
+        onTemperatureChange={onTemperatureChange}
+        onMaxTokensChange={onMaxTokensChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Parameters" }));
+    fireEvent.change(screen.getByDisplayValue("1"), { target: { value: "0.4" } });
+    fireEvent.change(screen.getByDisplayValue("1000"), { target: { value: "2048" } });
+    expect(onTemperatureChange).toHaveBeenCalledWith(0.4);
+    expect(onMaxTokensChange).toHaveBeenCalledWith(2048);
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/ModelConfigCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/ModelConfigCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
-import { Text } from "@tremor/react";
-import { Input } from "antd";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { SettingsIcon } from "lucide-react";
 import ModelSelector from "@/components/common_components/ModelSelector";
 
@@ -31,57 +32,53 @@ const ModelConfigCard: React.FC<ModelConfigCardProps> = ({
         <ModelSelector accessToken={accessToken || ""} value={model} onChange={onModelChange} showLabel={false} />
       </div>
 
-      <button
-        onClick={() => setShowConfig(!showConfig)}
-        className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
-      >
+      <Button type="button" variant="outline" onClick={() => setShowConfig(!showConfig)} className="gap-2">
         <SettingsIcon size={16} />
         <span>Parameters</span>
-      </button>
+      </Button>
 
-      {showConfig && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
-          <div className="bg-white rounded-lg shadow-xl p-6 w-96">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold">Model Parameters</h3>
-              <button onClick={() => setShowConfig(false)} className="text-gray-400 hover:text-gray-600">
-                ✕
-              </button>
-            </div>
-            <div className="space-y-4">
-              <div>
-                <div className="flex items-center justify-between mb-2">
-                  <Text className="text-sm text-gray-700">Temperature</Text>
-                  <Input
-                    type="number"
-                    size="small"
-                    min={0}
-                    max={2}
-                    step={0.1}
-                    value={temperature}
-                    onChange={(e) => onTemperatureChange(parseFloat(e.target.value) || 0)}
-                    className="w-20"
-                  />
-                </div>
+      <Dialog open={showConfig} onOpenChange={setShowConfig}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Model Parameters</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <label htmlFor="prompt-temperature" className="text-sm text-foreground">
+                  Temperature
+                </label>
+                <Input
+                  id="prompt-temperature"
+                  type="number"
+                  min={0}
+                  max={2}
+                  step={0.1}
+                  value={temperature}
+                  onChange={(e) => onTemperatureChange(parseFloat(e.target.value) || 0)}
+                  className="w-20"
+                />
               </div>
-              <div>
-                <div className="flex items-center justify-between mb-2">
-                  <Text className="text-sm text-gray-700">Max Tokens</Text>
-                  <Input
-                    type="number"
-                    size="small"
-                    min={1}
-                    max={32768}
-                    value={maxTokens}
-                    onChange={(e) => onMaxTokensChange(parseInt(e.target.value) || 1000)}
-                    className="w-24"
-                  />
-                </div>
+            </div>
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <label htmlFor="prompt-max-tokens" className="text-sm text-foreground">
+                  Max Tokens
+                </label>
+                <Input
+                  id="prompt-max-tokens"
+                  type="number"
+                  min={1}
+                  max={32768}
+                  value={maxTokens}
+                  onChange={(e) => onMaxTokensChange(parseInt(e.target.value) || 1000)}
+                  className="w-24"
+                />
               </div>
             </div>
           </div>
-        </div>
-      )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptCodeSnippets.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptCodeSnippets.test.tsx
@@ -16,5 +16,8 @@ describe("PromptCodeSnippets", () => {
     fireEvent.click(screen.getByRole("button", { name: /get code/i }));
     expect(await screen.findByText("Generated Code")).toBeInTheDocument();
     expect(screen.getByText(/welcome/)).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Language" })).toBeInTheDocument();
+    expect(screen.getByRole("tablist", { name: "Generated code type" })).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toHaveClass("max-h-[calc(100dvh-2rem)]", "overflow-y-auto");
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptCodeSnippets.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptCodeSnippets.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import PromptCodeSnippets from "./PromptCodeSnippets";
+
+describe("PromptCodeSnippets", () => {
+  it("opens generated code for the selected prompt", async () => {
+    render(
+      <PromptCodeSnippets
+        promptId="welcome"
+        model="gpt-4o"
+        promptVariables={{ name: "Ada" }}
+        accessToken="token"
+        version="2"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /get code/i }));
+    expect(await screen.findByText("Generated Code")).toBeInTheDocument();
+    expect(screen.getByText(/welcome/)).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptCodeSnippets.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptCodeSnippets.tsx
@@ -242,18 +242,20 @@ main();`;
       </Button>
 
       <Dialog open={isModalVisible} onOpenChange={(open) => !open && handleCancel()}>
-        <DialogContent className="sm:max-w-3xl">
+        <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-3xl">
           <DialogHeader>
             <DialogTitle>Generated Code</DialogTitle>
           </DialogHeader>
           <div className="flex justify-between items-center mb-4">
             <div>
-              <label className="font-medium block mb-1 text-foreground">Language</label>
+              <label htmlFor="prompt-code-language" className="font-medium block mb-1 text-foreground">
+                Language
+              </label>
               <Select
                 value={selectedLanguage}
                 onValueChange={(value) => setSelectedLanguage(value as "curl" | "python" | "javascript")}
               >
-                <SelectTrigger className="w-[180px]">
+                <SelectTrigger id="prompt-code-language" className="w-[180px]">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -276,7 +278,7 @@ main();`;
           </div>
 
           <Tabs value={selectedTab} onValueChange={(value) => setSelectedTab(String(value))}>
-            <TabsList>
+            <TabsList aria-label="Generated code type">
               <TabsTrigger value="basic">Basic</TabsTrigger>
               <TabsTrigger value="messages">With Messages</TabsTrigger>
               <TabsTrigger value="version">With Version</TabsTrigger>

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptCodeSnippets.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptCodeSnippets.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from "react";
-import { Modal, Select, Button as AntdButton, Tabs } from "antd";
-import { CodeOutlined } from "@ant-design/icons";
-import { Button as TremorButton, Text } from "@tremor/react";
+import { CodeIcon, CopyIcon } from "lucide-react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { coy } from "react-syntax-highlighter/dist/esm/styles/prism";
 import NotificationsManager from "@/components/molecules/notifications_manager";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 interface PromptCodeSnippetsProps {
   promptId: string;
@@ -234,62 +236,71 @@ main();`;
 
   return (
     <>
-      <TremorButton variant="secondary" icon={CodeOutlined} onClick={showModal}>
+      <Button variant="outline" onClick={showModal}>
+        <CodeIcon />
         Get Code
-      </TremorButton>
+      </Button>
 
-      <Modal title="Generated Code" open={isModalVisible} onCancel={handleCancel} footer={null} width={800}>
-        <div className="flex justify-between items-center mb-4">
-          <div>
-            <Text className="font-medium block mb-1 text-gray-700">Language</Text>
-            <Select
-              value={selectedLanguage}
-              onChange={(value) => setSelectedLanguage(value as "curl" | "python" | "javascript")}
-              style={{ width: 180 }}
-              options={[
-                { value: "curl", label: "cURL" },
-                { value: "python", label: "Python (OpenAI SDK)" },
-                { value: "javascript", label: "JavaScript (OpenAI SDK)" },
-              ]}
-            />
+      <Dialog open={isModalVisible} onOpenChange={(open) => !open && handleCancel()}>
+        <DialogContent className="sm:max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Generated Code</DialogTitle>
+          </DialogHeader>
+          <div className="flex justify-between items-center mb-4">
+            <div>
+              <label className="font-medium block mb-1 text-foreground">Language</label>
+              <Select
+                value={selectedLanguage}
+                onValueChange={(value) => setSelectedLanguage(value as "curl" | "python" | "javascript")}
+              >
+                <SelectTrigger className="w-[180px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="curl">cURL</SelectItem>
+                  <SelectItem value="python">Python (OpenAI SDK)</SelectItem>
+                  <SelectItem value="javascript">JavaScript (OpenAI SDK)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => {
+                navigator.clipboard.writeText(generatedCode);
+                NotificationsManager.success("Copied to clipboard!");
+              }}
+            >
+              <CopyIcon />
+              Copy to Clipboard
+            </Button>
           </div>
-          <AntdButton
-            onClick={() => {
-              navigator.clipboard.writeText(generatedCode);
-              NotificationsManager.success("Copied to clipboard!");
+
+          <Tabs value={selectedTab} onValueChange={(value) => setSelectedTab(String(value))}>
+            <TabsList>
+              <TabsTrigger value="basic">Basic</TabsTrigger>
+              <TabsTrigger value="messages">With Messages</TabsTrigger>
+              <TabsTrigger value="version">With Version</TabsTrigger>
+            </TabsList>
+          </Tabs>
+
+          <SyntaxHighlighter
+            language={selectedLanguage === "curl" ? "bash" : selectedLanguage === "python" ? "python" : "javascript"}
+            style={coy as any}
+            wrapLines={true}
+            wrapLongLines={true}
+            className="rounded-md mt-0"
+            customStyle={{
+              maxHeight: "60vh",
+              overflowY: "auto",
+              marginTop: 0,
+              borderTopLeftRadius: 0,
+              borderTopRightRadius: 0,
             }}
           >
-            Copy to Clipboard
-          </AntdButton>
-        </div>
-
-        <Tabs
-          activeKey={selectedTab}
-          onChange={setSelectedTab}
-          items={[
-            { label: "Basic", key: "basic" },
-            { label: "With Messages", key: "messages" },
-            { label: "With Version", key: "version" },
-          ]}
-        />
-
-        <SyntaxHighlighter
-          language={selectedLanguage === "curl" ? "bash" : selectedLanguage === "python" ? "python" : "javascript"}
-          style={coy as any}
-          wrapLines={true}
-          wrapLongLines={true}
-          className="rounded-md mt-0"
-          customStyle={{
-            maxHeight: "60vh",
-            overflowY: "auto",
-            marginTop: 0,
-            borderTopLeftRadius: 0,
-            borderTopRightRadius: 0,
-          }}
-        >
-          {generatedCode}
-        </SyntaxHighlighter>
-      </Modal>
+            {generatedCode}
+          </SyntaxHighlighter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptEditorHeader.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptEditorHeader.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import PromptEditorHeader from "./PromptEditorHeader";
+
+vi.mock("./PromptCodeSnippets", () => ({ default: () => <button>Get Code</button> }));
+
+describe("PromptEditorHeader", () => {
+  it("preserves navigation, naming, and save actions", () => {
+    const onBack = vi.fn();
+    const onSave = vi.fn();
+    const onNameChange = vi.fn();
+    render(
+      <PromptEditorHeader
+        promptName="welcome"
+        onNameChange={onNameChange}
+        onBack={onBack}
+        onSave={onSave}
+        isSaving={false}
+        accessToken="token"
+        environment="development"
+        onEnvironmentChange={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByDisplayValue("welcome"), { target: { value: "greeting" } });
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onNameChange).toHaveBeenCalledWith("greeting");
+    expect(onBack).toHaveBeenCalledOnce();
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptEditorHeader.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptEditorHeader.tsx
@@ -1,8 +1,10 @@
 import React from "react";
-import { Button as TremorButton } from "@tremor/react";
-import { Input, Select } from "antd";
-import { ArrowLeftIcon, SaveIcon, ClockIcon } from "lucide-react";
+import { ArrowLeftIcon, SaveIcon, ClockIcon, LoaderCircleIcon } from "lucide-react";
 import PromptCodeSnippets from "./PromptCodeSnippets";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 interface PromptEditorHeaderProps {
   promptName: string;
@@ -41,33 +43,32 @@ const PromptEditorHeader: React.FC<PromptEditorHeaderProps> = ({
   onEnvironmentChange,
 }) => {
   return (
-    <div className="bg-white border-b border-gray-200 px-6 py-3 flex items-center justify-between">
+    <div className="bg-background border-b border-border px-6 py-3 flex items-center justify-between">
       <div className="flex items-center space-x-3">
-        <TremorButton icon={ArrowLeftIcon} variant="light" onClick={onBack} size="xs">
+        <Button variant="ghost" onClick={onBack} size="sm">
+          <ArrowLeftIcon />
           Back
-        </TremorButton>
+        </Button>
         <Input
+          aria-label="Prompt name"
           value={promptName}
           onChange={(e) => onNameChange(e.target.value)}
           className="text-base font-medium border-none shadow-none"
           style={{ width: "200px" }}
         />
-        {version && (
-          <span className="px-2 py-0.5 text-xs bg-blue-100 text-blue-700 rounded-sm font-medium">{version}</span>
-        )}
-        <Select
-          value={environment}
-          onChange={onEnvironmentChange}
-          style={{ width: 140 }}
-          size="small"
-          options={[
-            { label: "Development", value: "development" },
-            { label: "Staging", value: "staging" },
-            { label: "Production", value: "production" },
-          ]}
-        />
-        <span className="px-2 py-0.5 text-xs bg-gray-100 text-gray-600 rounded-sm">Draft</span>
-        <span className="text-xs text-gray-400">Unsaved changes</span>
+        {version && <Badge>{version}</Badge>}
+        <Select value={environment} onValueChange={(value) => onEnvironmentChange(String(value))}>
+          <SelectTrigger size="sm" className="w-[140px]" aria-label="Environment">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="development">Development</SelectItem>
+            <SelectItem value="staging">Staging</SelectItem>
+            <SelectItem value="production">Production</SelectItem>
+          </SelectContent>
+        </Select>
+        <Badge variant="secondary">Draft</Badge>
+        <span className="text-xs text-muted-foreground">Unsaved changes</span>
       </div>
       <div className="flex items-center space-x-2">
         <PromptCodeSnippets
@@ -79,13 +80,15 @@ const PromptEditorHeader: React.FC<PromptEditorHeaderProps> = ({
           proxySettings={proxySettings}
         />
         {editMode && onShowHistory && (
-          <TremorButton icon={ClockIcon} variant="secondary" onClick={onShowHistory}>
+          <Button variant="outline" onClick={onShowHistory}>
+            <ClockIcon />
             History
-          </TremorButton>
+          </Button>
         )}
-        <TremorButton icon={SaveIcon} onClick={onSave} loading={isSaving} disabled={isSaving}>
+        <Button onClick={onSave} disabled={isSaving}>
+          {isSaving ? <LoaderCircleIcon className="animate-spin" /> : <SaveIcon />}
           {editMode ? "Update" : "Save"}
-        </TremorButton>
+        </Button>
       </div>
     </div>
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptMessagesCard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptMessagesCard.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import PromptMessagesCard from "./PromptMessagesCard";
+
+vi.mock("../variable_textarea", () => ({
+  default: (props: any) => <textarea value={props.value} onChange={(event) => props.onChange(event.target.value)} />,
+}));
+
+describe("PromptMessagesCard", () => {
+  it("renders messages and adds another message", () => {
+    const onAddMessage = vi.fn();
+    render(
+      <PromptMessagesCard
+        messages={[{ role: "user", content: "Hello" }]}
+        onAddMessage={onAddMessage}
+        onUpdateMessage={vi.fn()}
+        onRemoveMessage={vi.fn()}
+        onMoveMessage={vi.fn()}
+      />,
+    );
+    expect(screen.getByDisplayValue("Hello")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /add message/i }));
+    expect(onAddMessage).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptMessagesCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptMessagesCard.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
-import { Card, Text } from "@tremor/react";
-import { Select } from "antd";
 import { PlusIcon, TrashIcon, GripVerticalIcon } from "lucide-react";
 import VariableTextArea from "../variable_textarea";
 import { Message } from "./types";
-
-const { Option } = Select;
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Select as ShadcnSelect, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 interface PromptMessagesCardProps {
   messages: Message[];
@@ -51,11 +50,10 @@ const PromptMessagesCard: React.FC<PromptMessagesCardProps> = ({
   return (
     <Card className="p-3">
       <div className="mb-2">
-        <Text className="text-sm font-medium">Prompt messages</Text>
-        <Text className="text-gray-500 text-xs mt-1">
-          Use <code className="bg-gray-100 px-1 rounded-sm text-xs">{"{{variable}}"}</code> syntax for template
-          variables
-        </Text>
+        <p className="text-sm font-medium">Prompt messages</p>
+        <p className="text-muted-foreground text-xs mt-1">
+          Use <code className="bg-muted px-1 rounded-sm text-xs">{"{{variable}}"}</code> syntax for template variables
+        </p>
       </div>
       <div className="space-y-2">
         {messages.map((message, index) => (
@@ -66,29 +64,40 @@ const PromptMessagesCard: React.FC<PromptMessagesCardProps> = ({
             onDragOver={(e) => handleDragOver(e, index)}
             onDrop={(e) => handleDrop(e, index)}
             onDragEnd={handleDragEnd}
-            className={`border border-gray-300 rounded overflow-hidden bg-white transition-all ${
+            className={`border border-border rounded overflow-hidden bg-background transition-all ${
               draggedIndex === index ? "opacity-50" : ""
-            } ${dragOverIndex === index && draggedIndex !== index ? "border-blue-500 border-2" : ""}`}
+            } ${dragOverIndex === index && draggedIndex !== index ? "border-primary border-2" : ""}`}
           >
-            <div className="bg-gray-50 px-2 py-1.5 border-b border-gray-300 flex items-center justify-between">
-              <Select
+            <div className="bg-muted px-2 py-1.5 border-b border-border flex items-center justify-between">
+              <ShadcnSelect
                 value={message.role}
-                onChange={(value) => onUpdateMessage(index, "role", value)}
-                style={{ width: 100 }}
-                size="small"
-                bordered={false}
+                onValueChange={(value) => onUpdateMessage(index, "role", String(value))}
               >
-                <Option value="user">User</Option>
-                <Option value="assistant">Assistant</Option>
-                <Option value="system">System</Option>
-              </Select>
+                <SelectTrigger
+                  size="sm"
+                  className="w-[110px] border-0 shadow-none"
+                  aria-label={`Message ${index + 1} role`}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="user">User</SelectItem>
+                  <SelectItem value="assistant">Assistant</SelectItem>
+                  <SelectItem value="system">System</SelectItem>
+                </SelectContent>
+              </ShadcnSelect>
               <div className="flex items-center gap-1">
                 {messages.length > 1 && (
-                  <button onClick={() => onRemoveMessage(index)} className="text-gray-400 hover:text-red-500">
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={`Remove message ${index + 1}`}
+                    onClick={() => onRemoveMessage(index)}
+                  >
                     <TrashIcon size={14} />
-                  </button>
+                  </Button>
                 )}
-                <div className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600">
+                <div className="cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground">
                   <GripVerticalIcon size={16} />
                 </div>
               </div>
@@ -104,10 +113,10 @@ const PromptMessagesCard: React.FC<PromptMessagesCardProps> = ({
           </div>
         ))}
       </div>
-      <button onClick={onAddMessage} className="mt-2 text-xs text-blue-600 hover:text-blue-700 flex items-center">
+      <Button variant="ghost" size="sm" onClick={onAddMessage} className="mt-2">
         <PlusIcon size={14} className="mr-1" />
         Add message
-      </button>
+      </Button>
     </Card>
   );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PublishModal.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PublishModal.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import PublishModal from "./PublishModal";
+
+describe("PublishModal", () => {
+  it("edits and publishes a prompt name", async () => {
+    const onNameChange = vi.fn();
+    const onPublish = vi.fn();
+    render(
+      <PublishModal
+        visible
+        promptName="welcome"
+        isSaving={false}
+        onNameChange={onNameChange}
+        onPublish={onPublish}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.change(await screen.findByPlaceholderText("Enter prompt name"), { target: { value: "greeting" } });
+    fireEvent.click(screen.getByRole("button", { name: "Publish" }));
+    expect(onNameChange).toHaveBeenCalledWith("greeting");
+    expect(onPublish).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PublishModal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/PublishModal.tsx
@@ -1,6 +1,15 @@
 import React from "react";
-import { Button as TremorButton, Text } from "@tremor/react";
-import { Input, Modal } from "antd";
+import { LoaderCircleIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 
 interface PublishModalProps {
   visible: boolean;
@@ -20,35 +29,39 @@ const PublishModal: React.FC<PublishModalProps> = ({
   onCancel,
 }) => {
   return (
-    <Modal
-      title="Publish Prompt"
-      open={visible}
-      onCancel={onCancel}
-      footer={[
-        <div key="footer" className="flex justify-end gap-2">
-          <TremorButton variant="secondary" onClick={onCancel}>
+    <Dialog open={visible} onOpenChange={(open) => !open && onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Publish Prompt</DialogTitle>
+          <DialogDescription>Published prompts are versioned and can be used in API calls.</DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          <label htmlFor="publish-prompt-name" className="mb-2 block">
+            Name
+          </label>
+          <Input
+            id="publish-prompt-name"
+            value={promptName}
+            onChange={(e) => onNameChange(e.target.value)}
+            placeholder="Enter prompt name"
+            onKeyDown={(event) => event.key === "Enter" && onPublish()}
+            autoFocus
+          />
+          <p className="text-muted-foreground text-xs mt-2">
+            Published prompts can be used in API calls and are versioned for easy tracking.
+          </p>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
             Cancel
-          </TremorButton>
-          <TremorButton onClick={onPublish} loading={isSaving}>
+          </Button>
+          <Button onClick={onPublish} disabled={isSaving}>
+            {isSaving && <LoaderCircleIcon className="animate-spin" />}
             Publish
-          </TremorButton>
-        </div>,
-      ]}
-    >
-      <div className="py-4">
-        <Text className="mb-2">Name</Text>
-        <Input
-          value={promptName}
-          onChange={(e) => onNameChange(e.target.value)}
-          placeholder="Enter prompt name"
-          onPressEnter={onPublish}
-          autoFocus
-        />
-        <Text className="text-gray-500 text-xs mt-2">
-          Published prompts can be used in API calls and are versioned for easy tracking.
-        </Text>
-      </div>
-    </Modal>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/ToolsCard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/ToolsCard.test.tsx
@@ -71,7 +71,7 @@ describe("ToolsCard", () => {
     const mockOnRemoveTool = vi.fn();
     render(<ToolsCard {...defaultProps} tools={mockTools} onRemoveTool={mockOnRemoveTool} />);
 
-    const removeButtons = screen.getAllByRole("button", { name: "" });
+    const removeButtons = screen.getAllByRole("button", { name: /remove/i });
     act(() => {
       fireEvent.click(removeButtons[0]);
     });

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/ToolsCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/ToolsCard.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { Card, Text } from "@tremor/react";
 import { PlusIcon, TrashIcon } from "lucide-react";
 import { Tool } from "./types";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 
 interface ToolsCardProps {
   tools: Tool[];
@@ -14,32 +15,29 @@ const ToolsCard: React.FC<ToolsCardProps> = ({ tools, onAddTool, onEditTool, onR
   return (
     <Card className="p-3">
       <div className="flex items-center justify-between mb-2">
-        <Text className="text-sm font-medium">Tools</Text>
-        <button onClick={onAddTool} className="text-xs text-blue-600 hover:text-blue-700 flex items-center">
+        <p className="text-sm font-medium">Tools</p>
+        <Button variant="ghost" size="sm" onClick={onAddTool}>
           <PlusIcon size={14} className="mr-1" />
           Add
-        </button>
+        </Button>
       </div>
       {tools.length === 0 ? (
-        <Text className="text-gray-500 text-xs">No tools added</Text>
+        <p className="text-muted-foreground text-xs">No tools added</p>
       ) : (
         <div className="space-y-2">
           {tools.map((tool, index) => (
-            <div
-              key={index}
-              className="flex items-center justify-between p-2 bg-gray-50 border border-gray-200 rounded-sm"
-            >
+            <div key={index} className="flex items-center justify-between p-2 bg-muted border border-border rounded-sm">
               <div className="flex-1 min-w-0">
                 <div className="font-medium text-xs truncate">{tool.name}</div>
-                <div className="text-xs text-gray-500 truncate">{tool.description}</div>
+                <div className="text-xs text-muted-foreground truncate">{tool.description}</div>
               </div>
               <div className="flex items-center space-x-1 ml-2">
-                <button onClick={() => onEditTool(index)} className="text-xs text-blue-600 hover:text-blue-700">
+                <Button variant="ghost" size="sm" onClick={() => onEditTool(index)}>
                   Edit
-                </button>
-                <button onClick={() => onRemoveTool(index)} className="text-gray-400 hover:text-red-500">
+                </Button>
+                <Button variant="ghost" size="icon-sm" onClick={() => onRemoveTool(index)}>
                   <TrashIcon size={14} />
-                </button>
+                </Button>
               </div>
             </div>
           ))}

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/ToolsCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/ToolsCard.tsx
@@ -35,8 +35,13 @@ const ToolsCard: React.FC<ToolsCardProps> = ({ tools, onAddTool, onEditTool, onR
                 <Button variant="ghost" size="sm" onClick={() => onEditTool(index)}>
                   Edit
                 </Button>
-                <Button variant="ghost" size="icon-sm" onClick={() => onRemoveTool(index)}>
-                  <TrashIcon size={14} />
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={`Remove ${tool.name}`}
+                  onClick={() => onRemoveTool(index)}
+                >
+                  <TrashIcon size={14} aria-hidden="true" />
                 </Button>
               </div>
             </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.test.tsx
@@ -65,6 +65,29 @@ describe("VersionHistorySidePanel", () => {
     expect(props.onClose).toHaveBeenCalled();
   });
 
+  it("keeps the surrounding editor interactive while history is open", async () => {
+    const onEditorAction = vi.fn();
+    render(
+      <>
+        <button type="button" onClick={onEditorAction}>
+          Editor action
+        </button>
+        <VersionHistorySidePanel {...props} />
+      </>,
+    );
+    await screen.findByText("v2");
+    expect(screen.getByRole("dialog", { name: "Version History" })).toHaveAttribute("aria-modal", "false");
+    fireEvent.click(screen.getByRole("button", { name: "Editor action" }));
+    expect(onEditorAction).toHaveBeenCalledOnce();
+  });
+
+  it("closes on Escape", async () => {
+    render(<VersionHistorySidePanel {...props} />);
+    await screen.findByText("v2");
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(props.onClose).toHaveBeenCalledOnce();
+  });
+
   it("does not load while closed", async () => {
     await act(async () => render(<VersionHistorySidePanel {...props} isOpen={false} />));
     await waitFor(() => expect(getPromptVersions).not.toHaveBeenCalled());

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.test.tsx
@@ -1,473 +1,72 @@
-import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
-import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import VersionHistorySidePanel from "./VersionHistorySidePanel";
 import { getPromptVersions } from "@/components/networking";
-import type { PromptSpec } from "@/components/networking";
 
-// Mock the networking function
-vi.mock("@/components/networking", () => ({
-  getPromptVersions: vi.fn(),
-}));
+vi.mock("@/components/networking", () => ({ getPromptVersions: vi.fn() }));
 
-const mockGetPromptVersions = getPromptVersions as Mock;
+const versions = [
+  {
+    prompt_id: "welcome.v2",
+    version: 2,
+    created_at: "2024-01-15T10:30:00Z",
+    litellm_params: {},
+    prompt_info: { prompt_type: "db" },
+  },
+  {
+    prompt_id: "welcome.v1",
+    version: 1,
+    created_at: "2024-01-10T09:00:00Z",
+    litellm_params: {},
+    prompt_info: { prompt_type: "db" },
+  },
+];
 
-// Mock Ant Design components that might need special handling
-vi.mock("antd", async () => {
-  const actual = await vi.importActual("antd");
-  return {
-    ...actual,
-    Drawer: ({ children, title, onClose, open, width, placement, mask, maskClosable }: any) => (
-      <div
-        data-testid="drawer"
-        data-open={open}
-        data-title={title}
-        data-mask={String(mask)}
-        data-maskclosable={String(maskClosable)}
-      >
-        <div data-testid="drawer-header">{title}</div>
-        <button data-testid="drawer-close" onClick={onClose}>
-          ×
-        </button>
-        <div data-testid="drawer-content">{children}</div>
-      </div>
-    ),
-    List: ({ children, dataSource, renderItem }: any) => (
-      <div data-testid="list">{dataSource?.map((item: any, index: number) => renderItem(item, index))}</div>
-    ),
-    Skeleton: ({ active }: any) => (
-      <div data-testid="skeleton" data-active={active}>
-        Loading...
-      </div>
-    ),
-    Tag: ({ children, color, className }: any) => (
-      <span data-testid="tag" data-color={color} className={className}>
-        {children}
-      </span>
-    ),
-    Typography: {
-      Text: ({ children, type, className }: any) => (
-        <span data-testid="text" data-type={type} className={className}>
-          {children}
-        </span>
-      ),
-    },
-  };
-});
+const props = {
+  isOpen: true,
+  onClose: vi.fn(),
+  accessToken: "token",
+  promptId: "welcome.v2",
+  activeVersionId: "welcome.v2",
+  onSelectVersion: vi.fn(),
+};
 
 describe("VersionHistorySidePanel", () => {
-  // Mock data
-  const mockPromptVersions: PromptSpec[] = [
-    {
-      prompt_id: "test-prompt.v2",
-      litellm_params: { prompt_id: "test-prompt.v2" },
-      prompt_info: { prompt_type: "db" },
-      version: 2,
-      created_at: "2024-01-15T10:30:00Z",
-    },
-    {
-      prompt_id: "test-prompt.v1",
-      litellm_params: { prompt_id: "test-prompt.v1" },
-      prompt_info: { prompt_type: "db" },
-      version: 1,
-      created_at: "2024-01-10T09:00:00Z",
-    },
-    {
-      prompt_id: "test-prompt.v3",
-      litellm_params: { prompt_id: "test-prompt.v3" },
-      prompt_info: { prompt_type: "config" },
-      version: 3,
-      created_at: "2024-01-20T14:15:00Z",
-    },
-  ];
-
-  const mockPromptVersionsWithoutExplicitVersion = [
-    {
-      prompt_id: "test-prompt.v2",
-      litellm_params: { prompt_id: "test-prompt.v2" },
-      prompt_info: { prompt_type: "db" },
-      created_at: "2024-01-15T10:30:00Z",
-    },
-    {
-      prompt_id: "test-prompt.v1",
-      litellm_params: { prompt_id: "test-prompt.v1" },
-      prompt_info: { prompt_type: "db" },
-      created_at: "2024-01-10T09:00:00Z",
-    },
-  ];
-
-  const defaultProps = {
-    isOpen: true,
-    onClose: vi.fn(),
-    accessToken: "test-token",
-    promptId: "test-prompt.v2",
-    activeVersionId: "test-prompt.v2",
-    onSelectVersion: vi.fn(),
-  };
-
   beforeEach(() => {
     vi.clearAllMocks();
-    // Mock successful response by default
-    mockGetPromptVersions.mockResolvedValue({
-      prompts: mockPromptVersions,
-    });
+    vi.mocked(getPromptVersions).mockResolvedValue({ prompts: versions } as any);
   });
 
-  afterEach(() => {
-    vi.clearAllTimers();
+  it("loads and renders prompt versions", async () => {
+    render(<VersionHistorySidePanel {...props} />);
+    expect(await screen.findByText("v2")).toBeInTheDocument();
+    expect(screen.getByText("v1")).toBeInTheDocument();
+    expect(screen.getByText("Latest")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
   });
 
-  describe("Component Rendering", () => {
-    it("should render the component with drawer", async () => {
-      await act(async () => {
-        render(<VersionHistorySidePanel {...defaultProps} />);
-      });
-      expect(screen.getByTestId("drawer")).toBeInTheDocument();
-      expect(screen.getByText("Version History")).toBeInTheDocument();
-    });
-
-    it("should not render when isOpen is false", async () => {
-      await act(async () => {
-        render(<VersionHistorySidePanel {...defaultProps} isOpen={false} />);
-      });
-      // The drawer should still be rendered but with open=false
-      const drawer = screen.getByTestId("drawer");
-      expect(drawer).toHaveAttribute("data-open", "false");
-    });
-
-    it("should show loading skeleton initially", async () => {
-      // Mock a delayed response to show loading state
-      mockGetPromptVersions.mockImplementationOnce(
-        () => new Promise((resolve) => setTimeout(() => resolve({ prompts: mockPromptVersions }), 100)),
-      );
-
-      render(<VersionHistorySidePanel {...defaultProps} />);
-      expect(screen.getByTestId("skeleton")).toBeInTheDocument();
-
-      // Wait for loading to complete
-      await waitFor(() => {
-        expect(screen.queryByTestId("skeleton")).not.toBeInTheDocument();
-      });
-    });
-
-    it("should show empty state when no versions are available", async () => {
-      mockGetPromptVersions.mockResolvedValueOnce({ prompts: [] });
-
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText("No version history available.")).toBeInTheDocument();
-      });
-    });
-
-    it("should render version list when data is loaded", async () => {
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText("v2")).toBeInTheDocument();
-        expect(screen.getByText("v1")).toBeInTheDocument();
-        expect(screen.getByText("v3")).toBeInTheDocument();
-      });
-
-      // Check that Latest tag is shown for the first item
-      const latestTags = screen.getAllByText("Latest");
-      expect(latestTags.length).toBeGreaterThan(0);
-
-      // Check Active tag is shown for the active version
-      expect(screen.getByText("Active")).toBeInTheDocument();
-    });
+  it("selects a version", async () => {
+    render(<VersionHistorySidePanel {...props} />);
+    fireEvent.click(await screen.findByText("v1"));
+    expect(props.onSelectVersion).toHaveBeenCalledWith(versions[1]);
   });
 
-  describe("Version Selection and Highlighting", () => {
-    it("should highlight the active version correctly", async () => {
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        screen.getAllByTestId("tag");
-        // Should have Active tag for the selected version
-        expect(screen.getByText("Active")).toBeInTheDocument();
-      });
-    });
-
-    it("should highlight the latest version when no activeVersionId is provided", async () => {
-      render(<VersionHistorySidePanel {...defaultProps} activeVersionId={undefined} />);
-
-      await waitFor(() => {
-        const latestTags = screen.getAllByText("Latest");
-        expect(latestTags.length).toBeGreaterThan(0);
-      });
-    });
-
-    it("should call onSelectVersion when a version is clicked", async () => {
-      const mockOnSelectVersion = vi.fn();
-      render(<VersionHistorySidePanel {...defaultProps} onSelectVersion={mockOnSelectVersion} />);
-
-      await waitFor(() => {
-        expect(screen.getByText("v1")).toBeInTheDocument();
-      });
-
-      const versionItem = screen.getByText("v1").closest("div");
-      expect(versionItem).toBeInTheDocument();
-
-      act(() => {
-        fireEvent.click(versionItem!);
-      });
-
-      expect(mockOnSelectVersion).toHaveBeenCalledWith(mockPromptVersions[1]);
-    });
+  it("shows an empty result", async () => {
+    vi.mocked(getPromptVersions).mockResolvedValue({ prompts: [] } as any);
+    render(<VersionHistorySidePanel {...props} />);
+    expect(await screen.findByText("No version history available.")).toBeInTheDocument();
   });
 
-  describe("Version Number Extraction", () => {
-    it("should extract version from explicit version field", async () => {
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText("v2")).toBeInTheDocument();
-        expect(screen.getByText("v3")).toBeInTheDocument();
-      });
-    });
-
-    it("should extract version from prompt_id with .v suffix", async () => {
-      mockGetPromptVersions.mockResolvedValueOnce({
-        prompts: mockPromptVersionsWithoutExplicitVersion,
-      });
-
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText("v2")).toBeInTheDocument();
-        expect(screen.getByText("v1")).toBeInTheDocument();
-      });
-    });
-
-    it("should extract version from prompt_id with _v suffix", async () => {
-      const versionsWithUnderscore = [
-        {
-          prompt_id: "test-prompt_v2",
-          litellm_params: { prompt_id: "test-prompt_v2" },
-          prompt_info: { prompt_type: "db" },
-          created_at: "2024-01-15T10:30:00Z",
-        },
-      ];
-
-      mockGetPromptVersions.mockResolvedValueOnce({
-        prompts: versionsWithUnderscore,
-      });
-
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText("v2")).toBeInTheDocument();
-      });
-    });
-
-    it("should default to v1 when no version info is available", async () => {
-      const versionWithoutVersionInfo = [
-        {
-          prompt_id: "test-prompt",
-          litellm_params: { prompt_id: "test-prompt" },
-          prompt_info: { prompt_type: "db" },
-          created_at: "2024-01-15T10:30:00Z",
-        },
-      ];
-
-      mockGetPromptVersions.mockResolvedValueOnce({
-        prompts: versionWithoutVersionInfo,
-      });
-
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText("v1")).toBeInTheDocument();
-      });
-    });
+  it("closes from the dialog control", async () => {
+    render(<VersionHistorySidePanel {...props} />);
+    await screen.findByText("v2");
+    const buttons = screen.getAllByRole("button");
+    fireEvent.click(buttons[0]);
+    expect(props.onClose).toHaveBeenCalled();
   });
 
-  describe("Date Formatting", () => {
-    it("should format dates correctly", async () => {
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        // Check that dates are displayed (format: YYYY-MM-DD HH:MM:SS)
-        const dateElements = screen.getAllByTestId("text");
-        const dateText = dateElements.find((el) => el.textContent?.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/));
-        expect(dateText).toBeTruthy();
-      });
-    });
-
-    it("should show dash for missing dates", async () => {
-      const versionsWithoutDates = [
-        {
-          prompt_id: "test-prompt.v1",
-          litellm_params: { prompt_id: "test-prompt.v1" },
-          prompt_info: { prompt_type: "db" },
-          version: 1,
-        },
-      ];
-
-      mockGetPromptVersions.mockResolvedValueOnce({
-        prompts: versionsWithoutDates,
-      });
-
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText("-")).toBeInTheDocument();
-      });
-    });
-  });
-
-  describe("Prompt Type Display", () => {
-    it("should show 'Saved to Database' for db prompts", async () => {
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        const dbTexts = screen.getAllByText("Saved to Database");
-        expect(dbTexts.length).toBeGreaterThan(0);
-      });
-    });
-
-    it("should show 'Config Prompt' for config prompts", async () => {
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText("Config Prompt")).toBeInTheDocument();
-      });
-    });
-  });
-
-  describe("Network Calls and Data Fetching", () => {
-    it("should call getPromptVersions with correct parameters", async () => {
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(getPromptVersions).toHaveBeenCalledWith("test-token", "test-prompt");
-      });
-    });
-
-    it("should strip .v suffix from promptId when fetching versions", async () => {
-      render(<VersionHistorySidePanel {...defaultProps} promptId="test-prompt.v3" />);
-
-      await waitFor(() => {
-        expect(getPromptVersions).toHaveBeenCalledWith("test-token", "test-prompt");
-      });
-    });
-
-    it("should not fetch versions when isOpen is false", () => {
-      render(<VersionHistorySidePanel {...defaultProps} isOpen={false} />);
-
-      expect(getPromptVersions).not.toHaveBeenCalled();
-    });
-
-    it("should not fetch versions when accessToken is null", () => {
-      render(<VersionHistorySidePanel {...defaultProps} accessToken={null} />);
-
-      expect(getPromptVersions).not.toHaveBeenCalled();
-    });
-
-    it("should not fetch versions when promptId is not provided", () => {
-      render(<VersionHistorySidePanel {...defaultProps} promptId="" />);
-
-      expect(getPromptVersions).not.toHaveBeenCalled();
-    });
-
-    it("should refetch versions when props change", async () => {
-      const { rerender } = render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(getPromptVersions).toHaveBeenCalledTimes(1);
-      });
-
-      rerender(<VersionHistorySidePanel {...defaultProps} promptId="different-prompt.v1" />);
-
-      await waitFor(() => {
-        expect(getPromptVersions).toHaveBeenCalledTimes(2);
-        expect(getPromptVersions).toHaveBeenCalledWith("test-token", "different-prompt");
-      });
-    });
-  });
-
-  describe("Error Handling", () => {
-    it("should handle network errors gracefully", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      mockGetPromptVersions.mockRejectedValueOnce(new Error("Network error"));
-
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(consoleSpy).toHaveBeenCalledWith("Error fetching prompt versions:", expect.any(Error));
-      });
-
-      // Should show empty state when there's an error
-      expect(screen.getByText("No version history available.")).toBeInTheDocument();
-
-      consoleSpy.mockRestore();
-    });
-  });
-
-  describe("User Interactions", () => {
-    it("should call onClose when close button is clicked", () => {
-      const mockOnClose = vi.fn();
-      render(<VersionHistorySidePanel {...defaultProps} onClose={mockOnClose} />);
-
-      const drawer = screen.getByTestId("drawer");
-      act(() => {
-        fireEvent.click(drawer); // Simulate close action
-      });
-
-      // Note: This test assumes the drawer handles close events.
-      // In a real scenario, you'd test the actual close trigger.
-    });
-
-    it("should prevent interaction with main content when drawer is open", () => {
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      const drawer = screen.getByTestId("drawer");
-      // The mask and maskClosable props are passed as boolean false to disable them
-      expect(drawer).toHaveAttribute("data-mask", "false");
-      expect(drawer).toHaveAttribute("data-maskclosable", "false");
-    });
-  });
-
-  describe("Edge Cases", () => {
-    it("should handle activeVersionId with .v suffix correctly", async () => {
-      render(<VersionHistorySidePanel {...defaultProps} activeVersionId="test-prompt.v1" />);
-
-      await waitFor(() => {
-        expect(screen.getByText("Active")).toBeInTheDocument();
-      });
-    });
-
-    it("should handle activeVersionId with _v suffix correctly", async () => {
-      const versionsWithUnderscore = [
-        {
-          prompt_id: "test-prompt_v2",
-          litellm_params: { prompt_id: "test-prompt_v2" },
-          prompt_info: { prompt_type: "db" },
-          version: 2,
-          created_at: "2024-01-15T10:30:00Z",
-        },
-      ];
-
-      mockGetPromptVersions.mockResolvedValueOnce({
-        prompts: versionsWithUnderscore,
-      });
-
-      render(<VersionHistorySidePanel {...defaultProps} activeVersionId="test-prompt_v2" />);
-
-      await waitFor(() => {
-        expect(screen.getByText("Active")).toBeInTheDocument();
-      });
-    });
-
-    it("should sort versions correctly with version field", async () => {
-      // The component doesn't explicitly sort, but we can verify the order from the API response
-      render(<VersionHistorySidePanel {...defaultProps} />);
-
-      await waitFor(() => {
-        screen.getAllByTestId("tag");
-        // Verify versions are displayed as they come from the API
-        expect(screen.getByText("v2")).toBeInTheDocument();
-      });
-    });
+  it("does not load while closed", async () => {
+    await act(async () => render(<VersionHistorySidePanel {...props} isOpen={false} />));
+    await waitFor(() => expect(getPromptVersions).not.toHaveBeenCalled());
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.test.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen, waitFor } from "@/../tests/test-utils";
 import { getPromptVersions, PromptSpec } from "@/components/networking";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import VersionHistorySidePanel from "./VersionHistorySidePanel";
 
 vi.mock("@/components/networking", () => ({ getPromptVersions: vi.fn() }));
@@ -214,5 +215,24 @@ describe("VersionHistorySidePanel", () => {
     await user.keyboard("{Escape}");
 
     expect(props.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("should keep history open when Escape dismisses a modal above it", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <>
+        <VersionHistorySidePanel {...props} />
+        <Dialog defaultOpen>
+          <DialogContent>
+            <DialogTitle>Prompt modal</DialogTitle>
+          </DialogContent>
+        </Dialog>
+      </>,
+    );
+    await screen.findByRole("dialog", { name: "Prompt modal" });
+
+    await user.keyboard("{Escape}");
+
+    expect(props.onClose).not.toHaveBeenCalled();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.test.tsx
@@ -1,7 +1,8 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/../tests/test-utils";
+import { getPromptVersions, PromptSpec } from "@/components/networking";
 import VersionHistorySidePanel from "./VersionHistorySidePanel";
-import { getPromptVersions } from "@/components/networking";
 
 vi.mock("@/components/networking", () => ({ getPromptVersions: vi.fn() }));
 
@@ -18,9 +19,9 @@ const versions = [
     version: 1,
     created_at: "2024-01-10T09:00:00Z",
     litellm_params: {},
-    prompt_info: { prompt_type: "db" },
+    prompt_info: { prompt_type: "config" },
   },
-];
+] satisfies PromptSpec[];
 
 const props = {
   isOpen: true,
@@ -34,40 +35,163 @@ const props = {
 describe("VersionHistorySidePanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getPromptVersions).mockResolvedValue({ prompts: versions } as any);
+    vi.mocked(getPromptVersions).mockResolvedValue({ prompts: versions });
   });
 
-  it("loads and renders prompt versions", async () => {
-    render(<VersionHistorySidePanel {...props} />);
-    expect(await screen.findByText("v2")).toBeInTheDocument();
-    expect(screen.getByText("v1")).toBeInTheDocument();
-    expect(screen.getByText("Latest")).toBeInTheDocument();
-    expect(screen.getByText("Active")).toBeInTheDocument();
+  it("should render prompt versions", async () => {
+    renderWithProviders(<VersionHistorySidePanel {...props} />);
+
+    expect(await screen.findByRole("dialog", { name: "Version History" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /v2/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /v1/i })).toBeInTheDocument();
   });
 
-  it("selects a version", async () => {
-    render(<VersionHistorySidePanel {...props} />);
-    fireEvent.click(await screen.findByText("v1"));
-    expect(props.onSelectVersion).toHaveBeenCalledWith(versions[1]);
+  it("should show an accessible loading state while versions are pending", () => {
+    vi.mocked(getPromptVersions).mockImplementation(() => new Promise(() => {}));
+
+    renderWithProviders(<VersionHistorySidePanel {...props} />);
+
+    expect(screen.getByRole("status", { name: "Loading version history" })).toBeInTheDocument();
   });
 
-  it("shows an empty result", async () => {
-    vi.mocked(getPromptVersions).mockResolvedValue({ prompts: [] } as any);
-    render(<VersionHistorySidePanel {...props} />);
+  it("should show the empty state when no versions are available", async () => {
+    vi.mocked(getPromptVersions).mockResolvedValue({ prompts: [] });
+
+    renderWithProviders(<VersionHistorySidePanel {...props} />);
+
     expect(await screen.findByText("No version history available.")).toBeInTheDocument();
   });
 
-  it("closes from the dialog control", async () => {
-    render(<VersionHistorySidePanel {...props} />);
-    await screen.findByText("v2");
-    const buttons = screen.getAllByRole("button");
-    fireEvent.click(buttons[0]);
-    expect(props.onClose).toHaveBeenCalled();
+  it("should display explicit version numbers", async () => {
+    renderWithProviders(<VersionHistorySidePanel {...props} />);
+
+    expect(await screen.findByText("v2")).toBeInTheDocument();
+    expect(screen.getByText("v1")).toBeInTheDocument();
   });
 
-  it("keeps the surrounding editor interactive while history is open", async () => {
+  it.each([
+    ["dot suffix", "welcome.v7", { prompt_id: "welcome.v7", litellm_params: {}, prompt_info: { prompt_type: "db" } }],
+    [
+      "underscore suffix",
+      "welcome_v8",
+      { prompt_id: "welcome_v8", litellm_params: {}, prompt_info: { prompt_type: "db" } },
+    ],
+    ["no suffix", "welcome", { prompt_id: "welcome", litellm_params: {}, prompt_info: { prompt_type: "db" } }],
+  ])("should derive a version number from a %s", async (_case, promptId, prompt) => {
+    vi.mocked(getPromptVersions).mockResolvedValue({ prompts: [prompt] });
+
+    renderWithProviders(<VersionHistorySidePanel {...props} promptId={promptId} activeVersionId={undefined} />);
+
+    const expectedVersions = new Map([
+      ["welcome.v7", "v7"],
+      ["welcome_v8", "v8"],
+      ["welcome", "v1"],
+    ]);
+    const expectedVersion = expectedVersions.get(promptId)!;
+    expect(await screen.findByText(expectedVersion)).toBeInTheDocument();
+  });
+
+  it("should label the first version as latest", async () => {
+    renderWithProviders(<VersionHistorySidePanel {...props} />);
+
+    expect(await screen.findByText("Latest")).toBeInTheDocument();
+  });
+
+  it.each(["welcome.v1", "welcome_v1"])("should mark %s as the active version", async (activeVersionId) => {
+    renderWithProviders(<VersionHistorySidePanel {...props} activeVersionId={activeVersionId} />);
+
+    const versionOne = await screen.findByRole("button", { name: /v1/i });
+    expect(versionOne).toHaveTextContent("Active");
+  });
+
+  it("should mark the latest version active when no active version is supplied", async () => {
+    renderWithProviders(<VersionHistorySidePanel {...props} activeVersionId={undefined} />);
+
+    const latestVersion = await screen.findByRole("button", { name: /v2/i });
+    expect(latestVersion).toHaveTextContent("Active");
+  });
+
+  it("should display creation dates", async () => {
+    renderWithProviders(<VersionHistorySidePanel {...props} />);
+
+    expect(await screen.findByText(new Date(versions[0].created_at).toLocaleString())).toBeInTheDocument();
+  });
+
+  it("should show a placeholder when a creation date is unavailable", async () => {
+    vi.mocked(getPromptVersions).mockResolvedValue({
+      prompts: [{ prompt_id: "welcome.v1", version: 1, litellm_params: {}, prompt_info: { prompt_type: "db" } }],
+    });
+
+    renderWithProviders(<VersionHistorySidePanel {...props} />);
+
+    expect(await screen.findByText("-")).toBeInTheDocument();
+  });
+
+  it("should identify database and config prompt sources", async () => {
+    renderWithProviders(<VersionHistorySidePanel {...props} />);
+
+    expect(await screen.findByText("Saved to Database")).toBeInTheDocument();
+    expect(screen.getByText("Config Prompt")).toBeInTheDocument();
+  });
+
+  it("should fetch versions using the base prompt identifier", async () => {
+    renderWithProviders(<VersionHistorySidePanel {...props} promptId="welcome.v9" />);
+
+    await waitFor(() => expect(getPromptVersions).toHaveBeenCalledWith("token", "welcome"));
+  });
+
+  it.each([
+    ["closed", { isOpen: false }],
+    ["without a token", { accessToken: null }],
+    ["without a prompt identifier", { promptId: "" }],
+  ])("should not fetch versions when %s", async (_case, override) => {
+    renderWithProviders(<VersionHistorySidePanel {...props} {...override} />);
+
+    await waitFor(() => expect(getPromptVersions).not.toHaveBeenCalled());
+  });
+
+  it("should refetch versions when the prompt identifier changes", async () => {
+    const { rerender } = renderWithProviders(<VersionHistorySidePanel {...props} />);
+    await waitFor(() => expect(getPromptVersions).toHaveBeenCalledWith("token", "welcome"));
+
+    rerender(<VersionHistorySidePanel {...props} promptId="follow-up.v1" />);
+
+    await waitFor(() => expect(getPromptVersions).toHaveBeenLastCalledWith("token", "follow-up"));
+  });
+
+  it("should show the empty state when loading versions fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(getPromptVersions).mockRejectedValue(new Error("Network error"));
+
+    renderWithProviders(<VersionHistorySidePanel {...props} />);
+
+    expect(await screen.findByText("No version history available.")).toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalledWith("Error fetching prompt versions:", expect.any(Error));
+    consoleError.mockRestore();
+  });
+
+  it("should select a version", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<VersionHistorySidePanel {...props} />);
+
+    await user.click(await screen.findByRole("button", { name: /v1/i }));
+
+    expect(props.onSelectVersion).toHaveBeenCalledWith(versions[1]);
+  });
+
+  it("should close from the dialog control", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<VersionHistorySidePanel {...props} />);
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(props.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("should keep the surrounding editor interactive while history is open", async () => {
+    const user = userEvent.setup();
     const onEditorAction = vi.fn();
-    render(
+    renderWithProviders(
       <>
         <button type="button" onClick={onEditorAction}>
           Editor action
@@ -75,21 +199,20 @@ describe("VersionHistorySidePanel", () => {
         <VersionHistorySidePanel {...props} />
       </>,
     );
-    await screen.findByText("v2");
-    expect(screen.getByRole("dialog", { name: "Version History" })).toHaveAttribute("aria-modal", "false");
-    fireEvent.click(screen.getByRole("button", { name: "Editor action" }));
+
+    expect(await screen.findByRole("dialog", { name: "Version History" })).toHaveAttribute("aria-modal", "false");
+    await user.click(screen.getByRole("button", { name: "Editor action" }));
+
     expect(onEditorAction).toHaveBeenCalledOnce();
   });
 
-  it("closes on Escape", async () => {
-    render(<VersionHistorySidePanel {...props} />);
+  it("should close on Escape", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<VersionHistorySidePanel {...props} />);
     await screen.findByText("v2");
-    fireEvent.keyDown(document, { key: "Escape" });
-    expect(props.onClose).toHaveBeenCalledOnce();
-  });
 
-  it("does not load while closed", async () => {
-    await act(async () => render(<VersionHistorySidePanel {...props} isOpen={false} />));
-    await waitFor(() => expect(getPromptVersions).not.toHaveBeenCalled());
+    await user.keyboard("{Escape}");
+
+    expect(props.onClose).toHaveBeenCalledOnce();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import { getPromptVersions, PromptSpec } from "@/components/networking";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { XIcon } from "lucide-react";
 
@@ -31,6 +30,17 @@ const VersionHistorySidePanel: React.FC<VersionHistorySidePanelProps> = ({
       fetchVersions();
     }
   }, [isOpen, accessToken, promptId]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isOpen, onClose]);
 
   const fetchVersions = async () => {
     setLoading(true);
@@ -68,76 +78,83 @@ const VersionHistorySidePanel: React.FC<VersionHistorySidePanelProps> = ({
     return new Date(dateString).toLocaleString();
   };
 
+  if (!isOpen) return null;
+
   return (
-    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()} modal={false}>
-      <SheetContent side="right" showCloseButton={false} className="w-[400px] sm:max-w-[400px]">
-        <SheetClose render={<Button variant="ghost" size="icon-sm" className="absolute top-4 right-4" />}>
-          <XIcon />
-          <span className="sr-only">Close</span>
-        </SheetClose>
-        <SheetHeader>
-          <SheetTitle>Version History</SheetTitle>
-        </SheetHeader>
-        <div className="overflow-y-auto px-4 pb-4">
-          {loading ? (
-            <div className="space-y-3" aria-label="Loading version history">
-              <Skeleton className="h-24 w-full" />
-              <Skeleton className="h-24 w-full" />
-              <Skeleton className="h-24 w-full" />
-              <Skeleton className="h-24 w-full" />
-            </div>
-          ) : versions.length === 0 ? (
-            <div className="text-center py-8 text-muted-foreground">No version history available.</div>
-          ) : (
-            <div className="space-y-4">
-              {versions.map((item, index) => {
-                // Use version field for comparison since all items have the same prompt_id
-                const itemVersionNum = item.version || parseInt(getVersionNumber(item).replace("v", ""));
+    <aside
+      role="dialog"
+      aria-modal={false}
+      aria-labelledby="version-history-title"
+      className="fixed inset-y-0 right-0 z-50 flex w-[400px] max-w-full flex-col gap-4 border-l border-border bg-popover text-popover-foreground shadow-lg"
+    >
+      <Button type="button" variant="ghost" size="icon-sm" className="absolute top-4 right-4" onClick={onClose}>
+        <XIcon />
+        <span className="sr-only">Close</span>
+      </Button>
+      <header className="flex flex-col gap-1.5 p-4">
+        <h2 id="version-history-title" className="font-medium text-foreground">
+          Version History
+        </h2>
+      </header>
+      <div className="overflow-y-auto px-4 pb-4">
+        {loading ? (
+          <div className="space-y-3" aria-label="Loading version history">
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-24 w-full" />
+          </div>
+        ) : versions.length === 0 ? (
+          <div className="text-center py-8 text-muted-foreground">No version history available.</div>
+        ) : (
+          <div className="space-y-4">
+            {versions.map((item, index) => {
+              // Use version field for comparison since all items have the same prompt_id
+              const itemVersionNum = item.version || parseInt(getVersionNumber(item).replace("v", ""));
 
-                // Extract version number from activeVersionId (may have .vX suffix)
-                let activeVersionNum: number | null = null;
-                if (activeVersionId) {
-                  if (activeVersionId.includes(".v")) {
-                    activeVersionNum = parseInt(activeVersionId.split(".v")[1]);
-                  } else if (activeVersionId.includes("_v")) {
-                    activeVersionNum = parseInt(activeVersionId.split("_v")[1]);
-                  }
+              // Extract version number from activeVersionId (may have .vX suffix)
+              let activeVersionNum: number | null = null;
+              if (activeVersionId) {
+                if (activeVersionId.includes(".v")) {
+                  activeVersionNum = parseInt(activeVersionId.split(".v")[1]);
+                } else if (activeVersionId.includes("_v")) {
+                  activeVersionNum = parseInt(activeVersionId.split("_v")[1]);
                 }
+              }
 
-                // Default to latest (first item) if no activeVersionId
-                const isSelected = activeVersionNum ? itemVersionNum === activeVersionNum : index === 0;
+              // Default to latest (first item) if no activeVersionId
+              const isSelected = activeVersionNum ? itemVersionNum === activeVersionNum : index === 0;
 
-                return (
-                  <button
-                    type="button"
-                    key={`${item.prompt_id}-v${item.version || itemVersionNum}`}
-                    className={`w-full p-4 rounded-lg border cursor-pointer text-left transition-all hover:shadow-md ${
-                      isSelected ? "border-primary bg-accent" : "border-border bg-background hover:border-primary"
-                    }`}
-                    onClick={() => onSelectVersion?.(item)}
-                  >
-                    <div className="flex justify-between items-start mb-2">
-                      <div className="flex items-center gap-2">
-                        <Badge variant="secondary">{getVersionNumber(item)}</Badge>
-                        {index === 0 && <Badge>Latest</Badge>}
-                      </div>
-                      {isSelected && <Badge variant="secondary">Active</Badge>}
+              return (
+                <button
+                  type="button"
+                  key={`${item.prompt_id}-v${item.version || itemVersionNum}`}
+                  className={`w-full p-4 rounded-lg border cursor-pointer text-left transition-all hover:shadow-md ${
+                    isSelected ? "border-primary bg-accent" : "border-border bg-background hover:border-primary"
+                  }`}
+                  onClick={() => onSelectVersion?.(item)}
+                >
+                  <div className="flex justify-between items-start mb-2">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="secondary">{getVersionNumber(item)}</Badge>
+                      {index === 0 && <Badge>Latest</Badge>}
                     </div>
+                    {isSelected && <Badge variant="secondary">Active</Badge>}
+                  </div>
 
-                    <div className="flex flex-col gap-1">
-                      <span className="text-sm text-muted-foreground font-medium">{formatDate(item.created_at)}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {item.prompt_info?.prompt_type === "db" ? "Saved to Database" : "Config Prompt"}
-                      </span>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      </SheetContent>
-    </Sheet>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-sm text-muted-foreground font-medium">{formatDate(item.created_at)}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {item.prompt_info?.prompt_type === "db" ? "Saved to Database" : "Config Prompt"}
+                    </span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </aside>
   );
 };
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.tsx
@@ -35,7 +35,8 @@ const VersionHistorySidePanel: React.FC<VersionHistorySidePanelProps> = ({
     if (!isOpen) return;
 
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      const openModal = document.querySelector('[data-slot="dialog-content"][data-open]');
+      if (event.key === "Escape" && !openModal) onClose();
     };
 
     document.addEventListener("keydown", handleEscape);

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.tsx
@@ -1,8 +1,10 @@
-import { Drawer, List, Skeleton, Tag, Typography } from "antd";
 import React, { useEffect, useState } from "react";
 import { getPromptVersions, PromptSpec } from "@/components/networking";
-
-const { Text } = Typography;
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+import { XIcon } from "lucide-react";
 
 interface VersionHistorySidePanelProps {
   isOpen: boolean;
@@ -67,75 +69,75 @@ const VersionHistorySidePanel: React.FC<VersionHistorySidePanelProps> = ({
   };
 
   return (
-    <Drawer
-      title="Version History"
-      placement="right"
-      onClose={onClose}
-      open={isOpen}
-      width={400}
-      mask={false} // Allow interacting with the main editor while drawer is open
-      maskClosable={false}
-    >
-      {loading ? (
-        <Skeleton active paragraph={{ rows: 4 }} />
-      ) : versions.length === 0 ? (
-        <div className="text-center py-8 text-gray-500">No version history available.</div>
-      ) : (
-        <List
-          dataSource={versions}
-          renderItem={(item, index) => {
-            // Use version field for comparison since all items have the same prompt_id
-            const itemVersionNum = item.version || parseInt(getVersionNumber(item).replace("v", ""));
+    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()} modal={false}>
+      <SheetContent side="right" showCloseButton={false} className="w-[400px] sm:max-w-[400px]">
+        <SheetClose render={<Button variant="ghost" size="icon-sm" className="absolute top-4 right-4" />}>
+          <XIcon />
+          <span className="sr-only">Close</span>
+        </SheetClose>
+        <SheetHeader>
+          <SheetTitle>Version History</SheetTitle>
+        </SheetHeader>
+        <div className="overflow-y-auto px-4 pb-4">
+          {loading ? (
+            <div className="space-y-3" aria-label="Loading version history">
+              <Skeleton className="h-24 w-full" />
+              <Skeleton className="h-24 w-full" />
+              <Skeleton className="h-24 w-full" />
+              <Skeleton className="h-24 w-full" />
+            </div>
+          ) : versions.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">No version history available.</div>
+          ) : (
+            <div className="space-y-4">
+              {versions.map((item, index) => {
+                // Use version field for comparison since all items have the same prompt_id
+                const itemVersionNum = item.version || parseInt(getVersionNumber(item).replace("v", ""));
 
-            // Extract version number from activeVersionId (may have .vX suffix)
-            let activeVersionNum: number | null = null;
-            if (activeVersionId) {
-              if (activeVersionId.includes(".v")) {
-                activeVersionNum = parseInt(activeVersionId.split(".v")[1]);
-              } else if (activeVersionId.includes("_v")) {
-                activeVersionNum = parseInt(activeVersionId.split("_v")[1]);
-              }
-            }
+                // Extract version number from activeVersionId (may have .vX suffix)
+                let activeVersionNum: number | null = null;
+                if (activeVersionId) {
+                  if (activeVersionId.includes(".v")) {
+                    activeVersionNum = parseInt(activeVersionId.split(".v")[1]);
+                  } else if (activeVersionId.includes("_v")) {
+                    activeVersionNum = parseInt(activeVersionId.split("_v")[1]);
+                  }
+                }
 
-            // Default to latest (first item) if no activeVersionId
-            const isSelected = activeVersionNum ? itemVersionNum === activeVersionNum : index === 0;
+                // Default to latest (first item) if no activeVersionId
+                const isSelected = activeVersionNum ? itemVersionNum === activeVersionNum : index === 0;
 
-            return (
-              <div
-                key={`${item.prompt_id}-v${item.version || itemVersionNum}`}
-                className={`mb-4 p-4 rounded-lg border cursor-pointer transition-all hover:shadow-md ${
-                  isSelected ? "border-blue-500 bg-blue-50" : "border-gray-200 bg-white hover:border-blue-300"
-                }`}
-                onClick={() => onSelectVersion?.(item)}
-              >
-                <div className="flex justify-between items-start mb-2">
-                  <div className="flex items-center gap-2">
-                    <Tag className="m-0">{getVersionNumber(item)}</Tag>
-                    {index === 0 && (
-                      <Tag color="blue" className="m-0">
-                        Latest
-                      </Tag>
-                    )}
-                  </div>
-                  {isSelected && (
-                    <Tag color="green" className="m-0">
-                      Active
-                    </Tag>
-                  )}
-                </div>
+                return (
+                  <button
+                    type="button"
+                    key={`${item.prompt_id}-v${item.version || itemVersionNum}`}
+                    className={`w-full p-4 rounded-lg border cursor-pointer text-left transition-all hover:shadow-md ${
+                      isSelected ? "border-primary bg-accent" : "border-border bg-background hover:border-primary"
+                    }`}
+                    onClick={() => onSelectVersion?.(item)}
+                  >
+                    <div className="flex justify-between items-start mb-2">
+                      <div className="flex items-center gap-2">
+                        <Badge variant="secondary">{getVersionNumber(item)}</Badge>
+                        {index === 0 && <Badge>Latest</Badge>}
+                      </div>
+                      {isSelected && <Badge variant="secondary">Active</Badge>}
+                    </div>
 
-                <div className="flex flex-col gap-1">
-                  <Text className="text-sm text-gray-600 font-medium">{formatDate(item.created_at)}</Text>
-                  <Text type="secondary" className="text-xs">
-                    {item.prompt_info?.prompt_type === "db" ? "Saved to Database" : "Config Prompt"}
-                  </Text>
-                </div>
-              </div>
-            );
-          }}
-        />
-      )}
-    </Drawer>
+                    <div className="flex flex-col gap-1">
+                      <span className="text-sm text-muted-foreground font-medium">{formatDate(item.created_at)}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {item.prompt_info?.prompt_type === "db" ? "Saved to Database" : "Config Prompt"}
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 };
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.tsx
@@ -98,7 +98,7 @@ const VersionHistorySidePanel: React.FC<VersionHistorySidePanelProps> = ({
       </header>
       <div className="overflow-y-auto px-4 pb-4">
         {loading ? (
-          <div className="space-y-3" aria-label="Loading version history">
+          <div className="space-y-3" role="status" aria-label="Loading version history">
             <Skeleton className="h-24 w-full" />
             <Skeleton className="h-24 w-full" />
             <Skeleton className="h-24 w-full" />

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/EmptyState.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/EmptyState.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import EmptyState from "./EmptyState";
+
+describe("EmptyState", () => {
+  it("explains when variables must be filled", () => {
+    render(<EmptyState hasVariables />);
+    expect(screen.getByText(/fill in the variables/i)).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/EmptyState.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/EmptyState.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { RobotOutlined } from "@ant-design/icons";
+import { Bot } from "lucide-react";
 
 interface EmptyStateProps {
   hasVariables: boolean;
@@ -7,8 +7,8 @@ interface EmptyStateProps {
 
 const EmptyState: React.FC<EmptyStateProps> = ({ hasVariables }) => {
   return (
-    <div className="h-full flex flex-col items-center justify-center text-gray-400">
-      <RobotOutlined style={{ fontSize: "48px", marginBottom: "16px" }} />
+    <div className="h-full flex flex-col items-center justify-center text-muted-foreground">
+      <Bot className="mb-4 size-12" aria-hidden="true" />
       <span className="text-base">
         {hasVariables
           ? "Fill in the variables above, then type a message to start testing"

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageBubble.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageBubble.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import MessageBubble from "./MessageBubble";
+
+vi.mock("@/components/chat_ui/ResponseMetrics", () => ({ default: () => <div>metrics</div> }));
+
+describe("MessageBubble", () => {
+  it("renders assistant markdown and model", () => {
+    render(<MessageBubble message={{ role: "assistant", content: "**Hello**", model: "gpt-4o" }} />);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByText("gpt-4o")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageBubble.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageBubble.test.tsx
@@ -10,4 +10,9 @@ describe("MessageBubble", () => {
     expect(screen.getByText("Hello")).toBeInTheDocument();
     expect(screen.getByText("gpt-4o")).toBeInTheDocument();
   });
+
+  it("uses theme tokens for user messages", () => {
+    render(<MessageBubble message={{ role: "user", content: "Hello" }} />);
+    expect(screen.getByText("Hello").closest(".bg-accent")).toHaveClass("border-border");
+  });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageBubble.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageBubble.tsx
@@ -14,18 +14,15 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
   return (
     <div className={`mb-4 flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
       <div
-        className="max-w-[85%] rounded-lg shadow-xs p-3.5 px-4"
-        style={{
-          backgroundColor: message.role === "user" ? "#f0f8ff" : "#ffffff",
-          border: message.role === "user" ? "1px solid #e6f0fa" : "1px solid #f0f0f0",
-        }}
+        className={`max-w-[85%] rounded-lg border border-border p-3.5 px-4 shadow-xs ${
+          message.role === "user" ? "bg-accent" : "bg-card"
+        }`}
       >
         <div className="flex items-center gap-2 mb-1.5">
           <div
-            className="flex items-center justify-center w-6 h-6 rounded-full mr-1"
-            style={{
-              backgroundColor: message.role === "user" ? "#e6f0fa" : "#f5f5f5",
-            }}
+            className={`flex h-6 w-6 items-center justify-center rounded-full mr-1 ${
+              message.role === "user" ? "bg-primary/10" : "bg-muted"
+            }`}
           >
             {message.role === "user" ? (
               <User className="size-3 text-primary" aria-hidden="true" />

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageBubble.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageBubble.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { RobotOutlined, UserOutlined } from "@ant-design/icons";
+import { Bot, User } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { coy } from "react-syntax-highlighter/dist/esm/styles/prism";
@@ -28,14 +28,14 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
             }}
           >
             {message.role === "user" ? (
-              <UserOutlined style={{ fontSize: "12px", color: "#2563eb" }} />
+              <User className="size-3 text-primary" aria-hidden="true" />
             ) : (
-              <RobotOutlined style={{ fontSize: "12px", color: "#4b5563" }} />
+              <Bot className="size-3 text-muted-foreground" aria-hidden="true" />
             )}
           </div>
           <strong className="text-sm capitalize">{message.role}</strong>
           {message.role === "assistant" && message.model && (
-            <span className="text-xs px-2 py-0.5 rounded-sm bg-gray-100 text-gray-600 font-normal">
+            <span className="text-xs px-2 py-0.5 rounded-sm bg-muted text-muted-foreground font-normal">
               {message.model}
             </span>
           )}
@@ -78,7 +78,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
                     </SyntaxHighlighter>
                   ) : (
                     <code
-                      className={`${className} px-1.5 py-0.5 rounded-sm bg-gray-100 text-sm font-mono`}
+                      className={`${className} px-1.5 py-0.5 rounded-sm bg-muted text-sm font-mono`}
                       style={{ wordBreak: "break-word" }}
                       {...props}
                     >

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageInput.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageInput.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import MessageInput from "./MessageInput";
+
+describe("MessageInput", () => {
+  it("updates and sends a message", () => {
+    const onInputChange = vi.fn();
+    const onSend = vi.fn();
+    render(
+      <MessageInput
+        inputMessage="Hello"
+        isLoading={false}
+        isDisabled={false}
+        onInputChange={onInputChange}
+        onSend={onSend}
+        onKeyDown={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText(/type your message/i), { target: { value: "Hi" } });
+    fireEvent.click(screen.getByRole("button"));
+    expect(onInputChange).toHaveBeenCalledWith("Hi");
+    expect(onSend).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageInput.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageInput.test.tsx
@@ -17,8 +17,10 @@ describe("MessageInput", () => {
         onCancel={vi.fn()}
       />,
     );
-    fireEvent.change(screen.getByPlaceholderText(/type your message/i), { target: { value: "Hi" } });
-    fireEvent.click(screen.getByRole("button"));
+    const textarea = screen.getByPlaceholderText(/type your message/i);
+    expect(textarea).toHaveClass("field-sizing-content", "max-h-24", "overflow-y-auto");
+    fireEvent.change(textarea, { target: { value: "Hi" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
     expect(onInputChange).toHaveBeenCalledWith("Hi");
     expect(onSend).toHaveBeenCalledOnce();
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageInput.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageInput.tsx
@@ -32,7 +32,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
           placeholder="Type your message... (Shift+Enter for new line)"
           disabled={isLoading}
           rows={1}
-          className="field-sizing-fixed max-h-24 min-h-8 flex-1 resize-none border-0 bg-transparent px-0 py-1 text-sm shadow-none focus-visible:ring-0"
+          className="field-sizing-content max-h-24 min-h-8 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-0 py-1 text-sm shadow-none focus-visible:ring-0"
         />
 
         <Button

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageInput.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageInput.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { ArrowUpOutlined } from "@ant-design/icons";
-import { Button as TremorButton } from "@tremor/react";
-import { Input } from "antd";
-
-const { TextArea } = Input;
+import { ArrowUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
 
 interface MessageInputProps {
   inputMessage: string;
@@ -26,39 +24,33 @@ const MessageInput: React.FC<MessageInputProps> = ({
 }) => {
   return (
     <div className="flex items-center gap-2">
-      <div className="flex items-center flex-1 bg-white border border-gray-300 rounded-xl px-3 py-1 min-h-[44px]">
-        <TextArea
+      <div className="flex items-center flex-1 bg-background border border-border rounded-xl px-3 py-1 min-h-[44px]">
+        <Textarea
           value={inputMessage}
           onChange={(e) => onInputChange(e.target.value)}
           onKeyDown={onKeyDown}
           placeholder="Type your message... (Shift+Enter for new line)"
           disabled={isLoading}
-          className="flex-1"
-          autoSize={{ minRows: 1, maxRows: 4 }}
-          style={{
-            resize: "none",
-            border: "none",
-            boxShadow: "none",
-            background: "transparent",
-            padding: "4px 0",
-            fontSize: "14px",
-            lineHeight: "20px",
-          }}
+          rows={1}
+          className="field-sizing-fixed max-h-24 min-h-8 flex-1 resize-none border-0 bg-transparent px-0 py-1 text-sm shadow-none focus-visible:ring-0"
         />
 
-        <TremorButton
+        <Button
+          type="button"
+          size="icon-sm"
           onClick={onSend}
           disabled={isDisabled}
-          className="shrink-0 ml-2 w-8! h-8! min-w-8! p-0! rounded-full! bg-blue-600! hover:bg-blue-700! disabled:bg-gray-300! border-none! text-white! disabled:text-gray-500! flex! items-center! justify-center!"
+          className="ml-2 shrink-0 rounded-full"
+          aria-label="Send message"
         >
-          <ArrowUpOutlined style={{ fontSize: "14px" }} />
-        </TremorButton>
+          <ArrowUp aria-hidden="true" />
+        </Button>
       </div>
 
       {isLoading && (
-        <TremorButton onClick={onCancel} className="bg-red-50 hover:bg-red-100 text-red-600 border-red-200">
+        <Button type="button" variant="destructive" onClick={onCancel}>
           Cancel
-        </TremorButton>
+        </Button>
       )}
     </div>
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageList.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageList.test.tsx
@@ -1,0 +1,18 @@
+import { createRef } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import MessageList from "./MessageList";
+
+describe("MessageList", () => {
+  it("renders conversation messages", () => {
+    render(
+      <MessageList
+        messages={[{ role: "user", content: "Hello" }]}
+        isLoading={false}
+        hasVariables={false}
+        messagesEndRef={createRef<HTMLDivElement>()}
+      />,
+    );
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageList.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageList.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { LoadingOutlined } from "@ant-design/icons";
-import { Spin } from "antd";
+import { Loader2 } from "lucide-react";
 import EmptyState from "./EmptyState";
 import MessageBubble from "./MessageBubble";
 import { Message } from "./types";
@@ -13,8 +12,6 @@ interface MessageListProps {
 }
 
 const MessageList: React.FC<MessageListProps> = ({ messages, isLoading, hasVariables, messagesEndRef }) => {
-  const antIcon = <LoadingOutlined style={{ fontSize: 24 }} spin />;
-
   return (
     <div className="flex-1 overflow-y-auto p-4 pb-0">
       {messages.length === 0 && <EmptyState hasVariables={hasVariables} />}
@@ -25,7 +22,7 @@ const MessageList: React.FC<MessageListProps> = ({ messages, isLoading, hasVaria
 
       {isLoading && (
         <div className="flex justify-center items-center my-4">
-          <Spin indicator={antIcon} />
+          <Loader2 className="size-6 animate-spin text-muted-foreground" aria-label="Loading response" />
         </div>
       )}
       <div ref={messagesEndRef} style={{ height: "1px" }} />

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/VariableInput.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/VariableInput.test.tsx
@@ -1,0 +1,14 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import VariableInput from "./VariableInput";
+
+describe("VariableInput", () => {
+  it("updates a named template variable", () => {
+    const onVariableChange = vi.fn();
+    render(
+      <VariableInput extractedVariables={["name"]} variables={{ name: "Ada" }} onVariableChange={onVariableChange} />,
+    );
+    fireEvent.change(screen.getByPlaceholderText("Enter value for name"), { target: { value: "Grace" } });
+    expect(onVariableChange).toHaveBeenCalledWith("name", "Grace");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/VariableInput.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/VariableInput.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Input } from "antd";
+import { Input } from "@/components/ui/input";
 
 interface VariableInputProps {
   extractedVariables: string[];
@@ -13,12 +13,12 @@ const VariableInput: React.FC<VariableInputProps> = ({ extractedVariables, varia
   }
 
   return (
-    <div className="p-4 border-b border-gray-200 bg-blue-50">
-      <h3 className="text-sm font-semibold text-gray-700 mb-3">Fill in template variables to start testing</h3>
+    <div className="p-4 border-b border-border bg-accent">
+      <h3 className="text-sm font-semibold text-foreground mb-3">Fill in template variables to start testing</h3>
       <div className="space-y-2">
         {extractedVariables.map((varName) => (
           <div key={varName}>
-            <label className="block text-xs text-gray-600 mb-1 font-medium">
+            <label className="block text-xs text-muted-foreground mb-1 font-medium">
               {"{{"}
               {varName}
               {"}}"}
@@ -27,7 +27,6 @@ const VariableInput: React.FC<VariableInputProps> = ({ extractedVariables, varia
               value={variables[varName] || ""}
               onChange={(e) => onVariableChange(varName, e.target.value)}
               placeholder={`Enter value for ${varName}`}
-              size="small"
             />
           </div>
         ))}

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/index.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/index.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ConversationPanel from "./index";
+
+vi.mock("./useConversation", () => ({
+  useConversation: () => ({
+    isLoading: false,
+    messages: [],
+    inputMessage: "",
+    variables: {},
+    variablesFilled: true,
+    extractedVariables: [],
+    allVariablesFilled: true,
+    messagesEndRef: { current: null },
+    setInputMessage: vi.fn(),
+    handleSendMessage: vi.fn(),
+    handleCancelRequest: vi.fn(),
+    handleClearConversation: vi.fn(),
+    handleKeyDown: vi.fn(),
+    handleVariableChange: vi.fn(),
+  }),
+}));
+
+describe("ConversationPanel", () => {
+  it("renders the empty conversation input", () => {
+    render(<ConversationPanel prompt={{}} accessToken="token" />);
+    expect(screen.getByPlaceholderText(/type your message/i)).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/index.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { ClearOutlined } from "@ant-design/icons";
-import { Button as TremorButton } from "@tremor/react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { ConversationPanelProps } from "./types";
 import { useConversation } from "./useConversation";
 import VariableInput from "./VariableInput";
@@ -27,7 +27,7 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ prompt, accessTok
   } = useConversation(prompt, accessToken);
 
   return (
-    <div className="flex flex-col h-full bg-white">
+    <div className="flex flex-col h-full bg-background">
       {!variablesFilled && (
         <VariableInput
           extractedVariables={extractedVariables}
@@ -37,14 +37,11 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ prompt, accessTok
       )}
 
       {messages.length > 0 && (
-        <div className="p-3 border-b border-gray-200 bg-white flex justify-end">
-          <TremorButton
-            onClick={handleClearConversation}
-            className="bg-gray-100 hover:bg-gray-200 text-gray-700 border-gray-300"
-            icon={ClearOutlined}
-          >
+        <div className="p-3 border-b border-border bg-background flex justify-end">
+          <Button type="button" variant="outline" size="sm" onClick={handleClearConversation}>
+            <Trash2 aria-hidden="true" />
             Clear Chat
-          </TremorButton>
+          </Button>
         </div>
       )}
 
@@ -55,7 +52,7 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ prompt, accessTok
         messagesEndRef={messagesEndRef}
       />
 
-      <div className="p-4 border-t border-gray-200 bg-white">
+      <div className="p-4 border-t border-border bg-background">
         <VariableWarning extractedVariables={extractedVariables} variables={variables} />
 
         <MessageInput

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/tool_modal.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/tool_modal.test.tsx
@@ -1,0 +1,17 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ToolModal from "./tool_modal";
+
+describe("ToolModal", () => {
+  it("rejects invalid JSON and saves valid JSON", async () => {
+    const onSave = vi.fn();
+    render(<ToolModal visible initialJson="{}" onSave={onSave} onClose={vi.fn()} />);
+    const editor = await screen.findByPlaceholderText("Paste your tool JSON here...");
+    fireEvent.change(editor, { target: { value: "invalid" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(screen.getByText(/invalid json format/i)).toBeInTheDocument();
+    fireEvent.change(editor, { target: { value: '{"type":"function"}' } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(onSave).toHaveBeenCalledWith('{"type":"function"}');
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/tool_modal.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/tool_modal.test.tsx
@@ -6,6 +6,7 @@ describe("ToolModal", () => {
   it("rejects invalid JSON and saves valid JSON", async () => {
     const onSave = vi.fn();
     render(<ToolModal visible initialJson="{}" onSave={onSave} onClose={vi.fn()} />);
+    expect(await screen.findByRole("dialog")).toHaveClass("max-h-[calc(100dvh-2rem)]", "overflow-y-auto");
     const editor = await screen.findByPlaceholderText("Paste your tool JSON here...");
     fireEvent.change(editor, { target: { value: "invalid" } });
     fireEvent.click(screen.getByRole("button", { name: "Add" }));

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/tool_modal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/tool_modal.tsx
@@ -52,7 +52,7 @@ const ToolModal: React.FC<ToolModalProps> = ({ visible, initialJson, onSave, onC
 
   return (
     <Dialog open={visible} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="sm:max-w-3xl">
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>Add Tool</DialogTitle>
         </DialogHeader>

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/tool_modal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/tool_modal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { Modal, Button } from "antd";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
 interface ToolModalProps {
   visible: boolean;
@@ -50,34 +51,36 @@ const ToolModal: React.FC<ToolModalProps> = ({ visible, initialJson, onSave, onC
   };
 
   return (
-    <Modal
-      title={
-        <div className="flex items-center justify-between">
-          <span className="text-lg font-medium">Add Tool</span>
+    <Dialog open={visible} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Add Tool</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          {error && (
+            <div
+              role="alert"
+              className="p-3 bg-destructive/10 border border-destructive/20 rounded-sm text-destructive text-sm"
+            >
+              {error}
+            </div>
+          )}
+          <textarea
+            aria-label="Tool JSON"
+            value={json}
+            onChange={(e) => setJson(e.target.value)}
+            className="w-full min-h-[400px] px-4 py-3 border border-input rounded-lg text-sm font-mono focus:outline-hidden focus:ring-2 focus:ring-ring resize-none"
+            placeholder="Paste your tool JSON here..."
+          />
         </div>
-      }
-      open={visible}
-      onCancel={handleClose}
-      width={800}
-      footer={[
-        <Button key="cancel" onClick={handleClose}>
-          Cancel
-        </Button>,
-        <Button key="save" type="primary" onClick={handleSave}>
-          Add
-        </Button>,
-      ]}
-    >
-      <div className="space-y-3">
-        {error && <div className="p-3 bg-red-50 border border-red-200 rounded-sm text-red-600 text-sm">{error}</div>}
-        <textarea
-          value={json}
-          onChange={(e) => setJson(e.target.value)}
-          className="w-full min-h-[400px] px-4 py-3 border border-gray-300 rounded-lg text-sm font-mono focus:outline-hidden focus:ring-2 focus:ring-blue-500 resize-none"
-          placeholder="Paste your tool JSON here..."
-        />
-      </div>
-    </Modal>
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave}>Add</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/variable_textarea.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/variable_textarea.test.tsx
@@ -1,0 +1,14 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import VariableTextArea from "./variable_textarea";
+
+describe("VariableTextArea", () => {
+  it("updates text and identifies template variables", () => {
+    const onChange = vi.fn();
+    render(<VariableTextArea value="Hello {{name}}" onChange={onChange} placeholder="Prompt" />);
+    expect(screen.getByText("Detected variables:")).toBeInTheDocument();
+    expect(screen.getByText("name")).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText("Prompt"), { target: { value: "Hi" } });
+    expect(onChange).toHaveBeenCalledWith("Hi");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/variable_textarea.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/variable_textarea.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
-import { Input, Popover, Tag } from "antd";
-import { EditOutlined } from "@ant-design/icons";
-
-const { TextArea } = Input;
+import { PencilIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
 
 interface VariableTextAreaProps {
   value: string;
@@ -61,65 +63,22 @@ const VariableTextArea: React.FC<VariableTextAreaProps> = ({ value, onChange, pl
 
   return (
     <div className={`variable-textarea-container ${className}`}>
-      <style>
-        {`
-          .variable-highlight-text {
-            color: #f97316;
-            background-color: #fff7ed;
-            border-radius: 4px;
-            padding: 0 2px;
-            border: 1px solid #fed7aa;
-            font-family: monospace;
-          }
-        `}
-      </style>
-
       {/* Using standard TextArea for reliability */}
-      <TextArea
+      <Textarea
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         rows={rows}
-        className="font-sans"
+        className="field-sizing-fixed font-sans"
       />
 
       {/* Variable Management - Clear and Functional */}
       {variables.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-2 items-center">
-          <span className="text-xs text-gray-500 mr-1">Detected variables:</span>
+          <span className="text-xs text-muted-foreground mr-1">Detected variables:</span>
           {variables.map((variable, index) => (
             <Popover
               key={`${variable.start}-${index}`}
-              content={
-                <div className="p-2" style={{ minWidth: "200px" }}>
-                  <div className="text-xs text-gray-500 mb-2">Edit variable name</div>
-                  <Input
-                    size="small"
-                    value={newVariableName}
-                    onChange={(e) => setNewVariableName(e.target.value)}
-                    onPressEnter={handleVariableEdit}
-                    placeholder="Variable name"
-                    autoFocus
-                  />
-                  <div className="flex gap-2 mt-2">
-                    <button
-                      onClick={handleVariableEdit}
-                      className="text-xs px-2 py-1 bg-blue-500 text-white rounded-sm hover:bg-blue-600"
-                    >
-                      Save
-                    </button>
-                    <button
-                      onClick={() => {
-                        setEditingVariable(null);
-                        setNewVariableName("");
-                      }}
-                      className="text-xs px-2 py-1 bg-gray-200 text-gray-700 rounded-sm hover:bg-gray-300"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </div>
-              }
               open={editingVariable?.start === variable.start}
               onOpenChange={(open) => {
                 if (!open) {
@@ -127,23 +86,56 @@ const VariableTextArea: React.FC<VariableTextAreaProps> = ({ value, onChange, pl
                   setNewVariableName("");
                 }
               }}
-              trigger="click"
             >
-              <Tag
-                color="orange"
-                className="cursor-pointer hover:opacity-80 transition-all m-0"
-                icon={<EditOutlined />}
-                onClick={() => {
-                  setEditingVariable({
-                    oldName: variable.name,
-                    start: variable.start,
-                    end: variable.end,
-                  });
-                  setNewVariableName(variable.name);
-                }}
+              <PopoverTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-auto p-0"
+                    onClick={() => {
+                      setEditingVariable({
+                        oldName: variable.name,
+                        start: variable.start,
+                        end: variable.end,
+                      });
+                      setNewVariableName(variable.name);
+                    }}
+                  />
+                }
               >
-                {variable.name}
-              </Tag>
+                <Badge variant="outline" className="cursor-pointer">
+                  <PencilIcon className="size-3" />
+                  {variable.name}
+                </Badge>
+              </PopoverTrigger>
+              <PopoverContent className="w-[216px]">
+                <div className="p-2">
+                  <div className="text-xs text-muted-foreground mb-2">Edit variable name</div>
+                  <Input
+                    value={newVariableName}
+                    onChange={(e) => setNewVariableName(e.target.value)}
+                    onKeyDown={(event) => event.key === "Enter" && handleVariableEdit()}
+                    placeholder="Variable name"
+                    autoFocus
+                  />
+                  <div className="flex gap-2 mt-2">
+                    <Button size="sm" onClick={handleVariableEdit}>
+                      Save
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        setEditingVariable(null);
+                        setNewVariableName("");
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              </PopoverContent>
             </Popover>
           ))}
         </div>


### PR DESCRIPTION
## TLDR

Problem this solves:

- Prompt Management's form-free editor surfaces still used legacy dashboard UI primitives

How it solves it:

- Moves the route-owned editor, dialog, history, message, tool, and variable surfaces to installed shadcn primitives
- Preserves non-modal history interaction, short-viewport reachability, textarea growth, keyboard behavior, and theme tokens

## User Flow

Before: a proxy admin can build and test prompts, but the editor follows the legacy dashboard visual system

1. They open `http://localhost:4000/ui/?page=prompts`
2. They add or edit prompt messages, variables, model parameters, and tools
3. They inspect generated code, publish, or browse version history

After: the same flow uses the current dashboard visual system without behavior changes

1. They open `http://localhost:4000/ui/?page=prompts`
2. They add or edit prompt messages, variables, model parameters, and tools
3. They inspect generated code, publish, or browse version history while the editor remains interactive

## Relevant issues

Part of the ShadCN migration tracker

## Linear ticket

## Changes

Sixteen analyzer-approved Prompt Management files now use installed shadcn buttons, cards, dialogs, inputs, popovers, selects, skeletons, tabs, and textareas. The non-modal history panel remains route-local so it does not render a pointer-blocking overlay. Dialogs are viewport-bounded and scrollable, migrated surfaces use semantic theme tokens, and Escape only closes the topmost dialog

The analyzer reports `MIGRATE=0` after this change. One `TABLE` file, two `DEFERRED` form files, and 11 `SHARED` files remain separate migration tracks

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Before, captured from `9cc5a818c3`

![Prompts before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_pr_proof_20260811/pr-proof/2026-08-11/prompts-before.png)

After, captured from `3a603fae64`

![Prompts after](https://raw.githubusercontent.com/BerriAI/litellm/litellm_pr_proof_20260811/pr-proof/2026-08-11/prompts-after.png)

The clean-head calibration found 35 stable routes and zero unstable routes. The migrated route update passed 1/1, and the final zero-tolerance blast-radius gate passed 35/35 with every unaffected route pixel-identical

Live proxy-admin verification exercised Parameters, Generated Code tabs and language selection, variable renaming, nested Escape handling, the non-modal history contract, a content-sized message composer, and short-viewport scrolling. The final route suite passed 96/96 across 19 files, including 25 Version History tests

## Type

Refactoring

## Caveats (if any)

- Form, table, and shared-component migrations remain separate tracks
- Repository-wide TypeScript output retains unrelated existing test failures; no changed production file error was present

## QA runbook

1. Open `http://localhost:4000/ui/?page=prompts` as a proxy admin
2. Open Add New Prompt and edit the developer message and a prompt variable
3. Open Parameters and change temperature and max tokens
4. Open Generated Code, switch code type and language, then close with Escape
5. Open Version History and confirm the underlying editor remains interactive
6. Resize to a short viewport and confirm dialog controls remain reachable

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
