### PR TITLE
perf(guardrails): stop sending the conversation twice in the noma v2 payload

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
@@ -36,6 +36,13 @@ _AIDR_SCAN_ENDPOINT: Final = "/litellm/guardrail"
 _INTERVENED_INPUT_FIELDS: Final = ("texts", "images", "tools", "tool_calls")
 _DEFAULT_API_BASE_HOSTNAME: Final = urlparse(_DEFAULT_API_BASE).hostname
 
+_KEYS_DUPLICATING_SCAN_INPUTS: Final = ("messages", "input")
+_LOGGING_KEYS_DUPLICATING_SCAN_INPUTS: Final = _KEYS_DUPLICATING_SCAN_INPUTS + (
+    "additional_args",
+    "standard_logging_object",
+    "original_response",
+)
+
 
 class _Action(str, enum.Enum):
     BLOCKED = "BLOCKED"
@@ -131,9 +138,20 @@ class NomaV2Guardrail(CustomGuardrail):
         logging_obj: Optional["LiteLLMLoggingObj"],
         application_id: str | None,
     ) -> dict:
-        payload_request_data: Final = self._sanitize_payload_for_transport(request_data)
+        payload_request_data: Final = self._sanitize_payload_for_transport(
+            {key: value for key, value in request_data.items() if key not in _KEYS_DUPLICATING_SCAN_INPUTS}
+        )
         if logging_obj is not None:
-            payload_request_data["litellm_logging_obj"] = getattr(logging_obj, "model_call_details", None)
+            model_call_details: Final = getattr(logging_obj, "model_call_details", None)
+            payload_request_data["litellm_logging_obj"] = (
+                {
+                    key: value
+                    for key, value in model_call_details.items()
+                    if key not in _LOGGING_KEYS_DUPLICATING_SCAN_INPUTS
+                }
+                if isinstance(model_call_details, dict)
+                else model_call_details
+            )
 
         payload: Final[dict[str, Any]] = {
             "inputs": inputs,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma_v2.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma_v2.py
@@ -129,13 +129,50 @@ class TestNomaV2Configuration:
         )
 
         assert payload["inputs"] == inputs
-        assert payload["request_data"] == request_data
+        # Everything except the duplicated conversation is forwarded untouched, so a scanner-side
+        # change that starts reading a new request_data key needs no hook release.
+        assert payload["request_data"] == {
+            key: value for key, value in request_data.items() if key != "messages"
+        }
         assert payload["input_type"] == "request"
         assert payload["monitor_mode"] is False
         assert payload["application_id"] == "dynamic-app"
         assert "dynamic_params" not in payload
         assert "x-noma-context" not in payload
         assert "input" not in payload
