### PR TITLE
fix(router): never price a strategy-router alias

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8612,7 +8612,16 @@ class Router:
         Nothing is recorded for replay: a refresh walks the live routers instead,
         so a deleted, repointed or never-added deployment, and a discarded router,
         drop out of the rebuild on their own.
+
+        A strategy-router alias is never the deployment actually called or
+        billed, so custom pricing configured on it must not become a cost-map
+        price: an explicit zero would let ``_is_cost_explicitly_configured``
+        treat the alias as a genuinely free model and waive budget checks for
+        requests that route to (and bill as) a real deployment.
         """
+        if classify_strategy_router_model(model) is not None:
+            model_info = {k: v for k, v in model_info.items() if k not in CustomPricingLiteLLMParams.model_fields}
+
         if model_id is not None:
             litellm.register_model(model_cost={model_id: model_info}, persist_across_reloads=False)
 
@@ -11439,13 +11448,16 @@ class Router:
         # deployment the hook selected won't have them. Router-only fields
         # (tpm, rpm, weight, complexity_router_config, ...) are excluded from the
         # actual outbound LLM call downstream by litellm.types.utils.all_litellm_params,
-        # not here.
+        # not here. Custom pricing fields ARE call params, so they must be
+        # excluded here: they price the alias, not the deployment the hook
+        # selected, and forwarding them re-registers the routed deployment at
+        # the alias's price (an explicit 0 makes every alias request bill $0).
         if pre_routing_hook_response is not None:
             alias_index: Final = self.model_name_to_deployment_indices.get(model, [])
             if alias_index:
                 alias_litellm_params: Final = self.model_list[alias_index[0]].get("litellm_params", {})
                 for key, value in alias_litellm_params.items():
-                    if key != "model" and value is not None:
+                    if key != "model" and key not in CustomPricingLiteLLMParams.model_fields and value is not None:
                         request_kwargs.setdefault(key, value)
 
         return pre_routing_hook_response

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8620,7 +8620,9 @@ class Router:
         requests that route to (and bill as) a real deployment.
         """
         if classify_strategy_router_model(model) is not None:
-            model_info = {k: v for k, v in model_info.items() if k not in CustomPricingLiteLLMParams.model_fields}
+            model_info = {  # mutable-ok: filtered copy of the caller's entry, handed straight to register_model
+                k: v for k, v in model_info.items() if k not in CustomPricingLiteLLMParams.model_fields
+            }
 
         if model_id is not None:
             litellm.register_model(model_cost={model_id: model_info}, persist_across_reloads=False)

--- a/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
+++ b/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
@@ -162,6 +162,34 @@ class TestUnmappedModelBudgetEnforcement:
         # Subsequent call sees the new pricing and enforces budget.
         assert _is_model_cost_zero(model="ramping-model", llm_router=router) is False
 
+    def test_strategy_router_alias_with_zero_pricing_enforces_budget(self):
+        """An auto-router alias is never the deployment that gets called or
+        billed, so zero pricing configured on it must not waive budget checks
+        for requests that route to (and bill as) a real paid deployment."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "smart-router",
+                    "litellm_params": {
+                        "model": "auto_router/complexity_router/smart-router",
+                        "complexity_router_default_model": "paid-model",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                        "complexity_router_config": {"tiers": {"simple": "paid-model"}},
+                    },
+                    "model_info": {"id": "alias-id"},
+                },
+                {
+                    "model_name": "paid-model",
+                    "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-fake"},
+                    "model_info": {"id": "paid-id"},
+                },
+            ]
+        )
+
+        assert "input_cost_per_token" not in litellm.model_cost.get("alias-id", {})
+        assert _is_model_cost_zero(model="smart-router", llm_router=router) is False
+
     def test_handles_router_without_zero_cost_cache_attribute(self):
         """Tolerate router-like objects (e.g. ``MagicMock`` stand-ins) that
         do not expose ``_zero_cost_cache`` — the auth check must still

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2041,6 +2041,44 @@ class TestRouterPreRoutingAliasOverrides:
         assert request_kwargs["cache_control_injection_points"] == [{"location": "message", "role": "system"}]
 
     @pytest.mark.asyncio
