### PR TITLE
feat(logging): add async_post_call_failure_deployment_hook

### DIFF
--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -298,6 +298,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         request_data: Mapping[str, Any],
         exception: Exception,
         call_type: CallTypes | None,
+        fallback_depth: int | None = None,
     ) -> None:
         """
         Called once per failed deployment attempt - attempt 1, every retry, and
@@ -314,6 +315,15 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         Pairs with ``async_pre_call_deployment_hook`` and
         ``async_post_call_success_deployment_hook`` to complete the
         pre-call/success/failure lifecycle for a single deployment attempt.
+
+        ``fallback_depth`` is best-effort: ``None`` on the first attempt and on
+        any call made without a ``Router`` (a bare SDK call has no fallback
+        chain to be at a depth in), ``1`` on the first fallback hop, ``2`` on
+        the second, and so on. It reflects ``Router``'s own internal fallback
+        bookkeeping (``kwargs["fallback_depth"]``), not a value this hook
+        computes or guarantees the shape of across versions. It tracks
+        fallback hops only, not retries within the same model group - a
+        retry-only failure (no fallback yet) also reports ``None``.
 
         Default: no-op. Opt in by overriding. Keep overrides fast - this
         runs on the request's exception path, so a slow implementation

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -2,7 +2,7 @@
 #    On success, logs events to Promptlayer
 import re
 import traceback
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Optional
 
 from pydantic import BaseModel
@@ -291,6 +291,33 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
     ) -> LLMResponseTypes | None:
         """
         Allow modifying / reviewing the response just after it's received from the deployment.
