### PR TITLE
fix(interactions): accept the step-shaped input Google's Interactions API now requires

### DIFF
--- a/litellm/interactions/litellm_responses_transformation/transformation.py
+++ b/litellm/interactions/litellm_responses_transformation/transformation.py
@@ -2,13 +2,16 @@
 Transformation utilities for bridging Interactions API to Responses API.
 
 This module handles transforming between:
-- Interactions API format (Google's format with Turn[], system_instruction, etc.)
+- Interactions API format (Google's format with Step[], system_instruction, etc.)
 - Responses API format (OpenAI's format with input[], instructions, etc.)
 """
 
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Any, Final, cast
 
 from litellm.types.interactions import (
+    ConversationStep,
     InteractionInput,
     InteractionsAPIOptionalRequestParams,
     InteractionsAPIResponse,
@@ -18,6 +21,11 @@ from litellm.types.llms.openai import (
     ResponseInputParam,
     ResponsesAPIResponse,
 )
+
+STEP_TYPE_TO_RESPONSES_ROLE: Final[Mapping[str, str]] = MappingProxyType(
+    {"user_input": "user", "model_output": "assistant"}
+)
+INTERACTIONS_ROLE_TO_RESPONSES_ROLE: Final[Mapping[str, str]] = MappingProxyType({"model": "assistant"})
 
 
 class LiteLLMResponsesInteractionsConfig:
@@ -91,7 +99,8 @@ class LiteLLMResponsesInteractionsConfig:
 
         Interactions API input can be:
         - string: "Hello"
-        - Turn[]: [{"role": "user", "content": [...]}]
+        - Step[]: [{"type": "user_input", "content": [...]}]
+        - Turn[]: [{"role": "user", "content": [...]}], the shape Google replaced with Step[]
         - Content object
 
         Responses API input is:
@@ -103,46 +112,10 @@ class LiteLLMResponsesInteractionsConfig:
             return cast(ResponseInputParam, input)
 
         if isinstance(input, list):
-            # Turn[] format - convert to Responses API Message[] format
-            messages: Final = []
-            for turn in input:
-                if isinstance(turn, dict):
-                    role = turn.get("role", "user")
-                    content = turn.get("content", [])
-
-                    # Transform content array
-                    transformed_content = LiteLLMResponsesInteractionsConfig._transform_content_array(content)
-
-                    messages.append(
-                        {
-                            "role": role,
-                            "content": transformed_content,
-                        }
-                    )
-                elif isinstance(turn, Turn):
-                    # Pydantic model
-                    role = turn.role if hasattr(turn, "role") else "user"
-                    content = turn.content if hasattr(turn, "content") else []
-
-                    # Ensure content is a list for _transform_content_array
-                    # Cast to List[Any] to handle various content types
-                    if isinstance(content, list):
-                        content_list: list[Any] = list(content)
-                    elif content is not None:
-                        content_list = [content]
-                    else:
-                        content_list = []
-
-                    transformed_content = LiteLLMResponsesInteractionsConfig._transform_content_array(content_list)
-
-                    messages.append(
-                        {
-                            "role": role,
-                            "content": transformed_content,
-                        }
-                    )
-
-            return cast(ResponseInputParam, messages)
+            return cast(
+                ResponseInputParam,
+                [LiteLLMResponsesInteractionsConfig._transform_turn_to_message(turn) for turn in input],
+            )
 
         # Single content object - wrap in message
         if isinstance(input, dict):
@@ -160,6 +133,31 @@ class LiteLLMResponsesInteractionsConfig:
 
         # Fallback: convert to string
         return cast(ResponseInputParam, str(input))
+
+    @staticmethod
+    def _transform_turn_to_message(turn: ConversationStep | Turn | Mapping[str, Any] | str) -> Mapping[str, Any]:
+        """Map one turn of the conversation onto a Responses API message."""
+        if isinstance(turn, str):
+            return {"role": "user", "content": LiteLLMResponsesInteractionsConfig._transform_content_array([turn])}
+
+        fields: Final[Mapping[str, Any]] = turn if isinstance(turn, Mapping) else turn.model_dump()
+        content: Final[Any] = fields.get("content") or []
+        return {
+            "role": LiteLLMResponsesInteractionsConfig._responses_role(fields),
+            "content": LiteLLMResponsesInteractionsConfig._transform_content_array(
+                content if isinstance(content, list) else [content]
+            ),
+        }
+
+    @staticmethod
+    def _responses_role(turn_fields: Mapping[str, Any]) -> str:
+        """The Responses API role a turn speaks in, whether it is tagged by step type or by role."""
+        step_role: Final[str | None] = STEP_TYPE_TO_RESPONSES_ROLE.get(turn_fields.get("type") or "")
+        if step_role is not None:
+            return step_role
+
+        interactions_role: Final[str] = turn_fields.get("role") or "user"
+        return INTERACTIONS_ROLE_TO_RESPONSES_ROLE.get(interactions_role, interactions_role)
 
     @staticmethod
     def _transform_content_array(content: list[Any]) -> list[dict[str, Any]]:

--- a/litellm/types/interactions/README.md
+++ b/litellm/types/interactions/README.md
@@ -34,7 +34,9 @@ Then add the LiteLLM-specific types at the bottom of the generated file:
 **Content Types:**
 - `Content` - Union of all content types (text, image, audio, etc.)
 - `TextContent` - Text content with `type: "text"`
-- `Turn` - A turn in multi-turn conversation with `role` and `content`
+- `UserInputStep` / `ModelOutputStep` - A turn in a multi-turn conversation, tagged by `type`
+- `ConversationStep` - Either of the two step types above
+- `Turn` - The `role` + `content` turn Google replaced with steps, kept for callers still sending it
 
 **Tool Types:**
 - `Tool` - Union of all tool types

--- a/litellm/types/interactions/__init__.py
+++ b/litellm/types/interactions/__init__.py
@@ -18,6 +18,7 @@ from litellm.types.interactions.generated import (
     ContentDelta,
     ContentStart,
     ContentStop,
+    ConversationStep,
     CreateAgentInteractionParams,
     CreateModelInteractionParams,
     DeepResearchAgentConfig,
@@ -53,6 +54,7 @@ from litellm.types.interactions.generated import (
     McpServerToolCallContent,
     McpServerToolResultContent,
     ModelOption,
+    ModelOutputStep,
     ResponseModality,
     StepDelta,
     StepStart,
@@ -66,6 +68,7 @@ from litellm.types.interactions.generated import (
     UrlContextCallContent,
     UrlContextResultContent,
     Usage,
+    UserInputStep,
     VideoContent,
 )
 from litellm.types.interactions.generated import (
@@ -85,6 +88,7 @@ __all__ = [
     "ContentDelta",
     "ContentStart",
     "ContentStop",
+    "ConversationStep",
     "CreateAgentInteractionParams",
     # Generated types
     "CreateModelInteractionParams",
@@ -124,6 +128,7 @@ __all__ = [
     "McpServerToolCallContent",
     "McpServerToolResultContent",
     "ModelOption",
+    "ModelOutputStep",
     "ResponseModality",
     "StepDelta",
     # New schema SSE event types (Api-Revision: 2026-05-20)
@@ -138,5 +143,6 @@ __all__ = [
     "UrlContextCallContent",
     "UrlContextResultContent",
     "Usage",
+    "UserInputStep",
     "VideoContent",
 ]

--- a/litellm/types/interactions/generated.py
+++ b/litellm/types/interactions/generated.py
@@ -1046,12 +1046,37 @@ class InteractionSseEvent(
 # When regenerating this file, copy these types to the end.
 # See README.md for regeneration instructions.
 
+from collections.abc import Sequence
+
 from pydantic import PrivateAttr
 
 from litellm.types.llms.base import BaseLiteLLMOpenAIResponseObject
 
-# Type alias for input
-InteractionInput = str | Content | list[Content] | list[Turn]
+
+class UserInputStep(BaseModel):
+    """A conversation turn contributed by the user.
+
+    Google replaced `Turn`'s `role` field with the step's own `type`, so this is the
+    successor to `Turn(role="user")`.
+    """
+
+    type: Literal["user_input"] = "user_input"
+    content: Sequence[Content] | None = Field(None, description="The content of the step.")
+
+
+class ModelOutputStep(BaseModel):
+    """A conversation turn contributed by the model, the successor to `Turn(role="model")`."""
+
+    type: Literal["model_output"] = "model_output"
+    content: Sequence[Content] | None = Field(None, description="The content of the step.")
+
+
+# The subset of the spec's `Step` union that a caller replays as conversation history.
+ConversationStep = UserInputStep | ModelOutputStep
+
+# Type alias for input. `list[Turn]` is the shape Google dropped, kept so callers
+# written against it keep working.
+InteractionInput = str | Content | list[Content] | list[ConversationStep] | list[Turn]
 
 
 class InteractionsAPIResponse(BaseLiteLLMOpenAIResponseObject):

--- a/tests/test_litellm/interactions/interactions.openapi.json
+++ b/tests/test_litellm/interactions/interactions.openapi.json
@@ -1,0 +1,9423 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Gemini API",
+    "description": "The Gemini Interactions API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
+    "version": "v1beta",
+    "x-google-revision": "0"
+  },
+  "servers": [
+    {
+      "url": "https://generativelanguage.googleapis.com",
+      "description": "Global Endpoint"
+    }
+  ],
+  "paths": {
+    "/{api_version}/agents": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        }
+      ],
+      "get": {
+        "operationId": "ListAgents",
+        "description": "Lists all Agents.",
+        "parameters": [
+          {
+            "name": "page_size",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "page_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "parent",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "list": {
+                    "summary": "List Agents",
+                    "value": {
+                      "data": [
+                        {
+                          "created": "2025-11-26T12:25:15Z",
+                          "display_name": "My Research Agent",
+                          "id": "ag_abc123",
+                          "object": "agent",
+                          "system_instruction": "You are a helpful research assistant.",
+                          "updated": "2025-11-26T12:25:15Z"
+                        }
+                      ],
+                      "object": "list"
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListAgentsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "list",
+            "lang": "sh",
+            "source": "curl -X GET https://generativelanguage.googleapis.com/v1beta/agents \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "label": "list",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.agents.list()\nfor agent in response.agents or []:\n    print(agent.id)\n"
+          },
+          {
+            "label": "list",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst agents = await ai.agents.list();\nfor (const agent of (agents.agents ?? [])) {\n    console.log(agent.id);\n}\n"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "AgentListParams",
+            "group": "agents",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "agents",
+        "x-speakeasy-name-override": "list"
+      },
+      "post": {
+        "operationId": "CreateAgent",
+        "description": "Creates a new Agent (Typed version for SDK).",
+        "parameters": [],
+        "requestBody": {
+          "description": "The request body.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Agent"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "create": {
+                    "summary": "Create Agent",
+                    "value": {
+                      "created": "2025-11-26T12:25:15Z",
+                      "display_name": "My Research Agent",
+                      "id": "ag_abc123",
+                      "object": "agent",
+                      "system_instruction": "You are a helpful research assistant.",
+                      "tools": [
+                        {
+                          "type": "google_search"
+                        }
+                      ],
+                      "updated": "2025-11-26T12:25:15Z"
+                    }
+                  },
+                  "fork_from_env": {
+                    "summary": "Agent Forked from Environment",
+                    "value": {
+                      "created": "2025-11-26T12:25:15Z",
+                      "id": "my-data-analyst",
+                      "object": "agent",
+                      "system_instruction": "You are a data analyst. Use the template at /workspace/template.py for all reports.",
+                      "updated": "2025-11-26T12:25:15Z"
+                    }
+                  },
+                  "with_sources": {
+                    "summary": "Agent with Sources",
+                    "value": {
+                      "created": "2025-11-26T12:25:15Z",
+                      "id": "data-analyst-abc123",
+                      "object": "agent",
+                      "system_instruction": "You are a data analyst. Always include visualizations and export results as PDF.",
+                      "updated": "2025-11-26T12:25:15Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Agent"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "create",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/agents \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": \"research-assistant-abc123\",\n    \"base_agent\": \"antigravity-preview-05-2026\",\n    \"description\": \"A helpful research assistant.\",\n    \"system_instruction\": \"You are a helpful research assistant.\",\n    \"base_environment\": \"remote\",\n    \"tools\": [{\"type\": \"google_search\"}]\n  }'\n"
+          },
+          {
+            "label": "create",
+            "lang": "python",
+            "source": "import uuid\nfrom google import genai\n\nclient = genai.Client()\nagent = client.agents.create(\n    id=f\"research-assistant-{uuid.uuid4().hex[:8]}\",\n    base_agent=\"antigravity-preview-05-2026\",\n    description=\"A helpful research assistant.\",\n    system_instruction=\"You are a helpful research assistant.\",\n    base_environment=\"remote\",\n    tools=[{\"type\": \"google_search\"}],\n)\nprint(agent.id)\n\n# [cleanup]\nclient.agents.delete(agent.id)\n# [/cleanup]\n"
+          },
+          {
+            "label": "create",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst agentId = `research-assistant-${crypto.randomUUID().slice(0, 8)}`;\nconst agent = await ai.agents.create({\n    id: agentId,\n    base_agent: 'antigravity-preview-05-2026',\n    description: 'A helpful research assistant.',\n    system_instruction: 'You are a helpful research assistant.',\n    base_environment: 'remote',\n    tools: [{ type: 'google_search' }],\n});\nif (!agent.id) {\n    throw new Error('Agent creation failed: ID is undefined');\n}\nconsole.log(agent.id);\n\n// [cleanup]\nawait ai.agents.delete(agent.id);\n// [/cleanup]\n"
+          },
+          {
+            "label": "with_sources",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/agents \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": \"data-analyst-abc123\",\n    \"base_agent\": \"antigravity-preview-05-2026\",\n    \"system_instruction\": \"You are a data analyst. Always include visualizations and export results as PDF.\",\n    \"base_environment\": {\n      \"type\": \"remote\",\n      \"sources\": [\n        {\n          \"type\": \"inline\",\n          \"target\": \".agents/AGENTS.md\",\n          \"content\": \"Always use matplotlib for charts. Include a summary table in every report.\"\n        },\n        {\n          \"type\": \"repository\",\n          \"source\": \"https://github.com/my-org/analysis-templates\",\n          \"target\": \"/workspace/templates\"\n        }\n      ]\n    }\n  }'\n"
+          },
+          {
+            "label": "with_sources",
+            "lang": "python",
+            "source": "import uuid\nfrom google import genai\n\nclient = genai.Client()\nagent = client.agents.create(\n    id=f\"data-analyst-{uuid.uuid4().hex[:8]}\",\n    base_agent=\"antigravity-preview-05-2026\",\n    system_instruction=\"You are a data analyst. Always include visualizations and export results as PDF.\",\n    base_environment={\n        \"type\": \"remote\",\n        \"sources\": [\n            {\n                \"type\": \"inline\",\n                \"target\": \".agents/AGENTS.md\",\n                \"content\": \"Always use matplotlib for charts. Include a summary table in every report.\",\n            },\n            {\n                \"type\": \"repository\",\n                \"source\": \"https://github.com/my-org/analysis-templates\",\n                \"target\": \"/workspace/templates\",\n            },\n        ],\n    },\n)\nprint(f\"Created agent: {agent.id}\")\n\n# [cleanup]\nclient.agents.delete(agent.id)\n# [/cleanup]\n"
+          },
+          {
+            "label": "with_sources",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst agentId = `data-analyst-${crypto.randomUUID().slice(0, 8)}`;\nconst agent = await ai.agents.create({\n    id: agentId,\n    base_agent: 'antigravity-preview-05-2026',\n    system_instruction: 'You are a data analyst. Always include visualizations and export results as PDF.',\n    base_environment: {\n        type: 'remote',\n        sources: [\n            {\n                type: 'inline',\n                target: '.agents/AGENTS.md',\n                content: 'Always use matplotlib for charts. Include a summary table in every report.',\n            },\n            {\n                type: 'repository',\n                source: 'https://github.com/my-org/analysis-templates',\n                target: '/workspace/templates',\n            },\n        ],\n    },\n});\nconsole.log(`Created agent: ${agent.id}`);\n\n// [cleanup]\nif (agent.id) await ai.agents.delete(agent.id);\n// [/cleanup]\n"
+          },
+          {
+            "label": "fork_from_env",
+            "lang": "sh",
+            "source": "# Step 1: Set up the environment interactively\nRESPONSE=$(curl -s -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"agent\": \"antigravity-preview-05-2026\",\n    \"input\": \"Write a basic Hello World template to /workspace/template.py.\",\n    \"environment\": \"remote\"\n  }')\nENV_ID=$(echo $RESPONSE | python3 -c \"import sys,json; print(json.load(sys.stdin)['environment_id'])\")\n\n# Step 2: Fork that environment into a named agent\ncurl -X POST https://generativelanguage.googleapis.com/v1beta/agents \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d \"{\n    \\\"id\\\": \\\"my-data-analyst\\\",\n    \\\"base_agent\\\": \\\"antigravity-preview-05-2026\\\",\n    \\\"system_instruction\\\": \\\"You are a data analyst. Use the template at /workspace/template.py for all reports.\\\",\n    \\\"base_environment\\\": \\\"$ENV_ID\\\"\n  }\"\n"
+          },
+          {
+            "label": "fork_from_env",
+            "lang": "python",
+            "source": "import uuid\nfrom google import genai\n\nclient = genai.Client()\n\n# Step 1: Set up the environment interactively.\ninteraction = client.interactions.create(\n    agent=\"antigravity-preview-05-2026\",\n    input=\"Write a basic Hello World template to /workspace/template.py.\",\n    environment=\"remote\",\n)\n\n# Step 2: Fork that environment into a named agent.\nagent_id = f\"my-data-analyst-{uuid.uuid4().hex[:8]}\"\nagent = client.agents.create(\n    id=agent_id,\n    base_agent=\"antigravity-preview-05-2026\",\n    system_instruction=\"You are a data analyst. Use the template at /workspace/template.py for all reports.\",\n    base_environment=interaction.environment_id,\n)\nprint(f\"Forked agent: {agent.id}\")\n\n# [cleanup]\nclient.agents.delete(agent.id)\n# [/cleanup]\n"
+          },
+          {
+            "label": "fork_from_env",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\n\n// Step 1: Set up the environment interactively.\nconst interaction = await ai.interactions.create({\n    agent: 'antigravity-preview-05-2026',\n    input: 'Write a basic Hello World template to /workspace/template.py.',\n    environment: 'remote',\n});\n\n// Step 2: Fork that environment into a named agent.\nconst agentId = `my-data-analyst-${crypto.randomUUID().slice(0, 8)}`;\nconst agent = await ai.agents.create({\n    id: agentId,\n    base_agent: 'antigravity-preview-05-2026',\n    system_instruction: 'You are a data analyst. Use the template at /workspace/template.py for all reports.',\n    base_environment: interaction.environment_id,\n});\nconsole.log(`Forked agent: ${agent.id}`);\n\n// [cleanup]\nif (agent.id) await ai.agents.delete(agent.id);\n// [/cleanup]\n"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "AgentCreateParams",
+            "group": "agents",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "agents",
+        "x-speakeasy-name-override": "create"
+      }
+    },
+    "/{api_version}/agents/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "delete": {
+        "operationId": "DeleteAgent",
+        "description": "Deletes an Agent.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "delete": {
+                    "summary": "Delete Agent",
+                    "value": {}
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "delete",
+            "lang": "sh",
+            "source": "curl -X DELETE https://generativelanguage.googleapis.com/v1beta/agents/ag_abc123 \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "label": "delete",
+            "lang": "python",
+            "source": "import uuid\nfrom google import genai\n\nclient = genai.Client()\n\n# Create an agent so we have a valid ID to delete.\nagent_id = f\"delete-test-{uuid.uuid4().hex[:8]}\"\nclient.agents.create(\n    id=agent_id,\n    base_agent=\"waverunner\",\n    description=\"Temporary agent for deletion.\",\n    base_environment=\"remote\",\n)\n\nclient.agents.delete(agent_id)\nprint(\"Agent deleted successfully.\")\n"
+          },
+          {
+            "label": "delete",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\n\n// Create an agent so we have a valid ID to delete.\nconst agentId = `delete-test-${crypto.randomUUID().slice(0, 8)}`;\nawait ai.agents.create({\n    id: agentId,\n    base_agent: 'waverunner',\n    description: 'Temporary agent for deletion.',\n    base_environment: 'remote',\n});\n\nawait ai.agents.delete(agentId);\nconsole.log('Agent deleted successfully.');\n"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "AgentDeleteParams",
+            "group": "agents",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "agents",
+        "x-speakeasy-name-override": "delete"
+      },
+      "get": {
+        "operationId": "GetAgent",
+        "description": "Gets a specific Agent.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "get": {
+                    "summary": "Get Agent",
+                    "value": {
+                      "created": "2025-11-26T12:25:15Z",
+                      "display_name": "My Research Agent",
+                      "id": "ag_abc123",
+                      "object": "agent",
+                      "system_instruction": "You are a helpful research assistant.",
+                      "tools": [
+                        {
+                          "type": "google_search"
+                        }
+                      ],
+                      "updated": "2025-11-26T12:25:15Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Agent"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "get",
+            "lang": "sh",
+            "source": "curl -X GET https://generativelanguage.googleapis.com/v1beta/agents/ag_abc123 \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "label": "get",
+            "lang": "python",
+            "source": "import uuid\nfrom google import genai\n\nclient = genai.Client()\n\n# Create an agent so we have a valid ID to retrieve.\nagent_id = f\"test-agent-{uuid.uuid4().hex[:8]}\"\nclient.agents.create(\n    id=agent_id,\n    base_agent=\"waverunner\",\n    description=\"A test agent.\",\n    base_environment=\"remote\",\n)\n\nagent = client.agents.get(agent_id)\nprint(agent.id)\n\n# [cleanup]\nclient.agents.delete(agent.id)\n# [/cleanup]\n"
+          },
+          {
+            "label": "get",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\n\n// Create an agent so we have a valid ID to retrieve.\nconst agentId = `test-agent-${crypto.randomUUID().slice(0, 8)}`;\nawait ai.agents.create({\n    id: agentId,\n    base_agent: 'waverunner',\n    description: 'A test agent.',\n    base_environment: 'remote',\n});\n\nconst agent = await ai.agents.get(agentId);\nif (!agent.id) {\n    throw new Error('Agent retrieval failed: ID is undefined');\n}\nconsole.log(agent.id);\n\n// [cleanup]\nawait ai.agents.delete(agent.id);\n// [/cleanup]\n"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "AgentGetParams",
+            "group": "agents",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "agents",
+        "x-speakeasy-name-override": "get"
+      }
+    },
+    "/{api_version}/environments": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        }
+      ],
+      "get": {
+        "operationId": "ListEnvironments",
+        "description": "Lists environments.",
+        "parameters": [
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "Optional. Maximum number of environments to return.\\nIf unspecified, defaults to 50. Maximum is 1000.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "page_token",
+            "in": "query",
+            "description": "Optional. Pagination token.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListEnvironmentsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "environments"
+      },
+      "post": {
+        "operationId": "CreateEnvironment",
+        "description": "Creates an environment.",
+        "requestBody": {
+          "description": "Required. The environment to create.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEnvironmentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Environment"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "environments"
+      }
+    },
+    "/{api_version}/environments/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "description": "Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "delete": {
+        "operationId": "DeleteEnvironment",
+        "description": "Deletes an environment.",
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "environments"
+      },
+      "get": {
+        "operationId": "GetEnvironment",
+        "description": "Gets an environment.",
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Environment"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "environments"
+      }
+    },
+    "/{api_version}/interactions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        }
+      ],
+      "post": {
+        "operationId": "CreateInteraction",
+        "description": "Creates a new interaction.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/api_version"
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateAgentInteractionParams"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CreateModelInteractionParams"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "antigravity": {
+                    "summary": "Antigravity Agent",
+                    "value": {
+                      "agent": "antigravity-preview-05-2026",
+                      "created": "2025-11-26T12:22:47Z",
+                      "environment_id": "env_abc123",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "object": "interaction",
+                      "status": "completed",
+                      "steps": [
+                        {
+                          "type": "model_output",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "I've summarized the top 5 Hacker News stories and saved the results to /workspace/summary.md."
+                            }
+                          ]
+                        }
+                      ],
+                      "updated": "2025-11-26T12:22:47Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          {
+                            "modality": "text",
+                            "tokens": 50
+                          }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 50,
+                        "total_output_tokens": 500,
+                        "total_thought_tokens": 200,
+                        "total_tokens": 750,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "deep_research": {
+                    "summary": "Deep Research",
+                    "value": {
+                      "agent": "deep-research-pro-preview-12-2025",
+                      "created": "2025-11-26T12:22:47Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "object": "interaction",
+                      "status": "completed",
+                      "steps": [
+                        {
+                          "type": "model_output",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "Here is a comprehensive research report on the current state of cancer research..."
+                            }
+                          ]
+                        }
+                      ],
+                      "updated": "2025-11-26T12:22:47Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          {
+                            "modality": "text",
+                            "tokens": 20
+                          }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 20,
+                        "total_output_tokens": 1000,
+                        "total_thought_tokens": 500,
+                        "total_tokens": 1520,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "function_calling": {
+                    "summary": "Function Calling",
+                    "value": {
+                      "created": "2025-11-26T12:22:47Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3.6-flash",
+                      "object": "interaction",
+                      "status": "requires_action",
+                      "steps": [
+                        {
+                          "name": "get_weather",
+                          "type": "function_call",
+                          "arguments": {
+                            "location": "Boston, MA"
+                          },
+                          "id": "gth23981"
+                        }
+                      ],
+                      "updated": "2025-11-26T12:22:47Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          {
+                            "modality": "text",
+                            "tokens": 100
+                          }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 100,
+                        "total_output_tokens": 25,
+                        "total_thought_tokens": 0,
+                        "total_tokens": 125,
+                        "total_tool_use_tokens": 50
+                      }
+                    }
+                  },
+                  "multi_turn": {
+                    "summary": "Multi-turn",
+                    "value": {
+                      "created": "2025-11-26T12:22:47Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3.6-flash",
+                      "object": "interaction",
+                      "status": "completed",
+                      "steps": [
+                        {
+                          "type": "model_output",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "The capital of France is Paris."
+                            }
+                          ]
+                        }
+                      ],
+                      "updated": "2025-11-26T12:22:47Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          {
+                            "modality": "text",
+                            "tokens": 50
+                          }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 50,
+                        "total_output_tokens": 10,
+                        "total_thought_tokens": 0,
+                        "total_tokens": 60,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "multimodal_image": {
+                    "summary": "Image Input",
+                    "value": {
+                      "created": "2025-11-26T12:22:47Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3.6-flash",
+                      "object": "interaction",
+                      "status": "completed",
+                      "steps": [
+                        {
+                          "type": "model_output",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "A white humanoid robot with glowing blue eyes stands holding a red skateboard."
+                            }
+                          ]
+                        }
+                      ],
+                      "updated": "2025-11-26T12:22:47Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          {
+                            "modality": "text",
+                            "tokens": 10
+                          },
+                          {
+                            "modality": "image",
+                            "tokens": 258
+                          }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 268,
+                        "total_output_tokens": 20,
+                        "total_thought_tokens": 0,
+                        "total_tokens": 288,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "reuse_env": {
+                    "summary": "Reuse Environment",
+                    "value": {
+                      "agent": "antigravity-preview-05-2026",
+                      "created": "2025-11-26T12:23:00Z",
+                      "environment_id": "env_abc123",
+                      "id": "v1_Chd2ZTJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejAxMjM0NTY3ODkwMTIzNDU2Nzg",
+                      "object": "interaction",
+                      "status": "completed",
+                      "steps": [
+                        {
+                          "type": "model_output",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "I've updated /workspace/hello.py to accept a name argument and greet the user."
+                            }
+                          ]
+                        }
+                      ],
+                      "updated": "2025-11-26T12:23:00Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          {
+                            "modality": "text",
+                            "tokens": 80
+                          }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 80,
+                        "total_output_tokens": 200,
+                        "total_thought_tokens": 100,
+                        "total_tokens": 380,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "simple": {
+                    "summary": "Simple Request",
+                    "value": {
+                      "created": "2025-11-26T12:25:15Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3.6-flash",
+                      "object": "interaction",
+                      "status": "completed",
+                      "steps": [
+                        {
+                          "type": "model_output",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "Hello! I'm functioning perfectly and ready to assist you.\n\nHow are you doing today?"
+                            }
+                          ]
+                        }
+                      ],
+                      "updated": "2025-11-26T12:25:15Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          {
+                            "modality": "text",
+                            "tokens": 7
+                          }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 7,
+                        "total_output_tokens": 20,
+                        "total_thought_tokens": 22,
+                        "total_tokens": 49,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Interaction"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/InteractionSseStreamEvent"
+                },
+                "x-speakeasy-sse-sentinel": "[DONE]"
+              }
+            }
+          },
+          "4XX": {
+            "description": "Error creating interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Error creating interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "summary": "Creating an interaction",
+        "x-codeSamples": [
+          {
+            "label": "simple",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3.6-flash\",\n    \"input\": \"Hello, how are you?\"\n  }'\n"
+          },
+          {
+            "label": "simple",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\ninteraction = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    input=\"Hello, how are you?\",\n)\nprint(interaction.output_text)\n"
+          },
+          {
+            "label": "simple",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    input: 'Hello, how are you?',\n});\nconsole.log(interaction.output_text);\n"
+          },
+          {
+            "label": "multi_turn",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3.6-flash\",\n    \"input\": [\n      { \"type\": \"user_input\", \"content\": [{ \"type\": \"text\", \"text\": \"Hello!\" }] },\n      { \"type\": \"model_output\", \"content\": [{ \"type\": \"text\", \"text\": \"Hi there! How can I help you today?\" }] },\n      { \"type\": \"user_input\", \"content\": [{ \"type\": \"text\", \"text\": \"What is the capital of France?\" }] }\n    ]\n  }'\n"
+          },
+          {
+            "label": "multi_turn",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    input=[\n        { \"type\": \"user_input\", \"content\": [{ \"type\": \"text\", \"text\": \"Hello!\" }] },\n        { \"type\": \"model_output\", \"content\": [{ \"type\": \"text\", \"text\": \"Hi there! How can I help you today?\" }] },\n        { \"type\": \"user_input\", \"content\": [{ \"type\": \"text\", \"text\": \"What is the capital of France?\" }] }\n    ]\n)\nprint(response.output_text)\n"
+          },
+          {
+            "label": "multi_turn",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    input: [\n        { type: 'user_input', content: [{ type: 'text', text: 'Hello' }] },\n        { type: 'model_output', content: [{ type: 'text', text: 'Hi there! How can I help you today?' }] },\n        { type: 'user_input', content: [{ type: 'text', text: 'What is the capital of France?' }] }\n    ]\n});\nconsole.log(interaction.output_text);\n"
+          },
+          {
+            "label": "multimodal_image",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3.6-flash\",\n    \"input\": [\n      {\n        \"type\": \"text\",\n        \"text\": \"What is in this picture?\"\n      },\n      {\n        \"type\": \"image\",\n        \"data\": \"BASE64_ENCODED_IMAGE\",\n        \"mime_type\": \"image/png\"\n      }\n    ]\n  }'\n"
+          },
+          {
+            "label": "multimodal_image",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    input=[\n      { \"type\": \"text\", \"text\": \"What is in this picture?\" },\n      { \"type\": \"image\", \"data\": \"BASE64_ENCODED_IMAGE\", \"mime_type\": \"image/png\" }\n    ]\n)\nprint(response.output_text)\n"
+          },
+          {
+            "label": "multimodal_image",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    input: [\n      { type: 'text', text: 'What is in this picture?' },\n      { type: 'image', data: 'BASE64_ENCODED_IMAGE', mime_type: 'image/png' }\n    ]\n});\nconsole.log(interaction.output_text);\n"
+          },
+          {
+            "label": "function_calling",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3.6-flash\",\n    \"tools\": [\n      {\n        \"type\": \"function\",\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"location\": {\n              \"type\": \"string\",\n              \"description\": \"The city and state, e.g. San Francisco, CA\"\n            }\n          },\n          \"required\": [\n            \"location\"\n          ]\n        }\n      }\n    ],\n    \"input\": \"What is the weather like in Boston, MA?\"\n  }'\n"
+          },
+          {
+            "label": "function_calling",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    tools=[{\n        \"type\": \"function\",\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n                \"location\": {\n                    \"type\": \"string\",\n                    \"description\": \"The city and state, e.g. San Francisco, CA\"\n                }\n            },\n            \"required\": [\"location\"]\n        }\n    }],\n    input=\"What is the weather like in Boston, MA?\"\n)\nprint(response.steps[-1])\n"
+          },
+          {
+            "label": "function_calling",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    tools: [{\n        type: 'function',\n        name: 'get_weather',\n        description: 'Get the current weather in a given location',\n        parameters: {\n            type: 'object',\n            properties: {\n                location: {\n                    type: 'string',\n                    description: 'The city and state, e.g. San Francisco, CA'\n                }\n            },\n            required: ['location']\n        }\n    }],\n    input: 'What is the weather like in Boston, MA?'\n});\nconsole.log(interaction.steps.at(-1));\n"
+          },
+          {
+            "label": "deep_research",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"agent\": \"deep-research-pro-preview-12-2025\",\n    \"input\": \"Find a cure to cancer\",\n    \"background\": true\n  }'\n"
+          },
+          {
+            "label": "deep_research",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\ninteraction = client.interactions.create(\n    agent=\"deep-research-pro-preview-12-2025\",\n    input=\"find a cure to cancer\",\n    background=True,\n)\nprint(interaction.status)\n"
+          },
+          {
+            "label": "deep_research",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    agent: 'deep-research-pro-preview-12-2025',\n    input: 'find a cure to cancer',\n    background: true,\n});\nconsole.log(interaction.status);\n"
+          },
+          {
+            "label": "antigravity",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"agent\": \"antigravity-preview-05-2026\",\n    \"input\": \"Read Hacker News, summarize the top 5 stories, and save results as a markdown file.\",\n    \"environment\": \"remote\"\n  }'\n"
+          },
+          {
+            "label": "antigravity",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\ninteraction = client.interactions.create(\n    agent=\"antigravity-preview-05-2026\",\n    input=\"Read Hacker News, summarize the top 5 stories, and save results as a markdown file.\",\n    environment=\"remote\",\n)\nprint(interaction.output_text)\n"
+          },
+          {
+            "label": "antigravity",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    agent: 'antigravity-preview-05-2026',\n    input: 'Read Hacker News, summarize the top 5 stories, and save results as a markdown file.',\n    environment: 'remote',\n});\nconsole.log(interaction.output_text);\n"
+          },
+          {
+            "label": "reuse_env",
+            "lang": "sh",
+            "source": "# Step 1: Create an interaction with a fresh remote environment.\nRESPONSE=$(curl -s -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Api-Revision: 2026-05-20\" \\\n  -d '{\n    \"agent\": \"antigravity-preview-05-2026\",\n    \"input\": \"Write a hello world script at /workspace/hello.py.\",\n    \"environment\": \"remote\"\n  }')\nINTERACTION_ID=$(echo $RESPONSE | python3 -c \"import sys,json; print(json.load(sys.stdin)['id'])\")\nENV_ID=$(echo $RESPONSE | python3 -c \"import sys,json; print(json.load(sys.stdin)['environment_id'])\")\n\n# Step 2: Reuse the same environment in a follow-up interaction.\ncurl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d \"{\n    \\\"agent\\\": \\\"antigravity-preview-05-2026\\\",\n    \\\"input\\\": \\\"Modify the script to accept a name argument and greet the user.\\\",\n    \\\"environment\\\": \\\"$ENV_ID\\\",\n    \\\"previous_interaction_id\\\": \\\"$INTERACTION_ID\\\"\n  }\"\n"
+          },
+          {
+            "label": "reuse_env",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\n\n# Step 1: Create an interaction with a fresh remote environment.\ninteraction = client.interactions.create(\n    agent=\"antigravity-preview-05-2026\",\n    input=\"Write a hello world script at /workspace/hello.py.\",\n    environment=\"remote\",\n)\nprint(f\"Environment ID: {interaction.environment_id}\")\n\n# Step 2: Reuse the same environment in a follow-up interaction.\ninteraction_2 = client.interactions.create(\n    agent=\"antigravity-preview-05-2026\",\n    input=\"Modify the script to accept a name argument and greet the user.\",\n    environment=interaction.environment_id,\n    previous_interaction_id=interaction.id,\n)\nprint(interaction_2.output_text)\n"
+          },
+          {
+            "label": "reuse_env",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\n\n// Step 1: Create an interaction with a fresh remote environment.\nconst interaction = await ai.interactions.create({\n    agent: 'antigravity-preview-05-2026',\n    input: 'Write a hello world script at /workspace/hello.py.',\n    environment: 'remote',\n});\nconsole.log(`Environment ID: ${interaction.environment_id}`);\n\n// Step 2: Reuse the same environment in a follow-up interaction.\nconst interaction2 = await ai.interactions.create({\n    agent: 'antigravity-preview-05-2026',\n    input: 'Modify the script to accept a name argument and greet the user.',\n    environment: interaction.environment_id,\n    previous_interaction_id: interaction.id,\n});\nconsole.log(interaction2.output_text);\n"
+          },
+          {
+            "label": "with_sources",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"agent\": \"antigravity-preview-05-2026\",\n    \"input\": \"List all files under /workspace and summarize what you find.\",\n    \"environment\": {\n      \"type\": \"remote\",\n      \"sources\": [\n        {\n          \"type\": \"repository\",\n          \"source\": \"https://github.com/octocat/Spoon-Knife\",\n          \"target\": \"/workspace/repo\"\n        },\n        {\n          \"type\": \"inline\",\n          \"content\": \"Focus on Python files only.\",\n          \"target\": \"/workspace/notes.txt\"\n        }\n      ]\n    }\n  }'\n"
+          },
+          {
+            "label": "with_sources",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\ninteraction = client.interactions.create(\n    agent=\"antigravity-preview-05-2026\",\n    input=\"List all files under /workspace and summarize what you find.\",\n    environment={\n        \"type\": \"remote\",\n        \"sources\": [\n            {\n                \"type\": \"repository\",\n                \"source\": \"https://github.com/octocat/Spoon-Knife\",\n                \"target\": \"/workspace/repo\",\n            },\n            {\n                \"type\": \"inline\",\n                \"content\": \"Focus on Python files only.\",\n                \"target\": \"/workspace/notes.txt\",\n            },\n        ],\n    },\n)\nprint(interaction.output_text)\n"
+          },
+          {
+            "label": "with_sources",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    agent: 'antigravity-preview-05-2026',\n    input: 'List all files under /workspace and summarize what you find.',\n    environment: {\n        type: 'remote',\n        sources: [\n            {\n                type: 'repository',\n                source: 'https://github.com/octocat/Spoon-Knife',\n                target: '/workspace/repo',\n            },\n            {\n                type: 'inline',\n                content: 'Focus on Python files only.',\n                target: '/workspace/notes.txt',\n            },\n        ],\n    },\n});\nconsole.log(interaction.output_text);\n"
+          },
+          {
+            "label": "custom_agent",
+            "lang": "sh",
+            "source": "# Step 1: Create a custom agent.\ncurl -X POST https://generativelanguage.googleapis.com/v1beta/agents \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"id\": \"code-reviewer\",\n    \"base_agent\": \"antigravity-preview-05-2026\",\n    \"system_instruction\": \"You are a senior code reviewer. Check every file for bugs, style issues, and security vulnerabilities.\",\n    \"base_environment\": {\n      \"type\": \"remote\",\n      \"sources\": [{\n        \"type\": \"repository\",\n        \"source\": \"https://github.com/octocat/Spoon-Knife\",\n        \"target\": \"/workspace/repo\"\n      }]\n    }\n  }'\n\n# Step 2: Use the custom agent.\ncurl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"agent\": \"code-reviewer\",\n    \"input\": \"Review the latest changes in /workspace/repo/src and file a summary.\",\n    \"environment\": \"remote\"\n  }'\n"
+          },
+          {
+            "label": "custom_agent",
+            "lang": "python",
+            "source": "import uuid\nfrom google import genai\n\nclient = genai.Client()\n\n# Step 1: Create a custom agent.\nagent_id = f\"code-reviewer-{uuid.uuid4().hex[:8]}\"\nclient.agents.create(\n    id=agent_id,\n    base_agent=\"antigravity-preview-05-2026\",\n    system_instruction=\"You are a senior code reviewer. Check every file for bugs, style issues, and security vulnerabilities.\",\n    base_environment={\n        \"type\": \"remote\",\n        \"sources\": [{\n            \"type\": \"repository\",\n            \"source\": \"https://github.com/octocat/Spoon-Knife\",\n            \"target\": \"/workspace/repo\",\n        }],\n    },\n)\n\n# Step 2: Use the custom agent.\nresult = client.interactions.create(\n    agent=agent_id,\n    input=\"Review the latest changes in /workspace/repo/src and file a summary.\",\n    environment=\"remote\",\n)\nprint(result.output_text)\n\n# [cleanup]\nclient.agents.delete(agent_id)\n# [/cleanup]\n"
+          },
+          {
+            "label": "custom_agent",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\n\n// Step 1: Create a custom agent.\nconst agentId = `code-reviewer-${crypto.randomUUID().slice(0, 8)}`;\nawait ai.agents.create({\n    id: agentId,\n    base_agent: 'antigravity-preview-05-2026',\n    system_instruction: 'You are a senior code reviewer. Check every file for bugs, style issues, and security vulnerabilities.',\n    base_environment: {\n        type: 'remote',\n        sources: [{\n            type: 'repository',\n            source: 'https://github.com/octocat/Spoon-Knife',\n            target: '/workspace/repo',\n        }],\n    },\n});\n\n// Step 2: Use the custom agent.\nconst result = await ai.interactions.create({\n    agent: agentId,\n    input: 'Review the latest changes in /workspace/repo/src and file a summary.',\n    environment: 'remote',\n});\nconsole.log(result.output_text);\n\n// [cleanup]\nawait ai.agents.delete(agentId);\n// [/cleanup]\n"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "InteractionCreateParams",
+            "group": "interactions",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "interactions",
+        "x-speakeasy-name-override": "create"
+      }
+    },
+    "/{api_version}/interactions/{id}": {
+      "delete": {
+        "operationId": "deleteInteraction",
+        "description": "Deletes the interaction by id.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/api_version"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the interaction to delete.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful deletion of the interaction."
+          },
+          "4XX": {
+            "description": "Error deleting interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Error deleting interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "summary": "Deleting an interaction",
+        "x-codeSamples": [
+          {
+            "label": "delete",
+            "lang": "sh",
+            "source": "# [setup]\nINTERACTION_ID=$(curl -s -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\ -d '{\"model\": \"gemini-3.6-flash\", \"input\": \"Hello\"}' \\\n  | python3 -c \"import sys,json; print(json.load(sys.stdin)['id'])\")\n# [/setup]\n\ncurl -X DELETE \"https://generativelanguage.googleapis.com/v1beta/interactions/$INTERACTION_ID\" \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "label": "delete",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\n\n# [setup]\ncreated = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    input=\"Hello\",\n)\n# [/setup]\n\nclient.interactions.delete(id=created.id)\nprint(\"Interaction deleted successfully.\")\n"
+          },
+          {
+            "label": "delete",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\n\n// [setup]\nconst created = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    input: 'Hello',\n});\n// [/setup]\n\nawait ai.interactions.delete(created.id);\nconsole.log('Interaction deleted successfully.');\n"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "InteractionDeleteParams",
+            "group": "interactions",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "interactions",
+        "x-speakeasy-name-override": "delete"
+      },
+      "get": {
+        "operationId": "getInteractionById",
+        "description": "Retrieves the full details of a single interaction based on its `Interaction.id`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/api_version"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the interaction to retrieve.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include_input",
+            "in": "query",
+            "description": "If set to true, includes the input in the response.",
+            "deprecated": true,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "last_event_id",
+            "in": "query",
+            "description": "Optional. If set, resumes the interaction stream from the next chunk after the event marked by the event id. Can only be used if `stream` is true.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stream",
+            "in": "query",
+            "description": "If set to true, the generated content will be streamed incrementally.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful retrieval of the interaction.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "get": {
+                    "summary": "Get Interaction",
+                    "value": {
+                      "created": "2025-11-26T12:25:15Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3.6-flash",
+                      "object": "interaction",
+                      "status": "completed",
+                      "steps": [
+                        {
+                          "type": "model_output",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "I'm doing great, thank you for asking! How can I help you today?"
+                            }
+                          ]
+                        }
+                      ],
+                      "updated": "2025-11-26T12:25:15Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Interaction"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/InteractionSseStreamEvent"
+                },
+                "x-speakeasy-sse-sentinel": "[DONE]"
+              }
+            }
+          },
+          "4XX": {
+            "description": "Error getting interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Error getting interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "summary": "Retrieving an interaction",
+        "x-codeSamples": [
+          {
+            "label": "get",
+            "lang": "sh",
+            "source": "# [setup]\nINTERACTION_ID=$(curl -s -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Api-Revision: 2026-05-20\" \\\n  -d '{\"model\": \"gemini-3.6-flash\", \"input\": \"Say hello.\"}' \\\n  | python3 -c \"import sys,json; print(json.load(sys.stdin)['id'])\")\n# [/setup]\n\ncurl -X GET \"https://generativelanguage.googleapis.com/v1beta/interactions/$INTERACTION_ID\" \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Api-Revision: 2026-05-20\"\n"
+          },
+          {
+            "label": "get",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\n\n# [setup]\ncreated = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    input=\"Say hello.\"\n)\n# [/setup]\n\ninteraction = client.interactions.get(id=created.id)\nprint(interaction.status)\n"
+          },
+          {
+            "label": "get",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\n\n// [setup]\nconst created = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    input: 'Say hello.'\n});\n// [/setup]\n\nconst interaction = await ai.interactions.get(created.id);\nconsole.log(interaction.status);\n"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "InteractionGetParams",
+            "group": "interactions",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "interactions",
+        "x-speakeasy-name-override": "get",
+        "x-speakeasy-sse-overload": true
+      }
+    },
+    "/{api_version}/interactions/{id}/cancel": {
+      "post": {
+        "operationId": "cancelInteractionById",
+        "description": "Cancels an interaction by id. This only applies to background interactions that are still running.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/api_version"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the interaction to cancel.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful cancellation of the interaction.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "cancel": {
+                    "summary": "Cancel Interaction",
+                    "value": {
+                      "agent": "deep-research-pro-preview-12-2025",
+                      "created": "2026-06-22T04:55:47Z",
+                      "id": "v1_ChdVc0E0YXJTYk1zYlV6N0lQcXRXVG1BYxIXVXNBNGFyU2JNc2JVejdJUHF0V1RtQWM",
+                      "status": "cancelled",
+                      "steps": [
+                        {
+                          "type": "user_input",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "Research the history of the Google TPUs with a focus on 2025 specs."
+                            }
+                          ]
+                        }
+                      ],
+                      "updated": "2026-06-22T04:55:47Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Interaction"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Error cancelling interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Error cancelling interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "summary": "Canceling an interaction",
+        "x-codeSamples": [
+          {
+            "label": "cancel",
+            "lang": "sh",
+            "source": "# [setup]\nINTERACTION_ID=$(curl -s -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\ -d '{\"model\": \"gemini-3.6-flash\", \"input\": \"Write a long essay about the history of computing.\", \"background\": true}' \\\n  | python3 -c \"import sys,json; print(json.load(sys.stdin)['id'])\")\n# [/setup]\n\ncurl -X POST \"https://generativelanguage.googleapis.com/v1beta/interactions/$INTERACTION_ID/cancel\" \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "label": "cancel",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\n\n# Start a background interaction so it stays in-progress.\ncreated = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    input=\"Write a long essay about the history of computing.\",\n    tools=[{\"type\": \"computer_use\"}],\n    background=True,\n)\n\n# Cancel the in-progress interaction.\ninteraction = client.interactions.cancel(id=created.id)\nprint(interaction.status)\n"
+          },
+          {
+            "label": "cancel",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\n\n// Start a background interaction so it stays in-progress.\nconst created = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    input: 'Write a long essay about the history of computing.',\n    tools: [{ type: 'computer_use' }],\n    background: true,\n});\n\n// Cancel the in-progress interaction.\nconst interaction = await ai.interactions.cancel(created.id);\nconsole.log(interaction.status);\n"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "InteractionCancelParams",
+            "group": "interactions",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "interactions",
+        "x-speakeasy-name-override": "cancel"
+      }
+    },
+    "/{api_version}/triggers": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        }
+      ],
+      "get": {
+        "operationId": "ListTriggers",
+        "description": "Lists triggers for a project.",
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Optional. Filter expression (e.g., by state).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "Optional. The maximum number of triggers to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page_token",
+            "in": "query",
+            "description": "Optional. A page token from a previous ListTriggers call.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTriggersResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "TriggerListParams",
+            "group": "triggers",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "triggers",
+        "x-speakeasy-name-override": "list"
+      },
+      "post": {
+        "operationId": "CreateTrigger",
+        "description": "Creates a new trigger that will invoke the specified agent on the given cron schedule.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TriggerCreateParams"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Trigger"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "TriggerCreateParams",
+            "group": "triggers",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "triggers",
+        "x-speakeasy-name-override": "create"
+      }
+    },
+    "/{api_version}/triggers/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "description": "Resource name of the trigger.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "delete": {
+        "operationId": "DeleteTrigger",
+        "description": "Deletes a trigger.",
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "TriggerDeleteParams",
+            "group": "triggers",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "triggers",
+        "x-speakeasy-name-override": "delete"
+      },
+      "get": {
+        "operationId": "GetTrigger",
+        "description": "Gets details of a single trigger.",
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Trigger"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "TriggerGetParams",
+            "group": "triggers",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "triggers",
+        "x-speakeasy-name-override": "get"
+      },
+      "patch": {
+        "operationId": "UpdateTrigger",
+        "description": "Updates a trigger.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TriggerUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Trigger"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "TriggerUpdateParams",
+            "group": "triggers",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "triggers",
+        "x-speakeasy-name-override": "update"
+      }
+    },
+    "/{api_version}/triggers/{trigger_id}/executions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        },
+        {
+          "name": "trigger_id",
+          "in": "path",
+          "description": "Resource name of the trigger.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "ListTriggerExecutions",
+        "description": "Lists executions for a trigger.",
+        "parameters": [
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "Optional. The maximum number of executions to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page_token",
+            "in": "query",
+            "description": "Optional. A page token from a previous ListTriggerExecutions call.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTriggerExecutionsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "TriggerListExecutionsParams",
+            "group": "triggers",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "triggers",
+        "x-speakeasy-name-override": "list_executions"
+      },
+      "post": {
+        "operationId": "RunTrigger",
+        "description": "Runs a trigger immediately.",
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TriggerExecution"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "TriggerRunParams",
+            "group": "triggers",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "triggers",
+        "x-speakeasy-name-override": "run"
+      }
+    },
+    "/{api_version}/webhooks": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        }
+      ],
+      "get": {
+        "operationId": "ListWebhooks",
+        "description": "Lists all Webhooks.",
+        "parameters": [
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "Optional. The maximum number of webhooks to return. The service may return fewer than\nthis value. If unspecified, at most 50 webhooks will be returned.\nThe maximum value is 1000.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "page_token",
+            "in": "query",
+            "description": "Optional. A page token, received from a previous `ListWebhooks` call.\nProvide this to retrieve the subsequent page.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListWebhooksResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "WebhookListParams",
+            "group": "webhooks",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "webhooks",
+        "x-speakeasy-name-override": "list"
+      },
+      "post": {
+        "operationId": "CreateWebhook",
+        "description": "Creates a new Webhook.",
+        "parameters": [],
+        "requestBody": {
+          "description": "Required. The webhook to create.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Webhook"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Webhook"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "WebhookCreateParams",
+            "group": "webhooks",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "webhooks",
+        "x-speakeasy-name-override": "create"
+      }
+    },
+    "/{api_version}/webhooks/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "delete": {
+        "operationId": "DeleteWebhook",
+        "description": "Deletes a Webhook.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Required. The ID of the webhook to delete.\nFormat: `{webhook_id}`",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "WebhookDeleteParams",
+            "group": "webhooks",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "webhooks",
+        "x-speakeasy-name-override": "delete"
+      },
+      "get": {
+        "operationId": "GetWebhook",
+        "description": "Gets a specific Webhook.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Required. The ID of the webhook to retrieve.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Webhook"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "WebhookGetParams",
+            "group": "webhooks",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-group": "webhooks",
+        "x-speakeasy-name-override": "get"
+      },
+      "patch": {
+        "operationId": "UpdateWebhook",
+        "description": "Updates an existing Webhook.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Required. The ID of the webhook to update.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "update_mask",
+            "in": "query",
+            "description": "Optional. The list of fields to update.",
+            "schema": {
+              "type": "string",
+              "format": "google-fieldmask",
+              "pattern": "^(\\s*[^,\\s.]+(\\s*[,.]\\s*[^,\\s.]+)*)?$"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required. The webhook to update.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Webhook"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "webhooks",
+        "x-speakeasy-name-override": "update"
+      }
+    },
+    "/{api_version}/webhooks/{id}:ping": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "PingWebhook",
+        "description": "Sends a ping event to a Webhook.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Required. The ID of the webhook to ping.\nFormat: `{webhook_id}`",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PingWebhookRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PingWebhookResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "webhooks",
+        "x-speakeasy-name-override": "ping"
+      }
+    },
+    "/{api_version}/webhooks/{id}:rotateSigningSecret": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "RotateSigningSecret",
+        "description": "Generates a new signing secret for a Webhook.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Required. The ID of the webhook for which to generate a signing secret.\nFormat: `{webhook_id}`",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RotateSigningSecretRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RotateSigningSecretResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "webhooks",
+        "x-speakeasy-name-override": "rotate_signing_secret"
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "api_version": {
+        "name": "api_version",
+        "in": "path",
+        "description": "Which version of the API to use.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "google_genai_user_project": {
+        "name": "x-goog-user-project",
+        "in": "header",
+        "description": "Quota project header to send with Google GenAI API requests.",
+        "schema": {
+          "type": "string"
+        },
+        "x-speakeasy-name-override": "user_project"
+      }
+    },
+    "schemas": {
+      "Agent": {
+        "description": "An agent definition for the CreateAgent API.\nThis message is the target for annotation-parser-based JSON parsing.\nNew format:\n  {\n    \"id\": \"customer-sentinel\",\n    \"base_agent\": \"\",\n    \"system_instruction\": \"...\",\n    \"base_environment\": { \"type\": \"remote\", \"sources\": [...] },\n    \"tools\": [ {\"type\": \"code_execution\"} ]\n  }",
+        "type": "object",
+        "properties": {
+          "agent_config": {
+            "description": "Configuration parameters for the agent.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AntigravityAgentConfig"
+              }
+            ]
+          },
+          "base_agent": {
+            "description": "The base agent to extend.",
+            "type": "string"
+          },
+          "base_environment": {
+            "description": "The environment configuration for the agent.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EnvironmentConfig"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "description": {
+            "description": "Agent description for developers to quickly read and understand.",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique identifier for the agent.",
+            "type": "string"
+          },
+          "system_instruction": {
+            "description": "System instruction for the agent.",
+            "type": "string"
+          },
+          "tools": {
+            "description": "The tools available to the agent.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentTool"
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "Agent",
+            "group": "agents"
+          }
+        ],
+        "x-speakeasy-model-namespace": "agents"
+      },
+      "AgentOption": {
+        "title": "Agent",
+        "description": "The agent to interact with.",
+        "type": "string",
+        "enum": [
+          "deep-research-pro-preview-12-2025",
+          "deep-research-preview-04-2026",
+          "deep-research-max-preview-04-2026",
+          "antigravity-preview-05-2026"
+        ],
+        "x-speakeasy-enum-descriptions": [
+          "Gemini Deep Research Agent",
+          "Gemini Deep Research Agent",
+          "Gemini Deep Research Max Agent",
+          "Use the Antigravity managed agent to perform multi-step tasks that require reasoning, file operations, and tool use."
+        ],
+        "x-speakeasy-enum-format": "union",
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "AgentTool": {
+        "description": "A tool that the agent can use.",
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CodeExecution"
+          },
+          {
+            "$ref": "#/components/schemas/Function"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleSearch"
+          },
+          {
+            "$ref": "#/components/schemas/McpServer"
+          },
+          {
+            "$ref": "#/components/schemas/UrlContext"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "AgentTool",
+            "group": "agents"
+          }
+        ],
+        "x-speakeasy-model-namespace": "agents"
+      },
+      "AllowedTools": {
+        "description": "The configuration for allowed tools.",
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "any",
+              "none",
+              "validated"
+            ],
+            "x-google-enum-descriptions": [
+              "Auto tool choice.",
+              "Any tool choice.",
+              "No tool choice.",
+              "Validated tool choice."
+            ],
+            "x-speakeasy-exports": [
+              {
+                "name": "ToolChoiceType",
+                "group": "interactions"
+              }
+            ],
+            "x-speakeasy-model-namespace": "interactions",
+            "description": "The mode of the tool choice."
+          },
+          "tools": {
+            "description": "The names of the allowed tools.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "AllowedTools",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "AllowlistEntry": {
+        "description": "A single domain allowlist rule with optional header injection.",
+        "type": "object",
+        "properties": {
+          "domain": {
+            "description": "Domain to allow outbound requests to. Supports wildcards (e.g. '*.googleapis.com'). Use '*' to allow all domains.",
+            "type": "string"
+          },
+          "transform": {
+            "description": "Headers to inject on all outbound requests matching this domain. Accepts a single dict or a list of dicts. The egress proxy injects these automatically.",
+            "oneOf": [
+              {
+                "description": "A list of headers to inject.",
+                "type": "array",
+                "items": {
+                  "description": "A single header to inject.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "description": "A single header injection mapping, e.g., {\"Authorization\": \"Bearer token\"}.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "domain"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Annotation": {
+        "description": "Citation information for model-generated content.",
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/FileCitation"
+          },
+          {
+            "$ref": "#/components/schemas/PlaceCitation"
+          },
+          {
+            "$ref": "#/components/schemas/UrlCitation"
+          },
+          {
+            "$ref": "#/components/schemas/WordInfo"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "Annotation",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "AntigravityAgentConfig": {
+        "description": "Configuration for the Antigravity agent runtime.\nProvides server-side control over the agent's execution environment\nand tool configuration.",
+        "type": "object",
+        "properties": {
+          "max_total_tokens": {
+            "description": "Max total tokens for the agent run.",
+            "type": "string",
+            "format": "int64"
+          },
+          "model": {
+            "description": "The model to use for agent reasoning.",
+            "type": "string"
+          },
+          "type": {
+            "const": "antigravity"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "AntigravityAgentConfig",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ArgumentsDelta": {
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "type": "string"
+          },
+          "type": {
+            "const": "arguments_delta"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "AudioContent": {
+        "description": "An audio content block.",
+        "type": "object",
+        "properties": {
+          "channels": {
+            "description": "The number of audio channels.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "data": {
+            "description": "The audio content.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "mime_type": {
+            "description": "The mime type of the audio.",
+            "type": "string",
+            "enum": [
+              "audio/wav",
+              "audio/mp3",
+              "audio/aiff",
+              "audio/aac",
+              "audio/ogg",
+              "audio/flac",
+              "audio/mpeg",
+              "audio/m4a",
+              "audio/l16",
+              "audio/opus",
+              "audio/alaw",
+              "audio/mulaw"
+            ],
+            "x-google-enum-descriptions": [
+              "WAV audio format",
+              "MP3 audio format",
+              "AIFF audio format",
+              "AAC audio format",
+              "OGG audio format",
+              "FLAC audio format",
+              "MPEG audio format",
+              "M4A audio format",
+              "L16 audio format",
+              "OPUS audio format",
+              "ALAW audio format",
+              "MULAW audio format"
+            ]
+          },
+          "sample_rate": {
+            "description": "The sample rate of the audio.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "const": "audio"
+          },
+          "uri": {
+            "description": "The URI of the audio.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "audio": {
+              "summary": "Audio",
+              "value": {
+                "type": "audio",
+                "data": "BASE64_ENCODED_AUDIO",
+                "mime_type": "audio/wav"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "AudioContent",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "AudioDelta": {
+        "type": "object",
+        "properties": {
+          "channels": {
+            "description": "The number of audio channels.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "data": {
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "mime_type": {
+            "type": "string",
+            "enum": [
+              "audio/wav",
+              "audio/mp3",
+              "audio/aiff",
+              "audio/aac",
+              "audio/ogg",
+              "audio/flac",
+              "audio/mpeg",
+              "audio/m4a",
+              "audio/l16",
+              "audio/opus",
+              "audio/alaw",
+              "audio/mulaw"
+            ],
+            "x-google-enum-descriptions": [
+              "WAV audio format",
+              "MP3 audio format",
+              "AIFF audio format",
+              "AAC audio format",
+              "OGG audio format",
+              "FLAC audio format",
+              "MPEG audio format",
+              "M4A audio format",
+              "L16 audio format",
+              "OPUS audio format",
+              "ALAW audio format",
+              "MULAW audio format"
+            ]
+          },
+          "rate": {
+            "description": "Deprecated. Use sample_rate instead. The value is ignored.",
+            "type": "integer",
+            "deprecated": true,
+            "format": "int32"
+          },
+          "sample_rate": {
+            "description": "The sample rate of the audio.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "const": "audio"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "AudioResponseFormat": {
+        "description": "Configuration for audio output format.",
+        "type": "object",
+        "properties": {
+          "bit_rate": {
+            "description": "Bit rate in bits per second (bps). Only applicable for compressed formats\n(MP3, Opus).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "delivery": {
+            "description": "The delivery mode for the audio output.",
+            "type": "string",
+            "enum": [
+              "inline",
+              "uri"
+            ],
+            "x-google-enum-descriptions": [
+              "Audio data is returned inline in the response.",
+              "Audio data is returned as a URI."
+            ]
+          },
+          "mime_type": {
+            "description": "The MIME type of the audio output.",
+            "type": "string",
+            "enum": [
+              "audio/mp3",
+              "audio/ogg_opus",
+              "audio/l16",
+              "audio/wav",
+              "audio/alaw",
+              "audio/mulaw"
+            ],
+            "x-google-enum-descriptions": [
+              "MP3 audio format.",
+              "OGG Opus audio format.",
+              "Raw PCM (L16) audio format.",
+              "WAV audio format.",
+              "A-law audio format.",
+              "Mu-law audio format."
+            ]
+          },
+          "sample_rate": {
+            "description": "Sample rate in Hz.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "const": "audio"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "audio_response_format": {
+              "summary": "Audio Output",
+              "value": {
+                "type": "audio",
+                "sample_rate": 24000
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "AudioResponseFormat",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "CodeExecution": {
+        "description": "A tool that can be used by the model to execute code.",
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "code_execution"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-codeSamples": [
+          {
+            "label": "code_execution",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3.6-flash\",\n    \"tools\": [{\n      \"type\": \"code_execution\"\n    }],\n    \"input\": \"Calculate the first 10 Fibonacci numbers\"\n  }'\n"
+          },
+          {
+            "label": "code_execution",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    tools=[{\"type\": \"code_execution\"}],\n    input=\"Calculate the first 10 Fibonacci numbers\"\n)\nprint(response.output_text)\n"
+          },
+          {
+            "label": "code_execution",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    tools: [{ type: 'code_execution' }],\n    input: 'Calculate the first 10 Fibonacci numbers'\n});\nconsole.log(interaction.output_text);\n"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "CodeExecutionCallArguments": {
+        "description": "The arguments to pass to the code execution.",
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "The code to be executed.",
+            "type": "string"
+          },
+          "language": {
+            "description": "Programming language of the `code`.",
+            "type": "string",
+            "enum": [
+              "python"
+            ],
+            "x-google-enum-descriptions": [
+              "Python >= 3.10, with numpy and simpy available."
+            ]
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "CodeExecutionCallDelta": {
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/CodeExecutionCallArguments"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "code_execution_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "CodeExecutionCallStep": {
+        "description": "Code execution call step.",
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "Required. The arguments to pass to the code execution.",
+            "$ref": "#/components/schemas/CodeExecutionCallStepArguments"
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "code_execution_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "id",
+          "type"
+        ],
+        "examples": [
+          {
+            "code_execution_call": {
+              "summary": "CodeExecutionCallStep",
+              "value": {
+                "type": "code_execution_call",
+                "arguments": {
+                  "code": "print(sum(range(1, 11)))"
+                },
+                "id": "code_call_71021"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "CodeExecutionCallStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "CodeExecutionCallStepArguments": {
+        "description": "The arguments to pass to the code execution.",
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "The code to be executed.",
+            "type": "string"
+          },
+          "language": {
+            "description": "Programming language of the `code`.",
+            "type": "string",
+            "enum": [
+              "python"
+            ],
+            "x-google-enum-descriptions": [
+              "Python >= 3.10, with numpy and simpy available."
+            ]
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "CodeExecutionCallArguments",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "CodeExecutionCallArguments"
+      },
+      "CodeExecutionResultDelta": {
+        "type": "object",
+        "properties": {
+          "is_error": {
+            "type": "boolean"
+          },
+          "result": {
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "code_execution_result"
+          }
+        },
+        "required": [
+          "result",
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "CodeExecutionResultStep": {
+        "description": "Code execution result step.",
+        "type": "object",
+        "properties": {
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the code execution resulted in an error.",
+            "type": "boolean"
+          },
+          "result": {
+            "description": "Required. The output of the code execution.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "code_execution_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "examples": [
+          {
+            "code_execution_result": {
+              "summary": "CodeExecutionResultStep",
+              "value": {
+                "type": "code_execution_result",
+                "call_id": "code_call_71021",
+                "result": "55\n"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "CodeExecutionResultStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "CodeMenderAgentConfig": {
+        "description": "Configuration for the CodeMender agent.",
+        "type": "object",
+        "properties": {
+          "find_request": {
+            "description": "Parameters for finding vulnerabilities.",
+            "$ref": "#/components/schemas/FindRequest"
+          },
+          "fix_request": {
+            "description": "Parameters for fixing vulnerabilities.",
+            "$ref": "#/components/schemas/FixRequest"
+          },
+          "model": {
+            "description": "The name of the model to use for the CodeMender agent. One\nCodeMender session will only use one model.",
+            "type": "string"
+          },
+          "session_config": {
+            "description": "Optional session-specific configurations to override default agent\nbehavior.",
+            "$ref": "#/components/schemas/SessionConfig"
+          },
+          "session_id": {
+            "description": "Parameter for grouping multiple interactions that belong to\nthe same CodeMender session.",
+            "type": "string"
+          },
+          "type": {
+            "const": "code-mender"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "CodeMenderAgentConfig",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ComputerUse": {
+        "description": "A tool that can be used by the model to interact with the computer.",
+        "type": "object",
+        "properties": {
+          "disabled_safety_policies": {
+            "description": "Optional. Disabled safety policies for computer use.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "financial_transactions",
+                "sensitive_data_modification",
+                "communication_tool",
+                "account_creation",
+                "data_modification",
+                "user_consent_management",
+                "legal_terms_and_agreements"
+              ],
+              "x-google-enum-descriptions": [
+                "Safety policy for financial transactions.",
+                "Safety policy for sensitive data modification.",
+                "Safety policy for communication tools (e.g. Gmail, Chat, Meet).",
+                "Safety policy for account creation.",
+                "Safety policy for data modification.",
+                "Safety policy for user consent management.",
+                "Safety policy for legal terms and agreements."
+              ]
+            }
+          },
+          "enable_prompt_injection_detection": {
+            "description": "Whether enable the prompt injection detection check on computer-use\nrequest.",
+            "type": "boolean"
+          },
+          "environment": {
+            "description": "The environment being operated.",
+            "type": "string",
+            "enum": [
+              "browser",
+              "mobile",
+              "desktop"
+            ],
+            "x-google-enum-descriptions": [
+              "Operates in a web browser.",
+              "Operates in a mobile environment.",
+              "Operates in a desktop environment."
+            ]
+          },
+          "excluded_predefined_functions": {
+            "description": "The list of predefined functions that are excluded from the model call.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "type": {
+            "const": "computer_use"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-codeSamples": [
+          {
+            "label": "computer_use",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-computer-use-preview-10-2025\",\n    \"tools\": [{\n      \"type\": \"computer_use\"\n    }],\n    \"input\": \"Find a flight to Tokyo\"\n  }'\n"
+          },
+          {
+            "label": "computer_use",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-computer-use-preview-10-2025\",\n    tools=[{\"type\": \"computer_use\"}],\n    input=\"Find a flight to Tokyo\"\n)\nprint(response.output_text)\n"
+          },
+          {
+            "label": "computer_use",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-computer-use-preview-10-2025',\n    tools: [{ type: 'computer_use'}],\n    input: 'Find a flight to Tokyo'\n});\nconsole.log(interaction.output_text);\n"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Content": {
+        "description": "The content of the response.",
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AudioContent"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentContent"
+          },
+          {
+            "$ref": "#/components/schemas/ImageContent"
+          },
+          {
+            "$ref": "#/components/schemas/TextContent"
+          },
+          {
+            "$ref": "#/components/schemas/VideoContent"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "Content",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ContentDelta": {
+        "type": "object",
+        "properties": {
+          "delta": {
+            "$ref": "#/components/schemas/ContentDeltaData"
+          },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "content.delta"
+          },
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "delta",
+          "event_type",
+          "index"
+        ],
+        "examples": [
+          {
+            "content_delta": {
+              "summary": "Content Delta",
+              "value": {
+                "delta": {
+                  "type": "text",
+                  "text": "Elara\u2019s life was a symphony of quiet moments. A librarian, she found solace in the hushed aisles, the scent of aged paper, and the predictable rhythm of her days. Her small apartment, meticulously ordered, reflected this internal calm, save"
+                },
+                "event_type": "content.delta",
+                "index": 1
+              }
+            }
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ContentDeltaData": {
+        "description": "The delta content data for a content block.",
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AudioDelta"
+          },
+          {
+            "$ref": "#/components/schemas/CodeExecutionCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/CodeExecutionResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentDelta"
+          },
+          {
+            "$ref": "#/components/schemas/FileSearchCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/FileSearchResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/FunctionCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/FunctionResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleMapsCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleMapsResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleSearchCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleSearchResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/ImageDelta"
+          },
+          {
+            "$ref": "#/components/schemas/McpServerToolCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/McpServerToolResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/TextAnnotationDelta"
+          },
+          {
+            "$ref": "#/components/schemas/TextDelta"
+          },
+          {
+            "$ref": "#/components/schemas/ThoughtSignatureDelta"
+          },
+          {
+            "$ref": "#/components/schemas/ThoughtSummaryDelta"
+          },
+          {
+            "$ref": "#/components/schemas/UrlContextCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/UrlContextResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/VideoDelta"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ContentStart": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/Content"
+          },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "content.start"
+          },
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "content",
+          "event_type",
+          "index"
+        ],
+        "examples": [
+          {
+            "content_start": {
+              "summary": "Content Start",
+              "value": {
+                "content": {
+                  "type": "text"
+                },
+                "event_type": "content.start",
+                "index": 1
+              }
+            }
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ContentStop": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "content.stop"
+          },
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "event_type",
+          "index"
+        ],
+        "examples": [
+          {
+            "content_stop": {
+              "summary": "Content Stop",
+              "value": {
+                "event_type": "content.stop",
+                "index": 1
+              }
+            }
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "CreateAgentInteractionParams": {
+        "description": "Parameters for creating agent interactions",
+        "properties": {
+          "agent": {
+            "description": "The name of the `Agent` used for generating the interaction.",
+            "$ref": "#/components/schemas/AgentOption"
+          },
+          "agent_config": {
+            "description": "Configuration parameters for the agent interaction.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AntigravityAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/CodeMenderAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/DeepResearchAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/DynamicAgentConfig"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "type"
+            }
+          },
+          "background": {
+            "description": "Input only. Whether to run the model interaction in the background.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "created": {
+            "description": "Required. Output only. The time at which the response was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "environment": {
+            "description": "The environment configuration for the interaction. Can be an object specifying remote environment sources or a string referencing an existing environment ID.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EnvironmentConfig"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "environment_id": {
+            "description": "Output only. The environment ID for the interaction. Only populated if environment\nconfig is set in the request.",
+            "type": "string",
+            "readOnly": true
+          },
+          "id": {
+            "description": "Required. Output only. A unique identifier for the interaction completion.",
+            "type": "string",
+            "readOnly": true
+          },
+          "input": {
+            "$ref": "#/components/schemas/InteractionsInput"
+          },
+          "labels": {
+            "description": "The labels with user-defined metadata for the request.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "previous_interaction_id": {
+            "description": "The ID of the previous interaction, if any.",
+            "type": "string"
+          },
+          "response_format": {
+            "description": "Enforces that the generated response is a JSON object that complies with the JSON schema specified in this field.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ResponseFormat"
+              },
+              {
+                "type": "array",
+                "example": [
+                  {
+                    "type": "text",
+                    "mime_type": "application/json"
+                  }
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/ResponseFormat"
+                },
+                "x-speakeasy-model-namespace": "interactions"
+              }
+            ]
+          },
+          "response_mime_type": {
+            "description": "The mime type of the response. This is required if response_format is set.",
+            "type": "string",
+            "deprecated": true
+          },
+          "response_modalities": {
+            "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
+            "type": "array",
+            "deprecated": true,
+            "items": {
+              "$ref": "#/components/schemas/ResponseModality"
+            }
+          },
+          "safety_settings": {
+            "description": "Safety settings for the interaction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SafetySetting"
+            }
+          },
+          "service_tier": {
+            "description": "The service tier for the interaction.",
+            "$ref": "#/components/schemas/ServiceTier"
+          },
+          "status": {
+            "description": "Required. Output only. The status of the interaction.",
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete",
+              "budget_exceeded",
+              "queued"
+            ],
+            "readOnly": true,
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action/input from the user.",
+              "The interaction is completed.",
+              "The interaction failed.",
+              "The interaction was cancelled.",
+              "The interaction is completed, but contains incomplete results (e.g.\nhitting max_tokens).",
+              "The interaction was halted because the token budget was exceeded.",
+              "The interaction is queued, waiting for processing."
+            ]
+          },
+          "store": {
+            "description": "Input only. Whether to store the response and request for later retrieval.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "stream": {
+            "description": "Input only. Whether the interaction will be streamed.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "system_instruction": {
+            "description": "System instruction for the interaction.",
+            "type": "string"
+          },
+          "tools": {
+            "description": "A list of tool declarations the model may call during interaction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            }
+          },
+          "updated": {
+            "description": "Required. Output only. The time at which the response was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "webhook_config": {
+            "description": "Optional. Webhook configuration for receiving notifications when the\ninteraction completes.",
+            "$ref": "#/components/schemas/WebhookConfig"
+          }
+        },
+        "required": [
+          "agent",
+          "input"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "CreateAgentInteractionParamsNonStreaming",
+            "group": "interactions",
+            "representation": "input"
+          },
+          {
+            "name": "CreateAgentInteractionParamsStreaming",
+            "group": "interactions",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "CreateAgentInteraction"
+      },
+      "CreateEnvironmentRequest": {
+        "description": "Request for `CreateEnvironment`.",
+        "type": "object",
+        "properties": {
+          "network": {
+            "description": "Network configuration for the environment.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EnvironmentNetworkEgressAllowlist"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "disabled"
+                ],
+                "x-google-enum-descriptions": [
+                  "All network egress is blocked."
+                ]
+              }
+            ]
+          },
+          "sources": {
+            "description": "Sources to be mounted into the environment.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Source"
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "CreateEnvironmentRequest",
+            "group": "environments"
+          }
+        ],
+        "x-speakeasy-model-namespace": "environments"
+      },
+      "CreateModelInteractionParams": {
+        "description": "Parameters for creating model interactions",
+        "properties": {
+          "background": {
+            "description": "Input only. Whether to run the model interaction in the background.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "created": {
+            "description": "Required. Output only. The time at which the response was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "environment": {
+            "description": "The environment configuration for the interaction. Can be an object specifying remote environment sources or a string referencing an existing environment ID.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EnvironmentConfig"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "environment_id": {
+            "description": "Output only. The environment ID for the interaction. Only populated if environment\nconfig is set in the request.",
+            "type": "string",
+            "readOnly": true
+          },
+          "generation_config": {
+            "description": "Input only. Configuration parameters for the model interaction.",
+            "$ref": "#/components/schemas/GenerationConfig",
+            "writeOnly": true
+          },
+          "id": {
+            "description": "Required. Output only. A unique identifier for the interaction completion.",
+            "type": "string",
+            "readOnly": true
+          },
+          "input": {
+            "$ref": "#/components/schemas/InteractionsInput"
+          },
+          "labels": {
+            "description": "The labels with user-defined metadata for the request.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "model": {
+            "description": "The name of the `Model` used for generating the interaction.",
+            "$ref": "#/components/schemas/ModelOption"
+          },
+          "previous_interaction_id": {
+            "description": "The ID of the previous interaction, if any.",
+            "type": "string"
+          },
+          "response_format": {
+            "description": "Enforces that the generated response is a JSON object that complies with the JSON schema specified in this field.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ResponseFormat"
+              },
+              {
+                "type": "array",
+                "example": [
+                  {
+                    "type": "text",
+                    "mime_type": "application/json"
+                  }
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/ResponseFormat"
+                },
+                "x-speakeasy-model-namespace": "interactions"
+              }
+            ]
+          },
+          "response_mime_type": {
+            "description": "The mime type of the response. This is required if response_format is set.",
+            "type": "string",
+            "deprecated": true
+          },
+          "response_modalities": {
+            "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
+            "type": "array",
+            "deprecated": true,
+            "items": {
+              "$ref": "#/components/schemas/ResponseModality"
+            }
+          },
+          "safety_settings": {
+            "description": "Safety settings for the interaction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SafetySetting"
+            }
+          },
+          "service_tier": {
+            "description": "The service tier for the interaction.",
+            "$ref": "#/components/schemas/ServiceTier"
+          },
+          "status": {
+            "description": "Required. Output only. The status of the interaction.",
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete",
+              "budget_exceeded",
+              "queued"
+            ],
+            "readOnly": true,
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action/input from the user.",
+              "The interaction is completed.",
+              "The interaction failed.",
+              "The interaction was cancelled.",
+              "The interaction is completed, but contains incomplete results (e.g.\nhitting max_tokens).",
+              "The interaction was halted because the token budget was exceeded.",
+              "The interaction is queued, waiting for processing."
+            ]
+          },
+          "store": {
+            "description": "Input only. Whether to store the response and request for later retrieval.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "stream": {
+            "description": "Input only. Whether the interaction will be streamed.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "system_instruction": {
+            "description": "System instruction for the interaction.",
+            "type": "string"
+          },
+          "tools": {
+            "description": "A list of tool declarations the model may call during interaction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            }
+          },
+          "updated": {
+            "description": "Required. Output only. The time at which the response was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "webhook_config": {
+            "description": "Optional. Webhook configuration for receiving notifications when the\ninteraction completes.",
+            "$ref": "#/components/schemas/WebhookConfig"
+          }
+        },
+        "required": [
+          "input",
+          "model"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "CreateModelInteractionParamsNonStreaming",
+            "group": "interactions",
+            "representation": "input"
+          },
+          {
+            "name": "CreateModelInteractionParamsStreaming",
+            "group": "interactions",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "CreateModelInteraction"
+      },
+      "DeepResearchAgentConfig": {
+        "description": "Configuration for the Deep Research agent.",
+        "type": "object",
+        "properties": {
+          "collaborative_planning": {
+            "description": "Enables human-in-the-loop planning for the Deep Research agent. If set to\ntrue, the Deep Research agent will provide a research plan in its response.\nThe agent will then proceed only if the user confirms the plan in the next\nturn.",
+            "type": "boolean"
+          },
+          "enable_bigquery_tool": {
+            "description": "Enables bigquery tool for the Deep Research agent.",
+            "type": "boolean"
+          },
+          "thinking_summaries": {
+            "description": "Whether to include thought summaries in the response.",
+            "$ref": "#/components/schemas/ThinkingSummaries"
+          },
+          "type": {
+            "const": "deep-research"
+          },
+          "visualization": {
+            "description": "Whether to include visualizations in the response.",
+            "type": "string",
+            "enum": [
+              "off",
+              "auto"
+            ],
+            "x-google-enum-descriptions": [
+              "Do not include visualizations.",
+              "Automatically include visualizations."
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "DeepResearchAgentConfig",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "DeleteInteractionResponse": {
+        "description": "Response for InteractionService.DeleteInteraction.",
+        "type": "object",
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "DocumentContent": {
+        "description": "A document content block.",
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "The document content.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "mime_type": {
+            "description": "The mime type of the document.",
+            "type": "string",
+            "enum": [
+              "application/pdf",
+              "text/csv"
+            ],
+            "x-google-enum-descriptions": [
+              "PDF document format",
+              "CSV document format"
+            ]
+          },
+          "type": {
+            "const": "document"
+          },
+          "uri": {
+            "description": "The URI of the document.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "document": {
+              "summary": "Document",
+              "value": {
+                "type": "document",
+                "data": "BASE64_ENCODED_DOCUMENT",
+                "mime_type": "application/pdf"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "DocumentContent",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "DocumentDelta": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "mime_type": {
+            "type": "string",
+            "enum": [
+              "application/pdf",
+              "text/csv"
+            ],
+            "x-google-enum-descriptions": [
+              "PDF document format",
+              "CSV document format"
+            ]
+          },
+          "type": {
+            "const": "document"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "DynamicAgentConfig": {
+        "description": "Configuration for dynamic agents.",
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "dynamic"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": {
+          "description": "For agents that are not supported statically in the API definition."
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "DynamicAgentConfig",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Empty": {
+        "description": "A generic empty message that you can re-use to avoid defining duplicated\nempty messages in your APIs. A typical example is to use it as the request\nor the response type of an API method. For instance:\n\n    service Foo {\n      rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);\n    }",
+        "type": "object",
+        "x-speakeasy-exports": [
+          {
+            "name": "InteractionDeleteResponse",
+            "group": "interactions"
+          },
+          {
+            "name": "AgentDeleteResponse",
+            "group": "agents"
+          },
+          {
+            "name": "WebhookDeleteResponse",
+            "group": "webhooks"
+          },
+          {
+            "name": "TriggerDeleteResponse",
+            "group": "triggers"
+          },
+          {
+            "name": "EnvironmentDeleteResponse",
+            "group": "environments"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-stainless-empty-object": true
+      },
+      "Environment": {
+        "description": "An execution environment for an agent.",
+        "type": "object",
+        "properties": {
+          "created": {
+            "description": "Output only. The time at which the environment was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "type": "string",
+            "readOnly": true
+          },
+          "file_count": {
+            "description": "Output only. The number of files in the environment, output only.",
+            "type": "string",
+            "format": "int64",
+            "readOnly": true
+          },
+          "id": {
+            "description": "Required. Output only. The ID of the environment.",
+            "type": "string",
+            "readOnly": true
+          },
+          "last_accessed": {
+            "description": "Output only. The time at which the environment was last accessed in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "type": "string",
+            "readOnly": true
+          },
+          "network": {
+            "description": "Network configuration for the environment.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EnvironmentNetworkEgressAllowlist"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "disabled"
+                ],
+                "x-google-enum-descriptions": [
+                  "All network egress is blocked."
+                ]
+              }
+            ]
+          },
+          "size_bytes": {
+            "description": "Output only. The total size of the environment files in bytes, output only.",
+            "type": "string",
+            "format": "int64",
+            "readOnly": true
+          },
+          "sources": {
+            "description": "Sources to be mounted into the environment.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Source"
+            }
+          },
+          "status": {
+            "description": "Output only. The status of the environment container.",
+            "type": "string",
+            "enum": [
+              "active",
+              "expired"
+            ],
+            "readOnly": true,
+            "x-google-enum-descriptions": [
+              "",
+              ""
+            ]
+          },
+          "updated": {
+            "description": "Output only. The time at which the environment was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "Environment",
+            "group": "environments"
+          }
+        ],
+        "x-speakeasy-model-namespace": "environments"
+      },
+      "EnvironmentConfig": {
+        "description": "Configuration for a custom environment.",
+        "type": "object",
+        "properties": {
+          "environment_id": {
+            "description": "Optional. The environment ID for the interaction. If specified, the request will\nupdate the existing environment instead of creating a new one.",
+            "type": "string"
+          },
+          "network": {
+            "description": "Network configuration for the environment.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EnvironmentNetworkEgressAllowlist"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "disabled"
+                ],
+                "x-google-enum-descriptions": [
+                  "All network egress is blocked."
+                ]
+              }
+            ]
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Source"
+            }
+          },
+          "type": {
+            "const": "remote"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "inline_sources": {
+              "summary": "Inline Sources",
+              "value": {
+                "type": "remote",
+                "sources": [
+                  {
+                    "type": "inline",
+                    "content": "You are a data analyst. Always include visualizations and export results as PDF.",
+                    "target": ".agents/AGENTS.md"
+                  },
+                  {
+                    "type": "inline",
+                    "content": "---\nname: slide-maker\ndescription: Create HTML slide decks\n---\n# Slide Maker\n\nWhen asked to create a presentation:\n1. Analyze the input data\n2. Create an HTML slide deck with reveal.js\n3. Save to /workspace/output/slides.html",
+                    "target": ".agents/skills/slide-maker/SKILL.md"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "external_sources": {
+              "summary": "External Sources",
+              "value": {
+                "type": "remote",
+                "sources": [
+                  {
+                    "type": "repository",
+                    "source": "https://github.com/my-org/my-skills.git",
+                    "target": ".agents/skills"
+                  },
+                  {
+                    "type": "gcs",
+                    "source": "gs://my-bucket/my-folder",
+                    "target": "/workspace/data"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "network_allowlist": {
+              "summary": "Network Allowlist",
+              "value": {
+                "type": "remote",
+                "network": {
+                  "allowlist": [
+                    {
+                      "domain": "pypi.org"
+                    },
+                    {
+                      "domain": "*.github.com"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "proxy_credentials": {
+              "summary": "Proxy Credentials",
+              "value": {
+                "type": "remote",
+                "network": {
+                  "allowlist": [
+                    {
+                      "domain": "api.github.com",
+                      "transform": {
+                        "Authorization": "Bearer YOUR_GITHUB_TOKEN"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "Environment",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "Environment"
+      },
+      "EnvironmentNetworkEgressAllowlist": {
+        "description": "Outbound networking configuration for the sandbox. Accepts an object with an 'allowlist' array to restrict traffic, or the string 'disabled' to turn off all network access. Omit entirely to allow all outbound traffic with no header injection.",
+        "example": {
+          "allowlist": [
+            {
+              "domain": "github.com",
+              "transform": [
+                {
+                  "Authorization": "Bearer your-token"
+                }
+              ]
+            },
+            {
+              "domain": "*.googleapis.com"
+            }
+          ]
+        },
+        "oneOf": [
+          {
+            "title": "Allowlist",
+            "description": "Outbound networking configuration for the sandbox. When specified, restricts which external domains the sandbox can reach. Omit entirely to allow all outbound traffic with no header injection.",
+            "type": "object",
+            "properties": {
+              "allowlist": {
+                "description": "List of allowed outbound domains. Only requests to listed domains are permitted. Use [{'domain': '*'}] to allow all domains while still injecting headers on specific ones.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowlistEntry"
+                }
+              }
+            },
+            "example": {
+              "allowlist": [
+                {
+                  "domain": "pypi.org"
+                },
+                {
+                  "domain": "*.github.com"
+                }
+              ]
+            }
+          },
+          {
+            "title": "Disabled",
+            "description": "Turns all network off.",
+            "type": "string",
+            "enum": [
+              "disabled"
+            ],
+            "example": "disabled"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Error": {
+        "description": "Error message from an interaction.",
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "A URI that identifies the error type.",
+            "type": "string"
+          },
+          "message": {
+            "description": "A human-readable error message.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "Error",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ErrorEvent": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/Error"
+          },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "error"
+          }
+        },
+        "required": [
+          "event_type"
+        ],
+        "examples": [
+          {
+            "error_event": {
+              "summary": "Error Event",
+              "value": {
+                "error": {
+                  "code": "not_found",
+                  "message": "Failed to get completed interaction: Result not found."
+                },
+                "event_type": "error"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "ErrorEvent",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ExaAISearchConfig": {
+        "description": "Used to specify configuration for ExaAISearch.",
+        "type": "object",
+        "properties": {
+          "api_key": {
+            "description": "Required. The API key for ExaAiSearch.",
+            "type": "string"
+          },
+          "custom_config": {
+            "description": "Optional. This field can be used to pass any parameter from the Exa.ai Search API.",
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          }
+        },
+        "required": [
+          "api_key"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FileCitation": {
+        "description": "A file citation annotation.",
+        "type": "object",
+        "properties": {
+          "custom_metadata": {
+            "description": "User provided metadata about the retrieved context.",
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "document_uri": {
+            "description": "The URI of the file.",
+            "type": "string"
+          },
+          "end_index": {
+            "description": "End of the attributed segment, exclusive.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "file_name": {
+            "description": "The name of the file.",
+            "type": "string"
+          },
+          "media_id": {
+            "description": "Media ID in-case of image citations, if applicable.",
+            "type": "string"
+          },
+          "page_number": {
+            "description": "Page number of the cited document, if applicable.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "source": {
+            "description": "Source attributed for a portion of the text.",
+            "type": "string"
+          },
+          "start_index": {
+            "description": "Start of segment of the response that is attributed to this source.\n\nIndex indicates the start of the segment, measured in bytes.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "const": "file_citation"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "FileCitation",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FileContent": {
+        "description": "Content of a single file in the codebase.",
+        "type": "object",
+        "properties": {
+          "content": {
+            "description": "The UTF-8 encoded text content of the file.",
+            "type": "string"
+          },
+          "path": {
+            "description": "The relative path of the file from the project root.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FileSearch": {
+        "description": "A tool that can be used by the model to search files.",
+        "type": "object",
+        "properties": {
+          "file_search_store_names": {
+            "description": "The file search store names to search.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "metadata_filter": {
+            "description": "Metadata filter to apply to the semantic retrieval documents and chunks.",
+            "type": "string"
+          },
+          "top_k": {
+            "description": "The number of semantic retrieval chunks to retrieve.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "const": "file_search"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-codeSamples": [
+          {
+            "label": "file_search",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3.6-flash\",\n    \"tools\": [{\n      \"type\": \"file_search\",\n      \"file_search_store_names\": [\"fileSearchStores/m64d1sevsr4y-xfyawui3fxqg\"]\n    }],\n    \"input\": \"Who is the author of the book?\"\n  }'\n"
+          },
+          {
+            "label": "file_search",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\n\n# Create a file search store so we have a valid one to use.\nstore = client.file_search_stores.create()\n\nresponse = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    tools=[{\n        \"type\": \"file_search\",\n        \"file_search_store_names\": [store.name]\n    }],\n    input=\"What documents are available?\"\n)\nprint(response.output_text)\n\n# [cleanup]\nclient.file_search_stores.delete(name=store.name)\n# [/cleanup]\n"
+          },
+          {
+            "label": "file_search",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\n\n// Create a file search store so we have a valid one to use.\nconst store = await ai.fileSearchStores.create({});\nif (!store.name) {\n    throw new Error('Store creation failed: Name is undefined');\n}\n\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    tools: [{\n        type: 'file_search',\n        file_search_store_names: [store.name]\n    }],\n    input: 'What documents are available?'\n});\nconsole.log(interaction.output_text);\n\n// [cleanup]\nawait ai.fileSearchStores.delete({name: store.name});\n// [/cleanup]\n"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FileSearchCallDelta": {
+        "type": "object",
+        "properties": {
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "file_search_call"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FileSearchCallStep": {
+        "description": "File Search call step.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "file_search_call"
+          }
+        },
+        "required": [
+          "id",
+          "type"
+        ],
+        "examples": [
+          {
+            "file_search_call": {
+              "summary": "FileSearchCallStep",
+              "value": {
+                "type": "file_search_call",
+                "id": "file_call_88192"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "FileSearchCallStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FileSearchResult": {
+        "description": "The result of the File Search.",
+        "type": "object",
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FileSearchResultDelta": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileSearchResult"
+            }
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "file_search_result"
+          }
+        },
+        "required": [
+          "result",
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FileSearchResultStep": {
+        "description": "File Search result step.",
+        "type": "object",
+        "properties": {
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "file_search_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "type"
+        ],
+        "examples": [
+          {
+            "file_search_result": {
+              "summary": "FileSearchResultStep",
+              "value": {
+                "type": "file_search_result",
+                "call_id": "file_call_88192"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "FileSearchResultStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Filter": {
+        "description": "Config for filters.",
+        "type": "object",
+        "properties": {
+          "metadata_filter": {
+            "description": "Optional. String for metadata filtering.",
+            "type": "string"
+          },
+          "vector_distance_threshold": {
+            "description": "Optional. Only returns contexts with vector distance smaller than the\nthreshold.",
+            "type": "number",
+            "format": "double"
+          },
+          "vector_similarity_threshold": {
+            "description": "Optional. Only returns contexts with vector similarity larger than the\nthreshold.",
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FindRequest": {
+        "description": "Request parameters specific to FIND sessions, used for discovering\nvulnerabilities in a codebase.",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "Additional context or custom instructions provided by the user to guide\nthe vulnerability analysis.",
+            "type": "string"
+          },
+          "finding_id": {
+            "description": "The identifier of a specific finding to verify. This is primarily used in\nVERIFY mode to focus the agent's execution-based validation on a single\nvulnerability.",
+            "type": "string"
+          },
+          "mode": {
+            "description": "The mode of the find session.",
+            "type": "string",
+            "enum": [
+              "scan",
+              "verify"
+            ],
+            "x-google-enum-descriptions": [
+              "Fast scan using only the initial classifier.",
+              "Performs classification followed by detailed investigation."
+            ]
+          },
+          "source_files": {
+            "description": "A list of source files to provide as context for the scan.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileContent"
+            }
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FixRequest": {
+        "description": "Request parameters specific to FIX sessions, used for generating and\nvalidating security patches.",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "Additional context or custom instructions provided by the user to guide\nthe patch generation process.",
+            "type": "string"
+          },
+          "finding_id": {
+            "description": "The identifier of the specific security finding to be remediated. This ID\nmaps to a previously discovered vulnerability.",
+            "type": "string"
+          },
+          "source_files": {
+            "description": "A list of source files providing context for the remediation. These files\nare typically the ones containing the identified vulnerability.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileContent"
+            }
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Function": {
+        "description": "A tool that can be used by the model.",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "A description of the function.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the function.",
+            "type": "string"
+          },
+          "parameters": {
+            "description": "The JSON Schema for the function's parameters."
+          },
+          "type": {
+            "const": "function"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-codeSamples": [
+          {
+            "label": "function_calling",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3.6-flash\",\n    \"tools\": [{\n      \"type\": \"function\",\n      \"name\": \"get_weather\",\n      \"description\": \"Get the current weather in a given location\",\n      \"parameters\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\",\n            \"description\": \"The city and state, e.g. San Francisco, CA\"\n          }\n        },\n        \"required\": [\"location\"]\n      }\n    }],\n    \"input\": \"What is the weather like in Boston, MA?\"\n  }'\n"
+          },
+          {
+            "label": "function_calling",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    tools=[{\n        \"type\": \"function\",\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n                \"location\": {\n                    \"type\": \"string\",\n                    \"description\": \"The city and state, e.g. San Francisco, CA\"\n                }\n            },\n            \"required\": [\"location\"]\n        }\n    }],\n    input=\"What is the weather like in Boston?\"\n)\nprint(response.steps[-1])\n"
+          },
+          {
+            "label": "function_calling",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    tools: [{\n        type: 'function',\n        name: 'get_weather',\n        description: 'Get the current weather in a given location',\n        parameters: {\n            type: 'object',\n            properties: {\n                location: {\n                    type: 'string',\n                    description: 'The city and state, e.g. San Francisco, CA'\n                }\n            },\n            required: ['location']\n        }\n    }],\n    input: 'What is the weather like in Boston?'\n});\nconsole.log(interaction.steps.at(-1));\n"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "Function",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FunctionCallDelta": {
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "const": "function_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "id",
+          "name",
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FunctionCallStep": {
+        "description": "A function tool call step.",
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "Required. The arguments to pass to the function.",
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Required. The name of the tool to call.",
+            "type": "string"
+          },
+          "type": {
+            "const": "function_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "id",
+          "name",
+          "type"
+        ],
+        "examples": [
+          {
+            "function_call": {
+              "summary": "FunctionCallStep",
+              "value": {
+                "name": "get_weather",
+                "type": "function_call",
+                "arguments": {
+                  "location": "Boston, MA"
+                },
+                "id": "call_98231"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "FunctionCallStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FunctionResultDelta": {
+        "type": "object",
+        "properties": {
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "result": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ImageContent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TextContent"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "type": {
+            "const": "function_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "FunctionResultStep": {
+        "description": "Result of a function tool call.",
+        "type": "object",
+        "properties": {
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the tool call resulted in an error.",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The name of the tool that was called.",
+            "type": "string"
+          },
+          "result": {
+            "description": "Required. The result of the tool call.",
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ImageContent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TextContent"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "type": {
+            "const": "function_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "examples": [
+          {
+            "function_result": {
+              "summary": "FunctionResultStep",
+              "value": {
+                "name": "get_weather",
+                "type": "function_result",
+                "call_id": "call_98231",
+                "result": [
+                  {
+                    "type": "text",
+                    "text": "{\"weather\":\"sunny\"}"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "FunctionResultStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GenerationConfig": {
+        "description": "Configuration parameters for model interactions.",
+        "type": "object",
+        "properties": {
+          "image_config": {
+            "description": "Configuration for image interaction.",
+            "$ref": "#/components/schemas/ImageConfig",
+            "deprecated": true
+          },
+          "max_output_tokens": {
+            "description": "The maximum number of tokens to include in the response.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "seed": {
+            "description": "Seed used in decoding for reproducibility.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "speech_config": {
+            "description": "Configuration for speech interaction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpeechConfig"
+            }
+          },
+          "stop_sequences": {
+            "description": "A list of character sequences that will stop output interaction.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "thinking_level": {
+            "description": "The level of thought tokens that the model should generate.",
+            "$ref": "#/components/schemas/ThinkingLevel"
+          },
+          "thinking_summaries": {
+            "description": "Whether to include thought summaries in the response.",
+            "$ref": "#/components/schemas/ThinkingSummaries"
+          },
+          "tool_choice": {
+            "description": "The tool choice configuration.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ToolChoiceConfig"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "any",
+                  "none",
+                  "validated"
+                ],
+                "x-google-enum-descriptions": [
+                  "Auto tool choice.",
+                  "Any tool choice.",
+                  "No tool choice.",
+                  "Validated tool choice."
+                ],
+                "x-speakeasy-exports": [
+                  {
+                    "name": "ToolChoiceType",
+                    "group": "interactions"
+                  }
+                ],
+                "x-speakeasy-model-namespace": "interactions"
+              }
+            ]
+          },
+          "transcription_config": {
+            "description": "Optional. Configuration for speech recognition (transcription). If present, ASR is\nenabled.",
+            "$ref": "#/components/schemas/TranscriptionConfig"
+          },
+          "video_config": {
+            "description": "Configuration for video generation.",
+            "$ref": "#/components/schemas/VideoConfig"
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "GenerationConfig",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleMaps": {
+        "description": "A tool that can be used by the model to call Google Maps.",
+        "type": "object",
+        "properties": {
+          "enable_widget": {
+            "description": "Whether to return a widget context token in the tool call result of the\nresponse.",
+            "type": "boolean"
+          },
+          "latitude": {
+            "description": "The latitude of the user's location.",
+            "type": "number",
+            "format": "double"
+          },
+          "longitude": {
+            "description": "The longitude of the user's location.",
+            "type": "number",
+            "format": "double"
+          },
+          "type": {
+            "const": "google_maps"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-codeSamples": [
+          {
+            "label": "google_maps",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3.6-flash\",\n    \"tools\": [{\n      \"type\": \"google_maps\",\n      \"latitude\": 37.7749,\n      \"longitude\": -122.4194\n    }],\n    \"input\": \"What is the best food near me?\"\n  }'\n"
+          },
+          {
+            "label": "google_maps",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    tools=[{\n        \"type\": \"google_maps\",\n        \"latitude\": 37.7749,\n        \"longitude\": -122.4194\n    }],\n    input=\"What is the best food near me?\"\n)\nprint(response.output_text)\n"
+          },
+          {
+            "label": "google_maps",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    tools: [{\n        type: 'google_maps',\n        latitude: 37.7749,\n        longitude: -122.4194\n    }],\n    input: 'What is the best food near me?'\n});\nconsole.log(interaction.output_text);\n"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleMapsCallArguments": {
+        "description": "The arguments to pass to the Google Maps tool.",
+        "type": "object",
+        "properties": {
+          "queries": {
+            "description": "The queries to be executed.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleMapsCallDelta": {
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "The arguments to pass to the Google Maps tool.",
+            "$ref": "#/components/schemas/GoogleMapsCallArguments"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "google_maps_call"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleMapsCallStep": {
+        "description": "Google Maps call step.",
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "The arguments to pass to the Google Maps tool.",
+            "$ref": "#/components/schemas/GoogleMapsCallStepArguments"
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "google_maps_call"
+          }
+        },
+        "required": [
+          "id",
+          "type"
+        ],
+        "examples": [
+          {
+            "google_maps_call": {
+              "summary": "GoogleMapsCallStep",
+              "value": {
+                "type": "google_maps_call",
+                "arguments": {
+                  "latitude": 37.7749,
+                  "longitude": -122.4194
+                },
+                "id": "maps_call_39201"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "GoogleMapsCallStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleMapsCallStepArguments": {
+        "description": "The arguments to pass to the Google Maps tool.",
+        "type": "object",
+        "properties": {
+          "queries": {
+            "description": "The queries to be executed.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "GoogleMapsCallArguments",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "GoogleMapsCallArguments"
+      },
+      "GoogleMapsResult": {
+        "description": "The result of the Google Maps.",
+        "type": "object",
+        "properties": {
+          "places": {
+            "description": "The places that were found.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Places"
+            }
+          },
+          "widget_context_token": {
+            "description": "Resource name of the Google Maps widget context token.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleMapsResultDelta": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "description": "The results of the Google Maps.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GoogleMapsResult"
+            }
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "google_maps_result"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleMapsResultItem": {
+        "description": "The result of the Google Maps.",
+        "type": "object",
+        "properties": {
+          "places": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GoogleMapsResultPlaces"
+            }
+          },
+          "widget_context_token": {
+            "type": "string"
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "GoogleMapsResult",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "GoogleMapsResult"
+      },
+      "GoogleMapsResultPlaces": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "place_id": {
+            "type": "string"
+          },
+          "review_snippets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReviewSnippet"
+            }
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleMapsResultStep": {
+        "description": "Google Maps result step.",
+        "type": "object",
+        "properties": {
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GoogleMapsResultItem"
+            }
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "google_maps_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "examples": [
+          {
+            "google_maps_result": {
+              "summary": "GoogleMapsResultStep",
+              "value": {
+                "type": "google_maps_result",
+                "call_id": "maps_call_39201",
+                "result": [
+                  {
+                    "name": "Golden Gate Park",
+                    "place_id": "ChIJIQBpAG2ahYAR9R7bNdTLg8M",
+                    "rating": 4.8
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "GoogleMapsResultStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleSearch": {
+        "description": "A tool that can be used by the model to search Google.",
+        "type": "object",
+        "properties": {
+          "search_types": {
+            "description": "The types of search grounding to enable.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "web_search",
+                "image_search",
+                "enterprise_web_search"
+              ],
+              "x-google-enum-descriptions": [
+                "Setting this field enables web search. Only text results are returned.",
+                "Setting this field enables image search. Image bytes are returned.",
+                "Setting this field enables enterprise web search."
+              ]
+            }
+          },
+          "type": {
+            "const": "google_search"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-codeSamples": [
+          {
+            "label": "google_search",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3.6-flash\",\n    \"tools\": [{\n      \"type\": \"google_search\"\n    }],\n    \"input\": \"Who is the current president of France?\"\n  }'\n"
+          },
+          {
+            "label": "google_search",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    tools=[{\"type\": \"google_search\"}],\n    input=\"Who is the current president of France?\"\n)\nprint(response.output_text)\n"
+          },
+          {
+            "label": "google_search",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    tools: [{ type: 'google_search' }],\n    input: 'Who is the current president of France?'\n});\nconsole.log(interaction.output_text);\n"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleSearchCallArguments": {
+        "description": "The arguments to pass to Google Search.",
+        "type": "object",
+        "properties": {
+          "queries": {
+            "description": "Web search queries for the following-up web search.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleSearchCallDelta": {
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/GoogleSearchCallArguments"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "google_search_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleSearchCallStep": {
+        "description": "Google Search call step.",
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "Required. The arguments to pass to Google Search.",
+            "$ref": "#/components/schemas/GoogleSearchCallStepArguments"
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "search_type": {
+            "description": "The type of search grounding enabled.",
+            "type": "string",
+            "enum": [
+              "web_search",
+              "image_search",
+              "enterprise_web_search"
+            ],
+            "x-google-enum-descriptions": [
+              "Setting this field enables web search. Only text results are returned.",
+              "Setting this field enables image search. Image bytes are returned.",
+              "Setting this field enables enterprise web search."
+            ]
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "google_search_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "id",
+          "type"
+        ],
+        "examples": [
+          {
+            "google_search_call": {
+              "summary": "GoogleSearchCallStep",
+              "value": {
+                "type": "google_search_call",
+                "arguments": {
+                  "query": "Who won the men's 100m in Paris 2024?"
+                },
+                "id": "search_call_19201"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "GoogleSearchCallStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleSearchCallStepArguments": {
+        "description": "The arguments to pass to Google Search.",
+        "type": "object",
+        "properties": {
+          "queries": {
+            "description": "Web search queries for the following-up web search.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "GoogleSearchCallArguments",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "GoogleSearchCallArguments"
+      },
+      "GoogleSearchResult": {
+        "description": "The result of the Google Search.",
+        "type": "object",
+        "properties": {
+          "search_suggestions": {
+            "description": "Web content snippet that can be embedded in a web page or an app webview.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleSearchResultDelta": {
+        "type": "object",
+        "properties": {
+          "is_error": {
+            "type": "boolean"
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GoogleSearchResult"
+            }
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "google_search_result"
+          }
+        },
+        "required": [
+          "result",
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GoogleSearchResultItem": {
+        "description": "The result of the Google Search.",
+        "type": "object",
+        "properties": {
+          "search_suggestions": {
+            "description": "Web content snippet that can be embedded in a web page or an app webview.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "GoogleSearchResult",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "GoogleSearchResult"
+      },
+      "GoogleSearchResultStep": {
+        "description": "Google Search result step.",
+        "type": "object",
+        "properties": {
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the Google Search resulted in an error.",
+            "type": "boolean"
+          },
+          "result": {
+            "description": "Required. The results of the Google Search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GoogleSearchResultItem"
+            }
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "google_search_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "examples": [
+          {
+            "google_search_result": {
+              "summary": "GoogleSearchResultStep",
+              "value": {
+                "type": "google_search_result",
+                "call_id": "search_call_19201",
+                "result": [
+                  {
+                    "title": "Paris 2024 Olympics: Noah Lyles wins men's 100m gold",
+                    "url": "https://olympics.com/en/news/paris-2024-noah-lyles-wins-mens-100m-gold",
+                    "snippet": "American Noah Lyles won the Olympic men's 100m gold medal in a photo finish."
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "GoogleSearchResultStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "GroundingToolCount": {
+        "description": "The number of grounding tool counts.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The number of grounding tool counts.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "description": "The grounding tool type associated with the count.",
+            "type": "string",
+            "enum": [
+              "google_search",
+              "google_maps",
+              "retrieval"
+            ],
+            "x-google-enum-descriptions": [
+              "Grounding with Google Web Search and Image Search, & Web Grounding\nfor Enterprise.",
+              "Grounding with Google Maps.",
+              "Grounding with customer's data, for example, VertexAISearch."
+            ]
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "HarmCategory": {
+        "type": "string",
+        "enum": [
+          "hate_speech",
+          "dangerous_content",
+          "harassment",
+          "sexually_explicit",
+          "civic_integrity",
+          "image_hate",
+          "image_dangerous_content",
+          "image_harassment",
+          "image_sexually_explicit",
+          "jailbreak"
+        ],
+        "x-google-enum-deprecated": [
+          false,
+          false,
+          false,
+          false,
+          true,
+          false,
+          false,
+          false,
+          false,
+          false
+        ],
+        "x-google-enum-descriptions": [
+          "Content that promotes violence or incites hatred against individuals or\ngroups based on certain attributes.",
+          "Content that promotes, facilitates, or enables dangerous activities.",
+          "Abusive, threatening, or content intended to bully, torment, or ridicule.",
+          "Content that contains sexually explicit material.",
+          "Deprecated: Election filter is not longer supported.\nThe harm category is civic integrity.",
+          "Images that contain hate speech.",
+          "Images that contain dangerous content.",
+          "Images that contain harassment.",
+          "Images that contain sexually explicit content.",
+          "Prompts designed to bypass safety filters."
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "HarmCategory",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "HybridSearch": {
+        "description": "Config for Hybrid Search.",
+        "type": "object",
+        "properties": {
+          "alpha": {
+            "description": "Optional. Alpha value controls the weight between dense and sparse vector search\nresults.",
+            "type": "number",
+            "format": "float"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ImageConfig": {
+        "description": "The configuration for image interaction.",
+        "type": "object",
+        "properties": {
+          "aspect_ratio": {
+            "enum": [
+              "1:1",
+              "2:3",
+              "3:2",
+              "3:4",
+              "4:3",
+              "4:5",
+              "5:4",
+              "9:16",
+              "16:9",
+              "21:9",
+              "1:8",
+              "8:1",
+              "1:4",
+              "4:1"
+            ],
+            "x-google-enum-descriptions": [
+              "1:1 aspect ratio.",
+              "2:3 aspect ratio.",
+              "3:2 aspect ratio.",
+              "3:4 aspect ratio.",
+              "4:3 aspect ratio.",
+              "4:5 aspect ratio.",
+              "5:4 aspect ratio.",
+              "9:16 aspect ratio.",
+              "16:9 aspect ratio.",
+              "21:9 aspect ratio.",
+              "1:8 aspect ratio.",
+              "8:1 aspect ratio.",
+              "1:4 aspect ratio.",
+              "4:1 aspect ratio."
+            ]
+          },
+          "image_size": {
+            "enum": [
+              "1K",
+              "2K",
+              "4K",
+              "512"
+            ],
+            "x-google-enum-descriptions": [
+              "1K image size.",
+              "2K image size.",
+              "4K image size.",
+              "512 image size."
+            ]
+          }
+        },
+        "deprecated": true,
+        "x-speakeasy-exports": [
+          {
+            "name": "ImageConfig",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ImageContent": {
+        "description": "An image content block.",
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "The image content.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "mime_type": {
+            "description": "The mime type of the image.",
+            "type": "string",
+            "enum": [
+              "image/png",
+              "image/jpeg",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "image/gif",
+              "image/bmp",
+              "image/tiff"
+            ],
+            "x-google-enum-descriptions": [
+              "PNG image format",
+              "JPEG image format",
+              "WebP image format",
+              "HEIC image format",
+              "HEIF image format",
+              "GIF image format",
+              "BMP image format",
+              "TIFF image format"
+            ]
+          },
+          "resolution": {
+            "description": "The resolution of the media.",
+            "$ref": "#/components/schemas/MediaResolution"
+          },
+          "type": {
+            "const": "image"
+          },
+          "uri": {
+            "description": "The URI of the image.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "image": {
+              "summary": "Image",
+              "value": {
+                "type": "image",
+                "data": "BASE64_ENCODED_IMAGE",
+                "mime_type": "image/png"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "ImageContent",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ImageDelta": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "mime_type": {
+            "type": "string",
+            "enum": [
+              "image/png",
+              "image/jpeg",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "image/gif",
+              "image/bmp",
+              "image/tiff"
+            ],
+            "x-google-enum-descriptions": [
+              "PNG image format",
+              "JPEG image format",
+              "WebP image format",
+              "HEIC image format",
+              "HEIF image format",
+              "GIF image format",
+              "BMP image format",
+              "TIFF image format"
+            ]
+          },
+          "resolution": {
+            "description": "The resolution of the media.",
+            "$ref": "#/components/schemas/MediaResolution"
+          },
+          "type": {
+            "const": "image"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ImageResponseFormat": {
+        "description": "Configuration for image output format.",
+        "type": "object",
+        "properties": {
+          "aspect_ratio": {
+            "description": "The aspect ratio for the image output.",
+            "type": "string",
+            "enum": [
+              "1:1",
+              "2:3",
+              "3:2",
+              "3:4",
+              "4:3",
+              "4:5",
+              "5:4",
+              "9:16",
+              "16:9",
+              "21:9",
+              "1:8",
+              "8:1",
+              "1:4",
+              "4:1"
+            ],
+            "x-google-enum-descriptions": [
+              "1:1 aspect ratio.",
+              "2:3 aspect ratio.",
+              "3:2 aspect ratio.",
+              "3:4 aspect ratio.",
+              "4:3 aspect ratio.",
+              "4:5 aspect ratio.",
+              "5:4 aspect ratio.",
+              "9:16 aspect ratio.",
+              "16:9 aspect ratio.",
+              "21:9 aspect ratio.",
+              "1:8 aspect ratio.",
+              "8:1 aspect ratio.",
+              "1:4 aspect ratio.",
+              "4:1 aspect ratio."
+            ]
+          },
+          "delivery": {
+            "description": "The delivery mode for the image output.",
+            "type": "string",
+            "enum": [
+              "inline",
+              "uri"
+            ],
+            "x-google-enum-descriptions": [
+              "Image data is returned inline in the response.",
+              "Image data is returned as a URI."
+            ]
+          },
+          "image_size": {
+            "description": "The size of the image output.",
+            "type": "string",
+            "enum": [
+              "512",
+              "1K",
+              "2K",
+              "4K"
+            ],
+            "x-google-enum-descriptions": [
+              "512px image size.",
+              "1K image size.",
+              "2K image size.",
+              "4K image size."
+            ]
+          },
+          "mime_type": {
+            "description": "The MIME type of the image output.",
+            "type": "string",
+            "enum": [
+              "image/jpeg"
+            ],
+            "x-google-enum-descriptions": [
+              "JPEG image format."
+            ]
+          },
+          "type": {
+            "const": "image"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "image_response_format": {
+              "summary": "Image Output",
+              "value": {
+                "type": "image",
+                "aspect_ratio": "16:9",
+                "image_size": "1K",
+                "mime_type": "image/jpeg"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "ImageResponseFormat",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Interaction": {
+        "description": "The Interaction resource.",
+        "properties": {
+          "agent": {
+            "description": "The name of the `Agent` used for generating the interaction.",
+            "$ref": "#/components/schemas/AgentOption"
+          },
+          "agent_config": {
+            "description": "Configuration parameters for the agent interaction.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AntigravityAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/CodeMenderAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/DeepResearchAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/DynamicAgentConfig"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "type"
+            }
+          },
+          "created": {
+            "description": "Output only. The time at which the response was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "type": "string",
+            "readOnly": true
+          },
+          "environment": {
+            "description": "The environment configuration for the interaction. Can be an object specifying remote environment sources or a string referencing an existing environment ID.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EnvironmentConfig"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "environment_id": {
+            "description": "Output only. The environment ID for the interaction. Only populated if environment\nconfig is set in the request.",
+            "type": "string",
+            "readOnly": true
+          },
+          "errors": {
+            "description": "Output only. Diagnostic faults / platform errors recorded on the interaction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "readOnly": true
+          },
+          "generation_config": {
+            "description": "Input only. Configuration parameters for the model interaction.",
+            "$ref": "#/components/schemas/GenerationConfig",
+            "writeOnly": true
+          },
+          "id": {
+            "description": "Required. Output only. A unique identifier for the interaction completion.",
+            "type": "string",
+            "default": "",
+            "readOnly": true
+          },
+          "input": {
+            "$ref": "#/components/schemas/InteractionsInput"
+          },
+          "labels": {
+            "description": "The labels with user-defined metadata for the request.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "model": {
+            "description": "The name of the `Model` used for generating the interaction.",
+            "$ref": "#/components/schemas/ModelOption"
+          },
+          "output_audio": {
+            "description": "The last audio generated by the model in response to the current request.\n\nNote: this is added by the SDK.",
+            "$ref": "#/components/schemas/AudioContent"
+          },
+          "output_image": {
+            "description": "The last image generated by the model in response to the current request.\n\nNote: this is added by the SDK.",
+            "$ref": "#/components/schemas/ImageContent"
+          },
+          "output_text": {
+            "description": "Concatenated text from the last model output in response to the current request.\n\nNote: this is added by the SDK.",
+            "type": "string"
+          },
+          "output_video": {
+            "description": "The last video generated by the model in response to the current request.\n\nNote: this is added by the SDK.",
+            "$ref": "#/components/schemas/VideoContent"
+          },
+          "previous_interaction_id": {
+            "description": "The ID of the previous interaction, if any.",
+            "type": "string"
+          },
+          "response_format": {
+            "description": "Enforces that the generated response is a JSON object that complies with the JSON schema specified in this field.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ResponseFormat"
+              },
+              {
+                "type": "array",
+                "example": [
+                  {
+                    "type": "text",
+                    "mime_type": "application/json"
+                  }
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/ResponseFormat"
+                },
+                "x-speakeasy-model-namespace": "interactions"
+              }
+            ]
+          },
+          "response_mime_type": {
+            "description": "The mime type of the response. This is required if response_format is set.",
+            "type": "string",
+            "deprecated": true
+          },
+          "response_modalities": {
+            "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
+            "type": "array",
+            "deprecated": true,
+            "items": {
+              "$ref": "#/components/schemas/ResponseModality"
+            }
+          },
+          "safety_settings": {
+            "description": "Safety settings for the interaction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SafetySetting"
+            }
+          },
+          "service_tier": {
+            "description": "The service tier for the interaction.",
+            "$ref": "#/components/schemas/ServiceTier"
+          },
+          "status": {
+            "description": "Required. Output only. The status of the interaction.",
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete",
+              "budget_exceeded",
+              "queued"
+            ],
+            "readOnly": true,
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action/input from the user.",
+              "The interaction is completed.",
+              "The interaction failed.",
+              "The interaction was cancelled.",
+              "The interaction is completed, but contains incomplete results (e.g.\nhitting max_tokens).",
+              "The interaction was halted because the token budget was exceeded.",
+              "The interaction is queued, waiting for processing."
+            ]
+          },
+          "steps": {
+            "description": "Output only. The steps that make up the interaction, when included in the response.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Step"
+            },
+            "readOnly": true
+          },
+          "system_instruction": {
+            "description": "System instruction for the interaction.",
+            "type": "string"
+          },
+          "tools": {
+            "description": "A list of tool declarations the model may call during interaction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            }
+          },
+          "updated": {
+            "description": "Output only. The time at which the response was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "type": "string",
+            "readOnly": true
+          },
+          "usage": {
+            "description": "Output only. Statistics on the interaction request's token usage.",
+            "$ref": "#/components/schemas/Usage",
+            "readOnly": true
+          },
+          "webhook_config": {
+            "description": "Optional. Webhook configuration for receiving notifications when the\ninteraction completes.",
+            "$ref": "#/components/schemas/WebhookConfig"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "example": {
+          "created": "2025-12-04T15:01:45Z",
+          "id": "v1_ChdXS0l4YWZXTk9xbk0xZThQczhEcmlROBIXV0tJeGFmV05PcW5NMWU4UHM4RHJpUTg",
+          "model": "gemini-3.6-flash",
+          "object": "interaction",
+          "status": "completed",
+          "steps": [
+            {
+              "type": "model_output",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Hello! I'm doing well, functioning as expected. Thank you for asking! How are you doing today?"
+                }
+              ]
+            }
+          ],
+          "updated": "2025-12-04T15:01:45Z",
+          "usage": {
+            "input_tokens_by_modality": [
+              {
+                "modality": "text",
+                "tokens": 7
+              }
+            ],
+            "total_cached_tokens": 0,
+            "total_input_tokens": 7,
+            "total_output_tokens": 23,
+            "total_thought_tokens": 49,
+            "total_tokens": 79,
+            "total_tool_use_tokens": 0
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "Interaction",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "InteractionCompletedEvent": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "interaction.completed"
+          },
+          "interaction": {
+            "description": "Partial completed interaction resource emitted at the end of the stream.",
+            "$ref": "#/components/schemas/InteractionSseEventInteraction"
+          }
+        },
+        "required": [
+          "event_type",
+          "interaction"
+        ],
+        "examples": [
+          {
+            "interaction_completed": {
+              "summary": "Interaction Completed",
+              "value": {
+                "event_id": "evt_123",
+                "event_type": "interaction.completed",
+                "interaction": {
+                  "created": "2025-12-04T15:01:45Z",
+                  "id": "v1_ChdXS0l4YWZXTk9xbk0xZThQczhEcmlROBIXV0tJeGFmV05PcW5NMWU4UHM4RHJpUTg",
+                  "model": "gemini-3.6-flash",
+                  "status": "completed",
+                  "updated": "2025-12-04T15:01:45Z"
+                }
+              }
+            }
+          },
+          {
+            "interaction_completed": {
+              "summary": "Interaction Completed",
+              "value": {
+                "event_id": "evt_123",
+                "event_type": "interaction.completed",
+                "interaction": {
+                  "created": "2025-12-04T15:01:45Z",
+                  "id": "v1_ChdXS0l4YWZXTk9xbk0xZThQczhEcmlROBIXV0tJeGFmV05PcW5NMWU4UHM4RHJpUTg",
+                  "model": "gemini-3-flash-preview",
+                  "object": "interaction",
+                  "status": "completed",
+                  "updated": "2025-12-04T15:01:45Z"
+                }
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "InteractionCompletedEvent",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "InteractionCreatedEvent": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "interaction.created"
+          },
+          "interaction": {
+            "description": "Partial interaction resource emitted when the stream is created.",
+            "$ref": "#/components/schemas/InteractionSseEventInteraction"
+          }
+        },
+        "required": [
+          "event_type",
+          "interaction"
+        ],
+        "examples": [
+          {
+            "interaction_created": {
+              "summary": "Interaction Created",
+              "value": {
+                "event_id": "evt_123",
+                "event_type": "interaction.created",
+                "interaction": {
+                  "created": "2025-12-04T15:01:45Z",
+                  "id": "v1_ChdXS0l4YWZXTk9xbk0xZThQczhEcmlROBIXV0tJeGFmV05PcW5NMWU4UHM4RHJpUTg",
+                  "model": "gemini-3.6-flash",
+                  "status": "in_progress",
+                  "updated": "2025-12-04T15:01:45Z"
+                }
+              }
+            }
+          },
+          {
+            "interaction_created": {
+              "summary": "Interaction Created",
+              "value": {
+                "event_id": "evt_123",
+                "event_type": "interaction.created",
+                "interaction": {
+                  "id": "v1_ChdXS0l4YWZXTk9xbk0xZThQczhEcmlROBIXV0tJeGFmV05PcW5NMWU4UHM4RHJpUTg",
+                  "model": "gemini-3-flash-preview",
+                  "object": "interaction",
+                  "status": "in_progress"
+                }
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "InteractionCreatedEvent",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "InteractionSseEvent": {
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ErrorEvent"
+          },
+          {
+            "$ref": "#/components/schemas/InteractionCompletedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/InteractionCreatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/InteractionStatusUpdate"
+          },
+          {
+            "$ref": "#/components/schemas/StepDelta"
+          },
+          {
+            "$ref": "#/components/schemas/StepStart"
+          },
+          {
+            "$ref": "#/components/schemas/StepStop"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "InteractionSSEEvent",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "InteractionSSEEvent",
+        "discriminator": {
+          "propertyName": "event_type"
+        }
+      },
+      "InteractionSseEventInteraction": {
+        "description": "Partial interaction resource emitted by interaction lifecycle SSE events.\nStreaming lifecycle payloads may omit fields that are only available on\nfull non-streaming Interaction responses.\n",
+        "type": "object",
+        "properties": {
+          "agent": {
+            "description": "The agent to interact with.",
+            "type": "string"
+          },
+          "created": {
+            "description": "Output only. The time at which the response was created in ISO 8601 format.",
+            "type": "string",
+            "readOnly": true
+          },
+          "id": {
+            "description": "Required. Output only. A unique identifier for the interaction completion.",
+            "type": "string",
+            "readOnly": true
+          },
+          "model": {
+            "description": "The model that will complete your prompt.",
+            "type": "string"
+          },
+          "object": {
+            "description": "Output only. The resource type.",
+            "type": "string",
+            "readOnly": true
+          },
+          "service_tier": {
+            "description": "The service tier for the interaction.",
+            "$ref": "#/components/schemas/ServiceTier"
+          },
+          "status": {
+            "description": "Required. Output only. The status of the interaction.",
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete"
+            ],
+            "readOnly": true,
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action/input from the user.",
+              "The interaction is completed.",
+              "The interaction failed.",
+              "The interaction was cancelled.",
+              "The interaction is completed, but contains incomplete results (e.g. hitting max_tokens)."
+            ]
+          },
+          "steps": {
+            "description": "Output only. The steps that make up the interaction, if included in this event.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Step"
+            },
+            "readOnly": true
+          },
+          "updated": {
+            "description": "Output only. The time at which the response was last updated in ISO 8601 format.",
+            "type": "string",
+            "readOnly": true
+          },
+          "usage": {
+            "description": "Output only. Statistics on the interaction request's token usage.",
+            "$ref": "#/components/schemas/Usage",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "id",
+          "status"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "InteractionSseStreamEvent": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/InteractionSseEvent"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "InteractionSSEStreamEvent"
+      },
+      "InteractionStatusUpdate": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "interaction.status_update"
+          },
+          "interaction_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete",
+              "budget_exceeded",
+              "queued"
+            ],
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action/input from the user.",
+              "The interaction is completed.",
+              "The interaction failed.",
+              "The interaction was cancelled.",
+              "The interaction is completed, but contains incomplete results (e.g.\nhitting max_tokens).",
+              "The interaction was halted because the token budget was exceeded.",
+              "The interaction is queued, waiting for processing (e.g. waiting for\noff-peak capacity)."
+            ]
+          }
+        },
+        "required": [
+          "event_type",
+          "interaction_id",
+          "status"
+        ],
+        "examples": [
+          {
+            "interaction_status_update": {
+              "summary": "Interaction Status Update",
+              "value": {
+                "event_type": "interaction.status_update",
+                "interaction_id": "v1_ChdTMjQ0YWJ5TUF1TzcxZThQdjRpcnFRcxIXUzI0NGFieU1BdU83MWU4UHY0aXJxUXM",
+                "status": "in_progress"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "InteractionStatusUpdate",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "InteractionsInput": {
+        "description": "The input for the interaction.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Content"
+          },
+          {
+            "title": "StepList",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Step"
+            }
+          },
+          {
+            "title": "ContentList",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Content"
+            }
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ListAgentsResponse": {
+        "type": "object",
+        "properties": {
+          "agents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Agent"
+            }
+          },
+          "next_page_token": {
+            "type": "string"
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "AgentListResponse",
+            "group": "agents"
+          }
+        ],
+        "x-speakeasy-model-namespace": "agents",
+        "x-speakeasy-name-override": "AgentListResponse"
+      },
+      "ListEnvironmentsResponse": {
+        "description": "Response for `ListEnvironments`.",
+        "type": "object",
+        "properties": {
+          "environments": {
+            "description": "Environments belonging to the provided project.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Environment"
+            }
+          },
+          "next_page_token": {
+            "description": "Pagination token.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "EnvironmentListResponse",
+            "group": "environments"
+          }
+        ],
+        "x-speakeasy-model-namespace": "environments"
+      },
+      "ListTriggerExecutionsResponse": {
+        "description": "Response message for TriggerService.ListTriggerExecutions.",
+        "type": "object",
+        "properties": {
+          "next_page_token": {
+            "description": "A page token, received from a previous `ListTriggerExecutions` call.\nProvide this to retrieve the subsequent page.",
+            "type": "string"
+          },
+          "trigger_executions": {
+            "description": "The list of trigger executions.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TriggerExecution"
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "TriggerListExecutionsResponse",
+            "group": "triggers"
+          }
+        ],
+        "x-speakeasy-model-namespace": "triggers"
+      },
+      "ListTriggersResponse": {
+        "description": "Response message for TriggerService.ListTriggers.",
+        "type": "object",
+        "properties": {
+          "next_page_token": {
+            "description": "A page token, received from a previous `ListTriggers` call.\nProvide this to retrieve the subsequent page.",
+            "type": "string"
+          },
+          "triggers": {
+            "description": "The list of triggers.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Trigger"
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "TriggerListResponse",
+            "group": "triggers"
+          }
+        ],
+        "x-speakeasy-model-namespace": "triggers"
+      },
+      "ListWebhooksResponse": {
+        "description": "Response message for WebhookService.ListWebhooks.",
+        "type": "object",
+        "properties": {
+          "next_page_token": {
+            "description": "A token, which can be sent as `page_token` to retrieve the next page.\nIf this field is omitted, there are no subsequent pages.",
+            "type": "string"
+          },
+          "webhooks": {
+            "description": "The webhooks.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Webhook"
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "WebhookListResponse",
+            "group": "webhooks"
+          }
+        ],
+        "x-speakeasy-model-namespace": "webhooks",
+        "x-speakeasy-name-override": "WebhookListResponse"
+      },
+      "LocalEnvironmentConfig": {
+        "description": "Configuration for an environment that lives on the client connection rather\nthan in a server-managed sandbox.\n\nWhen set (via Interaction.local_environment), the agent's filesystem and\nshell are treated as living on the client: the agent's built-in environment\noperations (e.g. reading/listing/editing files and running commands) are\nsuspended on the server and yielded back to the client to execute, with their\nresults returned on a subsequent turn. This is mutually exclusive with a\nserver-managed `EnvironmentConfig` (remote_environment), since the\nenvironment is either on the client or in a server sandbox, never both.\n\nThis governs only the agent's built-in environment. Client-declared function\ntools are always executed on the client regardless of this field.",
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "local"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "McpServer": {
+        "description": "A MCPServer is a server that can be called by the model to perform actions.",
+        "type": "object",
+        "properties": {
+          "allowed_tools": {
+            "description": "The allowed tools.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AllowedTools"
+            }
+          },
+          "headers": {
+            "description": "Optional: Fields for authentication headers, timeouts, etc., if needed.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "description": "The name of the MCPServer.",
+            "type": "string"
+          },
+          "type": {
+            "const": "mcp_server"
+          },
+          "url": {
+            "description": "The full URL for the MCPServer endpoint.\nExample: \"https://api.example.com/mcp\"",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-codeSamples": [
+          {
+            "label": "mcp_server",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3.6-flash\",\n    \"tools\": [{\n      \"type\": \"mcp_server\",\n      \"name\": \"weather_service\",\n      \"url\": \"https://gemini-api-demos.uc.r.appspot.com/mcp\"\n    }],\n    \"input\": \"Today is 12-05-2025, what is the temperature today in London?\"\n  }'\n"
+          },
+          {
+            "label": "mcp_server",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    tools=[{\n        \"type\": \"mcp_server\",\n        \"name\": \"weather_service\",\n        \"url\": \"https://gemini-api-demos.uc.r.appspot.com/mcp\"\n    }],\n    input=\"Today is 12-05-2025, what is the temperature today in London?\"\n)\nprint(response.output_text)\n"
+          },
+          {
+            "label": "mcp_server",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    tools: [{\n        type: 'mcp_server',\n        name: 'weather_service',\n        url: 'https://gemini-api-demos.uc.r.appspot.com/mcp'\n    }],\n    input: 'Today is 12-05-2025, what is the temperature today in London?'\n});\nconsole.log(interaction.output_text);\n"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "MCPServer"
+      },
+      "McpServerToolCallDelta": {
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "server_name": {
+            "type": "string"
+          },
+          "type": {
+            "const": "mcp_server_tool_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "name",
+          "server_name",
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "MCPServerToolCallDelta"
+      },
+      "McpServerToolCallStep": {
+        "description": "MCPServer tool call step.",
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "Required. The JSON object of arguments for the function.",
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Required. The name of the tool which was called.",
+            "type": "string"
+          },
+          "server_name": {
+            "description": "Required. The name of the used MCP server.",
+            "type": "string"
+          },
+          "type": {
+            "const": "mcp_server_tool_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "id",
+          "name",
+          "server_name",
+          "type"
+        ],
+        "examples": [
+          {
+            "mcp_server_tool_call": {
+              "summary": "McpServerToolCallStep",
+              "value": {
+                "name": "calculate_tax",
+                "type": "mcp_server_tool_call",
+                "arguments": {
+                  "income": 120000,
+                  "state": "CA"
+                },
+                "id": "mcp_call_29012",
+                "server_name": "financial_mcp_server"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "MCPServerToolCallStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "MCPServerToolCallStep"
+      },
+      "McpServerToolResultDelta": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "result": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ImageContent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TextContent"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "server_name": {
+            "type": "string"
+          },
+          "type": {
+            "const": "mcp_server_tool_result"
+          }
+        },
+        "required": [
+          "result",
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "MCPServerToolResultDelta"
+      },
+      "McpServerToolResultStep": {
+        "description": "MCPServer tool result step.",
+        "type": "object",
+        "properties": {
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the tool which is called for this specific tool call.",
+            "type": "string"
+          },
+          "result": {
+            "description": "Required. The output from the MCP server call. Can be simple text or rich content.",
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ImageContent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TextContent"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "server_name": {
+            "description": "The name of the used MCP server.",
+            "type": "string"
+          },
+          "type": {
+            "const": "mcp_server_tool_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "examples": [
+          {
+            "mcp_server_tool_result": {
+              "summary": "McpServerToolResultStep",
+              "value": {
+                "type": "mcp_server_tool_result",
+                "call_id": "mcp_call_29012",
+                "result": {
+                  "tax_due": 32400
+                }
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "MCPServerToolResultStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "MCPServerToolResultStep"
+      },
+      "MediaProcessing": {
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/StaticMediaProcessing"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "MediaResolution": {
+        "type": "string",
+        "enum": [
+          "low",
+          "medium",
+          "high",
+          "ultra_high"
+        ],
+        "x-google-enum-descriptions": [
+          "Low resolution.",
+          "Medium resolution.",
+          "High resolution.",
+          "Ultra high resolution."
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ModalityTokens": {
+        "description": "The token count for a single response modality.",
+        "type": "object",
+        "properties": {
+          "modality": {
+            "description": "The modality associated with the token count.",
+            "$ref": "#/components/schemas/ResponseModality"
+          },
+          "tokens": {
+            "description": "Number of tokens for the modality.",
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ModelOption": {
+        "title": "Model",
+        "description": "The model that will complete your prompt.\\n\\nSee [models](https://ai.google.dev/gemini-api/docs/models) for additional details.",
+        "type": "string",
+        "enum": [
+          "gemini-2.5-flash",
+          "gemini-2.5-pro",
+          "gemma-4-26b-a4b-it",
+          "gemma-4-31b-it",
+          "gemini-flash-latest",
+          "gemini-flash-lite-latest",
+          "gemini-pro-latest",
+          "gemini-2.5-flash-lite",
+          "gemini-2.5-flash-image",
+          "gemini-3-flash-preview",
+          "gemini-3.1-pro-preview",
+          "gemini-3.1-pro-preview-customtools",
+          "gemini-3.1-flash-lite",
+          "gemini-3-pro-image",
+          "nano-banana-pro-preview",
+          "gemini-3.1-flash-image",
+          "gemini-3.5-flash",
+          "gemini-3.6-flash",
+          "lyria-3-clip-preview",
+          "lyria-3-pro-preview",
+          "gemini-robotics-er-1.6-preview",
+          "gemini-robotics-er-2-preview"
+        ],
+        "x-speakeasy-enum-descriptions": [
+          "Our first hybrid reasoning model which supports a 1M token context window and has thinking budgets.",
+          "Our state-of-the-art multipurpose model, which excels at coding and complex reasoning tasks.",
+          "Gemma 4 26B A4B IT",
+          "Gemma 4 31B IT",
+          "Latest release of Gemini Flash",
+          "Latest release of Gemini Flash-Lite",
+          "Latest release of Gemini Pro",
+          "Our smallest and most cost effective model, built for at scale usage.",
+          "Our native image generation model, optimized for speed, flexibility, and contextual understanding. Text input and output is priced the same as 2.5 Flash.",
+          "Our most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
+          "Our latest SOTA reasoning model with unprecedented depth and nuance, and powerful multimodal understanding and coding capabilities.",
+          "Gemini 3.1 Pro Preview optimized for custom tool usage",
+          "Our most cost-efficient model, optimized for high-volume agentic tasks, translation, and simple data processing.",
+          "Gemini 3 Pro Image",
+          "Gemini 3 Pro Image Preview",
+          "Gemini 3.1 Flash Image.",
+          "Our most intelligent model for sustained frontier performance in agentic and coding tasks.",
+          "Our most intelligent model for sustained frontier performance in agentic and coding tasks.",
+          "Our low-latency, music generation model optimized for high-fidelity audio clips and precise rhythmic control.",
+          "Our advanced, full-song generative model with deep compositional understanding, optimized for precise structural control and complex transitions across diverse musical styles.",
+          "Gemini Robotics-ER 1.6 Preview",
+          "Gemini Robotics Embodied Reasoning 2 Preview"
+        ],
+        "x-speakeasy-enum-format": "union",
+        "x-speakeasy-exports": [
+          {
+            "name": "Model",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "Model",
+        "x-speakeasy-unknown-values": "allow"
+      },
+      "ModelOutputStep": {
+        "description": "Output generated by the model.",
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Content"
+            }
+          },
+          "error": {
+            "description": "The error result of the operation in case of failure or cancellation.",
+            "$ref": "#/components/schemas/Status",
+            "deprecated": true
+          },
+          "type": {
+            "const": "model_output"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "model_output": {
+              "summary": "ModelOutputStep",
+              "value": {
+                "type": "model_output",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The capital of France is Paris."
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "ModelOutputStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ParallelAISearchConfig": {
+        "description": "Used to specify configuration for ParallelAISearch.",
+        "type": "object",
+        "properties": {
+          "api_key": {
+            "description": "Optional. The API key for ParallelAiSearch.",
+            "type": "string"
+          },
+          "custom_config": {
+            "description": "Optional. Custom configs for ParallelAiSearch.",
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "PingWebhookRequest": {
+        "description": "Request message for WebhookService.PingWebhook.",
+        "type": "object",
+        "x-speakeasy-exports": [
+          {
+            "name": "WebhookPingParams",
+            "group": "webhooks",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-model-namespace": "webhooks",
+        "x-stainless-empty-object": true
+      },
+      "PingWebhookResponse": {
+        "description": "Response message for WebhookService.PingWebhook.",
+        "type": "object",
+        "x-speakeasy-exports": [
+          {
+            "name": "WebhookPingResponse",
+            "group": "webhooks"
+          }
+        ],
+        "x-speakeasy-model-namespace": "webhooks",
+        "x-speakeasy-name-override": "WebhookPingResponse",
+        "x-stainless-empty-object": true
+      },
+      "PlaceCitation": {
+        "description": "A place citation annotation.",
+        "type": "object",
+        "properties": {
+          "end_index": {
+            "description": "End of the attributed segment, exclusive.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "description": "Title of the place.",
+            "type": "string"
+          },
+          "place_id": {
+            "description": "The ID of the place, in `places/{place_id}` format.",
+            "type": "string"
+          },
+          "review_snippets": {
+            "description": "Snippets of reviews that are used to generate answers about the\nfeatures of a given place in Google Maps.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReviewSnippet"
+            }
+          },
+          "start_index": {
+            "description": "Start of segment of the response that is attributed to this source.\n\nIndex indicates the start of the segment, measured in bytes.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "const": "place_citation"
+          },
+          "url": {
+            "description": "URI reference of the place.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "PlaceCitation",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Places": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Title of the place.",
+            "type": "string"
+          },
+          "place_id": {
+            "description": "The ID of the place, in `places/{place_id}` format.",
+            "type": "string"
+          },
+          "review_snippets": {
+            "description": "Snippets of reviews that are used to generate answers about the\nfeatures of a given place in Google Maps.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReviewSnippet"
+            }
+          },
+          "url": {
+            "description": "URI reference of the place.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RagResource": {
+        "description": "The definition of the Rag resource.",
+        "type": "object",
+        "properties": {
+          "rag_corpus": {
+            "description": "Optional. RagCorpora resource name.",
+            "type": "string"
+          },
+          "rag_file_ids": {
+            "description": "Optional. rag_file_id. The files should be in the same rag_corpus set in\nrag_corpus field.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RagRetrievalConfig": {
+        "description": "Specifies the context retrieval config.",
+        "type": "object",
+        "properties": {
+          "filter": {
+            "description": "Optional. Config for filters.",
+            "$ref": "#/components/schemas/Filter"
+          },
+          "hybrid_search": {
+            "description": "Optional. Config for Hybrid Search.",
+            "$ref": "#/components/schemas/HybridSearch"
+          },
+          "ranking": {
+            "description": "Optional. Config for ranking and reranking.",
+            "$ref": "#/components/schemas/Ranking"
+          },
+          "top_k": {
+            "description": "Optional. The number of contexts to retrieve.",
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RagStoreConfig": {
+        "description": "Use to specify configuration for RAG Store.",
+        "type": "object",
+        "properties": {
+          "rag_resources": {
+            "description": "Optional. The representation of the rag source.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RagResource"
+            }
+          },
+          "rag_retrieval_config": {
+            "description": "Optional. The retrieval config for the Rag query.",
+            "$ref": "#/components/schemas/RagRetrievalConfig"
+          },
+          "similarity_top_k": {
+            "description": "Optional. Number of top k results to return from the selected corpora.",
+            "type": "integer",
+            "deprecated": true,
+            "format": "int32"
+          },
+          "vector_distance_threshold": {
+            "description": "Optional. Only return results with vector distance smaller than the threshold.",
+            "type": "number",
+            "deprecated": true,
+            "format": "double"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RankService": {
+        "description": "Config for Rank Service.",
+        "type": "object",
+        "properties": {
+          "model_name": {
+            "description": "Optional. The model name of the rank service.",
+            "type": "string"
+          },
+          "ranking_config": {
+            "const": "rank_service"
+          }
+        },
+        "required": [
+          "ranking_config"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Ranking": {
+        "description": "Config for ranking and reranking.",
+        "type": "object",
+        "$ref": "#/components/schemas/RankService",
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ResponseFormat": {
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AudioResponseFormat"
+          },
+          {
+            "$ref": "#/components/schemas/ImageResponseFormat"
+          },
+          {
+            "$ref": "#/components/schemas/TextResponseFormat"
+          },
+          {
+            "$ref": "#/components/schemas/VideoResponseFormat"
+          },
+          {
+            "type": "object",
+            "additionalProperties": true
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ResponseModality": {
+        "type": "string",
+        "enum": [
+          "text",
+          "image",
+          "audio",
+          "video",
+          "document"
+        ],
+        "x-google-enum-descriptions": [
+          "Indicates the model should return text.",
+          "Indicates the model should return images.",
+          "Indicates the model should return audio.",
+          "Indicates the model should return video.",
+          "Indicates the model should return documents."
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Retrieval": {
+        "description": "A tool that can be used by the model to retrieve files.",
+        "type": "object",
+        "properties": {
+          "exa_ai_search_config": {
+            "description": "Used to specify configuration for ExaAISearch.",
+            "$ref": "#/components/schemas/ExaAISearchConfig"
+          },
+          "parallel_ai_search_config": {
+            "description": "Used to specify configuration for ParallelAISearch.",
+            "$ref": "#/components/schemas/ParallelAISearchConfig"
+          },
+          "rag_store_config": {
+            "description": "Used to specify configuration for RagStore.",
+            "$ref": "#/components/schemas/RagStoreConfig"
+          },
+          "retrieval_types": {
+            "description": "The types of file retrieval to enable.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "vertex_ai_search",
+                "rag_store",
+                "exa_ai_search",
+                "parallel_ai_search"
+              ],
+              "x-google-enum-descriptions": [
+                "",
+                "",
+                "",
+                ""
+              ]
+            }
+          },
+          "type": {
+            "const": "retrieval"
+          },
+          "vertex_ai_search_config": {
+            "description": "Used to specify configuration for VertexAISearch.",
+            "$ref": "#/components/schemas/VertexAISearchConfig"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RetrievalCallDelta": {
+        "description": "Used by Vertex Retrieval tools such as Parallel AI, Exa AI, Vertex AI Search,\netc. RetrievalType decides which tool is used.",
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "Required. The arguments to pass to the Retrieval tool.",
+            "$ref": "#/components/schemas/RetrievalStepArguments",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalStepArguments"
+              }
+            ]
+          },
+          "retrieval_type": {
+            "description": "The type of retrieval tools.",
+            "type": "string",
+            "enum": [
+              "vertex_ai_search",
+              "rag_store",
+              "exa_ai_search",
+              "parallel_ai_search"
+            ],
+            "x-google-enum-descriptions": [
+              "",
+              "",
+              "",
+              ""
+            ]
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "retrieval_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "type"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "RetrievalCallDelta",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RetrievalCallStep": {
+        "description": "Retrieval call step.\nUsed by Vertex Retrieval tools such as Parallel AI, Exa AI, Vertex AI Search,\netc. RetrievalType decides which tool is used.",
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "Required. The arguments to pass to the retrieval tool.",
+            "$ref": "#/components/schemas/RetrievalStepArguments",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalStepArguments"
+              }
+            ]
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "retrieval_type": {
+            "description": "The type of retrieval tools.",
+            "type": "string",
+            "enum": [
+              "vertex_ai_search",
+              "rag_store",
+              "exa_ai_search",
+              "parallel_ai_search"
+            ],
+            "x-google-enum-descriptions": [
+              "",
+              "",
+              "",
+              ""
+            ]
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "retrieval_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "id",
+          "type"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "RetrievalCallStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RetrievalResultDelta": {
+        "description": "Used by Vertex Retrieval tools such as Parallel AI, Exa AI, Vertex AI Search,\netc.\nToolResultDelta.type",
+        "type": "object",
+        "properties": {
+          "is_error": {
+            "description": "Whether the retrieval resulted in an error.",
+            "type": "boolean"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "retrieval_result"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "RetrievalResultDelta",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RetrievalResultStep": {
+        "description": "Vertex Retrieval result step.\nUsed by Vertex Retrieval tools such as Parallel AI, Exa AI, Vertex AI Search,\netc.",
+        "type": "object",
+        "properties": {
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the retrieval resulted in an error.",
+            "type": "boolean"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "retrieval_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "type"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "RetrievalResultStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RetrievalStepArguments": {
+        "description": "The arguments to pass to Retrieval tools.",
+        "type": "object",
+        "properties": {
+          "queries": {
+            "description": "Queries for Retrieval information.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "RetrievalCallArguments",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "RetrievalCallArguments"
+      },
+      "ReviewSnippet": {
+        "description": "Encapsulates a snippet of a user review that answers a question about\nthe features of a specific place in Google Maps.",
+        "type": "object",
+        "properties": {
+          "review_id": {
+            "description": "The ID of the review snippet.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Title of the review.",
+            "type": "string"
+          },
+          "url": {
+            "description": "A link that corresponds to the user review on Google Maps.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RotateSigningSecretRequest": {
+        "description": "Request message for WebhookService.RotateSigningSecret.",
+        "type": "object",
+        "properties": {
+          "revocation_behavior": {
+            "description": "Optional. The revocation behavior for previous signing secrets.",
+            "type": "string",
+            "enum": [
+              "revoke_previous_secrets_after_h24",
+              "revoke_previous_secrets_immediately"
+            ],
+            "x-google-enum-descriptions": [
+              "Generate a new signing secret and revoke all previous secrets after 24\nhours. Default and safest option for migrations.",
+              "Revoke all previous secrets immediately. Use with caution as this can\ninterrupt ongoing notifications."
+            ]
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "WebhookRotateSigningSecretParams",
+            "group": "webhooks",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-model-namespace": "webhooks"
+      },
+      "RotateSigningSecretResponse": {
+        "description": "Response message for WebhookService.RotateSigningSecret.",
+        "type": "object",
+        "properties": {
+          "secret": {
+            "description": "Output only. The newly generated signing secret.",
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "WebhookRotateSigningSecretResponse",
+            "group": "webhooks"
+          }
+        ],
+        "x-speakeasy-model-namespace": "webhooks",
+        "x-speakeasy-name-override": "WebhookRotateSigningSecretResponse"
+      },
+      "RunTriggerRequest": {
+        "description": "Request message for TriggerService.RunTrigger.",
+        "type": "object",
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "SafetySetting": {
+        "description": "A safety setting that affects the safety-blocking behavior.\n\nA SafetySetting consists of a\nharm category and a\nthreshold for that\ncategory.",
+        "type": "object",
+        "properties": {
+          "method": {
+            "description": "Optional. The method for blocking content. If not specified, the default\nbehavior is to use the probability score.",
+            "type": "string",
+            "enum": [
+              "severity",
+              "probability"
+            ],
+            "x-google-enum-descriptions": [
+              "The harm block method uses both probability and severity scores.",
+              "The harm block method uses the probability score."
+            ]
+          },
+          "threshold": {
+            "description": "Required. The threshold for blocking content. If the harm probability\nexceeds this threshold, the content will be blocked.",
+            "type": "string",
+            "enum": [
+              "block_low_and_above",
+              "block_medium_and_above",
+              "block_only_high",
+              "block_none",
+              "off"
+            ],
+            "x-google-enum-descriptions": [
+              "Block content with a low harm probability or higher.",
+              "Block content with a medium harm probability or higher.",
+              "Block content with a high harm probability.",
+              "Do not block any content, regardless of its harm probability.",
+              "Turn off the safety filter entirely."
+            ]
+          },
+          "type": {
+            "description": "Required. The type of harm category to be blocked.",
+            "$ref": "#/components/schemas/HarmCategory"
+          }
+        },
+        "required": [
+          "threshold",
+          "type"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "SafetySetting",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ServiceTier": {
+        "type": "string",
+        "enum": [
+          "flex",
+          "standard",
+          "priority",
+          "deferred"
+        ],
+        "x-google-enum-descriptions": [
+          "Flex service tier.",
+          "Standard service tier.",
+          "Priority service tier.",
+          "Deferred service tier."
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "SessionConfig": {
+        "description": "The configuration of CodeMender sessions.",
+        "type": "object",
+        "properties": {
+          "max_rounds": {
+            "description": "The maximum number of interaction rounds the agent is allowed to perform\nbefore reaching a timeout.",
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "SigningSecret": {
+        "description": "Represents a signing secret used to verify webhook payloads.",
+        "type": "object",
+        "properties": {
+          "expire_time": {
+            "description": "Output only. The expiration date of the signing secret.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "truncated_secret": {
+            "description": "Output only. The truncated version of the signing secret.",
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "SigningSecret",
+            "group": "webhooks"
+          }
+        ],
+        "x-speakeasy-model-namespace": "webhooks"
+      },
+      "Source": {
+        "description": "A source to be mounted into the environment.",
+        "type": "object",
+        "properties": {
+          "content": {
+            "description": "The inline content if `type` is `INLINE`.",
+            "type": "string"
+          },
+          "encoding": {
+            "description": "Optional encoding for inline content (e.g. `base64`).",
+            "type": "string"
+          },
+          "source": {
+            "description": "The source of the environment.\nFor GCS, this is the GCS path.\nFor GitHub, this is the GitHub path.",
+            "type": "string"
+          },
+          "target": {
+            "description": "Where the source should appear in the environment.",
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "gcs",
+              "inline",
+              "repository",
+              "skill_registry"
+            ],
+            "x-google-enum-descriptions": [
+              "A GCS bucket.",
+              "Inline content.",
+              "A generic repository. The protocol prefix in the source URL\nidentifies the provider (e.g., github://, gcs://).",
+              "A skill resource from the Skill Registry Service.\nSkill: projects/{project}/locations/{location}/skills/{skill}\nSkillRevision:\nprojects/{project}/locations/{location}/skills/{skill}/revisions/{revision}\nSupport mounting all skills under a project:\nprojects/{project}/locations/{location}/skills."
+            ]
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "SpeechConfig": {
+        "description": "The configuration for speech interaction.",
+        "type": "object",
+        "properties": {
+          "language": {
+            "description": "The language of the speech.",
+            "type": "string"
+          },
+          "speaker": {
+            "description": "The speaker's name, it should match the speaker name given in the prompt.",
+            "type": "string"
+          },
+          "voice": {
+            "description": "The voice of the speaker.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "SpeechConfig",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "StaticMediaProcessing": {
+        "type": "object",
+        "properties": {
+          "end_offset": {
+            "description": "Optional. Segment end time. Specified as a decimal number of seconds followed\nby an 's' suffix, e.g., \"30s\". Must be non-negative and greater than\n`start_offset` if `start_offset` is set.",
+            "type": "string",
+            "format": "google-duration"
+          },
+          "fps": {
+            "description": "Optional. Video frame-rate sampling density.",
+            "type": "number",
+            "format": "double"
+          },
+          "start_offset": {
+            "description": "Optional. Segment start time. Specified as a decimal number of seconds followed\nby an 's' suffix, e.g., \"10.5s\". Must be non-negative.",
+            "type": "string",
+            "format": "google-duration"
+          },
+          "type": {
+            "const": "static"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Status": {
+        "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). Each `Status` message contains\nthree pieces of data: error code, error message, and error details.\n\nYou can find out more about this error model and how to work with it in the\n[API Design Guide](https://cloud.google.com/apis/design/errors).",
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "The status code, which should be an enum value of google.rpc.Code.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "details": {
+            "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "description": "Properties of the object. Contains field @type with type URL."
+              }
+            }
+          },
+          "message": {
+            "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\ngoogle.rpc.Status.details field, or localized by the client.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Step": {
+        "description": "A step in the interaction.",
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CodeExecutionCallStep"
+          },
+          {
+            "$ref": "#/components/schemas/CodeExecutionResultStep"
+          },
+          {
+            "$ref": "#/components/schemas/FileSearchCallStep"
+          },
+          {
+            "$ref": "#/components/schemas/FileSearchResultStep"
+          },
+          {
+            "$ref": "#/components/schemas/FunctionCallStep"
+          },
+          {
+            "$ref": "#/components/schemas/FunctionResultStep"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleMapsCallStep"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleMapsResultStep"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleSearchCallStep"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleSearchResultStep"
+          },
+          {
+            "$ref": "#/components/schemas/McpServerToolCallStep"
+          },
+          {
+            "$ref": "#/components/schemas/McpServerToolResultStep"
+          },
+          {
+            "$ref": "#/components/schemas/ModelOutputStep"
+          },
+          {
+            "$ref": "#/components/schemas/ThoughtStep"
+          },
+          {
+            "$ref": "#/components/schemas/UrlContextCallStep"
+          },
+          {
+            "$ref": "#/components/schemas/UrlContextResultStep"
+          },
+          {
+            "$ref": "#/components/schemas/UserInputStep"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "Step",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "StepDelta": {
+        "type": "object",
+        "properties": {
+          "delta": {
+            "$ref": "#/components/schemas/StepDeltaData"
+          },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "step.delta"
+          },
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/StepDeltaMetadata"
+          }
+        },
+        "required": [
+          "delta",
+          "event_type",
+          "index"
+        ],
+        "examples": [
+          {
+            "step_delta": {
+              "summary": "Step Delta",
+              "value": {
+                "delta": {
+                  "type": "text",
+                  "text": "Hello"
+                },
+                "event_type": "step.delta",
+                "index": 0
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "StepDelta",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "StepDeltaData": {
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ArgumentsDelta"
+          },
+          {
+            "$ref": "#/components/schemas/AudioDelta"
+          },
+          {
+            "$ref": "#/components/schemas/CodeExecutionCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/CodeExecutionResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentDelta"
+          },
+          {
+            "$ref": "#/components/schemas/FileSearchCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/FileSearchResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/FunctionResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleMapsCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleMapsResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleSearchCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleSearchResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/ImageDelta"
+          },
+          {
+            "$ref": "#/components/schemas/McpServerToolCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/McpServerToolResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/RetrievalCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/RetrievalResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/TextAnnotationDelta"
+          },
+          {
+            "$ref": "#/components/schemas/TextDelta"
+          },
+          {
+            "$ref": "#/components/schemas/ThoughtSignatureDelta"
+          },
+          {
+            "$ref": "#/components/schemas/ThoughtSummaryDelta"
+          },
+          {
+            "$ref": "#/components/schemas/UrlContextCallDelta"
+          },
+          {
+            "$ref": "#/components/schemas/UrlContextResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/VideoDelta"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "StepDeltaMetadata": {
+        "description": "Optional metadata accompanying ANY streamed event.",
+        "type": "object",
+        "properties": {
+          "total_usage": {
+            "description": "Statistics on the interaction request's token usage.",
+            "$ref": "#/components/schemas/Usage"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "StepStart": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "step.start"
+          },
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "step": {
+            "$ref": "#/components/schemas/Step"
+          }
+        },
+        "required": [
+          "event_type",
+          "index",
+          "step"
+        ],
+        "examples": [
+          {
+            "step_start": {
+              "summary": "Step Start",
+              "value": {
+                "event_type": "step.start",
+                "index": 0,
+                "step": {
+                  "type": "model_output"
+                }
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "StepStart",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "StepStop": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "step.stop"
+          },
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "step_usage": {
+            "description": "Model usage stats for this specific step.",
+            "$ref": "#/components/schemas/Usage"
+          },
+          "usage": {
+            "description": "Cumulative model usage stats from the start of the session.",
+            "$ref": "#/components/schemas/Usage"
+          }
+        },
+        "required": [
+          "event_type",
+          "index"
+        ],
+        "examples": [
+          {
+            "step_stop": {
+              "summary": "Step Stop",
+              "value": {
+                "event_type": "step.stop",
+                "index": 0
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "StepStop",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "TextAnnotationDelta": {
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "description": "Citation information for model-generated content.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            }
+          },
+          "type": {
+            "const": "text_annotation_delta"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "TextContent": {
+        "description": "A text content block.",
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "description": "Citation information for model-generated content.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            }
+          },
+          "text": {
+            "description": "Required. The text content.",
+            "type": "string"
+          },
+          "type": {
+            "const": "text"
+          }
+        },
+        "required": [
+          "text",
+          "type"
+        ],
+        "examples": [
+          {
+            "text": {
+              "summary": "Text",
+              "value": {
+                "type": "text",
+                "text": "Hello, how are you?"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "TextContent",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "TextDelta": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "const": "text"
+          }
+        },
+        "required": [
+          "text",
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "TextResponseFormat": {
+        "description": "Configuration for text output format.",
+        "type": "object",
+        "properties": {
+          "mime_type": {
+            "description": "The MIME type of the text output.",
+            "type": "string",
+            "enum": [
+              "application/json",
+              "text/plain"
+            ],
+            "x-google-enum-descriptions": [
+              "JSON output format.",
+              "Plain text output format."
+            ]
+          },
+          "schema": {
+            "description": "The JSON schema that the output should conform to. Only applicable when\nmime_type is application/json.",
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "type": {
+            "const": "text"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "text_response_format": {
+              "summary": "Text Output (JSON Schema)",
+              "value": {
+                "type": "text",
+                "mime_type": "application/json",
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ingredients": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "recipe_name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ingredients",
+                    "recipe_name"
+                  ]
+                }
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "TextResponseFormat",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ThinkingLevel": {
+        "type": "string",
+        "enum": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ],
+        "x-google-enum-descriptions": [
+          "Little to no thinking.",
+          "Low thinking level.",
+          "Medium thinking level.",
+          "High thinking level."
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "ThinkingLevel",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ThinkingSummaries": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "none"
+        ],
+        "x-google-enum-descriptions": [
+          "Auto thinking summaries.",
+          "No thinking summaries."
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ThoughtContent": {
+        "description": "A thought content block.",
+        "type": "object",
+        "properties": {
+          "signature": {
+            "description": "Signature to match the backend source to be part of the generation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "summary": {
+            "description": "A summary of the thought.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ThoughtSummaryContent"
+            }
+          },
+          "type": {
+            "const": "thought"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "thought": {
+              "summary": "Thought",
+              "value": {
+                "type": "thought",
+                "signature": "CoMDAXLI2nynRYojJIy6B1Jh9os2crpWLfB0+19xcLsGG46bd8wjkF/6RNlRUdvHrXyjsHkG0BZFcuO/bPOyA6Xh5jANNgx82wPHjGExN8A4ZQn56FlMwyZoqFVQz0QyY1lfibFJ2zU3J87uw26OewzcuVX0KEcs+GIsZa3EA6WwqhbsOd3wtZB3Ua2Qf98VAWZTS5y/tWpql7jnU3/CU7pouxQr/Bwft3hwnJNesQ9/dDJTuaQ8Zprh9VRWf1aFFjpIueOjBRrlT3oW6/y/eRl/Gt9BQXCYTqg/38vHFUU4Wo/d9dUpvfCe/a3o97t2Jgxp34oFKcsVb4S5WJrykIkw+14DzVnTpCpbQNFckqvFLuqnJCkL0EQFtunBXI03FJpPu3T1XU6id8S7ojoJQZSauGUCgmaLqUGdMrd08oo81ecoJSLs51Re9N/lISGmjWFPGpqJLoGq6uo4FHz58hmeyXCgHG742BHz2P3MiH1CXHUT2J8mF6zLhf3SR9Qb3lkrobAh",
+                "summary": [
+                  {
+                    "type": "text",
+                    "text": "The user is asking about the weather. I should use the get_weather tool."
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "deprecated": true,
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ThoughtSignatureDelta": {
+        "type": "object",
+        "properties": {
+          "signature": {
+            "description": "Signature to match the backend source to be part of the generation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "thought_signature"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ThoughtStep": {
+        "description": "A thought step.",
+        "type": "object",
+        "properties": {
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "summary": {
+            "description": "A summary of the thought.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ThoughtSummaryContent"
+            }
+          },
+          "type": {
+            "const": "thought"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "thought": {
+              "summary": "ThoughtStep",
+              "value": {
+                "type": "thought",
+                "signature": "thought_sig_abcd1234",
+                "summary": [
+                  {
+                    "type": "text",
+                    "text": "The model is searching Google for the capital of France."
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "ThoughtStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ThoughtSummaryContent": {
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ImageContent"
+          },
+          {
+            "$ref": "#/components/schemas/TextContent"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ThoughtSummaryDelta": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "description": "A new summary item to be added to the thought.",
+            "$ref": "#/components/schemas/Content"
+          },
+          "type": {
+            "const": "thought_summary"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Tool": {
+        "description": "A tool that can be used by the model.",
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CodeExecution"
+          },
+          {
+            "$ref": "#/components/schemas/ComputerUse"
+          },
+          {
+            "$ref": "#/components/schemas/FileSearch"
+          },
+          {
+            "$ref": "#/components/schemas/Function"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleMaps"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleSearch"
+          },
+          {
+            "$ref": "#/components/schemas/McpServer"
+          },
+          {
+            "$ref": "#/components/schemas/Retrieval"
+          },
+          {
+            "$ref": "#/components/schemas/UrlContext"
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "Tool",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "ToolChoiceConfig": {
+        "description": "The tool choice configuration containing allowed tools.",
+        "type": "object",
+        "properties": {
+          "allowed_tools": {
+            "description": "The allowed tools.",
+            "$ref": "#/components/schemas/AllowedTools"
+          }
+        },
+        "example": {
+          "allowed_tools": {
+            "mode": "any",
+            "tools": [
+              "my_tool"
+            ]
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "ToolChoiceConfig",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "TranscriptionConfig": {
+        "description": "Configuration for speech recognition (transcription).",
+        "type": "object",
+        "properties": {
+          "adaptation_phrases": {
+            "description": "Optional. A list of phrases to bias the ASR model towards.",
+            "type": "array",
+            "deprecated": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "custom_vocabulary": {
+            "description": "Optional. A list of custom vocabulary phrases to bias the speech recognition model\ntoward recognizing specific terms.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "diarization_mode": {
+            "description": "Optional. Configures speaker diarization. Supported values: \"speaker\".",
+            "type": "string"
+          },
+          "language_codes": {
+            "description": "Optional. BCP-47 language codes providing hints about the languages present in the\naudio. If omitted or empty, defaults to automatic language detection.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "timestamp_granularities": {
+            "description": "Optional. The granularity of timestamps to include in the transcription output.\nSupported values: \"word\". If empty, no timestamps are generated.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "TranscriptionConfig",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Trigger": {
+        "description": "A trigger configuration that is scheduled to run an agent.",
+        "type": "object",
+        "properties": {
+          "consecutive_failure_count": {
+            "description": "Output only. The number of consecutive failures that have occurred\nsince the last successful execution.",
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "create_time": {
+            "description": "Output only. The time when the trigger was created.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "display_name": {
+            "description": "Optional. The display name of the trigger.",
+            "type": "string"
+          },
+          "environment_id": {
+            "description": "Optional. The environment ID for the trigger execution.",
+            "type": "string"
+          },
+          "execution_timeout_seconds": {
+            "description": "Optional. The execution timeout for the triggered interaction.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "description": "Required. Output only. Identifier. The ID of the trigger.",
+            "type": "string",
+            "readOnly": true,
+            "x-google-identifier": true
+          },
+          "interaction": {
+            "description": "Required. The interaction request template to be executed.",
+            "$ref": "#/components/schemas/Interaction"
+          },
+          "last_pause_time": {
+            "description": "Output only. The time when the trigger was last paused.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "last_resume_time": {
+            "description": "Output only. The time when the trigger was last resumed.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "last_run_time": {
+            "description": "Output only. The time when the trigger was last run.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "max_consecutive_failures": {
+            "description": "Optional. The maximum number of consecutive failures allowed before\nthe trigger is automatically paused (status becomes ERROR).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "next_run_time": {
+            "description": "Output only. The time when the trigger is scheduled to run next.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "previous_interaction_id": {
+            "description": "Output only. The ID of the last interaction created by this trigger.",
+            "type": "string",
+            "readOnly": true
+          },
+          "schedule": {
+            "description": "Required. The cron schedule on which the trigger should run.\nStandard cron format.",
+            "type": "string"
+          },
+          "status": {
+            "description": "Output only. The current status of the trigger.",
+            "type": "string",
+            "enum": [
+              "active",
+              "paused",
+              "error"
+            ],
+            "readOnly": true,
+            "x-google-enum-descriptions": [
+              "The trigger is active and will fire on schedule.",
+              "The trigger is paused and will not fire.",
+              "The trigger has entered an error state due to consecutive failures."
+            ]
+          },
+          "time_zone": {
+            "description": "Required. Time zone in which the schedule should be interpreted.",
+            "type": "string"
+          },
+          "update_time": {
+            "description": "Output only. The time when the trigger was last updated.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "id",
+          "interaction",
+          "schedule",
+          "time_zone"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "Trigger",
+            "group": "triggers",
+            "representation": "model"
+          }
+        ],
+        "x-speakeasy-model-namespace": "triggers"
+      },
+      "TriggerCreateParams": {
+        "description": "Parameters for creating a trigger.",
+        "type": "object",
+        "properties": {
+          "display_name": {
+            "description": "Optional. The display name of the trigger.",
+            "type": "string"
+          },
+          "environment_id": {
+            "description": "Optional. The environment ID for the trigger execution.",
+            "type": "string"
+          },
+          "execution_timeout_seconds": {
+            "description": "Optional. The execution timeout for the triggered interaction.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "interaction": {
+            "description": "Required. The interaction request template to be executed.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CreateAgentInteractionParams"
+              },
+              {
+                "$ref": "#/components/schemas/CreateModelInteractionParams"
+              }
+            ]
+          },
+          "max_consecutive_failures": {
+            "description": "Optional. The maximum number of consecutive failures allowed before the trigger is automatically paused (status becomes ERROR).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "schedule": {
+            "description": "Required. The cron schedule on which the trigger should run. Standard cron format.",
+            "type": "string"
+          },
+          "time_zone": {
+            "description": "Required. Time zone in which the schedule should be interpreted.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "interaction",
+          "schedule",
+          "time_zone"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "TriggerCreateParams",
+            "group": "triggers",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-model-namespace": "triggers"
+      },
+      "TriggerExecution": {
+        "description": "An execution instance of a trigger.",
+        "type": "object",
+        "properties": {
+          "end_time": {
+            "description": "Output only. The time when the execution finished.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "environment_id": {
+            "description": "Output only. The environment ID used for the execution.",
+            "type": "string",
+            "readOnly": true
+          },
+          "error": {
+            "description": "Output only. The error message if the execution failed.",
+            "type": "string",
+            "readOnly": true
+          },
+          "id": {
+            "description": "Required. Output only. Identifier. The ID of the trigger execution.",
+            "type": "string",
+            "readOnly": true,
+            "x-google-identifier": true
+          },
+          "interaction_id": {
+            "description": "Output only. The ID of the interaction created by this execution, if any.",
+            "type": "string",
+            "readOnly": true
+          },
+          "scheduled_time": {
+            "description": "Output only. The time when the execution was scheduled to run.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "start_time": {
+            "description": "Output only. The time when the execution started.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "status": {
+            "description": "Output only. The status of the execution.",
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "failed",
+              "skipped",
+              "timed_out"
+            ],
+            "readOnly": true,
+            "x-google-enum-descriptions": [
+              "The execution is currently in progress.",
+              "The execution completed successfully.",
+              "The execution failed.",
+              "The execution was skipped (e.g., previous execution still running).",
+              "The execution timed out."
+            ]
+          },
+          "trigger_id": {
+            "description": "Required. Output only. Identifier. The ID of the trigger that created this execution.",
+            "type": "string",
+            "readOnly": true,
+            "x-google-identifier": true
+          }
+        },
+        "required": [
+          "id",
+          "trigger_id"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "TriggerExecution",
+            "group": "triggers"
+          }
+        ],
+        "x-speakeasy-model-namespace": "triggers"
+      },
+      "TriggerUpdate": {
+        "description": "Represents the fields of a Trigger that can be updated.",
+        "type": "object",
+        "properties": {
+          "display_name": {
+            "description": "Optional. The display name of the trigger.",
+            "type": "string"
+          },
+          "status": {
+            "description": "Optional. The status of the trigger.",
+            "type": "string",
+            "enum": [
+              "active",
+              "paused",
+              "error"
+            ],
+            "x-google-enum-descriptions": [
+              "The trigger is active and will fire on schedule.",
+              "The trigger is paused and will not fire.",
+              "The trigger has entered an error state due to consecutive failures."
+            ]
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "TriggerUpdate",
+            "group": "triggers"
+          }
+        ],
+        "x-speakeasy-model-namespace": "triggers"
+      },
+      "UrlCitation": {
+        "description": "A URL citation annotation.",
+        "type": "object",
+        "properties": {
+          "end_index": {
+            "description": "End of the attributed segment, exclusive.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "start_index": {
+            "description": "Start of segment of the response that is attributed to this source.\n\nIndex indicates the start of the segment, measured in bytes.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "description": "The title of the URL.",
+            "type": "string"
+          },
+          "type": {
+            "const": "url_citation"
+          },
+          "url": {
+            "description": "The URL.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "URLCitation",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "URLCitation"
+      },
+      "UrlContext": {
+        "description": "A tool that can be used by the model to fetch URL context.",
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "url_context"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-codeSamples": [
+          {
+            "label": "url_context",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3.6-flash\",\n    \"tools\": [{\n      \"type\": \"url_context\"\n    }],\n    \"input\": \"Summarize https://www.example.com\"\n  }'\n"
+          },
+          {
+            "label": "url_context",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3.6-flash\",\n    tools=[{\"type\": \"url_context\"}],\n    input=\"Summarize https://www.example.com\"\n)\nprint(response.output_text)\n"
+          },
+          {
+            "label": "url_context",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3.6-flash',\n    tools: [{ type: 'url_context' }],\n    input: 'Summarize https://www.example.com'\n});\nconsole.log(interaction.output_text);\n"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "URLContext"
+      },
+      "UrlContextCallArguments": {
+        "description": "The arguments to pass to the URL context.",
+        "type": "object",
+        "properties": {
+          "urls": {
+            "description": "The URLs to fetch.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "URLContextCallArguments",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "URLContextCallArguments"
+      },
+      "UrlContextCallDelta": {
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/UrlContextCallArguments"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "url_context_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "URLContextCallDelta"
+      },
+      "UrlContextCallStep": {
+        "description": "URL context call step.",
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "Required. The arguments to pass to the URL context.",
+            "$ref": "#/components/schemas/UrlContextCallArguments"
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "url_context_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "id",
+          "type"
+        ],
+        "examples": [
+          {
+            "url_context_call": {
+              "summary": "UrlContextCallStep",
+              "value": {
+                "type": "url_context_call",
+                "arguments": {
+                  "urls": [
+                    "https://www.example.com"
+                  ]
+                },
+                "id": "url_call_10219"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "URLContextCallStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "URLContextCallStep"
+      },
+      "UrlContextResult": {
+        "description": "The result of the URL context.",
+        "type": "object",
+        "properties": {
+          "status": {
+            "description": "The status of the URL retrieval.",
+            "type": "string",
+            "enum": [
+              "success",
+              "error",
+              "paywall",
+              "unsafe"
+            ],
+            "x-google-enum-descriptions": [
+              "Url retrieval is successful.",
+              "Url retrieval is failed due to error.",
+              "Url retrieval is failed because the content is behind paywall.",
+              "Url retrieval is failed because the content is unsafe."
+            ]
+          },
+          "url": {
+            "description": "The URL that was fetched.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "URLContextResult",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "URLContextResult"
+      },
+      "UrlContextResultDelta": {
+        "type": "object",
+        "properties": {
+          "is_error": {
+            "type": "boolean"
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UrlContextResult"
+            }
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "url_context_result"
+          }
+        },
+        "required": [
+          "result",
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "URLContextResultDelta"
+      },
+      "UrlContextResultStep": {
+        "description": "URL context result step.",
+        "type": "object",
+        "properties": {
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the URL context resulted in an error.",
+            "type": "boolean"
+          },
+          "result": {
+            "description": "Required. The results of the URL context.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UrlContextResult"
+            }
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "url_context_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "examples": [
+          {
+            "url_context_result": {
+              "summary": "UrlContextResultStep",
+              "value": {
+                "type": "url_context_result",
+                "call_id": "url_call_10219",
+                "result": [
+                  {
+                    "title": "Example Domain",
+                    "url": "https://www.example.com",
+                    "snippet": "This domain is for use in illustrative examples in documents."
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "URLContextResultStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "URLContextResultStep"
+      },
+      "Usage": {
+        "description": "Statistics on the interaction request's token usage.",
+        "type": "object",
+        "properties": {
+          "cached_tokens_by_modality": {
+            "description": "A breakdown of cached token usage by modality.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokens"
+            }
+          },
+          "grounding_tool_count": {
+            "description": "Grounding tool count.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroundingToolCount"
+            }
+          },
+          "input_tokens_by_modality": {
+            "description": "A breakdown of input token usage by modality.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokens"
+            }
+          },
+          "output_tokens_by_modality": {
+            "description": "A breakdown of output token usage by modality.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokens"
+            }
+          },
+          "tool_use_tokens_by_modality": {
+            "description": "A breakdown of tool-use token usage by modality.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokens"
+            }
+          },
+          "total_cached_tokens": {
+            "description": "Number of tokens in the cached part of the prompt (the cached content).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "total_input_tokens": {
+            "description": "Number of tokens in the prompt (context).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "total_output_tokens": {
+            "description": "Total number of tokens across all the generated responses.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "total_thought_tokens": {
+            "description": "Number of tokens of thoughts for thinking models.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "total_tokens": {
+            "description": "Total token count for the interaction request (prompt + responses + other\ninternal tokens).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "total_tool_use_tokens": {
+            "description": "Number of tokens present in tool-use prompt(s).",
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "Usage",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "UserInputStep": {
+        "description": "Input provided by the user.",
+        "type": "object",
+        "properties": {
+          "content": {
+            "title": "ContentList",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Content"
+            }
+          },
+          "type": {
+            "const": "user_input"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "user_input": {
+              "summary": "UserInputStep",
+              "value": {
+                "type": "user_input",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "What is the capital of France?"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "UserInputStep",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "VertexAISearchConfig": {
+        "description": "Used to specify configuration for VertexAISearch.",
+        "type": "object",
+        "properties": {
+          "datastores": {
+            "description": "Optional. Used to specify Vertex AI Search datastores.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "engine": {
+            "description": "Optional. Used to specify Vertex AI Search engine.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "VideoConfig": {
+        "description": "Configuration options for video generation.",
+        "type": "object",
+        "properties": {
+          "task": {
+            "description": "Optional task mode for video generation. If not specified, the model\nautomatically determines the appropriate mode based on the provided text\nprompt and input media.",
+            "type": "string",
+            "enum": [
+              "text_to_video",
+              "image_to_video",
+              "reference_to_video",
+              "edit"
+            ],
+            "x-google-enum-descriptions": [
+              "Generates video solely from a text prompt.",
+              "Generates video from one or two source images. The first image defines\nthe starting frame, and the optional second image defines the ending\nframe.",
+              "Generates video using reference media (such as images, audio, or video).",
+              "Modifies an existing input video."
+            ]
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "VideoConfig",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "VideoContent": {
+        "description": "A video content block.",
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "The video content.",
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "mime_type": {
+            "description": "The mime type of the video.",
+            "type": "string",
+            "enum": [
+              "video/mp4",
+              "video/mpeg",
+              "video/mpg",
+              "video/mov",
+              "video/avi",
+              "video/x-flv",
+              "video/webm",
+              "video/wmv",
+              "video/3gpp"
+            ],
+            "x-google-enum-descriptions": [
+              "MP4 video format",
+              "MPEG video format",
+              "MPG video format",
+              "MOV video format",
+              "AVI video format",
+              "FLV video format",
+              "WebM video format",
+              "WMV video format",
+              "3GPP video format"
+            ]
+          },
+          "processing": {
+            "description": "How the model processes this video for understanding.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/MediaProcessing"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "static",
+                  "agentic"
+                ],
+                "x-google-enum-descriptions": [
+                  "Fixed-rate frame extraction. All frames placed in context.",
+                  "Model-driven dynamic navigation."
+                ]
+              }
+            ]
+          },
+          "resolution": {
+            "description": "The resolution of the media.",
+            "$ref": "#/components/schemas/MediaResolution"
+          },
+          "type": {
+            "const": "video"
+          },
+          "uri": {
+            "description": "The URI of the video.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "video": {
+              "summary": "Video",
+              "value": {
+                "type": "video",
+                "uri": "https://www.youtube.com/watch?v=9hE5-98ZeCg"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "VideoContent",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "VideoDelta": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "string",
+            "format": "byte",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "mime_type": {
+            "type": "string",
+            "enum": [
+              "video/mp4",
+              "video/mpeg",
+              "video/mpg",
+              "video/mov",
+              "video/avi",
+              "video/x-flv",
+              "video/webm",
+              "video/wmv",
+              "video/3gpp"
+            ],
+            "x-google-enum-descriptions": [
+              "MP4 video format",
+              "MPEG video format",
+              "MPG video format",
+              "MOV video format",
+              "AVI video format",
+              "FLV video format",
+              "WebM video format",
+              "WMV video format",
+              "3GPP video format"
+            ]
+          },
+          "resolution": {
+            "description": "The resolution of the media.",
+            "$ref": "#/components/schemas/MediaResolution"
+          },
+          "type": {
+            "const": "video"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "VideoResponseFormat": {
+        "description": "Configuration for video output format.",
+        "type": "object",
+        "properties": {
+          "aspect_ratio": {
+            "description": "The aspect ratio for the video output.",
+            "type": "string",
+            "enum": [
+              "16:9",
+              "9:16"
+            ],
+            "x-google-enum-descriptions": [
+              "16:9 aspect ratio.",
+              "9:16 aspect ratio."
+            ]
+          },
+          "delivery": {
+            "description": "The delivery mode for the video output.",
+            "type": "string",
+            "enum": [
+              "inline",
+              "uri"
+            ],
+            "x-google-enum-descriptions": [
+              "Video data is returned inline in the response.",
+              "Video data is returned as a URI."
+            ]
+          },
+          "duration": {
+            "description": "The duration for the video output.",
+            "type": "string",
+            "format": "google-duration"
+          },
+          "gcs_uri": {
+            "description": "The GCS URI to store the video output. Required for Vertex if delivery mode\nis URI.",
+            "type": "string"
+          },
+          "type": {
+            "const": "video"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "examples": [
+          {
+            "video_response_format": {
+              "summary": "Video Output",
+              "value": {
+                "type": "video",
+                "aspect_ratio": "16:9",
+                "delivery": "inline"
+              }
+            }
+          }
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "VideoResponseFormat",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Webhook": {
+        "description": "A Webhook resource.",
+        "type": "object",
+        "properties": {
+          "create_time": {
+            "description": "Output only. The timestamp when the webhook was created.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "id": {
+            "description": "Output only. The ID of the webhook.",
+            "type": "string",
+            "readOnly": true
+          },
+          "name": {
+            "description": "Optional. The user-provided name of the webhook.",
+            "type": "string"
+          },
+          "new_signing_secret": {
+            "description": "Output only. The new signing secret for the webhook. Only populated on create.",
+            "type": "string",
+            "readOnly": true
+          },
+          "signing_secrets": {
+            "description": "Output only. The signing secrets associated with this webhook.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SigningSecret"
+            },
+            "readOnly": true
+          },
+          "state": {
+            "description": "Output only. The state of the webhook.",
+            "type": "string",
+            "enum": [
+              "enabled",
+              "disabled",
+              "disabled_due_to_failed_deliveries"
+            ],
+            "readOnly": true,
+            "x-google-enum-descriptions": [
+              "The webhook is enabled.",
+              "The webhook is disabled by the user.",
+              "The webhook is disabled due to failed deliveries."
+            ]
+          },
+          "subscribed_events": {
+            "description": "Required. The events that the webhook is subscribed to.\nAvailable events:\n- batch.succeeded\n- batch.expired\n- batch.failed\n- interaction.requires_action\n- interaction.completed\n- interaction.failed\n- video.generated",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "batch.succeeded",
+                "batch.expired",
+                "batch.failed",
+                "interaction.requires_action",
+                "interaction.completed",
+                "interaction.failed",
+                "video.generated"
+              ],
+              "x-speakeasy-enum-descriptions": [
+                "Batch processing finished successfully.",
+                "Batch has not been processed within the 48h timeframe.",
+                "Batch job failed.",
+                "Interaction requires action (e.g., function calling).",
+                "Interaction completed successfully.",
+                "Interaction failed.",
+                "Video generation completed."
+              ],
+              "x-speakeasy-enum-format": "union",
+              "x-speakeasy-unknown-values": "allow"
+            }
+          },
+          "update_time": {
+            "description": "Output only. The timestamp when the webhook was last updated.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "uri": {
+            "description": "Required. The URI to which webhook events will be sent.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscribed_events",
+          "uri"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "Webhook",
+            "group": "webhooks"
+          },
+          {
+            "name": "WebhookInput",
+            "group": "webhooks",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-model-namespace": "webhooks"
+      },
+      "WebhookConfig": {
+        "description": "Message for configuring webhook events for a request.",
+        "type": "object",
+        "properties": {
+          "uris": {
+            "description": "Optional. If set, these webhook URIs will be used for webhook events instead of the\nregistered webhooks.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "user_metadata": {
+            "description": "Optional. The user metadata that will be returned on each event emission to the\nwebhooks.",
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "WebhookConfig",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "WebhookUpdate": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Optional. The user-provided name of the webhook.",
+            "type": "string"
+          },
+          "state": {
+            "description": "Optional. The state of the webhook.",
+            "type": "string",
+            "enum": [
+              "enabled",
+              "disabled",
+              "disabled_due_to_failed_deliveries"
+            ],
+            "x-google-enum-descriptions": [
+              "The webhook is enabled.",
+              "The webhook is disabled by the user.",
+              "The webhook is disabled due to failed deliveries."
+            ]
+          },
+          "subscribed_events": {
+            "description": "Optional. The events that the webhook is subscribed to.\nAvailable events:\n- batch.succeeded\n- batch.expired\n- batch.failed\n- interaction.requires_action\n- interaction.completed\n- interaction.failed\n- video.generated",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "batch.succeeded",
+                "batch.expired",
+                "batch.failed",
+                "interaction.requires_action",
+                "interaction.completed",
+                "interaction.failed",
+                "video.generated"
+              ],
+              "x-speakeasy-enum-descriptions": [
+                "Batch processing finished successfully.",
+                "Batch has not been processed within the 48h timeframe.",
+                "Batch job failed.",
+                "Interaction requires action (e.g., function calling).",
+                "Interaction completed successfully.",
+                "Interaction failed.",
+                "Video generation completed."
+              ],
+              "x-speakeasy-enum-format": "union",
+              "x-speakeasy-unknown-values": "allow"
+            }
+          },
+          "uri": {
+            "description": "Optional. The URI to which webhook events will be sent.",
+            "type": "string"
+          }
+        },
+        "x-speakeasy-exports": [
+          {
+            "name": "WebhookUpdate",
+            "group": "webhooks"
+          },
+          {
+            "name": "WebhookUpdateParams",
+            "group": "webhooks",
+            "representation": "input"
+          }
+        ],
+        "x-speakeasy-model-namespace": "webhooks"
+      },
+      "WordInfo": {
+        "description": "Word-level ASR annotation for transcription output.\nCarries the word text, optional timing, and optional speaker attribution.",
+        "type": "object",
+        "properties": {
+          "end_index": {
+            "description": "End of the attributed segment, exclusive.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "end_offset": {
+            "description": "End offset in time of the word relative to the start of the audio.\nPresent when timestamp_granularities contains \"word\".",
+            "type": "string",
+            "format": "google-duration"
+          },
+          "speaker": {
+            "description": "Optional. Speaker label for this word (e.g. \"spk_1\", \"spk_2\").\nPresent when diarization_mode is set in TranscriptionConfig.",
+            "type": "string"
+          },
+          "start_index": {
+            "description": "Start of segment of the response that is attributed to this source.\n\nIndex indicates the start of the segment, measured in bytes.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "start_offset": {
+            "description": "Start offset in time of the word relative to the start of the audio.\nPresent when timestamp_granularities contains \"word\".",
+            "type": "string",
+            "format": "google-duration"
+          },
+          "text": {
+            "description": "The transcribed word.",
+            "type": "string"
+          },
+          "type": {
+            "const": "word_info"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "x-speakeasy-exports": [
+          {
+            "name": "WordInfo",
+            "group": "interactions"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      }
+    },
+    "securitySchemes": {
+      "googleGenAIAuth": {
+        "type": "http",
+        "scheme": "custom",
+        "x-speakeasy-custom-security-scheme": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "accessToken": {
+                "description": "OAuth access token sent as a bearer Authorization header.",
+                "type": "string"
+              },
+              "apiKey": {
+                "description": "Gemini API key sent as x-goog-api-key.",
+                "type": "string"
+              },
+              "defaultHeaders": {
+                "description": "Additional default headers to apply before request-specific headers and auth.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": []
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "googleGenAIAuth": []
+    }
+  ],
+  "x-speakeasy-globals": {
+    "parameters": [
+      {
+        "$ref": "#/components/parameters/api_version"
+      },
+      {
+        "$ref": "#/components/parameters/google_genai_user_project"
+      }
+    ]
+  },
+  "x-speakeasy-retries": {
+    "backoff": {
+      "exponent": 2,
+      "initialInterval": 500,
+      "maxElapsedTime": 30000,
+      "maxInterval": 8000
+    },
+    "maxRetries": 4,
+    "retryConnectionErrors": true,
+    "statusCodes": [
+      408,
+      409,
+      429,
+      "5XX"
+    ],
+    "strategy": "attempt-count-backoff"
+  }
+}

--- a/tests/test_litellm/interactions/test_google_interactions_integration.py
+++ b/tests/test_litellm/interactions/test_google_interactions_integration.py
@@ -55,12 +55,12 @@ class TestGoogleInteractionsCreate:
             print(f"Usage: {response.usage}")
 
     def test_create_with_content_list(self, api_key):
-        """Test creating an interaction with a structured content list (Turn format)."""
+        """Test creating an interaction with a structured content list (Step format)."""
         response = interactions.create(
             model="gemini/gemini-2.5-flash",
             input=[
                 {
-                    "role": "user",
+                    "type": "user_input",
                     "content": [
                         {"type": "text", "text": "What is the capital of France?"}
                     ],
@@ -169,25 +169,25 @@ class TestGoogleInteractionsStreaming:
 
 
 class TestGoogleInteractionsMultiTurn:
-    """Tests for multi-turn conversations using Turn[] input."""
+    """Tests for multi-turn conversations using Step[] input."""
 
     def test_multi_turn_conversation(self, api_key):
-        """Test a multi-turn conversation per OpenAPI spec (Turn[] format)."""
+        """Test a multi-turn conversation per OpenAPI spec (Step[] format)."""
         response = interactions.create(
             model="gemini/gemini-2.5-flash",
             input=[
                 {
-                    "role": "user",
+                    "type": "user_input",
                     "content": [{"type": "text", "text": "My name is Alice."}],
                 },
                 {
-                    "role": "model",
+                    "type": "model_output",
                     "content": [
                         {"type": "text", "text": "Hello Alice! Nice to meet you."}
                     ],
                 },
                 {
-                    "role": "user",
+                    "type": "user_input",
                     "content": [{"type": "text", "text": "What is my name?"}],
                 },
             ],

--- a/tests/test_litellm/interactions/test_litellm_responses_transformation.py
+++ b/tests/test_litellm/interactions/test_litellm_responses_transformation.py
@@ -1,0 +1,95 @@
+"""
+Tests for the Interactions -> Responses input bridge.
+
+Covers both conversation shapes: the step form Google's spec uses today and the older
+role-tagged turns it replaced.
+"""
+
+from litellm.interactions.litellm_responses_transformation.transformation import (
+    LiteLLMResponsesInteractionsConfig,
+)
+from litellm.types.interactions import ModelOutputStep, TextContent, Turn, UserInputStep
+
+transform_input = LiteLLMResponsesInteractionsConfig._transform_interactions_input_to_responses_input
+
+
+def _roles(messages) -> list[str]:
+    return [message["role"] for message in messages]
+
+
+def _texts(messages) -> list[str]:
+    return [part["text"] for message in messages for part in message["content"]]
+
+
+class TestStepInput:
+    """A conversation sent as steps, the shape Google's current spec requires."""
+
+    def test_step_types_decide_the_role(self):
+        messages = transform_input(
+            [
+                {"type": "user_input", "content": [{"type": "text", "text": "My name is Alice."}]},
+                {"type": "model_output", "content": [{"type": "text", "text": "Hello Alice."}]},
+                {"type": "user_input", "content": [{"type": "text", "text": "What is my name?"}]},
+            ]
+        )
+
+        assert _roles(messages) == ["user", "assistant", "user"]
+        assert _texts(messages) == ["My name is Alice.", "Hello Alice.", "What is my name?"]
+
+    def test_typed_steps_behave_like_their_dicts(self):
+        messages = transform_input(
+            [
+                UserInputStep(content=[TextContent(type="text", text="My name is Alice.")]),
+                ModelOutputStep(content=[TextContent(type="text", text="Hello Alice.")]),
+            ]
+        )
+
+        assert _roles(messages) == ["user", "assistant"]
+        assert _texts(messages) == ["My name is Alice.", "Hello Alice."]
+
+
+class TestLegacyTurnInput:
+    """The role-tagged turns Google dropped still have to keep working."""
+
+    def test_model_turns_become_assistant_messages(self):
+        messages = transform_input(
+            [
+                {"role": "user", "content": [{"type": "text", "text": "My name is Alice."}]},
+                {"role": "model", "content": [{"type": "text", "text": "Hello Alice."}]},
+            ]
+        )
+
+        assert _roles(messages) == ["user", "assistant"]
+
+    def test_typed_turns_behave_like_their_dicts(self):
+        messages = transform_input(
+            [
+                Turn(role="user", content=[TextContent(type="text", text="My name is Alice.")]),
+                Turn(role="model", content=[TextContent(type="text", text="Hello Alice.")]),
+            ]
+        )
+
+        assert _roles(messages) == ["user", "assistant"]
+        assert _texts(messages) == ["My name is Alice.", "Hello Alice."]
+
+    def test_a_turn_without_a_role_is_the_user_speaking(self):
+        messages = transform_input([{"content": [{"type": "text", "text": "hi"}]}])
+
+        assert _roles(messages) == ["user"]
+
+    def test_string_content_is_wrapped_as_text(self):
+        messages = transform_input([Turn(role="user", content="hi")])
+
+        assert _roles(messages) == ["user"]
+        assert _texts(messages) == ["hi"]
+
+
+class TestOtherInputShapes:
+    def test_a_bare_string_passes_straight_through(self):
+        assert transform_input("Hello") == "Hello"
+
+    def test_a_single_content_object_becomes_one_user_message(self):
+        messages = transform_input({"type": "text", "text": "Hello"})
+
+        assert _roles(messages) == ["user"]
+        assert _texts(messages) == ["Hello"]

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -4,37 +4,35 @@ OpenAPI compliance tests for Google Interactions API.
 Validates that our SDK requests/responses match the OpenAPI spec at:
 https://ai.google.dev/static/api/interactions.openapi.json
 
+These assertions run against the pinned copy of that spec sitting next to this
+file, so they never depend on the network and never change meaning under an
+unrelated PR. Refresh the copy deliberately:
+
+    curl -sSfo tests/test_litellm/interactions/interactions.openapi.json \
+        https://ai.google.dev/static/api/interactions.openapi.json
+
+then fix whatever the assertions catch in the same PR. That review of the diff
+is the notification this suite exists to give us.
+
 Run with: pytest tests/test_litellm/interactions/test_openapi_compliance.py -v
 """
 
 import json
 import os
+from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 from openapi_core import OpenAPI
 
 OPENAPI_SPEC_URL = "https://ai.google.dev/static/api/interactions.openapi.json"
+PINNED_SPEC_PATH = Path(__file__).parent / "interactions.openapi.json"
 
 
 def _load_openapi_spec_dict() -> Dict[str, Any]:
-    """
-    Load the OpenAPI spec JSON.
-
-    In CI or offline environments, network access may not be available.
-    In that case, gracefully skip these tests instead of erroring.
-    """
-    try:
-        response = httpx.get(OPENAPI_SPEC_URL, timeout=5.0)
-        response.raise_for_status()
-        return response.json()
-    except Exception as e:  # pragma: no cover - defensive, env-dependent
-        pytest.skip(
-            f"Skipping Google Interactions OpenAPI compliance tests - "
-            f"unable to load spec from {OPENAPI_SPEC_URL}: {e}"
-        )
+    """Load the pinned copy of the OpenAPI spec."""
+    return json.loads(PINNED_SPEC_PATH.read_text())
 
 
 def _declared_type_value(variant_schema: Dict[str, Any]) -> Any:
@@ -167,17 +165,52 @@ class TestRequestCompliance:
         assert text_schema["properties"]["type"].get("const") == "text"
         print("✓ TextContent schema is correct")
 
-    def test_turn_schema(self, spec_dict):
-        """Verify Turn schema for multi-turn conversations."""
-        turn_schema = spec_dict["components"]["schemas"]["Turn"]
+    def test_multi_turn_input_is_a_list_of_role_tagged_steps(self, spec_dict):
+        """Verify a multi-turn conversation can be sent as alternating user/model steps.
 
-        assert "role" in turn_schema["properties"]
-        assert "content" in turn_schema["properties"]
+        Google dropped the `Turn` schema that used to carry an explicit `role`; a turn is now
+        a `Step`, and the role is the step's own `type` value. What our transformation needs is
+        that the input accepts a list of steps and that user and model steps stay distinguishable
+        and each carry content.
+        """
+        schemas = spec_dict["components"]["schemas"]
 
-        # Content can be string or Content[]
-        content_prop = turn_schema["properties"]["content"]
-        assert "oneOf" in content_prop
-        print("✓ Turn schema supports role + content")
+        step_list_variants = [
+            variant
+            for variant in schemas["InteractionsInput"]["oneOf"]
+            if variant.get("type") == "array"
+            and variant.get("items", {}).get("$ref", "").endswith("/Step")
+        ]
+        assert step_list_variants, (
+            f"input no longer accepts a list of steps: {schemas['InteractionsInput']['oneOf']}"
+        )
+
+        step_variants = {
+            option["$ref"].split("/")[-1]
+            for option in schemas["Step"].get("oneOf", [])
+            if "$ref" in option
+        }
+        assert {"UserInputStep", "ModelOutputStep"} <= step_variants, (
+            f"Step must cover both conversation roles, got {sorted(step_variants)}"
+        )
+
+        roles_by_step = {
+            step: _declared_type_value(schemas[step])
+            for step in ("UserInputStep", "ModelOutputStep")
+        }
+        assert roles_by_step == {
+            "UserInputStep": "user_input",
+            "ModelOutputStep": "model_output",
+        }, f"conversation roles are no longer reachable by step type, got {roles_by_step}"
+
+        for step in roles_by_step:
+            content_prop = schemas[step]["properties"]["content"]
+            assert content_prop["type"] == "array", f"{step}.content is not a list"
+            assert content_prop["items"]["$ref"].endswith(
+                "/Content"
+            ), f"{step}.content does not hold Content parts"
+
+        print(f"✓ Multi-turn input is a list of steps, roles: {roles_by_step}")
 
 
 class TestResponseCompliance:
@@ -188,14 +221,11 @@ class TestResponseCompliance:
         # The response is the dedicated `Interaction` schema. Google moved the
         # output-only fields (notably the `steps` array, formerly `outputs`)
         # off `CreateModelInteractionParams` and onto `Interaction`; the request
-        # schema no longer carries `steps`. Google later moved `role` off
-        # `Interaction` onto the per-turn `Turn` schema (asserted in
-        # test_turn_schema), so it is no longer a top-level output field here.
-        # Keep this aligned with the live spec.
+        # schema no longer carries `steps`. `role` is not an output field here
+        # either: it is carried by each step's own `type` (asserted in
+        # test_multi_turn_input_is_a_list_of_role_tagged_steps).
         schema = spec_dict["components"]["schemas"]["Interaction"]
 
-        # Output fields (readOnly). `role` was removed from the `Interaction`
-        # schema by Google; it now lives only on `Turn`.
         output_fields = [
             "id",
             "status",
@@ -314,11 +344,8 @@ class TestEndpointCompliance:
 
 if __name__ == "__main__":
     # Quick manual test
-    import httpx
-
-    print("Loading OpenAPI spec...")
-    response = httpx.get(OPENAPI_SPEC_URL)
-    spec = response.json()
+    print(f"Loading pinned OpenAPI spec ({PINNED_SPEC_PATH})...")
+    spec = _load_openapi_spec_dict()
 
     print(f"\nSpec version: {spec.get('openapi')}")
     print(f"API title: {spec.get('info', {}).get('title')}")

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -25,6 +25,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from openapi_core import OpenAPI
+from pydantic import TypeAdapter
+
+from litellm.types.interactions import (
+    InteractionInput,
+    ModelOutputStep,
+    UserInputStep,
+)
 
 OPENAPI_SPEC_URL = "https://ai.google.dev/static/api/interactions.openapi.json"
 PINNED_SPEC_PATH = Path(__file__).parent / "interactions.openapi.json"
@@ -211,6 +218,29 @@ class TestRequestCompliance:
             ), f"{step}.content does not hold Content parts"
 
         print(f"✓ Multi-turn input is a list of steps, roles: {roles_by_step}")
+
+    def test_our_input_type_accepts_the_specs_own_step_examples(self, spec_dict):
+        """Verify the input type LiteLLM publishes still accepts what the spec says to send.
+
+        Every other test here compares the spec to itself, so it stays green while our own
+        types rot. This one feeds Google's own example payloads through the type a caller
+        builds against, which is the drift that actually reaches a customer.
+        """
+        schemas = spec_dict["components"]["schemas"]
+        step_examples = [
+            example_body["value"]
+            for step in ("UserInputStep", "ModelOutputStep")
+            for example in schemas[step]["examples"]
+            for example_body in example.values()
+        ]
+        assert len(step_examples) == 2, f"spec no longer ships one example per step: {step_examples}"
+
+        parsed = TypeAdapter(InteractionInput).validate_python(step_examples)
+
+        assert [type(step) for step in parsed] == [UserInputStep, ModelOutputStep], (
+            f"our input type does not round-trip the spec's own steps, got {parsed}"
+        )
+        print("✓ Published input type accepts the spec's user_input and model_output steps")
 
 
 class TestResponseCompliance:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Google replaced the role-tagged turn with typed steps
- We still publish the turn list Google now rejects
- Replayed history reaches other providers as all-user
- Compliance tests fetched the spec live, so staging went red

How it solves it:

- Vendor the spec, read it from disk
- Publish the step shapes, keep the old turn working
- Map step types onto the roles a provider expects
- Check our own input type against the spec's examples

## User Flow

Before: a developer replaying a conversation through the gateway's interactions route is refused by Google, and on other providers the model is told it said nothing

1. They send POST http://localhost:4000/v1beta/interactions with `"model": "gemini-3.6-flash"` and the documented history, a list of `{"role": "user" | "model", "content": [...]}` turns
2. It comes back 400: `When using the steps-based API version, use step_list input format instead of turn_list`
3. They find Google's current shape, `{"type": "user_input" | "model_output", "content": [...]}`, but the Python types the SDK ships still describe the old role turn, so their editor and type checker flag every step they write
4. They send the same steps to a non-Google model with `"model": "claude-sonnet-5"`, which returns 200
5. The provider was handed all three steps as one user message, so the assistant's own earlier reply is quoted back to it as something the user said, and follow-ups that depend on who spoke drift

After: the same history is accepted by Google, type checks clean, and reaches other providers with the roles intact

1. They send POST http://localhost:4000/v1beta/interactions with `"model": "gemini-3.6-flash"` and `{"type": "user_input" | "model_output", "content": [...]}` steps
2. It comes back 200 with a `model_output` step answering from the replayed history
3. The shipped Python types accept those steps, and callers who kept sending the old role turn still type check
4. They send the same steps with `"model": "claude-sonnet-5"`, which returns 200
5. The provider now receives user, assistant, and user as three separate messages, so the model can tell its own earlier reply from the user's

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxies on two ports, both against real provider APIs: port 4917 runs `d86336a7c6` (`litellm_internal_staging`, whose interactions code is identical to this PR's base `c7f5527870`), port 4783 runs this PR at `dbf6b97b23`

Google rejects the turn list our types published, and answers the step list they publish now (both at `dbf6b97b23`, so the shape is the only variable):

```
$ curl -sS -X POST http://localhost:4783/v1beta/interactions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "gemini-3.6-flash", "input": [
          {"role": "user",  "content": [{"type": "text", "text": "My name is Alice."}]},
          {"role": "model", "content": [{"type": "text", "text": "Hello Alice!"}]},
          {"role": "user",  "content": [{"type": "text", "text": "What is my name? Answer with one word."}]}]}'

litellm.BadRequestError: GeminiException BadRequestError - {"error":{"message":"When using the steps-based API version, use step_list input format instead of turn_list.","code":"invalid_request"}}. Received Model Group=gemini-3.6-flash

$ curl -sS -X POST http://localhost:4783/v1beta/interactions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "gemini-3.6-flash", "input": [
          {"type": "user_input",   "content": [{"type": "text", "text": "My name is Alice."}]},
          {"type": "model_output", "content": [{"type": "text", "text": "Hello Alice!"}]},
          {"type": "user_input",   "content": [{"type": "text", "text": "What is my name? Answer with one word."}]}]}'

status: completed
steps: [{"content": [{"text": "Alice", "type": "text"}], "type": "model_output"}]
```

Same step history routed to a non-Google model, before and after, read off each proxy's own log of the request it sent upstream:

```
$ curl -sS -X POST http://localhost:$PORT/v1beta/interactions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "claude-sonnet-5", "custom_llm_provider": "anthropic", "input": [
          {"type": "user_input",   "content": [{"type": "text", "text": "Say the word ZEBRA and nothing else."}]},
          {"type": "model_output", "content": [{"type": "text", "text": "ZEBRA"}]},
          {"type": "user_input",   "content": [{"type": "text", "text": "Have you already said it? Answer with only YES or NO."}]}]}'
$ grep -A4 'POST Request Sent from LiteLLM' proxy.log | tail -1

BEFORE (port 4917, d86336a7c6), one user message, the model's own turn folded into it:
-d '{'model': 'claude-sonnet-5', 'messages': [{'role': 'user', 'content': [{'type': 'text', 'text': 'Say the word ZEBRA and nothing else.'}, {'type': 'text', 'text': 'ZEBRA'}, {'type': 'text', 'text': 'Have you already said it? Answer with only YES or NO.'}]}], 'tools': [], 'max_tokens': 128000}'

AFTER (port 4783, dbf6b97b23), three messages with the roles preserved:
-d '{'model': 'claude-sonnet-5', 'messages': [{'role': 'user', 'content': [{'type': 'text', 'text': 'Say the word ZEBRA and nothing else.'}]}, {'role': 'assistant', 'content': [{'type': 'text', 'text': 'ZEBRA'}]}, {'role': 'user', 'content': [{'type': 'text', 'text': 'Have you already said it? Answer with only YES or NO.'}]}], 'tools': [], 'max_tokens': 128000}'
```

The compliance suite itself used to fetch the spec at test time, which is how the staging shard went red without anyone touching it. Before, at base `c7f5527870`:

```
$ python -m pytest tests/test_litellm/interactions/test_openapi_compliance.py -q -p no:randomly
E       KeyError: 'Turn'
FAILED tests/test_litellm/interactions/test_openapi_compliance.py::TestRequestCompliance::test_turn_schema
1 failed, 12 passed in 0.68s

$ HTTPS_PROXY=http://127.0.0.1:9 HTTP_PROXY=http://127.0.0.1:9 ALL_PROXY=http://127.0.0.1:9 \
    python -m pytest tests/test_litellm/interactions/test_openapi_compliance.py -q -rs -p no:randomly
SKIPPED [1] ... unable to load spec from https://ai.google.dev/static/api/interactions.openapi.json: [Errno 61] Connection refused
13 skipped in 0.31s
```

After, at `dbf6b97b23`, on the pinned copy, with and without egress:

```
$ python -m pytest tests/test_litellm/interactions -q -p no:randomly
132 passed, 3 skipped in 34.55s

$ HTTPS_PROXY=http://127.0.0.1:9 HTTP_PROXY=http://127.0.0.1:9 ALL_PROXY=http://127.0.0.1:9 \
    python -m pytest tests/test_litellm/interactions/test_openapi_compliance.py -q -p no:randomly
14 passed in 0.30s
```

The new tests are mutation-checked, first by mutating the pinned spec under the multi-turn assertion:

```
$ # drop the step list from the input union      -> FAILED
$ # drop UserInputStep from the Step union       -> FAILED
$ # rename the user_input step type              -> FAILED
$ # make model_output content a string not array -> FAILED
$ # unmutated spec                               -> 14 passed
```

then by mutating the shipped code the same tests are meant to protect:

```
$ # input type forgets the step list             -> FAILED
$ # bridge ignores the step type                 -> FAILED (2 tests)
$ # bridge stops mapping model to assistant      -> FAILED (2 tests)
$ # legacy turn list ordered ahead of the steps  -> 22 passed, equivalent mutant: smart unions still match on the step type
$ # unmutated                                    -> 22 passed
```

## Type

🐛 Bug Fix

✅ Test

## Caveats (if any)

- The old turn list stays accepted; Google still refuses it
- The pinned spec needs a deliberate refresh to track Google
- Structured content is still forwarded to the Responses API unmapped, so `{"type": "text"}` is refused there, before and after this PR

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
