### PR TITLE
fix(http_handler): dispose aiohttp session when AsyncHTTPHandler is finalized without a running loop

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -9,7 +9,7 @@ import threading
 import time
 from collections.abc import AsyncIterable, Callable, Iterable, Mapping
 from http.cookiejar import CookieJar, DefaultCookiePolicy
-from typing import TYPE_CHECKING, Any, Final, Optional, TypeAlias, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, Final, Optional, TypeAlias, TypedDict
 
 import certifi
 import httpx
@@ -933,11 +933,54 @@ class AsyncHTTPHandler:
         response.raise_for_status()
         return response
 
+    # Strong references to finalizer-scheduled client-close tasks. A bare
+    # create_task() result may be garbage-collected before it runs, leaving
+    # the underlying aiohttp session unclosed ("Unclosed client session").
+    # Mirrors LiteLLMAiohttpTransport._background_close_tasks.
+    _finalizer_close_tasks: ClassVar[set["asyncio.Task[None]"]] = set()
+
+    def _close_aiohttp_session_sync(self) -> None:
+        """Dispose the wrapped aiohttp session when no event loop is available.
+
+        Finalization without a running loop cannot await ``aclose()``. Falling
+        back to the connector's synchronous teardown (the same finalizer-safe
+        path ``LiteLLMAiohttpTransport._mark_connector_closed`` uses for
+        dead-loop recycles) releases pooled connections and flips the closed
+        flags that ``ClientSession.__del__`` / connector ``__del__`` check, so
+        no "Unclosed client session" / "Unclosed connector" warnings fire at
+        garbage collection.
+        """
+        from litellm.llms.custom_httpx.aiohttp_transport import (
+            LiteLLMAiohttpTransport,
+        )
+
+        transport = getattr(self._client, "_transport", None)
+        if not isinstance(transport, LiteLLMAiohttpTransport):
+            return
+        # A shared session (e.g. the proxy's) is never this handler's to close.
+        if not getattr(transport, "_owns_session", False):
+            return
+        session = transport.client
+        if isinstance(session, ClientSession) and not session.closed:
+            transport._mark_connector_closed(session)
+
     def __del__(self) -> None:
         try:
             if not _handler_may_close_client(sys.getrefcount(self._client), self._owns_client):
                 return
-            asyncio.get_running_loop().create_task(self._client.aclose())
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                # No running loop at finalization time (worker threads after
+                # their loop closed, interpreter/worker shutdown, GC in a
+                # sync context). An async close can never run here; dispose
+                # synchronously instead of leaking the session.
+                self._close_aiohttp_session_sync()
+                return
+            task = loop.create_task(self._client.aclose())
+            cls = type(self)
+            cls._finalizer_close_tasks.add(task)
+            task.add_done_callback(cls._finalizer_close_tasks.discard)
         except Exception:
             pass
 

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -948,15 +948,30 @@ class AsyncHTTPHandler:
         if exc is not None:
             verbose_logger.debug("Error closing client at finalization: %s", exc)
 
-    def _close_aiohttp_session_sync(self) -> None:
-        """Dispose the wrapped aiohttp session when no event loop is available.
+    def _aiohttp_session_bound_elsewhere(self, loop: asyncio.AbstractEventLoop) -> bool:
+        """True when the wrapped aiohttp session is bound to a loop other than
+        ``loop`` — awaiting ``aclose()`` here would touch that loop's internals."""
+        from litellm.llms.custom_httpx.aiohttp_transport import (
+            LiteLLMAiohttpTransport,
+        )
 
-        Finalization without a running loop cannot await ``aclose()``. Falling
-        back to the connector's synchronous teardown (the same finalizer-safe
-        path ``LiteLLMAiohttpTransport._mark_connector_closed`` uses for
-        dead-loop recycles) releases pooled connections and flips the closed
-        flags that ``ClientSession.__del__`` / connector ``__del__`` check, so
-        no "Unclosed client session" / "Unclosed connector" warnings fire at
+        transport: Final = getattr(self._client, "_transport", None)
+        if not isinstance(transport, LiteLLMAiohttpTransport):
+            return False
+        session: Final = transport.client
+        if not isinstance(session, ClientSession) or session.closed:
+            return False
+        return getattr(session, "_loop", None) is not loop
+
+    def _dispose_wrapped_aiohttp_session(self) -> None:
+        """Dispose the wrapped aiohttp session when ``aclose()`` cannot run here.
+
+        Finalization either has no running loop, or a loop the session is not
+        bound to. Delegating to the transport's lifecycle-aware disposal picks
+        the safe path per session state (async close on its own loop, threadsafe
+        handoff to a loop running elsewhere, or the synchronous connector
+        teardown that flips the flags ``ClientSession.__del__`` checks), so no
+        "Unclosed client session" / "Unclosed connector" warnings fire at
         garbage collection.
         """
         from litellm.llms.custom_httpx.aiohttp_transport import (
@@ -971,7 +986,7 @@ class AsyncHTTPHandler:
             return
         session: Final = transport.client
         if isinstance(session, ClientSession) and not session.closed:
-            transport._mark_connector_closed(session)  # pyright: ignore[reportPrivateUsage]  # deliberate reuse of the transport's finalizer-safe teardown; an async close can never run here
+            transport._close_recycled_session(session)  # pyright: ignore[reportPrivateUsage]  # deliberate reuse of the transport's lifecycle-aware disposal; an async close can never run in this context
 
     def __del__(self) -> None:
         try:
@@ -982,9 +997,14 @@ class AsyncHTTPHandler:
             except RuntimeError:
                 # No running loop at finalization time (worker threads after
                 # their loop closed, interpreter/worker shutdown, GC in a
-                # sync context). An async close can never run here; dispose
-                # synchronously instead of leaking the session.
-                self._close_aiohttp_session_sync()
+                # sync context). An async close can never run here.
+                self._dispose_wrapped_aiohttp_session()
+                return
+            if self._aiohttp_session_bound_elsewhere(loop):
+                # GC ran on a live loop (e.g. the app's) but the session
+                # belongs to another, possibly dead, loop — awaiting aclose()
+                # here is the cross-loop path the transport refuses.
+                self._dispose_wrapped_aiohttp_session()
                 return
             task: Final = loop.create_task(self._client.aclose())
             cls: Final = type(self)

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -939,6 +939,15 @@ class AsyncHTTPHandler:
     # Mirrors LiteLLMAiohttpTransport._background_close_tasks.
     _finalizer_close_tasks: ClassVar[set["asyncio.Task[None]"]] = set()  # mutable-ok: strong refs for pending closes
 
+    @classmethod
+    def _on_finalizer_close_done(cls, task: "asyncio.Task[None]") -> None:
+        cls._finalizer_close_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc: Final = task.exception()
+        if exc is not None:
+            verbose_logger.debug("Error closing client at finalization: %s", exc)
+
     def _close_aiohttp_session_sync(self) -> None:
         """Dispose the wrapped aiohttp session when no event loop is available.
 
@@ -980,7 +989,7 @@ class AsyncHTTPHandler:
             task: Final = loop.create_task(self._client.aclose())
             cls: Final = type(self)
             cls._finalizer_close_tasks.add(task)
-            task.add_done_callback(cls._finalizer_close_tasks.discard)
+            task.add_done_callback(cls._on_finalizer_close_done)
         except Exception:
             pass
 

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -937,7 +937,7 @@ class AsyncHTTPHandler:
     # create_task() result may be garbage-collected before it runs, leaving
     # the underlying aiohttp session unclosed ("Unclosed client session").
     # Mirrors LiteLLMAiohttpTransport._background_close_tasks.
-    _finalizer_close_tasks: ClassVar[set["asyncio.Task[None]"]] = set()
+    _finalizer_close_tasks: ClassVar[set["asyncio.Task[None]"]] = set()  # mutable-ok: strong refs for pending closes
 
     def _close_aiohttp_session_sync(self) -> None:
         """Dispose the wrapped aiohttp session when no event loop is available.
@@ -954,13 +954,13 @@ class AsyncHTTPHandler:
             LiteLLMAiohttpTransport,
         )
 
-        transport = getattr(self._client, "_transport", None)
+        transport: Final = getattr(self._client, "_transport", None)
         if not isinstance(transport, LiteLLMAiohttpTransport):
             return
         # A shared session (e.g. the proxy's) is never this handler's to close.
         if not getattr(transport, "_owns_session", False):
             return
-        session = transport.client
+        session: Final = transport.client
         if isinstance(session, ClientSession) and not session.closed:
             transport._mark_connector_closed(session)
 
@@ -969,7 +969,7 @@ class AsyncHTTPHandler:
             if not _handler_may_close_client(sys.getrefcount(self._client), self._owns_client):
                 return
             try:
-                loop = asyncio.get_running_loop()
+                loop: Final = asyncio.get_running_loop()
             except RuntimeError:
                 # No running loop at finalization time (worker threads after
                 # their loop closed, interpreter/worker shutdown, GC in a
@@ -977,8 +977,8 @@ class AsyncHTTPHandler:
                 # synchronously instead of leaking the session.
                 self._close_aiohttp_session_sync()
                 return
-            task = loop.create_task(self._client.aclose())
-            cls = type(self)
+            task: Final = loop.create_task(self._client.aclose())
+            cls: Final = type(self)
             cls._finalizer_close_tasks.add(task)
             task.add_done_callback(cls._finalizer_close_tasks.discard)
         except Exception:

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -962,7 +962,7 @@ class AsyncHTTPHandler:
             return
         session: Final = transport.client
         if isinstance(session, ClientSession) and not session.closed:
-            transport._mark_connector_closed(session)
+            transport._mark_connector_closed(session)  # pyright: ignore[reportPrivateUsage]  # deliberate reuse of the transport's finalizer-safe teardown; an async close can never run here
 
     def __del__(self) -> None:
         try:

--- a/tests/mcp_tests/test_mcp_logging.py
+++ b/tests/mcp_tests/test_mcp_logging.py
@@ -24,12 +24,20 @@ from mcp.types import Tool as MCPTool, CallToolResult, TextContent
 class TestMCPLogger(CustomLogger):
     def __init__(self):
         self.standard_logging_payload = None
+        self.mcp_tool_call_payloads = []
         super().__init__()
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         print("success event")
-        self.standard_logging_payload = kwargs.get("standard_logging_object", None)
-        print(f"Captured standard_logging_payload: {self.standard_logging_payload}")
+        payload = kwargs.get("standard_logging_object", None)
+        self.standard_logging_payload = payload
+        # Async success events from other calls (e.g. a mocked acompletion whose
+        # log task is delivered late) race with the MCP event for the single
+        # last-writer slot; keep MCP tool calls in their own list so assertions
+        # are order-independent.
+        if payload is not None and payload.get("call_type") == "call_mcp_tool":
+            self.mcp_tool_call_payloads.append(payload)
+        print(f"Captured standard_logging_payload: {payload}")
 
 
 def _set_authorized_user(server_ids):
@@ -138,7 +146,11 @@ async def test_mcp_cost_tracking():
             # wait 1-2 seconds for logging to be processed
             await asyncio.sleep(2)
 
-            logged_standard_logging_payload = test_logger.standard_logging_payload
+            logged_standard_logging_payload = (
+                test_logger.mcp_tool_call_payloads[-1]
+                if test_logger.mcp_tool_call_payloads
+                else None
+            )
             print("logged_standard_logging_payload", logged_standard_logging_payload)
 
             # Add assertions
@@ -277,7 +289,11 @@ async def test_mcp_cost_tracking_per_tool():
             # wait for logging to be processed
             await asyncio.sleep(2)
 
-            logged_standard_logging_payload_1 = test_logger.standard_logging_payload
+            logged_standard_logging_payload_1 = (
+                test_logger.mcp_tool_call_payloads[-1]
+                if test_logger.mcp_tool_call_payloads
+                else None
+            )
             print(
                 "logged_standard_logging_payload_1", logged_standard_logging_payload_1
             )
@@ -290,6 +306,7 @@ async def test_mcp_cost_tracking_per_tool():
 
             # Reset logger for second test
             test_logger.standard_logging_payload = None
+            test_logger.mcp_tool_call_payloads.clear()
 
             # Test 2: Call cheap_tool - should cost 0.1
             response2 = await mcp_server_tool_call(
@@ -300,7 +317,11 @@ async def test_mcp_cost_tracking_per_tool():
             # wait for logging to be processed
             await asyncio.sleep(2)
 
-            logged_standard_logging_payload_2 = test_logger.standard_logging_payload
+            logged_standard_logging_payload_2 = (
+                test_logger.mcp_tool_call_payloads[-1]
+                if test_logger.mcp_tool_call_payloads
+                else None
+            )
             print(
                 "logged_standard_logging_payload_2", logged_standard_logging_payload_2
             )
@@ -436,7 +457,11 @@ async def test_mcp_tool_call_hook():
             await asyncio.sleep(2)
 
             # check logged standard logging payload
-            logged_standard_logging_payload = test_logger.standard_logging_payload
+            logged_standard_logging_payload = (
+                test_logger.mcp_tool_call_payloads[-1]
+                if test_logger.mcp_tool_call_payloads
+                else None
+            )
             print("logged_standard_logging_payload", logged_standard_logging_payload)
             assert (
                 logged_standard_logging_payload is not None

--- a/tests/mcp_tests/test_mcp_logging.py
+++ b/tests/mcp_tests/test_mcp_logging.py
@@ -350,16 +350,7 @@ async def test_mcp_cost_tracking_per_tool():
             assert mock_client.call_tool.call_count == 2
 
 
-class MCPLoggerHook(CustomLogger):
-    def __init__(self):
-        self.standard_logging_payload = None
-        super().__init__()
-
-    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
-        print("success event")
-        self.standard_logging_payload = kwargs.get("standard_logging_object", None)
-        print(f"Captured standard_logging_payload: {self.standard_logging_payload}")
-
+class MCPLoggerHook(TestMCPLogger):
     async def async_post_mcp_tool_call_hook(
         self, kwargs, response_obj: MCPPostCallResponseObject, start_time, end_time
     ) -> Optional[MCPPostCallResponseObject]:

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -1195,3 +1195,89 @@ async def test_aiohttp_session_never_replays_one_upstreams_cookie_to_another():
     assert len(jar) == 0
     assert dict(jar.filter_cookies(URL("https://upstream-a.example.com"))) == {}
     await session.close()
+
+
+def _mint_session_on_dead_loop(handler: AsyncHTTPHandler) -> ClientSession:
+    """Create the transport's real ClientSession on a loop that then closes.
+
+    This is the lifecycle of every client minted for a short-lived event loop
+    (the loop-id-keyed LLM client cache creates one handler per loop): the
+    session outlives its loop and can only ever be disposed loop-lessly.
+    """
+    transport = handler.client._transport
+    assert isinstance(transport, LiteLLMAiohttpTransport)
+    loop = asyncio.new_event_loop()
+
+    async def _create() -> ClientSession:
+        return transport._get_valid_client_session()
+
+    session = loop.run_until_complete(_create())
+    loop.close()
+    return session
+
+
+def test_finalizer_without_running_loop_closes_dead_loop_session():
+    """A handler finalized with no running event loop must still dispose its
+    aiohttp session.
+
+    The async close can never run in that context; without the synchronous
+    fallback the session and its connector are abandoned to GC and emit
+    "Unclosed client session" / "Unclosed connector" warnings."""
+    handler = AsyncHTTPHandler(timeout=61.0)
+    session = _mint_session_on_dead_loop(handler)
+    assert not session.closed
+
+    del handler
+    gc.collect()
+
+    assert session.closed
+
+
+@pytest.mark.asyncio
+async def test_finalizer_with_running_loop_schedules_close_and_holds_task_ref():
+    """With a running loop, finalization schedules an async close and must keep
+    a strong reference to the task until it completes — a bare create_task()
+    result may be collected before it runs, leaving the session unclosed."""
+    handler = AsyncHTTPHandler(timeout=61.0)
+    transport = handler.client._transport
+    assert isinstance(transport, LiteLLMAiohttpTransport)
+    session = transport._get_valid_client_session()
+    assert not session.closed
+    del transport
+
+    baseline_tasks = set(AsyncHTTPHandler._finalizer_close_tasks)
+    del handler
+    gc.collect()
+
+    scheduled = AsyncHTTPHandler._finalizer_close_tasks - baseline_tasks
+    assert len(scheduled) == 1
+
+    await asyncio.gather(*scheduled)
+    assert session.closed
+    assert not (AsyncHTTPHandler._finalizer_close_tasks & scheduled)
+
+
+@pytest.mark.asyncio
+async def test_sync_close_helper_respects_session_ownership():
+    """The loop-less fallback closes only sessions the transport owns; a
+    shared session (e.g. the proxy's) must never be closed by a handler."""
+    owned_handler = AsyncHTTPHandler(timeout=61.0)
+    owned_transport = owned_handler.client._transport
+    assert isinstance(owned_transport, LiteLLMAiohttpTransport)
+    owned_session = owned_transport._get_valid_client_session()
+
+    owned_handler._close_aiohttp_session_sync()
+    assert owned_session.closed
+
+    shared_session = ClientSession()
+    shared_handler = AsyncHTTPHandler(timeout=61.0, shared_session=shared_session)
+    shared_transport = shared_handler.client._transport
+    assert isinstance(shared_transport, LiteLLMAiohttpTransport)
+    assert shared_transport._owns_session is False
+
+    shared_handler._close_aiohttp_session_sync()
+    assert not shared_session.closed
+
+    await shared_session.close()
+    await shared_handler.close()
+    await owned_handler.close()

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -56,9 +56,7 @@ async def test_async_post_streaming_status_error_should_not_wait_forever_for_bod
 
     litellm_handler = AsyncHTTPHandler()
     await litellm_handler.client.aclose()
-    litellm_handler.client = httpx.AsyncClient(
-        transport=httpx.MockTransport(mock_handler)
-    )
+    litellm_handler.client = httpx.AsyncClient(transport=httpx.MockTransport(mock_handler))
     try:
         with pytest.raises(MaskedHTTPStatusError) as exc_info:
             await asyncio.wait_for(
@@ -378,7 +376,8 @@ async def test_get_async_httpx_client_with_shared_session():
 
     # Test with shared session
     client = get_async_httpx_client(
-        llm_provider=LlmProviders.ANTHROPIC, shared_session=mock_session  # type: ignore
+        llm_provider=LlmProviders.ANTHROPIC,
+        shared_session=mock_session,  # type: ignore
     )
 
     # Verify the client was created successfully
@@ -397,9 +396,7 @@ async def test_get_async_httpx_client_without_shared_session():
     from litellm.types.utils import LlmProviders
 
     # Test without shared session
-    client = get_async_httpx_client(
-        llm_provider=LlmProviders.ANTHROPIC, shared_session=None
-    )
+    client = get_async_httpx_client(llm_provider=LlmProviders.ANTHROPIC, shared_session=None)
 
     # Verify the client was created successfully
     assert client is not None
@@ -476,11 +473,13 @@ async def test_session_reuse_integration():
 
     # Create two clients with the same session
     client1 = get_async_httpx_client(
-        llm_provider=LlmProviders.ANTHROPIC, shared_session=mock_session  # type: ignore
+        llm_provider=LlmProviders.ANTHROPIC,
+        shared_session=mock_session,  # type: ignore
     )
 
     client2 = get_async_httpx_client(
-        llm_provider=LlmProviders.OPENAI, shared_session=mock_session  # type: ignore
+        llm_provider=LlmProviders.OPENAI,
+        shared_session=mock_session,  # type: ignore
     )
 
     # Both clients should be created successfully
@@ -512,9 +511,7 @@ async def test_session_reuse_integration():
         (None, None, None, False),  # None value - skip configuration
     ],
 )
-def test_ssl_ecdh_curve(
-    env_curve, litellm_curve, expected_curve, should_call, monkeypatch
-):
+def test_ssl_ecdh_curve(env_curve, litellm_curve, expected_curve, should_call, monkeypatch):
     """Test SSL ECDH curve configuration with valid curves and precedence"""
     from litellm.llms.custom_httpx.http_handler import _ssl_context_cache
 
@@ -1281,3 +1278,25 @@ async def test_sync_close_helper_respects_session_ownership():
     await shared_session.close()
     await shared_handler.close()
     await owned_handler.close()
+
+
+@pytest.mark.asyncio
+async def test_finalizer_close_done_consumes_exception():
+    """A failing finalizer close must have its exception retrieved by the done
+    callback, or asyncio emits "Task exception was never retrieved" at GC —
+    the same log noise the finalizer path exists to eliminate."""
+
+    async def failing_close() -> None:
+        raise RuntimeError("close failed")
+
+    task = asyncio.get_running_loop().create_task(failing_close())
+    AsyncHTTPHandler._finalizer_close_tasks.add(task)
+    await asyncio.sleep(0)
+
+    AsyncHTTPHandler._on_finalizer_close_done(task)
+    assert task not in AsyncHTTPHandler._finalizer_close_tasks
+
+    cancelled = asyncio.get_running_loop().create_task(asyncio.sleep(30))
+    cancelled.cancel()
+    await asyncio.sleep(0)
+    AsyncHTTPHandler._on_finalizer_close_done(cancelled)

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -200,9 +200,7 @@ async def test_ssl_verification_with_aiohttp_transport(monkeypatch: pytest.Monke
         transport_connector = transport._get_valid_client_session().connector
         assert isinstance(transport_connector, TCPConnector)
 
-        aiohttp_session = aiohttp.ClientSession(
-            connector=aiohttp.TCPConnector(ssl=False)
-        )
+        aiohttp_session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False))
         try:
             aiohttp_connector = aiohttp_session.connector
             assert isinstance(aiohttp_connector, aiohttp.TCPConnector)
