### PR TITLE
fix(dashscope): bill tiered pricing by the request-size tier, not graduated slicing

### DIFF
--- a/litellm/llms/dashscope/cost_calculator.py
+++ b/litellm/llms/dashscope/cost_calculator.py
@@ -7,7 +7,10 @@ Handles tiered pricing and prompt caching scenarios.
 from dataclasses import dataclass
 from typing import Final
 
-from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import calculate_tiered_cost
+from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import (
+    select_tier_for_input,
+    tier_rate,
+)
 from litellm.types.utils import ModelInfo, Usage
 from litellm.utils import get_model_info
 
@@ -46,31 +49,19 @@ def _extract_token_breakdown(usage: Usage) -> TokenBreakdown:
 def _calculate_prompt_cost(
     breakdown: TokenBreakdown,
     model_info: ModelInfo,
-    tiered_pricing: list[dict] | None,
+    tier: dict | None,
 ) -> float:
     """Calculate total prompt cost including cached tokens."""
-    if tiered_pricing:
-        text_cost: Final = calculate_tiered_cost(
-            tokens=breakdown.text_tokens,
-            tiered_pricing=tiered_pricing,
-            cost_key="input_cost_per_token",
-        )
-        cache_cost = calculate_tiered_cost(
-            tokens=breakdown.cached_tokens,
-            tiered_pricing=tiered_pricing,
-            cost_key="cache_read_input_token_cost",
-            fallback_cost_key="input_cost_per_token",
-        )
-        return text_cost + cache_cost
+    if tier is not None:
+        input_rate: Final = tier_rate(tier, "input_cost_per_token")
+        cache_rate: Final = tier_rate(tier, "cache_read_input_token_cost", "input_cost_per_token")
+        return (breakdown.text_tokens * input_rate) + (breakdown.cached_tokens * cache_rate)
 
     input_cost: Final = float(model_info.get("input_cost_per_token") or 0.0)
 
     # For cache_cost, first try the specific key, then fall back to input_cost.
     cache_cost_val: Final = model_info.get("cache_read_input_token_cost")
-    if cache_cost_val is None:
-        cache_cost = input_cost
-    else:
-        cache_cost = float(cache_cost_val)
+    cache_cost: Final = input_cost if cache_cost_val is None else float(cache_cost_val)
 
     return (breakdown.text_tokens * input_cost) + (breakdown.cached_tokens * cache_cost)
 
