### PR TITLE
feat: add Kimi K3 pricing for openrouter and novita

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -31754,6 +31754,23 @@
         "supports_video_input": true,
         "supports_vision": true
     },
+    "openrouter/moonshotai/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://openrouter.ai/api/v1/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "openrouter/openai/gpt-3.5-turbo": {
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "openrouter",
@@ -43380,6 +43397,23 @@
         "mode": "chat",
         "output_cost_per_token": 9e-07,
         "supports_function_calling": true
+    },
+    "novita/moonshotai/kimi-k3": {
+        "litellm_provider": "novita",
+        "mode": "chat",
+        "input_cost_per_token": 3e-06,
+        "output_cost_per_token": 1.5e-05,
+        "cache_read_input_token_cost": 3e-07,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "source": "https://api.novita.ai/v3/openai/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_video_input": true
     },
     "novita/deepseek/deepseek-v3.2": {
         "litellm_provider": "novita",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -31754,6 +31754,23 @@
         "supports_video_input": true,
         "supports_vision": true
     },
+    "openrouter/moonshotai/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://openrouter.ai/api/v1/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "openrouter/openai/gpt-3.5-turbo": {
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "openrouter",
@@ -43380,6 +43397,23 @@
         "mode": "chat",
         "output_cost_per_token": 9e-07,
         "supports_function_calling": true
