### PR TITLE
feat(azure_ai): shape FW-Kimi / Kimi like Moonshot for Foundry

### DIFF
--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -21,7 +21,7 @@ from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import ModelResponse, ProviderField
-from litellm.utils import _add_path_to_api_base, supports_tool_choice
+from litellm.utils import _add_path_to_api_base, supports_reasoning, supports_tool_choice
 
 
 class AzureFoundryErrorStrings(str, enum.Enum):
@@ -56,6 +56,112 @@ class AzureAIStudioConfig(OpenAIConfig):
             xai_config: Final = XAIChatConfig()
             return xai_config._supports_stop_reason(model)
         return True
+
+    # Kimi on Azure AI Foundry (native + Fireworks FW-* catalog) follows the same
+    # Moonshot chat contract: https://platform.kimi.ai/docs/guide/kimi-k3-quickstart
+    _KIMI_K3_FIXED_SAMPLING_PARAMS: Final = (
+        "temperature",
+        "top_p",
+        "n",
+        "presence_penalty",
+        "frequency_penalty",
+    )
+    _KIMI_K3_REASONING_EFFORT_VALUES: Final = frozenset({"low", "high", "max"})
+
+    def _normalize_azure_ai_model_id(self, model: str) -> str:
+        return model.split("/")[-1].lower()
+
+    def _is_kimi_reasoning_model(self, model: str) -> bool:
+        """
+        True for Kimi reasoning models on Azure AI Foundry / Fireworks catalog.
+
+        Name matching covers FW-Kimi-* and native kimi-k2.5+ / kimi-k3 ids even when
+        the local cost map has not been refreshed yet. Cost-map supports_reasoning is
+        a fallback for future azure_ai Kimi entries.
+        """
+        model_id = self._normalize_azure_ai_model_id(model)
+        if model_id.startswith("fw-kimi") or model_id.startswith("kimi-k2.") or model_id.startswith("kimi-k3"):
+            return True
+        if "kimi-k3" in model_id:
+            return True
+        try:
+            return supports_reasoning(model=model, custom_llm_provider="azure_ai")
+        except Exception:
+            return False
+
+    def _is_kimi_k3_model(self, model: str) -> bool:
+        model_id = self._normalize_azure_ai_model_id(model)
+        return model_id == "fw-kimi-k3" or "kimi-k3" in model_id
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        optional_params = super().map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=model,
+            drop_params=drop_params,
+        )
+        if not self._is_kimi_reasoning_model(model):
+            return optional_params
+
+        # Reasoning Kimi rejects non-default temperature (Moonshot + Foundry Fireworks)
+        optional_params.pop("temperature", None)
+
+        if self._is_kimi_k3_model(model):
+            # K3 fixes sampling server-side; omit or the Foundry gateway returns 400
+            for param in self._KIMI_K3_FIXED_SAMPLING_PARAMS:
+                optional_params.pop(param, None)
+            # Parent OpenAI mapping may omit reasoning_effort; K3 accepts low/high/max
+            if "reasoning_effort" in non_default_params:
+                effort = non_default_params["reasoning_effort"]
+                if effort in self._KIMI_K3_REASONING_EFFORT_VALUES:
+                    optional_params["reasoning_effort"] = effort
+                else:
+                    # Claude Code / Anthropic adapters often emit "medium"
+                    optional_params.pop("reasoning_effort", None)
+
+        return optional_params
+
+    def fill_reasoning_content(self, messages: list[AllMessageValues]) -> list[AllMessageValues]:
+        """
+        Kimi reasoning models require `reasoning_content` on every assistant
+        message that contains tool_calls (multi-turn tool-calling flows).
+
+        Mirrors MoonshotChatConfig.fill_reasoning_content for azure_ai/FW-Kimi-*
+        and azure_ai/kimi-* deployments.
+        """
+        result: Final[list[AllMessageValues]] = []
+        for msg in messages:
+            if (
+                msg.get("role") == "assistant"
+                and msg.get("tool_calls")
+                and not msg.get("reasoning_content")
+            ):
+                patched = dict(cast(dict, msg))
+                provider_fields = patched.get("provider_specific_fields") or {}
+                stored = provider_fields.get("reasoning_content")
+                if stored:
+                    patched["reasoning_content"] = stored
+                    cleaned_provider_fields = dict(provider_fields)
+                    cleaned_provider_fields.pop("reasoning_content", None)
+                    patched["provider_specific_fields"] = cleaned_provider_fields
+                else:
+                    litellm.verbose_logger.warning(
+                        "Azure AI Kimi reasoning model: assistant tool-call message is missing "
+                        "`reasoning_content`. Injecting a placeholder to satisfy API validation. "
+                        "For best results, preserve `reasoning_content` from the original "
+                        "assistant response when building multi-turn conversation history."
+                    )
+                    patched["reasoning_content"] = " "
+                result.append(cast(AllMessageValues, patched))
+            else:
+                result.append(msg)
+        return result
 
     def validate_environment(
         self,
@@ -222,6 +328,8 @@ class AzureAIStudioConfig(OpenAIConfig):
         if extra_body and isinstance(extra_body, dict):
             optional_params.update(extra_body)
         optional_params.pop("max_retries", None)
+        if self._is_kimi_reasoning_model(model):
+            messages = self.fill_reasoning_content(messages)
         return super().transform_request(model, messages, optional_params, litellm_params, headers)
 
     def transform_response(

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9419,6 +9419,29 @@
         "output_cost_per_token": 7e-07,
         "supports_tool_choice": true
     },
+    "azure_ai/FW-Kimi-K3": {
+        "input_cost_per_token": 3.3e-06,
+        "output_cost_per_token": 1.65e-05,
+        "cache_read_input_token_cost": 3.3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 262144,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k3-through-fireworks-ai-on-microsoft-foundry/4540187",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "azure_ai/kimi-k2.5": {
         "input_cost_per_token": 6e-07,
         "litellm_provider": "azure_ai",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9419,6 +9419,29 @@
         "output_cost_per_token": 7e-07,
         "supports_tool_choice": true
     },
+    "azure_ai/FW-Kimi-K3": {
+        "input_cost_per_token": 3.3e-06,
+        "output_cost_per_token": 1.65e-05,
+        "cache_read_input_token_cost": 3.3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 262144,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k3-through-fireworks-ai-on-microsoft-foundry/4540187",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "azure_ai/kimi-k2.5": {
         "input_cost_per_token": 6e-07,
         "litellm_provider": "azure_ai",

--- a/tests/test_litellm/llms/azure_ai/test_azure_ai_kimi_shaping.py
+++ b/tests/test_litellm/llms/azure_ai/test_azure_ai_kimi_shaping.py
@@ -1,0 +1,156 @@
+"""
+Unit tests for Azure AI Foundry / Fireworks Kimi request shaping.
+
+Mirrors the Moonshot Kimi multi-turn tool + fixed-sampling contract for
+azure_ai/FW-Kimi-* and azure_ai/kimi-* deployments.
+"""
+
+import json
+from importlib.resources import files
+
+import pytest
+
+from litellm.llms.azure_ai.chat.transformation import AzureAIStudioConfig
+
+
+@pytest.fixture(scope="module")
+def use_local_model_cost_map():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+    import litellm
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+
+    original_model_cost = litellm.model_cost
+    litellm.model_cost = json.loads(
+        files("litellm")
+        .joinpath("model_prices_and_context_window_backup.json")
+        .read_text(encoding="utf-8")
+    )
+    litellm.get_model_info.cache_clear()
+    _invalidate_model_cost_lowercase_map()
+    try:
+        yield litellm
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.get_model_info.cache_clear()
+        _invalidate_model_cost_lowercase_map()
+        monkeypatch.undo()
+
+
+class TestAzureAIKimiShaping:
+    def test_detects_fw_kimi_k3(self):
+        config = AzureAIStudioConfig()
+        assert config._is_kimi_reasoning_model("FW-Kimi-K3") is True
+        assert config._is_kimi_k3_model("FW-Kimi-K3") is True
+        assert config._is_kimi_k3_model("azure_ai/FW-Kimi-K3") is True
+
+    def test_detects_native_kimi_k26(self):
+        config = AzureAIStudioConfig()
+        assert config._is_kimi_reasoning_model("kimi-k2.6") is True
+        assert config._is_kimi_k3_model("kimi-k2.6") is False
+
+    def test_map_openai_params_drops_k3_fixed_sampling(self):
+        config = AzureAIStudioConfig()
+        result = config.map_openai_params(
+            non_default_params={
+                "temperature": 0.2,
+                "top_p": 0.5,
+                "n": 2,
+                "presence_penalty": 0.1,
+                "frequency_penalty": 0.1,
+                "max_tokens": 64,
+            },
+            optional_params={},
+            model="FW-Kimi-K3",
+            drop_params=True,
+        )
+        assert "temperature" not in result
+        assert "top_p" not in result
+        assert "n" not in result
+        assert "presence_penalty" not in result
+        assert "frequency_penalty" not in result
+        assert result.get("max_tokens") == 64
+
+    def test_map_openai_params_drops_invalid_reasoning_effort(self):
+        config = AzureAIStudioConfig()
+        result = config.map_openai_params(
+            non_default_params={"reasoning_effort": "medium", "max_tokens": 16},
+            optional_params={},
+            model="FW-Kimi-K3",
+            drop_params=True,
+        )
+        assert "reasoning_effort" not in result
+        assert result.get("max_tokens") == 16
+
+    def test_map_openai_params_keeps_valid_reasoning_effort(self):
+        config = AzureAIStudioConfig()
+        result = config.map_openai_params(
+            non_default_params={"reasoning_effort": "high", "max_tokens": 16},
+            optional_params={},
+            model="FW-Kimi-K3",
+            drop_params=True,
+        )
+        assert result.get("reasoning_effort") == "high"
+
+    def test_map_openai_params_k26_only_drops_temperature(self):
+        config = AzureAIStudioConfig()
+        result = config.map_openai_params(
+            non_default_params={"temperature": 0.2, "top_p": 0.5, "max_tokens": 16},
+            optional_params={},
+            model="kimi-k2.6",
+            drop_params=True,
+        )
+        assert "temperature" not in result
+        assert result.get("top_p") == 0.5
+
+    def test_fill_reasoning_content_injects_placeholder(self):
+        config = AzureAIStudioConfig()
+        messages = [
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "sunny"},
+        ]
+        result = config.fill_reasoning_content(messages)
+        assert result[1].get("reasoning_content") == " "
+
+    def test_transform_request_fills_reasoning_for_fw_kimi(self):
+        config = AzureAIStudioConfig()
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": "{}"},
+                    }
+                ],
+            }
+        ]
+        result = config.transform_request(
+            model="FW-Kimi-K3",
+            messages=messages,
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+        assert result["messages"][0].get("reasoning_content") == " "
+
+    def test_fw_kimi_k3_cost_map_entry(self, use_local_model_cost_map):
+        model_info = use_local_model_cost_map.get_model_info(model="azure_ai/FW-Kimi-K3")
+        assert model_info["supports_reasoning"] is True
+        assert model_info["max_input_tokens"] == 1048576
+        assert model_info["input_cost_per_token"] == pytest.approx(0.0000033)
+        assert model_info["output_cost_per_token"] == pytest.approx(0.0000165)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure Foundry `FW-Kimi-K3` rejects Claude-style sampling / medium `reasoning_effort`
- Multi-turn tool calls fail without `reasoning_content` on assistant messages

How it solves it:

- Mirror Moonshot Kimi shaping on `azure_ai` for FW-Kimi / kimi-* models
- Drop K3 fixed sampling params and invalid `reasoning_effort`
- Inject / promote `reasoning_content` before tool-call follow-ups

## User Flow

Before: a Claude Code session routed to `azure_ai/FW-Kimi-K3` dies after the first tool call

1. User sends POST https://litellm-domain/v1/messages with tools and model `FW-Kimi-K3`
2. First turn streams a tool call successfully
3. Follow-up with assistant `tool_use` + `tool_result` returns HTTP 400 `invalid_request_error` from Azure Foundry
4. Spend / logs show the failure on `FW-Kimi-K3` with no usable Azure detail

After: the same tool-call follow-up is reshaped and accepted

1. User sends the same POST https://litellm-domain/v1/messages with tools and model `FW-Kimi-K3`
2. First turn streams a tool call successfully
3. Follow-up includes `reasoning_content` (promoted or placeholder) and omits fixed sampling / invalid effort
4. Azure Foundry returns 200 and the agent continues the tool loop

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Unit coverage (live Azure Foundry proof still needs a sandbox key on a build that includes this commit):

```bash
python -m pytest tests/test_litellm/llms/azure_ai/test_azure_ai_kimi_shaping.py -q
# 9 passed
```

## Type

🆕 New Feature
🐛 Bug Fix

## Caveats (if any)

- Placeholder `reasoning_content` (" ") satisfies API validation but is weaker than replaying the real prior reasoning
- Cost-map entry for `azure_ai/FW-Kimi-K3` overlaps with pricing-only work in #35613; keep or rebase if that lands first

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Made with [Cursor](https://cursor.com)