### PR TITLE
fix(proxy): track spend for OpenAI passthrough /v1/embeddings

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/cohere_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/cohere_passthrough_logging_handler.py
@@ -82,7 +82,7 @@ class CoherePassthroughLoggingHandler(BasePassthroughLoggingHandler):
         Handle Cohere passthrough logging with route detection and cost tracking.
         """
         # Check if this is an embed endpoint
-        if "/v1/embed" in url_route:
+        if "/v1/embed" in url_route and "/v1/embeddings" not in url_route:
             model: Final = request_body.get("model", response_body.get("model", ""))
             try:
                 cohere_embed_config: Final = CohereEmbeddingConfig()

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
@@ -145,12 +145,7 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
 
     @staticmethod
     def is_openai_embeddings_route(url_route: str) -> bool:
-        """Check if the URL route is an OpenAI embeddings endpoint.
-
-        Matches `/v1/embeddings` only (same shape as chat/images/responses).
-        Classic Azure deployment paths (`/openai/deployments/{model}/embeddings`)
-        are intentionally out of scope.
-        """
+        """Check if the URL route is an OpenAI embeddings endpoint."""
         if not url_route:
             return False
         parsed_url: Final = urlparse(url_route)
@@ -271,32 +266,6 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
         return litellm_model_response, response_cost
 
     @staticmethod
-    def _build_embeddings_response_and_cost(
-        model: str,
-        response_body: dict,
-        custom_llm_provider: str,
-    ) -> tuple[EmbeddingResponse, float]:
-        litellm_model_response: Final = convert_to_model_response_object(
-            response_object=response_body,
-            model_response_object=EmbeddingResponse(),
-            response_type="embedding",
-        )
-        if not isinstance(litellm_model_response, EmbeddingResponse):
-            raise TypeError(
-                f"Expected EmbeddingResponse from convert_to_model_response_object, got {type(litellm_model_response)}"
-            )
-        response_cost: Final = litellm.completion_cost(
-            completion_response=litellm_model_response,
-            model=model,
-            custom_llm_provider=custom_llm_provider,
-            call_type="aembedding",
-        )
-        if not hasattr(litellm_model_response, "_hidden_params") or litellm_model_response._hidden_params is None:
-            litellm_model_response._hidden_params = {}
-        litellm_model_response._hidden_params["response_cost"] = response_cost
-        return litellm_model_response, response_cost
-
-    @staticmethod
     def openai_passthrough_handler(
         httpx_response: httpx.Response,
         response_body: dict,
@@ -377,14 +346,22 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
                     custom_llm_provider=custom_llm_provider,
                 )
             elif is_embeddings:
-                (
-                    litellm_model_response,
-                    response_cost,
-                ) = OpenAIPassthroughLoggingHandler._build_embeddings_response_and_cost(
-                    model=model,
-                    response_body=response_body,
-                    custom_llm_provider=custom_llm_provider,
+                litellm_model_response = convert_to_model_response_object(
+                    response_object=response_body,
+                    model_response_object=EmbeddingResponse(),
+                    response_type="embedding",
                 )
+                if not isinstance(litellm_model_response, EmbeddingResponse):
+                    raise TypeError(
+                        f"Expected EmbeddingResponse from convert_to_model_response_object, got {type(litellm_model_response)}"
+                    )
+                response_cost = litellm.completion_cost(
+                    completion_response=litellm_model_response,
+                    model=model,
+                    custom_llm_provider=custom_llm_provider,
+                    call_type="aembedding",
+                )
+                litellm_model_response._hidden_params["response_cost"] = response_cost
             elif is_image_generation:
                 # Handle image generation cost calculation
                 response_cost = OpenAIPassthroughLoggingHandler._calculate_image_generation_cost(

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
@@ -31,8 +31,8 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     EndpointType,
     PassthroughStandardLoggingPayload,
 )
-from litellm.types.utils import ImageResponse, LlmProviders, PassthroughCallTypes
-from litellm.utils import ModelResponse, TextCompletionResponse
+from litellm.types.utils import EmbeddingResponse, ImageResponse, LlmProviders, PassthroughCallTypes
+from litellm.utils import ModelResponse, TextCompletionResponse, convert_to_model_response_object
 
 # Hostnames that route to OpenAI-compatible APIs.
 #
@@ -142,6 +142,19 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
         return _is_openai_compatible_host(parsed_url.hostname) and (
             "/v1/responses" in parsed_url.path or "/responses" in parsed_url.path
         )
+
+    @staticmethod
+    def is_openai_embeddings_route(url_route: str) -> bool:
+        """Check if the URL route is an OpenAI embeddings endpoint.
+
+        Matches `/v1/embeddings` only (same shape as chat/images/responses).
+        Classic Azure deployment paths (`/openai/deployments/{model}/embeddings`)
+        are intentionally out of scope.
+        """
+        if not url_route:
+            return False
+        parsed_url: Final = urlparse(url_route)
+        return _is_openai_compatible_host(parsed_url.hostname) and "/v1/embeddings" in parsed_url.path
 
     def _get_user_from_metadata(
         self,
@@ -258,6 +271,32 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
         return litellm_model_response, response_cost
 
     @staticmethod
+    def _build_embeddings_response_and_cost(
+        model: str,
+        response_body: dict,
+        custom_llm_provider: str,
+    ) -> tuple[EmbeddingResponse, float]:
+        litellm_model_response: Final = convert_to_model_response_object(
+            response_object=response_body,
+            model_response_object=EmbeddingResponse(),
+            response_type="embedding",
+        )
+        if not isinstance(litellm_model_response, EmbeddingResponse):
+            raise TypeError(
+                f"Expected EmbeddingResponse from convert_to_model_response_object, got {type(litellm_model_response)}"
+            )
+        response_cost: Final = litellm.completion_cost(
+            completion_response=litellm_model_response,
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            call_type="aembedding",
+        )
+        if not hasattr(litellm_model_response, "_hidden_params") or litellm_model_response._hidden_params is None:
+            litellm_model_response._hidden_params = {}
+        litellm_model_response._hidden_params["response_cost"] = response_cost
+        return litellm_model_response, response_cost
+
+    @staticmethod
     def openai_passthrough_handler(
         httpx_response: httpx.Response,
         response_body: dict,
@@ -271,22 +310,21 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
         **kwargs,
     ) -> PassThroughEndpointLoggingTypedDict:
         """
