### PR TITLE
fix(langfuse): emit otel trace version and release on the keys langfuse v4 reads

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -90,7 +90,6 @@ class LangfuseOtelLogger(OpenTelemetry):
             "generation_name": LangfuseSpanAttributes.GENERATION_NAME,
             "generation_id": LangfuseSpanAttributes.GENERATION_ID,
             "parent_observation_id": LangfuseSpanAttributes.PARENT_OBSERVATION_ID,
-            "version": LangfuseSpanAttributes.GENERATION_VERSION,
             "mask_input": LangfuseSpanAttributes.MASK_INPUT,
             "mask_output": LangfuseSpanAttributes.MASK_OUTPUT,
             "trace_user_id": LangfuseSpanAttributes.TRACE_USER_ID,
@@ -99,12 +98,17 @@ class LangfuseOtelLogger(OpenTelemetry):
             "trace_name": LangfuseSpanAttributes.TRACE_NAME,
             "trace_id": LangfuseSpanAttributes.TRACE_ID,
             "trace_metadata": LangfuseSpanAttributes.TRACE_METADATA,
-            "trace_version": LangfuseSpanAttributes.TRACE_VERSION,
-            "trace_release": LangfuseSpanAttributes.TRACE_RELEASE,
+            "trace_release": LangfuseSpanAttributes.RELEASE,
             "existing_trace_id": LangfuseSpanAttributes.EXISTING_TRACE_ID,
             "update_trace_keys": LangfuseSpanAttributes.UPDATE_TRACE_KEYS,
             "debug_langfuse": LangfuseSpanAttributes.DEBUG_LANGFUSE,
         }
+
+        version: Final = (
+            metadata.get("version") if metadata.get("version") is not None else metadata.get("trace_version")
+        )
+        if version is not None:
+            safe_set_attribute(span, LangfuseSpanAttributes.VERSION.value, version)
 
         for key, enum_attr in mapping.items():
             if key in metadata and metadata[key] is not None:

--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -105,7 +105,7 @@ class LangfuseOtelLogger(OpenTelemetry):
         }
 
         version: Final = (
-            metadata.get("version") if metadata.get("version") is not None else metadata.get("trace_version")
+            metadata.get("trace_version") if metadata.get("trace_version") is not None else metadata.get("version")
         )
         if version is not None:
             safe_set_attribute(span, LangfuseSpanAttributes.VERSION.value, version)

--- a/litellm/integrations/otel/presets/langfuse.py
+++ b/litellm/integrations/otel/presets/langfuse.py
@@ -42,9 +42,7 @@ def langfuse_dynamic_headers(params: StandardCallbackDynamicParams) -> dict[str,
     public_key: Final = params.get("langfuse_public_key")
     secret_key: Final = params.get("langfuse_secret_key")
     if public_key and secret_key:
-        return {
-            "Authorization": _V1Langfuse._get_langfuse_authorization_header(
-                public_key=public_key, secret_key=secret_key
-            )
-        }
+        return _V1Langfuse._build_langfuse_otel_headers(
+            _V1Langfuse._get_langfuse_authorization_header(public_key=public_key, secret_key=secret_key)
+        )
     return {}

--- a/litellm/types/integrations/langfuse_otel.py
+++ b/litellm/types/integrations/langfuse_otel.py
@@ -16,12 +16,13 @@ class LangfuseOtelConfig(BaseModel):
 
 class LangfuseSpanAttributes(str, Enum):
     LANGFUSE_ENVIRONMENT = "langfuse.environment"
+    VERSION = "langfuse.version"
+    RELEASE = "langfuse.release"
 
     # ---- Generation-level metadata ----
     GENERATION_NAME = "langfuse.generation.name"
     GENERATION_ID = "langfuse.generation.id"
     PARENT_OBSERVATION_ID = "langfuse.generation.parent_observation_id"
-    GENERATION_VERSION = "langfuse.generation.version"
     MASK_INPUT = "langfuse.generation.mask_input"
     MASK_OUTPUT = "langfuse.generation.mask_output"
 
@@ -36,8 +37,6 @@ class LangfuseSpanAttributes(str, Enum):
     TRACE_NAME = "langfuse.trace.name"
     TRACE_ID = "langfuse.trace.id"
     TRACE_METADATA = "langfuse.trace.metadata"
-    TRACE_VERSION = "langfuse.trace.version"
-    TRACE_RELEASE = "langfuse.trace.release"
     EXISTING_TRACE_ID = "langfuse.trace.existing_id"
     UPDATE_TRACE_KEYS = "langfuse.trace.update_keys"
 

--- a/tests/test_litellm/integrations/otel/test_otel_v2_dynamic.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_dynamic.py
@@ -1,5 +1,6 @@
 """Per-request multi-tenant credential routing (V1 parity)."""
 
+import base64
 import os
 import sys
 
@@ -40,6 +41,17 @@ def test_langfuse_dynamic_headers_need_both_keys():
         "langfuse_otel", {"langfuse_public_key": "pk", "langfuse_secret_key": "sk"}
     )
     assert headers is not None and "Authorization" in headers
