### PR TITLE
fix(github_copilot): forward reasoning params for all reasoning-capable models

### DIFF
--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -17,7 +17,7 @@ from ..common_utils import (
     get_copilot_default_headers,
 )
 
-_CLAUDE_REASONING_PARAMS: Final = frozenset({"thinking", "reasoning_effort"})
+_REASONING_PARAMS: Final = frozenset({"thinking", "reasoning_effort"})
 
 
 class GithubCopilotConfig(OpenAIConfig):
@@ -116,23 +116,22 @@ class GithubCopilotConfig(OpenAIConfig):
         """
         Get supported OpenAI parameters for GitHub Copilot.
 
-        For Claude models that support extended thinking (Claude 4 family and Claude 3-7), includes thinking and reasoning_effort parameters.
-        For other models, returns standard OpenAI parameters (which may include reasoning_effort for o-series models).
+        Claude models that support extended thinking accept both thinking and reasoning_effort.
+        Other reasoning-capable Copilot models (Gemini, Grok, gpt-5 family) accept reasoning_effort only.
         """
         from litellm.utils import supports_reasoning
 
-        # Get base OpenAI parameters
         base_params: Final = super().get_supported_openai_params(model)
+        normalized: Final = model.lower()
 
-        # Add Claude-specific parameters for models that support extended thinking
-        if "claude" in model.lower() and supports_reasoning(
-            model=model.lower(),
-        ):
-            if "thinking" not in base_params:
-                base_params.append("thinking")
-            # reasoning_effort is not included by parent for Claude models, so add it
-            if "reasoning_effort" not in base_params:
-                base_params.append("reasoning_effort")
+        if not supports_reasoning(model=normalized):
+            return base_params
+
+        # thinking is Anthropic-native; only Claude accepts it
+        if "claude" in normalized and "thinking" not in base_params:
+            base_params.append("thinking")
+        if "reasoning_effort" not in base_params:
+            base_params.append("reasoning_effort")
 
         return base_params
 
@@ -145,13 +144,13 @@ class GithubCopilotConfig(OpenAIConfig):
     ) -> dict:
         # OpenAIConfig routes non-o-series/non-gpt-5 models to OpenAIGPTConfig, whose
         # whitelist has neither key, so advertising them alone dropped them (#25666)
-        supported: Final = frozenset(self.get_supported_openai_params(model)) & _CLAUDE_REASONING_PARAMS
-        claude_params: Final = {k: v for k, v in non_default_params.items() if k in supported}
+        supported: Final = frozenset(self.get_supported_openai_params(model)) & _REASONING_PARAMS
+        reasoning_params: Final = {k: v for k, v in non_default_params.items() if k in supported}
         remaining: Final = {k: v for k, v in non_default_params.items() if k not in supported}
 
         return super().map_openai_params(
             non_default_params=remaining,
-            optional_params={**optional_params, **claude_params},
+            optional_params={**optional_params, **reasoning_params},
             model=model,
             drop_params=drop_params,
         )

--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -137,11 +137,11 @@ class GithubCopilotConfig(OpenAIConfig):
 
     def map_openai_params(
         self,
-        non_default_params: dict,
-        optional_params: dict,
+        non_default_params: dict,  # mutable-ok: matches the BaseConfig override signature
+        optional_params: dict,  # mutable-ok: matches the BaseConfig override signature
         model: str,
         drop_params: bool,
-    ) -> dict:
+    ) -> dict:  # mutable-ok: matches the BaseConfig override signature
         # OpenAIConfig routes non-o-series/non-gpt-5 models to OpenAIGPTConfig, whose
         # whitelist has neither key, so advertising them alone dropped them (#25666)
         supported: Final = frozenset(self.get_supported_openai_params(model)) & _REASONING_PARAMS

--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -17,6 +17,8 @@ from ..common_utils import (
     get_copilot_default_headers,
 )
 
