### PR TITLE
fix(responses): sync logging stream state

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2666,7 +2666,7 @@ class BaseLLMHTTPHandler:
         if extra_body:
             data.update(extra_body)
         stream = bool(stream or data.get("stream"))
-        logging_obj.stream = stream
+        logging_obj.stream = stream  # rebind-ok: record provider-resolved stream mode
         logging_obj.model_call_details.update(stream=stream)
 
         # Preserve the OpenAI-style request context (not sent to the provider) for streaming
@@ -2856,7 +2856,7 @@ class BaseLLMHTTPHandler:
         if extra_body:
             data.update(extra_body)
         stream = bool(stream or data.get("stream"))
-        logging_obj.stream = stream
+        logging_obj.stream = stream  # rebind-ok: record provider-resolved stream mode
         logging_obj.model_call_details.update(stream=stream)
 
         # Preserve the OpenAI-style request context (not sent to the provider) for streaming

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2666,6 +2666,8 @@ class BaseLLMHTTPHandler:
         if extra_body:
             data.update(extra_body)
         stream = bool(stream or data.get("stream"))
+        logging_obj.stream = stream
+        logging_obj.model_call_details.update(stream=stream)
 
         # Preserve the OpenAI-style request context (not sent to the provider) for streaming
         # hooks/metadata; the streaming iterator now consumes this to run deployment hooks
@@ -2854,6 +2856,8 @@ class BaseLLMHTTPHandler:
         if extra_body:
             data.update(extra_body)
         stream = bool(stream or data.get("stream"))
+        logging_obj.stream = stream
+        logging_obj.model_call_details.update(stream=stream)
 
         # Preserve the OpenAI-style request context (not sent to the provider) for streaming
         # hooks/metadata; the streaming iterator now consumes this to run deployment hooks

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -94,6 +94,10 @@ def test_prepare_fake_stream_request():
 
 
 def test_response_api_handler_streams_when_provider_transform_adds_stream():
+    from datetime import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
     handler = BaseLLMHTTPHandler()
     config = Mock()
     config.validate_environment.return_value = {}
@@ -111,7 +115,22 @@ def test_response_api_handler_streams_when_provider_transform_adds_stream():
             request=httpx.Request("POST", "https://chatgpt.example.com/responses"),
         )
     )
-    logging_obj = Mock()
+    logging_obj = Logging(
+        model="gpt-5.3-codex",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="completion",
+        start_time=datetime.now(),
+        litellm_call_id="test-call",
+        function_id="test-function",
+    )
+    logging_obj.update_environment_variables(
+        model="gpt-5.3-codex",
+        user=None,
+        optional_params={"stream": False},
+        litellm_params={},
+        custom_llm_provider="chatgpt",
+    )
 
     handler.response_api_handler(
         model="gpt-5.3-codex",
@@ -126,6 +145,10 @@ def test_response_api_handler_streams_when_provider_transform_adds_stream():
 
     assert client.post.call_args.kwargs["stream"] is True
     assert client.post.call_args.kwargs["json"]["stream"] is True
+    assert logging_obj.stream is True
+    assert logging_obj.model_call_details["stream"] is True
+    logging_obj.has_run_logging(event_type="async_success")
+    assert logging_obj.should_run_logging(event_type="async_success") is True
 
 
 def test_response_api_handler_runs_agentic_hooks_in_sync_path(monkeypatch):
@@ -255,6 +278,7 @@ async def test_async_response_api_handler_streams_when_provider_transform_adds_s
         )
     )
     logging_obj = Mock()
+    logging_obj.model_call_details = {}
 
     await handler.async_response_api_handler(
         model="gpt-5.3-codex",
@@ -269,6 +293,8 @@ async def test_async_response_api_handler_streams_when_provider_transform_adds_s
 
     assert client.post.call_args.kwargs["stream"] is True
     assert client.post.call_args.kwargs["json"]["stream"] is True
+    assert logging_obj.stream is True
+    assert logging_obj.model_call_details["stream"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bridged ChatGPT responses calls could miss cost tracking
- Internal streams were logged as non-streaming requests

How it solves it:

- Records the provider-resolved streaming state before iteration
- Keeps logging deduplication open until stream assembly completes

## User Flow

Before: a developer sends a non-streaming chat request through a ChatGPT Responses API deployment, but the proxy can record no spend

1. They send `POST https://litellm-domain/v1/chat/completions` with `"stream": false`
2. The deployment internally uses a streaming ChatGPT Responses API request
3. The developer receives a normal non-streaming completion
4. `https://litellm-domain/ui/?page=logs` can show no tracked cost for that request

After: the same request returns normally and the proxy records its assembled response cost

1. They send `POST https://litellm-domain/v1/chat/completions` with `"stream": false`
2. The deployment internally uses a streaming ChatGPT Responses API request
3. The developer receives a normal non-streaming completion
4. `https://litellm-domain/ui/?page=logs` shows the tracked cost for that request

## Relevant issues


## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes relevant lint and unit tests locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Focused unit coverage verifies that both sync and async Responses API handlers copy provider-forced streaming state to the shared logging object. The sync test also verifies that async success logging remains eligible after the first internal chunk.

Verified at commit `91534fa481`:

`uv run pytest tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_handler.py tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py -q`

Result: 87 passed.

## Type

🐛 Bug Fix

## Caveats (if any)

- Live ChatGPT credentials were not available for end-to-end proof

### Final Attestation

- [x] The tests check provider-forced streams and logging deduplication
