### PR TITLE
fix(responses): raise on failed chat streams

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1445,16 +1445,16 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                 usage=usage,
             )
         elif event_type in ("response.failed", "error"):
-            response_data = parsed_chunk.get("response") or {}
-            if not isinstance(response_data, dict):
-                response_data = {}
-            error_data = response_data.get("error") or parsed_chunk.get("error") or parsed_chunk
+            failure_response_data = parsed_chunk.get("response") or {}
+            if not isinstance(failure_response_data, dict):
+                failure_response_data = {}
+            error_data = failure_response_data.get("error") or parsed_chunk.get("error") or parsed_chunk
             error_message = error_data.get("message") if isinstance(error_data, dict) else None
             raise litellm.APIError(
                 status_code=500,
                 message=error_message or "Responses API stream failed",
                 llm_provider="",
-                model=response_data.get("model", ""),
+                model=failure_response_data.get("model", ""),
             )
         else:
             pass

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1444,6 +1444,18 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                 ],
                 usage=usage,
             )
+        elif event_type in ("response.failed", "error"):
+            response_data = parsed_chunk.get("response") or {}
+            if not isinstance(response_data, dict):
+                response_data = {}
+            error_data = response_data.get("error") or parsed_chunk.get("error") or parsed_chunk
+            error_message = error_data.get("message") if isinstance(error_data, dict) else None
+            raise litellm.APIError(
+                status_code=500,
+                message=error_message or "Responses API stream failed",
+                llm_provider="",
+                model=response_data.get("model", ""),
+            )
         else:
             pass
         # For any unhandled event types, create a minimal valid chunk or skip

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -18,6 +18,37 @@ from litellm.completion_extras.litellm_responses_transformation.transformation i
 )
 
 
+@pytest.mark.parametrize(
+    ("chunk", "message"),
+    [
+        (
+            {
+                "type": "response.failed",
+                "response": {
+                    "model": "gpt-5.6-luna",
+                    "error": {"code": "server_error", "message": "upstream failed"},
+                },
+            },
+            "upstream failed",
+        ),
+        ({"type": "error", "code": "server_error", "message": "stream failed"}, "stream failed"),
+        (
+            {"type": "response.failed", "response": "invalid", "error": {"message": "malformed failure"}},
+            "malformed failure",
+        ),
+    ],
+)
+def test_response_stream_failure_raises_api_error(chunk, message):
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    with pytest.raises(litellm.APIError, match=message) as exc_info:
+        OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(chunk)
+
+    assert exc_info.value.status_code == 500
+
+
 def test_convert_chat_completion_messages_to_responses_api_image_input():
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         LiteLLMResponsesTransformationHandler,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Failed Responses streams silently become successful empty chat completions
- Router fallbacks never run after upstream stream failures

How it solves it:

- Raise an API error for failed and error events
- Cover both upstream event shapes with regression tests

## User Flow

Before: a developer streaming chat completions receives an empty success when the upstream model fails

1. They send `POST https://<proxy>/v1/chat/completions` with `"stream": true`
2. The upstream Responses model emits `response.failed` or `error`
3. The stream closes with an empty `finish_reason=stop`
4. Configured fallback models never run

After: the same upstream failure triggers normal error and fallback handling

1. They send `POST https://<proxy>/v1/chat/completions` with `"stream": true`
2. The upstream Responses model emits `response.failed` or `error`
3. LiteLLM surfaces the provider message as an API error
4. Configured fallback models can run, or the client sees the error

## Relevant issues

Fixes #36768

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The linked issue includes the intermittent live provider capture. The deterministic regression suite feeds both raw failure event shapes through the chat bridge:

```text
67 passed, 1 warning in 2.02s
```

## Type

🐛 Bug Fix

## Caveats (if any)

- An already-open SSE remains HTTP 200 but no longer ends silently

## QA runbook

N/A — this PR adds a focused unit regression, not an e2e test.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
