### PR TITLE
fix: enable reasoning_effort for Mistral reasoning models

### DIFF
--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -83,6 +83,18 @@ class MistralConfig(OpenAIGPTConfig):
     def get_config(cls):
         return super().get_config()
 
+    def _is_mistral_reasoning_model(self, model: str) -> bool:
+        """Return True for Mistral chat models that support reasoning_effort."""
+        if not model:
+            return False
+
+        normalized = model.lower()
+
+        if "magistral" in normalized:
+            return True
+
+        return "mistral-medium-3-5" in normalized or "mistral-small-latest" in normalized
+
     def get_supported_openai_params(self, model: str) -> list[str]:
         supported_params: Final = [
             "stream",
@@ -98,8 +110,9 @@ class MistralConfig(OpenAIGPTConfig):
             "parallel_tool_calls",
         ]
 
-        # Add reasoning support for magistral models
-        if "magistral" in model.lower():
+        # Add reasoning support for Mistral models that Mistral documents as
+        # supporting reasoning_effort / thinking.
+        if self._is_mistral_reasoning_model(model):
             supported_params.extend(["thinking", "reasoning_effort"])
 
         return supported_params
@@ -168,10 +181,10 @@ class MistralConfig(OpenAIGPTConfig):
                 optional_params["extra_body"] = {"random_seed": value}
             if param == "response_format":
                 optional_params["response_format"] = value
-            if param == "reasoning_effort" and "magistral" in model.lower():
+            if param == "reasoning_effort" and self._is_mistral_reasoning_model(model):
                 # Flag that we need to add reasoning system prompt
                 optional_params["_add_reasoning_prompt"] = True
-            if param == "thinking" and "magistral" in model.lower():
+            if param == "thinking" and self._is_mistral_reasoning_model(model):
                 # Flag that we need to add reasoning system prompt
                 optional_params["_add_reasoning_prompt"] = True
             if param == "parallel_tool_calls":
@@ -522,14 +535,18 @@ class MistralConfig(OpenAIGPTConfig):
     ) -> dict:
         """
         Transform the overall request to be sent to the API.
-        For magistral models, adds reasoning system prompt when reasoning_effort is specified.
+        For Mistral reasoning models, adds reasoning system prompt when reasoning_effort is specified.
 
         Returns:
             dict: The transformed request. Sent as the body of the API call.
         """
-        # Add reasoning system prompt if needed (for magistral models)
-        if "magistral" in model.lower() and optional_params.get("_add_reasoning_prompt", False):
+        # Add reasoning system prompt if needed for Mistral reasoning models.
+        # On any other model, strip the internal flag so it never leaks into the
+        # provider payload.
+        if self._is_mistral_reasoning_model(model):
             messages = self._add_reasoning_system_prompt_if_needed(messages, optional_params)
