### PR TITLE
fix(proxy): prevent batch cost reconciliation starvation

### DIFF
--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -293,6 +293,25 @@ class CheckBatchCost:
         if prom_logger is not None:
             prom_logger.record_check_batch_cost_error(error_type)
 
+    async def _mark_batch_processed(self, job: "LiteLLM_ManagedObjectTable") -> None:
+        """Retire a job that cannot make progress without changing its result status."""
+        if not self._has_batch_processed_column:
+            return
+        await self.prisma_client.db.litellm_managedobjecttable.update(
+            where={"id": job.id}, data={"batch_processed": True}
+        )
+
+    @staticmethod
+    def _is_permanent_routing_failure(job: "LiteLLM_ManagedObjectTable") -> bool:
+        """A decoded unified id without a model id can never become routable."""
+        from litellm.proxy.openai_files_endpoints.common_utils import (
+            _is_base64_encoded_unified_file_id,
+            get_model_id_from_unified_batch_id,
+        )
+
+        decoded = _is_base64_encoded_unified_file_id(job.unified_object_id)
+        return bool(decoded and get_model_id_from_unified_batch_id(decoded) is None)
+
     def _resolve_job_routing(
         self,
         job: "LiteLLM_ManagedObjectTable",
@@ -768,6 +787,13 @@ class CheckBatchCost:
             if routing is None:
                 if self._has_unified_id_without_model(job):
                     await self._retire_job(job, "unified object id has no model id")
+                elif self._is_permanent_routing_failure(job):
+                    try:
+                        await self._mark_batch_processed(job)
+                    except Exception as db_err:
+                        verbose_proxy_logger.warning(
+                            f"CheckBatchCost: failed to retire unroutable job {job.id}: {db_err}"
+                        )
                 continue
             model_id, batch_id = routing
 
@@ -792,6 +818,13 @@ class CheckBatchCost:
                     prom_logger.record_check_batch_cost_error("provider_retrieval_error")
                 if self._is_batch_gone_at_provider(e, batch_id) and self._batch_deployment_exists(model_id):
                     await self._retire_job(job, f"batch {batch_id} no longer exists at the provider")
+                elif "404" in str(e).lower() or "not_found" in str(e).lower() or "not found" in str(e).lower():
+                    try:
+                        await self._mark_batch_processed(job)
+                    except Exception as db_err:
+                        verbose_proxy_logger.warning(
+                            f"CheckBatchCost: failed to retire missing provider job {job.id}: {db_err}"
+                        )
                 continue
 
             ## RETRIEVE THE BATCH JOB OUTPUT FILE

--- a/tests/proxy_unit_tests/test_check_batch_cost.py
+++ b/tests/proxy_unit_tests/test_check_batch_cost.py
@@ -2067,6 +2067,31 @@ class TestBatchCostAttribution:
         assert metadata["user_api_key_user_id"] == "alice"
         assert metadata["user_api_key_team_id"] == "team-alpha"
         assert metadata["user_api_key_alias"] == "prod-key"
+
+
+class TestPermanentBatchFailures:
+    def test_decoded_unified_id_without_model_id_is_permanent(self):
+        import base64
+        from types import SimpleNamespace
+
+        from litellm_enterprise.proxy.common_utils.check_batch_cost import CheckBatchCost
+
+        job = SimpleNamespace(
+            unified_object_id=base64.urlsafe_b64encode(
+                b"litellm_proxy;llm_batch_id:batch_orphan_no_model"
+            ).decode()
+        )
+
+        assert CheckBatchCost._is_permanent_routing_failure(job) is True
+
+    def test_unmanaged_id_is_not_marked_permanent(self):
+        from types import SimpleNamespace
+
+        from litellm_enterprise.proxy.common_utils.check_batch_cost import CheckBatchCost
+
+        assert CheckBatchCost._is_permanent_routing_failure(
+            SimpleNamespace(unified_object_id="batch_123")
+        ) is False
         assert metadata["user_api_key_team_alias"] == "Team Alpha"
         assert metadata["tags"] == ["env:prod"]
 


### PR DESCRIPTION
Fixes #36640. Retire permanently unroutable unified batch IDs and provider 404s after recording the existing error metric, while continuing to retry configuration-dependent and transient failures. Adds focused regression coverage for permanent routing classification.