### PR TITLE
feat(spend): add filter_time_by parameter to /spend/logs/v2 for endTime filtering

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2305,7 +2305,6 @@ async def ui_view_spend_logs(
             code=status.HTTP_400_BAD_REQUEST,
         )
 
-    # Validate filter_time_by
     valid_filter_fields: Final = ("startTime", "endTime")
     if filter_time_by not in valid_filter_fields:
         raise ProxyException(

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2249,6 +2249,10 @@ async def ui_view_spend_logs(
         default="desc",
         description="Sort order: asc or desc",
     ),
+    filter_time_by: str | None = fastapi.Query(
+        default="startTime",
+        description="Filter field for date range: 'startTime' (default) or 'endTime'"
+    )
 ):
     """
     View spend logs with pagination support.
@@ -2302,6 +2306,17 @@ async def ui_view_spend_logs(
             code=status.HTTP_400_BAD_REQUEST,
         )
 
+    # Validate filter_time_by
+    valid_filter_fields = {"startTime", "endTime"}
+    if filter_time_by not in valid_filter_fields:
+        raise ProxyException(
+            message=f"Invalid filter_time_by: {filter_time_by}. Must be one of: {', '.join(sorted(valid_filter_fields))}",
+            type="bad_request",
+            param="filter_time_by",
+            code=status.HTTP_400_BAD_REQUEST,
+        )
+    filter_time_field = "startTime" if filter_time_by == "startTime" else "endTime"
+
     try:
         is_admin_view: Final = _is_admin_view_safe(user_api_key_dict=user_api_key_dict)
         is_request_id_lookup: Final = request_id is not None and not is_v2
@@ -2343,7 +2358,7 @@ async def ui_view_spend_logs(
         # Build where conditions
         where_conditions: Final[dict[str, Any]] = {}
         if start_date_obj is not None and end_date_obj is not None:
-            where_conditions["startTime"] = {
+            where_conditions[filter_time_field] = {
                 "gte": start_date_obj.isoformat(),  # Already in UTC, no need to add Z
                 "lte": end_date_obj.isoformat(),
             }
@@ -2477,10 +2492,10 @@ async def ui_view_spend_logs(
         # against the plain `timestamp` column does not depend on the DB session
         # timezone (see #22529). Absent for a request_id-only lookup (see above).
         if start_date_obj is not None and end_date_obj is not None:
-            sql_conditions.append(f"\"startTime\" >= (${p}::timestamptz AT TIME ZONE 'UTC')")
+            sql_conditions.append(f"\"{filter_time_field}\" >= (${p}::timestamptz AT TIME ZONE 'UTC')")
             sql_params.append(start_date_obj)
             p += 1
-            sql_conditions.append(f"\"startTime\" <= (${p}::timestamptz AT TIME ZONE 'UTC')")
+            sql_conditions.append(f"\"{filter_time_field}\" <= (${p}::timestamptz AT TIME ZONE 'UTC')")
             sql_params.append(end_date_obj)
             p += 1
 

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2250,9 +2250,8 @@ async def ui_view_spend_logs(
         description="Sort order: asc or desc",
     ),
     filter_time_by: str | None = fastapi.Query(
-        default="startTime",
-        description="Filter field for date range: 'startTime' (default) or 'endTime'"
-    )
+        default="startTime", description="Filter field for date range: 'startTime' (default) or 'endTime'"
+    ),
 ):
     """
     View spend logs with pagination support.
@@ -2307,7 +2306,7 @@ async def ui_view_spend_logs(
         )
 
     # Validate filter_time_by