+    async def test_alias_custom_pricing_is_not_applied_to_request_kwargs(self):
+        """Custom pricing on the alias prices the alias, not the tier deployment
+        the hook picked. Unlike the router-only fields, pricing fields are real
+        call params, so forwarding them would re-register the routed deployment
+        at the alias's price - an explicit 0 billing every request as free."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "smart-router",
+                    "litellm_params": {
+                        "model": "auto_router/complexity_router",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                        "input_cost_per_second": 0.0,
+                        "drop_params": True,
+                        "complexity_router_config": {"tiers": {"SIMPLE": "gpt-4o-mini"}},
+                        "complexity_router_default_model": "gpt-4o",
+                    },
+                },
+                {"model_name": "gpt-4o-mini", "litellm_params": {"model": "openai/gpt-4o-mini"}},
+                {"model_name": "gpt-4o", "litellm_params": {"model": "openai/gpt-4o"}},
+            ]
+        )
+        request_kwargs: dict = {}
+
+        result = await router.async_pre_routing_hook(
+            model="smart-router",
+            request_kwargs=request_kwargs,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert result is not None
+        # Non-pricing alias params still carry over.
+        assert request_kwargs["drop_params"] is True
+        for field in ("input_cost_per_token", "output_cost_per_token", "input_cost_per_second"):
+            assert field not in request_kwargs
+
+    @pytest.mark.asyncio
     async def test_alias_overrides_exclude_only_model(self):
         """`model` (the alias marker, e.g. auto_router/complexity_router) is
         excluded since it's never a real provider model. Router-only fields

--- a/tests/test_litellm/test_router_model_cost_isolation.py
+++ b/tests/test_litellm/test_router_model_cost_isolation.py
@@ -1471,3 +1471,61 @@ def test_replay_live_router_model_cost_rebuilds_every_live_router():
     finally:
         litellm.model_cost = saved_model_cost
         _invalidate_model_cost_lowercase_map()
+
+
+def test_strategy_router_alias_pricing_never_enters_model_cost(monkeypatch):
+    """
+    A strategy-router alias is never the deployment actually called or billed,
+    so custom pricing configured on it must not be registered under its
+    model_id - an explicit zero there makes the budget check treat the alias
+    as a genuinely free model while requests bill as a real deployment. The
+    strip must also survive a price-data reload, which rebuilds entries by
+    walking the live routers.
+    """
+    from litellm import utils as litellm_utils
+    monkeypatch.setattr(
+        litellm_utils,
+        "_runtime_registered_model_cost",
+        dict(litellm_utils._runtime_registered_model_cost),
+    )
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "smart-router",
+                "litellm_params": {
+                    "model": "auto_router/complexity_router/smart-router",
+                    "complexity_router_default_model": "paid-model",
+                    "input_cost_per_token": 0.0,
+                    "output_cost_per_token": 0.0,
+                    "complexity_router_config": {"tiers": {"simple": "paid-model"}},
+                },
+                "model_info": {"id": "strategy-alias-id", "max_input_tokens": 128000},
+            },
+            {
+                "model_name": "paid-model",
+                "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-fake"},
+                "model_info": {"id": "strategy-alias-paid-id"},
+            },
+        ],
+    )
+
+    def _assert_alias_unpriced():
+        entry = litellm.model_cost.get("strategy-alias-id")
+        assert entry is not None, "Alias metadata should still be registered"
+        assert entry["max_input_tokens"] == 128000
+        assert "input_cost_per_token" not in entry
+        assert "output_cost_per_token" not in entry
+
+    _assert_alias_unpriced()
+
+    saved_model_cost = litellm.model_cost
+    try:
+        _simulate_price_data_reload(
+            {"gpt-4o": {"litellm_provider": "openai", "mode": "chat"}},
+        )
+        _assert_alias_unpriced()
+        assert router.model_list
+    finally:
+        litellm.model_cost = saved_model_cost
+        _invalidate_model_cost_lowercase_map()


