### PR TITLE
fix(batches): strip NUL bytes from passthrough batch tags before the managed object write

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/batch_attribution.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/batch_attribution.py
@@ -10,17 +10,18 @@ from collections.abc import Mapping, Sequence
 from typing import Final
 
 from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.safe_json_dumps import strip_null_bytes
 
 
 def optional_str(value: object) -> str | None:
     return value if isinstance(value, str) else None
 
 
-def _optional_str_tuple(value: object) -> tuple[str, ...] | None:
+def _sanitized_str_tuple(value: object) -> tuple[str, ...] | None:
     if not isinstance(value, list):
         return None
     items: Final[Sequence[object]] = value
-    return tuple(tag for tag in items if isinstance(tag, str))
+    return tuple(strip_null_bytes(tag) for tag in items if isinstance(tag, str))
 
 
 def is_collection_route(url_route: str, collection_suffix: str) -> bool:
@@ -37,12 +38,12 @@ def request_tags_from_metadata(request_metadata: Mapping[str, object]) -> tuple[
     tagged key does not put its tags in the top-level metadata "tags" on the
     passthrough path)
     """
-    tags: Final = _optional_str_tuple(request_metadata.get("tags"))
+    tags: Final = _sanitized_str_tuple(request_metadata.get("tags"))
     if tags:
         return tags
     key_auth_metadata: Final = request_metadata.get("user_api_key_auth_metadata")
     if isinstance(key_auth_metadata, dict):
-        return _optional_str_tuple(key_auth_metadata.get("tags"))
+        return _sanitized_str_tuple(key_auth_metadata.get("tags"))
     return None
 
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
@@ -955,6 +955,16 @@ class TestAnthropicBatchPassthroughCostTracking:
         return mock_managed_files_hook.store_unified_object_id.call_args[1]
 
     @pytest.mark.asyncio
+    async def test_persisted_tags_are_db_safe(self, mock_logging_obj):
+        """Regression for PostgreSQL 22P05, asserted on the value that actually reaches
+        store_unified_object_id so it stays pinned if the sanitation moves."""
+        call_kwargs = await self._store_with_metadata(
+            mock_logging_obj, {"user_api_key": "hashed-key-a", "tags": ["clean", "bad\x00tag"]}
+        )
+
+        assert call_kwargs["request_tags"] == ("clean", "badtag")
+
+    @pytest.mark.asyncio
     async def test_create_persists_key_hash_and_tags(self, mock_logging_obj):
         """Regression (LIT-5288): the batch create must persist the creating key's hashed
         token and its tags so CheckBatchCost can attribute the batch-cost spend row to the

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_batch_attribution.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_batch_attribution.py
@@ -70,6 +70,28 @@ class TestRequestTagsFromMetadata:
     def test_malformed_key_auth_metadata_is_ignored(self):
         assert request_tags_from_metadata({"user_api_key_auth_metadata": "nope"}) is None
 
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            (["bad\x00tag"], ("badtag",)),
+            (["\x00leading"], ("leading",)),
+            (["trailing\x00"], ("trailing",)),
+            (["a\x00b\x00c"], ("abc",)),
+            (["\x00"], ("",)),
+            # every element, not just the first
+            (["clean", "bad\x00tag"], ("clean", "badtag")),
+            (["one\x00", "two\x00", "three\x00"], ("one", "two", "three")),
+        ],
+    )
+    def test_nul_bytes_are_stripped_from_request_tags(self, raw, expected):
+        """Regression for PostgreSQL 22P05: an unstripped NUL aborts the managed object row
+        insert, so the batch is never cost tracked."""
+        assert request_tags_from_metadata({"tags": raw}) == expected
+
+    def test_nul_bytes_are_stripped_from_key_tags_fallback(self):
+        """Regression for PostgreSQL 22P05: the key-tags fallback shares the same helper."""
+        assert request_tags_from_metadata({"user_api_key_auth_metadata": {"tags": ["key\x00tag"]}}) == ("keytag",)
+
 
 @pytest.mark.parametrize(
     "url_route, suffix, expected",

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_ai_batch_passthrough.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_ai_batch_passthrough.py
@@ -336,6 +336,17 @@ class TestVertexAIBatchPassthroughHandler:
         mock_managed_files_hook.store_unified_object_id.assert_called_once()
         return mock_managed_files_hook.store_unified_object_id.call_args[1]
 
+    def test_persisted_tags_are_db_safe(self, mock_logging_obj, mock_managed_files_hook):
+        """Regression for PostgreSQL 22P05, asserted for Vertex too so moving the
+        sanitation somewhere that only covers Anthropic fails loudly."""
+        call_kwargs = self._store_with_metadata(
+            mock_logging_obj,
+            mock_managed_files_hook,
+            {"user_api_key": "hashed-key-a", "tags": ["clean", "bad\x00tag"]},
+        )
+
+        assert call_kwargs["request_tags"] == ("clean", "badtag")
+
     def test_create_persists_key_hash_and_tags(
         self, mock_logging_obj, mock_managed_files_hook
     ):


### PR DESCRIPTION
## TLDR

Problem this solves:

- A batch created through a passthrough with a tag containing a NUL code point is never cost tracked. PostgreSQL rejects NUL in jsonb with `22P05`, and because the tags go into the managed object's CREATE payload, the error aborts the entire row insert rather than just that column
- With no `LiteLLM_ManagedObjectTable` row, `CheckBatchCost` never discovers the batch, so a batch that really ran and really billed at the provider produces no spend anywhere. The create-time write is fire and forget, so nothing retries it
- This is a regression from #36468. Before that PR the passthrough passed neither `request_tags` nor `persist_attribution`, so no caller-supplied string reached the jsonb column and the row was written fine

How it solves it:

- Apply the existing `strip_null_bytes` in the shared tag helper, which is where the value that reaches the DB is built. That is the layer the rest of the repo sanitizes at (`spend_tracking_utils.py` does the same for `LiteLLM_SpendLogs.request_tags`), and it covers both the Anthropic and the Vertex passthrough, since both build tags through this one helper
- Rename the helper to `_sanitized_str_tuple`, because after this change it no longer merely coerces and a future caller should not assume verbatim pass through

## User Flow

Someone sends a batch create with a tag containing a NUL, most plausibly from a tag value assembled out of a fixed-width or C-derived field. Today that batch is billed by the provider and is invisible to litellm. After this change the tag is sanitized, the row is written, and the batch is attributed and costed like any other.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy against the real Anthropic Batches API with a real Postgres, running the same payload on the merged code and then on the fix. The tag carries a real NUL, sent the way a caller would, as a JSON escape inside body `metadata.tags`:

```bash
# body sent (the  is a real NUL in the transmitted JSON)
{"metadata":{"tags":["badtag"]},
 "requests":[{"custom_id":"b1","params":{"model":"claude-haiku-4-5-20251001","max_tokens":32,
              "messages":[{"role":"user","content":"nul probe"}]}}]}

curl -X POST http://127.0.0.1:20473/anthropic/v1/messages/batches \
  -H "Authorization: Bearer $VK" -H 'anthropic-version: 2023-06-01' -H 'Content-Type: application/json' \
  --data-binary @payload.json
```

Before, on the merged code:

```
anthropic accepted, batch: msgbatch_01GpokeTSQRMEXqz9ruGqDdn

$ select count(*) from "LiteLLM_ManagedObjectTable" where model_object_id='msgbatch_01GpokeTSQRMEXqz9ruGqDdn';
 0

proxy log:
  Failed to store Anthropic batch managed object with unified_object_id=bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpjZjg3...
  22P05
  unsupported Unicode escape sequence
```

The batch is running and billing at Anthropic with no row and no spend

After, same payload, same rig:

```
anthropic accepted, batch: msgbatch_01RMebeoXhhv2T24N9jkHgUs

model_object_id | msgbatch_01RMebeoXhhv2T24N9jkHgUs
api_key         | 0259b9b7466430203ebb3092c8b0f17e1447b2f10ddcda8ba4a3c9ffb860a16b
request_tags    | ["badtag"]

22P05 errors since restart: 0
```

## Type

🐛 Bug Fix

## Caveats (if any)

A tag that is entirely NUL sanitizes to an empty string rather than disappearing. That is deliberate: `safe_dumps` already turns `[""]` into `[""]` on the ordinary chat path, so batch tags now behave exactly like chat tags rather than diverging. `db_spend_update_writer` guards `if tag_name and isinstance(tag_name, str)` before entity tag spend and budgets, so a blank tag is skipped there; only the daily tag spend rollup records it, and that is pre-existing behavior shared with every other surface

NUL is not the only byte PostgreSQL rejects in jsonb. An unpaired UTF-16 surrogate survives `strip_null_bytes` and would fail the same way. It is left out of this PR deliberately to keep the diff to the observed regression, and the general fix belongs in `safe_json_dumps` so this call site and `safe_dumps` close it together

## QA runbook

1. Run a proxy with a DB and an Anthropic model registered under the same `model_name` the batch body sends
2. Create a key with tags, then `POST /anthropic/v1/messages/batches` with body `metadata.tags` containing a value with a NUL in it
3. Confirm `LiteLLM_ManagedObjectTable` has a row for that batch and its `request_tags` holds the sanitized tag
4. Confirm the proxy log has no `22P05` and no "Failed to store" line
5. Wait for the batch to complete and for the next `CheckBatchCost` cycle, then confirm the `aretrieve_batch` spend row exists and carries the sanitized tag

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/36688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5eb395720b390dd17813973f00b5cf729a177374. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->