### PR TITLE
fix(proxy): honor explicit null budget_duration on team and key create + clearable UI dropdowns

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -805,7 +805,7 @@ def _enforce_upperbound_key_params(
         upperbound_value = getattr(litellm.upperbound_key_generate_params, key, None)
         if upperbound_value is not None:
             if value is None:
-                if fill_defaults:
+                if fill_defaults and key not in data.model_fields_set:
                     setattr(data, key, upperbound_value)
             else:
                 if key in [
@@ -888,7 +888,7 @@ async def _common_key_generation_helper(
     if litellm.default_key_generate_params is not None:
         for elem in data:
             key, value = elem
-            if value is None and key in [
+            if key not in data.model_fields_set and key in [
                 "max_budget",
                 "user_id",
                 "team_id",
@@ -898,7 +898,9 @@ async def _common_key_generation_helper(
                 "budget_duration",
                 "duration",
             ]:
-                setattr(data, key, litellm.default_key_generate_params.get(key, None))
+                default_value = litellm.default_key_generate_params.get(key)
+                if default_value is not None:
+                    setattr(data, key, default_value)
             elif key == "models" and value == []:
                 setattr(data, key, litellm.default_key_generate_params.get(key, []))
             elif key == "metadata" and value == {}:

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -805,7 +805,7 @@ def _enforce_upperbound_key_params(
         upperbound_value = getattr(litellm.upperbound_key_generate_params, key, None)
         if upperbound_value is not None:
             if value is None:
-                if fill_defaults and key not in data.model_fields_set:
+                if fill_defaults:
                     setattr(data, key, upperbound_value)
             else:
                 if key in [

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -888,16 +888,21 @@ async def _common_key_generation_helper(
     if litellm.default_key_generate_params is not None:
         for elem in data:
             key, value = elem
-            if key not in data.model_fields_set and key in [
-                "max_budget",
-                "user_id",
-                "team_id",
-                "max_parallel_requests",
-                "tpm_limit",
-                "rpm_limit",
-                "budget_duration",
-                "duration",
-            ]:
+            if (
+                value is None
+                and (key != "budget_duration" or key not in data.model_fields_set)
+                and key
+                in [
+                    "max_budget",
+                    "user_id",
+                    "team_id",
+                    "max_parallel_requests",
+                    "tpm_limit",
+                    "rpm_limit",
+                    "budget_duration",
+                    "duration",
+                ]
+            ):
                 default_value = litellm.default_key_generate_params.get(key)
                 if default_value is not None:
                     setattr(data, key, default_value)

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1322,7 +1322,7 @@ async def new_team(
             "rpm_limit",
             "team_member_permissions",
         ):
-            if getattr(data, field, None) is None:
+            if field not in data.model_fields_set:
                 default_value = _get_default_team_param(field)
                 if default_value is not None:
                     setattr(data, field, default_value)

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1313,8 +1313,9 @@ async def new_team(
             if isinstance(default_organization_id, str):
                 data.organization_id = default_organization_id
 
-        # Apply defaults from litellm.default_team_params for any fields
-        # not explicitly provided in the request.
+        # Apply defaults from litellm.default_team_params to null fields.
+        # budget_duration alone distinguishes explicit null (a deliberate
+        # never-resetting budget, which the default must not override) from omitted.
         for field in (
             "max_budget",
             "budget_duration",
@@ -1322,7 +1323,9 @@ async def new_team(
             "rpm_limit",
             "team_member_permissions",
         ):
-            if field not in data.model_fields_set:
+            if getattr(data, field, None) is None and (
+                field != "budget_duration" or field not in data.model_fields_set
+            ):
                 default_value = _get_default_team_param(field)
                 if default_value is not None:
                     setattr(data, field, default_value)

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -666,7 +666,7 @@ async def get_internal_user_settings():
 )
 async def get_default_team_settings():
     """
-    Get all SSO settings from the litellm_settings configuration.
+    Get the default team parameters (litellm_settings.default_team_params).
     Returns a structured object with values and descriptions for UI display.
     """
     from litellm.proxy.proxy_server import proxy_config
@@ -894,8 +894,9 @@ async def update_default_team_settings(
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
-    Update the default team parameters for SSO users.
-    These settings will be applied to new teams created from SSO.
+    Update the default team parameters (litellm_settings.default_team_params).
+    Applied to every new team for fields not explicitly provided in the create request;
+    `models` only applies to teams automatically created via SSO Groups.
     """
     if settings.organization_id is not None:
         await _validate_default_organization_exists(settings.organization_id)

--- a/litellm/types/proxy/management_endpoints/ui_sso.py
+++ b/litellm/types/proxy/management_endpoints/ui_sso.py
@@ -202,28 +202,29 @@ class SSOConfig(LiteLLMPydanticObjectBase):
 
 class DefaultTeamSSOParams(LiteLLMPydanticObjectBase):
     """
-    Default parameters to apply when a new team is automatically created by LiteLLM via SSO Groups
+    Default parameters applied to every /team/new call for fields not explicitly provided in the request.
+    `models` is the exception: it only applies to teams automatically created by LiteLLM via SSO Groups.
     """
 
     models: list[str] = Field(
         default=[],
-        description="Default list of models that new automatically created teams can access",
+        description="Default list of models for teams automatically created via SSO Groups",
     )
     max_budget: float | None = Field(
         default=None,
-        description="Default maximum budget (in USD) for new automatically created teams",
+        description="Default maximum budget (in USD) for new teams, when not explicitly provided",
     )
     budget_duration: str | None = Field(
         default=None,
-        description="Default budget duration for new automatically created teams (e.g. 'daily', 'weekly', 'monthly')",
+        description="Default budget duration for new teams, when not explicitly provided (e.g. '24h', '7d', '30d')",
     )
     tpm_limit: int | None = Field(
         default=None,
-        description="Default tpm limit for new automatically created teams",
+        description="Default tpm limit for new teams, when not explicitly provided",
     )
     rpm_limit: int | None = Field(
         default=None,
-        description="Default rpm limit for new automatically created teams",
+        description="Default rpm limit for new teams, when not explicitly provided",
     )
     team_member_permissions: list[KeyManagementRoutes] | None = Field(
         default=None,

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -15663,8 +15663,9 @@ async def test_key_generate_omitted_budget_duration_still_takes_default_key_gene
 
 
 @pytest.mark.asyncio
-async def test_key_generate_explicit_null_budget_duration_beats_upperbound_fill(monkeypatch):
-    """upperbound_key_generate_params is a ceiling, so it must not resurrect a duration the caller nulled out."""
+async def test_key_generate_explicit_null_budget_duration_cannot_bypass_upperbound(monkeypatch):
+    """upperbound_key_generate_params is an admin ceiling: an explicit null must not mint an uncapped key,
+    otherwise any key creator could bypass configured limits (duration, budgets, rate limits)."""
     from litellm.types.proxy.management_endpoints.ui_sso import (
         LiteLLM_UpperboundKeyGenerateParams,
     )
@@ -15679,8 +15680,8 @@ async def test_key_generate_explicit_null_budget_duration_beats_upperbound_fill(
 
     key_row = await _generate_key_and_get_persisted_row(GenerateKeyRequest(budget_duration=None), mock_insert_data)
 
-    assert key_row["budget_duration"] is None
-    assert key_row["budget_reset_at"] is None
+    assert key_row["budget_duration"] == "30d"
+    assert key_row["budget_reset_at"] is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -15600,3 +15600,105 @@ async def test_unblock_key_stamps_settings_updated_at(monkeypatch):
     sent = mock_prisma_client.db.litellm_verificationtoken.update.call_args.kwargs["data"]
     assert sent["blocked"] is False
     assert before <= sent["settings_updated_at"] <= after
+
+
+def _wire_key_generation_prisma(monkeypatch):
+    created_key = MagicMock(token="hashed_token_123", litellm_budget_table=None, object_permission=None)
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.insert_data = AsyncMock(return_value=created_key)
+    mock_prisma_client.db = MagicMock()
+    mock_prisma_client.db.litellm_verificationtoken = MagicMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(return_value=None)
+    mock_prisma_client.db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
+    mock_prisma_client.db.litellm_verificationtoken.count = AsyncMock(return_value=0)
+    mock_prisma_client.db.litellm_verificationtoken.update = AsyncMock(return_value=created_key)
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    return mock_prisma_client.insert_data
+
+
+async def _generate_key_and_get_persisted_row(data: GenerateKeyRequest, mock_insert_data):
+    await _common_key_generation_helper(
+        data=data,
+        user_api_key_dict=UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+            api_key="sk-1234",
+            user_id="1234",
+        ),
+        litellm_changed_by=None,
+        team_table=None,
+    )
+    key_call = next(c for c in mock_insert_data.call_args_list if c.kwargs["table_name"] == "key")
+    return key_call.kwargs["data"]
+
+
+@pytest.mark.asyncio
+async def test_key_generate_explicit_null_budget_duration_beats_default_key_generate_params(monkeypatch):
+    """An explicit `"budget_duration": null` asks for a budget that never resets.
+
+    Gating on the value alone made that indistinguishable from omitting the field,
+    so the configured default overrode the opt-out and budget_reset_at got stamped.
+    """
+    monkeypatch.setattr(litellm, "default_key_generate_params", {"budget_duration": "30d"})
+    mock_insert_data = _wire_key_generation_prisma(monkeypatch)
+
+    key_row = await _generate_key_and_get_persisted_row(GenerateKeyRequest(budget_duration=None), mock_insert_data)
+
+    assert key_row["budget_duration"] is None
+    assert key_row["budget_reset_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_key_generate_omitted_budget_duration_still_takes_default_key_generate_params(monkeypatch):
+    """Omitting the field keeps applying the default, the behavior the explicit-null fix must not break."""
+    monkeypatch.setattr(litellm, "default_key_generate_params", {"budget_duration": "30d"})
+    mock_insert_data = _wire_key_generation_prisma(monkeypatch)
+
+    key_row = await _generate_key_and_get_persisted_row(GenerateKeyRequest(), mock_insert_data)
+
+    assert key_row["budget_duration"] == "30d"
+    assert key_row["budget_reset_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_key_generate_explicit_null_budget_duration_beats_upperbound_fill(monkeypatch):
+    """upperbound_key_generate_params is a ceiling, so it must not resurrect a duration the caller nulled out."""
+    from litellm.types.proxy.management_endpoints.ui_sso import (
+        LiteLLM_UpperboundKeyGenerateParams,
+    )
+
+    monkeypatch.setattr(litellm, "default_key_generate_params", None)
+    monkeypatch.setattr(
+        litellm,
+        "upperbound_key_generate_params",
+        LiteLLM_UpperboundKeyGenerateParams(budget_duration="30d"),
+    )
+    mock_insert_data = _wire_key_generation_prisma(monkeypatch)
+
+    key_row = await _generate_key_and_get_persisted_row(GenerateKeyRequest(budget_duration=None), mock_insert_data)
+
+    assert key_row["budget_duration"] is None
+    assert key_row["budget_reset_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_key_generate_omitted_budget_duration_still_filled_by_upperbound(monkeypatch):
+    """The upperbound's long-standing fill-on-omitted behavior stays untouched."""
+    from litellm.types.proxy.management_endpoints.ui_sso import (
+        LiteLLM_UpperboundKeyGenerateParams,
+    )
+
+    monkeypatch.setattr(litellm, "default_key_generate_params", None)
+    monkeypatch.setattr(
+        litellm,
+        "upperbound_key_generate_params",
+        LiteLLM_UpperboundKeyGenerateParams(budget_duration="30d"),
+    )
+    mock_insert_data = _wire_key_generation_prisma(monkeypatch)
+
+    key_row = await _generate_key_and_get_persisted_row(GenerateKeyRequest(), mock_insert_data)
+
+    assert key_row["budget_duration"] == "30d"
+    assert key_row["budget_reset_at"] is not None

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -11171,14 +11171,12 @@ async def test_new_team_omitted_budget_duration_still_takes_configured_default(
 
 
 @pytest.mark.asyncio
-async def test_new_team_explicit_null_max_budget_beats_configured_default(
+async def test_new_team_explicit_null_max_budget_still_takes_configured_default(
     mock_db_client, mock_admin_auth, monkeypatch
 ):
-    """The whole default_team_params loop is gated on what the request set, not budget_duration alone.
-
-    Scoped to default_team_params: the legacy default_team_settings max_budget
-    fallback is still value-gated, so it is pinned off here.
-    """
+    """The explicit-null opt-out is budget_duration-only: nulling limit fields
+    (max_budget, tpm/rpm) must not skip configured defaults, or any team creator
+    could mint uncapped teams (veria finding on PR #36699)."""
     from fastapi import Request
 
     import litellm
@@ -11196,4 +11194,4 @@ async def test_new_team_explicit_null_max_budget_beats_configured_default(
     )
 
     team_data = mock_team_create.call_args.kwargs["data"]
-    assert team_data.get("max_budget") is None
+    assert team_data.get("max_budget") == 100.0

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -11094,3 +11094,106 @@ async def test_new_team_output_token_estimate_rejected_for_non_admin():
 
     assert str(exc.value.code) == "403"
     assert "on a team" in str(exc.value.message)
+
+
+def _wire_new_team_prisma(mock_db_client):
+    mock_db_client.jsonify_team_object = lambda db_data: db_data
+    mock_db_client.get_data = AsyncMock(return_value=None)
+    mock_db_client.db = MagicMock()
+
+    created_team = MagicMock(team_id="team-defaults")
+    created_team.model_dump.return_value = {"team_id": "team-defaults"}
+
+    mock_db_client.db.litellm_teamtable = MagicMock()
+    mock_db_client.db.litellm_teamtable.count = AsyncMock(return_value=0)
+    mock_db_client.db.litellm_teamtable.create = AsyncMock(return_value=created_team)
+    mock_db_client.db.litellm_teamtable.update = AsyncMock(return_value=created_team)
+    mock_db_client.db.litellm_usertable = MagicMock()
+    mock_db_client.db.litellm_usertable.update = AsyncMock(return_value=MagicMock())
+
+    return mock_db_client.db.litellm_teamtable.create
+
+
+@pytest.mark.asyncio
+async def test_new_team_explicit_null_budget_duration_beats_configured_default(
+    mock_db_client, mock_admin_auth, monkeypatch
+):
+    """An explicit `"budget_duration": null` asks for a lifetime budget that never resets.
+
+    Gating on the value alone made that indistinguishable from omitting the field,
+    so the default overrode the opt-out and budget_reset_at got stamped.
+    """
+    from fastapi import Request
+
+    import litellm
+    from litellm.proxy._types import NewTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import new_team
+
+    monkeypatch.setattr(litellm, "default_team_settings", None)
+    monkeypatch.setattr(litellm, "default_team_params", {"budget_duration": "30d"})
+    mock_team_create = _wire_new_team_prisma(mock_db_client)
+
+    await new_team(
+        data=NewTeamRequest(team_alias="lifetime-budget-team", budget_duration=None),
+        http_request=MagicMock(spec=Request),
+        user_api_key_dict=mock_admin_auth,
+    )
+
+    team_data = mock_team_create.call_args.kwargs["data"]
+    assert team_data.get("budget_duration") is None
+    assert team_data.get("budget_reset_at") is None
+
+
+@pytest.mark.asyncio
+async def test_new_team_omitted_budget_duration_still_takes_configured_default(
+    mock_db_client, mock_admin_auth, monkeypatch
+):
+    """Omitting the field keeps applying the default, the behavior the explicit-null fix must not break."""
+    from fastapi import Request
+
+    import litellm
+    from litellm.proxy._types import NewTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import new_team
+
+    monkeypatch.setattr(litellm, "default_team_settings", None)
+    monkeypatch.setattr(litellm, "default_team_params", {"budget_duration": "30d"})
+    mock_team_create = _wire_new_team_prisma(mock_db_client)
+
+    await new_team(
+        data=NewTeamRequest(team_alias="default-budget-team"),
+        http_request=MagicMock(spec=Request),
+        user_api_key_dict=mock_admin_auth,
+    )
+
+    team_data = mock_team_create.call_args.kwargs["data"]
+    assert team_data.get("budget_duration") == "30d"
+    assert team_data.get("budget_reset_at") is not None
+
+
+@pytest.mark.asyncio
+async def test_new_team_explicit_null_max_budget_beats_configured_default(
+    mock_db_client, mock_admin_auth, monkeypatch
+):
+    """The whole default_team_params loop is gated on what the request set, not budget_duration alone.
+
+    Scoped to default_team_params: the legacy default_team_settings max_budget
+    fallback is still value-gated, so it is pinned off here.
+    """
+    from fastapi import Request
+
+    import litellm
+    from litellm.proxy._types import NewTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import new_team
+
+    monkeypatch.setattr(litellm, "default_team_settings", None)
+    monkeypatch.setattr(litellm, "default_team_params", {"max_budget": 100.0})
+    mock_team_create = _wire_new_team_prisma(mock_db_client)
+
+    await new_team(
+        data=NewTeamRequest(team_alias="unlimited-budget-team", max_budget=None),
+        http_request=MagicMock(spec=Request),
+        user_api_key_dict=mock_admin_auth,
+    )
+
+    team_data = mock_team_create.call_args.kwargs["data"]
+    assert team_data.get("max_budget") is None

--- a/ui/litellm-dashboard/src/components/Teams.test.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.test.tsx
@@ -1,12 +1,19 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { NuqsTestingAdapter, OnUrlUpdateFunction } from "nuqs/adapters/testing";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useTeamMetadataSchema } from "@/app/(dashboard)/hooks/teams/useTeamMetadataSchema";
 import NotificationsManager from "./molecules/notifications_manager";
 import { fetchAvailableModelsForTeamOrKey } from "./key_team_helpers/fetch_available_models_team_key";
-import { fetchMCPAccessGroups, getGuardrailsList, getPoliciesList, teamCreateCall } from "./networking";
+import {
+  fetchMCPAccessGroups,
+  getDefaultTeamSettings,
+  getGuardrailsList,
+  getPoliciesList,
+  teamCreateCall,
+} from "./networking";
 import Teams from "./Teams";
 
 const can = vi.fn();
@@ -34,6 +41,7 @@ vi.mock("./networking", () => ({
   v2TeamListCall: vi.fn(),
   getGuardrailsList: vi.fn().mockResolvedValue({ guardrails: [] }),
   getPoliciesList: vi.fn().mockResolvedValue({ policies: [] }),
+  getDefaultTeamSettings: vi.fn().mockResolvedValue({ values: {} }),
 }));
 
 // Teams invalidates teamsTableKeys on mutations; the selected team is passed up from the table.
@@ -645,6 +653,105 @@ describe("Teams - access_group_ids in team create", () => {
           models: ["no-default-models"],
         }),
       );
+    });
+  });
+});
+
+describe("Teams - Reset Budget in team create", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTeamInfoView.mockClear();
+    vi.mocked(fetchAvailableModelsForTeamOrKey).mockResolvedValue(["gpt-4"]);
+    vi.mocked(fetchMCPAccessGroups).mockResolvedValue([]);
+    vi.mocked(getGuardrailsList).mockResolvedValue({ guardrails: [] });
+    vi.mocked(getDefaultTeamSettings).mockResolvedValue({ values: { budget_duration: "30d" } });
+    vi.mocked(teamCreateCall).mockResolvedValue({
+      team_id: "new-team-1",
+      team_alias: "Test Team",
+      models: ["gpt-4"],
+      organization_id: null,
+      keys: [],
+      members_with_roles: [],
+      spend: 0,
+    });
+    mockUseOrganizations.mockReturnValue({ data: null });
+  });
+
+  const openCreateModal = async () => {
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />);
+
+    const createButton = screen.getAllByRole("button", { name: /create team/i })[0];
+    act(() => {
+      fireEvent.click(createButton);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/team name/i)).toBeInTheDocument();
+    });
+  };
+
+  const resetBudgetField = () => screen.getByText("Reset Budget").closest(".ant-form-item") as HTMLElement;
+
+  const submitCreateModal = async () => {
+    fireEvent.change(screen.getByLabelText(/team name/i), { target: { value: "Test Team" } });
+
+    const createTeamSubmitButtons = screen.getAllByRole("button", { name: /create team/i });
+    fireEvent.click(createTeamSubmitButtons[createTeamSubmitButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(teamCreateCall).toHaveBeenCalled();
+    });
+
+    return vi.mocked(teamCreateCall).mock.calls[0][1];
+  };
+
+  it("should send an explicit null budget_duration when Never resets is selected", async () => {
+    await openCreateModal();
+
+    await userEvent.click(within(resetBudgetField()).getByRole("combobox"));
+    await userEvent.click(await screen.findByText("Never resets"));
+
+    const payload = await submitCreateModal();
+
+    expect(payload.budget_duration).toBeNull();
+    expect(JSON.stringify(payload)).toContain('"budget_duration":null');
+  });
+
+  it("should omit budget_duration entirely when Reset Budget is left untouched", async () => {
+    await openCreateModal();
+
+    const payload = await submitCreateModal();
+
+    expect(payload.budget_duration).toBeUndefined();
+    expect(JSON.stringify(payload)).not.toContain("budget_duration");
+  });
+
+  it("should send the picked duration when one is selected", async () => {
+    await openCreateModal();
+
+    await userEvent.click(within(resetBudgetField()).getByRole("combobox"));
+    await userEvent.click(await screen.findByText("weekly"));
+
+    const payload = await submitCreateModal();
+
+    expect(payload.budget_duration).toBe("7d");
+  });
+
+  it("should show the configured server default as the Reset Budget placeholder", async () => {
+    await openCreateModal();
+
+    await waitFor(() => {
+      expect(within(resetBudgetField()).getByText("Default: monthly (30d)")).toBeInTheDocument();
+    });
+  });
+
+  it("should fall back to the n/a placeholder when the default settings fetch fails", async () => {
+    vi.mocked(getDefaultTeamSettings).mockRejectedValue(new Error("Unauthorized"));
+
+    await openCreateModal();
+
+    await waitFor(() => {
+      expect(within(resetBudgetField()).getByText("n/a")).toBeInTheDocument();
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/Teams.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.tsx
@@ -9,7 +9,7 @@ import { Accordion, AccordionBody, AccordionHeader, TextInput } from "@tremor/re
 import { Button, Form, Input, Layout, Modal, Select, Switch, Tabs, theme, Tooltip, Typography } from "antd";
 import { Plus, Users } from "lucide-react";
 import React, { useEffect, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { Button as UIButton } from "@/components/ui/button";
 import { teamsTableKeys } from "@/app/(dashboard)/hooks/teams/useTeams";
@@ -29,7 +29,11 @@ import MCPServerSelector from "./mcp_server_management/MCPServerSelector";
 import MCPToolPermissions from "./mcp_server_management/MCPToolPermissions";
 import NotificationsManager from "./molecules/notifications_manager";
 import { extractProxyErrorMessage } from "@/lib/http/client";
-import { Organization, getGuardrailsList, getPoliciesList, teamDeleteCall } from "./networking";
+import BudgetDurationDropdown, {
+  getBudgetDurationLabel,
+  NEVER_RESETS_BUDGET_DURATION,
+} from "./common_components/budget_duration_dropdown";
+import { Organization, getDefaultTeamSettings, getGuardrailsList, getPoliciesList, teamDeleteCall } from "./networking";
 import NumericalInput from "./shared/numerical_input";
 import VectorStoreSelector from "./vector_store_management/VectorStoreSelector";
 import SearchToolSelector from "./search_tools/SearchToolSelector";
@@ -115,6 +119,18 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
   const [modelAliases, setModelAliases] = useState<{ [key: string]: string }>({});
   const [routerSettings, setRouterSettings] = useState<RouterSettingsAccordionValue | null>(null);
   const [routerSettingsKey, setRouterSettingsKey] = useState<number>(0);
+
+  const { data: defaultTeamSettings } = useQuery({
+    queryKey: ["defaultTeamSettings"],
+    queryFn: () => getDefaultTeamSettings(accessToken as string),
+    enabled: isTeamModalVisible && accessToken != null,
+    retry: false,
+    staleTime: 60_000,
+  });
+  const defaultBudgetDuration: string | undefined = defaultTeamSettings?.values?.budget_duration ?? undefined;
+  const budgetDurationPlaceholder = defaultBudgetDuration
+    ? `Default: ${getBudgetDurationLabel(defaultBudgetDuration)} (${defaultBudgetDuration})`
+    : "n/a";
 
   useEffect(() => {
     form.setFieldValue("models", []);
@@ -247,6 +263,10 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
           formValues.organization_id = null;
         } else {
           formValues.organization_id = organizationId.trim();
+        }
+
+        if (formValues.budget_duration === NEVER_RESETS_BUDGET_DURATION) {
+          formValues.budget_duration = null;
         }
 
         NotificationsManager.info("Creating Team");
@@ -645,11 +665,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
                 <NumericalInput step={0.01} precision={2} width={200} />
               </Form.Item>
               <Form.Item className="mt-8" label="Reset Budget" name="budget_duration">
-                <Select defaultValue={null} placeholder="n/a">
-                  <Select.Option value="24h">daily</Select.Option>
-                  <Select.Option value="7d">weekly</Select.Option>
-                  <Select.Option value="30d">monthly</Select.Option>
-                </Select>
+                <BudgetDurationDropdown showNeverResets placeholder={budgetDurationPlaceholder} />
               </Form.Item>
               <Form.Item label="Tokens per minute Limit (TPM)" name="tpm_limit">
                 <NumericalInput step={1} width={400} />

--- a/ui/litellm-dashboard/src/components/common_components/budget_duration_dropdown.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/budget_duration_dropdown.tsx
@@ -3,12 +3,15 @@ import { Select } from "antd";
 
 const { Option } = Select;
 
+export const NEVER_RESETS_BUDGET_DURATION = "none";
+
 interface BudgetDurationDropdownProps {
   value?: string | null;
   onChange?: (value: string | undefined) => void;
   className?: string;
   style?: React.CSSProperties;
   placeholder?: string;
+  showNeverResets?: boolean;
 }
 
 const BudgetDurationDropdown: React.FC<BudgetDurationDropdownProps> = ({
@@ -17,6 +20,7 @@ const BudgetDurationDropdown: React.FC<BudgetDurationDropdownProps> = ({
   className = "",
   style = {},
   placeholder = "n/a",
+  showNeverResets = false,
 }) => {
   return (
     <Select
@@ -27,6 +31,7 @@ const BudgetDurationDropdown: React.FC<BudgetDurationDropdownProps> = ({
       placeholder={placeholder}
       allowClear
     >
+      {showNeverResets ? <Option value={NEVER_RESETS_BUDGET_DURATION}>Never resets</Option> : null}
       <Option value="1h">hourly</Option>
       <Option value="24h">daily</Option>
       <Option value="7d">weekly</Option>

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx
@@ -249,7 +249,16 @@ vi.mock("../molecules/notifications_manager", () => ({
 }));
 
 vi.mock("../agent_management/AgentSelector", () => ({ default: () => null }));
-vi.mock("../common_components/budget_duration_dropdown", () => ({ default: () => null }));
+vi.mock("../common_components/budget_duration_dropdown", () => ({
+  NEVER_RESETS_BUDGET_DURATION: "none",
+  default: ({ showNeverResets, onChange }: { showNeverResets?: boolean; onChange?: (value: string) => void }) => (
+    <select data-testid="budget-duration-dropdown" onChange={(event) => onChange?.(event.target.value)}>
+      <option value="">n/a</option>
+      {showNeverResets ? <option value="none">Never resets</option> : null}
+      <option value="30d">monthly</option>
+    </select>
+  ),
+}));
 vi.mock("../common_components/check_openapi_schema", () => ({ default: () => null }));
 vi.mock("../common_components/KeyLifecycleSettings", () => ({ default: () => null }));
 vi.mock("../common_components/ModelAliasManager", () => ({ default: () => null }));
@@ -818,6 +827,60 @@ describe("CreateKey", () => {
       expect(getPromptsList).not.toHaveBeenCalled();
       expect(screen.queryByPlaceholderText(POLICIES_PLACEHOLDER)).not.toBeInTheDocument();
       expect(screen.queryByPlaceholderText(PROMPTS_PLACEHOLDER)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("budget reset", () => {
+    const openModal = async () => {
+      renderWithProviders(<CreateKey {...defaultProps} />);
+
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: /create new key/i }));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("budget-duration-dropdown")).toBeInTheDocument();
+      });
+    };
+
+    const submit = async () => {
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: /create key/i }));
+      });
+
+      await waitFor(() => {
+        expect(mockKeyCreateCall).toHaveBeenCalled();
+      });
+
+      return mockKeyCreateCall.mock.calls[0][2];
+    };
+
+    it("should send an explicit null budget_duration when 'Never resets' is selected", async () => {
+      await openModal();
+
+      expect(screen.getByRole("option", { name: "Never resets" })).toBeInTheDocument();
+
+      act(() => {
+        fireEvent.change(screen.getByTestId("budget-duration-dropdown"), { target: { value: "none" } });
+        formMock.setFieldValue("key_alias", "Never Resets Key");
+      });
+
+      const formValues = await submit();
+
+      expect("budget_duration" in formValues).toBe(true);
+      expect(formValues.budget_duration).toBeNull();
+    });
+
+    it("should omit budget_duration entirely when the reset dropdown is untouched", async () => {
+      await openModal();
+
+      act(() => {
+        formMock.setFieldValue("key_alias", "Inherits Default Key");
+      });
+
+      const formValues = await submit();
+
+      expect("budget_duration" in formValues).toBe(false);
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -18,7 +18,7 @@ import { rolesWithWriteAccess } from "../../utils/roles";
 import AgentSelector from "../agent_management/AgentSelector";
 import { mapDisplayToInternalNames } from "../callback_info_helpers";
 import AccessGroupSelector from "../common_components/AccessGroupSelector";
-import BudgetDurationDropdown from "../common_components/budget_duration_dropdown";
+import BudgetDurationDropdown, { NEVER_RESETS_BUDGET_DURATION } from "../common_components/budget_duration_dropdown";
 import SchemaFormFields from "../common_components/check_openapi_schema";
 import KeyLifecycleSettings from "../common_components/KeyLifecycleSettings";
 import ModelAliasManager from "../common_components/ModelAliasManager";
@@ -540,6 +540,10 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
 
       if (Object.keys(budgetFallbacks).length > 0) {
         formValues.budget_fallbacks = budgetFallbacks;
+      }
+
+      if (formValues.budget_duration === NEVER_RESETS_BUDGET_DURATION) {
+        formValues.budget_duration = null;
       }
 
       let response;
@@ -1064,6 +1068,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                     help={`Team Reset Budget: ${team?.budget_duration !== null && team?.budget_duration !== undefined ? team?.budget_duration : "None"}`}
                   >
                     <BudgetDurationDropdown
+                      showNeverResets
                       placeholder="Never resets"
                       onChange={(value) => form.setFieldValue("budget_duration", value)}
                     />

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
@@ -959,6 +959,83 @@ describe("TeamInfoView", () => {
         );
       });
     });
+
+    const openSettingsEditorForTeam = async (
+      user: ReturnType<typeof userEvent.setup>,
+      teamOverrides: Record<string, unknown>,
+    ) => {
+      vi.mocked(networking.teamInfoCall).mockResolvedValue(createMockTeamData(teamOverrides));
+      vi.mocked(networking.teamUpdateCall).mockResolvedValue({ data: {}, team_id: "123" } as any);
+
+      renderWithProviders(<TeamInfoView {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.queryAllByText("Test Team").length).toBeGreaterThan(0);
+      });
+
+      await user.click(screen.getByRole("tab", { name: "Settings" }));
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /edit settings/i }));
+      await waitFor(() => {
+        expect(screen.getByLabelText("Team Name")).toBeInTheDocument();
+      });
+
+      return screen.getByText("Reset Budget").closest(".ant-form-item") as HTMLElement;
+    };
+
+    it("should send an explicit null budget_duration when a stored Reset Budget is cleared", async () => {
+      const user = userEvent.setup({ delay: null });
+      const resetBudgetItem = await openSettingsEditorForTeam(user, { budget_duration: "30d" });
+
+      const clearIcon = resetBudgetItem.querySelector(".ant-select-clear");
+      expect(clearIcon).not.toBeNull();
+      fireEvent.mouseDown(clearIcon as Element);
+
+      await waitFor(() => {
+        expect(within(resetBudgetItem).getByText("Never resets")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(networking.teamUpdateCall).toHaveBeenCalled();
+      });
+
+      const updateArg = vi.mocked(networking.teamUpdateCall).mock.calls[0][1];
+      expect(updateArg.budget_duration).toBeNull();
+      expect(JSON.stringify(updateArg)).toContain('"budget_duration":null');
+    });
+
+    it("should keep a stored Reset Budget when the form is saved untouched", async () => {
+      const user = userEvent.setup({ delay: null });
+      await openSettingsEditorForTeam(user, { budget_duration: "30d" });
+
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(networking.teamUpdateCall).toHaveBeenCalled();
+      });
+
+      expect(vi.mocked(networking.teamUpdateCall).mock.calls[0][1].budget_duration).toBe("30d");
+    });
+
+    it("should send the newly picked budget_duration when one is selected", async () => {
+      const user = userEvent.setup({ delay: null });
+      const resetBudgetItem = await openSettingsEditorForTeam(user, { budget_duration: null });
+
+      await user.click(within(resetBudgetItem).getByRole("combobox"));
+      await user.click(await screen.findByText("weekly"));
+
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(networking.teamUpdateCall).toHaveBeenCalled();
+      });
+
+      expect(vi.mocked(networking.teamUpdateCall).mock.calls[0][1].budget_duration).toBe("7d");
+    });
   });
 
   describe("metadata key-value editing", () => {

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -36,6 +36,7 @@ import { CheckIcon, CopyIcon } from "lucide-react";
 import React, { useEffect, useMemo, useState } from "react";
 import { copyToClipboard as utilCopyToClipboard } from "../../utils/dataUtils";
 import AccessGroupSelector from "../common_components/AccessGroupSelector";
+import BudgetDurationDropdown from "../common_components/budget_duration_dropdown";
 import {
   computeTeamModelBadges,
   normalizeTeamModelSelection,
@@ -526,7 +527,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         model_rpm_limit: modelRpmLimit,
         max_budget: values.max_budget,
         soft_budget: sanitizeNumeric(values.soft_budget),
-        budget_duration: values.budget_duration,
+        budget_duration: values.budget_duration ?? null,
         metadata: {
           ...parsedMetadata,
           ...passthroughRoutesMetadata,
@@ -1152,11 +1153,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     </Accordion>
 
                     <Form.Item label="Reset Budget" name="budget_duration">
-                      <Select placeholder="n/a">
-                        <Select.Option value="24h">daily</Select.Option>
-                        <Select.Option value="7d">weekly</Select.Option>
-                        <Select.Option value="30d">monthly</Select.Option>
-                      </Select>
+                      <BudgetDurationDropdown placeholder="Never resets" />
                     </Form.Item>
 
                     <Form.Item label="Tokens per minute Limit (TPM)" name="tpm_limit">

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -4333,7 +4333,7 @@ export interface paths {
         };
         /**
          * Get Default Team Settings
-         * @description Get all SSO settings from the litellm_settings configuration.
+         * @description Get the default team parameters (litellm_settings.default_team_params).
          *     Returns a structured object with values and descriptions for UI display.
          */
         get: operations["get_default_team_settings_get_default_team_settings_get"];
@@ -14723,8 +14723,9 @@ export interface paths {
         head?: never;
         /**
          * Update Default Team Settings
-         * @description Update the default team parameters for SSO users.
-         *     These settings will be applied to new teams created from SSO.
+         * @description Update the default team parameters (litellm_settings.default_team_params).
+         *     Applied to every new team for fields not explicitly provided in the create request;
+         *     `models` only applies to teams automatically created via SSO Groups.
          */
         patch: operations["update_default_team_settings_update_default_team_settings_patch"];
         trace?: never;
@@ -24336,22 +24337,23 @@ export interface components {
         };
         /**
          * DefaultTeamSSOParams
-         * @description Default parameters to apply when a new team is automatically created by LiteLLM via SSO Groups
+         * @description Default parameters applied to every /team/new call for fields not explicitly provided in the request.
+         *     `models` is the exception: it only applies to teams automatically created by LiteLLM via SSO Groups.
          */
         DefaultTeamSSOParams: {
             /**
              * Budget Duration
-             * @description Default budget duration for new automatically created teams (e.g. 'daily', 'weekly', 'monthly')
+             * @description Default budget duration for new teams, when not explicitly provided (e.g. '24h', '7d', '30d')
              */
             budget_duration?: string | null;
             /**
              * Max Budget
-             * @description Default maximum budget (in USD) for new automatically created teams
+             * @description Default maximum budget (in USD) for new teams, when not explicitly provided
              */
             max_budget?: number | null;
             /**
              * Models
-             * @description Default list of models that new automatically created teams can access
+             * @description Default list of models for teams automatically created via SSO Groups
              * @default []
              */
             models: string[];
@@ -24362,7 +24364,7 @@ export interface components {
             organization_id?: string | null;
             /**
              * Rpm Limit
-             * @description Default rpm limit for new automatically created teams
+             * @description Default rpm limit for new teams, when not explicitly provided
              */
             rpm_limit?: number | null;
             /**
@@ -24372,7 +24374,7 @@ export interface components {
             team_member_permissions?: components["schemas"]["KeyManagementRoutes"][] | null;
             /**
              * Tpm Limit
-             * @description Default tpm limit for new automatically created teams
+             * @description Default tpm limit for new teams, when not explicitly provided
              */
             tpm_limit?: number | null;
         };


### PR DESCRIPTION
## TLDR

Problem this solves:

- Configured defaults overwrite a deliberate "no budget reset" on team and key create
- Explicitly sending `budget_duration: null` was indistinguishable from omitting it
- Team UI forms had no way to pick or restore "never resets"

How it solves it:

- `/team/new` and `/key/generate` skip the configured default for an explicitly-null `budget_duration`
- Other fields keep default-fill on null, so limits cannot be nulled away
- Team and key create forms gain a "Never resets" option sending explicit null
- Team edit form gains a clearable dropdown that persists the clear
- `default_team_params` docstrings now match the docs site (applies to all teams, not just SSO)

## User Flow

Before: an admin who wants a team budget that never resets cannot get one; every new team comes back with a 30 day reset

1. The proxy has a monthly budget reset configured under the Default Team Settings tab at http://localhost:4000/ui/?page=teams
2. The admin clicks Create New Team, sets a Max Budget, and leaves Reset Budget untouched on "n/a" (there is no selectable "no reset" choice)
3. The created team shows Reset: 30d and a Budget Reset date on the 1st of next month
4. They open the team's Settings tab to remove the interval, but the Reset Budget dropdown has no empty choice and no clear button, so the 30 day reset is permanent

After: the same admin can pick "Never resets" at creation and can clear the interval on any existing team

1. The proxy has a monthly budget reset configured under the Default Team Settings tab at http://localhost:4000/ui/?page=teams
2. The admin clicks Create New Team, sets a Max Budget, and picks "Never resets" in the Reset Budget dropdown, whose placeholder now reads "Default: monthly (30d)"
3. The created team shows Budget Reset: Never
4. On an older team stuck at 30d, they open Settings, click the clear icon on the Reset Budget field, save, and the team shows Budget Reset: Never
5. Leaving the field untouched still inherits the configured monthly default, exactly as before

## Relevant issues

## Linear ticket

Refs LIT-4309

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on port 4309 with the dev config plus:

```yaml
litellm_settings:
  default_team_params:
    budget_duration: 30d
    max_budget: 100
```

Before, at 32535987e8: an explicit null is silently overridden by the configured default

```
$ curl -s http://localhost:4309/team/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"team_alias": "lit4309-qa-before-explicit-null", "budget_duration": null, "max_budget": 25}'
{
 "team_alias": "lit4309-qa-before-explicit-null",
 "budget_duration": "30d",
 "budget_reset_at": "2026-09-01T00:00:00Z",
 "max_budget": 25.0
}
```

After, at 1224f85a64: explicit null wins, so the team never resets

```
$ curl -s http://localhost:4309/team/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"team_alias": "lit4309-qa-explicit-null", "budget_duration": null, "max_budget": 25}'
{
 "team_alias": "lit4309-qa-explicit-null",
 "budget_duration": null,
 "budget_reset_at": null,
 "max_budget": 25.0
}
```

Omitting the field still inherits the configured default, unchanged from before

```
$ curl -s http://localhost:4309/team/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"team_alias": "lit4309-qa-omitted"}'
{
 "team_alias": "lit4309-qa-omitted",
 "budget_duration": "30d",
 "budget_reset_at": "2026-09-01T00:00:00Z",
 "max_budget": 100.0
}
```

And clearing an existing team's interval over the API persists

```
$ curl -s http://localhost:4309/team/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"team_id": "b723c1cf-...", "budget_duration": null}'
{
 "budget_duration": null,
 "budget_reset_at": null
}
```

Key level, at 601a56b49c, with `default_key_generate_params: {budget_duration: 30d}`: omitted inherits, explicit null wins

```
$ curl -s http://localhost:4309/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"key_alias": "lit4309-key-omitted"}'
{"key_alias": "lit4309-key-omitted", "budget_duration": "30d", ...}
$ curl -s "http://localhost:4309/key/info?key=<that key>" -H 'Authorization: Bearer sk-1234'
{"budget_duration": "30d", "budget_reset_at": "2026-09-01T00:00:00+00:00", ...}

$ curl -s http://localhost:4309/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"key_alias": "lit4309-key-explicit-null", "budget_duration": null}'
{"key_alias": "lit4309-key-explicit-null", "budget_duration": null, "budget_reset_at": null, ...}
```

With `upperbound_key_generate_params: {budget_duration: 30d}` instead, at 76c5374bd4: both omitted and explicit null are filled to "30d", since the upperbound is an admin ceiling that callers cannot opt out of

At 8e40e19a45, the opt-out is scoped to `budget_duration` only: nulling a limit field still inherits its default

```
$ curl -s http://localhost:4309/team/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"team_alias": "lit4309-qa-null-both", "budget_duration": null, "max_budget": null}'
{"budget_duration": null, "budget_reset_at": null, "max_budget": 100.0, ...}
```

UI, create team modal. Before: placeholder is a bare "n/a" that is not selectable, and the only options are daily, weekly, monthly, so "never resets" cannot be expressed. After: a real "Never resets" option, and the placeholder surfaces the configured default

<img src="https://raw.githubusercontent.com/BerriAI/litellm/361a00e57fc70fe4c2ffbe4cbe0919ee80a9c333/before_team_create.png" width="49%" alt="Before: create team reset budget dropdown"> <img src="https://raw.githubusercontent.com/BerriAI/litellm/361a00e57fc70fe4c2ffbe4cbe0919ee80a9c333/after_team_create.png" width="49%" alt="After: create team reset budget dropdown with Never resets and default placeholder">

UI, team settings edit form, hovering the Reset Budget field. Before: no clear affordance, so a team stuck on monthly can never go back to lifetime. After: the field is clearable, and clearing then saving persists an explicit null

<img src="https://raw.githubusercontent.com/BerriAI/litellm/361a00e57fc70fe4c2ffbe4cbe0919ee80a9c333/before_team_edit.png" width="49%" alt="Before: team settings reset budget without clear icon"> <img src="https://raw.githubusercontent.com/BerriAI/litellm/361a00e57fc70fe4c2ffbe4cbe0919ee80a9c333/after_team_edit_clear.png" width="49%" alt="After: team settings reset budget with clear icon on hover">

## Type

🐛 Bug Fix

## Caveats (if any)

- `default_team_params` still applies to manual creates, matching the docs site; unchanged
- Team edit save now sends explicit null when blank; server outcome identical
- Team forms now also offer hourly, matching key and user forms
- Explicit-null opt-out is `budget_duration` only, per review: nulling `max_budget`/`tpm_limit`/`rpm_limit` still takes the default
- `upperbound_key_generate_params` still fills omitted AND explicitly-null fields; caps are not opt-out

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