+    },
+    "novita/moonshotai/kimi-k3": {
+        "litellm_provider": "novita",
+        "mode": "chat",
+        "input_cost_per_token": 3e-06,
+        "output_cost_per_token": 1.5e-05,
+        "cache_read_input_token_cost": 3e-07,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "source": "https://api.novita.ai/v3/openai/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_video_input": true
     },
     "novita/deepseek/deepseek-v3.2": {
         "litellm_provider": "novita",

--- a/tests/test_litellm/test_kimi_k3_pricing.py
+++ b/tests/test_litellm/test_kimi_k3_pricing.py
@@ -1,0 +1,141 @@
+"""
+Regression test: Kimi K3 had no entry in either model-cost map, so every call
+routed through ``openrouter/moonshotai/kimi-k3`` or ``novita/moonshotai/kimi-k3``
+logged $0 spend instead of its real cost.
+
+These tests pin the published per-token costs in both the primary price map and
+the ``litellm/`` backup, keep the two files in agreement, and assert that
+``cost_per_token`` resolves to a non-zero, exact dollar amount so the silent
+$0 regression cannot come back.
+
+``openrouter/moonshotai/kimi-k3`` deliberately carries no ``max_output_tokens``:
+OpenRouter reports ``top_provider.max_completion_tokens: null`` for this model,
+so no published value exists. The assertion below pins that absence so nobody
+backfills it with the context length by assumption.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from litellm.cost_calculator import cost_per_token
+
+OPENROUTER_MODEL = "openrouter/moonshotai/kimi-k3"
+NOVITA_MODEL = "novita/moonshotai/kimi-k3"
+
+EXPECTED_INPUT_COST = 3e-06
+EXPECTED_OUTPUT_COST = 1.5e-05
+EXPECTED_CACHE_READ_COST = 3e-07
+EXPECTED_MAX_INPUT_TOKENS = 1048576
+
+
+def _load_json(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _backup_path() -> str:
+    return os.path.join(
+        os.path.dirname(litellm.__file__),
+        "model_prices_and_context_window_backup.json",
+    )
+
+
+def _main_path() -> str:
+    return os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "model_prices_and_context_window.json",
+    )
+
+
+@pytest.fixture(scope="module")
+def use_local_model_cost_map():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+
+    original_model_cost = litellm.model_cost
+    litellm.model_cost = _load_json(_backup_path())
+    litellm.get_model_info.cache_clear()
+    _invalidate_model_cost_lowercase_map()
+    try:
+        yield litellm
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.get_model_info.cache_clear()
+        _invalidate_model_cost_lowercase_map()
+        monkeypatch.undo()
+
+
+@pytest.mark.parametrize("model", [OPENROUTER_MODEL, NOVITA_MODEL])
+class TestKimiK3PricingData:
+    """Both price maps must carry the published Kimi K3 costs, and agree."""
+
+    def test_costs_present_in_both_maps(self, model):
+        for path in (_main_path(), _backup_path()):
+            entry = _load_json(path)[model]
+            assert entry["input_cost_per_token"] == EXPECTED_INPUT_COST
+            assert entry["output_cost_per_token"] == EXPECTED_OUTPUT_COST
+            assert entry["cache_read_input_token_cost"] == EXPECTED_CACHE_READ_COST
+            assert entry["max_input_tokens"] == EXPECTED_MAX_INPUT_TOKENS
+            assert entry["mode"] == "chat"
+            assert entry["supports_prompt_caching"] is True
+            assert entry["supports_vision"] is True
+            assert entry["supports_video_input"] is True
+
+    def test_maps_agree(self, model):
+        assert _load_json(_main_path())[model] == _load_json(_backup_path())[model]
+
+    def test_output_costs_more_than_input(self, model):
+        entry = _load_json(_backup_path())[model]
+        assert entry["output_cost_per_token"] > entry["input_cost_per_token"]
+        assert entry["cache_read_input_token_cost"] < entry["input_cost_per_token"]
+
+
+def test_openrouter_entry_has_no_unverified_max_output_tokens():
+    for path in (_main_path(), _backup_path()):
+        assert "max_output_tokens" not in _load_json(path)[OPENROUTER_MODEL]
+
+
+def test_novita_entry_max_output_tokens():
+    for path in (_main_path(), _backup_path()):
+        assert _load_json(path)[NOVITA_MODEL]["max_output_tokens"] == EXPECTED_MAX_INPUT_TOKENS
+
+
+@pytest.mark.parametrize(
+    "model,provider",
+    [(OPENROUTER_MODEL, "openrouter"), (NOVITA_MODEL, "novita")],
+)
+def test_get_model_info_surfaces_costs(use_local_model_cost_map, model, provider):
+    info = use_local_model_cost_map.get_model_info(model)
+
+    assert info["litellm_provider"] == provider
+    assert info["input_cost_per_token"] == EXPECTED_INPUT_COST
+    assert info["output_cost_per_token"] == EXPECTED_OUTPUT_COST
+    assert info["cache_read_input_token_cost"] == EXPECTED_CACHE_READ_COST
+    assert info["max_input_tokens"] == EXPECTED_MAX_INPUT_TOKENS
+
+
+@pytest.mark.parametrize(
+    "model,provider",
+    [(OPENROUTER_MODEL, "openrouter"), (NOVITA_MODEL, "novita")],
+)
+def test_cost_per_token_is_not_zero(use_local_model_cost_map, model, provider):
+    prompt_usd, completion_usd = cost_per_token(
+        model=model,
+        prompt_tokens=1_000_000,
+        completion_tokens=1_000_000,
+        custom_llm_provider=provider,
+    )
+
+    assert prompt_usd == pytest.approx(3.0)
+    assert completion_usd == pytest.approx(15.0)
+    assert prompt_usd + completion_usd > 0


### PR DESCRIPTION
Kimi K3 had no entry in either model cost map, so calls routed through openrouter/moonshotai/kimi-k3 or novita/moonshotai/kimi-k3 logged $0 spend and silently under-counted budgets, spend alerts and per-key limits

Prices come from the provider APIs directly, recorded in each entry's source field. Novita quotes price_per_m in units of 1e-10 USD per token, confirmed against the three existing novita/moonshotai entries already in the map. Both providers independently report $3.00 per million input, $15.00 per million output and $0.30 per million cached input

The openrouter entry intentionally omits max_output_tokens because OpenRouter reports top_provider.max_completion_tokens as null for this model. A test pins that absence so it does not get backfilled with the context length by assumption

Refs #33921

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- <blah>
- ...

How it solves it:

- <blah>
- ...

## User Flow

<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision

Example:

Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request comes back with real token counts, so the dashboard shows real spend

1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
-->

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Caveats (if any)

<!-- Short bullet points, just like the TLDR: one line per bullet, roughly 10 words max
     Call out known limitations, follow-up work, or anything a reviewer should watch out for
     Leave this section empty if there are none -->

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
