### PR TITLE
fix(langfuse)!: source the emitted metadata blob from StandardLoggingPayload

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -2,8 +2,9 @@
 #    On success, logs events to Langfuse
 import os
 import traceback
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from packaging.version import Version
@@ -30,6 +31,7 @@ from litellm.types.utils import (
     ImageResponse,
     ModelResponse,
     RerankResponse,
+    StandardLoggingMetadata,
     StandardLoggingPayload,
     StandardLoggingPromptManagementMetadata,
     TextCompletionResponse,
@@ -44,6 +46,11 @@ else:
     DynamicLoggingCache = Any
     StatefulTraceClient = Any
     Langfuse = Any
+
+
+_DENIED_STEERING_KEYS: Final = frozenset({"headers", "endpoint", "caching_groups", "previous_models"})
+_NO_METADATA: Final[Mapping[str, Any]] = MappingProxyType({})
+_REDACTED_PROXY_HEADERS: Final[frozenset[str]] = frozenset({"authorization", "cookie", "referer"})
 
 
 def _extract_cache_read_input_tokens(usage_obj) -> int:
@@ -512,16 +519,14 @@ class LangFuseLogger:
                 else []
             )
 
-            if standard_logging_object is None:
-                end_user_id = None
-                prompt_management_metadata: StandardLoggingPromptManagementMetadata | None = None
-            else:
-                end_user_id = standard_logging_object["metadata"].get("user_api_key_end_user_id", None)
-
-                prompt_management_metadata = cast(
-                    StandardLoggingPromptManagementMetadata | None,
-                    standard_logging_object["metadata"].get("prompt_management_metadata", None),
-                )
+            allowlisted_metadata: Final[StandardLoggingMetadata | dict[str, Any]] = (
+                standard_logging_object["metadata"] if standard_logging_object is not None else _NO_METADATA
+            )
+            end_user_id: Final = allowlisted_metadata.get("user_api_key_end_user_id", None)
+            prompt_management_metadata: Final[StandardLoggingPromptManagementMetadata | None] = cast(
+                StandardLoggingPromptManagementMetadata | None,
+                allowlisted_metadata.get("prompt_management_metadata", None),
+            )
 
             # Clean Metadata before logging - never log raw metadata
             # the raw metadata can contain circular references which leads to infinite recursion
@@ -540,12 +545,7 @@ class LangFuseLogger:
                         tags.append(f"{key}:{value}")
 
                     # clean litellm metadata before logging
-                    if key in [
-                        "headers",
-                        "endpoint",
-                        "caching_groups",
-                        "previous_models",
-                    ]:
+                    if key in _DENIED_STEERING_KEYS:
                         continue
                     else:
                         clean_metadata[key] = value
@@ -630,19 +630,18 @@ class LangFuseLogger:
                     trace_params["output"] = output if not mask_output else "redacted-by-litellm"
 
             if debug is True or (isinstance(debug, str) and debug.lower() == "true"):
-                if "metadata" in trace_params:
-                    # log the raw_metadata in the trace
-                    trace_params["metadata"]["metadata_passed_to_litellm"] = metadata
-                else:
-                    trace_params["metadata"] = {"metadata_passed_to_litellm": metadata}
+                debug_metadata: Final = {
+                    key: value for key, value in metadata.items() if isinstance(value, (str, int, float, bool))
+                }
+                trace_params["metadata"] = {
+                    **(trace_params.get("metadata") or _NO_METADATA),
+                    "metadata_passed_to_litellm": debug_metadata,
+                }
 
             cost: Final = kwargs.get("response_cost", None)
             verbose_logger.debug("trace: %s", cost)
 