+
+
+def test_langfuse_dynamic_headers_carry_v4_ingestion_version():
+    headers = dynamic_otlp_headers(
+        "langfuse_otel", {"langfuse_public_key": "pk", "langfuse_secret_key": "sk"}
+    )
+    expected_auth = "Basic " + base64.b64encode(b"pk:sk").decode()
+    assert headers == {
+        "Authorization": expected_auth,
+        "x-langfuse-ingestion-version": "4",
+    }
 
 
 def test_weave_dynamic_headers():

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -211,7 +211,7 @@ class TestLangfuseOtelIntegration:
                 LangfuseSpanAttributes.GENERATION_NAME.value: "gen-name",
                 LangfuseSpanAttributes.GENERATION_ID.value: "gen-id",
                 LangfuseSpanAttributes.PARENT_OBSERVATION_ID.value: "parent-id",
-                LangfuseSpanAttributes.GENERATION_VERSION.value: "v1",
+                LangfuseSpanAttributes.VERSION.value: "v1",
                 LangfuseSpanAttributes.MASK_INPUT.value: True,
                 LangfuseSpanAttributes.MASK_OUTPUT.value: False,
                 LangfuseSpanAttributes.TRACE_USER_ID.value: "user-123",
@@ -221,8 +221,7 @@ class TestLangfuseOtelIntegration:
                 LangfuseSpanAttributes.TRACE_NAME.value: "trace-name",
                 LangfuseSpanAttributes.TRACE_ID.value: "traceid",  # stripped dashes
                 LangfuseSpanAttributes.TRACE_METADATA.value: json.dumps({"k": "v"}),