-    valid_filter_fields = {"startTime", "endTime"}
+    valid_filter_fields: Final = ("startTime", "endTime")
     if filter_time_by not in valid_filter_fields:
         raise ProxyException(
             message=f"Invalid filter_time_by: {filter_time_by}. Must be one of: {', '.join(sorted(valid_filter_fields))}",
@@ -2315,7 +2314,7 @@ async def ui_view_spend_logs(
             param="filter_time_by",
             code=status.HTTP_400_BAD_REQUEST,
         )
-    filter_time_field = "startTime" if filter_time_by == "startTime" else "endTime"
+    filter_time_field: Final = "startTime" if filter_time_by == "startTime" else "endTime"
 
     try:
         is_admin_view: Final = _is_admin_view_safe(user_api_key_dict=user_api_key_dict)

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -881,6 +881,237 @@ async def test_ui_view_spend_logs_sort_validation_errors(
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
 
 
+# req_a: start 10:00:00, end 10:05:00
+# req_b: start 09:55:00, end 10:00:30
+# req_c: start 10:10:00, end 10:12:00
+_FILTER_TIME_TEST_LOGS = [
+    {
+        "request_id": "req_a",
+        "api_key": "sk-test-key",
+        "user": "user1",
+        "spend": 0.10,
+        "total_tokens": 500,
+        "startTime": "2025-01-01T10:00:00+00:00",
+        "endTime": "2025-01-01T10:05:00+00:00",
+        "model": "gpt-3.5-turbo",
+    },
+    {
+        "request_id": "req_b",
+        "api_key": "sk-test-key",
+        "user": "user1",
+        "spend": 0.05,
+        "total_tokens": 200,
+        "startTime": "2025-01-01T09:55:00+00:00",
+        "endTime": "2025-01-01T10:00:30+00:00",
+        "model": "gpt-3.5-turbo",
+    },
+    {
+        "request_id": "req_c",
+        "api_key": "sk-test-key",
+        "user": "user1",
+        "spend": 0.20,
+        "total_tokens": 50,
+        "startTime": "2025-01-01T10:10:00+00:00",
+        "endTime": "2025-01-01T10:12:00+00:00",
+        "model": "gpt-3.5-turbo",
+    },
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "filter_time_by,start_date,end_date,expected_request_ids,expected_filter_field",
+    [
+        # filter_time_by not passed -> defaults to startTime
+        (None, "2025-01-01 09:59:00", "2025-01-01 10:01:00", ["req_a"], "startTime"),
+        # explicit startTime behaves identically to the default
+        (
+            "startTime",
+            "2025-01-01 09:59:00",
+            "2025-01-01 10:01:00",
+            ["req_a"],
+            "startTime",
+        ),
+        # endTime flips the result: req_a ends at 10:05 (outside), req_b at 10:00:30 (inside)
+        (
+            "endTime",
+            "2025-01-01 09:59:00",
+            "2025-01-01 10:01:00",
+            ["req_b"],
+            "endTime",
+        ),
+        # endTime window catching req_a's endTime 10:05
+        ("endTime", "2025-01-01 10:04:00", "2025-01-01 10:06:00", ["req_a"], "endTime"),
+        # startTime window catching req_b's startTime 09:55
+        (
+            "startTime",
+            "2025-01-01 09:54:00",
+            "2025-01-01 09:56:00",
+            ["req_b"],
+            "startTime",
+        ),
+        # wide window: both req_a and req_b fall inside regardless of the field
+        (
+            "startTime",
+            "2025-01-01 09:54:00",
+            "2025-01-01 10:06:00",
+            ["req_a", "req_b"],
+            "startTime",
+        ),
+        (
+            "endTime",
+            "2025-01-01 09:54:00",
+            "2025-01-01 10:06:00",
+            ["req_a", "req_b"],
+            "endTime",
+        ),
+    ],
+)
+async def test_ui_view_spend_logs_filter_time_by(
+    client,
+    monkeypatch,
+    filter_time_by,
+    start_date,
+    end_date,
+    expected_request_ids,
+    expected_filter_field,
+):
+    """Test that the date range is applied to startTime (default) or endTime."""
+    base_logs = list(_FILTER_TIME_TEST_LOGS)
+
+    async def mock_count(*args, **kwargs):
+        return len(base_logs)
+
+    captured_sql = []
+
+    async def mock_query_raw(sql_query, *params):
+        captured_sql.append(sql_query)
+        # The endpoint emits `"<field>" >= ($n::timestamptz ...)` for whichever
+        # column filter_time_by selected; parse it back out of the SQL so the
+        # mock applies the date window against the same column the endpoint chose.
+        field_match = re.search(r'"(\w+)" >= \(\$(\d+)', sql_query)
+        if field_match:
+            filter_field = field_match.group(1)
+            gte_param = params[int(field_match.group(2)) - 1]
+            lte_match = re.search(r'"(\w+)" <= \(\$(\d+)', sql_query)
+            lte_param = params[int(lte_match.group(2)) - 1] if lte_match else None
+        else:
+            filter_field, gte_param, lte_param = None, None, None
+
+        filtered = []
+        for log in base_logs:
+            if filter_field is not None and gte_param is not None and lte_param is not None:
+                log_dt = datetime.datetime.fromisoformat(log[filter_field].replace("Z", "+00:00"))
+                if log_dt < gte_param or log_dt > lte_param:
+                    continue
+            filtered.append(log)
+
+        if "COUNT(*)" in sql_query:
+            cap_plus_one = params[-1]
+            return [{"total_count": min(len(filtered), cap_plus_one)}]
+        page_size = params[-2] if len(params) >= 2 else 50
+        skip = params[-1] if len(params) >= 1 else 0
+        return [row for row in filtered[skip : skip + page_size]]
+
+    class MockPrismaClient:
+        def __init__(self):
+            self.db = MagicMock()
+            self.db.litellm_spendlogs = MagicMock()
+            self.db.litellm_spendlogs.count = AsyncMock(side_effect=mock_count)
+            self.db.query_raw = AsyncMock(side_effect=mock_query_raw)
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MockPrismaClient())
+    monkeypatch.setattr(
+        "litellm.proxy.spend_tracking.spend_management_endpoints._is_admin_view_safe",
+        lambda user_api_key_dict: True,
+    )
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+
+    try:
+        params = {
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+        if filter_time_by is not None:
+            params["filter_time_by"] = filter_time_by
+
+        response = client.get(
+            "/spend/logs/ui",
+            params=params,
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert "data" in data
+
+        actual_ids = [log["request_id"] for log in data["data"]]
+        assert actual_ids == expected_request_ids, (
+            f"Expected {expected_request_ids}, got {actual_ids} "
+            f"(filter_time_by={filter_time_by}, start_date={start_date}, end_date={end_date})"
+        )
+
+        page_sql = next((sql for sql in captured_sql if "COUNT(*)" not in sql), None)
+        assert page_sql is not None, "expected a page query"
+        assert f'"{expected_filter_field}" >=' in page_sql, (
+            f"SQL must filter on `{expected_filter_field}`, got:\n{page_sql}"
+        )
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "filter_time_by",
+    [
+        None,  # httpx encodes None as an empty query value
+        "timestamp",
+        "invalid_field",
+    ],
+)
+async def test_ui_view_spend_logs_filter_time_by_validation_errors(client, monkeypatch, filter_time_by):
+    """Test that invalid filter_time_by values return 400."""
+
+    async def mock_count(*args, **kwargs):
+        return 0
+
+    class MockPrismaClient:
+        def __init__(self):
+            self.db = MagicMock()
+            self.db.litellm_spendlogs = MagicMock()
+            self.db.litellm_spendlogs.find_many = AsyncMock(return_value=[])
+            self.db.litellm_spendlogs.count = AsyncMock(side_effect=mock_count)
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MockPrismaClient())
+    monkeypatch.setattr(
+        "litellm.proxy.spend_tracking.spend_management_endpoints._is_admin_view_safe",
+        lambda user_api_key_dict: True,
+    )
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+
+    try:
+        start_date = "2024-12-25 00:00:00"
+        end_date = "2025-01-02 23:59:59"
+
+        response = client.get(
+            "/spend/logs/ui",
+            params={
+                "start_date": start_date,
+                "end_date": end_date,
+                "filter_time_by": filter_time_by,
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 400
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
 @pytest.mark.asyncio
 async def test_ui_view_spend_logs_sort_by_request_duration_ms(client, monkeypatch):
     """Test that request_duration_ms is accepted as a valid sort_by field."""

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
@@ -194,6 +194,7 @@ async def test_spend_logs_ui_wraps_params_in_at_time_zone_utc(monkeypatch):
         sort_by="startTime",
         sort_order="desc",
         user_api_key_dict=auth,
+        filter_time_by="startTime",
     )
 
     assert mock_prisma.db.query_raw.called, "query_raw should have been called"
@@ -257,6 +258,7 @@ async def test_spend_logs_ui_uses_bounded_count_not_full_scan(monkeypatch):
         sort_by="startTime",
         sort_order="desc",
         user_api_key_dict=auth,
+        filter_time_by="startTime",
     )
 
     mock_prisma.db.litellm_spendlogs.count.assert_not_called()
@@ -321,6 +323,7 @@ async def test_spend_logs_ui_caps_total_for_large_result_sets(monkeypatch):
         sort_by="startTime",
         sort_order="desc",
         user_api_key_dict=auth,
+        filter_time_by="startTime",
     )
 
     assert response["total"] == SPEND_LOGS_PAGINATION_COUNT_CAP
