### PR TITLE
test: rename tests that a later definition shadowed

### DIFF
--- a/tests/llm_translation/test_optional_params.py
+++ b/tests/llm_translation/test_optional_params.py
@@ -1137,7 +1137,7 @@ def test_ollama_pydantic_obj():
     )
 
 
-def test_gemini_frequency_penalty():
+def test_gemini_frequency_penalty_listed_in_vertex_ai_supported_params():
     from litellm.utils import get_supported_openai_params
 
     optional_params = get_supported_openai_params(

--- a/tests/logging_callback_tests/test_sqs_logger.py
+++ b/tests/logging_callback_tests/test_sqs_logger.py
@@ -151,7 +151,7 @@ async def test_async_sqs_logger_error_flush():
 
 
 @pytest.mark.asyncio
-async def test_async_log_success_event_adds_to_queue(monkeypatch):
+async def test_async_log_success_event_adds_to_queue_with_real_create_task(monkeypatch):
     monkeypatch.setattr("litellm.aws_sqs_callback_params", {})
     logger = SQSLogger(sqs_queue_url="https://example.com", sqs_region_name="us-west-2")
 
@@ -163,7 +163,7 @@ async def test_async_log_success_event_adds_to_queue(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_async_log_failure_event_adds_to_queue(monkeypatch):
+async def test_async_log_failure_event_adds_to_queue_with_real_create_task(monkeypatch):
     monkeypatch.setattr("litellm.aws_sqs_callback_params", {})
     logger = SQSLogger(sqs_queue_url="https://example.com", sqs_region_name="us-west-2")
 
@@ -180,7 +180,7 @@ async def test_async_log_failure_event_adds_to_queue(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_async_send_batch_triggers_tasks(monkeypatch):
+async def test_async_send_batch_does_not_await_send_directly(monkeypatch):
     monkeypatch.setattr("litellm.aws_sqs_callback_params", {})
     logger = SQSLogger(sqs_queue_url="https://example.com", sqs_region_name="us-west-2")
     logger.async_send_message = AsyncMock()

--- a/tests/logging_callback_tests/test_sqs_logger.py
+++ b/tests/logging_callback_tests/test_sqs_logger.py
@@ -151,7 +151,7 @@ async def test_async_sqs_logger_error_flush():
 
 
 @pytest.mark.asyncio
-async def test_async_log_success_event_adds_to_queue_with_real_create_task(monkeypatch):
+async def test_async_log_success_event_adds_to_queue(monkeypatch):
     monkeypatch.setattr("litellm.aws_sqs_callback_params", {})
     logger = SQSLogger(sqs_queue_url="https://example.com", sqs_region_name="us-west-2")
 
@@ -163,7 +163,7 @@ async def test_async_log_success_event_adds_to_queue_with_real_create_task(monke
 
 
 @pytest.mark.asyncio
-async def test_async_log_failure_event_adds_to_queue_with_real_create_task(monkeypatch):
+async def test_async_log_failure_event_adds_to_queue(monkeypatch):
     monkeypatch.setattr("litellm.aws_sqs_callback_params", {})
     logger = SQSLogger(sqs_queue_url="https://example.com", sqs_region_name="us-west-2")
 
@@ -181,14 +181,31 @@ async def test_async_log_failure_event_adds_to_queue_with_real_create_task(monke
 
 @pytest.mark.asyncio
 async def test_async_send_batch_does_not_await_send_directly(monkeypatch):
+    # create_task stays real here: with it mocked out the await_count assertion
+    # below would hold trivially. Every task it spawns is cancelled at the end,
+    # including the infinite periodic_flush the SQSLogger constructor starts.
     monkeypatch.setattr("litellm.aws_sqs_callback_params", {})
+    spawned = []
+    real_create_task = asyncio.create_task
+
+    def spy_create_task(coro, *args, **kwargs):
+        task = real_create_task(coro, *args, **kwargs)
+        spawned.append(task)
+        return task
+
+    monkeypatch.setattr(asyncio, "create_task", spy_create_task)
+
     logger = SQSLogger(sqs_queue_url="https://example.com", sqs_region_name="us-west-2")
     logger.async_send_message = AsyncMock()
-
     logger.log_queue = [{"log": 1}, {"log": 2}]
-    await logger.async_send_batch()
 
-    assert logger.async_send_message.await_count == 0  # uses create_task internally
+    try:
+        await logger.async_send_batch()
+        assert logger.async_send_message.await_count == 0
+    finally:
+        for task in spawned:
+            task.cancel()
+        await asyncio.gather(*spawned, return_exceptions=True)
 
 
 # =============================================================================

--- a/tests/test_litellm/integrations/test_prometheus_labels.py
+++ b/tests/test_litellm/integrations/test_prometheus_labels.py
@@ -61,7 +61,7 @@ def test_user_email_in_required_metrics():
         print(f"✅ {metric_name} contains user_email label")
 
 
-def test_model_id_in_required_metrics():
+def test_model_id_in_extended_metric_set():
     """
     Test that model_id label is present in all the metrics that should have it
     """

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2077,7 +2077,7 @@ def test_bedrock_tools_unpack_defs_no_oom_with_nested_refs():
     assert "$defs" not in tool_schema, "$defs should be removed after expansion"
 
 
-def test_anthropic_messages_pt_file_block_preserves_cache_control():
+def test_anthropic_messages_pt_file_block_cache_control_with_explicit_provider():
     """
     Test that cache_control on file-type content blocks is preserved
     when translating to Anthropic message format.

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -877,7 +877,7 @@ def test_translate_openai_content_to_anthropic_thinking_and_redacted_thinking():
     assert result[1]["data"] == "REDACTED"
 
 
-def test_translate_streaming_openai_chunk_to_anthropic_with_thinking():
+def test_translate_streaming_openai_chunk_to_anthropic_thinking_delta():
     choices = [
         StreamingChoices(
             finish_reason=None,

--- a/tests/test_litellm/proxy/client/test_client.py
+++ b/tests/test_litellm/proxy/client/test_client.py
@@ -22,7 +22,7 @@ def api_key():
     return "test-api-key"
 
 
-def test_client_initialization(base_url, api_key):
+def test_client_initialization_wires_resource_clients(base_url, api_key):
     """Test that the Client is properly initialized with all resource clients"""
     client = Client(base_url=base_url, api_key=api_key)
 
@@ -63,7 +63,7 @@ def test_client_initialization_strips_trailing_slash():
     assert client.http._base_url == "http://localhost:8000"
 
 
-def test_client_without_api_key(base_url):
+def test_client_without_api_key_propagates_none_to_resource_clients(base_url):
     """Test that the client works without an API key"""
     client = Client(base_url=base_url)
 

--- a/tests/test_litellm/proxy/client/test_models.py
+++ b/tests/test_litellm/proxy/client/test_models.py
@@ -143,7 +143,7 @@ def test_list_invalid_api_keys(base_url, api_key):
     assert "Authorization" not in request.headers
 
 
-def test_client_initialization_strips_trailing_slash():
+def test_models_client_initialization_strips_trailing_slash():
     """Test that the client properly strips trailing slashes from base_url during initialization"""
     client = ModelsManagementClient(base_url="http://localhost:8000/////")
     assert client._base_url == "http://localhost:8000"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Eight tests are silently unreachable, shadowed by a same-named `def`
- Python keeps only the last binding, so pytest never collects them
- Each dead copy asserts something its survivor does not
- The files still look like they cover those scenarios

How it solves it:

- Rename each dead copy to say what it actually covers
- Only the eight `def` lines change, plus task cleanup in one SQS test

## User Flow

No end user flow changes. This PR only renames test functions, so there is no
route, request, or screen that behaves differently before and after.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This change has no runtime surface: it renames test functions only. There is
nothing to call against a live proxy, so a curl transcript would not demonstrate
anything about it.

What it can be checked against is pytest's own collector, at commit `a5b84d337a`.
Collecting the seven touched files:

| | Before | After |
|---|---|---|
| Collected node IDs | 401 | 409 |

The eight added IDs are exactly the eight new names and nothing else, and no ID
was lost. All eight pass, and running the seven touched files in full gives 409
passed.

On the review point about leaked tasks, measured on
`tests/logging_callback_tests/test_sqs_logger.py` against staging: 17 passed with
2 `periodic_flush was never awaited` warnings before, 18 passed with the same 2
after. The restored test adds no leak; those 2 warnings are pre-existing and come
from the survivors mocking `create_task` with `MagicMock`.

What each dead copy covers that its survivor does not:

| Renamed to | Covers |
|---|---|
| `..._listed_in_vertex_ai_supported_params` | `get_supported_openai_params` for vertex_ai, not `get_optional_params` for gemini |
| `test_async_send_batch_does_not_await_send_directly` | send is not awaited directly |
| `test_model_id_in_extended_metric_set` | the `model_id` label on twelve further metrics |
| `..._cache_control_with_explicit_provider` | explicit model and llm_provider, real base64 PDF |
| `..._to_anthropic_thinking_delta` | `thinking_delta`, where the survivor covers `signature_delta` |
| `test_client_initialization_wires_resource_clients` | resource clients carry the right base URL and key |
| `..._propagates_none_to_resource_clients` | a null key reaches models, chat and keys |
| `test_models_client_initialization_strips_trailing_slash` | `ModelsManagementClient` built directly |

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

- Four shadowed copies were deliberately left alone, not renamed
- Two are a bare `pass` and a lone import, so they cannot fail
- Two SQS ones assert exactly what their survivors assert
- All four belong in a deletion set rather than here
- Newly reachable tests can surface latent flakiness in CI

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