@@ -78,31 +69,19 @@ def _calculate_prompt_cost(
 def _calculate_completion_cost(
     breakdown: TokenBreakdown,
     model_info: ModelInfo,
-    tiered_pricing: list[dict] | None,
+    tier: dict | None,
 ) -> float:
     """Calculate total completion cost including reasoning tokens."""
-    if tiered_pricing:
-        completion_cost: Final = calculate_tiered_cost(
-            tokens=breakdown.completion_tokens,
-            tiered_pricing=tiered_pricing,
-            cost_key="output_cost_per_token",
-        )
-        reasoning_cost = calculate_tiered_cost(
-            tokens=breakdown.reasoning_tokens,
-            tiered_pricing=tiered_pricing,
-            cost_key="output_cost_per_reasoning_token",
-            fallback_cost_key="output_cost_per_token",
-        )
-        return completion_cost + reasoning_cost
+    if tier is not None:
+        output_rate: Final = tier_rate(tier, "output_cost_per_token")
+        reasoning_rate: Final = tier_rate(tier, "output_cost_per_reasoning_token", "output_cost_per_token")
+        return (breakdown.completion_tokens * output_rate) + (breakdown.reasoning_tokens * reasoning_rate)
 
     output_cost: Final = float(model_info.get("output_cost_per_token") or 0.0)
 
     # For reasoning_cost, first try the specific key, then fall back to output_cost.
     reasoning_cost_val: Final = model_info.get("output_cost_per_reasoning_token")
-    if reasoning_cost_val is None:
-        reasoning_cost = output_cost
-    else:
-        reasoning_cost = float(reasoning_cost_val)
+    reasoning_cost: Final = output_cost if reasoning_cost_val is None else float(reasoning_cost_val)
 
     return (breakdown.completion_tokens * output_cost) + (breakdown.reasoning_tokens * reasoning_cost)
 
@@ -122,11 +101,13 @@ def cost_per_token(model: str, usage: Usage) -> tuple[float, float]:
     """
     model_info: Final = get_model_info(model=model, custom_llm_provider="dashscope")
     breakdown: Final = _extract_token_breakdown(usage)
-    tiered_pricing = model_info.get("tiered_pricing") if isinstance(model_info.get("tiered_pricing"), list) else None
+    raw_tiered: Final = model_info.get("tiered_pricing")
+    tiered_pricing: Final = raw_tiered if isinstance(raw_tiered, list) else None
 
-    prompt_cost = _calculate_prompt_cost(breakdown=breakdown, model_info=model_info, tiered_pricing=tiered_pricing)
-    completion_cost: Final = _calculate_completion_cost(
-        breakdown=breakdown, model_info=model_info, tiered_pricing=tiered_pricing
-    )
+    total_input_tokens: Final = breakdown.text_tokens + breakdown.cached_tokens
+    tier: Final = select_tier_for_input(tiered_pricing, total_input_tokens) if tiered_pricing else None
+
+    prompt_cost: Final = _calculate_prompt_cost(breakdown=breakdown, model_info=model_info, tier=tier)
+    completion_cost: Final = _calculate_completion_cost(breakdown=breakdown, model_info=model_info, tier=tier)
 
     return prompt_cost, completion_cost

--- a/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
@@ -2,7 +2,7 @@
 Test suite for Dashscope cost calculation functionality.
 
 Tests the cost calculation for Dashscope models including:
-- Correctly calculates graduated tiered pricing.
+- Selects one pricing tier by total input tokens and bills the whole request at it.
 - Falls back to flat-rate pricing for non-tiered models.
 - Handles interactions with cached tokens.
 - Correctly calculates costs for token counts exceeding the highest defined tier.
@@ -73,41 +73,78 @@ class TestDashscopeCostCalculator:
         assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-10)
         assert math.isclose(completion_cost, expected_completion_cost, rel_tol=1e-10)
 
-    def test_dashscope_tiered_pricing_spanning_multiple_tiers(self):
+    def test_dashscope_tiered_pricing_selects_tier_by_total_input(self):
         """
-        Tests the dashscope tiered pricing with the corrected graduated calculation logic.
-        This is the most important test for validating the fix.
+        Dashscope tiered pricing is all-or-nothing: the tier is selected by the total
+        input token count of the request, and every input and output token is billed at
+        that one tier's rate (not graduated, income-tax-style slicing). A 300k input
+        request exceeds the 256k first-tier range, so the whole request bills at tier 2.
         """
-        # Tiering for qwen-flash: Tier 1: [0, 256k], Tier 2: [256k, 1M]
         usage = Usage(prompt_tokens=300000, completion_tokens=300000)
         prompt_cost, completion_cost = dashscope_cost_per_token(
             model="qwen-flash", usage=usage
         )
 
         model_info = litellm.get_model_info("dashscope/qwen-flash")
-        tier_1 = model_info["tiered_pricing"][0]
         tier_2 = model_info["tiered_pricing"][1]
 
-        # Expected prompt cost: (256,000 tokens * tier_1_price) + (44,000 tokens * tier_2_price)
-        expected_prompt_cost = (256000 * tier_1["input_cost_per_token"]) + (
-            44000 * tier_2["input_cost_per_token"]
-        )
-
-        # Expected completion cost: (256,000 tokens * tier_1_price) + (44,000 tokens * tier_2_price)
-        expected_completion_cost = (256000 * tier_1["output_cost_per_token"]) + (
-            44000 * tier_2["output_cost_per_token"]
-        )
+        expected_prompt_cost = 300000 * tier_2["input_cost_per_token"]
+        expected_completion_cost = 300000 * tier_2["output_cost_per_token"]
 
         assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-10)
         assert math.isclose(completion_cost, expected_completion_cost, rel_tol=1e-10)
 
+        graduated_prompt_cost = (256000 * model_info["tiered_pricing"][0]["input_cost_per_token"]) + (
+            44000 * tier_2["input_cost_per_token"]
+        )
+        assert not math.isclose(prompt_cost, graduated_prompt_cost, rel_tol=1e-10)
+
+    def test_dashscope_tiered_pricing_matches_request_size_tier_selection(self):
+        """
+        Regression for #34729: the calculator must agree with the request-size tier model
+        the proxy budget code uses (select_tier_for_input), not graduated slicing. For a
+        300k input / 2k output qwen-flash request the whole thing bills at tier 2, and the
+        result must not equal the old graduated total that under-charged.
+        """
+        from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import (
+            calculate_tiered_cost,
+            select_tier_for_input,
+            tier_rate,
+        )
+
+        input_tokens = 300000
+        output_tokens = 2000
+        usage = Usage(
+            prompt_tokens=input_tokens,
+            completion_tokens=output_tokens,
+            total_tokens=input_tokens + output_tokens,
+        )
+        prompt_cost, completion_cost = dashscope_cost_per_token(
+            model="qwen-flash", usage=usage
+        )
+
+        tiered_pricing = litellm.get_model_info("dashscope/qwen-flash")["tiered_pricing"]
+        selected_tier = select_tier_for_input(tiered_pricing, input_tokens)
+        expected_prompt_cost = input_tokens * tier_rate(selected_tier, "input_cost_per_token")
+        expected_completion_cost = output_tokens * tier_rate(selected_tier, "output_cost_per_token")
+
+        assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-10)
+        assert math.isclose(completion_cost, expected_completion_cost, rel_tol=1e-10)
+
+        graduated_prompt_cost = calculate_tiered_cost(
+            input_tokens, tiered_pricing, "input_cost_per_token"
+        )
+        assert not math.isclose(prompt_cost, graduated_prompt_cost, rel_tol=1e-10)
+
     def test_dashscope_tiered_pricing_with_caching(self):
         """
-        Tests tiered pricing with cached tokens. This replaces the old, incorrect test.
-        Uses qwen3-coder-plus, which has cache-specific pricing defined.
+        Tiered pricing with cached tokens. The tier is chosen by the total input token
+        count (cached + new), then cached tokens bill at that tier's cache rate and new
+        tokens at that tier's input rate. qwen3-coder-plus tiers start at [0, 32k], so a
+        50k input request lands in the [32k, 128k] tier and every input token bills there.
         """
         usage = Usage(
-            prompt_tokens=50000,  # 10k cached + 40k new
+            prompt_tokens=50000,
             completion_tokens=1000,
             total_tokens=51000,
             prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=10000),
@@ -116,17 +153,10 @@ class TestDashscopeCostCalculator:
         prompt_cost, _ = dashscope_cost_per_token(model="qwen3-coder-plus", usage=usage)
 
         model_info = litellm.get_model_info("dashscope/qwen3-coder-plus")
-        tier_1 = model_info["tiered_pricing"][0]
-        tier_2 = model_info["tiered_pricing"][1]
+        selected_tier = model_info["tiered_pricing"][1]
 
-        # 10k cached tokens are all in the first tier
-        expected_cache_cost = 10000 * tier_1["cache_read_input_token_cost"]
-
-        # 40k new tokens: 32k in tier 1, and the remaining 8k in tier 2
-        expected_text_cost = (32000 * tier_1["input_cost_per_token"]) + (
-            8000 * tier_2["input_cost_per_token"]
-        )
-
+        expected_cache_cost = 10000 * selected_tier["cache_read_input_token_cost"]
+        expected_text_cost = 40000 * selected_tier["input_cost_per_token"]
         expected_total_prompt_cost = expected_cache_cost + expected_text_cost
 
         assert math.isclose(prompt_cost, expected_total_prompt_cost, rel_tol=1e-10)
@@ -172,8 +202,9 @@ class TestDashscopeCostCalculator:
 
     def test_dashscope_tiered_pricing_string_costs_exceeding_highest_tier(self):
         """
-        Regression: string-valued tier costs must also be coerced in the
-        remaining-tokens path that charges tokens above the highest tier.
+        Regression: string-valued tier costs must be coerced to float. An input above the
+        highest declared range falls back to the last (most expensive) tier, and the whole
+        request bills at that tier's rate.
         """
         self._register_string_valued_tiered_model("dashscope/qwen-str-tier-test")
 
@@ -182,14 +213,8 @@ class TestDashscopeCostCalculator:
             model="qwen-str-tier-test", usage=usage
         )
 
-        # prompt: 1000 @ tier1 + 1000 @ tier2 + 500 remaining @ tier2 rate
-        expected_prompt_cost = (
-            (1000 * float("4e-07")) + (1000 * float("8e-07")) + (500 * float("8e-07"))
-        )
-        # completion: 1000 @ tier1 + 1000 @ tier2 + 1000 remaining @ tier2 rate
-        expected_completion_cost = (
-            (1000 * float("1.6e-06")) + (1000 * float("3.2e-06")) + (1000 * float("3.2e-06"))
-        )
+        expected_prompt_cost = 2500 * float("8e-07")
+        expected_completion_cost = 3000 * float("3.2e-06")
 
         assert prompt_cost > 0
         assert completion_cost > 0
@@ -198,27 +223,17 @@ class TestDashscopeCostCalculator:
 
     def test_dashscope_tiered_pricing_exceeding_highest_tier(self):
         """
-        Tests tiered pricing when token count exceeds the highest defined tier range.
-        This replaces the old, incorrect test and validates the new fallback logic.
+        Tests tiered pricing when the input token count exceeds the highest defined tier
+        range. The request falls back to the last (most expensive) tier and every input
+        token bills at that tier's rate.
         """
-        usage = Usage(
-            prompt_tokens=1200000, completion_tokens=1000
-        )  # Max defined range for qwen-flash is 1M
+        usage = Usage(prompt_tokens=1200000, completion_tokens=1000)
 
         prompt_cost, _ = dashscope_cost_per_token(model="qwen-flash", usage=usage)
 
         model_info = litellm.get_model_info("dashscope/qwen-flash")
-        tier_1 = model_info["tiered_pricing"][0]
         tier_2 = model_info["tiered_pricing"][1]
 
-        # Expected cost: (tier_1_tokens * tier_1_price) + (tokens_up_to_max_range_in_tier_2 * tier_2_price) + (remaining_tokens * tier_2_price)
-        tokens_in_tier_2_range = 1000000 - 256000
-        remaining_tokens_over_max = 1200000 - 1000000
-
-        expected_prompt_cost = (
-            (256000 * tier_1["input_cost_per_token"])
-            + (tokens_in_tier_2_range * tier_2["input_cost_per_token"])
-            + (remaining_tokens_over_max * tier_2["input_cost_per_token"])
-        )
+        expected_prompt_cost = 1200000 * tier_2["input_cost_per_token"]
 
         assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-10)


### PR DESCRIPTION
## TLDR

Problem this solves:

- DashScope tiered pricing was billed with graduated, income-tax-style slicing
- Alibaba Model Studio instead picks one tier by total input tokens and bills the whole request at it
- large Qwen requests were under-charged, and logged spend disagreed with the budget reservation code

How it solves it:

- select one tier from the request's total input tokens, using the existing `select_tier_for_input`
- bill every input and output token (and cached and reasoning tokens) at that single tier's rate

## User Flow

Before: a developer sending a large qwen-flash request sees logged spend far below what Alibaba actually bills

1. They send a 300k input, 2k output request to `dashscope/qwen-flash`
2. The dashboard logs the input at roughly $0.024, because the first 256k tokens were priced at the cheap tier 1 rate and only the overflow at tier 2
3. Their Alibaba invoice charges all 300k input tokens at the tier 2 rate, about $0.075, so the gateway under-reports spend and budget enforcement is too loose

After: logged spend matches Alibaba's request-size tier model

1. They send the same 300k input, 2k output request
2. The whole request is priced at the tier selected by its 300k input size (tier 2), logging about $0.075 input
3. This matches what `select_tier_for_input` already reserves for the budget, so reservation and post-response accounting agree

## Relevant issues

Fixes #34729

## Linear ticket

## Type

🐛 Bug Fix

## Changes

`litellm/llms/dashscope/cost_calculator.py` used `calculate_tiered_cost`, which sums each token bucket across tier ranges (graduated slicing) and re-tiers the cached-token count independently from zero. Alibaba Model Studio selects a single tier from the request's total input tokens and bills all input and output tokens at that tier, which is exactly what the proxy budget reservation path already does through `select_tier_for_input`. The calculator now selects the tier once from the total input token count and applies that tier's input, cache, output and reasoning rates, so cost accounting and budget reservation no longer disagree. Flat-priced models are unchanged. The tests that encoded the old graduated behavior are updated to the request-size model, and a regression test asserts the calculator agrees with `select_tier_for_input` and no longer equals the old graduated total.

## Screenshots / Proof of Fix

Captured at commit ffe55f2734 against the bundled model cost map (no mocks). A live-proxy run is welcome; this shows the exact cost the calculator now returns for the issue's reproduction.

```
qwen-flash, 300000 input / 2000 output
old graduated:        input 0.0238   output 0.0008
new request-size tier: input 0.075    output 0.004
select_tier_for_input expected: input 0.075, output 0.004  (matches)
```

Full dashscope cost suite:

```
$ python -m pytest tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py -q
8 passed
```

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
