### PR TITLE
fix(streaming): dict-usage arm drops prompt_tokens_details/completion_tokens_details its sibling arms preserve

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1526,13 +1526,6 @@ class CustomStreamWrapper:
 
             if response_obj["usage"] is not None:
                 if isinstance(response_obj["usage"], dict):
-                    # Pass the full dict through: rebuilding from only
-                    # prompt/completion/total tokens drops
-                    # prompt_tokens_details (cached_tokens),
-                    # completion_tokens_details (reasoning_tokens) and cache
-                    # token counts that the Usage/BaseModel arms below
-                    # preserve. Usage.__init__ coerces nested detail dicts
-                    # into their wrapper types and tolerates extra keys.
                     setattr(
                         model_response,
                         "usage",

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1526,14 +1526,17 @@ class CustomStreamWrapper:
 
             if response_obj["usage"] is not None:
                 if isinstance(response_obj["usage"], dict):
+                    # Pass the full dict through: rebuilding from only
+                    # prompt/completion/total tokens drops
+                    # prompt_tokens_details (cached_tokens),
+                    # completion_tokens_details (reasoning_tokens) and cache
+                    # token counts that the Usage/BaseModel arms below
+                    # preserve. Usage.__init__ coerces nested detail dicts
+                    # into their wrapper types and tolerates extra keys.
                     setattr(
                         model_response,
                         "usage",
-                        litellm.Usage(
-                            prompt_tokens=response_obj["usage"].get("prompt_tokens", None) or None,
-                            completion_tokens=response_obj["usage"].get("completion_tokens", None) or None,
-                            total_tokens=response_obj["usage"].get("total_tokens", None) or None,
-                        ),
+                        litellm.Usage(**response_obj["usage"]),
                     )
                 elif isinstance(response_obj["usage"], Usage):
                     setattr(

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -6,7 +6,7 @@ import pytest
 
 import asyncio
 import traceback
-from typing import Optional
+from typing import Final, Optional
 
 import litellm
 from litellm import verbose_logger
@@ -4771,3 +4771,102 @@ class TestStableStreamingResponseId:
         )
         wrapper.response_id = "chatcmpl-from-provider"
         assert wrapper.model_response_creator().id == "chatcmpl-from-provider"
+
+
+def _final_chunk_with_dict_usage(choices) -> ModelResponseStream:
+    """A stream chunk whose ``usage`` is a plain dict.
+
+    ``ModelResponseStream.__init__`` coerces a dict ``usage`` kwarg into
+    ``litellm.Usage``, so the dict is attached after construction — the same
+    shape a custom ``streaming_decoder`` (or any third-party iterator that
+    bypasses litellm chunk construction) delivers to ``chunk_creator``.
+    """
+    chunk: Final = ModelResponseStream(
+        id="chatcmpl-dict-usage-test",
+        created=1754900000,
+        model="gpt-4o",
+        object="chat.completion.chunk",
+        choices=choices,
+    )
+    chunk.usage = {  # mutable-ok: wire-shaped usage payload under test
+        "prompt_tokens": 100,
+        "completion_tokens": 10,
+        "total_tokens": 110,
+        "prompt_tokens_details": {"cached_tokens": 80},  # mutable-ok: wire payload
+        "completion_tokens_details": {"reasoning_tokens": 5},  # mutable-ok: wire payload
+        "cache_creation_input_tokens": 42,
+    }
+    return chunk
+
+
+def test_dispatch_provider_chunk_dict_usage_preserves_token_details(
+    logging_obj: Logging,
+):
+    """The openai else-branch of ``_dispatch_provider_chunk`` handles three
+    usage shapes: ``Usage`` (passed through), ``BaseModel``
+    (``Usage(**model_dump())``), and plain ``dict``. The dict arm used to
+    rebuild ``litellm.Usage`` from only prompt/completion/total tokens,
+    silently dropping ``prompt_tokens_details`` (cached_tokens),
+    ``completion_tokens_details`` (reasoning_tokens), and cache token counts
+    that both sibling arms preserve.
+    """
+    wrapper: Final = CustomStreamWrapper(
+        completion_stream=None,
+        model="gpt-4o",
+        logging_obj=logging_obj,
+        custom_llm_provider="openai",
+        stream_options={"include_usage": True},  # mutable-ok: constructor payload
+    )
+    chunk: Final = _final_chunk_with_dict_usage(
+        choices=[
+            StreamingChoices(finish_reason="stop", index=0, delta=Delta(content=None))
+        ]  # mutable-ok: chunk payload
+    )
+    model_response: Final = wrapper.model_response_creator()
+    wrapper._dispatch_provider_chunk(
+        chunk=chunk,
+        model_response=model_response,
+        completion_obj={"content": ""},  # mutable-ok: dispatch scratch dict
+    )
+
+    usage: Final = model_response.usage
+    assert isinstance(usage, Usage)
+    assert usage.prompt_tokens == 100
+    assert usage.completion_tokens == 10
+    assert usage.total_tokens == 110
+    assert usage.prompt_tokens_details is not None, (
+        "dict-usage arm dropped prompt_tokens_details (its Usage/BaseModel sibling arms preserve it)"
+    )
+    assert usage.prompt_tokens_details.cached_tokens == 80
+    assert usage.completion_tokens_details is not None
+    assert usage.completion_tokens_details.reasoning_tokens == 5
+    assert getattr(usage, "cache_creation_input_tokens", None) == 42
+
+
+def test_chunk_creator_usage_only_chunk_with_dict_usage_keeps_details(
+    logging_obj: Logging,
+):
+    """End-to-end through ``chunk_creator``: a usage-only final chunk (empty
+    ``choices``, ``stream_options.include_usage`` set) takes the early-return
+    path, so whatever the dict-usage arm wrote is exactly what the consumer
+    receives — there is no later aggregation to repair it.
+    """
+    wrapper: Final = CustomStreamWrapper(
+        completion_stream=None,
+        model="gpt-4o",
+        logging_obj=logging_obj,
+        custom_llm_provider="openai",
+        stream_options={"include_usage": True},  # mutable-ok: constructor payload
+    )
+    chunk: Final = _final_chunk_with_dict_usage(choices=[])  # mutable-ok: empty choices list
+    result: Final = wrapper.chunk_creator(chunk=chunk)
+
+    assert result is not None
+    usage: Final = result.usage
+    assert isinstance(usage, Usage)
+    assert usage.prompt_tokens_details is not None, (
+        "usage-only early return delivered a Usage stripped of prompt_tokens_details to the stream consumer"
+    )
+    assert usage.prompt_tokens_details.cached_tokens == 80
+    assert usage.completion_tokens_details is not None
+    assert usage.completion_tokens_details.reasoning_tokens == 5


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cached-token counts vanish from streamed usage on one path
- Reasoning-token counts vanish the same way
- Cost is then billed at full input rate, not cache rate
- Three shapes of the same field behave inconsistently

How it solves it:

- Pass the whole usage payload through instead of three fields
- Detail counts survive, matching the other two shapes
- A legitimate zero count is no longer turned into null

## User Flow

Before: a developer whose app streams through a custom decoder gets a final usage object with its cache and reasoning breakdown stripped, so cached input is billed at the full rate.

1. They send POST `https://litellm-domain/v1/chat/completions` with `"stream": true` and `"stream_options": {"include_usage": true}`, against a deployment reached through a custom streaming decoder
2. The upstream provider reports 100 prompt tokens of which 80 were cache hits, plus 5 reasoning tokens
3. The final SSE chunk arrives carrying `"usage"` with `prompt_tokens: 100`, but `prompt_tokens_details` is missing entirely
4. Their app records 100 fully-priced input tokens instead of 20 fresh + 80 cache-read
5. `https://litellm-domain/ui/?page=logs` shows that request over-billed, with no cache saving visible

After: the same request keeps its breakdown.

1. They send the same POST `https://litellm-domain/v1/chat/completions` with `"stream": true` and `"stream_options": {"include_usage": true}`
2. The upstream provider reports the same 100 prompt tokens, 80 cached, 5 reasoning
3. The final SSE chunk now carries `"usage"` including `prompt_tokens_details.cached_tokens: 80` and `completion_tokens_details.reasoning_tokens: 5`
4. Their app records 20 fresh input tokens plus 80 at the cache-read rate
5. `https://litellm-domain/ui/?page=logs` shows the cache saving on that request

## Relevant issues

Not a fix for #36168 — that issue is about SDK usage objects on choices-bearing chunks and already has three open PRs (#36089, #36169, #36170). I verified none of them touches this branch; this is a separate inconsistency found while reading that area.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Captured at commit `09889e1986` (`litellm_internal_staging`).

Honest scoping first: every in-repo chunk producer normalizes usage before this point, so on current code this arm is reached by chunks LiteLLM did not build — a custom `streaming_decoder` (a public hook on the openai-like and databricks handlers) or any third-party iterator whose chunks carry a dict-valued usage. I verified by execution that such a chunk reaches and executes this arm end-to-end. No live provider call participates in the conversion, so the proof drives the real streaming path directly rather than a mocked one.

**Before the fix** — the usage-only final chunk delivered to the stream consumer:

```
Usage(completion_tokens=10, prompt_tokens=100, total_tokens=110,
      completion_tokens_details=None, prompt_tokens_details=None)
```

`cached_tokens=80` and `reasoning_tokens=5` were both dropped.

**After the fix**, same input:

```
Usage(completion_tokens=10, prompt_tokens=100, total_tokens=110,
      prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=80),
      completion_tokens_details=CompletionTokensDetailsWrapper(reasoning_tokens=5),
      cache_creation_input_tokens=42)
```

The two sibling shapes of the same field (a `Usage` object, and any other `BaseModel`) already preserved all of this; only the dict shape did not.

## Type

🐛 Bug Fix

## Caveats

- Reached today only via non-LiteLLM-built chunks (custom decoders)
- Behavior change: a legitimate `0` count stays `0` instead of becoming null

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
