### PR TITLE
fix(docker): support OpenShift arbitrary-UID runs on the stock image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,13 @@ RUN HOME=/opt/prisma XDG_CACHE_HOME=/opt/prisma/.cache PRISMA_BINARY_CACHE_DIR=/
 RUN sed -i 's/\r$//' docker/entrypoint.sh && chmod +x docker/entrypoint.sh && \
     sed -i 's/\r$//' docker/prod_entrypoint.sh && chmod +x docker/prod_entrypoint.sh
 
+# OpenShift-style platforms run the container as an arbitrary UID that is
+# always in group 0. Aligning group perms with owner perms here (not in the
+# runtime stage) lets the COPY layers below carry them, so that UID can run
+# the DB schema step (prisma generate + migrate) on the stock image without
+# duplicating the venv in an extra runtime chmod layer.
+RUN chgrp -R 0 /app && chmod -R g=u /app
+
 # Runtime stage
 FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
@@ -104,7 +111,10 @@ USER root
 RUN apk add --no-cache bash openssl tzdata nodejs python3 libsndfile
 
 WORKDIR /app
+# HOME=/app gives arbitrary-UID (OpenShift) runs a writable home for caches
+# that default to $HOME/.cache; /root is unreadable to those UIDs.
 ENV PATH="/app/.venv/bin:${PATH}" \
+    HOME=/app \
     PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \
     PRISMA_CLI_PATH=/opt/prisma/binaries/node_modules/.bin/prisma \
     PRISMA_CLI_QUERY_ENGINE_TYPE=binary \
@@ -132,6 +142,9 @@ COPY --from=builder /opt/prisma /opt/prisma
 
 RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
     find /app/.venv -type d -path "*/tornado/test" -delete && \
+    mkdir -p /app/.cache && \
+    chgrp 0 /app /app/.cache && \
+    chmod g=u /app /app/.cache && \
     chmod -R a+rX /opt/prisma && \
     test -x /opt/prisma/binaries/node_modules/.bin/prisma && \
     test -f /opt/prisma/binaries/node_modules/prisma/build/index.js && \


### PR DESCRIPTION
## TLDR

Problem this solves:

- OpenShift runs containers as a random UID in group 0
- Stock image only grants root write on /app
- DB schema step fails, so customers must rebuild the image internally

How it solves it:

- Builder stage aligns group perms with owner perms on /app
- Runtime COPY layers carry them, so no extra venv-sized chmod layer
- HOME=/app plus group-writable /app give arbitrary UIDs a writable cache home

## User Flow

Before: a platform engineer deploying the stock image on OpenShift sees the database schema step die on permissions

1. They pull the published litellm image into their internal registry unchanged
2. They deploy it on OpenShift with DATABASE_URL set; the restricted SCC starts the pod as a random UID in group 0
3. Pod logs show permission denied from the schema step (prisma generate cannot write) and the pod crash-loops
4. They are told to rebuild the image with a custom Dockerfile that fixes permissions, which their security team rejects as a two step supply chain

After: the same image runs the schema step and serves traffic with no rebuild

1. They pull the published litellm image into their internal registry unchanged
2. They deploy it on OpenShift with DATABASE_URL set; the restricted SCC starts the pod as a random UID in group 0
3. The schema step completes, the proxy listens on port 4000, and GET https://litellm-route/health/liveliness returns 200
4. No internal rebuild or Dockerfile patch is needed

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The sandbox this change was authored in cannot pull from cgr.dev, docker.io, or ghcr.io (egress policy), so a full image build was not possible there. The permission mechanism itself was verified at commit 731efa75 by recreating the image's file layout and running as OpenShift would (random UID, group 0):

```
=== control: stock perms (root:root 755/644), as uid 12345 gid 0 ===
touch: cannot touch '.../site-packages/prisma/generated.py': Permission denied
exit=1
=== with fix: chgrp -R 0 + chmod -R g=u ===
write-into-prisma-pkg=OK
mkdir-under-app=OK
```

End to end proof to capture on a machine with registry access, before marking ready for review:

1. `docker build -t litellm-openshift .`
2. `docker run -d --name pg -e POSTGRES_PASSWORD=pw -p 5432:5432 postgres:16`
3. `docker run --rm --user 12345:0 -p 4000:4000 -e DATABASE_URL=postgresql://postgres:pw@host.docker.internal:5432/postgres -e LITELLM_MASTER_KEY=sk-1234 -e OPENAI_API_KEY=$OPENAI_API_KEY litellm-openshift` and confirm the schema step logs succeed under the arbitrary UID
4. `curl http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model": "gpt-5.2", "messages": [{"role": "user", "content": "ping"}]}'` and confirm a real completion comes back

## Type

🐛 Bug Fix

## Caveats (if any)

- Default user stays root; docker run behavior is unchanged
- HOME is now /app, so root runs cache under /app instead of /root
- docker/Dockerfile.non_root already had this treatment; this brings the stock image level
- docker/Dockerfile.database is a separate copy and can follow up if wanted

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgVRuPQX65G9WnhqjoYaae)_