### PR TITLE
fix(responses_bridge): map max reasoning effort instead of dropping it

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -63,6 +63,9 @@ if TYPE_CHECKING:
     from litellm.types.utils import Choices
 
 
+_REASONING_EFFORT_LEVELS: Final = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max"})
+
+
 class _ReasoningSummaryText(TypedDict):
     type: str
     text: str
@@ -1001,23 +1004,11 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         )
 
         # If string is passed, map with optional summary based on flag/env var
-        if reasoning_effort == "none":
-            return Reasoning(effort="none", summary="detailed") if auto_summary_enabled else Reasoning(effort="none")
-        elif reasoning_effort == "high":
-            return Reasoning(effort="high", summary="detailed") if auto_summary_enabled else Reasoning(effort="high")
-        elif reasoning_effort == "xhigh":
-            return Reasoning(effort="xhigh", summary="detailed") if auto_summary_enabled else Reasoning(effort="xhigh")
-        elif reasoning_effort == "medium":
-            return (
-                Reasoning(effort="medium", summary="detailed") if auto_summary_enabled else Reasoning(effort="medium")
-            )
-        elif reasoning_effort == "low":
-            return Reasoning(effort="low", summary="detailed") if auto_summary_enabled else Reasoning(effort="low")
-        elif reasoning_effort == "minimal":
-            return (
-                Reasoning(effort="minimal", summary="detailed") if auto_summary_enabled else Reasoning(effort="minimal")
-            )
-        return None
+        if reasoning_effort not in _REASONING_EFFORT_LEVELS:
+            return None
+        if auto_summary_enabled:
+            return Reasoning(effort=reasoning_effort, summary="detailed")
+        return Reasoning(effort=reasoning_effort)
 
     def _add_web_search_tool(
         self,

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -3,7 +3,7 @@ import json
 import os
 import sys
 import unittest
-from typing import List, Optional, Tuple
+from typing import Final, List, Optional, Tuple
 from unittest.mock import ANY, MagicMock, Mock, patch
 
 import httpx
@@ -3408,6 +3408,6 @@ def test_map_reasoning_effort_rejects_unknown_level():
         LiteLLMResponsesTransformationHandler,
     )
 
-    handler = LiteLLMResponsesTransformationHandler()
+    handler: Final = LiteLLMResponsesTransformationHandler()
 
     assert handler._map_reasoning_effort("banana") is None

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1521,7 +1521,7 @@ def test_map_reasoning_effort_adds_summary_detailed():
     handler = LiteLLMResponsesTransformationHandler()
 
     # Test all string effort levels - DEFAULT BEHAVIOR (no summary)
-    effort_levels = ["none", "low", "medium", "high", "xhigh", "minimal"]
+    effort_levels = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
     # Save original flag value
     original_flag = litellm.reasoning_auto_summary
@@ -3400,3 +3400,14 @@ def test_output_item_done_with_stream_map_keeps_empty_delta():
     )
     assert chunk.choices[0].delta.tool_calls is None
     assert chunk.choices[0].finish_reason is None
+
+
+def test_map_reasoning_effort_rejects_unknown_level():
+    """An unrecognized effort must map to None so it is not forwarded upstream."""
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    assert handler._map_reasoning_effort("banana") is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- `reasoning_effort: "max"` is silently ignored on responses-bridge models
- Callers get a normal 200 at default reasoning depth

How it solves it:

- Add `max` to the accepted effort levels
- Replace the per-level if/elif chain with a membership check

## User Flow

Before: a developer raising reasoning depth to the highest level on a responses-mode model gets default depth back, and nothing says otherwise

1. They send POST http://localhost:4000/v1/chat/completions for a model that routes through the responses bridge, with `"reasoning_effort": "max"`
2. The reply comes back 200, and `usage.completion_tokens_details.reasoning_tokens` reads 50
3. They lower it to `"xhigh"` and resend, expecting fewer reasoning tokens, but get 62, more than `max` produced
4. They try an obviously invalid `"reasoning_effort": "banana"` to see whether the field is read at all, and that also returns 200, so nothing distinguishes an ignored value from an accepted one

After: the highest level reaches the provider, and the token counts line up with the requested depth

1. They send the same POST with `"reasoning_effort": "max"`
2. The reply comes back 200 with `reasoning_tokens` at 91, well above the other levels
3. They lower it to `"xhigh"` and resend, and now get 39, below `max` as expected
4. `"banana"` still returns without reasoning applied, since an unrecognized level is deliberately not forwarded

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

`_map_reasoning_effort` enumerated `none`, `minimal`, `low`, `medium`, `high` and `xhigh`, then fell through to `return None` for anything else. `max` is a level several providers accept, so requesting it produced the same outcome as sending nothing at all. The existing test iterated a list of effort levels that was missing `max` as well, so implementation and test shared the same blind spot and the gap stayed green.

The per-level branches differed only by the literal they passed through, so they are replaced by a membership check against the supported levels. Adding a level is now a one-line change to the frozenset, and unknown values still map to `None` rather than being forwarded.

Both runs below hit a live proxy on localhost:4000 against a real `github_copilot/gpt-5.6-sol` deployment routed through the responses bridge, using the same prompt and `max_tokens` each time, and they cost real tokens. `reasoning_tokens` is the signal that matters: if a level is honored, raising it has to raise that count.

Before, at 09889e198:

```
$ for e in low xhigh max; do
    printf "%-6s " "$e"
    curl -s -X POST http://localhost:4000/v1/chat/completions \
      -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
      -d "{\"model\":\"gpt-5.6-sol\",\"messages\":[{\"role\":\"user\",\"content\":\"Count the letter r in strawberry, think step by step.\"}],\"max_tokens\":900,\"reasoning_effort\":\"$e\"}" \
    | jq -c '.usage.completion_tokens_details.reasoning_tokens'
  done

low    32
xhigh  62
max    50
```

`max` landing between `low` and `xhigh` is the tell: the field never left the gateway, so the provider applied its own default

After, at 30df6d4bd:

```
$ for e in low xhigh max; do ... same command ... done

low    38
xhigh  39
max    91
```

`max` now produces the deepest reasoning of the three, which is only possible if the level reached the provider

## Type

🐛 Bug Fix

## Caveats (if any)

- Unknown levels still map to `None`, matching the previous contract