+        """
+
+    async def async_post_call_failure_deployment_hook(
+        self,
+        request_data: Mapping[str, Any],
+        exception: Exception,
+        call_type: CallTypes | None,
+    ) -> None:
+        """
+        Called once per failed deployment attempt - attempt 1, every retry, and
+        every fallback chain step - because the router re-invokes the wrapped
+        function on each attempt, re-entering this hook's call site fresh
+        every time.
+
+        This is a DEPLOYMENT-LEVEL signal, distinct from the REQUEST-LEVEL
+        ``async_log_failure_event``, which fires once per logical client
+        request behind a dedup gate. ``request_data`` is this attempt's own
+        kwargs, not a value shared across the fallback chain, so unlike
+        ``async_log_failure_event`` there's nothing stale to watch out for.
+
+        Pairs with ``async_pre_call_deployment_hook`` and
+        ``async_post_call_success_deployment_hook`` to complete the
+        pre-call/success/failure lifecycle for a single deployment attempt.
+
+        Default: no-op. Opt in by overriding. Keep overrides fast - this
+        runs on the request's exception path, so a slow implementation
+        delays error propagation to the caller.
         """
 
     async def async_post_call_streaming_deployment_hook(

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -308,9 +308,11 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
 
         This is a DEPLOYMENT-LEVEL signal, distinct from the REQUEST-LEVEL
         ``async_log_failure_event``, which fires once per logical client
-        request behind a dedup gate. ``request_data`` is this attempt's own
-        kwargs, not a value shared across the fallback chain, so unlike
-        ``async_log_failure_event`` there's nothing stale to watch out for.
+        request behind a dedup gate. ``request_data`` is mostly this
+        attempt's own kwargs, with one exception: it omits
+        ``attempted_targets``, the router's own bookkeeping of which fallback
+        targets this request has already tried, since that one object *is*
+        shared by reference across every hop of the live fallback walk.
 
         Pairs with ``async_pre_call_deployment_hook`` and
         ``async_post_call_success_deployment_hook`` to complete the
@@ -323,11 +325,20 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         bookkeeping (``kwargs["fallback_depth"]``), not a value this hook
         computes or guarantees the shape of across versions. It tracks
         fallback hops only, not retries within the same model group - a
-        retry-only failure (no fallback yet) also reports ``None``.
+        retry-only failure (no fallback yet) also reports ``None``. If an
+        override predates this field it's simply never passed, rather than
+        raising - safe to leave off an override written before it existed.
+
+        ``exception`` is a same-class snapshot, not the exact object about to
+        be re-raised to the real caller: read it freely, but setting an
+        attribute on it (e.g. ``status_code``) has no effect on what the
+        caller actually receives.
 
         Default: no-op. Opt in by overriding. Keep overrides fast - this
         runs on the request's exception path, so a slow implementation
-        delays error propagation to the caller.
+        delays error propagation to the caller. The reported failure
+        duration is captured before this hook runs, so a slow override
+        doesn't inflate that metric, but the caller still waits for it.
         """
 
     async def async_post_call_streaming_deployment_hook(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1796,7 +1796,15 @@ def client(original_function):
                     print_verbose(f"Error while checking max token limit: {e}")
 
             # MODEL CALL
-            result = await original_function(*args, **kwargs)
+            try:
+                result = await original_function(*args, **kwargs)
+            except Exception as deployment_error:
+                await async_post_call_failure_deployment_hook(
+                    request_data=kwargs,
+                    exception=deployment_error,
+                    call_type=call_type,
+                )
+                raise
             end_time = datetime.datetime.now()
 
             if _is_streaming_request(
@@ -1921,11 +1929,6 @@ def client(original_function):
                     await logging_obj.async_failure_handler(e, traceback_exception, start_time, end_time)
                 except Exception as e:
                     raise e
-            await async_post_call_failure_deployment_hook(
-                request_data=kwargs,
-                exception=e,
-                call_type=call_type,
-            )
 
             call_type = original_function.__name__
             num_retries, kwargs = _get_wrapper_num_retries(kwargs=kwargs, exception=e)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -35,6 +35,7 @@ from importlib import resources
 from inspect import iscoroutine
 from io import StringIO
 from os.path import abspath, dirname, join
+from types import MappingProxyType
 
 import dotenv
 import httpx
@@ -1320,7 +1321,7 @@ async def async_post_call_failure_deployment_hook(
 
     _raw_fallback_depth: Final = request_data.get("fallback_depth")
     fallback_depth: Final = _raw_fallback_depth if isinstance(_raw_fallback_depth, int) else None
-    safe_request_data: Final = {k: v for k, v in request_data.items() if k != "attempted_targets"}
+    safe_request_data: Final = MappingProxyType({k: v for k, v in request_data.items() if k != "attempted_targets"})
     safe_exception: Final = _snapshot_exception_for_hook(exception)
 
     CustomLogger: Final = _get_cached_custom_logger()

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1263,17 +1263,26 @@ async def async_post_call_failure_deployment_hook(
     in its own try/except: it runs on the wrapper's exception path, so a
     broken callback must never replace the real exception that's about to be
     re-raised to the caller.
+
+    Reads ``fallback_depth`` off ``request_data`` (set by ``Router`` on each
+    fallback hop) and passes it through to the callback; ``None`` when
+    missing or not an int, since a bare SDK call has no fallback chain.
     """
     try:
         typed_call_type = CallTypes(call_type)
     except ValueError:
         typed_call_type = None  # unknown call type
 
+    _raw_fallback_depth: Final = request_data.get("fallback_depth")
+    fallback_depth: Final = _raw_fallback_depth if isinstance(_raw_fallback_depth, int) else None
+
     CustomLogger: Final = _get_cached_custom_logger()
     for callback in litellm.callbacks:
         if isinstance(callback, CustomLogger):
             try:
-                await callback.async_post_call_failure_deployment_hook(request_data, exception, typed_call_type)
+                await callback.async_post_call_failure_deployment_hook(
+                    request_data, exception, typed_call_type, fallback_depth=fallback_depth
+                )
             except Exception as callback_error:  # noqa: BLE001  # a broken callback must not mask the real failure
                 verbose_logger.debug(
                     "async_post_call_failure_deployment_hook error in %s: %s",

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -129,6 +129,9 @@ def _snapshot_exception_for_hook(exception: Exception) -> Exception:
         snapshot.__traceback__ = exception.__traceback__
         snapshot.__cause__ = exception.__cause__
         snapshot.__context__ = exception.__context__
+        # Setting __cause__ implicitly forces __suppress_context__ to True (CPython
+        # behavior for `raise ... from ...`), so this must be set after, not before.
+        snapshot.__suppress_context__ = exception.__suppress_context__
         return snapshot
     except Exception:  # noqa: BLE001  # any snapshot failure must fall back to the live object, not break the failure path
         return exception

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1921,11 +1921,11 @@ def client(original_function):
                     await logging_obj.async_failure_handler(e, traceback_exception, start_time, end_time)
                 except Exception as e:
                     raise e
-                await async_post_call_failure_deployment_hook(
-                    request_data=kwargs,
-                    exception=e,
-                    call_type=call_type,
-                )
+            await async_post_call_failure_deployment_hook(
+                request_data=kwargs,
+                exception=e,
+                call_type=call_type,
+            )
 
             call_type = original_function.__name__
             num_retries, kwargs = _get_wrapper_num_retries(kwargs=kwargs, exception=e)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -100,6 +100,37 @@ def _get_cached_custom_logger():
     return _CustomLogger
 
 
+@lru_cache(maxsize=None)
+def _accepts_fallback_depth_kwarg_for_class(cls: type) -> bool:
+    """
+    Whether cls's async_post_call_failure_deployment_hook override accepts a
+    fallback_depth keyword, cached per class so a signature the base class added after a
+    subscriber's override was written (e.g. the PR's own earlier 3-arg proof-of-fix
+    example) doesn't raise TypeError - swallowed at debug level - on every call.
+    """
+    params: Final = inspect.signature(cls.async_post_call_failure_deployment_hook).parameters
+    return "fallback_depth" in params or any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
+def _snapshot_exception_for_hook(exception: Exception) -> Exception:
+    """
+    A same-class copy of exception that skips __init__ (many litellm exceptions require
+    constructor args beyond what .args carries, so copy.copy's pickle-based reconstruction
+    fails on them). Handed to failure-hook callbacks instead of the live object so a
+    callback setting e.g. exception.status_code cannot change the status code the real
+    caller actually receives. Falls back to the live object if snapshotting fails for a
+    type this doesn't anticipate, since the real exception must still reach the callback.
+    """
+    try:
+        cls: Final = type(exception)
+        snapshot: Final = cls.__new__(cls)
+        snapshot.__dict__.update(exception.__dict__)
+        snapshot.args = exception.args
+        return snapshot
+    except Exception:  # noqa: BLE001  # any snapshot failure must fall back to the live object, not break the failure path
+        return exception
+
+
 def _get_cached_custom_guardrail():
     """
     Get cached CustomGuardrail class.
@@ -1267,6 +1298,14 @@ async def async_post_call_failure_deployment_hook(
     Reads ``fallback_depth`` off ``request_data`` (set by ``Router`` on each
     fallback hop) and passes it through to the callback; ``None`` when
     missing or not an int, since a bare SDK call has no fallback chain.
+
+    Callbacks receive a same-class snapshot of ``exception``, not the live
+    object that's about to be re-raised, so a callback setting an attribute
+    on it (e.g. ``status_code``) cannot change what the real caller sees.
+    ``request_data`` omits ``attempted_targets``: unlike the rest of this
+    attempt's own kwargs, it's the *same* object shared by reference across
+    every hop of the live fallback walk, so a callback calling ``.record()``
+    on it would make the router skip a deployment it hasn't actually tried.
     """
     try:
         typed_call_type = CallTypes(call_type)
@@ -1275,14 +1314,21 @@ async def async_post_call_failure_deployment_hook(
 
     _raw_fallback_depth: Final = request_data.get("fallback_depth")
     fallback_depth: Final = _raw_fallback_depth if isinstance(_raw_fallback_depth, int) else None
+    safe_request_data: Final = {k: v for k, v in request_data.items() if k != "attempted_targets"}
+    safe_exception: Final = _snapshot_exception_for_hook(exception)
 
     CustomLogger: Final = _get_cached_custom_logger()
     for callback in litellm.callbacks:
         if isinstance(callback, CustomLogger):
             try:
-                await callback.async_post_call_failure_deployment_hook(
-                    request_data, exception, typed_call_type, fallback_depth=fallback_depth
-                )
+                if _accepts_fallback_depth_kwarg_for_class(type(callback)):
+                    await callback.async_post_call_failure_deployment_hook(
+                        safe_request_data, safe_exception, typed_call_type, fallback_depth=fallback_depth
+                    )
+                else:
+                    await callback.async_post_call_failure_deployment_hook(
+                        safe_request_data, safe_exception, typed_call_type
+                    )
             except Exception as callback_error:  # noqa: BLE001  # a broken callback must not mask the real failure
                 verbose_logger.debug(
                     "async_post_call_failure_deployment_hook error in %s: %s",
@@ -1708,6 +1754,9 @@ def client(original_function):
         is_completion_with_fallbacks: Final = kwargs.get("fallbacks") is not None
         kwargs.pop("_is_litellm_internal_call", None)  # discard if injected
         _is_litellm_internal_call: Final = is_internal_call.get()
+        _deployment_call_end_time: datetime.datetime | None = (
+            None  # rebind-ok: set once, from inside the except below, only if the model call itself fails
+        )
 
         try:
             if logging_obj is None:
@@ -1799,11 +1848,15 @@ def client(original_function):
             try:
                 result = await original_function(*args, **kwargs)
             except Exception as deployment_error:
-                await async_post_call_failure_deployment_hook(
-                    request_data=kwargs,
-                    exception=deployment_error,
-                    call_type=call_type,
-                )
+                _deployment_call_end_time = datetime.datetime.now()  # noqa: DTZ005  # matches the naive datetimes this whole function already times start_time/end_time with
+                try:
+                    await async_post_call_failure_deployment_hook(
+                        request_data=kwargs,
+                        exception=deployment_error,
+                        call_type=call_type,
+                    )
+                except BaseException:  # noqa: S110, BLE001  # hook dispatch - including cancellation mid-await - must never replace the real deployment failure, so there is nothing to do with what it raises
+                    pass
                 raise
             end_time = datetime.datetime.now()
 
@@ -1917,7 +1970,9 @@ def client(original_function):
             return result
         except Exception as e:
             traceback_exception: Final = traceback.format_exc()
-            end_time = datetime.datetime.now()
+            # Reuse the timestamp taken right when the deployment call itself failed, before
+            # the failure hook ran, so a slow callback doesn't inflate the reported duration.
+            end_time = _deployment_call_end_time if _deployment_call_end_time is not None else datetime.datetime.now()  # noqa: DTZ005  # matches the naive datetimes this whole function already times start_time/end_time with
             if logging_obj and not _is_litellm_internal_call:
                 try:
                     logging_obj.failure_handler(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1253,6 +1253,35 @@ async def async_post_call_success_deployment_hook(
     return response
 
 
+async def async_post_call_failure_deployment_hook(
+    request_data: Mapping[str, Any], exception: Exception, call_type: str
+) -> None:
+    """
+    Notify CustomLogger callbacks that a deployment attempt failed.
+
+    Unlike its pre-call/post-success siblings, this wraps each callback call
+    in its own try/except: it runs on the wrapper's exception path, so a
+    broken callback must never replace the real exception that's about to be
+    re-raised to the caller.
+    """
+    try:
+        typed_call_type = CallTypes(call_type)
+    except ValueError:
+        typed_call_type = None  # unknown call type
+
+    CustomLogger: Final = _get_cached_custom_logger()
+    for callback in litellm.callbacks:
+        if isinstance(callback, CustomLogger):
+            try:
+                await callback.async_post_call_failure_deployment_hook(request_data, exception, typed_call_type)
+            except Exception as callback_error:  # noqa: BLE001  # a broken callback must not mask the real failure
+                verbose_logger.debug(
+                    "async_post_call_failure_deployment_hook error in %s: %s",
+                    type(callback).__name__,
+                    callback_error,
+                )
+
+
 def post_call_processing(
     original_response,
     model,
@@ -1883,6 +1912,11 @@ def client(original_function):
                     await logging_obj.async_failure_handler(e, traceback_exception, start_time, end_time)
                 except Exception as e:
                     raise e
+                await async_post_call_failure_deployment_hook(
+                    request_data=kwargs,
+                    exception=e,
+                    call_type=call_type,
+                )
 
             call_type = original_function.__name__
             num_retries, kwargs = _get_wrapper_num_retries(kwargs=kwargs, exception=e)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -126,6 +126,9 @@ def _snapshot_exception_for_hook(exception: Exception) -> Exception:
         snapshot: Final = cls.__new__(cls)
         snapshot.__dict__.update(exception.__dict__)
         snapshot.args = exception.args
+        snapshot.__traceback__ = exception.__traceback__
+        snapshot.__cause__ = exception.__cause__
+        snapshot.__context__ = exception.__context__
         return snapshot
     except Exception:  # noqa: BLE001  # any snapshot failure must fall back to the live object, not break the failure path
         return exception

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -5483,3 +5483,30 @@ async def test_wrapper_async_failure_hook_latency_does_not_inflate_reported_dura
 
     assert len(reported_durations) == 1
     assert reported_durations[0] < 0.5
+
+
+@pytest.mark.asyncio
+async def test_wrapper_async_failure_hook_exception_snapshot_preserves_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: the exception snapshot handed to failure-hook callbacks (see
+    test_..._exception_mutation_does_not_change_raised_exception above) must still carry
+    __traceback__/__cause__/__context__, not just __dict__/args - a callback formatting or
+    inspecting the failure chain needs the real traceback, not an empty one."""
+    received: list[Exception] = []
+
+    class TracebackCapturingLogger(CustomLogger):
+        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type, fallback_depth=None):
+            received.append(exception)
+
+    monkeypatch.setattr(litellm, "callbacks", [TracebackCapturingLogger()])
+
+    with pytest.raises(litellm.AuthenticationError):
+        await litellm.acompletion(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response=litellm.AuthenticationError(message="bad key", llm_provider="openai", model="gpt-4o-mini"),
+        )
+
+    assert len(received) == 1
+    assert received[0].__traceback__ is not None

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -37,6 +37,7 @@ from litellm.utils import (
     _check_provider_match,
     _get_potential_model_names,
     _is_streaming_request,
+    _snapshot_exception_for_hook,
     async_post_call_failure_deployment_hook,
     client,
     get_api_key,
@@ -5510,3 +5511,27 @@ async def test_wrapper_async_failure_hook_exception_snapshot_preserves_traceback
 
     assert len(received) == 1
     assert received[0].__traceback__ is not None
+
+
+def test_snapshot_exception_for_hook_preserves_suppress_context_flag() -> None:
+    """Regression: setting __cause__ has a documented CPython side effect of implicitly
+    forcing __suppress_context__ to True, even when the real exception's own
+    __suppress_context__ is False (the common case: no `raise ... from`, just an
+    exception raised while handling another one, which chains __context__ but does not
+    suppress it). Snapshotting __cause__ before __suppress_context__ would silently flip
+    a real exception's __suppress_context__=False to True on the snapshot, hiding a
+    chained context a callback formatting it should still see."""
+    def _raise_chained_without_from() -> None:
+        try:
+            raise ValueError("inner cause")
+        except ValueError:
+            raise RuntimeError("outer error")  # no `from` clause: implicit chaining, not suppressed
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _raise_chained_without_from()
+
+    e = exc_info.value
+    assert e.__suppress_context__ is False  # sanity check on the real exception itself
+    snapshot = _snapshot_exception_for_hook(e)
+    assert snapshot.__suppress_context__ is False
+    assert snapshot.__context__ is e.__context__

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -5224,3 +5224,57 @@ async def test_wrapper_async_fires_post_call_failure_deployment_hook_on_internal
 
     assert len(recorder.calls) == 1
     assert isinstance(recorder.calls[0][1], litellm.AuthenticationError)
+
+
+@pytest.mark.asyncio
+async def test_wrapper_async_does_not_fire_failure_hook_for_pre_call_budget_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: a BudgetExceededError raised before any deployment call is attempted
+    (the [OPTIONAL] CHECK BUDGET gate) is not a deployment attempt failure and must not
+    reach async_post_call_failure_deployment_hook."""
+    recorder = _RecordingDeploymentFailureLogger()
+    monkeypatch.setattr(litellm, "callbacks", [recorder])
+    monkeypatch.setattr(litellm, "max_budget", 0.0001)
+    monkeypatch.setattr(litellm, "_current_cost", 100.0)
+
+    with pytest.raises(litellm.BudgetExceededError):
+        await litellm.acompletion(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="should never be reached",
+        )
+
+    assert recorder.calls == []
+
+
+@pytest.mark.asyncio
+async def test_wrapper_async_does_not_fire_failure_hook_for_post_success_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: an error raised after the deployment call already succeeded (e.g. inside
+    async_post_call_success_deployment_hook or post_call_processing) is not a deployment
+    attempt failure and must not reach async_post_call_failure_deployment_hook."""
+
+    class ExplodingSuccessLogger(CustomLogger):
+        def __init__(self) -> None:
+            super().__init__()
+            self.failure_calls: list[Exception] = []
+
+        async def async_post_call_success_deployment_hook(self, request_data, response, call_type):
+            raise RuntimeError("boom in success hook, model call itself succeeded")
+
+        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type, fallback_depth=None):
+            self.failure_calls.append(exception)
+
+    exploding_logger = ExplodingSuccessLogger()
+    monkeypatch.setattr(litellm, "callbacks", [exploding_logger])
+
+    with pytest.raises(RuntimeError, match="boom in success hook"):
+        await litellm.acompletion(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="this call succeeds",
+        )
+
+    assert exploding_logger.failure_calls == []

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -4996,8 +4997,9 @@ class _RecordingDeploymentFailureLogger(CustomLogger):
 async def test_async_post_call_failure_deployment_hook_calls_custom_logger_callbacks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The dispatcher must call the CustomLogger hook with the exception it was given
-    and the call_type resolved to its CallTypes enum member."""
+    """The dispatcher must call the CustomLogger hook with an equivalent exception (not
+    necessarily the same object - see test_..._snapshots_exception_so_callback_mutations_..._
+    below) and the call_type resolved to its CallTypes enum member."""
     recorder = _RecordingDeploymentFailureLogger()
     monkeypatch.setattr(litellm, "callbacks", [recorder])
 
@@ -5009,7 +5011,8 @@ async def test_async_post_call_failure_deployment_hook_calls_custom_logger_callb
     assert len(recorder.calls) == 1
     request_data, received_exc, call_type, fallback_depth = recorder.calls[0]
     assert request_data == {"model": "gpt-4o-mini"}
-    assert received_exc is exc
+    assert isinstance(received_exc, ValueError)
+    assert str(received_exc) == str(exc)
     assert call_type == CallTypes.acompletion
     assert fallback_depth is None
 
@@ -5286,3 +5289,197 @@ async def test_wrapper_async_does_not_fire_failure_hook_for_post_success_error(
         )
 
     assert exploding_logger.failure_calls == []
+
+
+@pytest.mark.asyncio
+async def test_wrapper_async_calls_hook_override_missing_fallback_depth_param(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: an override written before fallback_depth existed (this PR's own earlier
+    proof-of-fix example used exactly this 3-arg signature) must still fire, not raise a
+    TypeError on the fallback_depth keyword that gets swallowed at debug level."""
+
+    class ThreeArgLogger(CustomLogger):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls: list[tuple[dict, Exception, CallTypes | None]] = []
+
+        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type):
+            self.calls.append((request_data, exception, call_type))
+
+    three_arg_logger = ThreeArgLogger()
+    monkeypatch.setattr(litellm, "callbacks", [three_arg_logger])
+
+    with pytest.raises(litellm.AuthenticationError):
+        await litellm.acompletion(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response=litellm.AuthenticationError(message="bad key", llm_provider="openai", model="gpt-4o-mini"),
+        )
+
+    assert len(three_arg_logger.calls) == 1
+    assert isinstance(three_arg_logger.calls[0][1], litellm.AuthenticationError)
+
+
+@pytest.mark.asyncio
+async def test_wrapper_async_failure_hook_exception_mutation_does_not_change_raised_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: a callback setting an attribute on the exception it receives (e.g.
+    status_code, as a real caller would read to determine the HTTP response) must not
+    change what the actual caller ends up with - the hook must not have write access to
+    the real exception about to be re-raised."""
+
+    class StatusCodeMutatingLogger(CustomLogger):
+        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type, fallback_depth=None):
+            exception.status_code = 429
+
+    monkeypatch.setattr(litellm, "callbacks", [StatusCodeMutatingLogger()])
+
+    with pytest.raises(litellm.AuthenticationError) as exc_info:
+        await litellm.acompletion(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response=litellm.AuthenticationError(message="bad key", llm_provider="openai", model="gpt-4o-mini"),
+        )
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_deployment_hook_omits_attempted_targets_from_request_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: attempted_targets is the router's own live fallback-walk bookkeeping,
+    shared by reference across every hop of a single request - unlike the rest of
+    request_data, it is not this attempt's own isolated copy. A callback calling .record()
+    on it would make the router skip a deployment it hasn't actually tried, so the
+    dispatcher must never hand it to a callback."""
+    recorder = _RecordingDeploymentFailureLogger()
+    monkeypatch.setattr(litellm, "callbacks", [recorder])
+
+    sentinel_targets = object()
+    await async_post_call_failure_deployment_hook(
+        request_data={"model": "gpt-4o-mini", "attempted_targets": sentinel_targets},
+        exception=ValueError("x"),
+        call_type="acompletion",
+    )
+
+    assert recorder.calls[0][0].get("attempted_targets") is None
+
+
+@pytest.mark.asyncio
+async def test_router_fallback_not_skipped_when_failure_hook_callback_touches_attempted_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: even a callback that tries to record a target on whatever it's handed as
+    attempted_targets must not affect the live Router fallback walk - the healthy fallback
+    deployment must still be reachable, not silently skipped as already-attempted.
+
+    attempted_targets is only present in kwargs starting from the second hop onward (the
+    first deployment's own failure predates the router's own fallback bookkeeping), so this
+    needs a 3-deployment chain: mid-group's failure is where the callback sees
+    attempted_targets and can prematurely mark good-group as tried. Uses per-deployment
+    mock_timeout/mock_response, not a request-level mock_response, which Router carries
+    into every hop's kwargs and would mask this test's real signal."""
+
+    class RecordingAttemptLogger(CustomLogger):
+        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type, fallback_depth=None):
+            attempted = request_data.get("attempted_targets")
+            if attempted is not None:
+                attempted.record("good-group")
+
+    monkeypatch.setattr(litellm, "callbacks", [RecordingAttemptLogger()])
+
+    def _mock_timeout_deployment(model_name: str) -> dict:
+        return {
+            "model_name": model_name,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "api_key": "fake",
+                "mock_timeout": True,
+                "timeout": 0.001,
+                "num_retries": 0,
+            },
+        }
+
+    router = litellm.Router(
+        model_list=[
+            _mock_timeout_deployment("bad-group"),
+            _mock_timeout_deployment("mid-group"),
+            {
+                "model_name": "good-group",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "fake",
+                    "mock_response": "fallback worked",
+                    "num_retries": 0,
+                },
+            },
+        ],
+        num_retries=0,
+        fallbacks=[{"bad-group": ["mid-group", "good-group"]}],
+    )
+
+    response = await router.acompletion(
+        model="bad-group",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert response.choices[0].message.content == "fallback worked"
+
+
+@pytest.mark.asyncio
+async def test_wrapper_async_preserves_original_exception_when_hook_await_is_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: if the caller's own timeout (e.g. asyncio.wait_for) fires while the
+    failure hook is still being awaited, the real deployment exception must still reach
+    the caller - not get replaced by CancelledError/TimeoutError from the hook's own
+    await getting cancelled."""
+
+    class SlowLogger(CustomLogger):
+        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type, fallback_depth=None):
+            await asyncio.sleep(5)
+
+    monkeypatch.setattr(litellm, "callbacks", [SlowLogger()])
+
+    with pytest.raises(litellm.AuthenticationError):
+        await asyncio.wait_for(
+            litellm.acompletion(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                mock_response=litellm.AuthenticationError(message="bad key", llm_provider="openai", model="gpt-4o-mini"),
+            ),
+            timeout=0.2,
+        )
+
+
+@pytest.mark.asyncio
+async def test_wrapper_async_failure_hook_latency_does_not_inflate_reported_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: a slow failure-hook callback must not inflate the duration reported to
+    async_log_failure_event - that's real observability data (e.g. latency dashboards),
+    and the hook's own runtime is not part of how long the deployment call itself took."""
+    reported_durations: list[float] = []
+
+    class SlowLoggerWithDurationCapture(CustomLogger):
+        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type, fallback_depth=None):
+            await asyncio.sleep(1)
+
+        async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+            reported_durations.append((end_time - start_time).total_seconds())
+
+    monkeypatch.setattr(litellm, "callbacks", [SlowLoggerWithDurationCapture()])
+
+    with pytest.raises(litellm.AuthenticationError):
+        await litellm.acompletion(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response=litellm.AuthenticationError(message="bad key", llm_provider="openai", model="gpt-4o-mini"),
+        )
+    await asyncio.sleep(0.1)
+
+    assert len(reported_durations) == 1
+    assert reported_durations[0] < 0.5

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -9,6 +9,7 @@ from jsonschema import validate
 
 
 import litellm
