### PR TITLE
fix(bedrock): route knowledge base ingestion to control plane

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1014,7 +1014,9 @@ async def bedrock_proxy_route(
         raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
 
     aws_region_name: Final = litellm.utils.get_secret(secret_name="AWS_REGION_NAME")
-    if _is_bedrock_agent_runtime_route(endpoint=endpoint):  # handle bedrock agents
+    if _is_bedrock_agent_control_plane_route(endpoint=endpoint):
+        base_target_url: Final = f"https://bedrock-agent.{aws_region_name}.amazonaws.com"
+    elif _is_bedrock_agent_runtime_route(endpoint=endpoint):  # handle bedrock agents
         base_target_url: Final = f"https://bedrock-agent-runtime.{aws_region_name}.amazonaws.com"
     else:
         return await bedrock_llm_proxy_route(
@@ -1048,7 +1050,7 @@ async def bedrock_proxy_route(
         data: Final = await request.json()
     except Exception as e:
         raise HTTPException(status_code=400, detail={"error": e})
-    _request: Final = AWSRequest(method="POST", url=str(updated_url), data=json.dumps(data), headers=headers)
+    _request: Final = AWSRequest(method=request.method, url=str(updated_url), data=json.dumps(data), headers=headers)
     sigv4.add_auth(_request)
     prepped: Final = _request.prepare()
 
@@ -1164,6 +1166,11 @@ def _is_bedrock_agent_runtime_route(endpoint: str) -> bool:
         if _route in endpoint:
             return True
     return False
+
+
+def _is_bedrock_agent_control_plane_route(endpoint: str) -> bool:
+    normalized_endpoint: Final = endpoint.strip("/")
+    return re.fullmatch(r"knowledgebases/[^/]+/datasources/[^/]+/documents", normalized_endpoint) is not None
 
 
 @router.api_route(

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1014,7 +1014,7 @@ async def bedrock_proxy_route(
         raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
 
     aws_region_name: Final = litellm.utils.get_secret(secret_name="AWS_REGION_NAME")
-    if _is_bedrock_agent_control_plane_route(endpoint=endpoint):
+    if request.method == "PUT" and _is_bedrock_agent_control_plane_route(endpoint=endpoint):
         base_target_url: Final = f"https://bedrock-agent.{aws_region_name}.amazonaws.com"
     elif _is_bedrock_agent_runtime_route(endpoint=endpoint):  # handle bedrock agents
         base_target_url: Final = f"https://bedrock-agent-runtime.{aws_region_name}.amazonaws.com"

--- a/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
+++ b/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
@@ -502,6 +502,18 @@ def test_is_bedrock_agent_control_plane_route():
             "PUT",
             "https://bedrock-agent.ap-northeast-2.amazonaws.com/knowledgebases/kb-123/datasources/ds-456/documents",
         ),
+        (
+            "knowledgebases/kb-123/datasources/ds-456/documents",
+            "POST",
+            "https://bedrock-agent-runtime.ap-northeast-2.amazonaws.com/"
+            "knowledgebases/kb-123/datasources/ds-456/documents",
+        ),
+        (
+            "knowledgebases/kb-123/datasources/ds-456/documents",
+            "DELETE",
+            "https://bedrock-agent-runtime.ap-northeast-2.amazonaws.com/"
+            "knowledgebases/kb-123/datasources/ds-456/documents",
+        ),
     ),
 )
 async def test_bedrock_agent_route_target_and_sigv4_method(

--- a/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
+++ b/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
@@ -3,7 +3,7 @@ import os
 import sys
 from datetime import datetime
 from unittest.mock import AsyncMock, Mock, patch, MagicMock
-from typing import Optional
+from typing import Final, Optional
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -466,6 +466,120 @@ def test_is_bedrock_agent_runtime_route():
         is False
     )
     assert _is_bedrock_agent_runtime_route("/some/random/endpoint") is False
+
+
+def test_is_bedrock_agent_control_plane_route():
+    from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+        _is_bedrock_agent_control_plane_route,
+        _is_bedrock_agent_runtime_route,
+    )
+
+    direct_ingestion_endpoint: Final = (
+        "/knowledgebases/kb-123/datasources/ds-456/documents"
+    )
+
+    assert _is_bedrock_agent_control_plane_route(direct_ingestion_endpoint) is True
+    assert _is_bedrock_agent_runtime_route(direct_ingestion_endpoint) is True
+    assert (
+        _is_bedrock_agent_control_plane_route(
+            "/knowledgebases/kb-123/retrieve"
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "method", "expected_url"),
+    (
+        (
+            "knowledgebases/kb-123/retrieve",
+            "POST",
+            "https://bedrock-agent-runtime.ap-northeast-2.amazonaws.com/knowledgebases/kb-123/retrieve",
+        ),
+        (
+            "knowledgebases/kb-123/datasources/ds-456/documents",
+            "PUT",
+            "https://bedrock-agent.ap-northeast-2.amazonaws.com/knowledgebases/kb-123/datasources/ds-456/documents",
+        ),
+    ),
+)
+async def test_bedrock_agent_route_target_and_sigv4_method(
+    endpoint: str, method: str, expected_url: str
+):
+    from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+        bedrock_proxy_route,
+    )
+
+    body: Final = json.dumps({"documents": []}).encode()
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request: Final = Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": f"/bedrock/{endpoint}",
+            "headers": ((b"content-type", b"application/json"),),
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "scheme": "http",
+        },
+        receive,
+    )
+    prepared_request: Final = MagicMock(
+        url=expected_url,
+        headers={"Authorization": "AWS4-HMAC-SHA256 signed"},
+        body=body,
+    )
+    upstream_response: Final = MagicMock()
+    endpoint_func: Final = AsyncMock(return_value=upstream_response)
+    credentials: Final = MagicMock()
+
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.litellm.utils.get_secret",
+            return_value="ap-northeast-2",
+        ),
+        patch(
+            "litellm.llms.bedrock.chat.BedrockConverseLLM.get_credentials",
+            return_value=credentials,
+        ),
+        patch("botocore.auth.SigV4Auth") as sigv4_auth,
+        patch("botocore.awsrequest.AWSRequest") as aws_request,
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+            return_value=endpoint_func,
+        ) as create_route,
+    ):
+        aws_request.return_value.prepare.return_value = prepared_request
+
+        response: Final = await bedrock_proxy_route(
+            endpoint=endpoint,
+            request=request,
+            fastapi_response=fastapi.Response(),
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        )
+
+    assert response is upstream_response
+    aws_request.assert_called_once_with(
+        method=method,
+        url=expected_url,
+        data=json.dumps({"documents": []}),
+        headers={"Content-Type": "application/json"},
+    )
+    sigv4_auth.assert_called_once_with(credentials, "bedrock", "ap-northeast-2")
+    sigv4_auth.return_value.add_auth.assert_called_once_with(aws_request.return_value)
+    create_route.assert_called_once_with(
+        endpoint=endpoint,
+        target=expected_url,
+        custom_headers=prepared_request.headers,
+        is_streaming_request=False,
+        _forward_headers=True,
+    )
+    endpoint_func.assert_awaited_once()
 
 
 def test_init_kwargs_filters_pricing_params(mock_request, mock_user_api_key_dict):