+        else:
+            optional_params.pop("_add_reasoning_prompt", None)
 
         # Call parent transform_request which handles _transform_messages
         return super().transform_request(

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -30847,9 +30847,9 @@
         "source": "https://docs.mistral.ai/models/model-cards/mistral-small-4-0-26-03",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_reasoning": true,
         "supports_vision": true
     },
     "mistral/mistral-small-3-2-2506": {

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -359,6 +359,113 @@ class TestMistralReasoningSupport:
         assert result.get("temperature") == 0.7
         assert "_add_reasoning_prompt" not in result
 
+    def test_is_mistral_reasoning_model(self):
+        """Test model detection covers documented reasoning models and rejects others."""
+        mistral_config = MistralConfig()
+
+        # Reasoning-capable models
+        assert mistral_config._is_mistral_reasoning_model("magistral-medium-latest") is True
+        assert mistral_config._is_mistral_reasoning_model("mistral/MAGISTRAL-SMALL-2506") is True
+        assert mistral_config._is_mistral_reasoning_model("mistral-medium-3-5") is True
+        assert mistral_config._is_mistral_reasoning_model("mistral/Mistral-Medium-3-5") is True
+        assert mistral_config._is_mistral_reasoning_model("mistral-small-latest") is True
+
+        # Edge and non-reasoning models
+        assert mistral_config._is_mistral_reasoning_model("") is False
+        assert mistral_config._is_mistral_reasoning_model("mistral-large-latest") is False
+
+    def test_get_supported_openai_params_medium_3_5_and_small_latest(self):
+        """Test that mistral-medium-3-5 and mistral-small-latest support reasoning params.
+
+        Regression for https://github.com/BerriAI/litellm/issues/36407.
+        """
+        mistral_config = MistralConfig()
+
+        for model in [
+            "mistral/mistral-medium-3-5",
+            "mistral-medium-3-5",
+            "mistral/mistral-small-latest",
+            "mistral-small-latest",
+        ]:
+            supported_params = mistral_config.get_supported_openai_params(model)
+            assert "reasoning_effort" in supported_params, f"Failed for model: {model}"
+            assert "thinking" in supported_params, f"Failed for model: {model}"
+
+    def test_get_supported_openai_params_legacy_models_excluded(self):
+        """Test that legacy / non-reasoning models do not gain reasoning params."""
+        mistral_config = MistralConfig()
+
+        for model in [
+            "mistral/mistral-large-latest",
+            "open-mistral-7b",
+            "mistral/mistral-7b-instruct",
+        ]:
+            supported_params = mistral_config.get_supported_openai_params(model)
+            assert "reasoning_effort" not in supported_params, f"Failed for model: {model}"
+            assert "thinking" not in supported_params, f"Failed for model: {model}"
+
+    def test_map_openai_params_reasoning_effort_medium_3_5_and_small_latest(self):
+        """Test that reasoning_effort maps for newly enabled reasoning models."""
+        mistral_config = MistralConfig()
+
+        for model in ["mistral/mistral-medium-3-5", "mistral/mistral-small-latest"]:
+            optional_params = {}
+            result = mistral_config.map_openai_params(
+                non_default_params={"reasoning_effort": "low"},
+                optional_params=optional_params,
+                model=model,
+                drop_params=False,
+            )
+            assert result.get("_add_reasoning_prompt") is True, f"Failed for model: {model}"
+
+    def test_transform_request_medium_3_5_adds_reasoning_prompt(self):
+        """Test transform_request adds the system prompt for mistral-medium-3-5."""
+        mistral_config = MistralConfig()
+
+        messages = [{"role": "user", "content": "What is 15 * 7?"}]
+        optional_params = {"_add_reasoning_prompt": True}
+
+        result = mistral_config.transform_request(
+            model="mistral/mistral-medium-3-5",
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+
+        assert len(result["messages"]) == 2
+        assert result["messages"][0]["role"] == "system"
+        assert "<think>" in result["messages"][0]["content"]
+        assert result["messages"][1]["role"] == "user"
+
+        # Internal flag must never reach the provider payload
+        assert "_add_reasoning_prompt" not in result
+
+    def test_transform_request_non_reasoning_model_strips_internal_flag(self):
+        """Regression: a stray internal flag must be stripped, not sent to Mistral.
+
+        Mistral's API rejects unknown fields (422 extra_forbidden), so an internal
+        key like _add_reasoning_prompt reaching the payload breaks the request.
+        """
+        mistral_config = MistralConfig()
+
+        messages = [{"role": "user", "content": "What is 15 * 7?"}]
+        optional_params = {"_add_reasoning_prompt": True}
+
+        result = mistral_config.transform_request(
+            model="mistral/mistral-large-latest",
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+
+        # No system prompt injected for non-reasoning models...
+        assert len(result["messages"]) == 1
+        assert result["messages"][0]["role"] == "user"
+        # ...and the internal flag must not leak into the provider payload
+        assert "_add_reasoning_prompt" not in result
+
 
 def test_mistral_streaming_chunk_preserves_thinking_blocks():
     """Ensure streaming chunks keep magistral reasoning content."""


### PR DESCRIPTION
## Summary

Enable `reasoning_effort` for Mistral chat models that Mistral documents as
supporting it, not just the models whose name contains `magistral`.

## Problem

`POST /v1/chat/completions` with `model=mistral-medium-3-5` and
`reasoning_effort` fails with:

```
litellm.UnsupportedParamsError: mistral does not support parameters:
['reasoning_effort'], for model=mistral-medium-3-5
```

This happens because the Mistral chat transformation only adds
`reasoning_effort`/`thinking` to the supported param set when the model name
contains `"magistral"`. `mistral-medium-3-5` does not match that check, so
LiteLLM rejects the parameter before it reaches Mistral.

## Why this is a real bug

Mistral's own docs state that `mistral-medium-3-5` supports adjustable
reasoning via `reasoning_effort`, and that `mistral-small-latest` does as
well. Rejecting a parameter that the provider accepts is a translation bug,
not a user configuration issue.

## Fix

Add a MistralConfig helper that decides whether a Mistral chat model supports
reasoning params according to Mistral's documented reasoning model set, and
use it in both:

- `get_supported_openai_params`, so `reasoning_effort`/`thinking` are accepted
- `map_openai_params`, so they are forwarded for the same models

At minimum, this enables the parameters for `magistral-*`, `mistral-medium-3-5`,
and `mistral-small-latest`, without enabling `reasoning_effort` for every
`mistral-*` model by default.

## Test plan

This is a request-translation/allowlist fix, so it can be verified without
hitting the real Mistral API:

- `MistralConfig.get_supported_openai_params("mistral-medium-3-5")` now
  includes `reasoning_effort`
- `MistralConfig.get_supported_openai_params("mistral-small-latest")` now
  includes `reasoning_effort`
- `MistralConfig.get_supported_openai_params("magistral-medium-latest")` still
  includes `reasoning_effort`
- Non-reasoning Mistral models such as legacy `mistral-7b` variants do not
  gain `reasoning_effort` from this change

## References

Fixes #36407