+from litellm._internal_context import is_internal_call
 from litellm._logging import (
     CorrelationContextFilter,
     JsonFormatter,
@@ -5196,3 +5197,30 @@ async def test_router_multi_hop_fallback_chain_reports_depth_per_hop(monkeypatch
 
     assert len(recorder.calls) == 3
     assert [call[3] for call in recorder.calls] == [None, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_wrapper_async_fires_post_call_failure_deployment_hook_on_internal_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: a failed attempt made while is_internal_call is set (e.g. an emulated
+    file-search step) must still reach async_post_call_failure_deployment_hook, matching
+    async_pre_call_deployment_hook, which already fires unconditionally for such calls."""
+    recorder = _RecordingDeploymentFailureLogger()
+    monkeypatch.setattr(litellm, "callbacks", [recorder])
+
+    token = is_internal_call.set(True)
+    try:
+        with pytest.raises(litellm.AuthenticationError):
+            await litellm.acompletion(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                mock_response=litellm.AuthenticationError(
+                    message="bad key", llm_provider="openai", model="gpt-4o-mini"
+                ),
+            )
+    finally:
+        is_internal_call.reset(token)
+
+    assert len(recorder.calls) == 1
+    assert isinstance(recorder.calls[0][1], litellm.AuthenticationError)

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -16,6 +16,7 @@ from litellm._logging import (
     trace_id_var,
     verbose_logger,
 )
+from litellm.integrations.custom_logger import CustomLogger
 from litellm.proxy.utils import is_valid_api_key
 from litellm.types.utils import (
     CallTypes,
@@ -34,6 +35,8 @@ from litellm.utils import (
     _check_provider_match,
     _get_potential_model_names,
     _is_streaming_request,
+    async_post_call_failure_deployment_hook,
+    client,
     get_api_key,
     get_llm_provider,
     get_non_default_completion_params,
@@ -4977,3 +4980,124 @@ def test_completion_does_not_leak_rust_flag_into_provider_request_body():
     create_kwargs = mock_client.chat.completions.with_raw_response.create.call_args.kwargs
     assert "rust" not in create_kwargs
     assert "rust" not in (create_kwargs.get("extra_body") or {})
+
+
+class _RecordingDeploymentFailureLogger(CustomLogger):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[tuple[dict, Exception, CallTypes | None]] = []
+
+    async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type):
+        self.calls.append((request_data, exception, call_type))
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_deployment_hook_calls_custom_logger_callbacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dispatcher must call the CustomLogger hook with the exception it was given
+    and the call_type resolved to its CallTypes enum member."""
+    recorder = _RecordingDeploymentFailureLogger()
+    monkeypatch.setattr(litellm, "callbacks", [recorder])
+
+    exc = ValueError("deployment failed")
+    await async_post_call_failure_deployment_hook(
+        request_data={"model": "gpt-4o-mini"}, exception=exc, call_type="acompletion"
+    )
+
+    assert len(recorder.calls) == 1
+    request_data, received_exc, call_type = recorder.calls[0]
+    assert request_data == {"model": "gpt-4o-mini"}
+    assert received_exc is exc
+    assert call_type == CallTypes.acompletion
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_deployment_hook_falls_back_to_none_call_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unrecognized call_type string must resolve to None rather than raising."""
+    recorder = _RecordingDeploymentFailureLogger()
+    monkeypatch.setattr(litellm, "callbacks", [recorder])
+
+    await async_post_call_failure_deployment_hook(
+        request_data={}, exception=ValueError("x"), call_type="not_a_real_call_type"
+    )
+
+    assert recorder.calls[0][2] is None
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_deployment_hook_swallows_callback_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A callback that raises inside the hook must not propagate out of the dispatcher."""
+
+    class ExplodingLogger(CustomLogger):
+        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type):
+            raise RuntimeError("hook exploded")
+
+    monkeypatch.setattr(litellm, "callbacks", [ExplodingLogger()])
+
+    await async_post_call_failure_deployment_hook(request_data={}, exception=ValueError("x"), call_type="acompletion")
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_deployment_hook_skips_non_custom_logger_callbacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Callable (function-based) callbacks are not CustomLogger instances and must be skipped."""
+    called: list[bool] = []
+
+    async def fn_callback(*args: object, **kwargs: object) -> None:
+        called.append(True)
+
+    monkeypatch.setattr(litellm, "callbacks", [fn_callback])
+
+    await async_post_call_failure_deployment_hook(request_data={}, exception=ValueError("x"), call_type="acompletion")
+
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_wrapper_async_fires_post_call_failure_deployment_hook_once_per_failed_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: a failed deployment call must reach async_post_call_failure_deployment_hook
+    exactly once, sourced from wrapper_async's own except block rather than the dedup-gated
+    async_log_failure_event path, which would miss retries/fallback chain attempts 2+."""
+    recorder = _RecordingDeploymentFailureLogger()
+    monkeypatch.setattr(litellm, "callbacks", [recorder])
+
+    with pytest.raises(litellm.AuthenticationError):
+        await litellm.acompletion(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response=litellm.AuthenticationError(message="bad key", llm_provider="openai", model="gpt-4o-mini"),
+        )
+
+    assert len(recorder.calls) == 1
+    _, received_exc, call_type = recorder.calls[0]
+    assert isinstance(received_exc, litellm.AuthenticationError)
+    assert call_type == CallTypes.acompletion
+
+
+@pytest.mark.asyncio
+async def test_wrapper_async_raises_original_exception_even_if_hook_callback_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken async_post_call_failure_deployment_hook override must never shadow the real
+    exception the caller is waiting on."""
+
+    class ExplodingLogger(CustomLogger):
+        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type):
+            raise RuntimeError("hook exploded")
+
+    monkeypatch.setattr(litellm, "callbacks", [ExplodingLogger()])
+
+    with pytest.raises(litellm.AuthenticationError, match="bad key"):
+        await litellm.acompletion(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response=litellm.AuthenticationError(message="bad key", llm_provider="openai", model="gpt-4o-mini"),
+        )

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -5071,12 +5071,20 @@ async def test_async_post_call_failure_deployment_hook_swallows_callback_errors(
     """A callback that raises inside the hook must not propagate out of the dispatcher."""
 
     class ExplodingLogger(CustomLogger):
+        def __init__(self) -> None:
+            super().__init__()
+            self.called = False
+
         async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type, fallback_depth=None):
+            self.called = True
             raise RuntimeError("hook exploded")
 
-    monkeypatch.setattr(litellm, "callbacks", [ExplodingLogger()])
+    exploding_logger = ExplodingLogger()
+    monkeypatch.setattr(litellm, "callbacks", [exploding_logger])
 
     await async_post_call_failure_deployment_hook(request_data={}, exception=ValueError("x"), call_type="acompletion")
+
+    assert exploding_logger.called
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4985,10 +4985,10 @@ def test_completion_does_not_leak_rust_flag_into_provider_request_body():
 class _RecordingDeploymentFailureLogger(CustomLogger):
     def __init__(self) -> None:
         super().__init__()
-        self.calls: list[tuple[dict, Exception, CallTypes | None]] = []
+        self.calls: list[tuple[dict, Exception, CallTypes | None, int | None]] = []
 
-    async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type):
-        self.calls.append((request_data, exception, call_type))
+    async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type, fallback_depth=None):
+        self.calls.append((request_data, exception, call_type, fallback_depth))
 
 
 @pytest.mark.asyncio
@@ -5006,10 +5006,11 @@ async def test_async_post_call_failure_deployment_hook_calls_custom_logger_callb
     )
 
     assert len(recorder.calls) == 1
-    request_data, received_exc, call_type = recorder.calls[0]
+    request_data, received_exc, call_type, fallback_depth = recorder.calls[0]
     assert request_data == {"model": "gpt-4o-mini"}
     assert received_exc is exc
     assert call_type == CallTypes.acompletion
+    assert fallback_depth is None
 
 
 @pytest.mark.asyncio
@@ -5028,13 +5029,48 @@ async def test_async_post_call_failure_deployment_hook_falls_back_to_none_call_t
 
 
 @pytest.mark.asyncio
+async def test_async_post_call_failure_deployment_hook_passes_through_fallback_depth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """fallback_depth on request_data (set by Router on each fallback hop) must reach the
+    callback unchanged, so a subscriber can tell which fallback hop this failure is from."""
+    recorder = _RecordingDeploymentFailureLogger()
+    monkeypatch.setattr(litellm, "callbacks", [recorder])
+
+    await async_post_call_failure_deployment_hook(
+        request_data={"fallback_depth": 2}, exception=ValueError("x"), call_type="acompletion"
+    )
+
+    assert recorder.calls[0][3] == 2
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_deployment_hook_fallback_depth_defaults_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """fallback_depth must be None, not raise or pass through garbage, when request_data has
+    no fallback_depth at all (first attempt, or a bare SDK call with no Router) or a
+    non-int value there."""
+    recorder = _RecordingDeploymentFailureLogger()
+    monkeypatch.setattr(litellm, "callbacks", [recorder])
+
+    await async_post_call_failure_deployment_hook(request_data={}, exception=ValueError("x"), call_type="acompletion")
+    await async_post_call_failure_deployment_hook(
+        request_data={"fallback_depth": "not-an-int"}, exception=ValueError("y"), call_type="acompletion"
+    )
+
+    assert recorder.calls[0][3] is None
+    assert recorder.calls[1][3] is None
+
+
+@pytest.mark.asyncio
 async def test_async_post_call_failure_deployment_hook_swallows_callback_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A callback that raises inside the hook must not propagate out of the dispatcher."""
 
     class ExplodingLogger(CustomLogger):
-        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type):
+        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type, fallback_depth=None):
             raise RuntimeError("hook exploded")
 
     monkeypatch.setattr(litellm, "callbacks", [ExplodingLogger()])
