### PR TITLE
fix: guardrail logs miss rows at the date range edges outside UTC

### DIFF
--- a/tests/test_litellm/proxy/guardrails/test_usage_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_usage_endpoints.py
@@ -10,7 +10,7 @@ orphans), and logs missed their logical-name alias.
 
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -237,3 +237,48 @@ async def test_logs_resolves_config_guardrail_logical_name():
         )
     where = prisma.db.litellm_spendlogguardrailindex.find_many.call_args.kwargs["where"]
     assert where["guardrail_id"] == {"in": ["yaml-uuid", "yaml-pii"]}
+
+
+# ---- date window ------------------------------------------------------------
+
+
+async def _logs_where(*, start_date: str, end_date: str) -> dict:
+    """Run the logs handler and hand back the Prisma filter it built."""
+    prisma = _prisma(find_unique=None)
+    handler = _config_handler(_yaml_guardrail(guardrail_id="yaml-uuid", name="yaml-pii"))
+    p1, p2 = _patches(prisma, handler)
+    with p1, p2:
+        await guardrails_usage_logs(
+            guardrail_id="yaml-uuid",
+            policy_id=None,
+            page=1,
+            page_size=50,
+            action=None,
+            start_date=start_date,
+            end_date=end_date,
+            user_api_key_dict=ADMIN,
+        )
+    return prisma.db.litellm_spendlogguardrailindex.find_many.call_args.kwargs["where"]
+
+
+@pytest.mark.asyncio
+async def test_logs_honors_an_explicit_instant():
+    """
+    Regression (#36515): the dashboard resolves the viewer's local day to instants,
+    because a bare date is padded to UTC midnight and lands the window offset-hours
+    away from the range that was picked. Dropping this branch silently reinstates
+    that bug in the UI, so the exact instant must survive to the filter.
+    """
+    where = await _logs_where(start_date="2026-08-09T18:30:00Z", end_date="2026-08-10T18:29:59Z")
+
+    assert where["start_time"]["gte"] == datetime(2026, 8, 9, 18, 30, tzinfo=timezone.utc)
+    assert where["start_time"]["lte"] == datetime(2026, 8, 10, 18, 29, 59, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_logs_pads_a_bare_date_to_the_utc_day():
+    """A bare date keeps its documented whole-UTC-day meaning for existing callers."""
+    where = await _logs_where(start_date="2026-08-10", end_date="2026-08-10")
+
+    assert where["start_time"]["gte"] == datetime(2026, 8, 10, 0, 0, tzinfo=timezone.utc)
+    assert where["start_time"]["lte"] == datetime(2026, 8, 10, 23, 59, 59, tzinfo=timezone.utc)

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/_components/GuardrailDetail.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/_components/GuardrailDetail.integration.test.tsx
@@ -1,0 +1,65 @@
+import { waitFor } from "@testing-library/react";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GuardrailDetail } from "./GuardrailDetail";
+import { renderWithProviders, testQueryClient } from "../../../../../tests/test-utils";
+
+// Pinned off UTC on purpose: where the local day and the UTC day coincide, a bare
+// date and the resolved instants are the same request and this proves nothing.
+const originalTimezone = process.env.TZ;
+beforeAll(() => {
+  process.env.TZ = "Asia/Kolkata";
+});
+afterAll(() => {
+  process.env.TZ = originalTimezone;
+});
+
+const fetchMock = vi.fn();
+
+const emptyOkResponse = {
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  json: async () => ({ logs: [], total: 0, rows: [], chart: [], series: [] }),
+};
+
+const usageLogsQuery = (): URLSearchParams | undefined => {
+  const call = fetchMock.mock.calls.map(([url]) => String(url)).find((url) => url.includes("/guardrails/usage/logs"));
+  return call === undefined ? undefined : new URL(call, "http://x").searchParams;
+};
+
+describe("GuardrailDetail sends the viewer's local day as instants", () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    fetchMock.mockResolvedValue(emptyOkResponse);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithProviders(
+      <GuardrailDetail
+        guardrailId="g-1"
+        onBack={() => {}}
+        accessToken="sk-test"
+        startDate="2026-08-10"
+        endDate="2026-08-10"
+      />,
+    );
+  });
+
+  it("resolves the picker's dates instead of forwarding them verbatim", async () => {
+    await waitFor(() => expect(usageLogsQuery()).toBeDefined());
+    const params = usageLogsQuery();
+
+    // 00:00 and 23:59:59 on 2026-08-10 in IST, expressed as instants.
+    expect(params?.get("start_date")).toBe("2026-08-09T18:30:00Z");
+    expect(params?.get("end_date")).toBe("2026-08-10T18:29:59Z");
+  });
+
+  it("never sends a bare calendar date, which the endpoint would read as UTC", async () => {
+    await waitFor(() => expect(usageLogsQuery()).toBeDefined());
+    const params = usageLogsQuery();
+
+    expect(params?.get("start_date")).not.toBe("2026-08-10");
+    expect(params?.get("end_date")).not.toBe("2026-08-10");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/_components/GuardrailDetail.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/_components/GuardrailDetail.integration.test.tsx
@@ -51,8 +51,8 @@ describe("GuardrailDetail sends the viewer's local day as instants", () => {
     const params = usageLogsQuery();
 
     // 00:00 and 23:59:59 on 2026-08-10 in IST, expressed as instants.
-    expect(params?.get("start_date")).toBe("2026-08-09T18:30:00Z");
-    expect(params?.get("end_date")).toBe("2026-08-10T18:29:59Z");
+    expect(params?.get("start_date")).toBe("2026-08-09T18:30:00.000Z");
+    expect(params?.get("end_date")).toBe("2026-08-10T18:29:59.999Z");
   });
 
   it("never sends a bare calendar date, which the endpoint would read as UTC", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/_components/GuardrailDetail.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/_components/GuardrailDetail.tsx
@@ -4,6 +4,7 @@ import { Button, Col, Row, Spin, Tabs } from "antd";
 import React, { useMemo, useState } from "react";
 import { getGuardrailsUsageDetail, getGuardrailsUsageLogs } from "@/components/networking";
 import { EvaluationSettingsModal } from "./EvaluationSettingsModal";
+import { toUtcInstantRange } from "@/components/GuardrailsMonitor/guardrailLogsWindow";
 import { LogViewer } from "@/components/GuardrailsMonitor/LogViewer";
 import { MetricCard } from "@/components/GuardrailsMonitor/MetricCard";
 import type { LogEntry } from "@/components/GuardrailsMonitor/mockData";
@@ -37,15 +38,16 @@ export function GuardrailDetail({ guardrailId, onBack, accessToken = null, start
     queryFn: () => getGuardrailsUsageDetail(accessToken!, guardrailId, startDate, endDate),
     enabled: !!accessToken && !!guardrailId,
   });
+  const logsWindow = useMemo(() => toUtcInstantRange(startDate, endDate), [startDate, endDate]);
   const { data: logsData, isLoading: logsLoading } = useQuery({
-    queryKey: ["guardrails-usage-logs", guardrailId, logsPage, logsPageSize],
+    queryKey: ["guardrails-usage-logs", guardrailId, logsPage, logsPageSize, logsWindow.start, logsWindow.end],
     queryFn: () =>
       getGuardrailsUsageLogs(accessToken!, {
         guardrailId,
         page: logsPage,
         pageSize: logsPageSize,
-        startDate,
-        endDate,
+        startDate: logsWindow.start,
+        endDate: logsWindow.end,
       }),
     enabled: !!accessToken && !!guardrailId,
   });

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/guardrailLogsWindow.test.ts
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/guardrailLogsWindow.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { toUtcInstantRange } from "./guardrailLogsWindow";
+
+// The bug is invisible under UTC: there, the local day and the UTC day coincide and a
+// naive implementation passes. Every case below pins a non-UTC zone so a regression
+// fails instead of silently agreeing.
+const withTimezone = (zone: string) => {
+  const original = process.env.TZ;
+  beforeAll(() => {
+    process.env.TZ = zone;
+  });
+  afterAll(() => {
+    process.env.TZ = original;
+  });
+};
+
+describe("toUtcInstantRange, east of UTC (Asia/Kolkata, +05:30)", () => {
+  withTimezone("Asia/Kolkata");
+
+  it("resolves the local day to instants rather than the UTC day", () => {
+    expect(toUtcInstantRange("2026-08-10", "2026-08-10")).toEqual({
+      start: "2026-08-09T18:30:00Z",
+      end: "2026-08-10T18:29:59Z",
+    });
+  });
+
+  it("keeps a row just after local midnight inside the range", () => {
+    const { start, end } = toUtcInstantRange("2026-08-10", "2026-08-10");
+    // 2026-08-09T20:00:00Z is 01:30 on 2026-08-10 in IST, so it belongs to that local day.
+    // Padding the bare date to 2026-08-10T00:00:00Z, as the endpoint does, excludes it.
+    const row = Date.parse("2026-08-09T20:00:00Z");
+    expect(row).toBeGreaterThanOrEqual(Date.parse(start));
+    expect(row).toBeLessThanOrEqual(Date.parse(end));
+    expect(row).toBeLessThan(Date.parse("2026-08-10T00:00:00Z"));
+    // Guards against snapping to a UTC midnight in either direction.
+    expect(Date.parse(start)).toBeGreaterThan(Date.parse("2026-08-09T00:00:00Z"));
+    expect(Date.parse(end)).toBeGreaterThan(Date.parse("2026-08-10T00:00:00Z"));
+  });
+
+  it("does not reach past the end of the local day", () => {
+    const { end } = toUtcInstantRange("2026-08-10", "2026-08-10");
+    // 23:59:59Z is 05:29 on 2026-08-11 in IST, a day the viewer did not ask for.
+    expect(Date.parse(end)).toBeLessThan(Date.parse("2026-08-10T23:59:59Z"));
+    // ...but it must still cover the whole local day, which a UTC-day ceiling truncates.
+    expect(Date.parse(end)).toBeGreaterThan(Date.parse("2026-08-10T12:00:00Z"));
+  });
+
+  it("spans a multi-day range end to end", () => {
+    expect(toUtcInstantRange("2026-08-03", "2026-08-10")).toEqual({
+      start: "2026-08-02T18:30:00Z",
+      end: "2026-08-10T18:29:59Z",
+    });
+  });
+});
+
+describe("toUtcInstantRange, west of UTC (America/Los_Angeles, -07:00 in August)", () => {
+  withTimezone("America/Los_Angeles");
+
+  it("resolves the local day to instants rather than the UTC day", () => {
+    expect(toUtcInstantRange("2026-08-10", "2026-08-10")).toEqual({
+      start: "2026-08-10T07:00:00Z",
+      end: "2026-08-11T06:59:59Z",
+    });
+  });
+
+  it("keeps a row late in the local day inside the range", () => {
+    const { start, end } = toUtcInstantRange("2026-08-10", "2026-08-10");
+    // 2026-08-11T02:00:00Z is 19:00 on 2026-08-10 in PT, still the viewer's Aug 10.
+    // The endpoint's 2026-08-10T23:59:59Z ceiling would drop it.
+    const row = Date.parse("2026-08-11T02:00:00Z");
+    expect(row).toBeGreaterThanOrEqual(Date.parse(start));
+    expect(row).toBeLessThanOrEqual(Date.parse(end));
+    expect(row).toBeGreaterThan(Date.parse("2026-08-10T23:59:59Z"));
+  });
+});
+
+describe("toUtcInstantRange, on UTC", () => {
+  withTimezone("UTC");
+
+  it("matches the day the endpoint would have assumed", () => {
+    expect(toUtcInstantRange("2026-08-10", "2026-08-10")).toEqual({
+      start: "2026-08-10T00:00:00Z",
+      end: "2026-08-10T23:59:59Z",
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/guardrailLogsWindow.test.ts
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/guardrailLogsWindow.test.ts
@@ -20,8 +20,8 @@ describe("toUtcInstantRange, east of UTC (Asia/Kolkata, +05:30)", () => {
 
   it("resolves the local day to instants rather than the UTC day", () => {
     expect(toUtcInstantRange("2026-08-10", "2026-08-10")).toEqual({
-      start: "2026-08-09T18:30:00Z",
-      end: "2026-08-10T18:29:59Z",
+      start: "2026-08-09T18:30:00.000Z",
+      end: "2026-08-10T18:29:59.999Z",
     });
   });
 
@@ -46,10 +46,16 @@ describe("toUtcInstantRange, east of UTC (Asia/Kolkata, +05:30)", () => {
     expect(Date.parse(end)).toBeGreaterThan(Date.parse("2026-08-10T12:00:00Z"));
   });
 
+  it("keeps a row in the final millisecond of the local day", () => {
+    const { end } = toUtcInstantRange("2026-08-10", "2026-08-10");
+    // 23:59:59.500 local. Truncating the inclusive bound to whole seconds drops it.
+    expect(Date.parse(end)).toBeGreaterThanOrEqual(Date.parse("2026-08-10T18:29:59.500Z"));
+  });
+
   it("spans a multi-day range end to end", () => {
     expect(toUtcInstantRange("2026-08-03", "2026-08-10")).toEqual({
-      start: "2026-08-02T18:30:00Z",
-      end: "2026-08-10T18:29:59Z",
+      start: "2026-08-02T18:30:00.000Z",
+      end: "2026-08-10T18:29:59.999Z",
     });
   });
 });
@@ -59,8 +65,8 @@ describe("toUtcInstantRange, west of UTC (America/Los_Angeles, -07:00 in August)
 
   it("resolves the local day to instants rather than the UTC day", () => {
     expect(toUtcInstantRange("2026-08-10", "2026-08-10")).toEqual({
-      start: "2026-08-10T07:00:00Z",
-      end: "2026-08-11T06:59:59Z",
+      start: "2026-08-10T07:00:00.000Z",
+      end: "2026-08-11T06:59:59.999Z",
     });
   });
 
@@ -80,8 +86,8 @@ describe("toUtcInstantRange, on UTC", () => {
 
   it("matches the day the endpoint would have assumed", () => {
     expect(toUtcInstantRange("2026-08-10", "2026-08-10")).toEqual({
-      start: "2026-08-10T00:00:00Z",
-      end: "2026-08-10T23:59:59Z",
+      start: "2026-08-10T00:00:00.000Z",
+      end: "2026-08-10T23:59:59.999Z",
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/guardrailLogsWindow.ts
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/guardrailLogsWindow.ts
@@ -1,0 +1,18 @@
+import moment from "moment";
+
+export interface UtcInstantRange {
+  start: string;
+  end: string;
+}
+
+/**
+ * `/guardrails/usage/logs` filters `start_time`, a real timestamp column, but pads a
+ * bare `YYYY-MM-DD` out to `T00:00:00+00:00` / `T23:59:59+00:00`. Sending the picker's
+ * local calendar date therefore shifts the window by the viewer's UTC offset. Resolving
+ * the local day here and sending instants keeps the bound exact; the endpoint already
+ * parses a value carrying a `T`.
+ */
+export const toUtcInstantRange = (startDate: string, endDate: string): UtcInstantRange => ({
+  start: moment(startDate).startOf("day").utc().format(),
+  end: moment(endDate).endOf("day").utc().format(),
+});

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/guardrailLogsWindow.ts
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/guardrailLogsWindow.ts
@@ -5,14 +5,14 @@ export interface UtcInstantRange {
   end: string;
 }
 
+const UTC_INSTANT = "YYYY-MM-DDTHH:mm:ss.SSS[Z]";
+
 /**
- * `/guardrails/usage/logs` filters `start_time`, a real timestamp column, but pads a
- * bare `YYYY-MM-DD` out to `T00:00:00+00:00` / `T23:59:59+00:00`. Sending the picker's
- * local calendar date therefore shifts the window by the viewer's UTC offset. Resolving
- * the local day here and sending instants keeps the bound exact; the endpoint already
- * parses a value carrying a `T`.
+ * `/guardrails/usage/logs` pads a bare `YYYY-MM-DD` to a whole UTC day, so the picker's
+ * local date lands the viewer's offset away from the range they chose. Milliseconds are
+ * kept because the inclusive end bound otherwise drops the final 999ms of that day.
  */
 export const toUtcInstantRange = (startDate: string, endDate: string): UtcInstantRange => ({
-  start: moment(startDate).startOf("day").utc().format(),
-  end: moment(endDate).endOf("day").utc().format(),
+  start: moment(startDate).startOf("day").utc().format(UTC_INSTANT),
+  end: moment(endDate).endOf("day").utc().format(UTC_INSTANT),
 });


### PR DESCRIPTION
## TLDR

Problem this solves:

- Guardrail logs silently drop rows near the range edges
- Only bites viewers off UTC, by their offset
- On IST that hides 5.5 hours of every range

How it solves it:

- Send the picker's local day as UTC instants
- Endpoint already takes a timestamp, so nothing changes server side
- Tests pin non-UTC zones, where the bug is visible

## User Flow

Before: an admin on IST opens a guardrail's logs for today and some of the morning's requests are missing, with nothing to say so

1. They open http://localhost:4000/ui/?page=guardrails-monitor and pick a guardrail
2. They set the date range to today and open the Logs tab
3. Requests made between midnight and 05:30 their time are absent from the list
4. The counts above the list include those requests, so the list and the totals disagree
5. Widening the range to yesterday brings the missing requests back

After: the same range shows every request made on that day

1. They open http://localhost:4000/ui/?page=guardrails-monitor and pick a guardrail
2. They set the date range to today and open the Logs tab
3. Every request made that day is listed, including the ones just after midnight
4. The list and the counts above it agree
5. Nothing after the end of their day leaks in

## Relevant issues

Fixes #36515

## Linear ticket



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4000 with Postgres, a `litellm_content_filter` guardrail on `default_on: true`, and four real DeepSeek calls labelled `test message 1` to `4`. Browser on IST (UTC+5:30).

`test message 1` sits at `2026-08-11 20:00` UTC, which is `2026-08-12 01:30` IST, so it belongs to the viewer's 12 Aug.

To set that up from scratch:

1. Run the proxy against Postgres with a guardrail on `default_on: true`, and log in to the dashboard

```yaml
guardrails:
  - guardrail_name: "tz-repro-filter"
    litellm_params:
      guardrail: litellm_content_filter
      mode: pre_call
      default_on: true
      blocked_words:
        - keyword: "hunter2"
          action: "BLOCK"
```

2. Send four requests so guardrail rows get written

```bash
for i in 1 2 3 4; do
  curl -s -o /dev/null http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer <auth token>" -H "Content-Type: application/json" \
    -d "{\"model\":\"<your model>\",\"messages\":[{\"role\":\"user\",\"content\":\"test message $i\"}],\"max_tokens\":16}"
  sleep 1
done
```

3. Move the earliest row into the gap between local midnight and UTC midnight. On IST that is anywhere from 18:30 UTC the previous day. Both tables need it, since the filter reads the index while the returned timestamp comes from the spend log

```sql
UPDATE "LiteLLM_SpendLogGuardrailIndex" SET start_time = TIMESTAMP '2026-08-11 20:00:00'
WHERE request_id = (SELECT request_id FROM "LiteLLM_SpendLogGuardrailIndex" ORDER BY start_time ASC LIMIT 1);

UPDATE "LiteLLM_SpendLogs" SET "startTime" = TIMESTAMP '2026-08-11 20:00:00'
WHERE request_id IN (SELECT request_id FROM "LiteLLM_SpendLogGuardrailIndex" WHERE start_time = TIMESTAMP '2026-08-11 20:00:00');
```

4. In the dashboard, set the range to 12 Aug on the overview page, then click into the guardrail. Order matters before the fix, because the date window is missing from the query key, so changing the range on the detail page never refetches


Before, at 7e80e094c4. This is what the dashboard sent for a range of 12 Aug to 12 Aug:

```
$ curl -sG http://localhost:4000/guardrails/usage/logs \
    -H "Authorization: Bearer <auth token>" \
    --data-urlencode "guardrail_id=$GUARDRAIL_ID" \
    --data-urlencode "start_date=2026-08-12" \
    --data-urlencode "end_date=2026-08-12"

total = 3
  2026-08-12T12:51:27.139000+00:00  test message 2
  2026-08-12T12:51:29.263000+00:00  test message 3
  2026-08-12T12:51:30.966000+00:00  test message 4
```

After, at d37f1c81dc. Same picker choice, same data, this is what the dashboard now sends:

```
$ curl -sG http://localhost:4000/guardrails/usage/logs \
    -H "Authorization: Bearer <auth token>" \
    --data-urlencode "guardrail_id=$GUARDRAIL_ID" \
    --data-urlencode "start_date=2026-08-11T18:30:00Z" \
    --data-urlencode "end_date=2026-08-12T18:29:59Z"

total = 4
  2026-08-11T20:00:00+00:00         test message 1
  2026-08-12T12:51:27.139000+00:00  test message 2
  2026-08-12T12:51:29.263000+00:00  test message 3
  2026-08-12T12:51:30.966000+00:00  test message 4
```

The same thing in the dashboard, Guardrails Monitor with the range set to 12 Aug.

Before, at 7e80e094c4. The tile counts the request, the list below it does not, and `test message 1` is nowhere:

> Requests Evaluated 4, Showing 3 of 3 entries
<img width="2000" height="959" alt="before-12aug" src="https://github.com/user-attachments/assets/f040160d-6771-4eee-b475-ac441b3db573" />

After, at d37f1c81dc. `test message 1` is back and the tile matches the list:

> Requests Evaluated 4, Showing 4 of 4 entries
<img width="2000" height="1060" alt="after-12aug" src="https://github.com/user-attachments/assets/a0d8a132-14f1-47e5-9193-eadf099bfdf2" />

## Type

🐛 Bug Fix

## Caveats (if any)

- No server change; relies on the existing instant handling
- Two python tests added to pin that branch
- `LogViewer.tsx` has the same bug, already proposed in #35390
- Four tests in `guardrails-monitor/page.integration.test.tsx` already fail on base

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
