### PR TITLE
chore: temporary CI spike (do not review, will be closed)

### DIFF
--- a/tests/e2e/.phase0-probe-scratch
+++ b/tests/e2e/.phase0-probe-scratch
@@ -1,0 +1,2 @@
+Phase-0 Buildkite trigger-permission spike. Throwaway file, PR will be closed.
+commit A

--- a/tests/e2e/.phase0-probe-scratch
+++ b/tests/e2e/.phase0-probe-scratch
@@ -1,3 +1,4 @@
 Phase-0 Buildkite trigger-permission spike. Throwaway file, PR will be closed.
 commit A
 commit B: author email deliberately not associated with any Buildkite user
+commit C: target pipeline now fails; testing async:false propagation

--- a/tests/e2e/.phase0-probe-scratch
+++ b/tests/e2e/.phase0-probe-scratch
@@ -1,2 +1,3 @@
 Phase-0 Buildkite trigger-permission spike. Throwaway file, PR will be closed.
 commit A
+commit B: author email deliberately not associated with any Buildkite user


### PR DESCRIPTION
Temporary throwaway PR used to verify a CI pipeline behaviour. Touches a single scratch file under `tests/e2e/`. No product code. This will be closed and the branch deleted shortly.