-        Handle OpenAI passthrough logging with cost tracking for chat completions, image generation, image editing, and responses API.
+        Handle OpenAI passthrough logging with cost tracking for chat completions,
+        embeddings, image generation, image editing, and responses API.
         """
-        # Check if this is a supported endpoint for cost tracking
         is_chat_completions: Final = OpenAIPassthroughLoggingHandler.is_openai_chat_completions_route(url_route)
+        is_embeddings: Final = OpenAIPassthroughLoggingHandler.is_openai_embeddings_route(url_route)
         is_image_generation: Final = OpenAIPassthroughLoggingHandler.is_openai_image_generation_route(url_route)
         is_image_editing: Final = OpenAIPassthroughLoggingHandler.is_openai_image_editing_route(url_route)
         is_responses: Final = OpenAIPassthroughLoggingHandler.is_openai_responses_route(url_route)
 
-        if not (is_chat_completions or is_image_generation or is_image_editing or is_responses):
-            # For unsupported endpoints, return None to let the system fall back to generic behavior
+        if not (is_chat_completions or is_embeddings or is_image_generation or is_image_editing or is_responses):
             return {
                 "result": None,
                 "kwargs": kwargs,
             }
 
-        # Extract model from request or response
         model: Final = request_body.get("model", response_body.get("model", ""))
         if not model:
             verbose_proxy_logger.warning("No model found in request or response for OpenAI passthrough cost tracking")
@@ -307,7 +345,7 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
         try:
             response_cost = 0.0
             litellm_model_response: (
-                ModelResponse | TextCompletionResponse | ImageResponse | ResponsesAPIResponse | None
+                ModelResponse | TextCompletionResponse | EmbeddingResponse | ImageResponse | ResponsesAPIResponse | None
             ) = None
             handler_instance: Final = OpenAIPassthroughLoggingHandler()
 
@@ -336,6 +374,15 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
                 response_cost = litellm.completion_cost(
                     completion_response=litellm_model_response,
                     model=model,
+                    custom_llm_provider=custom_llm_provider,
+                )
+            elif is_embeddings:
+                (
+                    litellm_model_response,
+                    response_cost,
+                ) = OpenAIPassthroughLoggingHandler._build_embeddings_response_and_cost(
+                    model=model,
+                    response_body=response_body,
                     custom_llm_provider=custom_llm_provider,
                 )
             elif is_image_generation:
@@ -432,9 +479,13 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             endpoint_type: Final = (
                 "chat_completions"
                 if is_chat_completions
+                else "embeddings"
+                if is_embeddings
                 else "image_generation"
                 if is_image_generation
                 else "image_editing"
+                if is_image_editing
+                else "responses"
             )
             verbose_proxy_logger.debug(
                 f"OpenAI passthrough cost tracking - Endpoint: {endpoint_type}, Model: {model}, Cost: ${response_cost:.6f}"

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
@@ -351,10 +351,6 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
                     model_response_object=EmbeddingResponse(),
                     response_type="embedding",
                 )
-                if not isinstance(litellm_model_response, EmbeddingResponse):
-                    raise TypeError(
-                        f"Expected EmbeddingResponse from convert_to_model_response_object, got {type(litellm_model_response)}"
-                    )
                 response_cost = litellm.completion_cost(
                     completion_response=litellm_model_response,
                     model=model,

--- a/litellm/proxy/pass_through_endpoints/success_handler.py
+++ b/litellm/proxy/pass_through_endpoints/success_handler.py
@@ -353,9 +353,6 @@ class PassThroughEndpointLogging:
         for route in self.TRACKED_COHERE_ROUTES:
             if route not in url_route:
                 continue
-            # `/v1/embed` is a prefix of OpenAI's `/v1/embeddings`. Skip the
-            # Cohere match when the longer OpenAI path is present so OpenAI
-            # embeddings cost tracking is not stolen by the Cohere branch.
             if route == "/v1/embed" and "/v1/embeddings" in url_route:
                 continue
             return True
@@ -429,10 +426,6 @@ class PassThroughEndpointLogging:
         outer dispatch filters Responses calls out before reaching the
         handler — the inner branch is then unreachable and Responses
         calls land in `LiteLLM_SpendLogs` with zero tokens / zero spend.
-
-        `/v1/embeddings` is included for the same reason: without it the
-        handler never runs and billable embedding tokens write no spend
-        row at all (budget under-enforcement).
         """
         from .llm_provider_handlers.openai_passthrough_logging_handler import (
             OpenAIPassthroughLoggingHandler,

--- a/litellm/proxy/pass_through_endpoints/success_handler.py
+++ b/litellm/proxy/pass_through_endpoints/success_handler.py
@@ -349,10 +349,17 @@ class PassThroughEndpointLogging:
                 return True
         return False
 
-    def is_cohere_route(self, url_route: str):
+    def is_cohere_route(self, url_route: str) -> bool:
         for route in self.TRACKED_COHERE_ROUTES:
-            if route in url_route:
-                return True
+            if route not in url_route:
+                continue
+            # `/v1/embed` is a prefix of OpenAI's `/v1/embeddings`. Skip the
+            # Cohere match when the longer OpenAI path is present so OpenAI
+            # embeddings cost tracking is not stolen by the Cohere branch.
+            if route == "/v1/embed" and "/v1/embeddings" in url_route:
+                continue
+            return True
+        return False
 
     def is_assemblyai_route(self, url_route: str):
         parsed_url: Final = urlparse(url_route)
@@ -422,6 +429,10 @@ class PassThroughEndpointLogging:
         outer dispatch filters Responses calls out before reaching the
         handler — the inner branch is then unreachable and Responses
         calls land in `LiteLLM_SpendLogs` with zero tokens / zero spend.
+
+        `/v1/embeddings` is included for the same reason: without it the
+        handler never runs and billable embedding tokens write no spend
+        row at all (budget under-enforcement).
         """
         from .llm_provider_handlers.openai_passthrough_logging_handler import (
             OpenAIPassthroughLoggingHandler,
@@ -429,6 +440,7 @@ class PassThroughEndpointLogging:
 
         return (
             OpenAIPassthroughLoggingHandler.is_openai_chat_completions_route(url_route)
+            or OpenAIPassthroughLoggingHandler.is_openai_embeddings_route(url_route)
             or OpenAIPassthroughLoggingHandler.is_openai_image_generation_route(url_route)
             or OpenAIPassthroughLoggingHandler.is_openai_image_editing_route(url_route)
             or OpenAIPassthroughLoggingHandler.is_openai_responses_route(url_route)

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_cohere_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_cohere_passthrough_logging_handler.py
@@ -7,9 +7,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.cohere_passthrough_logging_handler import (
@@ -69,12 +67,8 @@ class TestCoherePassthroughLoggingHandler:
         )
 
     @patch("litellm.completion_cost")
-    @patch(
-        "litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload"
-    )
-    @patch(
-        "litellm.llms.cohere.embed.v1_transformation.CohereEmbeddingConfig._transform_response"
-    )
+    @patch("litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload")
+    @patch("litellm.llms.cohere.embed.v1_transformation.CohereEmbeddingConfig._transform_response")
     def test_cohere_embed_passthrough_cost_tracking(
         self, mock_transform_response, mock_get_standard_logging, mock_completion_cost
     ):
@@ -92,9 +86,7 @@ class TestCoherePassthroughLoggingHandler:
         mock_embedding_response.object = "list"
         from litellm.types.utils import Usage
 
-        mock_embedding_response.usage = Usage(
-            prompt_tokens=3, completion_tokens=0, total_tokens=3
-        )
+        mock_embedding_response.usage = Usage(prompt_tokens=3, completion_tokens=0, total_tokens=3)
 
         mock_transform_response.return_value = mock_embedding_response
         mock_completion_cost.return_value = 3.6e-07  # Expected cost for embed-v4.0
@@ -150,6 +142,38 @@ class TestCoherePassthroughLoggingHandler:
         assert hasattr(result["result"], "data")
         assert hasattr(result["result"], "model")
         assert result["result"].model == "embed-english-v3.0"
+
+    @patch(
+        "litellm.proxy.pass_through_endpoints.llm_provider_handlers.base_passthrough_logging_handler.BasePassthroughLoggingHandler.passthrough_chat_handler"
+    )
+    @patch("litellm.completion_cost")
+    def test_openai_embeddings_route_does_not_use_cohere_embed_path(self, mock_completion_cost, mock_chat_handler):
+        mock_chat_handler.return_value = {"result": None, "kwargs": {}}
+        response_body = {
+            "object": "list",
+            "model": "text-embedding-3-small",
+            "data": [{"object": "embedding", "index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 6, "total_tokens": 6},
+        }
+        result = self.handler.cohere_passthrough_handler(
+            httpx_response=self._create_mock_httpx_response(response_body),
+            response_body=response_body,
+            logging_obj=self._create_mock_logging_obj(),
+            url_route="https://api.openai.com/v1/embeddings",
+            result="",
+            start_time=self.start_time,
+            end_time=self.end_time,
+            cache_hit=False,
+            request_body={"model": "text-embedding-3-small", "input": "PROOF_SENTINEL_TEXT"},
+            passthrough_logging_payload=PassthroughStandardLoggingPayload(
+                url="https://api.openai.com/v1/embeddings",
+                request_body={"model": "text-embedding-3-small", "input": "PROOF_SENTINEL_TEXT"},
+                request_method="POST",
+            ),
+        )
+        mock_completion_cost.assert_not_called()
+        mock_chat_handler.assert_called_once()
+        assert result == {"result": None, "kwargs": {}}
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
@@ -8,9 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.openai_passthrough_logging_handler import (
@@ -70,9 +68,7 @@ class TestOpenAIPassthroughLoggingHandler:
         mock_response.headers = {"content-type": "application/json"}
         return mock_response
 
-    def _create_passthrough_logging_payload(
-        self, user: str = "test_user"
-    ) -> PassthroughStandardLoggingPayload:
+    def _create_passthrough_logging_payload(self, user: str = "test_user") -> PassthroughStandardLoggingPayload:
         """Create a mock passthrough logging payload"""
         return PassthroughStandardLoggingPayload(
             url="https://api.openai.com/v1/chat/completions",
@@ -113,9 +109,7 @@ class TestOpenAIPassthroughLoggingHandler:
 
         # Negative cases
         assert (
-            OpenAIPassthroughLoggingHandler.is_openai_chat_completions_route(
-                "https://api.openai.com/v1/models"
-            )
+            OpenAIPassthroughLoggingHandler.is_openai_chat_completions_route("https://api.openai.com/v1/models")
             == False
         )
         assert (
@@ -125,15 +119,10 @@ class TestOpenAIPassthroughLoggingHandler:
             == False
         )
         assert (
-            OpenAIPassthroughLoggingHandler.is_openai_chat_completions_route(
-                "https://api.anthropic.com/v1/messages"
-            )
+            OpenAIPassthroughLoggingHandler.is_openai_chat_completions_route("https://api.anthropic.com/v1/messages")
             == False
         )
-        assert (
-            OpenAIPassthroughLoggingHandler.is_openai_chat_completions_route("")
-            == False
-        )
+        assert OpenAIPassthroughLoggingHandler.is_openai_chat_completions_route("") == False
 
     def test_is_openai_image_generation_route(self):
         """Test OpenAI image generation route detection"""
@@ -159,9 +148,7 @@ class TestOpenAIPassthroughLoggingHandler:
             == False
         )
         assert (
-            OpenAIPassthroughLoggingHandler.is_openai_image_generation_route(
-                "https://api.openai.com/v1/images/edits"
-            )
+            OpenAIPassthroughLoggingHandler.is_openai_image_generation_route("https://api.openai.com/v1/images/edits")
             == False
         )
         assert (
@@ -170,32 +157,23 @@ class TestOpenAIPassthroughLoggingHandler:
             )
             == False
         )
-        assert (
-            OpenAIPassthroughLoggingHandler.is_openai_image_generation_route("")
-            == False
-        )
+        assert OpenAIPassthroughLoggingHandler.is_openai_image_generation_route("") == False
 
     def test_is_openai_image_editing_route(self):
         """Test OpenAI image editing route detection"""
         # Positive cases
         assert (
-            OpenAIPassthroughLoggingHandler.is_openai_image_editing_route(
-                "https://api.openai.com/v1/images/edits"
-            )
+            OpenAIPassthroughLoggingHandler.is_openai_image_editing_route("https://api.openai.com/v1/images/edits")
             == True
         )
         assert (
-            OpenAIPassthroughLoggingHandler.is_openai_image_editing_route(
-                "https://openai.azure.com/v1/images/edits"
-            )
+            OpenAIPassthroughLoggingHandler.is_openai_image_editing_route("https://openai.azure.com/v1/images/edits")
             == True
         )
 
         # Negative cases
         assert (
-            OpenAIPassthroughLoggingHandler.is_openai_image_editing_route(
-                "https://api.openai.com/v1/chat/completions"
-            )
+            OpenAIPassthroughLoggingHandler.is_openai_image_editing_route("https://api.openai.com/v1/chat/completions")
             == False
         )
         assert (
@@ -210,118 +188,91 @@ class TestOpenAIPassthroughLoggingHandler:
             )
             == False
         )
-        assert (
-            OpenAIPassthroughLoggingHandler.is_openai_image_editing_route("") == False
-        )
+        assert OpenAIPassthroughLoggingHandler.is_openai_image_editing_route("") == False
 
     def test_is_openai_responses_route(self):
         """Test OpenAI responses API route detection"""
         # Positive cases
+        assert OpenAIPassthroughLoggingHandler.is_openai_responses_route("https://api.openai.com/v1/responses") == True
         assert (
-            OpenAIPassthroughLoggingHandler.is_openai_responses_route(
-                "https://api.openai.com/v1/responses"
-            )
-            == True
+            OpenAIPassthroughLoggingHandler.is_openai_responses_route("https://openai.azure.com/v1/responses") == True
         )
-        assert (
-            OpenAIPassthroughLoggingHandler.is_openai_responses_route(
-                "https://openai.azure.com/v1/responses"
-            )
-            == True
-        )
-        assert (
-            OpenAIPassthroughLoggingHandler.is_openai_responses_route(
-                "https://api.openai.com/responses"
-            )
-            == True
-        )
+        assert OpenAIPassthroughLoggingHandler.is_openai_responses_route("https://api.openai.com/responses") == True
 
         # Negative cases
         assert (
-            OpenAIPassthroughLoggingHandler.is_openai_responses_route(
-                "https://api.openai.com/v1/chat/completions"
-            )
+            OpenAIPassthroughLoggingHandler.is_openai_responses_route("https://api.openai.com/v1/chat/completions")
             == False
         )
         assert (
-            OpenAIPassthroughLoggingHandler.is_openai_responses_route(
-                "https://api.openai.com/v1/images/generations"
-            )
+            OpenAIPassthroughLoggingHandler.is_openai_responses_route("https://api.openai.com/v1/images/generations")
             == False
         )
         assert (
-            OpenAIPassthroughLoggingHandler.is_openai_responses_route(
-                "http://localhost:4000/openai/v1/responses"
-            )
+            OpenAIPassthroughLoggingHandler.is_openai_responses_route("http://localhost:4000/openai/v1/responses")
             == False
         )
         assert OpenAIPassthroughLoggingHandler.is_openai_responses_route("") == False
 
+    def test_is_openai_embeddings_route(self):
+        assert (
+            OpenAIPassthroughLoggingHandler.is_openai_embeddings_route("https://api.openai.com/v1/embeddings") is True
+        )
+        assert (
+            OpenAIPassthroughLoggingHandler.is_openai_embeddings_route("https://openai.azure.com/v1/embeddings") is True
+        )
+        assert (
+            OpenAIPassthroughLoggingHandler.is_openai_embeddings_route(
+                "https://my-resource.cognitiveservices.azure.com/v1/embeddings"
+            )
+            is True
+        )
+        assert (
+            OpenAIPassthroughLoggingHandler.is_openai_embeddings_route(
+                "https://my-resource.openai.azure.com/openai/deployments/text-embedding-3-small/embeddings"
+            )
+            is False
+        )
+        assert (
+            OpenAIPassthroughLoggingHandler.is_openai_embeddings_route("https://api.openai.com/v1/chat/completions")
+            is False
+        )
+        assert (
+            OpenAIPassthroughLoggingHandler.is_openai_embeddings_route(
+                "http://localhost:4000/openai_passthrough/v1/embeddings"
+            )
+            is False
+        )
+        assert OpenAIPassthroughLoggingHandler.is_openai_embeddings_route("") is False
+
     def test_is_openai_route_recognizes_cognitiveservices_azure_com(self):
         """Azure OpenAI resources created via the newer "Azure AI Foundry" /
         Cognitive Services pathway live on `*.cognitiveservices.azure.com`
-        subdomains rather than the older `openai.azure.com`. All four
+        subdomains rather than the older `openai.azure.com`. The
         is_openai_*_route methods must recognize both Azure subdomains so
         cost tracking applies regardless of which Azure naming the user's
         resource happens to be on.
         """
-        cognitive_chat = (
-            "https://my-resource.cognitiveservices.azure.com/v1/chat/completions"
-        )
-        cognitive_images_gen = (
-            "https://my-resource.cognitiveservices.azure.com/v1/images/generations"
-        )
-        cognitive_images_edit = (
-            "https://my-resource.cognitiveservices.azure.com/v1/images/edits"
-        )
-        cognitive_responses = (
-            "https://my-resource.cognitiveservices.azure.com/v1/responses"
-        )
+        cognitive_chat = "https://my-resource.cognitiveservices.azure.com/v1/chat/completions"
+        cognitive_images_gen = "https://my-resource.cognitiveservices.azure.com/v1/images/generations"
+        cognitive_images_edit = "https://my-resource.cognitiveservices.azure.com/v1/images/edits"
+        cognitive_responses = "https://my-resource.cognitiveservices.azure.com/v1/responses"
+        cognitive_embeddings = "https://my-resource.cognitiveservices.azure.com/v1/embeddings"
 
-        assert (
-            OpenAIPassthroughLoggingHandler.is_openai_chat_completions_route(
-                cognitive_chat
-            )
-            is True
-        )
-        assert (
-            OpenAIPassthroughLoggingHandler.is_openai_image_generation_route(
-                cognitive_images_gen
-            )
-            is True
-        )
-        assert (
-            OpenAIPassthroughLoggingHandler.is_openai_image_editing_route(
-                cognitive_images_edit
-            )
-            is True
-        )
-        assert (
-            OpenAIPassthroughLoggingHandler.is_openai_responses_route(
-                cognitive_responses
-            )
-            is True
-        )
+        assert OpenAIPassthroughLoggingHandler.is_openai_chat_completions_route(cognitive_chat) is True
+        assert OpenAIPassthroughLoggingHandler.is_openai_image_generation_route(cognitive_images_gen) is True
+        assert OpenAIPassthroughLoggingHandler.is_openai_image_editing_route(cognitive_images_edit) is True
+        assert OpenAIPassthroughLoggingHandler.is_openai_responses_route(cognitive_responses) is True
+        assert OpenAIPassthroughLoggingHandler.is_openai_embeddings_route(cognitive_embeddings) is True
 
         # Cross-route negatives still hold for cognitiveservices hosts.
-        assert (
-            OpenAIPassthroughLoggingHandler.is_openai_chat_completions_route(
-                cognitive_responses
-            )
-            is False
-        )
-        assert (
-            OpenAIPassthroughLoggingHandler.is_openai_responses_route(cognitive_chat)
-            is False
-        )
+        assert OpenAIPassthroughLoggingHandler.is_openai_chat_completions_route(cognitive_responses) is False
+        assert OpenAIPassthroughLoggingHandler.is_openai_responses_route(cognitive_chat) is False
+        assert OpenAIPassthroughLoggingHandler.is_openai_embeddings_route(cognitive_chat) is False
 
     @patch("litellm.completion_cost")
-    @patch(
-        "litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload"
-    )
-    def test_openai_passthrough_handler_success(
-        self, mock_get_standard_logging, mock_completion_cost
-    ):
+    @patch("litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload")
+    def test_openai_passthrough_handler_success(self, mock_get_standard_logging, mock_completion_cost):
         """Test successful cost tracking for OpenAI chat completions"""
         # Arrange
         mock_completion_cost.return_value = 0.000045
@@ -370,9 +321,7 @@ class TestOpenAIPassthroughLoggingHandler:
         assert mock_logging_obj.model_call_details["custom_llm_provider"] == "openai"
 
     @patch("litellm.completion_cost")
-    def test_openai_passthrough_handler_non_chat_completions(
-        self, mock_completion_cost
-    ):
+    def test_openai_passthrough_handler_non_chat_completions(self, mock_completion_cost):
         """Test that non-chat-completions routes fall back to base handler"""
         # Arrange
         mock_httpx_response = self._create_mock_httpx_response()
@@ -406,12 +355,8 @@ class TestOpenAIPassthroughLoggingHandler:
         # The important thing is that our specific OpenAI handler logic didn't run
 
     @patch("litellm.completion_cost")
-    @patch(
-        "litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload"
-    )
-    def test_openai_passthrough_handler_with_user_tracking(
-        self, mock_get_standard_logging, mock_completion_cost
-    ):
+    @patch("litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload")
+    def test_openai_passthrough_handler_with_user_tracking(self, mock_get_standard_logging, mock_completion_cost):
         """Test cost tracking with user information"""
         # Arrange
         mock_completion_cost.return_value = 0.000123
@@ -464,15 +409,10 @@ class TestOpenAIPassthroughLoggingHandler:
         assert "litellm_params" in result["kwargs"]
         assert "proxy_server_request" in result["kwargs"]["litellm_params"]
         assert "body" in result["kwargs"]["litellm_params"]["proxy_server_request"]
-        assert (
-            result["kwargs"]["litellm_params"]["proxy_server_request"]["body"]["user"]
-            == "test_user_123"
-        )
+        assert result["kwargs"]["litellm_params"]["proxy_server_request"]["body"]["user"] == "test_user_123"
 
     @patch("litellm.completion_cost")
-    def test_openai_passthrough_handler_cost_calculation_error(
-        self, mock_completion_cost
-    ):
+    def test_openai_passthrough_handler_cost_calculation_error(self, mock_completion_cost):
         """Test error handling in cost calculation"""
         # Arrange
         mock_completion_cost.side_effect = Exception("Cost calculation failed")
@@ -521,9 +461,7 @@ class TestOpenAIPassthroughLoggingHandler:
 
     @patch(f"{OpenAIPassthroughLoggingHandler.__module__}.get_standard_logging_object_payload")
     @patch("litellm.completion_cost", return_value=3.3e-06)
-    def test_streaming_responses_cost_uses_completed_response(
-        self, mock_completion_cost, mock_get_standard_logging
-    ):
+    def test_streaming_responses_cost_uses_completed_response(self, mock_completion_cost, mock_get_standard_logging):
         response_id = "resp_PROOFSENTINEL0123456789abcdef"
         completed_event = {
             "type": "response.completed",
@@ -796,12 +734,8 @@ class TestOpenAIPassthroughLoggingHandler:
         mock_completion_cost.assert_not_called()
 
     @patch("litellm.completion_cost")
-    @patch(
-        "litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload"
-    )
-    def test_different_models_cost_tracking(
-        self, mock_get_standard_logging, mock_completion_cost
-    ):
+    @patch("litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload")
+    def test_different_models_cost_tracking(self, mock_get_standard_logging, mock_completion_cost):
         """Test cost tracking for different OpenAI models"""
         # Arrange
         mock_get_standard_logging.return_value = {"test": "logging_payload"}
@@ -868,12 +802,8 @@ class TestOpenAIPassthroughLoggingHandler:
         assert handler.get_provider_config("gpt-4o") is not None
 
     @patch("litellm.completion_cost")
-    @patch(
-        "litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload"
-    )
-    def test_azure_passthrough_tags_metadata_model_provider(
-        self, mock_get_standard_logging, mock_completion_cost
-    ):
+    @patch("litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload")
+    def test_azure_passthrough_tags_metadata_model_provider(self, mock_get_standard_logging, mock_completion_cost):
         """Test that tags, metadata, model, and custom_llm_provider are preserved for Azure passthrough in UI"""
         # Arrange
         mock_completion_cost.return_value = 0.000045
@@ -929,9 +859,7 @@ class TestOpenAIPassthroughLoggingHandler:
 
         # Verify model and custom_llm_provider are set correctly
         assert result["kwargs"]["model"] == "gpt-4o"
-        assert (
-            result["kwargs"]["custom_llm_provider"] == "azure"
-        )  # Should preserve Azure, not default to "openai"
+        assert result["kwargs"]["custom_llm_provider"] == "azure"  # Should preserve Azure, not default to "openai"
         assert result["kwargs"]["response_cost"] == 0.000045
 
         # Verify metadata tags are preserved in litellm_params
@@ -955,12 +883,8 @@ class TestOpenAIPassthroughLoggingHandler:
         assert call_args[1]["custom_llm_provider"] == "azure"
 
     @patch("litellm.completion_cost")
-    @patch(
-        "litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload"
-    )
-    @patch(
-        "litellm.llms.openai.responses.transformation.OpenAIResponsesAPIConfig.transform_response_api_response"
-    )
+    @patch("litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload")
+    @patch("litellm.llms.openai.responses.transformation.OpenAIResponsesAPIConfig.transform_response_api_response")
     def test_responses_api_cost_tracking(
         self,
         mock_transform_responses,
@@ -1052,9 +976,7 @@ class TestOpenAIPassthroughLoggingHandler:
         assert mock_logging_obj.model_call_details["custom_llm_provider"] == "openai"
 
     @patch("litellm.completion_cost")
-    @patch(
-        "litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload"
-    )
+    @patch("litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload")
     def test_responses_api_uses_responses_transformer_not_chat_completions(
         self, mock_get_standard_logging, mock_completion_cost
     ):
@@ -1185,9 +1107,7 @@ class TestOpenAIPassthroughIntegration:
         mock_response.headers = {"content-type": "application/json"}
         return mock_response
 
-    def _create_passthrough_logging_payload(
-        self, user: str = "test_user"
-    ) -> PassthroughStandardLoggingPayload:
+    def _create_passthrough_logging_payload(self, user: str = "test_user") -> PassthroughStandardLoggingPayload:
         """Create a mock passthrough logging payload"""
         return PassthroughStandardLoggingPayload(
             url="https://api.openai.com/v1/chat/completions",
@@ -1201,59 +1121,32 @@ class TestOpenAIPassthroughIntegration:
     def test_is_openai_route_detection(self):
         """Test OpenAI route detection in the main success handler"""
         # Positive cases
-        assert (
-            self.handler.is_openai_route("https://api.openai.com/v1/chat/completions")
-            == True
-        )
-        assert (
-            self.handler.is_openai_route("https://openai.azure.com/v1/chat/completions")
-            == True
-        )
+        assert self.handler.is_openai_route("https://api.openai.com/v1/chat/completions") == True
+        assert self.handler.is_openai_route("https://openai.azure.com/v1/chat/completions") == True
         assert self.handler.is_openai_route("https://api.openai.com/v1/models") == True
         # Azure OpenAI on the shared Cognitive Services domain, identified by an
         # OpenAI-style path segment.
         assert (
-            self.handler.is_openai_route(
-                "https://my-resource.cognitiveservices.azure.com/v1/chat/completions"
-            )
-            == True
+            self.handler.is_openai_route("https://my-resource.cognitiveservices.azure.com/v1/chat/completions") == True
         )
 
         # Negative cases
-        assert (
-            self.handler.is_openai_route(
-                "http://localhost:4000/openai/v1/chat/completions"
-            )
-            == False
-        )
-        assert (
-            self.handler.is_openai_route("https://api.anthropic.com/v1/messages")
-            == False
-        )
-        assert (
-            self.handler.is_openai_route("https://api.assemblyai.com/v2/transcript")
-            == False
-        )
+        assert self.handler.is_openai_route("http://localhost:4000/openai/v1/chat/completions") == False
+        assert self.handler.is_openai_route("https://api.anthropic.com/v1/messages") == False
+        assert self.handler.is_openai_route("https://api.assemblyai.com/v2/transcript") == False
         # Non-OpenAI Azure Cognitive Services share the `cognitiveservices.azure.com`
         # domain but must NOT be classified as OpenAI routes (no OpenAI path segment).
         assert (
-            self.handler.is_openai_route(
-                "https://my-resource.cognitiveservices.azure.com/speechtotext/v3.1/recognize"
-            )
+            self.handler.is_openai_route("https://my-resource.cognitiveservices.azure.com/speechtotext/v3.1/recognize")
             == False
         )
         assert (
-            self.handler.is_openai_route(
-                "https://my-resource.cognitiveservices.azure.com/vision/v3.2/analyze"
-            )
-            == False
+            self.handler.is_openai_route("https://my-resource.cognitiveservices.azure.com/vision/v3.2/analyze") == False
         )
         # A look-alike domain that merely contains an OpenAI host as a substring
         # must be rejected by the suffix-based hostname match.
         assert (
-            self.handler.is_openai_route(
-                "https://cognitiveservices.azure.com.attacker.example/v1/chat/completions"
-            )
+            self.handler.is_openai_route("https://cognitiveservices.azure.com.attacker.example/v1/chat/completions")
             == False
         )
         assert self.handler.is_openai_route("") == False
@@ -1274,52 +1167,152 @@ class TestOpenAIPassthroughIntegration:
         remove Responses from the OR-chain without a test failure.
         """
         # Responses must be supported on api.openai.com and openai.azure.com.
-        assert (
-            self.handler._is_supported_openai_endpoint(
-                "https://api.openai.com/v1/responses"
-            )
-            is True
-        )
-        assert (
-            self.handler._is_supported_openai_endpoint(
-                "https://openai.azure.com/v1/responses"
-            )
-            is True
-        )
+        assert self.handler._is_supported_openai_endpoint("https://api.openai.com/v1/responses") is True
+        assert self.handler._is_supported_openai_endpoint("https://openai.azure.com/v1/responses") is True
         # The other supported endpoints stay supported (no regression).
-        assert (
-            self.handler._is_supported_openai_endpoint(
-                "https://api.openai.com/v1/chat/completions"
-            )
-            is True
-        )
-        assert (
-            self.handler._is_supported_openai_endpoint(
-                "https://api.openai.com/v1/images/generations"
-            )
-            is True
-        )
-        assert (
-            self.handler._is_supported_openai_endpoint(
-                "https://api.openai.com/v1/images/edits"
-            )
-            is True
-        )
+        assert self.handler._is_supported_openai_endpoint("https://api.openai.com/v1/chat/completions") is True
+        assert self.handler._is_supported_openai_endpoint("https://api.openai.com/v1/images/generations") is True
+        assert self.handler._is_supported_openai_endpoint("https://api.openai.com/v1/images/edits") is True
         # Unsupported OpenAI endpoints (e.g. /v1/models) still return False.
+        assert self.handler._is_supported_openai_endpoint("https://api.openai.com/v1/models") is False
         assert (
             self.handler._is_supported_openai_endpoint(
-                "https://api.openai.com/v1/models"
+                "https://my-resource.openai.azure.com/openai/deployments/text-embedding-3-small/embeddings"
             )
             is False
         )
+
+    def test_is_supported_openai_endpoint_includes_embeddings(self):
+        assert self.handler._is_supported_openai_endpoint("https://api.openai.com/v1/embeddings") is True
+        assert self.handler._is_supported_openai_endpoint("https://openai.azure.com/v1/embeddings") is True
+
+    def test_is_cohere_route_does_not_match_openai_embeddings(self):
+        assert self.handler.is_cohere_route("https://api.cohere.com/v1/embed") is True
+        assert self.handler.is_cohere_route("https://api.cohere.com/v2/chat") is True
+        assert self.handler.is_cohere_route("https://api.openai.com/v1/embeddings") is False
+
+    @patch("litellm.completion_cost")
+    @patch("litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload")
+    def test_openai_passthrough_handler_embeddings_sets_response_cost(
+        self, mock_get_standard_logging, mock_completion_cost
+    ):
+        mock_completion_cost.return_value = 2.8e-07
+        mock_get_standard_logging.return_value = {"test": "logging_payload"}
+
+        response_body = {
+            "object": "list",
+            "model": "text-embedding-3-small",
+            "data": [
+                {
+                    "object": "embedding",
+                    "index": 0,
+                    "embedding": [0.1, 0.2],
+                }
+            ],
+            "usage": {"prompt_tokens": 14, "total_tokens": 14},
+        }
+        mock_httpx_response = self._create_mock_httpx_response(response_body)
+        mock_logging_obj = self._create_mock_logging_obj()
+        passthrough_payload = PassthroughStandardLoggingPayload(
+            url="https://api.openai.com/v1/embeddings",
+            request_body={
+                "model": "text-embedding-3-small",
+                "input": "PROOF_SENTINEL_TEXT",
+            },
+            request_method="POST",
+        )
+        kwargs = {
+            "passthrough_logging_payload": passthrough_payload,
+            "litellm_params": {},
+        }
+
+        result = OpenAIPassthroughLoggingHandler.openai_passthrough_handler(
+            httpx_response=mock_httpx_response,
+            response_body=response_body,
+            logging_obj=mock_logging_obj,
+            url_route="https://api.openai.com/v1/embeddings",
+            result="",
+            start_time=self.start_time,
+            end_time=self.end_time,
+            cache_hit=False,
+            request_body={
+                "model": "text-embedding-3-small",
+                "input": "PROOF_SENTINEL_TEXT",
+            },
+            **kwargs,
+        )
+
+        assert result["result"] is not None
+        assert result["kwargs"]["response_cost"] == 2.8e-07
+        assert result["kwargs"]["model"] == "text-embedding-3-small"
+        assert result["kwargs"]["custom_llm_provider"] == "openai"
+        mock_completion_cost.assert_called_once()
+        assert mock_completion_cost.call_args.kwargs["call_type"] == "aembedding"
+        assert mock_logging_obj.model_call_details["response_cost"] == 2.8e-07
 
     @patch(
         "litellm.proxy.pass_through_endpoints.llm_provider_handlers.openai_passthrough_logging_handler.OpenAIPassthroughLoggingHandler.openai_passthrough_handler"
     )
     @pytest.mark.asyncio
-    async def test_success_handler_dispatches_responses_api_to_openai_handler(
-        self, mock_openai_handler
-    ):
+    async def test_success_handler_dispatches_embeddings_to_openai_handler(self, mock_openai_handler):
+        mock_openai_handler.return_value = {
+            "result": {"object": "list"},
+            "kwargs": {
+                "response_cost": 2.8e-07,
+                "model": "text-embedding-3-small",
+                "custom_llm_provider": "openai",
+            },
+        }
+
+        mock_httpx_response = MagicMock(spec=httpx.Response)
+        mock_httpx_response.text = (
+            '{"object":"list","model":"text-embedding-3-small",'
+            '"data":[{"object":"embedding","index":0,"embedding":[0.1]}],'
+            '"usage":{"prompt_tokens":14,"total_tokens":14}}'
+        )
+
+        mock_logging_obj = AsyncMock()
+        mock_logging_obj.model_call_details = {}
+        mock_logging_obj.async_success_handler = AsyncMock()
+
+        passthrough_payload = PassthroughStandardLoggingPayload(
+            url="https://api.openai.com/v1/embeddings",
+            request_body={
+                "model": "text-embedding-3-small",
+                "input": "PROOF_SENTINEL_TEXT",
+            },
+            request_method="POST",
+        )
+
+        await self.handler.pass_through_async_success_handler(
+            httpx_response=mock_httpx_response,
+            response_body={
+                "object": "list",
+                "model": "text-embedding-3-small",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1]}],
+                "usage": {"prompt_tokens": 14, "total_tokens": 14},
+            },
+            logging_obj=mock_logging_obj,
+            url_route="https://api.openai.com/v1/embeddings",
+            result="",
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            cache_hit=False,
+            request_body={
+                "model": "text-embedding-3-small",
+                "input": "PROOF_SENTINEL_TEXT",
+            },
+            passthrough_logging_payload=passthrough_payload,
+        )
+
+        mock_openai_handler.assert_called_once()
+        assert mock_openai_handler.call_args.kwargs["url_route"] == "https://api.openai.com/v1/embeddings"
+
+    @patch(
+        "litellm.proxy.pass_through_endpoints.llm_provider_handlers.openai_passthrough_logging_handler.OpenAIPassthroughLoggingHandler.openai_passthrough_handler"
+    )
+    @pytest.mark.asyncio
+    async def test_success_handler_dispatches_responses_api_to_openai_handler(self, mock_openai_handler):
         """End-to-end dispatch test for the Responses API path.
 
         Pre-fix: `_is_supported_openai_endpoint` returned False for
@@ -1395,9 +1388,7 @@ class TestOpenAIPassthroughIntegration:
         }
 
         mock_httpx_response = MagicMock(spec=httpx.Response)
-        mock_httpx_response.text = (
-            '{"id": "chatcmpl-123", "choices": [{"message": {"content": "Hello"}}]}'
-        )
+        mock_httpx_response.text = '{"id": "chatcmpl-123", "choices": [{"message": {"content": "Hello"}}]}'
 
         mock_logging_obj = AsyncMock()
         mock_logging_obj.model_call_details = {}
@@ -1590,14 +1581,10 @@ class TestOpenAIPassthroughIntegration:
         # Test the _response_cost_calculator method
         calculated_cost = logging_obj._response_cost_calculator(result=image_response)
 
-        assert (
-            calculated_cost == test_cost
-        ), f"Expected {test_cost}, got {calculated_cost}"
+        assert calculated_cost == test_cost, f"Expected {test_cost}, got {calculated_cost}"
 
     @patch("litellm.cost_calculator.default_image_cost_calculator")
-    def test_openai_passthrough_handler_image_generation(
-        self, mock_image_cost_calculator
-    ):
+    def test_openai_passthrough_handler_image_generation(self, mock_image_cost_calculator):
         """Test successful cost tracking for OpenAI image generation"""
         # Arrange
         mock_image_cost_calculator.return_value = 0.040

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
@@ -1190,6 +1190,8 @@ class TestOpenAIPassthroughIntegration:
         assert self.handler.is_cohere_route("https://api.cohere.com/v1/embed") is True
         assert self.handler.is_cohere_route("https://api.cohere.com/v2/chat") is True
         assert self.handler.is_cohere_route("https://api.openai.com/v1/embeddings") is False
+        assert self.handler.is_cohere_route("https://api.cohere.com/v1/rerank") is False
+        assert self.handler.is_cohere_route("http://localhost:4000/openai_passthrough/v1/embeddings") is False
 
     @patch("litellm.completion_cost")
     @patch("litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload")
@@ -1246,9 +1248,43 @@ class TestOpenAIPassthroughIntegration:
         assert result["kwargs"]["response_cost"] == 2.8e-07
         assert result["kwargs"]["model"] == "text-embedding-3-small"
         assert result["kwargs"]["custom_llm_provider"] == "openai"
+        assert result["result"]._hidden_params["response_cost"] == 2.8e-07
         mock_completion_cost.assert_called_once()
         assert mock_completion_cost.call_args.kwargs["call_type"] == "aembedding"
         assert mock_logging_obj.model_call_details["response_cost"] == 2.8e-07
+
+    @patch(
+        "litellm.proxy.pass_through_endpoints.llm_provider_handlers.openai_passthrough_logging_handler.OpenAIPassthroughLoggingHandler.passthrough_chat_handler"
+    )
+    @patch("litellm.completion_cost")
+    def test_openai_passthrough_handler_embeddings_without_model_falls_back(
+        self, mock_completion_cost, mock_chat_handler
+    ):
+        mock_chat_handler.return_value = {"result": None, "kwargs": {}}
+        response_body = {
+            "object": "list",
+            "data": [{"object": "embedding", "index": 0, "embedding": [0.1]}],
+            "usage": {"prompt_tokens": 1, "total_tokens": 1},
+        }
+        result = OpenAIPassthroughLoggingHandler.openai_passthrough_handler(
+            httpx_response=self._create_mock_httpx_response(response_body),
+            response_body=response_body,
+            logging_obj=self._create_mock_logging_obj(),
+            url_route="https://api.openai.com/v1/embeddings",
+            result="",
+            start_time=self.start_time,
+            end_time=self.end_time,
+            cache_hit=False,
+            request_body={"input": "PROOF_SENTINEL_TEXT"},
+            passthrough_logging_payload=PassthroughStandardLoggingPayload(
+                url="https://api.openai.com/v1/embeddings",
+                request_body={"input": "PROOF_SENTINEL_TEXT"},
+                request_method="POST",
+            ),
+        )
+        mock_completion_cost.assert_not_called()
+        mock_chat_handler.assert_called_once()
+        assert result == {"result": None, "kwargs": {}}
 
     @patch(
         "litellm.proxy.pass_through_endpoints.llm_provider_handlers.openai_passthrough_logging_handler.OpenAIPassthroughLoggingHandler.openai_passthrough_handler"


### PR DESCRIPTION
## TLDR

Problem this solves:

- OpenAI passthrough embeddings returned 200 with no key spend
- Budget limits could be bypassed on `/openai_passthrough/v1/embeddings`

How it solves it:

- Bill OpenAI passthrough `/v1/embeddings` like other supported OpenAI routes
- Stop Cohere `/v1/embed` matching from stealing OpenAI `/v1/embeddings`

## User Flow

Before: a developer embeds via OpenAI passthrough and their key spend never moves, so budgets are under-enforced

1. They send POST http://localhost:4000/openai_passthrough/v1/embeddings with `{"model":"text-embedding-3-small","input":"PROOF_SENTINEL_TEXT"}` using a virtual key
2. The response is HTTP 200 with `usage.prompt_tokens: 6`
3. GET http://localhost:4000/key/info for that key still shows the same `info.spend` after flush
4. Another caller can keep embedding on that route without the key budget catching the usage

After: the same passthrough embedding increases key spend by the embedding cost

1. They send the same POST http://localhost:4000/openai_passthrough/v1/embeddings with `{"model":"text-embedding-3-small","input":"PROOF_SENTINEL_TEXT"}`
2. The response is still HTTP 200 with `usage.prompt_tokens: 6`
3. After spend flush, GET http://localhost:4000/key/info shows `info.spend` increased by `1.2e-7`
4. That usage now counts against the key budget

## Relevant issues

Fixes #36646

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Proxy:

```bash
python litellm/proxy/proxy_cli.py \
  --config litellm/proxy/dev_config.yaml \
  --detailed_debug --reload --use_v2_migration_resolver
```

**Before** (first live passthrough run on this branch while the proxy was still serving pre-fix behavior; HEAD `f64479e74d`)

Translated control billed correctly:

```bash
curl -i -X POST "http://localhost:4000/v1/embeddings" \
  -H "Authorization: Bearer $VIRTUAL_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"text-embedding-3-small","input":"PROOF_SENTINEL_TEXT"}'
```

Result:

```
HTTP/1.1 200 OK
x-litellm-response-cost: 1.2e-07
```

Passthrough returned success but did not bill the key:

```bash
curl -i -X POST "http://localhost:4000/openai_passthrough/v1/embeddings" \
  -H "Authorization: Bearer $VIRTUAL_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"text-embedding-3-small","input":"PROOF_SENTINEL_TEXT"}'
```

Result:

```
HTTP/1.1 200 OK
```

Key spend did not increase until the proxy was restarted onto the fix. Missing `x-litellm-response-cost` on passthrough is expected on this path and is not the success signal for this bug

**After** (commit `1eaca98690acfefe9f0640d5940b6b4a0324b530`)

```bash
echo "commit=$(git rev-parse HEAD)"
echo "spend_before=$(curl -s http://localhost:4000/key/info -H "Authorization: Bearer $VIRTUAL_KEY" | jq '.info.spend')"

curl -s -D - -o /tmp/emb_pt_body.json -X POST "http://localhost:4000/openai_passthrough/v1/embeddings" \
  -H "Authorization: Bearer $VIRTUAL_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"text-embedding-3-small","input":"PROOF_SENTINEL_TEXT"}' \
  | head -n 20

jq '{model, usage}' /tmp/emb_pt_body.json
sleep 90
echo "spend_after=$(curl -s http://localhost:4000/key/info -H "Authorization: Bearer $VIRTUAL_KEY" | jq '.info.spend')"
```

Result:

```
commit=1eaca98690acfefe9f0640d5940b6b4a0324b530
spend_before=0.0
HTTP/1.1 200 OK
usage: {"prompt_tokens": 6, "total_tokens": 6}
spend_after=1.2E-7
```

Translated control on the same key/model still works: HTTP 200 with `x-litellm-response-cost: 1.2e-07`

A second live run on the same fix also showed spend move `2.4e-7` -> `3.6e-7` (+`1.2e-7`)

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

- Classic Azure `/openai/deployments/.../embeddings` is out of scope
- Passthrough often omits `x-litellm-response-cost` because cost is computed after headers are sent; key spend after flush is the success signal for this bug

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
