### PR TITLE
fix(ollama): ensure streaming chunks share consistent id and tool_calls finish_reason

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -164,9 +164,17 @@ class OllamaChatConfig(BaseConfig):
                 optional_params["repeat_penalty"] = value
             if param == "stop":
                 optional_params["stop"] = value
-            if param == "response_format" and isinstance(value, dict) and value.get("type") == "json_object":
+            if (
+                param == "response_format"
+                and isinstance(value, dict)
+                and value.get("type") == "json_object"
+            ):
                 optional_params["format"] = "json"
-            if param == "response_format" and isinstance(value, dict) and value.get("type") == "json_schema":
+            if (
+                param == "response_format"
+                and isinstance(value, dict)
+                and value.get("type") == "json_schema"
+            ):
                 if value.get("json_schema") and value["json_schema"].get("schema"):
                     optional_params["format"] = value["json_schema"]["schema"]
             if param == "reasoning_effort" and value is not None:
@@ -265,7 +273,9 @@ class OllamaChatConfig(BaseConfig):
                             )
                         )
                         new_tools.append(ollama_tool_call)
-            reasoning_content, parsed_content = _extract_reasoning_content(cast(dict, m))
+            reasoning_content, parsed_content = _extract_reasoning_content(
+                cast(dict, m)
+            )
             content_str = convert_content_list_to_str(cast(AllMessageValues, m))
             images = extract_images_from_message(cast(AllMessageValues, m))
 
@@ -337,13 +347,17 @@ class OllamaChatConfig(BaseConfig):
         response_json: Final = raw_response.json()
 
         ## RESPONSE OBJECT
-        _done_reason: Final = map_finish_reason(response_json.get("done_reason") or "stop")
+        _done_reason: Final = map_finish_reason(
+            response_json.get("done_reason") or "stop"
+        )
         model_response.choices[0].finish_reason = _done_reason
         response_json_message: Final = response_json.get("message")
         if response_json_message is not None:
             if "thinking" in response_json_message:
                 # remap 'thinking' to 'reasoning_content'
-                response_json_message["reasoning_content"] = response_json_message["thinking"]
+                response_json_message["reasoning_content"] = response_json_message[
+                    "thinking"
+                ]
                 del response_json_message["thinking"]
             elif response_json_message.get("content") is not None:
                 # parse reasoning content from content
@@ -351,7 +365,9 @@ class OllamaChatConfig(BaseConfig):
                     _parse_content_for_reasoning,
                 )
 
-                reasoning_content, content = _parse_content_for_reasoning(response_json_message["content"])
+                reasoning_content, content = _parse_content_for_reasoning(
+                    response_json_message["content"]
+                )
                 response_json_message["reasoning_content"] = reasoning_content
                 response_json_message["content"] = content
 
@@ -367,8 +383,12 @@ class OllamaChatConfig(BaseConfig):
                     {
                         "id": f"call_{uuid.uuid4()}",
                         "function": {
-                            "name": function_call.get("name", litellm_params.get("function_name")),
-                            "arguments": json.dumps(function_call.get("arguments", function_call)),
+                            "name": function_call.get(
+                                "name", litellm_params.get("function_name")
+                            ),
+                            "arguments": json.dumps(
+                                function_call.get("arguments", function_call)
+                            ),
                         },
                         "type": "function",
                     }
@@ -386,7 +406,9 @@ class OllamaChatConfig(BaseConfig):
                 model_response.choices[0].finish_reason = "tool_calls"
         model_response.created = int(time.time())
         model_response.model = "ollama_chat/" + model
-        prompt_tokens = response_json.get("prompt_eval_count", litellm.token_counter(messages=messages))
+        prompt_tokens = response_json.get(
+            "prompt_eval_count", litellm.token_counter(messages=messages)
+        )
         completion_tokens: Final = response_json.get(
             "eval_count",
             litellm.token_counter(text=response_json["message"]["content"]),
@@ -402,8 +424,12 @@ class OllamaChatConfig(BaseConfig):
         )
         return model_response
 
