### PR TITLE
fix(cost): honor an explicit zero tier rate instead of the fallback

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/tiered_pricing.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tiered_pricing.py
@@ -25,6 +25,17 @@ def _coerce_cost_per_token(value: float | str | None) -> float:
     return float(value)
 
 
+def _resolve_tier_cost_per_token(
+    tier: dict,
+    cost_key: str,
+    fallback_cost_key: str | None,
+) -> float:
+    primary: Final = tier.get(cost_key)
+    if primary is not None:
+        return _coerce_cost_per_token(primary)
+    return _coerce_cost_per_token(tier.get(fallback_cost_key, 0))
+
+
 def calculate_tiered_cost(
     tokens: int,
     tiered_pricing: list[dict],
@@ -84,8 +95,7 @@ def calculate_tiered_cost(
 
         if tier_end > tier_start:
             tokens_in_tier = tier_end - tier_start
-            cost_per_token = tier.get(cost_key) or tier.get(fallback_cost_key, 0)
-            total_cost += tokens_in_tier * _coerce_cost_per_token(cost_per_token)
+            total_cost += tokens_in_tier * _resolve_tier_cost_per_token(tier, cost_key, fallback_cost_key)
             tokens_processed = tier_end
 
     # After loop, check if any tokens remain (i.e., tokens > highest tier's end range)
@@ -93,8 +103,7 @@ def calculate_tiered_cost(
     if tokens_processed < tokens and sorted_tiers:
         last_tier: Final = sorted_tiers[-1]
         remaining_tokens: Final = tokens - tokens_processed
-        cost_per_token = last_tier.get(cost_key) or last_tier.get(fallback_cost_key, 0)
-        total_cost += remaining_tokens * _coerce_cost_per_token(cost_per_token)
+        total_cost += remaining_tokens * _resolve_tier_cost_per_token(last_tier, cost_key, fallback_cost_key)
 
     return total_cost
 
@@ -135,5 +144,4 @@ def tier_rate(
     fallback_cost_key: str | None = None,
 ) -> float:
     """Read a per-token rate from a tier, coercing YAML string costs to float."""
-    raw: Final = tier.get(cost_key) or tier.get(fallback_cost_key, 0)
-    return _coerce_cost_per_token(raw)
+    return _resolve_tier_cost_per_token(tier, cost_key, fallback_cost_key)

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tiered_pricing.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tiered_pricing.py
@@ -1,0 +1,72 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import (
+    calculate_tiered_cost,
+    tier_rate,
+)
+
+
+def test_calculate_tiered_cost_honors_explicit_zero_primary_rate():
+    tiers = [
+        {
+            "range": [0, 100000],
+            "input_cost_per_token": 1e-6,
+            "cache_read_input_token_cost": 0.0,
+        }
+    ]
+
+    cost = calculate_tiered_cost(
+        tokens=10000,
+        tiered_pricing=tiers,
+        cost_key="cache_read_input_token_cost",
+        fallback_cost_key="input_cost_per_token",
+    )
+
+    assert cost == 0.0
+
+
+def test_calculate_tiered_cost_honors_explicit_zero_primary_rate_in_overflow_tier():
+    tiers = [
+        {
+            "range": [0, 100000],
+            "input_cost_per_token": 1e-6,
+            "cache_read_input_token_cost": 0.0,
+        }
+    ]
+
+    cost = calculate_tiered_cost(
+        tokens=150000,
+        tiered_pricing=tiers,
+        cost_key="cache_read_input_token_cost",
+        fallback_cost_key="input_cost_per_token",
+    )
+
+    assert cost == 0.0
+
+
+def test_calculate_tiered_cost_falls_back_when_primary_rate_is_missing():
+    tiers = [{"range": [0, 100000], "input_cost_per_token": 1e-6}]
+
+    cost = calculate_tiered_cost(
+        tokens=10000,
+        tiered_pricing=tiers,
+        cost_key="cache_read_input_token_cost",
+        fallback_cost_key="input_cost_per_token",
+    )
+
+    assert cost == 10000 * 1e-6
+
+
+def test_tier_rate_honors_explicit_zero_primary_rate():
+    tier = {"cache_read_input_token_cost": 0.0, "input_cost_per_token": 1e-6}
+
+    assert tier_rate(tier, "cache_read_input_token_cost", "input_cost_per_token") == 0.0
+
+
+def test_tier_rate_falls_back_when_primary_rate_is_missing():
+    tier = {"input_cost_per_token": 1e-6}
+
+    assert tier_rate(tier, "cache_read_input_token_cost", "input_cost_per_token") == 1e-6


### PR DESCRIPTION
## TLDR

Problem this solves:

- A tiered-pricing tier that prices cached reads or reasoning tokens at an explicit `0.0` is billed at the fallback rate instead of being free
- `calculate_tiered_cost` and `tier_rate` resolved a tier's per-token cost with `tier.get(cost_key) or tier.get(fallback_cost_key, 0)`, and the `or` short-circuits on a falsy `0.0`, so a real zero price looks like a missing key and falls through to the fallback

How it solves it:

- Add `_resolve_tier_cost_per_token`, which returns the primary rate whenever the key is present (including `0.0`) and only reads the fallback when the key is absent (`None`)
- Route all three sites (the in-range tier, the beyond-highest-tier overflow, and `tier_rate`) through that helper

## User Flow

A user configures a Dashscope (or any tiered) model whose tier sets `cache_read_input_token_cost: 0` while `input_cost_per_token` is nonzero, then sends a request whose prompt has cached tokens. Before this change every cached token is billed at `input_cost_per_token`; after it, the cached tokens are correctly billed at `0`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

`calculate_tiered_cost` is a pure function, so the before/after is visible without a network call. A tier with free cache reads and a nonzero input rate:

```python
from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import calculate_tiered_cost
tiers = [{"range": [0, 100000], "input_cost_per_token": 1e-6, "cache_read_input_token_cost": 0.0}]
calculate_tiered_cost(tokens=10000, tiered_pricing=tiers, cost_key="cache_read_input_token_cost", fallback_cost_key="input_cost_per_token")
```

Before: `0.01` (10000 cached tokens billed at the full input rate). After: `0.0`

End-to-end QA a maintainer can run against a live proxy: register a Dashscope model whose tier carries `cache_read_input_token_cost: 0`, then

```bash
curl http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $LITELLM_KEY" -H "Content-Type: application/json" -d '{"model":"<dashscope-tiered-model>","messages":[{"role":"user","content":"<long prompt reused to trigger a cache hit>"}]}'
```

run it twice so the second request reports cached prompt tokens, then confirm the logged prompt cost at http://localhost:4000/ui/?page=logs charges those cached tokens at 0 rather than the input rate

## Type

🐛 Bug Fix

## Changes

`_resolve_tier_cost_per_token` in `litellm/litellm_core_utils/llm_cost_calc/tiered_pricing.py`, used by `calculate_tiered_cost` (both the in-range and overflow sites) and `tier_rate`. This restores the behavior of #30749, which removed the same `or` short-circuit from the Dashscope calculator before the logic was extracted into this shared helper

## Caveats (if any)

## QA runbook

Covered by the new regression tests in `tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tiered_pricing.py`: an explicit `0.0` primary rate stays `0.0` at both the in-range and overflow sites and in `tier_rate`, while a missing key still falls back. The three zero-honoring tests fail on the current code and pass after the fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