-            clean_metadata["litellm_response_cost"] = cost
-            if standard_logging_object is not None:
-                hidden_params: Final = standard_logging_object.get("hidden_params", {})
-                clean_metadata["hidden_params"] = filter_exceptions_from_params(hidden_params)
+            hidden_params: Final = standard_logging_object.get("hidden_params") if standard_logging_object else None
 
             if (
                 litellm.langfuse_default_tags is not None
@@ -654,22 +653,24 @@ class LangFuseLogger:
                     tags.append(f"proxy_base_url:{proxy_base_url}")
 
             api_base: Final = litellm_params.get("api_base", None)
-            if api_base:
-                clean_metadata["api_base"] = api_base
-
             vertex_location: Final = kwargs.get("vertex_location", None)
-            if vertex_location:
-                clean_metadata["vertex_location"] = vertex_location
-
             aws_region_name: Final = kwargs.get("aws_region_name", None)
-            if aws_region_name:
-                clean_metadata["aws_region_name"] = aws_region_name
+
+            candidate_enrichments: Final = (
+                ("litellm_response_cost", cost, True),
+                ("hidden_params", filter_exceptions_from_params(hidden_params), hidden_params is not None),
+                ("api_base", api_base, bool(api_base)),
+                ("vertex_location", vertex_location, bool(vertex_location)),
+                ("aws_region_name", aws_region_name, bool(aws_region_name)),
+                ("cache_hit", kwargs.get("cache_hit") or False, self._supports_tags() and "cache_hit" in kwargs),
+            )
+            enrichments: Final[Mapping[str, Any]] = {
+                key: value for key, value, include in candidate_enrichments if include
+            }
 
             if self._supports_tags():
-                if "cache_hit" in kwargs:
-                    if kwargs["cache_hit"] is None:
-                        kwargs["cache_hit"] = False
-                    clean_metadata["cache_hit"] = kwargs["cache_hit"]
+                if "cache_hit" in kwargs and kwargs["cache_hit"] is None:
+                    kwargs["cache_hit"] = False  # rebind-ok: pre-existing normalization other integrations rely on
                 if existing_trace_id is None:
                     trace_params.update({"tags": tags})
 
@@ -682,13 +683,13 @@ class LangFuseLogger:
                 if headers:
                     for key, value in headers.items():
                         # these headers can leak our API keys and/or JWT tokens
-                        if key.lower() not in ["authorization", "cookie", "referer"]:
+                        if key.lower() not in _REDACTED_PROXY_HEADERS:
                             clean_headers[key] = value
 
             trace: Final[StatefulTraceClient] = self.Langfuse.trace(**trace_params)
 
             # Log provider specific information as a span
-            log_provider_specific_information_as_span(trace, clean_metadata)
+            log_provider_specific_information_as_span(trace, enrichments)
 
             # Log guardrail information as a span
             self._log_guardrail_information_as_span(
@@ -761,7 +762,10 @@ class LangFuseLogger:
                 "output": output if not mask_output else "redacted-by-litellm",
                 "usage": usage,
                 "usage_details": usage_details,
-                "metadata": log_requester_metadata(clean_metadata),
+                "metadata": {
+                    **log_requester_metadata(redact_user_api_key_info(metadata=allowlisted_metadata)),
+                    **enrichments,
+                },
                 "level": level,
                 "version": clean_metadata.pop("version", None),
             }
@@ -1058,7 +1062,7 @@ def _add_prompt_to_generation_params(
 
 def log_provider_specific_information_as_span(
     trace,
-    clean_metadata,
+    clean_metadata: Mapping[str, Any],
 ):
     """
     Logs provider-specific information as spans.
@@ -1098,7 +1102,7 @@ def log_provider_specific_information_as_span(
             )
 
 
-def log_requester_metadata(clean_metadata: dict):
+def log_requester_metadata(clean_metadata: Mapping[str, Any]):
     returned_metadata: Final = {}
     requester_metadata: Final = clean_metadata.get("requester_metadata") or {}
     for k, v in clean_metadata.items():

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -314,7 +314,7 @@ class TestLangfuseUsageDetails(unittest.TestCase):
                 "litellm_params": {"metadata": {}},
                 "optional_params": {},
                 "litellm_call_id": "test-call-id-null-usage",
-                "standard_logging_object": None,
+                "standard_logging_object": self._build_standard_logging_payload(),
                 "response_cost": 0.0,
             }
 
@@ -382,16 +382,14 @@ class TestLangfuseUsageDetails(unittest.TestCase):
             "model_id": "model-123",
             "model_group": "openai",
             "api_base": "https://api.openai.com",
+            # only real StandardLoggingMetadata fields: session_id, trace_name,
+            # headers and friends are request-metadata keys the allowlist drops,
+            # so a payload carrying them cannot occur in production
             "metadata": {
                 "user_api_key_end_user_id": None,
                 "prompt_management_metadata": None,
-                "session_id": None,
-                "trace_name": None,
-                "trace_version": None,
-                "headers": None,
-                "endpoint": None,
-                "caching_groups": None,
-                "previous_models": None,
+                "user_api_key_hash": "hashed-key",
+                "user_api_key_alias": "canary-alias",
             },
             "hidden_params": {},
             "request_tags": [],
@@ -503,14 +501,251 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         # litellm_trace_id should be preferred over litellm_call_id
         assert self.last_trace_kwargs.get("id") == "trace-id-from-kwargs"
 
-    def test_log_langfuse_v2_uses_litellm_trace_id_when_standard_logging_object_none(
-        self,
-    ):
+    CANARY = "sk-lf-canary-SECRET-d4e5f6"
+
+    def _canary_request_metadata(self):
+        """Raw request metadata shaped like the proxy builds it, credentials included."""
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        team_logging = [
+            {
+                "callback_name": "langfuse",
+                "callback_vars": {"langfuse_secret_key": self.CANARY},
+            }
+        ]
+        return {
+            "user_api_key_auth": UserAPIKeyAuth(
+                api_key="hashed-key",
+                team_metadata={"logging": team_logging},
+            ),
+            "user_api_key_team_metadata": {"logging": team_logging},
+            "user_api_key_metadata": {"secret_manager_settings": {"vault_token": self.CANARY}},
+            "session_id": "canary-session",
+            "trace_name": "canary-trace",
+            "first_custom": "keep-first",
+            "second_custom": "keep-second",
+            "endpoint": "/v1/chat/completions",
+            "headers": {"authorization": f"Bearer {self.CANARY}"},
+        }
+
+    def _emitted_payload_text(self):
+        """Every blob this logger handed to the langfuse SDK, as one searchable string."""
+        import json
+
+        blobs = [self.last_trace_kwargs]
+        if self.mock_langfuse_trace.generation.call_args is not None:
+            blobs.append(self.mock_langfuse_trace.generation.call_args.kwargs)
+        blobs.extend(call.kwargs for call in self.mock_langfuse_trace.span.call_args_list)
+        return json.dumps(blobs, default=repr)
+
+    def _drive_with_canary(self, extra_metadata=None, hidden_params=None):
+        metadata = {**self._canary_request_metadata(), **(extra_metadata or {})}
+        payload = self._build_standard_logging_payload(trace_id="canary-trace-id")
+        if hidden_params is not None:
+            payload["hidden_params"] = hidden_params
+        kwargs = {**self._build_langfuse_kwargs(payload), "response_cost": 0.25}
+        self.last_trace_kwargs = {}
+        self.mock_langfuse_trace.generation.reset_mock()
+        self.mock_langfuse_trace.span.reset_mock()
+
+        with patch(
+            "litellm.integrations.langfuse.langfuse._add_prompt_to_generation_params",
+            side_effect=lambda generation_params, **kw: generation_params,
+            create=True,
+        ):
+            self.logger._log_langfuse_v2(
+                user_id="user-1",
+                metadata=metadata,
+                litellm_params={"metadata": metadata},
+                output=None,
+                start_time=datetime.datetime(2024, 1, 1, 12, 0, 0),
+                end_time=datetime.datetime(2024, 1, 1, 12, 0, 1),
+                kwargs=kwargs,
+                optional_params={},
+                input=None,
+                response_obj=None,
+                level="INFO",
+                litellm_call_id="canary-call-id",
+            )
+        return self.mock_langfuse_trace.generation.call_args.kwargs["metadata"]
+
+    def test_team_callback_credentials_never_reach_langfuse(self):
         """
-        When standard_logging_object is None (failure case where
-        get_standard_logging_object_payload threw), litellm_trace_id from kwargs
-        should be used as the Langfuse trace_id. This matches the DB Session ID.
+        Regression for the credential leak: request metadata carries the whole
+        UserAPIKeyAuth object, whose team_metadata holds the customer's own langfuse
+        keys. The emitted blob is sourced from StandardLoggingPayload, so none of the
+        three credential carriers can ride along.
         """
+        generation_metadata = self._drive_with_canary()
+
+        assert self.CANARY not in self._emitted_payload_text()
+        for leaked_key in (
+            "user_api_key_auth",
+            "user_api_key_team_metadata",
+            "user_api_key_metadata",
+        ):
+            assert leaked_key not in generation_metadata
+
+    def test_debug_langfuse_dump_carries_no_credentials(self):
+        """
+        debug_langfuse dumps request metadata into the trace as a second emit site.
+        It must be sourced from the allowlisted payload too.
+        """
+        self._drive_with_canary(extra_metadata={"debug_langfuse": True})
+
+        dumped = self.last_trace_kwargs["metadata"]["metadata_passed_to_litellm"]
+        assert "user_api_key_auth" not in dumped
+        assert self.CANARY not in self._emitted_payload_text()
+
+    def test_raw_request_metadata_reaches_the_emitted_blob_through_no_key(self):
+        """
+        The emitted blob is the allowlist plus litellm enrichments, nothing else.
+        Nothing from raw request metadata is copied across, whatever its type, which
+        is what makes the credential exclusion structural rather than a filter that
+        has to be kept correct. Proxy callers keep their own metadata under the
+        allowlisted requester_metadata key.
+        """
+        generation_metadata = self._drive_with_canary()
+
+        for caller_key in ("first_custom", "second_custom", "session_id", "trace_name"):
+            assert caller_key not in generation_metadata
+
+    def test_provider_specific_span_receives_the_emitted_blob(self):
+        """
+        The provider span reads hidden_params, which is an enrichment on the emitted
+        blob rather than a key of request metadata. Handing it the steering dict
+        instead would silently stop emitting vertex grounding spans.
+        """
+        self._drive_with_canary(hidden_params={"vertex_ai_grounding_metadata": ["ground-a", "ground-b"]})
+
+        span_inputs = [call.kwargs.get("input") for call in self.mock_langfuse_trace.span.call_args_list]
+        assert span_inputs == ["ground-a", "ground-b"]
+        assert self.CANARY not in self._emitted_payload_text()
+
+    def test_caller_cannot_spoof_an_allowlisted_identity_field(self):
+        """
+        Request metadata never reaches the blob, so a caller naming user_api_key_alias
+        cannot have their value emitted in place of the proxy-resolved one.
+        """
+        generation_metadata = self._drive_with_canary(
+            extra_metadata={"user_api_key_alias": "spoofed-by-caller"}
+        )
+
+        assert generation_metadata["user_api_key_alias"] == "canary-alias"
+
+    def test_caller_nested_metadata_cannot_erase_a_litellm_enrichment(self):
+        """
+        log_requester_metadata drops any top-level key whose name also appears inside
+        requester_metadata. Sourcing the blob from the allowlist populates that nested
+        dict for real, so a caller naming a key litellm_response_cost would otherwise
+        blank out the cost litellm computed. Enrichments are layered after the dedupe.
+        """
+        payload = self._build_standard_logging_payload(trace_id="canary-trace-id")
+        payload["metadata"]["requester_metadata"] = {"litellm_response_cost": "caller-value", "api_base": "caller"}
+        kwargs = {**self._build_langfuse_kwargs(payload), "response_cost": 0.25}
+        metadata = self._canary_request_metadata()
+        self.mock_langfuse_trace.generation.reset_mock()
+
+        with patch(
+            "litellm.integrations.langfuse.langfuse._add_prompt_to_generation_params",
+            side_effect=lambda generation_params, **kw: generation_params,
+            create=True,
+        ):
+            self.logger._log_langfuse_v2(
+                user_id="user-1",
+                metadata=metadata,
+                litellm_params={"metadata": metadata, "api_base": "https://real-api-base"},
+                output=None,
+                start_time=datetime.datetime(2024, 1, 1, 12, 0, 0),
+                end_time=datetime.datetime(2024, 1, 1, 12, 0, 1),
+                kwargs=kwargs,
+                optional_params={},
+                input=None,
+                response_obj=None,
+                level="INFO",
+                litellm_call_id="canary-call-id",
+            )
+
+        generation_metadata = self.mock_langfuse_trace.generation.call_args.kwargs["metadata"]
+        assert generation_metadata["litellm_response_cost"] == 0.25
+        assert generation_metadata["api_base"] == "https://real-api-base"
+
+    def test_denied_steering_keys_and_enrichments(self):
+        """
+        endpoint is a plain string, so without the deny-list it would ride the
+        string re-injection straight into the emitted blob. The enrichments are
+        litellm-computed and must survive the move off clean_metadata.
+        """
+        generation_metadata = self._drive_with_canary()
+
+        assert "endpoint" not in generation_metadata
+        assert "headers" not in generation_metadata
+        assert generation_metadata["litellm_response_cost"] == 0.25
+        assert "hidden_params" in generation_metadata
+
+    def test_cache_hit_is_normalized_on_the_shared_kwargs(self):
+        """
+        kwargs here is the shared model_call_details dict. Callbacks that run after
+        langfuse read cache_hit off it and copy it into their own payloads, so
+        dropping the None to False normalization records None for datadog, logfire,
+        generic_api and spend tracking.
+        """
+        metadata = self._canary_request_metadata()
+        payload = self._build_standard_logging_payload(trace_id="canary-trace-id")
+        kwargs = {**self._build_langfuse_kwargs(payload), "cache_hit": None}
+
+        with patch(
+            "litellm.integrations.langfuse.langfuse._add_prompt_to_generation_params",
+            side_effect=lambda generation_params, **kw: generation_params,
+            create=True,
+        ):
+            self.logger._log_langfuse_v2(
+                user_id="user-1",
+                metadata=metadata,
+                litellm_params={"metadata": metadata},
+                output=None,
+                start_time=datetime.datetime(2024, 1, 1, 12, 0, 0),
+                end_time=datetime.datetime(2024, 1, 1, 12, 0, 1),
+                kwargs=kwargs,
+                optional_params={},
+                input=None,
+                response_obj=None,
+                level="INFO",
+                litellm_call_id="canary-call-id",
+            )
+
+        assert kwargs["cache_hit"] is False
+
+    def test_redact_user_api_key_info_still_strips_the_emitted_blob(self):
+        """
+        The flag used to act on the raw-derived blob. That blob is now sourced from
+        StandardLoggingPayload, which is where the user_api_key_* fields live, so the
+        redaction has to run on the assembled payload or the flag silently stops working.
+        """
+        with patch.object(litellm, "redact_user_api_key_info", True):
+            generation_metadata = self._drive_with_canary()
+
+        assert not [key for key in generation_metadata if key.startswith("user_api_key")]
+
+    def test_steering_keys_still_read_from_raw_metadata(self):
+        """
+        Only the emitted payload moves to StandardLoggingPayload. The control fields
+        keep reading raw metadata, which is what Braintrust's migration got wrong.
+        """
+        self._drive_with_canary()
+
+        assert self.last_trace_kwargs.get("session_id") == "canary-session"
+        assert self.last_trace_kwargs.get("name") == "canary-trace"
+
+    def test_failure_trace_survives_a_missing_standard_logging_object(self):
+        """
+        get_standard_logging_object_payload is fail-open and returns None on any
+        exception, which is exactly the failed-request case Langfuse most needs to
+        show. The trace is still emitted with the litellm_trace_id fallback, and the
+        blob degrades to caller strings plus enrichments rather than falling back to
+        raw metadata, which would ship the UserAPIKeyAuth object.
+        """
+        metadata = self._canary_request_metadata()
         kwargs = {
             "standard_logging_object": None,
             "model": "gpt-4",
@@ -520,16 +755,17 @@ class TestLangfuseUsageDetails(unittest.TestCase):
             "litellm_trace_id": "trace-id-failure",
         }
         self.last_trace_kwargs = {}
+        self.mock_langfuse_trace.generation.reset_mock()
 
         with patch(
             "litellm.integrations.langfuse.langfuse._add_prompt_to_generation_params",
             side_effect=lambda generation_params, **kwargs: generation_params,
             create=True,
         ):
-            self.logger._log_langfuse_v2(
+            trace_id, _ = self.logger._log_langfuse_v2(
                 user_id="user-1",
-                metadata={},
-                litellm_params={"metadata": {}},
+                metadata=metadata,
+                litellm_params={"metadata": metadata},
                 output=None,
                 start_time=datetime.datetime.utcnow(),
                 end_time=datetime.datetime.utcnow(),
@@ -541,8 +777,18 @@ class TestLangfuseUsageDetails(unittest.TestCase):
                 litellm_call_id="call-id-different",
             )
 
-        # Must use litellm_trace_id, not litellm_call_id
+        import json
+
+        assert trace_id == "trace-id-failure"
         assert self.last_trace_kwargs.get("id") == "trace-id-failure"
+        generation_metadata = self.mock_langfuse_trace.generation.call_args.kwargs["metadata"]
+        assert "user_api_key_auth" not in generation_metadata
+        assert self.CANARY not in self._emitted_payload_text()
+        assert "first_custom" not in generation_metadata
+        # hidden_params comes off the payload, so it is omitted rather than emitted
+        # as an unserializable placeholder
+        assert "hidden_params" not in generation_metadata
+        json.dumps(generation_metadata)
 
     def test_log_langfuse_v2_session_id_passed_as_trace_session_id(self):
         """


### PR DESCRIPTION
> ## BREAKING CHANGE FOR LANGFUSE TRACE CONSUMERS
>
> **THIS PR CHANGES WHAT IS LOGGED TO LANGFUSE. READ BEFORE UPGRADING.**
>
> **1. ROUGHLY 20 METADATA FIELDS NO LONGER APPEAR ON THE GENERATION.** Measured live, 52 keys down to 38. Any saved Langfuse filter, dashboard or alert built on these will stop matching:
> `model_group`, `model_info`, `deployment`, `deployment_model_name`, `model_group_alias`, `model_group_size`, `litellm_api_version`, `litellm_received_at`, `litellm_parent_otel_span`, `queue_time_seconds`, `attempted_retries`, `max_retries`, `agent_id`, `caller_tags`, `inherited_tags`, `global_max_parallel_requests`, `user_api_key`, and the remaining `user_api_key_*` budget and permission-id fields.
> `model_group` and the deployment id are still recoverable from `hidden_params`.
>
> **2. DIRECT-SDK CALLERS LOSE FLAT CUSTOM METADATA.** `metadata={"my_key": "v"}` no longer reaches the generation. Nest it instead, and it arrives under `requester_metadata`:
> `metadata={"metadata": {"my_key": "v"}}`
> Proxy callers are NOT affected; their request-body metadata already rides under `requester_metadata`, nesting intact.
>
> **3. `debug_langfuse` NOW EMITS CALLER SCALARS, NOT THE EXACT RAW METADATA.** Dicts and lists are filtered out, because the raw dump was a second copy of the credential leak this PR fixes.
>
> Docs corrected in BerriAI/litellm-docs#902.

## TLDR

Problem this solves:

- A team's own Langfuse keys arrive inside that team's own Langfuse traces
- Request metadata carries the whole auth object, unfiltered
- `debug_langfuse` ships the same credentials a second time

How it solves it:

- Emitted blob is the StandardLoggingPayload allowlist plus enrichments
- Nothing is copied across from raw metadata, so exclusion is structural
- Steering keys keep reading raw metadata, so behavior is unchanged
- Debug dump emits caller scalars, never the auth object

## User Flow

Before: a team that configured its own Langfuse destination finds its Langfuse secret key sitting in the traces it can read

1. An admin configures the team with Langfuse credentials, so its traffic is traced to the team's own Langfuse project
2. A member of that team sends POST https://litellm-domain/v1/chat/completions with their team key, and gets a normal 200
3. They open the trace in their Langfuse project and expand the generation's metadata
4. Under `user_api_key_auth.team_metadata.logging[0].callback_vars` they can read `langfuse_secret_key` and `langfuse_public_key` in full
5. Anyone who can read that Langfuse project, including members with no admin rights on the gateway, can now authenticate as the team's Langfuse destination

After: the same trace carries the request's identity and cost, and no credentials

1. The admin configures the team the same way
2. The member sends the same POST https://litellm-domain/v1/chat/completions and gets the same 200
3. They open the trace and expand the generation's metadata
4. `user_api_key_auth` is gone, along with `user_api_key_team_metadata` and `user_api_key_metadata`; key alias, team alias, spend and cost are still there, and anything they passed in `metadata` still shows up under `requester_metadata`
5. Reading the Langfuse project no longer reveals the team's Langfuse credentials

## Relevant issues

## Linear ticket

Resolves LIT-5492

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy with real Postgres, a real Gemini call, and the Langfuse destination pointed at a local sink that records the exact outbound bytes. A marker credential is planted in the team row's `callback_vars`, in the legacy plaintext shape that predates at-rest encryption.

Setup, once:

```bash
curl -X POST http://127.0.0.1:4483/team/new -H "Authorization: Bearer $MASTER" -H 'Content-Type: application/json' -d '{
 "team_alias": "canary",
 "metadata": {"logging": [{"callback_name":"langfuse","callback_type":"success",
   "callback_vars":{"langfuse_public_key":"pk-lf-SIBMARKER-PUBLIC-a1b2c3",
                    "langfuse_secret_key":"sk-lf-SIBMARKER-SECRET-d4e5f6",
                    "langfuse_host":"http://127.0.0.1:9483/langfuse"}}]}}'
```

BEFORE, at `fdd72b5b23`:

```bash
curl -s -X POST http://127.0.0.1:4483/v1/chat/completions -H "Authorization: Bearer $TEAMKEY" \
  -H 'Content-Type: application/json' \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"say hi"}]}'
# then grep the captured POST /api/public/ingestion body
grep -aoc 'sk-lf-SIBMARKER-SECRET-d4e5f6' captures/*ingestion*.bin
1        # normal request
2        # same request with "metadata": {"debug_langfuse": true}
```

The captured body, verbatim:

```
"team_metadata": {"logging": [{"callback_name": "langfuse", "callback_type": "success",
"callback_vars": {"langfuse_host": "http://127.0.0.1:9483/langfuse",
"langfuse_public_key": "pk-lf-SIBMARKER-PUBLIC-a1b2c3",
"langfuse_secret_key": "sk-lf-SIBMARKER-SECRET-d4e5f6"}}]}
```

AFTER, at `bd0f074a6a`, same rig, same team row, four scenarios:

```bash
grep -aoc 'sk-lf-SIBMARKER-SECRET-d4e5f6' captures/*ingestion*.bin
0   # A  normal request, the reported scenario
0   # B  same request with "metadata": {"debug_langfuse": true}
0   # C  same request with "metadata": {"trace_name": "rca-check"}
1   # D  "metadata": {"existing_trace_id":"t-1","update_trace_keys":["user_api_key_auth"]}
```

Legs A, B and C on the wire:

```
A  generation: 38 keys | user_api_key_auth absent | user_api_key_team_metadata absent
   requester_metadata = {"my_tag": "t", "nested": {"a": 1}}      caller metadata intact, nesting preserved
B  debug dump: 20 scalar keys, auth object absent
C  trace name = "rca-check"                                       steering still reads raw metadata
```

Leg D is a pre-existing hole this PR does not close, disclosed rather than hidden. `update_trace_keys`
names a key that the existing-trace branch pops out of raw metadata straight onto `trace_params`, which
never passes through the allowlisted blob. The generation metadata is clean even on that leg; the auth
object lands as a top-level field on the trace object. The channel is byte-identical before and after
this commit. It belongs to LIT-5484, which owns the steering redesign.

### Real Langfuse cloud, same team, same request

Both traces were produced against Langfuse cloud with the team's own credentials, stored encrypted
at rest, so the destination resolves correctly and the value that leaks is ciphertext rather than a
usable secret.

Before, the generation metadata carries 52 keys. The team's own Langfuse credentials are readable at
`user_api_key_auth.team_metadata.logging[0].callback_vars`, which is the path the report describes.

![Before the fix](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr36744/assets/lit5492-before-fix.png)

After, the same request emits 38 allowlisted fields. `user_api_key_auth` and the `callback_vars` it
carried are gone. `user_api_key_auth_metadata` reads as an empty object, which is the stripped copy
rather than the leaking field, and the caller's own metadata still arrives under `requester_metadata`.

![After the fix](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr36744/assets/lit5492-after-fix.png)

Emitted metadata delta, measured on the same live rig, base 52 keys to head 38:

dropped, credential carriers: `user_api_key_auth`, `user_api_key_team_metadata`, `user_api_key_metadata`

dropped, proxy and router internals with no allowlist entry: `agent_id`, `attempted_retries`, `caller_tags`, `deployment`, `deployment_model_name`, `global_max_parallel_requests`, `inherited_tags`, `litellm_api_version`, `litellm_parent_otel_span`, `litellm_received_at`, `max_retries`, `model_group`, `model_group_alias`, `model_group_size`, `model_info`, `queue_time_seconds`, `user_api_end_user_max_budget`, `user_api_key`, `user_api_key_end_user_model_max_budget`, `user_api_key_model_max_budget`, `user_api_key_object_permission_id`, `user_api_key_team_object_permission_id`

added: `applied_guardrails`, `cold_storage_object_key`, `mcp_tool_call_metadata`, `prompt_management_metadata`, `requester_custom_headers`, `routing_decision`, `spend_logs_metadata`, `team_alias`, `team_id`, `usage_object`, `vector_store_request_metadata`

`model_group` and `model_id` remain recoverable from `hidden_params`, and request tags still reach Langfuse as first-class trace tags rather than as a metadata key.

Note the Langfuse SDK reports the destination's own public key in its ingestion envelope under `metadata.public_key`. That is the SDK authenticating, not our payload, and it is unchanged by this PR.

## Type

🐛 Bug Fix

## Caveats (if any)

- Proxy callers are unaffected: metadata rides under `requester_metadata`
- Direct-SDK callers lose top-level custom keys from the generation blob
- Langfuse docs promise arbitrary metadata passthrough; needs a docs update
- `_log_langfuse_v1` still ships raw metadata, unreachable on langfuse>=2
- `update_trace_keys` can still name the auth object; owned by LIT-5484

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what metadata reaches external Langfuse projects (security fix with behavior shifts for custom top-level metadata); core proxy logging path is widely used but the change is localized to Langfuse v2 assembly.
> 
> **Overview**
> Fixes a **credential leak** where team Langfuse keys and other proxy auth objects were copied from raw request metadata into Langfuse generation/trace payloads.
> 
> **Langfuse v2 logging** now builds the emitted metadata blob from **`standard_logging_object["metadata"]`** (the StandardLoggingPayload allowlist) plus explicit **enrichments** (response cost, filtered `hidden_params`, `api_base`, regions, `cache_hit`). Raw request metadata is no longer merged into that blob, so fields like `user_api_key_auth` and team callback vars cannot ride along structurally.
> 
> **Generation metadata** is assembled as allowlisted fields (with `redact_user_api_key_info`) layered with enrichments; **provider spans** read `hidden_params` from enrichments instead of the old steering dict. **`debug_langfuse`** still attaches caller context to the trace, but only **scalar** keys from request metadata—never the full auth object. Steering controls (`session_id`, `trace_name`, deny-listed keys like `headers`/`endpoint`) **still read raw metadata**; shared **`cache_hit` None→False** normalization on kwargs is preserved.
> 
> Adds regression tests (canary credentials, debug dump, spoofing, missing `standard_logging_object` on failures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7189980331dc3c11e0c4526ea5796eb713aa638c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