@@ -5077,9 +5113,10 @@ async def test_wrapper_async_fires_post_call_failure_deployment_hook_once_per_fa
         )
 
     assert len(recorder.calls) == 1
-    _, received_exc, call_type = recorder.calls[0]
+    _, received_exc, call_type, fallback_depth = recorder.calls[0]
     assert isinstance(received_exc, litellm.AuthenticationError)
     assert call_type == CallTypes.acompletion
+    assert fallback_depth is None
 
 
 @pytest.mark.asyncio
@@ -5090,7 +5127,7 @@ async def test_wrapper_async_raises_original_exception_even_if_hook_callback_err
     exception the caller is waiting on."""
 
     class ExplodingLogger(CustomLogger):
-        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type):
+        async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type, fallback_depth=None):
             raise RuntimeError("hook exploded")
 
     monkeypatch.setattr(litellm, "callbacks", [ExplodingLogger()])
@@ -5101,3 +5138,61 @@ async def test_wrapper_async_raises_original_exception_even_if_hook_callback_err
             messages=[{"role": "user", "content": "hi"}],
             mock_response=litellm.AuthenticationError(message="bad key", llm_provider="openai", model="gpt-4o-mini"),
         )
+
+
+@pytest.mark.asyncio
+async def test_router_fallback_chain_reports_increasing_fallback_depth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: a real Router fallback chain must report fallback_depth=None on the
+    first, pre-fallback attempt and fallback_depth=1 on the first fallback hop - the
+    concrete scenario async_post_call_failure_deployment_hook exists to make visible."""
+    recorder = _RecordingDeploymentFailureLogger()
+    monkeypatch.setattr(litellm, "callbacks", [recorder])
+
+    router = litellm.Router(
+        model_list=[
+            {"model_name": "bad-group", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "bad-a"}},
+            {"model_name": "good-group", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "bad-b"}},
+        ],
+        num_retries=0,
+        fallbacks=[{"bad-group": ["good-group"]}],
+    )
+
+    with pytest.raises(litellm.AuthenticationError):
+        await router.acompletion(
+            model="bad-group",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response=litellm.AuthenticationError(message="bad key", llm_provider="openai", model="gpt-4o-mini"),
+        )
+
+    assert len(recorder.calls) == 2
+    assert recorder.calls[0][3] is None
+    assert recorder.calls[1][3] == 1
+
+
+@pytest.mark.asyncio
+async def test_router_multi_hop_fallback_chain_reports_depth_per_hop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: fallback_depth must keep incrementing across more than one fallback
+    hop (group-a -> group-b -> group-c, all failing), not just report 1 for every
+    fallback attempt regardless of how deep the chain has gone."""
+    recorder = _RecordingDeploymentFailureLogger()
+    monkeypatch.setattr(litellm, "callbacks", [recorder])
+
+    router = litellm.Router(
+        model_list=[
+            {"model_name": "group-a", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "bad-a"}},
+            {"model_name": "group-b", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "bad-b"}},
+            {"model_name": "group-c", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "bad-c"}},
+        ],
+        num_retries=0,
+        fallbacks=[{"group-a": ["group-b", "group-c"]}],
+    )
+
+    with pytest.raises(litellm.AuthenticationError):
+        await router.acompletion(
+            model="group-a",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response=litellm.AuthenticationError(message="bad key", llm_provider="openai", model="gpt-4o-mini"),
+        )
+
+    assert len(recorder.calls) == 3
+    assert [call[3] for call in recorder.calls] == [None, 1, 2]


### PR DESCRIPTION
## TLDR

Problem this solves:

- CustomLogger has no per-attempt deployment failure signal, only a request-level one gated to fire once
- Fallback chain attempts past the first are invisible to callbacks that need a per-deployment count

How it solves it:

- Adds async_post_call_failure_deployment_hook, completing the existing pre-call/post-success hook pair
- Fires once per real deployment attempt from wrapper_async's own except block, no dedup coordination needed
- Passes through fallback_depth as a best-effort optional field, so a callback can tell how many fallback hops deep the current failure is without re-deriving Router's own bookkeeping

## User Flow

Before: a developer building a custom failure counter for a fallback-routed model group only sees the first deployment's failure, so a chain where the first two deployments fail and the third succeeds looks like one failure happened instead of two

1. They register a CustomLogger overriding async_log_failure_event and send a request against a model group with two always-failing deployments and one healthy deployment, with fallbacks configured
2. Their callback's counter increments once for the whole request, not once per failed deployment

After: the same developer overrides the new hook instead and sees one increment per failed deployment attempt

1. They register a CustomLogger overriding async_post_call_failure_deployment_hook and send the same request
2. Their callback fires once for each of the two failing deployments before the third deployment's response comes back, so the counter reads 2

## Relevant issues

Resolves #37177

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Commit 9d70e09f4e

Proxy config:

```yaml
model_list:
  - model_name: bad-deployment
    litellm_params:
      model: anthropic/claude-haiku-4-5-20251001
      api_key: bad-key-force-failure
  - model_name: good-deployment
    litellm_params:
      model: anthropic/claude-haiku-4-5-20251001
      api_key: os.environ/ANTHROPIC_API_KEY

litellm_settings:
  callbacks:
    - verify_logger.failure_logger
```

verify_logger.py registered as a callback:

```python
from litellm.integrations.custom_logger import CustomLogger

class FailureLogger(CustomLogger):
    async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type):
        model = request_data.get("model", "unknown")
        print(f"[FailureLogger] deployment failure: model={model} exc={type(exception).__name__} call_type={call_type}", flush=True)

failure_logger = FailureLogger()
```

Command:

```bash
curl -s -X POST http://localhost:4112/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-local-verify-master-key" \
  -d '{"model": "bad-deployment", "messages": [{"role": "user", "content": "say hi in exactly 3 words"}], "fallbacks": ["good-deployment"]}'
```

Response:

```json
{"id":"chatcmpl-03f82279-b8f9-4e3b-8b45-7bd5059e4be8","created":1786505256,"model":"claude-haiku-4-5-20251001","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hi there friend","role":"assistant"}}],"usage":{"completion_tokens":6,"prompt_tokens":15,"total_tokens":21}}
```

Server log, in order:

```
[FailureLogger] deployment failure: model=anthropic/claude-haiku-4-5-20251001 exc=AuthenticationError call_type=CallTypes.acompletion
23:27:36 - LiteLLM Router:INFO: router.py:3045 - litellm.acompletion(model=anthropic/claude-haiku-4-5-20251001) 200 OK
INFO:     127.0.0.1:50830 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```

The failure hook fires for the failed bad-deployment attempt before the fallback response from good-deployment arrives. Before this change the method does not exist on CustomLogger, so a callback overriding it is simply never called

### fallback_depth, verified against a real multi-hop Router fallback chain

```python
import asyncio
import litellm
from litellm.integrations.custom_logger import CustomLogger

class Probe(CustomLogger):
    async def async_post_call_failure_deployment_hook(self, request_data, exception, call_type, fallback_depth=None):
        print(f"[PROBE] model={request_data.get('model')} fallback_depth={fallback_depth}")

probe = Probe()
litellm.callbacks = [probe]

router = litellm.Router(
    model_list=[
        {"model_name": "group-a", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "bad-a"}},
        {"model_name": "group-b", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "bad-b"}},
        {"model_name": "group-c", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "bad-c"}},
    ],
    num_retries=0,
    fallbacks=[{"group-a": ["group-b", "group-c"]}],
)

async def main():
    try:
        await router.acompletion(
            model="group-a",
            messages=[{"role": "user", "content": "hi"}],
            mock_response=litellm.AuthenticationError(message="bad key", llm_provider="openai", model="gpt-4o-mini"),
        )
    except Exception as e:
        print(f"[PROBE] final exception: {type(e).__name__}")

asyncio.run(main())
```

Output:

```
[PROBE] model=openai/gpt-4o-mini fallback_depth=None
[PROBE] model=openai/gpt-4o-mini fallback_depth=1
[PROBE] model=openai/gpt-4o-mini fallback_depth=2
[PROBE] final exception: AuthenticationError
```

fallback_depth is None on the original, pre-fallback attempt, then increments once per fallback hop, matching Router's own internal depth tracking exactly.

## Type

🆕 New Feature

## Caveats (if any)

- Async-only, mirroring async_pre_call_deployment_hook and async_post_call_success_deployment_hook, which also have no sync counterpart today
- Fires on every attempt with no first-attempt flag, unlike the existing gated async_log_failure_event; a callback that wants to avoid double-counting a logical request's first attempt against both hooks needs to track that itself
- fallback_depth is best-effort and reflects Router's internal bookkeeping as-is; it tracks fallback hops only, not retries within the same model group, and there is no accompanying "is this the last hop" field since that would require replicating Router's own fallback-graph resolution (order-based fallbacks, weighted failover, multi-level chains) to compute reliably

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot async completion exception path and Router fallback bookkeeping; mistakes could mask real errors or skew failure telemetry, though the design isolates callback failures and strips shared router state.
> 
> **Overview**
> Adds **`async_post_call_failure_deployment_hook`** on `CustomLogger`, giving integrators a **per-deployment-attempt** failure signal (first try, retries, and each Router fallback hop), separate from the deduped request-level `async_log_failure_event`.
> 
> **`wrapper_async`** now invokes a new dispatcher around the model call’s `except` path: it notifies registered `CustomLogger` instances, then re-raises the original failure. Callback errors, cancellation mid-hook, and slow hooks must not replace or inflate the caller-visible error or failure-duration metrics (end time is captured before the hook runs).
> 
> The dispatcher passes **sanitized `request_data`** (`attempted_targets` stripped so callbacks cannot corrupt Router fallback state), an optional **`fallback_depth`** from Router kwargs (with signature detection so older 3-arg overrides still work), and a **same-class exception snapshot** so mutating the hook’s exception does not change what the client receives. Broad regression tests cover Router multi-hop depth, internal calls, budget/pre-call vs post-success errors, and snapshot/traceback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d1577c030a0cbe47194beaecc2e5c838338061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->