### PR DESCRIPTION
## Relevant issues

Reported internally: budget checks silently skipped for `auto_router` model groups, while real spend accrues on the routed deployment

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm` directory
- [x] I have added a screenshot / evidence of my new feature working

## Type

🐛 Bug Fix

## Changes

A strategy-router alias (`auto_router/complexity_router/<name>`) is never the deployment that gets called or billed. Custom pricing configured on one was still treated as real pricing in two places, and an explicit `0` on the alias broke both budgets and cost tracking

**1. Budget checks skipped**

Router init copies the alias's pricing into `litellm.model_cost[<alias deployment id>]`. `_is_cost_explicitly_configured()` sees the key, `_is_model_cost_zero()` returns `True`, and `user_api_key_auth.py` skips every budget check for the group. The request then routes to a paid deployment and accrues real spend, so an over-budget key keeps spending through the alias

**2. Real spend billed $0**

The alias-params merge copies the alias's `litellm_params` onto `request_kwargs`. Pricing fields are legitimate call params, so they survive to `litellm.acompletion`, which registers them under the routed deployment id. `_select_model_name_for_cost_calc` then prefers that id and the paid call is logged at the alias price

Both are fixed at the writer, not at the readers

- `_register_deployment_in_model_cost` drops `CustomPricingLiteLLMParams` fields when the deployment model is an alias, which covers all three registration call sites (boot, `/model/new` upsert, price-map reload replay)
- the alias-params merge excludes the same field set

Alias-ness comes from `classify_strategy_router_model`, so semantic, complexity, adaptive and quality routers are all covered. Non-alias deployments take a byte-identical path, so explicitly zero-priced real deployments keep their intended budget waiver

Behavior change: pricing set on an alias is now ignored entirely, including non-zero pricing. Requests are priced by the deployment that actually served them

## Evidence

Local proxy, 4 groups: `paid-gpt4o` (control), `free-local` (real deployment, explicit zeros, must keep bypassing), `ar-plain` (alias, no pricing), `ar-priced` (alias, explicit zeros). `fail_closed_budget_enforcement: true`, key at `spend=999 / max_budget=0.01`, every group backed by the same paid deployment

Budget matrix

| group | before | after |
| --- | --- | --- |
| paid-gpt4o | 429 | 429 |
| free-local | 200 | 200 |
| ar-plain | 429 | 429 |
| ar-priced | **200** | **429** |

Before, `ar-priced` logged `Skipping all budget checks for model=ar-priced`. After, no alias produces that line

Cost matrix, same downstream deployment

| group | before | after |
| --- | --- | --- |
| paid-gpt4o | 0.0075 | 0.0075 |
| ar-plain | 0.0075 | 0.0075 |
| ar-priced | **0.0** | **0.0075** |

Also verified after the fix: an alias created through `/model/new` (DB-defined) bills 0.0075 and returns 429 for the over-budget key, and `/v1/chat/completions`, `/v1/responses` and `/v1/messages` all return 429

## Tests

New coverage:

- `tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py` an alias with zero pricing does not reach the cost map and `_is_model_cost_zero` stays `False`
- `tests/test_litellm/router_strategy/test_complexity_router.py` alias pricing is not forwarded to `request_kwargs`, while non-pricing alias params still are
- `tests/test_litellm/test_router_model_cost_isolation.py` alias pricing never enters the cost map, at boot and after a price-map reload

## Follow-up, not in this PR

The UI still renders pricing inputs for auto-routers in Edit Settings, though `isAnyAutoRouter` already gates Test Connection and credentials there. Those inputs are now a no-op, so hiding them is a separate UI change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 58903bd65bbb38ffcba80d9254391d9a89444e9c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->