### PR TITLE
fix(ui): show and edit key-level router settings on a virtual key

### DIFF
--- a/ui/litellm-dashboard/src/components/common_components/RouterSettingsSummary.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/RouterSettingsSummary.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import RouterSettingsSummary from "./RouterSettingsSummary";
+
+describe("RouterSettingsSummary", () => {
+  it("should list each configured fallback mapping", () => {
+    render(
+      <RouterSettingsSummary
+        routerSettings={{
+          fallbacks: [{ "gpt-4": ["gpt-4o", "claude-sonnet"] }, { "gpt-4o": ["gpt-4o-mini"] }],
+          num_retries: 3,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("gpt-4")).toBeInTheDocument();
+    expect(screen.getByText("gpt-4o, claude-sonnet")).toBeInTheDocument();
+    expect(screen.getByText("gpt-4o")).toBeInTheDocument();
+    expect(screen.getByText("gpt-4o-mini")).toBeInTheDocument();
+    expect(screen.getByText("Number of Retries: 3")).toBeInTheDocument();
+  });
+
+  it("should show the empty state when every setting is null", () => {
+    render(<RouterSettingsSummary routerSettings={{ fallbacks: null, num_retries: null }} />);
+
+    expect(screen.getByText("No router settings configured")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/common_components/RouterSettingsSummary.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/RouterSettingsSummary.tsx
@@ -1,0 +1,56 @@
+import { Badge } from "@/components/ui/badge";
+import { hasRouterSettings } from "./routerSettingsPayload";
+
+interface RouterSettingsSummaryProps {
+  routerSettings: Record<string, unknown> | null | undefined;
+  emptyText?: string;
+}
+
+const fallbackEntries = (fallbacks: unknown): Array<[string, string[]]> => {
+  if (!Array.isArray(fallbacks)) return [];
+  return fallbacks.flatMap((entry) =>
+    entry && typeof entry === "object" ? (Object.entries(entry) as Array<[string, string[]]>) : [],
+  );
+};
+
+export default function RouterSettingsSummary({
+  routerSettings,
+  emptyText = "No router settings configured",
+}: RouterSettingsSummaryProps) {
+  if (!hasRouterSettings(routerSettings)) {
+    return <div className="text-gray-400">{emptyText}</div>;
+  }
+
+  const settings = routerSettings as Record<string, unknown>;
+  const fallbacks = fallbackEntries(settings.fallbacks);
+
+  return (
+    <div className="space-y-1 text-sm">
+      {settings.routing_strategy != null && (
+        <div>
+          Routing Strategy: <Badge variant="secondary">{String(settings.routing_strategy)}</Badge>
+        </div>
+      )}
+      {settings.num_retries != null && <div>Number of Retries: {String(settings.num_retries)}</div>}
+      {settings.allowed_fails != null && <div>Allowed Failures: {String(settings.allowed_fails)}</div>}
+      {settings.cooldown_time != null && <div>Cooldown Time: {String(settings.cooldown_time)}s</div>}
+      {settings.timeout != null && <div>Timeout: {String(settings.timeout)}s</div>}
+      {settings.retry_after != null && <div>Retry After: {String(settings.retry_after)}s</div>}
+      {Boolean(settings.enable_tag_filtering) && <div>Tag Filtering: Enabled</div>}
+      {fallbacks.length > 0 && (
+        <div>
+          <div>Fallbacks:</div>
+          <div className="mt-1 space-y-1">
+            {fallbacks.map(([model, targets]) => (
+              <div key={model} className="text-xs text-gray-600">
+                <span className="font-medium">{model}</span>
+                <span className="mx-1 text-gray-400">-&gt;</span>
+                {Array.isArray(targets) ? targets.join(", ") : String(targets)}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/litellm-dashboard/src/components/common_components/routerSettingsPayload.test.ts
+++ b/ui/litellm-dashboard/src/components/common_components/routerSettingsPayload.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { hasRouterSettings, routerSettingsEditorValue, routerSettingsUpdate } from "./routerSettingsPayload";
+
+describe("hasRouterSettings", () => {
+  it("should treat unset, empty and all-null settings as absent", () => {
+    expect(hasRouterSettings(undefined)).toBe(false);
+    expect(hasRouterSettings(null)).toBe(false);
+    expect(hasRouterSettings({})).toBe(false);
+    expect(
+      hasRouterSettings({ num_retries: null, fallbacks: [], model_group_alias: {}, enable_tag_filtering: false }),
+    ).toBe(false);
+  });
+
+  it("should detect configured settings", () => {
+    expect(hasRouterSettings({ num_retries: 3 })).toBe(true);
+    expect(hasRouterSettings({ fallbacks: [{ "gpt-4": ["gpt-4o"] }] })).toBe(true);
+    expect(hasRouterSettings({ enable_tag_filtering: true })).toBe(true);
+    expect(hasRouterSettings({ num_retries: 0 })).toBe(true);
+  });
+});
+
+describe("routerSettingsEditorValue", () => {
+  it("should hand the editor only the fields it renders", () => {
+    expect(
+      routerSettingsEditorValue({
+        num_retries: 2,
+        tag_routing_prefix: "team-",
+        fallbacks: [{ "gpt-4": ["gpt-4o"] }],
+      }),
+    ).toStrictEqual({ router_settings: { num_retries: 2, fallbacks: [{ "gpt-4": ["gpt-4o"] }] } });
+  });
+
+  it("should keep an explicitly stored null so the editor renders it as empty", () => {
+    expect(routerSettingsEditorValue({ num_retries: null })).toStrictEqual({ router_settings: { num_retries: null } });
+  });
+
+  it("should leave the editor uninitialised when the key has no stored settings", () => {
+    expect(routerSettingsEditorValue(null)).toBeUndefined();
+    expect(routerSettingsEditorValue(undefined)).toBeUndefined();
+  });
+});
+
+describe("routerSettingsUpdate", () => {
+  const fallbacks = [{ "gpt-4": ["gpt-4o"] }];
+  // Accepted by UpdateRouterConfig on /key/update but not rendered by the accordion.
+  const unsupported = {
+    tag_routing_prefix: "team-",
+    model_group_retry_policy: { "gpt-4": { TimeoutErrorRetries: 2 } },
+  };
+
+  // The editor is a fixed-field form, so the merge has to hold two opposing guarantees at once:
+  // routing fields it cannot render survive, and a field it does render that the admin emptied
+  // is still sent as null. Orderings vary because an object spread resolves collisions by position.
+  const storedOrderings: Array<[string, Record<string, unknown>]> = [
+    ["unsupported fields first", { ...unsupported, num_retries: 2, fallbacks }],
+    ["unsupported fields last", { num_retries: 2, fallbacks, ...unsupported }],
+    [
+      "unsupported fields interleaved",
+      {
+        tag_routing_prefix: unsupported.tag_routing_prefix,
+        num_retries: 2,
+        model_group_retry_policy: unsupported.model_group_retry_policy,
+        fallbacks,
+      },
+    ],
+  ];
+
+  it.each(storedOrderings)(
+    "should keep unsupported stored fields and still clear an emptied editor field (%s)",
+    (_ordering, stored) => {
+      const result = routerSettingsUpdate({ num_retries: 4, fallbacks: null }, stored);
+
+      expect(result).toMatchObject({ ...unsupported, num_retries: 4, fallbacks: null });
+    },
+  );
+
+  it("should send an empty object, not a null blob, when the last stored setting is cleared", () => {
+    expect(routerSettingsUpdate({ fallbacks: null, num_retries: null }, { fallbacks, num_retries: 2 })).toEqual({});
+  });
+
+  it("should keep clearing owned fields explicitly while an unsupported setting still stands", () => {
+    expect(routerSettingsUpdate({ fallbacks: null, num_retries: null }, { fallbacks, ...unsupported })).toMatchObject({
+      ...unsupported,
+      fallbacks: null,
+      num_retries: null,
+    });
+  });
+
+  it("should null every editor-owned field the editor left out", () => {
+    expect(routerSettingsUpdate({ fallbacks: null }, { timeout: 30, ...unsupported })).toEqual({
+      ...unsupported,
+      routing_strategy: null,
+      allowed_fails: null,
+      cooldown_time: null,
+      num_retries: null,
+      timeout: null,
+      retry_after: null,
+      fallbacks: null,
+      context_window_fallbacks: null,
+      retry_policy: null,
+      model_group_alias: null,
+      enable_tag_filtering: null,
+      routing_strategy_args: null,
+    });
+  });
+
+  it("should send the edited settings when the user configured something", () => {
+    expect(routerSettingsUpdate({ fallbacks }, null)).toMatchObject({ fallbacks });
+  });
+
+  it("should leave the field off when nothing is stored and nothing was configured", () => {
+    expect(routerSettingsUpdate({ fallbacks: null, num_retries: null }, {})).toBeUndefined();
+    expect(routerSettingsUpdate(undefined, { fallbacks })).toBeUndefined();
+  });
+});

--- a/ui/litellm-dashboard/src/components/common_components/routerSettingsPayload.ts
+++ b/ui/litellm-dashboard/src/components/common_components/routerSettingsPayload.ts
@@ -1,0 +1,63 @@
+import { RouterSettingsAccordionValue } from "./RouterSettingsAccordion";
+
+export type RouterSettings = RouterSettingsAccordionValue["router_settings"];
+
+const EDITOR_OWNED_FIELDS: Record<keyof RouterSettings, true> = {
+  routing_strategy: true,
+  allowed_fails: true,
+  cooldown_time: true,
+  num_retries: true,
+  timeout: true,
+  retry_after: true,
+  fallbacks: true,
+  context_window_fallbacks: true,
+  retry_policy: true,
+  model_group_alias: true,
+  enable_tag_filtering: true,
+  routing_strategy_args: true,
+};
+
+const EDITOR_OWNED_KEYS = Object.keys(EDITOR_OWNED_FIELDS) as Array<keyof RouterSettings>;
+
+const isMeaningfulRouterSetting = (value: unknown): boolean => {
+  if (value === null || value === undefined || value === "" || value === false) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return true;
+};
+
+export const hasRouterSettings = (settings: Record<string, unknown> | null | undefined): boolean =>
+  settings != null && Object.values(settings).some(isMeaningfulRouterSetting);
+
+/**
+ * The stored settings narrowed to what the editor renders. The stored blob is untyped JSON
+ * from /key/info, so this projection is the one place it is read as RouterSettings.
+ */
+export const routerSettingsEditorValue = (
+  stored: Record<string, unknown> | null | undefined,
+): RouterSettingsAccordionValue | undefined =>
+  stored
+    ? {
+        router_settings: Object.fromEntries(
+          EDITOR_OWNED_KEYS.filter((key) => key in stored).map((key) => [key, stored[key]]),
+        ) as RouterSettings,
+      }
+    : undefined;
+
+/**
+ * Router settings to put on a /key/update payload, or undefined to leave the field off.
+ * The editor only renders EDITOR_OWNED_FIELDS, so its value is merged over the stored object
+ * rather than replacing it, and routing fields the editor cannot show survive an unrelated edit.
+ * Emptying every field sends {}, which the proxy reads as "no key-level override" so the key
+ * falls back to its team and global settings, where an all-null blob would pin it to nulls.
+ */
+export const routerSettingsUpdate = (
+  edited: RouterSettings | null | undefined,
+  stored: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | undefined => {
+  if (!edited) return undefined;
+  const editorOwned = Object.fromEntries(EDITOR_OWNED_KEYS.map((key) => [key, edited[key] ?? null]));
+  const merged: Record<string, unknown> = { ...stored, ...editorOwned };
+  if (hasRouterSettings(merged)) return merged;
+  return hasRouterSettings(stored) ? {} : undefined;
+};

--- a/ui/litellm-dashboard/src/components/common_components/routerSettingsWiring.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/routerSettingsWiring.test.tsx
@@ -1,0 +1,79 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { FallbackGroup } from "../Settings/RouterSettings/Fallbacks/FallbackGroupConfig";
+import type { RouterSettingsFormValue } from "../router_settings/RouterSettingsForm";
+import RouterSettingsAccordion from "./RouterSettingsAccordion";
+import { routerSettingsEditorValue } from "./routerSettingsPayload";
+
+vi.mock("../networking", () => ({
+  getRouterSettingsCall: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/components/llm_calls/fetch_models", () => ({
+  fetchAvailableModels: vi.fn().mockResolvedValue([{ model_group: "gpt-5.5" }, { model_group: "gpt-4o-mini" }]),
+  fetchAvailableModelsForTeam: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@tremor/react", () => ({
+  TabGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Tab: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabPanels: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabPanel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../router_settings/RouterSettingsForm", () => ({
+  default: ({ value }: { value: RouterSettingsFormValue }) => (
+    <div data-testid="loadbalancing">{JSON.stringify(value.routerSettings)}</div>
+  ),
+}));
+
+vi.mock("../Settings/RouterSettings/Fallbacks/FallbackSelectionForm", () => ({
+  FallbackSelectionForm: ({ groups }: { groups: FallbackGroup[] }) => (
+    <div data-testid="fallbacks">
+      {groups.map((g) => `${g.primaryModel ?? "none"}->${g.fallbackModels.join("|") || "none"}`).join(" ")}
+    </div>
+  ),
+}));
+
+// Captured verbatim from GET /key/info on a live proxy for a key created through the UI.
+// tag_routing_prefix is stored on the key and accepted by /key/update, but the accordion
+// has no control for it, so the projection must drop it without losing the rest.
+const KEY_INFO_ROUTER_SETTINGS: Record<string, unknown> = {
+  fallbacks: [{ "gpt-5.5": ["gpt-4o-mini"] }],
+  num_retries: 3,
+  tag_routing_prefix: "team-",
+};
+
+const renderAccordion = (stored: Record<string, unknown> | null): ReactElement => (
+  <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    <RouterSettingsAccordion accessToken="test-token" value={routerSettingsEditorValue(stored)} />
+  </QueryClientProvider>
+);
+
+describe("key router settings wiring, /key/info payload through to rendered output", () => {
+  it("should prefill both tabs from the stored settings", async () => {
+    render(renderAccordion(KEY_INFO_ROUTER_SETTINGS));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("fallbacks")).toHaveTextContent("gpt-5.5->gpt-4o-mini");
+    });
+    expect(JSON.parse(screen.getByTestId("loadbalancing").textContent ?? "{}")).toMatchObject({ num_retries: 3 });
+  });
+
+  it("should not leak a field the accordion has no control for into the editor", async () => {
+    render(renderAccordion(KEY_INFO_ROUTER_SETTINGS));
+
+    await waitFor(() => expect(screen.getByTestId("loadbalancing")).toBeInTheDocument());
+    expect(screen.getByTestId("loadbalancing").textContent).not.toContain("tag_routing_prefix");
+  });
+
+  it("should render an empty editor for a key holding only fields it cannot show", async () => {
+    render(renderAccordion({ tag_routing_prefix: "team-" }));
+
+    await waitFor(() => expect(screen.getByTestId("fallbacks")).toHaveTextContent("none->none"));
+    expect(JSON.parse(screen.getByTestId("loadbalancing").textContent ?? "null")).toEqual({});
+  });
+});

--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -95,6 +95,7 @@ export interface KeyResponse {
   object_permission?: ObjectPermission | null;
   access_group_ids?: string[];
   budget_fallbacks?: Record<string, string[]>;
+  router_settings?: Record<string, unknown> | null;
   budget_limits?: Array<{ budget_duration: string; max_budget: number; reset_at?: string }>;
   auto_rotate?: boolean;
   rotation_interval?: string;

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -59,6 +59,24 @@ vi.mock("../organisms/create_key_button", () => ({
   fetchTeamModels: vi.fn().mockResolvedValue(["team-model-1", "team-model-2"]),
 }));
 
+const routerSettingsMocks = vi.hoisted(() => ({
+  receivedValue: undefined as { router_settings: Record<string, unknown> } | undefined,
+  editedValue: null as Record<string, unknown> | null,
+}));
+
+vi.mock("../common_components/RouterSettingsAccordion", async () => {
+  const { forwardRef, useImperativeHandle } = await import("react");
+  return {
+    default: forwardRef(({ value }: { value?: { router_settings: Record<string, unknown> } }, ref) => {
+      routerSettingsMocks.receivedValue = value;
+      useImperativeHandle(ref, () => ({
+        getValue: () => ({ router_settings: routerSettingsMocks.editedValue ?? value?.router_settings ?? {} }),
+      }));
+      return <div data-testid="router-settings-accordion" />;
+    }),
+  };
+});
+
 vi.mock("@/app/(dashboard)/hooks/organizations/useOrganizations", () => ({
   useOrganizations: vi.fn().mockReturnValue({
     data: [
@@ -160,6 +178,83 @@ describe("KeyEditView", () => {
     last_rotation_at: undefined,
     key_rotation_at: undefined,
   };
+  describe("router settings", () => {
+    const UNSUPPORTED_STORED_FIELD = { tag_routing_prefix: "team-" };
+    const STORED_ROUTER_SETTINGS = {
+      num_retries: 2,
+      fallbacks: [{ "gpt-4": ["gpt-4o"] }],
+      ...UNSUPPORTED_STORED_FIELD,
+    };
+
+    const renderWithRouterSettings = (onSubmit: (values: Record<string, unknown>) => Promise<void>) =>
+      renderWithProviders(
+        <KeyEditView
+          keyData={{ ...MOCK_KEY_DATA, router_settings: STORED_ROUTER_SETTINGS }}
+          onCancel={() => {}}
+          onSubmit={onSubmit}
+          accessToken="test-token"
+          userID="test-user"
+          userRole="proxy_admin"
+          premiumUser={true}
+        />,
+      );
+
+    beforeEach(() => {
+      routerSettingsMocks.receivedValue = undefined;
+      routerSettingsMocks.editedValue = null;
+    });
+
+    it("should load the fields it renders into the editor and withhold the ones it does not", async () => {
+      renderWithRouterSettings(async () => {});
+
+      await waitFor(() => {
+        expect(routerSettingsMocks.receivedValue).toStrictEqual({
+          router_settings: { num_retries: 2, fallbacks: [{ "gpt-4": ["gpt-4o"] }] },
+        });
+      });
+    });
+
+    it("should submit edited fallbacks alongside routing fields the editor cannot show", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      renderWithRouterSettings(onSubmit);
+      routerSettingsMocks.editedValue = { num_retries: 2, fallbacks: [{ "gpt-4": ["gpt-4o", "gpt-4o-mini"] }] };
+
+      fireEvent.click(screen.getByText("Save Changes"));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            router_settings: expect.objectContaining({
+              ...UNSUPPORTED_STORED_FIELD,
+              num_retries: 2,
+              fallbacks: [{ "gpt-4": ["gpt-4o", "gpt-4o-mini"] }],
+            }),
+          }),
+        );
+      });
+    });
+
+    it("should submit cleared router settings so removing every fallback is persisted", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      renderWithRouterSettings(onSubmit);
+      routerSettingsMocks.editedValue = { num_retries: null, fallbacks: null };
+
+      fireEvent.click(screen.getByText("Save Changes"));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            router_settings: expect.objectContaining({
+              ...UNSUPPORTED_STORED_FIELD,
+              num_retries: null,
+              fallbacks: null,
+            }),
+          }),
+        );
+      });
+    });
+  });
+
   it("should render", async () => {
     const { getByText } = renderWithProviders(
       <KeyEditView

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -6,7 +6,7 @@ import PolicySelector from "@/components/policies/PolicySelector";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { TextInput, Button as TremorButton } from "@tremor/react";
 import { Form, Input, Select, Switch, Tooltip } from "antd";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { hasCapability } from "../../utils/capabilities";
 import { isProxyAdminRole, rolesWithWriteAccess } from "../../utils/roles";
 import AgentSelector from "../agent_management/AgentSelector";
@@ -17,6 +17,8 @@ import KeyLifecycleSettings from "../common_components/KeyLifecycleSettings";
 import PassThroughRoutesSelector from "../common_components/PassThroughRoutesSelector";
 import RateLimitTypeFormItem from "../common_components/RateLimitTypeFormItem";
 import OrganizationDropdown from "../common_components/OrganizationDropdown";
+import RouterSettingsAccordion, { RouterSettingsAccordionRef } from "../common_components/RouterSettingsAccordion";
+import { routerSettingsEditorValue, routerSettingsUpdate } from "../common_components/routerSettingsPayload";
 import { extractLoggingSettings, formatMetadataForDisplay, stripTagsFromMetadata } from "../key_info_utils";
 import { estimateFields, estimateRules, estimateTooltips, withNormalizedEstimates } from "./estimatedOutputTokens";
 import { canonicalBudgetDuration, keyTypeFromRoutes } from "./keyEditFieldNormalizers";
@@ -91,6 +93,7 @@ export function KeyEditView({
   const [budgetFallbacks, setBudgetFallbacks] = useState<Record<string, string[]>>(
     keyData.budget_fallbacks && typeof keyData.budget_fallbacks === "object" ? keyData.budget_fallbacks : {},
   );
+  const routerSettingsRef = useRef<RouterSettingsAccordionRef>(null);
   const { data: organizations, isLoading: isOrganizationsLoading } = useOrganizations();
   const { data: projects } = useProjects();
   const { data: uiSettingsData } = useUISettings();
@@ -284,6 +287,14 @@ export function KeyEditView({
         values.budget_fallbacks = budgetFallbacks;
       } else if (hadExistingFallbacks) {
         values.budget_fallbacks = {};
+      }
+
+      const routerSettings = routerSettingsUpdate(
+        routerSettingsRef.current?.getValue()?.router_settings,
+        keyData.router_settings,
+      );
+      if (routerSettings) {
+        values.router_settings = routerSettings;
       }
 
       await onSubmit(withNormalizedEstimates(values));
@@ -799,6 +810,15 @@ export function KeyEditView({
           <Input value={projectDisplay ?? ""} disabled />
         </Form.Item>
       )}
+      <Form.Item label="Router Settings">
+        <RouterSettingsAccordion
+          ref={routerSettingsRef}
+          accessToken={accessToken || ""}
+          teamId={keyData.team_id}
+          value={routerSettingsEditorValue(keyData.router_settings)}
+        />
+      </Form.Item>
+
       <Form.Item label="Logging Settings" name="logging_settings">
         <EditLoggingSettings
           value={form.getFieldValue("logging_settings")}

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -189,6 +189,25 @@ describe("KeyInfoView", () => {
     });
   });
 
+  it("should render the key's saved router fallbacks", async () => {
+    vi.mocked(useAuthorized).mockReturnValue(baseUseAuthorizedMock);
+
+    renderWithProviders(
+      <KeyInfoView
+        keyData={{ ...MOCK_KEY_DATA, router_settings: { num_retries: 2, fallbacks: [{ "gpt-4": ["gpt-4o"] }] } }}
+        onClose={() => {}}
+        keyId={"test-key-id"}
+        onKeyDataUpdate={() => {}}
+        teams={[]}
+      />,
+    );
+
+    expect(await screen.findByText("Router Settings")).toBeInTheDocument();
+    expect(screen.getByText("gpt-4")).toBeInTheDocument();
+    expect(screen.getByText("gpt-4o")).toBeInTheDocument();
+    expect(screen.getByText("Number of Retries: 2")).toBeInTheDocument();
+  });
+
   it("should render tags", async () => {
     vi.mocked(useAuthorized).mockReturnValue(baseUseAuthorizedMock);
 

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -13,6 +13,8 @@ import { isProxyAdminRole, isUserTeamAdminForSingleTeam, rolesWithWriteAccess } 
 import { mapDisplayToInternalNames, mapInternalToDisplayNames } from "../callback_info_helpers";
 import AutoRotationView from "../common_components/AutoRotationView";
 import DeleteResourceModal from "../common_components/DeleteResourceModal";
+import RouterSettingsSummary from "../common_components/RouterSettingsSummary";
+import { hasRouterSettings } from "../common_components/routerSettingsPayload";
 import { extractLoggingSettings, formatMetadataForDisplay, stripTagsFromMetadata } from "../key_info_utils";
 import { KeyResponse } from "../key_team_helpers/key_list";
 import LoggingSettingsView from "../logging_settings_view";
@@ -833,6 +835,15 @@ export default function KeyInfoView({
                             {fallbacks.join(", ")}
                           </div>
                         ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {hasRouterSettings(currentKeyData.router_settings) && (
+                    <div>
+                      <Text className="font-medium">Router Settings</Text>
+                      <div className="mt-1">
+                        <RouterSettingsSummary routerSettings={currentKeyData.router_settings} />
                       </div>
                     </div>
                   )}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Key router settings vanish when a key is reopened
- Saved fallbacks cannot be verified or edited
- A fixed-field editor would wipe unlisted routing fields

How it solves it:

- Key info panel summarises the stored router settings
- Edit view embeds the router settings accordion
- Editor value merges over the stored object, never replaces it

The API side needed no change, which I confirmed rather than assumed: `router_settings` is a top-level column on the key, `/key/generate` and `/key/update` both persist it, and `/key/info` returns it unstripped

One behaviour change to adjudicate: clearing every key-level router setting removes the key-level override, so the key inherits team and global routing rather than pinning an empty override. An admin who clears a fallback and then sees a request still fall back is seeing the team's fallback, not a stale key one. The alternative, writing a blob of nulls, is a state no control in the UI can produce deliberately or display afterwards, so it would strand keys in a mode their operator cannot see or undo. Proof for both is below

## User Flow

Before: an admin who set fallbacks while creating a virtual key cannot see or change them afterwards

1. They open http://litellm-domain/ui/?page=api-keys and click Create New Key, expand Router Settings, add a fallback from `gpt-5.5` to `gpt-4o-mini`, and save
2. They click the new key, then Edit, and the panel shows budget, models, rate limits and tags with no Router Settings anywhere on screen
3. There is nothing to read the saved fallback off, and nothing to change it with, so the only way to correct a routing policy is to delete the key and issue a new one, which every consumer of that key then has to be handed
4. They call `GET /key/info?key=sk-...` by hand and the response does carry `router_settings`, confirming the values are stored and just never rendered

After: the same admin reads the saved fallbacks on the key and edits them in place

1. They create the same key the same way
2. They click the key and the info panel now shows a Router Settings block listing `gpt-5.5 -> gpt-4o-mini` and Number of Retries
3. They click Edit and a Router Settings section is on the form, prefilled from the key, with a Loadbalancing tab and a Fallbacks tab
4. They add `gpt-4o-mini` as a second fallback target, bump Number of Retries, and click Save Changes
5. Reopening the key shows the new values, and any routing field the form does not render, `tag_routing_prefix` for instance, is still on the key untouched
6. Clearing every fallback and saving sticks as well, and the key goes back to its team and global routing rather than being pinned to empty values

## Relevant issues

## Linear ticket

Resolves LIT-5200

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### API level, live proxy on `localhost:4200` against the real OpenAI API

Captured at `91fbdee7d3c13f6770fa9017f5d019c0d3626949`, whose payload logic is unchanged in the current head. The accordion is a fixed-field form covering twelve settings, while `/key/update` accepts `UpdateRouterConfig`, which has seventeen. `tag_routing_prefix` below stands in for the five a key can hold that the form cannot render. Leg 3 is the old behaviour, leg 4 is this PR.

```
### 1. create a virtual key carrying router settings. tag_routing_prefix is a valid /key/update field the accordion does not render
$ curl -X POST /key/generate -d {"key_alias": "...", "router_settings": {"num_retries": 3, "fallbacks": [{"gpt-5.5": ["gpt-4o-mini"]}], "tag_routing_prefix": "team-"}}

### 2. /key/info returns them, so a reopened edit view has something to show
$ curl /key/info?key=$KEY | jq .info.router_settings
{"fallbacks": [{"gpt-5.5": ["gpt-4o-mini"]}], "num_retries": 3, "tag_routing_prefix": "team-"}

### 3. BEFORE this PR: the edit view sent the accordion's own output verbatim (Number of Retries 3 -> 5)
$ curl -X POST /key/update -d {"key": "$KEY_A", "router_settings": {"allowed_fails": null, "context_window_fallbacks": null, "cooldown_time": null, "enable_tag_filtering": false, "fallbacks": [{"gpt-5.5": ["gpt-4o-mini"]}], "model_group_alias": null, "num_retries": 5, "retry_after": null, "retry_policy": null, "routing_strategy": null, "routing_strategy_args": null, "timeout": null}}
{"allowed_fails": null, "context_window_fallbacks": null, "cooldown_time": null, "enable_tag_filtering": false, "fallbacks": [{"gpt-5.5": ["gpt-4o-mini"]}], "model_group_alias": null, "num_retries": 5, "retry_after": null, "retry_policy": null, "routing_strategy": null, "routing_strategy_args": null, "timeout": null}
-> tag_routing_prefix survived: False

### 4. WITH this PR: the same edit, merged over what was stored
$ curl -X POST /key/update -d {"key": "$KEY_B", "router_settings": {"allowed_fails": null, "context_window_fallbacks": null, "cooldown_time": null, "enable_tag_filtering": false, "fallbacks": [{"gpt-5.5": ["gpt-4o-mini"]}], "model_group_alias": null, "num_retries": 5, "retry_after": null, "retry_policy": null, "routing_strategy": null, "routing_strategy_args": null, "tag_routing_prefix": "team-", "timeout": null}}
{"allowed_fails": null, "context_window_fallbacks": null, "cooldown_time": null, "enable_tag_filtering": false, "fallbacks": [{"gpt-5.5": ["gpt-4o-mini"]}], "model_group_alias": null, "num_retries": 5, "retry_after": null, "retry_policy": null, "routing_strategy": null, "routing_strategy_args": null, "tag_routing_prefix": "team-", "timeout": null}
-> tag_routing_prefix survived: True

### 5. WITH this PR: the admin empties every field the accordion owns
$ curl -X POST /key/update -d {"key": "$KEY_C", "router_settings": {}}
{}
-> an empty object, which the proxy reads as no key-level override, not a blob of nulls

### 6. the edited key still serves traffic, against the real OpenAI API
$ curl -X POST /v1/chat/completions -H 'Authorization: Bearer $KEY_B' -d '{"model":"gpt-5.5",...}'
{"model": "gpt-5.5", "content": "routed", "usage": 31}
```

### Clear semantics, proved live rather than read off the source

`lit5200-broken` is a deployment carrying a deliberately invalid provider key, so its primary always fails and whichever fallback is in force is the one that answers. The team and the key point at different targets, so the response's model names which level won.

```
### 0. setup: lit5200-broken is a deployment with a deliberately invalid key, so the primary always fails
team router_settings.fallbacks = [{"lit5200-broken": ["lit5200-team-target"]}]
key  router_settings.fallbacks = [{"lit5200-broken": ["lit5200-key-target"]}]

### 1. the key's own fallback wins over the team's
$ curl -X POST /v1/chat/completions -H 'Authorization: Bearer $KEY' -d '{"model":"lit5200-broken",...}'
-> served by gpt-4.1-mini-2025-04-14 

### 2. the all-null blob the old editor would have sent on a clear
$ curl /key/info?key=$KEY | jq .info.router_settings
{"allowed_fails": null, "context_window_fallbacks": null, "cooldown_time": null, "enable_tag_filtering": false, "fallbacks": null, "model_group_alias": null, "num_retries": null, "retry_after": null, "retry_policy": null, "routing_strategy": null, "routing_strategy_args": null, "timeout": null}
$ curl -X POST /v1/chat/completions ...
-> REQUEST FAILED 429: No deployments available for selected model, Try again in 5 seconds. Passed model=lit5200-broken. pre-call-checks=False, cooldown_list=['0f877d24-6896
-> a non-empty blob still counts as a key-level override, so the key is pinned to no fallbacks

### 3. the empty object this PR sends on a clear
$ curl /key/info?key=$KEY | jq .info.router_settings
{}
$ curl -X POST /v1/chat/completions ...
-> served by gpt-4o-mini-2024-07-18
-> the key-level override is gone, so the key inherits the team's fallback
```

Leg 2 and leg 3 run back to back against the same cooldown state, so the only thing separating a failed request from a served one is whether a fallback was reachable.

### Admin UI

Same key, same database, same proxy, with the dashboard bundle as the only variable. The key stores `num_retries: 3`, a `gpt-5.5 -> gpt-4o-mini` fallback, and a `tag_routing_prefix` the form deliberately does not render. The two builds were distinguished by a string the base build cannot produce, since every human-readable label in this feature already exists at team level in `TeamInfo.tsx` and would have matched either build. That check ran against every chunk actually served over HTTP and carried a positive control, because a probe that enumerates nothing reports exactly the same as one that finds nothing

Key detail panel, before and after:

![Key detail before, Budget Reset runs straight into Tags](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit5200/lit5200-1-detail-before.png)

![Key detail after, Router Settings renders the stored retries and fallback](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit5200/lit5200-2-detail-after.png)

Edit form, before and after:

![Edit form before, Team ID runs straight into Logging Settings](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit5200/lit5200-3-edit-before.png)

![Edit form after, Router Settings with the stored fallback prefilled and editable](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit5200/lit5200-4-edit-after.png)

## Type

🐛 Bug Fix

## Caveats (if any)

- Backend already round-tripped the field; this is UI only
- Emptying every field clears the key-level override entirely
- Pre-existing and out of scope: the merge composes against the stored settings the drawer loaded when it opened, so two admins editing one key at the same time still lose each other's unexposed fields. That is the ordinary full-object read-modify-write hazard this codebase has elsewhere, and fixing it properly needs optimistic concurrency on the key row rather than anything this diff can do

## Review notes

The editor's field set is derived from `Record<keyof RouterSettings, true>`, so adding a control to the accordion without listing it in `routerSettingsPayload.ts` is a compile error rather than a silent regression to replace semantics. That one field set drives both directions: `routerSettingsEditorValue` projects the stored blob down to what the form renders on the way in, and `routerSettingsUpdate` merges the form's value back over the stored object on the way out. `/key/info` returns untyped JSON, so the projection is the single place it is read as `RouterSettings`, which keeps `any` off `KeyResponse`.

Both halves of the merge contract are pinned in one test, since neither direction alone proves it: an unsupported stored field has to survive an unrelated edit, and a field the editor owns that the admin emptied has to reach the server as `null`. That test runs `it.each` over three orderings of the stored keys, because an object spread resolves collisions by position.

The projection tests use `toStrictEqual` on purpose. `toEqual` treats a key present with value `undefined` as absent, so it passes against a projection that drops the filter and hands the editor all twelve keys as `undefined`.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