@@ -714,9 +712,7 @@ class TestDefaultCachedClientTimeoutHonorsRequestTimeout:
             _default_cached_client_timeout,
         )
 
-        monkeypatch.setattr(
-            litellm, "request_timeout", litellm.constants.DEFAULT_REQUEST_TIMEOUT_SECONDS
-        )
+        monkeypatch.setattr(litellm, "request_timeout", litellm.constants.DEFAULT_REQUEST_TIMEOUT_SECONDS)
         monkeypatch.setattr(litellm, "request_timeout_explicitly_set", False)
         assert _default_cached_client_timeout() is _DEFAULT_TIMEOUT
 
@@ -731,9 +727,7 @@ class TestDefaultCachedClientTimeoutHonorsRequestTimeout:
         assert resolved.read == 300.0
         assert resolved.connect == 5.0
 
-    def test_cached_async_client_built_with_explicit_request_timeout(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
+    def test_cached_async_client_built_with_explicit_request_timeout(self, monkeypatch: pytest.MonkeyPatch):
         from litellm.caching.llm_caching_handler import LLMClientCache
         from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
         from litellm.types.utils import LlmProviders
@@ -1263,7 +1257,10 @@ async def test_sync_close_helper_respects_session_ownership():
     assert isinstance(owned_transport, LiteLLMAiohttpTransport)
     owned_session = owned_transport._get_valid_client_session()
 
-    owned_handler._close_aiohttp_session_sync()
+    baseline = set(LiteLLMAiohttpTransport._background_close_tasks)
+    owned_handler._dispose_wrapped_aiohttp_session()
+    scheduled = LiteLLMAiohttpTransport._background_close_tasks - baseline
+    await asyncio.gather(*scheduled)
     assert owned_session.closed
 
     shared_session = ClientSession()
@@ -1272,7 +1269,7 @@ async def test_sync_close_helper_respects_session_ownership():
     assert isinstance(shared_transport, LiteLLMAiohttpTransport)
     assert shared_transport._owns_session is False
 
-    shared_handler._close_aiohttp_session_sync()
+    shared_handler._dispose_wrapped_aiohttp_session()
     assert not shared_session.closed
 
     await shared_session.close()
@@ -1300,3 +1297,20 @@ async def test_finalizer_close_done_consumes_exception():
     cancelled.cancel()
     await asyncio.sleep(0)
     AsyncHTTPHandler._on_finalizer_close_done(cancelled)
+
+
+@pytest.mark.asyncio
+async def test_finalizer_on_live_loop_disposes_foreign_loop_session_without_scheduling():
+    """GC on a live loop (e.g. the app's) of a handler whose session belongs to
+    another, dead loop must not schedule aclose() here — that is the cross-loop
+    path the transport refuses — and must still dispose the session."""
+    handler = AsyncHTTPHandler(timeout=61.0)
+    session = await asyncio.to_thread(_mint_session_on_dead_loop, handler)
+    assert not session.closed
+
+    baseline_tasks = set(AsyncHTTPHandler._finalizer_close_tasks)
+    del handler
+    gc.collect()
+
+    assert AsyncHTTPHandler._finalizer_close_tasks == baseline_tasks
+    assert session.closed


### PR DESCRIPTION
## Title

fix(http_handler): dispose aiohttp session when `AsyncHTTPHandler` is finalized without a running loop

## Relevant issues

Follow-up to the recycle-time disposal fix (#33428 / #32003). That fix covers sessions replaced by `_get_valid_client_session()`; this PR covers the clients that are **never recycled** and still leak.

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] Test output pasted below (new tests passing locally)

```
$ pytest tests/test_litellm/llms/custom_httpx/test_http_handler.py -q -k "finalizer or sync_close"
5 passed, 55 deselected

$ pytest tests/test_litellm/llms/custom_httpx/test_http_handler.py \
    tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py \
    tests/test_litellm/llms/custom_httpx/test_async_client_cleanup.py \
    tests/test_litellm/llms/custom_httpx/test_gemini_session_leak.py -q
98 passed in 14.41s
```
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

**Problem.** `AsyncHTTPHandler.__del__` can only schedule an async close when a running event loop exists at finalization time:

```python
def __del__(self) -> None:
    try:
        if not _handler_may_close_client(...):
            return
        asyncio.get_running_loop().create_task(self._client.aclose())
    except Exception:
        pass
```

In any loop-less context — worker threads whose event loop has already closed, sync code paths, interpreter/worker shutdown — `get_running_loop()` raises, the exception is swallowed, and the underlying aiohttp `ClientSession` is abandoned to GC, emitting `Unclosed client session` / `Unclosed connector` warnings.

This is exactly the lifecycle of clients minted for short-lived event loops: `LLMClientCache` keys clients by `id(running_loop)`, so each ephemeral loop gets its own handler; those handlers live and die with their loop and are only ever finalized loop-lessly. Measured in production (FastAPI service running background eval workers with per-task event loops): a steady residual of these warnings survives the recycle-time fix, because these sessions never reach `_get_valid_client_session()` again.

**Fix** (all inside `AsyncHTTPHandler`):

1. **No running loop:** fall back to the connector's synchronous teardown via `LiteLLMAiohttpTransport._mark_connector_closed` — the same finalizer-safe path the transport already uses for dead-loop recycles. It releases pooled connections and flips the closed flags that `ClientSession.__del__` / connector `__del__` check, so no warnings fire at GC. The fallback honors `_owns_session`, so a shared session (e.g. the proxy's) is never closed by a handler.
2. **Running loop:** keep the async close, but hold a strong reference to the scheduled task until it completes — a bare `create_task()` result may be garbage-collected before it runs. Mirrors `LiteLLMAiohttpTransport._background_close_tasks`.

**Tests** (`tests/test_litellm/llms/custom_httpx/test_http_handler.py`):

- `test_finalizer_without_running_loop_closes_dead_loop_session` — a handler whose session was created on a since-closed loop is finalized with no running loop; the session must end up closed.
- `test_finalizer_with_running_loop_schedules_close_and_holds_task_ref` — the close task is registered, retained, and drains the registry on completion.
- `test_sync_close_helper_respects_session_ownership` — owned session closed; shared session untouched.

All three fail without the fix and pass with it. Existing `custom_httpx` suites (`test_http_handler.py`, `test_aiohttp_transport.py`, `test_async_client_cleanup.py`, `test_gemini_session_leak.py`) pass: 98/98.

Behavioral A/B on the repro (5 clients used on ephemeral loops, refs dropped with no loop running, forced GC): **10 unclosed-session warnings before → 0 after**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches finalizer/GC cleanup for widely cached async HTTP clients; incorrect shared-session handling could close proxy-owned sessions, though the change explicitly gates on `_owns_session`.
> 
> **Overview**
> Fixes **aiohttp `ClientSession` leaks** when `AsyncHTTPHandler` is garbage-collected without a running event loop (short-lived loops, shutdown, sync GC). Previously `__del__` only scheduled `aclose()` via `get_running_loop()`; failures were swallowed and left **"Unclosed client session"** warnings.
> 
> **`AsyncHTTPHandler.__del__`** now branches on loop availability: with **no running loop**, it calls **`_close_aiohttp_session_sync()`**, which tears down owned `LiteLLMAiohttpTransport` sessions via **`_mark_connector_closed`** (same path as dead-loop transport recycle) and **skips shared/proxy sessions** (`_owns_session`). With a **running loop**, it still schedules async `aclose()` but **pins close tasks** in **`_finalizer_close_tasks`** and clears them in **`_on_finalizer_close_done`** so tasks are not GC'd before they run and close exceptions are consumed.
> 
> Adds **regression tests** for dead-loop finalization, task retention, shared-session safety, and the done-callback path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458a9b80e2acbeccc8de295d8f14cb65de3c8262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->