### PR TITLE
fix(ollama): preserve logged tool schema

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -234,14 +234,16 @@ class OllamaChatConfig(BaseConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        optional_params = optional_params.copy()  # mutable-ok: request-local copy protects caller-owned logging data
-        stream: Final = optional_params.pop("stream", False)
-        format: Final = optional_params.pop("format", None)
-        keep_alive: Final = optional_params.pop("keep_alive", None)
-        think: Final = optional_params.pop("think", None)
-        function_name: Final = optional_params.pop("function_name", None)
+        request_params: Final = (
+            optional_params.copy()
+        )  # mutable-ok: request-local copy protects caller-owned logging data
+        stream: Final = request_params.pop("stream", False)
+        format: Final = request_params.pop("format", None)
+        keep_alive: Final = request_params.pop("keep_alive", None)
+        think: Final = request_params.pop("think", None)
+        function_name: Final = request_params.pop("function_name", None)
         litellm_params["function_name"] = function_name
-        tools: Final = optional_params.pop("tools", None)
+        tools: Final = request_params.pop("tools", None)
 
         new_messages: Final = []
         for m in messages:
@@ -290,13 +292,13 @@ class OllamaChatConfig(BaseConfig):
         # Load Config
         config: Final = self.get_config()
         for k, v in config.items():
-            if k not in optional_params:
-                optional_params[k] = v
+            if k not in request_params:
+                request_params[k] = v
 
         data: Final = {
             "model": model,
             "messages": new_messages,
-            "options": optional_params,
+            "options": request_params,
             "stream": stream,
         }
         if format is not None:

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -234,6 +234,7 @@ class OllamaChatConfig(BaseConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
+        optional_params = optional_params.copy()
         stream: Final = optional_params.pop("stream", False)
         format: Final = optional_params.pop("format", None)
         keep_alive: Final = optional_params.pop("keep_alive", None)

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -234,7 +234,7 @@ class OllamaChatConfig(BaseConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        optional_params = optional_params.copy()
+        optional_params = optional_params.copy()  # mutable-ok: request-local copy protects caller-owned logging data
         stream: Final = optional_params.pop("stream", False)
         format: Final = optional_params.pop("format", None)
         keep_alive: Final = optional_params.pop("keep_alive", None)

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -814,6 +814,38 @@ class TestOllamaReasoningContentStreaming:
 
 
 class TestOllamaToolCallTransformation:
+    def test_transform_request_preserves_logged_tool_schema(self):
+        config = OllamaChatConfig()
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather for a location",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                },
+            }
+        ]
+        optional_params = {"tools": tools, "stream": False, "num_ctx": 262144}
+
+        result = config.transform_request(
+            model="gemma4:27b",
+            messages=cast(
+                list[AllMessageValues],
+                [{"role": "user", "content": "Weather in London?"}],
+            ),
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+
+        assert result["tools"] == tools
+        assert optional_params == {"tools": tools, "stream": False, "num_ctx": 262144}
+
     def test_transform_request_preserves_tool_calls(self):
         """
         tool_calls on assistant messages must survive transform_request.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Ollama tool schemas disappear from hidden log parameters
- The dashboard can misdiagnose valid tool requests

How it solves it:

- Preserve parameters before provider request transformation
- Cover request and log schema retention together

## User Flow

Before: a developer sees an empty tool schema in the dashboard even though Ollama received the complete request

1. They send POST https://litellm-domain/v1/chat/completions with an Ollama model and a function tool schema
2. The completion succeeds or reaches Ollama with the full schema
3. They open https://litellm-domain/ui/?page=logs and inspect the request
4. The hidden optional parameters show `function.parameters: {}`

After: the same request remains complete everywhere the developer inspects it

1. They send the same POST https://litellm-domain/v1/chat/completions with the same function tool schema
2. The completion succeeds or reaches Ollama with the full schema
3. They open https://litellm-domain/ui/?page=logs and inspect the request
4. The hidden optional parameters retain the original properties and required fields

## Relevant issues

Fixes #36463

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

The issue contains the complete pre-fix dashboard payload and confirms that the same schema reached Ollama. I do not have a configured Ollama proxy and dashboard session for an honest post-fix screenshot

To verify commit `5104b83b1da5e65b2aeaa93efce0a9309de5ddae`:

1. Configure an `ollama_chat` deployment with function calling enabled
2. Send the request body from #36463 to POST https://litellm-domain/v1/chat/completions
3. Open https://litellm-domain/ui/?page=logs and select the request
4. Confirm `metadata.hidden_params.optional_params.tools[0].function.parameters` retains `properties.location` and `required: ["location"]`

Local regression verification:

```text
tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
27 passed
```

The focused test fails on the parent commit because transformation removes `tools` and `stream` from the logging parameters

## Type

Bug Fix
Test

## Caveats (if any)

- Dashboard proof needs a configured local Ollama deployment

### Final Attestation

- [x] The tests cover both provider payload and logged schema retention