-                LangfuseSpanAttributes.TRACE_VERSION.value: "t-ver",
-                LangfuseSpanAttributes.TRACE_RELEASE.value: "rel-1",
+                LangfuseSpanAttributes.RELEASE.value: "rel-1",
                 LangfuseSpanAttributes.EXISTING_TRACE_ID.value: "existing-id",
                 LangfuseSpanAttributes.UPDATE_TRACE_KEYS.value: json.dumps(
                     ["key1", "key2"]
@@ -239,6 +238,52 @@ class TestLangfuseOtelIntegration:
             assert (
                 actual == expected
             ), "Mismatch between expected and actual OTEL attribute mapping."
+
+    @pytest.mark.parametrize(
+        "metadata, expected_version",
+        [
+            (
+                {"version": "v-observation", "trace_version": "v-trace"},
+                "v-observation",
+            ),
+            ({"trace_version": "v-trace"}, "v-trace"),
+            ({"version": "v-observation"}, "v-observation"),
+            ({"version": "", "trace_version": "v-trace"}, ""),
+            ({}, None),
+        ],
+        ids=[
+            "observation-wins-and-becomes-trace-version",
+            "trace-only",
+            "observation-only",
+            "empty-observation-version-is-not-absent",
+            "neither-key-emits-nothing",
+        ],
+    )
+    def test_version_emitted_on_langfuse_v4_key(self, metadata, expected_version):
+        kwargs = {"litellm_params": {"metadata": {"trace_release": "rel-9", **metadata}}}
+
+        with patch(
+            "litellm.integrations.arize._utils.safe_set_attribute"
+        ) as mock_safe_set_attribute:
+            LangfuseOtelLogger._set_langfuse_specific_attributes(
+                MagicMock(), kwargs, None
+            )
+
+        emitted = {
+            call.args[1]: call.args[2] for call in mock_safe_set_attribute.call_args_list
+        }
+
+        if expected_version is None:
+            assert "langfuse.version" not in emitted
+        else:
+            assert emitted["langfuse.version"] == expected_version
+        assert emitted["langfuse.release"] == "rel-9"
+        for retired_key in (
+            "langfuse.generation.version",
+            "langfuse.trace.version",
+            "langfuse.trace.release",
+        ):
+            assert retired_key not in emitted
 
     def test_set_langfuse_specific_attributes_with_content(self):
         """Test that _set_langfuse_specific_attributes correctly sets observation.output with regular content response."""

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -211,7 +211,7 @@ class TestLangfuseOtelIntegration:
                 LangfuseSpanAttributes.GENERATION_NAME.value: "gen-name",
                 LangfuseSpanAttributes.GENERATION_ID.value: "gen-id",
                 LangfuseSpanAttributes.PARENT_OBSERVATION_ID.value: "parent-id",
-                LangfuseSpanAttributes.VERSION.value: "v1",
+                LangfuseSpanAttributes.VERSION.value: "t-ver",
                 LangfuseSpanAttributes.MASK_INPUT.value: True,
                 LangfuseSpanAttributes.MASK_OUTPUT.value: False,
                 LangfuseSpanAttributes.TRACE_USER_ID.value: "user-123",
@@ -244,18 +244,18 @@ class TestLangfuseOtelIntegration:
         [
             (
                 {"version": "v-observation", "trace_version": "v-trace"},
-                "v-observation",
+                "v-trace",
             ),
             ({"trace_version": "v-trace"}, "v-trace"),
             ({"version": "v-observation"}, "v-observation"),
-            ({"version": "", "trace_version": "v-trace"}, ""),
+            ({"version": "v-observation", "trace_version": ""}, ""),
             ({}, None),
         ],
         ids=[
-            "observation-wins-and-becomes-trace-version",
+            "trace-version-wins-as-documented",
             "trace-only",
-            "observation-only",
-            "empty-observation-version-is-not-absent",
+            "observation-version-is-the-fallback",
+            "empty-trace-version-is-not-absent",
             "neither-key-emits-nothing",
         ],
     )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every trace exported by the `langfuse_otel` callback reports `version` and `release` as null in Langfuse, because litellm writes them to attribute keys Langfuse v4 does not recognize. The values do reach Langfuse, they just land in the generic span attribute bag where nothing resolves them
- Team-scoped and key-scoped OTel v2 exports drop `x-langfuse-ingestion-version`, which the other three exporter paths already send. Langfuse treats those spans as legacy ingestion, which can delay them by up to ten minutes

How it solves it:

- Emits a single `langfuse.version` (Langfuse v4 lifts it to the trace when it sits on the root span, and litellm's langfuse_otel span is the root span) and `langfuse.release`, replacing `langfuse.generation.version`, `langfuse.trace.version` and `langfuse.trace.release`
- Routes `langfuse_dynamic_headers` through the existing `_build_langfuse_otel_headers` builder that the static and v1 dynamic paths already use, so all four exporter paths now agree

## Background

The wrong names date to #12956, which extended the OTel enum for parity with the vanilla Langfuse integration by prefixing litellm's own metadata key names into a `langfuse.trace.*` / `langfuse.generation.*` namespace. That namespace was local rather than taken from Langfuse, so the keys were never read. The same commit also produced `langfuse.trace.user_id` and `langfuse.trace.session_id`, and #13659 later corrected those two to `user.id` and `session.id` against Langfuse's published constants, leaving version and release behind. This finishes that correction against the same reference

## User Flow

A proxy configured with `litellm_settings.callbacks: ["langfuse_otel"]`, where callers set `trace_version`, `version` or `trace_release` in request `metadata`, either in the body on `/chat/completions` or through `langfuse_*` request headers. Those users can now filter and group by version and release in Langfuse instead of seeing null

## Relevant issues


## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against a real Langfuse Cloud project (server 4.10.0) and real Gemini calls, on the base tree first and then on this branch. Same config both times:

```yaml
model_list:
  - model_name: gemini-flash
    litellm_params:
      model: gemini/gemini-2.5-flash
      api_key: os.environ/GEMINI_API_KEY

litellm_settings:
  callbacks: ["langfuse_otel"]
```

Request:

```bash
curl -s -X POST "http://127.0.0.1:4071/v1/chat/completions" \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"say pong"}],
       "metadata":{"trace_name":"otel-demo","trace_user_id":"user-1","session_id":"sess-1",
                   "trace_version":"v9.9.9","trace_release":"rel-1",
                   "trace_metadata":{"team":"platform","env":"prod"}}}'
```

Read back through the Langfuse API:

```bash
curl -s -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" \
  "$LANGFUSE_HOST/api/public/traces?limit=1" \
  | python3 -c 'import json,sys; t=json.load(sys.stdin)["data"][0]; print("version:",t["version"]); print("release:",t["release"]); print("userId:",t["userId"]); print("sessionId:",t["sessionId"])'
```

Before, on `litellm_internal_staging`:

```
version: None
release: None
userId: user-1
sessionId: sess-1
```

and the span still carried the two values, unresolved, in its attribute bag:

```
langfuse-ish raw attrs on the generation span:
['langfuse.observation.type', 'langfuse.trace.name', 'langfuse.trace.version', 'langfuse.trace.release']
```

After, on this branch:

```
version: v9.9.9
release: rel-1
userId: user-1
sessionId: sess-1
```

Precedence check, same rig, sending both keys at once:

```bash
curl -s -X POST "http://127.0.0.1:4071/v1/chat/completions" \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"say pong"}],
       "metadata":{"trace_name":"otel-precedence","version":"v-observation-fallback","trace_version":"v-trace-wins"}}'
```

```
trace version     : v-trace-wins
generation version: v-trace-wins
```

## Type

🐛 Bug Fix

## Changes

`litellm/types/integrations/langfuse_otel.py` drops `GENERATION_VERSION` and `TRACE_VERSION` in favour of one `VERSION = "langfuse.version"`, and renames `TRACE_RELEASE` to `RELEASE` with the value `langfuse.release`. Two enum members holding the same string would have become Python aliases, so `TRACE_VERSION` would have silently collapsed into `GENERATION_VERSION` and disappeared from iteration; a single member is the honest shape

`litellm/integrations/langfuse/langfuse_otel.py` resolves the one remaining version slot before the mapping loop, preferring `trace_version` and falling back to `version`. Dict iteration order would otherwise have decided this silently

`litellm/integrations/otel/presets/langfuse.py` builds its per-request headers with `_build_langfuse_otel_headers`, matching the static preset and both v1 dynamic paths

## Caveats (if any)

Langfuse v4 exposes one `langfuse.version` per span and litellm emits one span, so when a caller sets both `trace_version` and `version` on the same request only one can survive. This keeps `trace_version`, matching both the documented contract in `docs/observability/langfuse_integration.md` ("set langfuse Trace Version (if not set, defaults to Generation Version)") and the legacy `langfuse` SDK callback. Callers setting only one of the two keys, which is the common case, are unaffected

`langfuse.trace.version` and `langfuse.trace.release` no longer appear on the span at all. They were inert as far as Langfuse ingestion was concerned, but they were visible as raw attributes, so anyone filtering a saved Langfuse view on those attribute names will need to move to `langfuse.version` and `langfuse.release`

The attribute half of this fix applies to the OTel v1 path. With `LITELLM_OTEL_V2` enabled, `langfuse_otel` resolves to the v2 logger and attributes come from `LangfuseMapper`, which emits neither version nor release today, along with several other trace fields. That parity gap is pre-existing and left for a follow-up. The header half of this fix does apply to v2

Several other attributes in the same mapping are also outside the v4 vocabulary, including `langfuse.generation.name`, `langfuse.generation.id`, `langfuse.generation.parent_observation_id`, `langfuse.trace.id`, `langfuse.trace.existing_id`, `langfuse.trace.update_keys` and `langfuse.debug`. They are inert rather than wrong, and none of them has a v4 replacement this PR is adding, so removing them would be behavior deletion with no compensating gain. Left alone deliberately. `langfuse.trace.metadata` is emitted as a flat JSON blob rather than the per-key form, and that flat form was confirmed working against a live Langfuse project, so it is also untouched

## QA runbook

Point a proxy at a Langfuse project with `callbacks: ["langfuse_otel"]`, send a chat completion carrying `trace_version` and `trace_release` in `metadata`, then open the trace in Langfuse and confirm the version and release fields are populated rather than empty. Repeat with a key-scoped or team-scoped Langfuse credential to confirm the export still arrives

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