+
+    def test_build_scan_payload_drops_conversation_duplicated_in_request_data(
+        self, noma_v2_guardrail
+    ):
+        """The scan reads the conversation from `inputs`; repeating it in `request_data` uploaded
+        the whole thing - base64 images included - a second time."""
+        inputs = {"texts": ["hello"]}
+        request_data = {
+            "messages": [{"role": "user", "content": "hello"}],
+            "input": [{"role": "user", "content": "hello"}],
+            "metadata": {"headers": {"x-noma-application-id": "header-app"}},
+            "litellm_call_id": "call-id-1",
+            "stream": True,
+        }
+
+        payload = noma_v2_guardrail._build_scan_payload(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+            logging_obj=None,
+            application_id="dynamic-app",
+        )
+
+        assert "messages" not in payload["request_data"]
+        assert "input" not in payload["request_data"]
+        # Keys the scanner reads for context must survive.
+        assert payload["request_data"]["metadata"] == request_data["metadata"]
+        assert payload["request_data"]["litellm_call_id"] == "call-id-1"
+        assert payload["request_data"]["stream"] is True
+        # The conversation still reaches the scanner through `inputs`.
+        assert payload["inputs"] == inputs
+        # The caller's dict is untouched.
+        assert "messages" in request_data
 
     def test_build_scan_payload_deep_copies_request_data(self, noma_v2_guardrail):
         request_data = {
@@ -153,11 +190,11 @@ class TestNomaV2Configuration:
         payload["request_data"]["metadata"]["headers"][
             "x-noma-application-id"
         ] = "mutated-value"
-        payload["request_data"]["messages"][0]["content"] = "changed-content"
 
         assert (
             request_data["metadata"]["headers"]["x-noma-application-id"] == "header-app"
         )
+        # Trimming the duplicated conversation must not mutate the caller's dict either.
         assert request_data["messages"][0]["content"] == "hello"
 
     def test_build_scan_payload_survives_unpicklable_request_data(
@@ -191,14 +228,13 @@ class TestNomaV2Configuration:
 
         assert isinstance(payload["request_data"], dict)
         assert payload["request_data"]["event_loop"] == "<fake-uvloop-loop>"
-        assert payload["request_data"]["messages"] == [
-            {"role": "user", "content": "hello"}
-        ]
+        assert "messages" not in payload["request_data"]
 
         # Original request_data must not have been mutated by the copy.
         assert request_data["event_loop"] is unpicklable
+        assert request_data["messages"] == [{"role": "user", "content": "hello"}]
 
-    def test_build_scan_payload_passes_model_call_details_as_is(
+    def test_build_scan_payload_passes_model_call_details_without_conversation(
         self, noma_v2_guardrail
     ):
         class _LoggingObj:
@@ -206,6 +242,16 @@ class TestNomaV2Configuration:
                 self.model_call_details = {
                     "model": "gpt-4.1-mini",
                     "messages": [{"role": "user", "content": "hello"}],
+                    "input": [{"role": "user", "content": "hello"}],
+                    "additional_args": {
+                        "complete_input_dict": {"messages": [{"role": "user", "content": "hello"}]}
+                    },
+                    "standard_logging_object": {
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "response": {"choices": []},
+                    },
+                    "original_response": {"choices": []},
+                    "complete_streaming_response": {"status": "completed"},
                     "stream": False,
                     "call_type": "acompletion",
                     "litellm_call_id": "call-id-123",
@@ -224,8 +270,8 @@ class TestNomaV2Configuration:
         )
 
         assert payload["request_data"]["litellm_logging_obj"] == {
+            "complete_streaming_response": {"status": "completed"},
             "model": "gpt-4.1-mini",
-            "messages": [{"role": "user", "content": "hello"}],
             "stream": False,
             "call_type": "acompletion",
             "litellm_call_id": "call-id-123",
@@ -235,6 +281,23 @@ class TestNomaV2Configuration:
         }
         assert "logging_obj" not in payload
         assert request_data["litellm_logging_obj"] == "<Logging object>"
+
+    def test_build_scan_payload_forwards_non_dict_model_call_details_unchanged(
+        self, noma_v2_guardrail
+    ):
+        class _LoggingObjWithoutDetails:
+            def __init__(self) -> None:
+                self.model_call_details = None
+
+        payload = noma_v2_guardrail._build_scan_payload(
+            inputs={"texts": ["hello"]},
+            request_data={"litellm_call_id": "call-id-1"},
+            input_type="request",
+            logging_obj=_LoggingObjWithoutDetails(),
+            application_id="test-app",
+        )
+
+        assert payload["request_data"]["litellm_logging_obj"] is None
 
     @pytest.mark.asyncio
     async def test_call_noma_scan_sanitizes_response_model_dump_object(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Guardrail scan payload repeats the same conversation up to three times
- Image heavy requests upload roughly 95% redundant bytes
- The proxy also pays to serialize that duplicate

How it solves it:

- Drops `messages` and `input` from the forwarded request data
- Drops the same two keys from the forwarded logging details
- Trims before serialization, so the duplicate is never encoded

## User Flow

Before: a developer sending an image heavy chat completion through a proxy with the Noma guardrail enabled waits on a scan upload several times larger than the images they sent

1. They send POST https://litellm-domain/v1/chat/completions carrying a few base64 `image_url` parts
2. The proxy uploads a scan request whose body is roughly double the size of what they sent, because the conversation is repeated inside it
3. The call takes noticeably longer than the same request with the guardrail turned off, and the gap grows with the number of images

After: the same request uploads only the content being scanned

1. They send the same POST https://litellm-domain/v1/chat/completions with the same base64 `image_url` parts
2. The proxy uploads a scan request close to the size of what they sent, with no repeated copy of the conversation
3. The call returns faster, and the guardrail allows or blocks it exactly as before

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I could not capture a live run: this needs a proxy pointed at a Noma scan endpoint plus real provider spend, and I don't have either here. Captured at commit 46f64c7257, here is the runbook to reproduce it, which shows the payload size the guardrail uploads

Point the guardrail at a local sink so the scan body can be measured, and run the proxy against a real provider

```bash
python3 -c "
import http.server
class H(http.server.BaseHTTPRequestHandler):
    def do_POST(self):
        n = int(self.headers['Content-Length'])
        self.rfile.read(n)
        print(f'scan payload: {n/1048576:.1f} MB', flush=True)
        self.send_response(200); self.end_headers()
        self.wfile.write(b'{\"action\":\"NONE\"}')
http.server.HTTPServer(('127.0.0.1', 8099), H).serve_forever()"
```

```yaml
guardrails:
  - guardrail_name: noma
    litellm_params:
      guardrail: noma_v2
      mode: pre_call
      api_base: http://127.0.0.1:8099
      api_key: dummy
```

```bash
python litellm/proxy/proxy_cli.py --config <that config> --detailed_debug

IMG=$(python3 -c "print('A'*400000)")
curl -s http://localhost:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d "{\"model\":\"gpt-4o\",\"messages\":[{\"role\":\"user\",\"content\":[
       {\"type\":\"text\",\"text\":\"describe\"},
       {\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,$IMG\"}}]}]}" > /dev/null
```

The sink prints the scan payload size. On `litellm_internal_staging` it reports roughly twice the image bytes, once inside `inputs` and again inside `request_data`. On this branch it reports roughly the image bytes once

For scale, a production scan of an image heavy request measured 100 MB in total, of which 94.8 MB was the forwarded request data against 5.1 MB of the content actually scanned

## Type

🧹 Refactoring

## Caveats (if any)

- `test_provider_specific_params_include_noma_v2_fields` already fails on staging
- `test_self_managed_path_without_api_key_omits_authorization_header` already fails on staging
- Both reproduce with this change stashed, so CI is not fully green
- Proof of fix above still needs a live run

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fc660e751205070d32dd51e8f84ba4a1a4568061. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->