@@ -366,6 +369,7 @@ async def test_spend_logs_ui_empty_page_reports_zero_total(monkeypatch):
         sort_by="startTime",
         sort_order="desc",
         user_api_key_dict=auth,
+        filter_time_by="startTime",
     )
 
     mock_prisma.db.litellm_spendlogs.count.assert_not_called()
@@ -413,6 +417,7 @@ async def test_spend_logs_ui_out_of_range_page_keeps_total(monkeypatch):
         sort_by="startTime",
         sort_order="desc",
         user_api_key_dict=auth,
+        filter_time_by="startTime",
     )
 
     mock_prisma.db.litellm_spendlogs.count.assert_not_called()

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -51494,6 +51494,8 @@ export interface operations {
                 sort_by?: string;
                 /** @description Sort order: asc or desc */
                 sort_order?: string | null;
+                /** @description Filter field for date range: 'startTime' (default) or 'endTime' */
+                filter_time_by?: string | null;
             };
             header?: never;
             path?: never;
@@ -51602,6 +51604,8 @@ export interface operations {
                 sort_by?: string;
                 /** @description Sort order: asc or desc */
                 sort_order?: string | null;
+                /** @description Filter field for date range: 'startTime' (default) or 'endTime' */
+                filter_time_by?: string | null;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## TLDR

**Problem this solves:**
- `/spend/logs/v2` only filters by `startTime`, making long-running requests invisible for billing when scanned by completion time windows
- Requests that start at 14:30 and end at 14:34 are lost because they appear with `startTime=14:30` but are scanned at 14:34-14:36

**How it solves it:**
- Adds `filter_time_by` parameter with values `startTime` (default) or `endTime`
- Existing `start_date`/`end_date` filters apply to the chosen field

---

## User Flow

**Before this feature (today):** The billing team tries to collect all completed requests from the last 2 minutes for automated synchronization, but filtering by `startTime` prevents them from finding requests that started earlier and finished in the target window.

1. Every 2 minutes, the system sends `GET https://litellm-domain/spend/logs/v2?start_date=2026-08-12%2014:30:00&end_date=2026-08-12%2014:32:00&page=1&page_size=100`
2. It receives `200 OK` with an empty `data` array and `total_count=0`, because the request sent at 14:30 hasn't completed yet and hasn't appeared in logs
3. At 14:32, the system sends `GET https://litellm-domain/spend/logs/v2?start_date=2026-08-12%2014:32:00&end_date=2026-08-12%2014:34:00&page=1&page_size=100`
4. It receives `200 OK` with an empty `data` array and `total_count=0`, because the request is still running
5. At 14:34, the request completes. A log entry appears with `startTime=14:30:00` and `endTime=14:34:30`. The system sends `GET https://litellm-domain/spend/logs/v2?start_date=2026-08-12%2014:34:00&end_date=2026-08-12%2014:36:00&page=1&page_size=100`
6. It receives `200 OK` with an empty `data` array and `total_count=0` — the request is **NOT FOUND**, because the filter looks for records with `startTime` between 14:34 and 14:36, but this request has `startTime=14:30:00`
7. At 14:36, the system continues scanning, but the request is now lost forever — it never fell into any scanned window
8. 🔧 **Workaround:** The system is forced to scan large ranges, e.g., `GET https://litellm-domain/spend/logs/v2?start_date=2026-08-12%2014:00:00&end_date=2026-08-12%2015:00:00&page=1&page_size=1000`, fetch thousands of records, and filter by `endTime` locally. This takes minutes, consumes memory, and is unsuitable for automated synchronization

**After this feature (ideal user flow):** The billing team can filter requests by their completion time, and all completed requests correctly fall into the right window.

1. Every 2 minutes, the system sends `GET https://litellm-domain/spend/logs/v2?start_date=2026-08-12%2014:30:00&end_date=2026-08-12%2014:32:00&filter_time_by=endTime&page=1&page_size=100`
2. It receives `200 OK` with an empty `data` array and `total_count=0`, because the request sent at 14:30 hasn't completed yet
3. At 14:32, the system sends `GET https://litellm-domain/spend/logs/v2?start_date=2026-08-12%2014:32:00&end_date=2026-08-12%2014:34:00&filter_time_by=endTime&page=1&page_size=100`
4. It receives `200 OK` with an empty `data` array and `total_count=0`, because the request is still running
5. At 14:34, the request completes. A log entry appears with `startTime=14:30:00` and `endTime=14:34:30`. The system sends `GET https://litellm-domain/spend/logs/v2?start_date=2026-08-12%2014:34:00&end_date=2026-08-12%2014:36:00&filter_time_by=endTime&page=1&page_size=100`
6. It receives `200 OK` with `data` containing the log entry where `endTime=14:34:30` — the request is **FOUND**, because the filter looks for records with `endTime` between 14:34 and 14:36
7. At 14:36, the system continues scanning, and all requests are correctly accounted for in billing regardless of their duration
8. ✅ Automated synchronization runs fast and reliably, financial reports are accurate, and no manual workarounds are needed

---

## Relevant issues

Closes #36666

## Linear ticket

*No response*

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<img width="771" height="516" alt="image" src="https://github.com/user-attachments/assets/2509cd21-e07a-4375-ae75-4ec98786be6a" />

<img width="771" height="516" alt="image" src="https://github.com/user-attachments/assets/127d52da-0189-4003-91a6-6764eb00fb97" />

<img width="771" height="1074" alt="image" src="https://github.com/user-attachments/assets/caf9aa95-20df-4a57-8d95-dfd56f8f8dcb" />

<img width="768" height="599" alt="image" src="https://github.com/user-attachments/assets/8c1f0bf3-2dc5-4579-bb5a-8515b99f3dd7" />



## Test results

<img width="1961" height="481" alt="image" src="https://github.com/user-attachments/assets/cece2d8b-7016-4bc3-8336-7da0d0256334" />


## Type

🆕 New Feature
✅ Test

## Caveats (if any)

*No response*

## QA runbook

*No response*

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR