### PR TITLE
fix(proxy): log requests rejected for an unparsable body in spend logs

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1060,6 +1060,31 @@ async def _read_request_body_deferring_parse_failure(
     return populate_request_with_path_params(request_data=parsed_body, request=request), None
 
 
+async def _record_unparsable_body_failure(
+    user_api_key_dict: UserAPIKeyAuth,
+    body_parse_exception: ProxyException,
+    route: str,
+) -> None:
+    """Record the 400 an unparsable body earns as a failed request log.
+
+    The endpoint never runs for these, so no downstream failure hook writes the
+    spend log row the Admin UI reads. Logging must not change what the caller
+    sees, so a failure here is swallowed and the 400 is raised either way.
+    """
+    from litellm.proxy.proxy_server import proxy_logging_obj
+
+    try:
+        await proxy_logging_obj.post_call_failure_hook(  # pyright: ignore[reportUnknownMemberType]  # bare dict in sig
+            request_data={},  # mutable-ok: the failure hook seeds the call id and metadata onto this dict
+            original_exception=body_parse_exception,
+            user_api_key_dict=user_api_key_dict,
+            error_type=ProxyErrorTypes.bad_request_error,
+            route=route,
+        )
+    except Exception as e:  # noqa: BLE001  # any logging failure must leave the caller's 400 untouched
+        verbose_proxy_logger.exception("Failed to log the request rejected for an unparsable body: %s", e)
+
+
 async def _user_api_key_auth_builder(
     request: Request,
     api_key: str,
@@ -2673,6 +2698,11 @@ async def user_api_key_auth(
     user_api_key_auth_obj.request_route = normalize_request_route(route)
 
     if body_parse_exception is not None:
+        await _record_unparsable_body_failure(
+            user_api_key_dict=user_api_key_auth_obj,
+            body_parse_exception=body_parse_exception,
+            route=route,
+        )
         raise body_parse_exception
 
     # Resolve caller identity once, here at the seam, into a single per-request

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -4847,6 +4847,79 @@ async def test_user_api_key_auth_authenticates_before_raising_malformed_body_err
             setattr(_proxy_server_mod, k, v)
 
 
+async def _run_auth_with_malformed_body(post_call_failure_hook):
+    """Drive ``user_api_key_auth`` for an authenticated caller whose body never parses,
+    with ``proxy_logging_obj.post_call_failure_hook`` swapped for the passed double.
+    Returns the raised ProxyException."""
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    builder_token = UserAPIKeyAuth(api_key="sk-test", user_id="u1", team_id="team-1")
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [(b"content-type", b"application/json")],
+            "method": "POST",
+        }
+    )
+    request._url = URL(url="/chat/completions")
+    request._body = b'{}{"model": "gpt-4o"}'
+
+    attrs = _proxy_attrs_for_centralized_checks(user_custom_auth=None)
+    attrs["proxy_logging_obj"].post_call_failure_hook = post_call_failure_hook
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        with (
+            patch(
+                "litellm.proxy.auth.user_api_key_auth._user_api_key_auth_builder",
+                new_callable=AsyncMock,
+                return_value=builder_token,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.RouteChecks.should_call_route",
+            ),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await user_api_key_auth(request=request, api_key="Bearer sk-test")
+        return exc_info.value
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
+async def test_user_api_key_auth_logs_the_failure_for_a_body_that_never_parses():
+    """The endpoint never runs for an unparsable body, so the 400 the caller sees only
+    reaches Request Logs if auth runs the failure hook that writes the spend log row."""
+    hook = AsyncMock(return_value=None)
+
+    raised = await _run_auth_with_malformed_body(hook)
+
+    assert "Invalid JSON payload" in str(raised.message)
+    assert raised.code == str(status.HTTP_400_BAD_REQUEST)
+    hook.assert_awaited_once()
+    hook_kwargs = hook.await_args.kwargs
+    assert hook_kwargs["original_exception"] is raised
+    assert hook_kwargs["error_type"] == ProxyErrorTypes.bad_request_error
+    assert hook_kwargs["route"] == "/chat/completions"
+    assert hook_kwargs["user_api_key_dict"].user_id == "u1"
+    assert hook_kwargs["user_api_key_dict"].team_id == "team-1"
+
+
+@pytest.mark.asyncio
+async def test_user_api_key_auth_returns_the_parse_error_even_if_logging_it_fails():
+    """Logging the rejected request must never change what the caller sees."""
+    raised = await _run_auth_with_malformed_body(AsyncMock(side_effect=Exception("logging is down")))
+
+    assert "Invalid JSON payload" in str(raised.message)
+    assert raised.code == str(status.HTTP_400_BAD_REQUEST)
+
+
 @pytest.mark.asyncio
 async def test_user_api_key_auth_malformed_body_with_rejected_key_still_returns_the_parse_error():
     """The body is read before the key is authenticated, so a caller who sends both a
@@ -4892,6 +4965,58 @@ async def test_user_api_key_auth_malformed_body_with_rejected_key_still_returns_
 
         assert "Invalid JSON payload" in str(exc_info.value.message)
         assert exc_info.value.code == str(status.HTTP_400_BAD_REQUEST)
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
+async def test_user_api_key_auth_does_not_double_log_a_malformed_body_from_a_rejected_key():
+    """The auth failure this caller also earns is already logged by the handler that
+    rejected the key, so the unparsable-body hook must stay out of that path and leave
+    Request Logs with one row instead of two."""
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [(b"content-type", b"application/json")],
+            "method": "POST",
+        }
+    )
+    request._url = URL(url="/chat/completions")
+    request._body = b'{}{"model": "gpt-4o"}'
+
+    hook = AsyncMock(return_value=None)
+    attrs = _proxy_attrs_for_centralized_checks(user_custom_auth=None)
+    attrs["proxy_logging_obj"].post_call_failure_hook = hook
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        with (
+            patch(
+                "litellm.proxy.auth.user_api_key_auth._user_api_key_auth_builder",
+                new_callable=AsyncMock,
+                side_effect=ProxyException(
+                    message="Authentication Error, invalid key",
+                    type="auth_error",
+                    param="None",
+                    code=status.HTTP_401_UNAUTHORIZED,
+                ),
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.RouteChecks.should_call_route",
+            ),
+        ):
+            with pytest.raises(ProxyException):
+                await user_api_key_auth(request=request, api_key="Bearer sk-bad")
+
+        await asyncio.sleep(0.05)
+        hook.assert_not_awaited()
     finally:
         for k, v in originals.items():
             setattr(_proxy_server_mod, k, v)


### PR DESCRIPTION
## TLDR

Problem this solves:

- A 400 for an unparsable body leaves no Request Logs row
- Failure filter returns "No logs found" for a client-visible failure
- The rejection happens in auth, before any endpoint logs it

How it solves it:

- Auth reports that rejection through the endpoints' failure hook
- The row carries failure status, code 400, and the client's message
- Best-effort: a logging failure leaves the caller's 400 unchanged

## User Flow

Before: a platform engineer investigating a client-visible 400 finds no trace of the request

1. Their app sends POST https://litellm-domain/v1/chat/completions with a body that is not valid JSON
2. The gateway answers HTTP 400 with `Invalid JSON payload: unexpected content after document`
3. They open https://litellm-domain/ui/?page=logs, set the window to the minute of that call and switch the status filter to Failure
4. Request Logs shows "No logs found", so nothing records that the request ever reached the gateway, and there is no request id, key, or timestamp to follow

After: the same request leaves a searchable failure row

1. Their app sends the same POST https://litellm-domain/v1/chat/completions with the same invalid body
2. The gateway answers the same HTTP 400 with the same `Invalid JSON payload: unexpected content after document`
3. They open https://litellm-domain/ui/?page=logs for the same window with the status filter on Failure
4. Request Logs lists the request, classified as a failure, showing error code 400, the same error text the client got, the timestamp of the response, and the key that sent it

## Relevant issues

## Linear ticket

Resolves LIT-5198

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on port 4198 against a Postgres on 5498, calling the real OpenAI API on a paid key. The control leg is a real 200 with a real spend row, so the failure leg is being read against a working pipeline

**Before, at `b0626cad8c8fcd61b20544b85a3e0d48e74649d1` (the merge base, no fix)**

```
$ grep -c _record_unparsable_body_failure litellm/proxy/auth/user_api_key_auth.py
0

$ curl -s -o /dev/null -w '%{http_code}' localhost:4198/health/readiness
200

$ curl -sS -w '\nHTTP %{http_code}\n' http://localhost:4198/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model":"gpt-good","messages":[{"role":"user","content":"say hi"}],"max_tokens":5}'
{"id":"chatcmpl-EC6iacmT9NPyqYVvUBIniN8ckuiwi","created":1786554468,"model":"gpt-good","object":"chat.completion","choices":[{"finish_reason":"length","index":0,"message":{"content":"Hi! How can I","role":"assistant"}}],"usage":{"completion_tokens":5,"prompt_tokens":9,"total_tokens":14}}
HTTP 200

$ curl -sS -w '\nHTTP %{http_code}\n' http://localhost:4198/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{}{"model": "gpt-good"}'
{"error":{"message":"Invalid JSON payload: unexpected content after document: line 1 column 3 (char 2)","type":"invalid_request_error","param":"request_body","code":"400"}}
HTTP 400

$ psql -c 'select status, model, error_code, error_message from "LiteLLM_SpendLogs"'
 status  |       model        | error_code | error_message
---------+--------------------+------------+---------------
 success | openai/gpt-4o-mini |            | -
(1 row)
```

The 200 is logged. The 400 the client saw is not there at all

**After, at `fcb407adc1c6adc3f97c39c0aec25769e2276862`**

```
$ grep -c _record_unparsable_body_failure litellm/proxy/auth/user_api_key_auth.py
2

$ curl -s -o /dev/null -w '%{http_code}' localhost:4198/health/readiness
200

$ curl -sS -w '\nHTTP %{http_code}\n' http://localhost:4198/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model":"gpt-good","messages":[{"role":"user","content":"say hi"}],"max_tokens":5}'
{"id":"chatcmpl-EC6jL5EykI5DXcNVeNcBFpZWg2ErD","created":1786554515,"model":"gpt-good","object":"chat.completion","choices":[{"finish_reason":"length","index":0,"message":{"content":"Hi! How can I","role":"assistant"}}],"usage":{"completion_tokens":5,"prompt_tokens":9,"total_tokens":14}}
HTTP 200

$ curl -sS -w '\nHTTP %{http_code}\n' http://localhost:4198/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{}{"model": "gpt-good"}'
{"error":{"message":"Invalid JSON payload: unexpected content after document: line 1 column 3 (char 2)","type":"invalid_request_error","param":"request_body","code":"400"}}
HTTP 400

$ psql -c 'select status, model, error_code, error_message from "LiteLLM_SpendLogs"'
 status  |       model        | error_code |                          error_message
---------+--------------------+------------+------------------------------------------------------------------
 success | openai/gpt-4o-mini |            | -
 failure |                    | 400        | Invalid JSON payload: unexpected content after document: line 1
(2 rows)
```

Same 200, same 400, and the 400 now has a failure row carrying the exact message the client got

**The ticket's other two cases, at `fcb407adc1c6adc3f97c39c0aec25769e2276862`**, checked on the same proxy so the fix can be kept narrow. A model whose provider credential was revoked, and an out of range `temperature`, both already produced correctly classified failure rows before this change, and still do

```
$ curl -sS -w '\nHTTP %{http_code}\n' ... -d '{"model":"gpt-badkey","messages":[{"role":"user","content":"say hi"}],"max_tokens":5}'
{"error":{"message":"litellm.AuthenticationError: AuthenticationError: OpenAIException - Incorrect API key provided: sk-proj-**********************************0000. ... Received Model Group=gpt-badkey","type":null,"param":null,"code":"401"}}
HTTP 401

$ curl -sS -w '\nHTTP %{http_code}\n' ... -d '{"model":"gpt-good","messages":[{"role":"user","content":"say hi"}],"temperature":5,"max_tokens":5}'
{"error":{"message":"litellm.BadRequestError: OpenAIException - Invalid 'temperature': decimal above maximum value. Expected a value <= 2, but got 5 instead.. Received Model Group=gpt-good","type":"invalid_request_error","param":"temperature","code":"400"}}
HTTP 400

$ curl -sS -G localhost:4198/spend/logs/ui --data-urlencode 'status_filter=failure' ... -H 'Authorization: Bearer sk-1234'
total failures: 3
  failure | 400 | Invalid JSON payload: unexpected content after document: line 1 column 3 (char
  failure | 401 | litellm.AuthenticationError: AuthenticationError: OpenAIException - Incorrect
  failure | decimal_above_max_value | litellm.BadRequestError: OpenAIException - Invalid 'temperature': decimal abov
```

That last call is the query the Admin UI Request Logs page runs behind the Failure filter, so all three of the ticket's failures are now returned by it

## Review notes

Greptile flagged that the failure hook is awaited before the 400 is re-raised, so this path could be delayed by a slow logging callback, and suggested bounding it or moving it off the critical path. Taking the cost question first, since it is the real one: this change does make the malformed-body 400 slower, because before it that response did no logging at all. Measured on a live proxy, 120 samples a leg after a 20 request warmup, malformed-body 400 only

```
merge base b0626cad, run 1 : n=120 median=1.30ms mean=1.32ms p90=1.53ms
head       fcb407ad        : n=120 median=5.56ms mean=5.69ms p90=6.13ms
merge base b0626cad, run 2 : n=120 median=1.57ms mean=1.62ms p90=1.76ms
```

The base was measured twice around the head run and moved 0.27ms between them, so the roughly 4ms delta is the change and not drift. For scale, on the merge base with none of this applied, a 403 for a model the key cannot access, which already logs through this same hook, costs

```
merge base b0626cad : n=120 median=9.40ms mean=9.55ms p90=9.87ms
```

So the malformed-body path now pays about 4ms of the logging cost that every already-logged failure path pays, and still returns faster than an existing sibling failure does today. That is the tradeoff on offer: the alternative to paying it is the bug

On bounding, `litellm/` has 60 awaited call sites of `post_call_failure_hook` and none is wrapped in `asyncio.wait_for` or `asyncio.timeout`. That includes `auth_exception_handler.py`, which logs the invalid-key 401 this same ticket reproduces, plus about twenty sites in `proxy_server.py` covering the 4xx and 5xx paths. A stalling callback already stalls all of them. Bounding only this one would make it behave unlike its sixty siblings on a timeout constant chosen from nothing

On moving it off the critical path, detaching it into a background task would buy back the 4ms, and it is the more tempting of the two suggestions because it looks free. It is not: a detached task can be dropped at shutdown or on cancellation, so the failure row this change exists to write becomes the row that silently goes missing during precisely the restarts and cancellations people reach for the logs to explain. It would also diverge from all 60 siblings, for a saving smaller than the cost an already-logged failure pays today

Greptile also noted the tests set module attributes on `proxy_server`, which does cut against the repo's testing guidance. It is the surrounding file's existing convention, forced by `user_api_key_auth` resolving its dependencies through a late import from `proxy_server`: the neighbouring tests already drive it through the shared `_proxy_attrs_for_centralized_checks` helper and restore the originals in a `finally`, and the new tests follow that shape. Reworking that import seam so these tests can inject properly is a real improvement, and a separate refactor rather than something this fix should carry

## Type

🐛 Bug Fix

## Caveats (if any)

- The row has no model: no body parsed, so none is known
- Rejected key plus bad body still logs once, from the auth handler

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