+_CLAUDE_REASONING_PARAMS: Final = frozenset({"thinking", "reasoning_effort"})
+
 
 class GithubCopilotConfig(OpenAIConfig):
     def __init__(
@@ -133,6 +135,26 @@ class GithubCopilotConfig(OpenAIConfig):
                 base_params.append("reasoning_effort")
 
         return base_params
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        # OpenAIConfig routes non-o-series/non-gpt-5 models to OpenAIGPTConfig, whose
+        # whitelist has neither key, so advertising them alone dropped them (#25666)
+        supported: Final = frozenset(self.get_supported_openai_params(model)) & _CLAUDE_REASONING_PARAMS
+        claude_params: Final = {k: v for k, v in non_default_params.items() if k in supported}
+        remaining: Final = {k: v for k, v in non_default_params.items() if k not in supported}
+
+        return super().map_openai_params(
+            non_default_params=remaining,
+            optional_params={**optional_params, **claude_params},
+            model=model,
+            drop_params=drop_params,
+        )
 
     def _determine_initiator(self, messages: list[AllMessageValues]) -> str:
         """

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -982,3 +982,71 @@ def test_openai_handler_repairs_github_copilot_empty_choices(
     assert result.choices[0].message.content == "Hi there"
     assert result.choices[0].finish_reason == "stop"
     mock_request.assert_called_once()
+
+
+def test_map_openai_params_forwards_reasoning_effort_for_claude():
+    """Claude reasoning params must survive map_openai_params, not just be advertised.
+
+    Regression test for the gap behind #25666: GithubCopilotConfig overrode
+    get_supported_openai_params() to advertise ``thinking``/``reasoning_effort``
+    for extended-thinking Claude models, but never overrode map_openai_params().
+    Mapping therefore fell through to OpenAIConfig -> OpenAIGPTConfig, whose
+    supported-param whitelist has neither key, so both were silently discarded
+    and never reached the Copilot API. The advertise-only assertions in
+    test_get_supported_openai_params_claude_model passed the whole time, because
+    they never inspect the mapped output.
+    """
+    config = GithubCopilotConfig()
+    model = "claude-sonnet-4-20250514"
+
+    # Guard the premise: the param is advertised as supported for this model.
+    assert "reasoning_effort" in config.get_supported_openai_params(model)
+
+    mapped = config.map_openai_params(
+        non_default_params={"reasoning_effort": "high"},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+    assert mapped.get("reasoning_effort") == "high"
+
+    mapped_thinking = config.map_openai_params(
+        non_default_params={"thinking": {"type": "enabled", "budget_tokens": 4096}},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+    assert mapped_thinking.get("thinking") == {
+        "type": "enabled",
+        "budget_tokens": 4096,
+    }
+
+
+def test_map_openai_params_does_not_forward_reasoning_for_unsupported_claude():
+    """A Claude model without extended thinking must not gain reasoning params."""
+    config = GithubCopilotConfig()
+    model = "claude-3.5-sonnet"
+
+    assert "reasoning_effort" not in config.get_supported_openai_params(model)
+
+    mapped = config.map_openai_params(
+        non_default_params={"reasoning_effort": "high"},
+        optional_params={},
+        model=model,
+        drop_params=True,
+    )
+    assert "reasoning_effort" not in mapped
+
+
+def test_map_openai_params_preserves_standard_openai_params_for_claude():
+    """The Claude passthrough must not regress ordinary OpenAI param mapping."""
+    config = GithubCopilotConfig()
+
+    mapped = config.map_openai_params(
+        non_default_params={"temperature": 0.5, "max_tokens": 128},
+        optional_params={},
+        model="claude-sonnet-4-20250514",
+        drop_params=False,
+    )
+    assert mapped.get("temperature") == 0.5
+    assert mapped.get("max_tokens") == 128

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -1050,3 +1050,45 @@ def test_map_openai_params_preserves_standard_openai_params_for_claude():
     )
     assert mapped.get("temperature") == 0.5
     assert mapped.get("max_tokens") == 128
+
+
+def test_non_claude_reasoning_model_forwards_reasoning_effort():
+    """Reasoning-capable non-Claude Copilot models must also keep reasoning_effort.
+
+    Copilot serves Gemini, Grok and MAI models that advertise reasoning_effort in
+    its own model catalog, but the provider previously gated the param on the
+    model id containing "claude", so every other family had it dropped while the
+    upstream API would have accepted it.
+    """
+    config = GithubCopilotConfig()
+    model = "gemini-2.5-pro"
+
+    with patch(
+        "litellm.utils.supports_reasoning",
+        return_value=True,
+    ):
+        supported = config.get_supported_openai_params(model)
+        assert "reasoning_effort" in supported
+        # thinking is Anthropic-native and must stay Claude-only
+        assert "thinking" not in supported
+
+        mapped = config.map_openai_params(
+            non_default_params={"reasoning_effort": "high"},
+            optional_params={},
+            model=model,
+            drop_params=False,
+        )
+        assert mapped.get("reasoning_effort") == "high"
+
+
+def test_non_reasoning_model_keeps_reasoning_effort_out():
+    """A model the catalog reports as non-reasoning must not gain the param."""
+    config = GithubCopilotConfig()
+
+    with patch(
+        "litellm.utils.supports_reasoning",
+        return_value=False,
+    ):
+        supported = config.get_supported_openai_params("gpt-4o")
+        assert "reasoning_effort" not in supported
+        assert "thinking" not in supported

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -3,7 +3,7 @@ import json
 import os
 import sys
 from datetime import datetime, timedelta
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Final
 from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
@@ -985,24 +985,13 @@ def test_openai_handler_repairs_github_copilot_empty_choices(
 
 
 def test_map_openai_params_forwards_reasoning_effort_for_claude():
-    """Claude reasoning params must survive map_openai_params, not just be advertised.
+    """Claude reasoning params must survive mapping, not just be advertised (#25666)."""
+    config: Final = GithubCopilotConfig()
+    model: Final = "claude-sonnet-4-20250514"
 
-    Regression test for the gap behind #25666: GithubCopilotConfig overrode
-    get_supported_openai_params() to advertise ``thinking``/``reasoning_effort``
-    for extended-thinking Claude models, but never overrode map_openai_params().
-    Mapping therefore fell through to OpenAIConfig -> OpenAIGPTConfig, whose
-    supported-param whitelist has neither key, so both were silently discarded
-    and never reached the Copilot API. The advertise-only assertions in
-    test_get_supported_openai_params_claude_model passed the whole time, because
-    they never inspect the mapped output.
-    """
-    config = GithubCopilotConfig()
-    model = "claude-sonnet-4-20250514"
-
-    # Guard the premise: the param is advertised as supported for this model.
     assert "reasoning_effort" in config.get_supported_openai_params(model)
 
-    mapped = config.map_openai_params(
+    mapped: Final = config.map_openai_params(
         non_default_params={"reasoning_effort": "high"},
         optional_params={},
         model=model,
@@ -1010,7 +999,7 @@ def test_map_openai_params_forwards_reasoning_effort_for_claude():
     )
     assert mapped.get("reasoning_effort") == "high"
 
-    mapped_thinking = config.map_openai_params(
+    mapped_thinking: Final = config.map_openai_params(
         non_default_params={"thinking": {"type": "enabled", "budget_tokens": 4096}},
         optional_params={},
         model=model,
@@ -1024,12 +1013,12 @@ def test_map_openai_params_forwards_reasoning_effort_for_claude():
 
 def test_map_openai_params_does_not_forward_reasoning_for_unsupported_claude():
     """A Claude model without extended thinking must not gain reasoning params."""
-    config = GithubCopilotConfig()
-    model = "claude-3.5-sonnet"
+    config: Final = GithubCopilotConfig()
+    model: Final = "claude-3.5-sonnet"
 
     assert "reasoning_effort" not in config.get_supported_openai_params(model)
 
-    mapped = config.map_openai_params(
+    mapped: Final = config.map_openai_params(
         non_default_params={"reasoning_effort": "high"},
         optional_params={},
         model=model,
@@ -1040,9 +1029,9 @@ def test_map_openai_params_does_not_forward_reasoning_for_unsupported_claude():
 
 def test_map_openai_params_preserves_standard_openai_params_for_claude():
     """The Claude passthrough must not regress ordinary OpenAI param mapping."""
-    config = GithubCopilotConfig()
+    config: Final = GithubCopilotConfig()
 
-    mapped = config.map_openai_params(
+    mapped: Final = config.map_openai_params(
         non_default_params={"temperature": 0.5, "max_tokens": 128},
         optional_params={},
         model="claude-sonnet-4-20250514",
@@ -1053,26 +1042,20 @@ def test_map_openai_params_preserves_standard_openai_params_for_claude():
 
 
 def test_non_claude_reasoning_model_forwards_reasoning_effort():
-    """Reasoning-capable non-Claude Copilot models must also keep reasoning_effort.
-
-    Copilot serves Gemini, Grok and MAI models that advertise reasoning_effort in
-    its own model catalog, but the provider previously gated the param on the
-    model id containing "claude", so every other family had it dropped while the
-    upstream API would have accepted it.
-    """
-    config = GithubCopilotConfig()
-    model = "gemini-2.5-pro"
+    """Reasoning-capable non-Claude Copilot models must also keep reasoning_effort."""
+    config: Final = GithubCopilotConfig()
+    model: Final = "gemini-2.5-pro"
 
     with patch(
         "litellm.utils.supports_reasoning",
         return_value=True,
     ):
-        supported = config.get_supported_openai_params(model)
+        supported: Final = config.get_supported_openai_params(model)
         assert "reasoning_effort" in supported
         # thinking is Anthropic-native and must stay Claude-only
         assert "thinking" not in supported
 
-        mapped = config.map_openai_params(
+        mapped: Final = config.map_openai_params(
             non_default_params={"reasoning_effort": "high"},
             optional_params={},
             model=model,
@@ -1083,12 +1066,12 @@ def test_non_claude_reasoning_model_forwards_reasoning_effort():
 
 def test_non_reasoning_model_keeps_reasoning_effort_out():
     """A model the catalog reports as non-reasoning must not gain the param."""
-    config = GithubCopilotConfig()
+    config: Final = GithubCopilotConfig()
 
     with patch(
         "litellm.utils.supports_reasoning",
         return_value=False,
     ):
-        supported = config.get_supported_openai_params("gpt-4o")
+        supported: Final = config.get_supported_openai_params("gpt-4o")
         assert "reasoning_effort" not in supported
         assert "thinking" not in supported


### PR DESCRIPTION
## TLDR

Problem this solves:

- Copilot reasoning models silently ignore `reasoning_effort`
- Invalid effort values return 200 instead of a validation error

How it solves it:

- Override `map_openai_params` so the params survive mapping
- Gate them on the model's reasoning capability, not its name

## User Flow

Before: a developer calling a reasoning-capable Copilot model through the proxy asks for deeper reasoning and gets none, with no error to tell them why

1. They start the proxy with a `github_copilot/claude-opus-5` deployment and send POST http://localhost:4000/v1/chat/completions with `"reasoning_effort": "max"`
2. The reply comes back 200, but the model reasons no harder than a request that omitted the field entirely
3. They suspect a typo and send the same request with `"reasoning_effort": "banana"`, an obviously invalid value
4. That also returns 200 with a normal answer, so nothing in the response ever reveals that the field was discarded before it left the gateway
5. They switch to `github_copilot/gemini-3.6-flash`, which Copilot also lists as reasoning-capable, and see the same silence: `"minimal"` and `"high"` come back with 327 and 318 reasoning tokens, effectively identical

After: the request reaches the provider, and a bad value is reported instead of swallowed

1. They start the proxy with the same deployment and send POST http://localhost:4000/v1/chat/completions with `"reasoning_effort": "max"`
2. The reply comes back 200 and the model reasons at the requested depth
3. They send the same request with `"reasoning_effort": "banana"`
4. They now get a 400 naming the field and listing the values the model accepts, so an invalid effort is caught instead of quietly dropped
5. On `github_copilot/gemini-3.6-flash` the same request is now honored too: `"minimal"` returns no reasoning tokens at all while `"high"` returns 379, and an invalid value is rejected with that model's own supported list

## Relevant issues

Fixes #25666

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

There were two layers to this. `GithubCopilotConfig` advertised `thinking` and `reasoning_effort` through `get_supported_openai_params`, but it never overrode `map_openai_params`, and `OpenAIConfig` routes anything that is not an o-series or gpt-5 model to `OpenAIGPTConfig`, whose supported-param whitelist carries neither key, so mapping dropped both before the request was built. On top of that, the advertising itself was gated on the model id containing "claude", so Gemini, Grok and MAI models that Copilot lists as reasoning-capable never got the param either. `thinking` stays Claude-only because it is Anthropic-native.

The existing tests only assert that the params appear in the advertised list, never that they survive mapping, which is why this stayed green.

All runs below hit a live proxy on localhost:4000 against real `github_copilot` deployments, and they cost real tokens. An invalid effort value is the clearest probe here: the provider rejects it, so a 200 proves the field never left the gateway.

Before, at 09889e198:

```
$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model":"claude-opus-5","messages":[{"role":"user","content":"What is 17*23?"}],"max_tokens":40,"reasoning_effort":"banana"}'

{"id":"msg_011CdzUmSQVEwsqJ7o1jiZk9","created":1786611870,"model":"claude-opus-5",
 "object":"chat.completion","choices":[{"finish_reason":"length","index":0,
 "message":{"content":"**17 × 23 = 391**\n\nYou can verify this quickly: 17 × 23 = 17",
 "role":"assistant"}}]}
```

An unsupported value came back 200, which is only possible if the field was discarded on the way out. The same probe on `gemini-3.6-flash` also returned 200, and comparing effort levels on that model showed 327 reasoning tokens for `minimal` against 318 for `high`, with no real separation between them.

After, at 8aa15d6d7:

```
$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model":"claude-opus-5","messages":[{"role":"user","content":"What is 17*23?"}],"max_tokens":40,"reasoning_effort":"banana"}'

{"error":{"message":"litellm.BadRequestError: Github_copilotException - reasoning_effort \"banana\" is not supported by model claude-opus-5; supported values: [low medium high xhigh max]. Received Model Group=claude-opus-5","code":"400"}}

$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model":"gemini-3.6-flash","messages":[{"role":"user","content":"hi"}],"max_tokens":20,"reasoning_effort":"banana"}'

{"error":{"message":"litellm.BadRequestError: Github_copilotException - reasoning_effort \"banana\" is not supported by model gemini-3.6-flash; supported values: [minimal low medium high]. Received Model Group=gemini-3.6-flash","code":"400"}}

$ for e in minimal high; do
    printf "%-8s " "$e"
    curl -s -X POST http://localhost:4000/v1/chat/completions \
      -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
      -d "{\"model\":\"gemini-3.6-flash\",\"messages\":[{\"role\":\"user\",\"content\":\"Count the letter r in strawberry, think step by step.\"}],\"max_tokens\":900,\"reasoning_effort\":\"$e\"}" \
    | jq -c '.usage.completion_tokens_details.reasoning_tokens'
  done

minimal  null
high     379
```

Each 400 carries the provider's own validation text, and the two models list different supported values, which is the evidence that the field now reaches each of them. On Gemini the effort levels finally separate: `minimal` spends no reasoning tokens while `high` spends 379

## Type

🐛 Bug Fix

## Caveats (if any)

- `thinking` stays Claude-only; other families take `reasoning_effort` only
