### PR TITLE
fix(router): don't wipe model_group_alias when updating other router settings

### DIFF
--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -121,7 +121,7 @@ class UpdateRouterConfig(BaseModel):
     retry_after: float | None = None
     fallbacks: list[dict] | None = None
     context_window_fallbacks: list[dict] | None = None
-    model_group_alias: dict[str, str | dict] | None = {}
+    model_group_alias: dict[str, str | dict] | None = None
     enable_tag_filtering: bool | None = None
     tag_routing_prefix: str | None = None
 

--- a/tests/test_litellm/test_router_retry_policy_update.py
+++ b/tests/test_litellm/test_router_retry_policy_update.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import ValidationError
+from pydantic_core import PydanticUndefined
 
 sys.path.insert(0, os.path.abspath("../.."))
 
@@ -81,6 +82,29 @@ def test_update_router_config_rejects_malformed_model_group_retry_policy():
         UpdateRouterConfig(
             model_group_retry_policy={"gpt-4": {"RateLimitErrorRetries": "x"}}
         )
+
+
+def test_update_router_config_omits_unset_model_group_alias():
+    """A payload that touches only retry fields must not resurrect
+    ``model_group_alias`` in its ``exclude_none`` dump. ``/config/update``
+    merges that dump over the stored ``router_settings`` row, so a non-None
+    default here (the old ``= {}``) would overwrite a configured alias map
+    with an empty dict on every unrelated save."""
+    dumped = UpdateRouterConfig(retry_policy={"BadRequestErrorRetries": 5}).model_dump(exclude_none=True)
+    assert "model_group_alias" not in dumped
+
+
+def test_update_router_config_has_no_non_none_field_defaults():
+    """Recurrence guard for the model_group_alias overwrite bug: every field
+    must default to None (or be required) so ``/config/update``'s
+    ``dict(exclude_none=True)`` merge carries only keys the caller actually
+    sent. A field added later with ``= {}`` / ``= []`` / a ``default_factory``
+    would silently clobber that key in the stored router_settings row."""
+    for name, field in UpdateRouterConfig.model_fields.items():
+        assert field.default is None or field.default is PydanticUndefined, (
+            f"{name} has non-None default {field.default!r}"
+        )
+        assert field.default_factory is None, f"{name} uses a default_factory"
 
 
 # ---------------------------------------------------------------------------
@@ -283,3 +307,48 @@ async def test_config_update_persists_and_reads_back_retry_policy(monkeypatch):
     assert read_back.BadRequestErrorRetries == 5
     assert read_back.TimeoutErrorRetries == 3
     assert read_back.RateLimitErrorRetries == 7
+
+
+@pytest.mark.asyncio
+async def test_config_update_retry_policy_preserves_model_group_alias(monkeypatch):
+    """Saving only retry_policy through /config/update must not wipe a
+    previously configured model_group_alias. Both live in the single
+    ``router_settings`` LiteLLM_Config JSON row, and the merge writes the
+    ``UpdateRouterConfig`` ``exclude_none`` dump over it. A non-None
+    ``model_group_alias`` default used to leak ``{}`` into that dump and
+    overwrite the stored map; the poisoned row then flows through
+    ``update_settings`` and wipes the live router too, so both are asserted."""
+    from litellm.proxy import proxy_server
+    from litellm.proxy._types import ConfigYAML, LitellmUserRoles, UserAPIKeyAuth
+
+    router = _build_router()
+
+    fake_table = _FakeConfigTable()
+    fake_table.rows["router_settings"] = _FakeConfigRow(
+        "router_settings", {"model_group_alias": {"gpt-4": "azure-gpt-4"}}
+    )
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_config = fake_table
+
+    async def _apply_router_settings(*args, **kwargs):
+        await proxy_server.proxy_config._add_router_settings_from_db_config(
+            config_data={}, llm_router=router, prisma_client=prisma_client
+        )
+
+    monkeypatch.setattr(proxy_server, "prisma_client", prisma_client)
+    monkeypatch.setattr(proxy_server, "llm_router", router)
+    monkeypatch.setattr(proxy_server.proxy_config, "add_deployment", _apply_router_settings)
+    monkeypatch.setattr(proxy_server.proxy_config, "get_config", AsyncMock(return_value={}))
+
+    await proxy_server.update_config(
+        config_info=ConfigYAML(router_settings=UpdateRouterConfig(retry_policy=RetryPolicy(RateLimitErrorRetries=7))),
+        user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1234"),
+    )
+
+    persisted = fake_table.rows["router_settings"].param_value
+    assert persisted["model_group_alias"] == {"gpt-4": "azure-gpt-4"}
+    assert persisted["retry_policy"]["RateLimitErrorRetries"] == 7
+
+    assert router.model_group_alias == {"gpt-4": "azure-gpt-4"}
+    assert isinstance(router.retry_policy, RetryPolicy)
+    assert router.retry_policy.RateLimitErrorRetries == 7

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -34241,11 +34241,8 @@ export interface components {
             model_group_affinity_config?: {
                 [key: string]: string[];
             } | null;
-            /**
-             * Model Group Alias
-             * @default {}
-             */
-            model_group_alias: {
+            /** Model Group Alias */
+            model_group_alias?: {
                 [key: string]: string | {
                     [key: string]: unknown;
                 };


### PR DESCRIPTION
## TLDR

Problem this solves:

- Saving retry settings wipes all configured model group aliases
- Aliases and retry settings share one stored settings row

How it solves it:

- Stop the alias field defaulting to an empty map
- An unset alias is now omitted, so the merge keeps it

## User Flow

Before: an admin who set up model group aliases loses every one of them the moment they save any retry setting

1. Admin opens http://litellm-domain/ui/?page=models, Model Group Alias tab, maps `gpt-4` to `azure-gpt-4`, saves, and sees the alias listed
2. Admin switches to the Model Retry Settings tab on the same page, sets RateLimitError retries to 7, clicks Save
3. Admin reopens the Model Group Alias tab and the list is now empty
4. A request to POST http://litellm-domain/v1/chat/completions with `"model": "gpt-4"` no longer resolves to `azure-gpt-4` and comes back as a model-not-found error

After: saving retry settings leaves the aliases exactly as they were

1. Admin opens http://litellm-domain/ui/?page=models, Model Group Alias tab, maps `gpt-4` to `azure-gpt-4`, saves, and sees the alias listed
2. Admin switches to the Model Retry Settings tab on the same page, sets RateLimitError retries to 7, clicks Save
3. Admin reopens the Model Group Alias tab and `gpt-4` to `azure-gpt-4` is still listed
4. A request to POST http://litellm-domain/v1/chat/completions with `"model": "gpt-4"` still resolves to `azure-gpt-4`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduced against a live proxy on localhost:4000 backed by a database, master key `sk-1234`. The alias and the retry save both go through the same endpoints the Admin UI uses.

Before, on commit `b0626cad8c` (pre-fix):

```
# 1. Set a model group alias (same call the Model Group Alias tab makes)
curl -sX POST http://localhost:4000/config/update \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"router_settings": {"model_group_alias": {"gpt-4": "azure-gpt-4"}}}'

# 2. Confirm it is stored
curl -s http://localhost:4000/get/config/callbacks \
  -H "Authorization: Bearer sk-1234" | jq '.router_settings.model_group_alias'
# {"gpt-4": "azure-gpt-4"}

# 3. Save ONLY retry settings (same call the Model Retry Settings tab makes)
curl -sX POST http://localhost:4000/config/update \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"router_settings": {"retry_policy": {"RateLimitErrorRetries": 7}}}'

# 4. Alias is gone
curl -s http://localhost:4000/get/config/callbacks \
  -H "Authorization: Bearer sk-1234" | jq '.router_settings.model_group_alias'
# {}      <-- BUG: the alias was wiped
```

After, on commit `8760bb0702` (this branch, with the fix): steps 1 to 3 identical, step 4 returns the alias intact:

```
curl -s http://localhost:4000/get/config/callbacks \
  -H "Authorization: Bearer sk-1234" | jq '.router_settings.model_group_alias'
# {"gpt-4": "azure-gpt-4"}      <-- alias preserved after saving retry settings
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Aliases defined only in `config.yaml` were unaffected; DB / UI aliases were the ones lost

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