### PR DESCRIPTION
## TLDR

Problem this solves:

Knowledge Base direct ingestion targets Agent Runtime
PUT passthrough requests are signed as POST

How it solves it:

Routes direct ingestion to Bedrock Agent
Signs requests using the original HTTP method
Preserves existing Knowledge Base Retrieve routing
Adds regression coverage for both routes

## User Flow

Before: a developer cannot ingest Knowledge Base documents through the Bedrock passthrough

They send PUT https://litellm-domain/bedrock/knowledgebases/{knowledgeBaseId}/datasources/{dataSourceId}/documents with document content
The request fails because it reaches Bedrock Agent Runtime instead of the Bedrock Agent API


After: the same developer can ingest Knowledge Base documents through the Bedrock passthrough

They send the same PUT https://litellm-domain/bedrock/knowledgebases/{knowledgeBaseId}/datasources/{dataSourceId}/documents with document content
The request reaches the Bedrock Agent API with the correct PUT signature
They receive HTTP 202 with documentDetails describing the ingestion request

Existing Knowledge Base Retrieve requests continue to work:

They send POST https://litellm-domain/bedrock/knowledgebases/{knowledgeBaseId}/retrieve
The request reaches Bedrock Agent Runtime
They receive the expected retrieval results

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live AWS Bedrock end-to-end verification was completed in the internal environment.

Screenshots and raw AWS responses cannot be attached because the verification was performed in a bank production-like environment where capturing or exporting request/response data is restricted by security policy.

Verified behavior:

Before

Commit: 09889e1986faa7b97d1d213040aa442b2aa393f6

PUT /bedrock/knowledgebases/{knowledgeBaseId}/datasources/{dataSourceId}/documents

The request was routed to Bedrock Agent Runtime and direct ingestion failed.

After

Commit: 2c049bdb517b1ff477230d9f02ee194a08d3c841

PUT /bedrock/knowledgebases/{knowledgeBaseId}/datasources/{dataSourceId}/documents

The same request was routed to the Bedrock Agent control-plane endpoint and completed successfully with HTTP 202.

The change was also covered by regression tests verifying:

Knowledge Base Retrieve remains routed to Bedrock Agent Runtime
Knowledge Base direct ingestion routes to Bedrock Agent
Direct ingestion preserves the original PUT method for SigV4 signing

Raw request/response evidence is not included due to internal security restrictions.

## Type

🐛 Bug Fix

## Caveats (if any)

- Only Knowledge Base direct ingestion routing is added

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
