### PR TITLE
fix(langfuse): coerce header-sourced mask and trace-update steering values

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -2,7 +2,7 @@
 #    On success, logs events to Langfuse
 import os
 import traceback
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, cast
 
@@ -73,6 +73,22 @@ def _extract_cache_read_input_tokens(usage_obj) -> int:
                 cache_read_input_tokens = cached_tokens
 
     return cache_read_input_tokens
+
+
+def _as_steering_flag(value: object) -> bool:
+    """A string ``str_to_bool`` does not recognise falls back to its truthiness."""
+    if isinstance(value, str):
+        parsed: Final = str_to_bool(value)
+        return bool(value) if parsed is None else parsed
+    return bool(value)
+
+
+def _as_steering_key_sequence(value: object) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return tuple(key.strip() for key in value.split(",") if key.strip())
+    if isinstance(value, Iterable):
+        return tuple(str(key) for key in value)
+    return ()
 
 
 def resolve_langfuse_credentials(
@@ -552,10 +568,10 @@ class LangFuseLogger:
             # This allows continuing an existing trace while still returning the correct trace_id
             if existing_trace_id is not None:
                 trace_id = existing_trace_id
-            update_trace_keys: Final = cast(list, clean_metadata.pop("update_trace_keys", []))
+            update_trace_keys: Final = _as_steering_key_sequence(clean_metadata.pop("update_trace_keys", ()))
             debug: Final = clean_metadata.pop("debug_langfuse", None)
-            mask_input: Final = clean_metadata.pop("mask_input", False)
-            mask_output: Final = clean_metadata.pop("mask_output", False)
+            mask_input: Final = _as_steering_flag(clean_metadata.pop("mask_input", False))
+            mask_output: Final = _as_steering_flag(clean_metadata.pop("mask_output", False))
             # Look for masking function in the dedicated location first (set by scrub_sensitive_keys_in_metadata)
             # Fall back to metadata for backwards compatibility
             masking_function: Final = litellm_params.get("_langfuse_masking_function") or clean_metadata.pop(

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -994,3 +994,136 @@ def test_langfuse_logger_reuses_the_shared_cached_client(monkeypatch):
     gc.collect()
 
     assert not first.langfuse_client.is_closed
+
+
+_LANGFUSE_REDACTED = "redacted-by-litellm"
+
+
+def _steering_logger() -> LangFuseLogger:
+    """``__new__`` skips the SDK and network setup in ``__init__``."""
+    logger = LangFuseLogger.__new__(LangFuseLogger)
+    logger.Langfuse = MagicMock()
+    logger.langfuse_sdk_version = "2.60.0"
+    return logger
+
+
+def _emit(logger: LangFuseLogger, *, metadata=None, headers=None):
+    """``log_event_on_langfuse`` is the entry point that folds ``langfuse_*`` headers into metadata."""
+    now = datetime.datetime.now()
+    response_obj = litellm.ModelResponse(
+        choices=[{"message": {"role": "assistant", "content": "the-output"}}]
+    )
+    logger.log_event_on_langfuse(
+        kwargs={
+            "call_type": "completion",
+            "litellm_params": {
+                "metadata": dict(metadata or {}),
+                "proxy_server_request": {"headers": dict(headers or {})},
+            },
+            "messages": [{"role": "user", "content": "the-input"}],
+            "optional_params": {},
+        },
+        response_obj=response_obj,
+        start_time=now,
+        end_time=now,
+    )
+    return (
+        logger.Langfuse.trace.call_args.kwargs,
+        logger.Langfuse.trace.return_value.generation.call_args.kwargs,
+    )
+
+
+def test_mask_input_header_false_keeps_the_prompt():
+    logger = _steering_logger()
+
+    trace_params, generation_params = _emit(logger, headers={"langfuse_mask_input": "false"})
+
+    assert trace_params["input"] == {"messages": [{"role": "user", "content": "the-input"}]}
+    assert generation_params["input"] == {"messages": [{"role": "user", "content": "the-input"}]}
+
+
+def test_mask_input_header_true_redacts_the_prompt():
+    logger = _steering_logger()
+
+    trace_params, generation_params = _emit(logger, headers={"langfuse_mask_input": "true"})
+
+    assert trace_params["input"] == _LANGFUSE_REDACTED
+    assert generation_params["input"] == _LANGFUSE_REDACTED
+
+
+def test_mask_output_header_false_keeps_the_completion():
+    logger = _steering_logger()
+
+    trace_params, generation_params = _emit(logger, headers={"langfuse_mask_output": "false"})
+
+    assert trace_params["output"] != _LANGFUSE_REDACTED
+    assert generation_params["output"] != _LANGFUSE_REDACTED
+
+
+def test_mask_output_header_true_redacts_the_completion():
+    logger = _steering_logger()
+
+    trace_params, generation_params = _emit(logger, headers={"langfuse_mask_output": "true"})
+
+    assert trace_params["output"] == _LANGFUSE_REDACTED
+    assert generation_params["output"] == _LANGFUSE_REDACTED
+
+
+@pytest.mark.parametrize(
+    "mask_input, expect_redacted",
+    [
+        (False, False),
+        (True, True),
+        # An unrecognised string keeps its truthiness, so existing behaviour is unchanged
+        ("yes", True),
+    ],
+)
+def test_mask_input_from_the_request_body_is_unchanged(mask_input, expect_redacted):
+    logger = _steering_logger()
+
+    trace_params, _ = _emit(logger, metadata={"mask_input": mask_input})
+
+    assert (trace_params["input"] == _LANGFUSE_REDACTED) is expect_redacted
+
+
+def test_update_trace_keys_header_applies_every_key():
+    logger = _steering_logger()
+
+    trace_params, _ = _emit(
+        logger,
+        headers={
+            "langfuse_existing_trace_id": "trace-1",
+            "langfuse_update_trace_keys": "trace_release, trace_tail",
+            "langfuse_trace_release": "v1.2.3",
+            "langfuse_trace_tail": "last",
+        },
+    )
+
+    assert trace_params["release"] == "v1.2.3"
+    assert trace_params["tail"] == "last"
+
+
+def test_update_trace_keys_from_the_request_body_list_is_unchanged():
+    logger = _steering_logger()
+
+    trace_params, _ = _emit(
+        logger,
+        metadata={
+            "existing_trace_id": "trace-1",
+            "update_trace_keys": ["trace_release"],
+            "trace_release": "v1.2.3",
+        },
+    )
+
+    assert trace_params["release"] == "v1.2.3"
+
+
+def test_update_trace_keys_matches_whole_keys_not_substrings():
+    logger = _steering_logger()
+
+    trace_params, _ = _emit(
+        logger,
+        headers={"langfuse_existing_trace_id": "trace-1", "langfuse_update_trace_keys": "my_input"},
+    )
+
+    assert "input" not in trace_params


### PR DESCRIPTION
## TLDR

Problem this solves:

- A `langfuse_mask_input: false` request header redacted the prompt it was asked to keep. Header values arrive as strings and the trace path reads `mask_input` / `mask_output` with a bare truthiness check, so the string `"false"` is truthy and the payload is replaced with `redacted-by-litellm`
- A `langfuse_update_trace_keys: trace_release` request header silently did nothing. The value is iterated directly, so a string is walked one character at a time and every requested key fails to match

How it solves it:

- Read the two boolean controls through `str_to_bool`, which `langfuse.py` already imports, and keep the current truthiness for anything it does not recognise
- Read `update_trace_keys` as a tuple of key names, splitting a string on commas and passing a list or tuple through unchanged

The coercion sits at the consumption site in `_log_langfuse_v2` rather than in `add_metadata_from_header`. That helper is shared with `langfuse_otel.py`, which exports the raw metadata value as a span attribute and only JSON-encodes `list` and `dict`, so coercing there would have changed the OTel wire format for `update_trace_keys` into a Python repr. It also writes in place into the metadata dict every other logger reads. Popping from `clean_metadata` keeps the blast radius to this one integration.

## User Flow

A proxy caller steering their own Langfuse trace with `langfuse_*` request headers. `langfuse_mask_input: false` now leaves the prompt in the trace, and `langfuse_update_trace_keys` now applies the keys it names, matching what the same values already did when sent in the request body.

## Relevant issues

## Linear ticket

Refs LIT-5484

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on `127.0.0.1:20484`, real Gemini calls through `gemini/gemini-3.6-flash`, with the Langfuse destination pointed at a local endpoint that records the exact outbound `/api/public/ingestion` bytes so the trace body can be read back verbatim.

### Bug 1, before the fix

Two requests differing only by the header that says do not mask:

```
curl -sS http://127.0.0.1:20484/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"what is 2+2"}],"max_tokens":30}'

curl -sS http://127.0.0.1:20484/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -H "langfuse_mask_input: false" \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"what is 3+3"}],"max_tokens":30}'
```

What the proxy sent to Langfuse:

```
{"input":{"messages":[{"role":"user","content":"what is 2+2"}]}}
{"input":"redacted-by-litellm"}
```

### Bug 1, after the fix

Same two requests plus the explicit opposite:

```
{"input":{"messages":[{"role":"user","content":"what is 2+2"}]}}
{"input":{"messages":[{"role":"user","content":"what is 3+3"}]}}
{"input":"redacted-by-litellm"}
```

The first is the unchanged control, the second is `mask_input: false` now keeping the prompt, the third is `mask_input: true` still redacting.

### Bug 2, before the fix

The same intent expressed as a body list and as headers:

```
curl -sS http://127.0.0.1:20484/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"hi"}],"max_tokens":10,
       "metadata":{"existing_trace_id":"trace-FROM-BODY","update_trace_keys":["trace_release"],"trace_release":"v1.2.3"}}'

curl -sS http://127.0.0.1:20484/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -H "langfuse_existing_trace_id: trace-FROM-HEADER" \
  -H "langfuse_update_trace_keys: trace_release" \
  -H "langfuse_trace_release: v1.2.3" \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"hi"}],"max_tokens":10}'
```

What the proxy sent to Langfuse:

```
{"id":"trace-FROM-BODY","release":"v1.2.3"}
{"id":"trace-FROM-HEADER","release":null}
```

### Bug 2, after the fix

Same two requests, plus a comma-separated pair:

```
{"id":"trace-FROM-BODY","release":"v1.2.3","public":null}
{"id":"trace-FROM-HEADER","release":"v1.2.3","public":null}
{"id":"trace-FROM-HEADER-MULTI","release":"v1.2.3","public":true}
```

The header form now matches the body form, and `langfuse_update_trace_keys: trace_release,trace_public` applies both.

## Type

🐛 Bug Fix

## Caveats (if any)

**Behavior changes.** The coercion runs wherever the value is read, so it also applies to a value sent in the request body. A body sending the string `"false"` for `mask_input` or `mask_output` stops being redacted, and a body sending a string for `update_trace_keys` gets whole-key matching instead of substring matching. A producer sweep over `litellm/`, `ui/litellm-dashboard/`, `litellm/proxy/client/`, `tests/e2e/`, `cookbook/` and `enterprise/` found no first-party producer that puts a string into any of the three; every one uses a real bool or a list, and both pass through unchanged. `update_trace_keys` is not in `LITELLM_TRACE_CONTROL_METADATA_FIELDS`, so it is never promoted from a request body at all. The substring change only moves values like `my_input` and `outputs`, which nothing first-party emits.

**Deliberately not fixed here.** `str_to_bool` recognises only `"true"` and `"false"`, so a header spelling the same intent as `0`, `no` or `off` still redacts, exactly as it does today. Folding those in means either duplicating the `_is_false_like` vocabulary from `litellm/proxy/litellm_pre_call_utils.py` or relocating that helper into core, which is a wider change than this fix needs. `debug_langfuse` keeps its own inline string check for the same reason.

**Out of scope.** The typed steering channel on `StandardCallbackDynamicParams`, the matching `_SAFE_CLIENT_CALLBACK_PARAMS` entry, having `langfuse_otel.py` share one vocabulary instead of duplicating the mapping, closing the unbounded `trace_*` namespace, and the in-place mutation of the shared metadata dict in `add_metadata_from_header` are all tracked on LIT-5484 for a follow-up.

## QA runbook

1. Start a proxy with `success_callback: ["langfuse"]` and point `LANGFUSE_HOST` at a Langfuse project you can read
2. `curl` a chat completion with no `langfuse_*` header and confirm the prompt appears on the trace
3. Repeat with `-H "langfuse_mask_input: false"` and confirm the prompt still appears
4. Repeat with `-H "langfuse_mask_input: true"` and confirm the input reads `redacted-by-litellm`
5. Send a request with `-H "langfuse_existing_trace_id: <id>" -H "langfuse_update_trace_keys: trace_release" -H "langfuse_trace_release: v1.2.3"` and confirm the trace carries `release: v1.2.3`
6. Repeat step 5 with `-H "langfuse_update_trace_keys: trace_release,trace_public"` and a `langfuse_trace_public` header, and confirm both land

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/36740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1600b4b13d388020a3cb152748ad474a0e433d79. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->