-    def get_error_class(self, error_message: str, status_code: int, headers: dict | Headers) -> BaseLLMException:
-        return OllamaError(status_code=status_code, message=error_message, headers=headers)
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: dict | Headers
+    ) -> BaseLLMException:
+        return OllamaError(
+            status_code=status_code, message=error_message, headers=headers
+        )
 
     def get_model_response_iterator(
         self,
@@ -422,6 +448,12 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
     started_reasoning_content: bool = False
     finished_reasoning_content: bool = False
     saw_tool_calls: bool = False
+
+    def __init__(
+        self, streaming_response, sync_stream: bool, json_mode: bool | None = False
+    ):
+        super().__init__(streaming_response, sync_stream, json_mode)
+        self.response_id: str = str(uuid.uuid4())
 
     def _is_function_call_complete(self, function_args: str | dict) -> bool:
         if isinstance(function_args, dict):
@@ -472,10 +504,14 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
                     function_args = tool_call.get("function").get("arguments")
                     if function_args is not None and len(function_args) > 0:
                         if isinstance(function_args, dict):
-                            tool_call["function"]["arguments"] = json.dumps(function_args)
-                        is_function_call_complete = self._is_function_call_complete(function_args)
+                            tool_call["function"]["arguments"] = json.dumps(
+                                function_args
+                            )
+                        is_function_call_complete = self._is_function_call_complete(
+                            function_args
+                        )
                         if is_function_call_complete:
-                            tool_call["id"] = str(uuid.uuid4())
+                            tool_call["id"] = f"call_{uuid.uuid4()}"
 
             # PROCESS REASONING CONTENT
             reasoning_content: str | None = None
@@ -484,7 +520,10 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
                 reasoning_content = chunk["message"].get("thinking")
                 self.started_reasoning_content = True
             if chunk["message"].get("content"):
-                if self.started_reasoning_content and not self.finished_reasoning_content:
+                if (
+                    self.started_reasoning_content
+                    and not self.finished_reasoning_content
+                ):
                     self.finished_reasoning_content = True
 
                 message_content = chunk["message"].get("content")
@@ -497,7 +536,10 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
                     message_content = message_content.replace("</think>", "")
                     self.finished_reasoning_content = True
 
-                if self.started_reasoning_content and not self.finished_reasoning_content:
+                if (
+                    self.started_reasoning_content
+                    and not self.finished_reasoning_content
+                ):
                     reasoning_content = message_content
                 else:
                     content = message_content
@@ -533,11 +575,12 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             usage: Final = ChatCompletionUsageBlock(
                 prompt_tokens=chunk.get("prompt_eval_count", 0),
                 completion_tokens=chunk.get("eval_count", 0),
-                total_tokens=chunk.get("prompt_eval_count", 0) + chunk.get("eval_count", 0),
+                total_tokens=chunk.get("prompt_eval_count", 0)
+                + chunk.get("eval_count", 0),
             )
 
             return ModelResponseStream(
-                id=str(uuid.uuid4()),
+                id=self.response_id,
                 object="chat.completion.chunk",
                 created=int(time.time()),  # ollama created_at is in UTC
                 usage=usage,

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -421,6 +421,7 @@ class OllamaChatConfig(BaseConfig):
 class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
     started_reasoning_content: bool = False
     finished_reasoning_content: bool = False
+    saw_tool_calls: bool = False
 
     def _is_function_call_complete(self, function_args: str | dict) -> bool:
         if isinstance(function_args, dict):
@@ -466,9 +467,12 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             # process tool calls - if complete function arg - add id to tool call
             tool_calls: Final = chunk["message"].get("tool_calls")
             if tool_calls is not None:
+                self.saw_tool_calls = True
                 for tool_call in tool_calls:
                     function_args = tool_call.get("function").get("arguments")
                     if function_args is not None and len(function_args) > 0:
+                        if isinstance(function_args, dict):
+                            tool_call["function"]["arguments"] = json.dumps(function_args)
                         is_function_call_complete = self._is_function_call_complete(function_args)
                         if is_function_call_complete:
                             tool_call["id"] = str(uuid.uuid4())
@@ -506,9 +510,12 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
 
             if chunk["done"] is True:
                 finish_reason = chunk.get("done_reason") or "stop"
-                # Override finish_reason when tool_calls are present
+                # Override finish_reason when tool_calls are present in this
+                # chunk or were seen earlier in the stream.  Ollama sends tool
+                # calls in separate chunks, so the final done chunk may not
+                # contain them.
                 # Fixes: https://github.com/BerriAI/litellm/issues/18922
-                if tool_calls is not None:
+                if tool_calls is not None or self.saw_tool_calls:
                     finish_reason = "tool_calls"
                 choices = [
                     StreamingChoices(

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -92,7 +92,9 @@ class OllamaConfig(BaseConfig):
     repeat_penalty: float | None = None
     temperature: float | None = None
     seed: int | None = None
-    stop: list | None = None  # stop is a list based on this - https://github.com/ollama/ollama/pull/442
+    stop: list | None = (
+        None  # stop is a list based on this - https://github.com/ollama/ollama/pull/442
+    )
     tfs_z: float | None = None
     num_predict: int | None = None
     top_k: int | None = None
@@ -231,10 +233,16 @@ class OllamaConfig(BaseConfig):
           "name": "mistral"
         }'
         """
-        return OllamaModelInfo().get_model_info(model=model, api_base=api_base, api_key=api_key)
+        return OllamaModelInfo().get_model_info(
+            model=model, api_base=api_base, api_key=api_key
+        )
 
-    def get_error_class(self, error_message: str, status_code: int, headers: dict | Headers) -> BaseLLMException:
-        return OllamaError(status_code=status_code, message=error_message, headers=headers)
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: dict | Headers
+    ) -> BaseLLMException:
+        return OllamaError(
+            status_code=status_code, message=error_message, headers=headers
+        )
 
     def transform_response(
         self,
@@ -285,7 +293,9 @@ class OllamaConfig(BaseConfig):
                                     "id": f"call_{uuid.uuid4()}",
                                     "function": {
                                         "name": function_call["name"],
-                                        "arguments": json.dumps(function_call["arguments"]),
+                                        "arguments": json.dumps(
+                                            function_call["arguments"]
+                                        ),
                                     },
                                     "type": "function",
                                 }
@@ -306,8 +316,12 @@ class OllamaConfig(BaseConfig):
                     reasoning_content: str | None = None
                     content: str | None = None
                     if response_text is not None:
-                        reasoning_content, content = _parse_content_for_reasoning(response_text)
-                    message = litellm.Message(content=content, reasoning_content=reasoning_content)
+                        reasoning_content, content = _parse_content_for_reasoning(
+                            response_text
+                        )
+                    message = litellm.Message(
+                        content=content, reasoning_content=reasoning_content
+                    )
                     model_response.choices[0].message = message
                     model_response.choices[0].finish_reason = "stop"
         else:
@@ -349,7 +363,9 @@ class OllamaConfig(BaseConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        custom_prompt_dict: Final = litellm_params.get("custom_prompt_dict") or litellm.custom_prompt_dict
+        custom_prompt_dict: Final = (
+            litellm_params.get("custom_prompt_dict") or litellm.custom_prompt_dict
+        )
 
         text_completion_request: Final = litellm_params.get("text_completion")
         if model in custom_prompt_dict:
@@ -387,7 +403,9 @@ class OllamaConfig(BaseConfig):
         if format is not None:
             data["format"] = format
         if images is not None:
-            data["images"] = [_convert_image(convert_to_ollama_image(image)) for image in images]
+            data["images"] = [
+                _convert_image(convert_to_ollama_image(image)) for image in images
+            ]
         if think is not None:
             data["think"] = think
 
@@ -444,12 +462,17 @@ class OllamaConfig(BaseConfig):
 
 
 class OllamaTextCompletionResponseIterator(BaseModelResponseIterator):
-    def __init__(self, streaming_response, sync_stream: bool, json_mode: bool | None = False):
+    def __init__(
+        self, streaming_response, sync_stream: bool, json_mode: bool | None = False
+    ):
         super().__init__(streaming_response, sync_stream, json_mode)
         self.started_reasoning_content: bool = False
         self.finished_reasoning_content: bool = False
+        self.saw_tool_calls: bool = False
 
-    def _handle_string_chunk(self, str_line: str) -> GenericStreamingChunk | ModelResponseStream:
+    def _handle_string_chunk(
+        self, str_line: str
+    ) -> GenericStreamingChunk | ModelResponseStream:
         return self.chunk_parser(json.loads(str_line))
 
     def chunk_parser(self, chunk: dict) -> GenericStreamingChunk | ModelResponseStream:
@@ -464,7 +487,12 @@ class OllamaTextCompletionResponseIterator(BaseModelResponseIterator):
                 text = ""
                 is_finished = True
                 finish_reason = "stop"
-                prompt_eval_count: Final[int | None] = chunk.get("prompt_eval_count", None)
+                # Override finish_reason when tool_calls were detected in the stream
+                if self.saw_tool_calls:
+                    finish_reason = "tool_calls"
+                prompt_eval_count: Final[int | None] = chunk.get(
+                    "prompt_eval_count", None
+                )
                 eval_count: Final[int | None] = chunk.get("eval_count", None)
 
                 usage: ChatCompletionUsageBlock | None = None
@@ -482,6 +510,18 @@ class OllamaTextCompletionResponseIterator(BaseModelResponseIterator):
                 )
             elif chunk["response"]:
                 text = chunk["response"]
+                # Check if this chunk contains a JSON function call
+                if text and self.json_mode:
+                    try:
+                        parsed = json.loads(text)
+                        if (
+                            isinstance(parsed, dict)
+                            and "name" in parsed
+                            and "arguments" in parsed
+                        ):
+                            self.saw_tool_calls = True
+                    except (json.JSONDecodeError, TypeError):
+                        pass
                 reasoning_content: str | None = None
                 content: str | None = None
                 if text is not None:
@@ -492,7 +532,10 @@ class OllamaTextCompletionResponseIterator(BaseModelResponseIterator):
                         text = text.replace("</think>", "")
                         self.finished_reasoning_content = True
 
-                    if self.started_reasoning_content and not self.finished_reasoning_content:
+                    if (
+                        self.started_reasoning_content
+                        and not self.finished_reasoning_content
+                    ):
                         reasoning_content = text
                     else:
                         content = text
@@ -501,7 +544,9 @@ class OllamaTextCompletionResponseIterator(BaseModelResponseIterator):
                     choices=[
                         StreamingChoices(
                             index=0,
-                            delta=Delta(reasoning_content=reasoning_content, content=content),
+                            delta=Delta(
+                                reasoning_content=reasoning_content, content=content
+                            ),
                         )
                     ],
                     finish_reason=finish_reason,

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -906,3 +906,147 @@ class TestOllamaToolCallTransformation:
         assert tool_msg["content"] == "Sunny, 72°F"
         assert "tool_call_id" in tool_msg, "tool_call_id must be forwarded to Ollama"
         assert tool_msg["tool_call_id"] == "call_abc123"
+
+
+class TestOllamaStreamingToolCallId:
+    """Test that streaming chunks share a consistent id and tool_calls get call_ prefix."""
+
+    def test_streaming_chunks_have_consistent_id(self):
+        """All chunks in a streaming response must share the same id (OpenAI spec)."""
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+        first_id = iterator.response_id
+
+        chunk1 = {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {"role": "assistant", "content": "Hello"},
+            "done": False,
+        }
+        chunk2 = {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {"role": "assistant", "content": " world"},
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 5,
+            "eval_count": 2,
+        }
+
+        result1 = iterator.chunk_parser(chunk1)
+        result2 = iterator.chunk_parser(chunk2)
+
+        # Both chunks must have the same id
+        assert (
+            result1.id == first_id
+        ), f"First chunk id {result1.id} != expected {first_id}"
+        assert (
+            result2.id == first_id
+        ), f"Second chunk id {result2.id} != expected {first_id}"
+
+    def test_streaming_tool_call_id_has_call_prefix(self):
+        """Tool call ids in streaming must start with 'call_' like non-streaming."""
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        chunk = {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"location": "Tokyo"},
+                        }
+                    }
+                ],
+            },
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 10,
+            "eval_count": 5,
+        }
+
+        result = iterator.chunk_parser(chunk)
+        tool_call = result.choices[0].delta.tool_calls[0]
+        assert tool_call["id"].startswith(
+            "call_"
+        ), f"Expected 'call_' prefix, got: {tool_call['id']}"
+
+    def test_streaming_finish_reason_tool_calls(self):
+        """finish_reason must be 'tool_calls' when tool_calls present in done chunk."""
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        chunk = {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"location": "Tokyo"},
+                        }
+                    }
+                ],
+            },
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 10,
+            "eval_count": 5,
+        }
+
+        result = iterator.chunk_parser(chunk)
+        assert result.choices[0].finish_reason == "tool_calls"
+
+    def test_streaming_saw_tool_calls_propagates_to_done_chunk(self):
+        """If tool_calls seen in earlier chunk, done chunk must have finish_reason='tool_calls'."""
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        # First chunk: has tool_calls, not done
+        tool_chunk = {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"location": "Tokyo"},
+                        }
+                    }
+                ],
+            },
+            "done": False,
+        }
+        iterator.chunk_parser(tool_chunk)
+
+        # Second chunk: done, no tool_calls
+        done_chunk = {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 10,
+            "eval_count": 5,
+        }
+        result = iterator.chunk_parser(done_chunk)
+        assert result.choices[0].finish_reason == "tool_calls"


### PR DESCRIPTION
## Problem

When using Ollama with strict OpenAI API clients (e.g. Zed's coding agent), tool calling fails because:

1. **Each streaming chunk gets a different `id`**  OpenAI's spec requires all chunks in a streaming response to share the same `id`. Previously, `OllamaChatCompletionResponseIterator.chunk_parser` called `str(uuid.uuid4())` on every chunk, so the `tool_calls` chunk and the `finish_reason` chunk had different ids. Clients that use `id` to correlate chunks could not associate the tool call with the finish reason, causing tool arguments to be lost (received as `{}`).

2. **Streaming tool call `id` missing `call_` prefix**  The non-streaming path used `f"call_{uuid.uuid4()}"` but the streaming path used `str(uuid.uuid4())`, creating an inconsistency that some clients reject.

3. **Completion streaming `finish_reason` always `"stop"`**  `OllamaTextCompletionResponseIterator` hardcoded `finish_reason = "stop"` in the done chunk, even when a tool call was made. Clients requiring strict OpenAI spec compliance halt streaming and never execute the tool call.

## Fix

### `litellm/llms/ollama/chat/transformation.py`
- Added `__init__` to `OllamaChatCompletionResponseIterator` that generates a stable `self.response_id`
- Changed `chunk_parser` to return `id=self.response_id` instead of a fresh UUID per chunk
- Changed streaming tool call id to `f"call_{uuid.uuid4()}"` to match the non-streaming format

### `litellm/llms/ollama/completion/transformation.py`
- Added `saw_tool_calls` flag to `OllamaTextCompletionResponseIterator`
- Added JSON function call detection in the `response` branch (when `json_mode` is active)
- Override `finish_reason` to `"tool_calls"` in the done chunk when tool calls were detected

### `tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py`
Added `TestOllamaStreamingToolCallId` with 4 tests:
- `test_streaming_chunks_have_consistent_id`  all chunks share the same id
- `test_streaming_tool_call_id_has_call_prefix`  streaming tool call ids start with `call_`
- `test_streaming_finish_reason_tool_calls`  done chunk with tool_calls gets `finish_reason="tool_calls"`
- `test_streaming_saw_tool_calls_propagates_to_done_chunk`  tool_calls in earlier chunk propagate `finish_reason` to the done chunk

## Validation

```
tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py  30 passed
tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py  13 passed
```

All ruff/black checks pass on the modified source files.

## Related

- Fixes #18922