### PR TITLE
fix(bedrock): drop trailing empty Converse chunk

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -565,6 +565,9 @@ class AWSEventStreamDecoder:
             if "trace" in chunk_data:
                 trace: Final = chunk_data.get("trace")
                 model_response_provider_specific_fields["trace"] = trace
+            is_content_event: Final = any(
+                key in chunk_data for key in ("role", "start", "delta", "contentBlockIndex", "stopReason")
+            )
             response: Final = ModelResponseStream(
                 choices=[
                     StreamingChoices(
@@ -572,7 +575,7 @@ class AWSEventStreamDecoder:
                         index=0,  # Always 0 - Bedrock never returns multiple choices
                         delta=Delta(
                             content=text,
-                            role="assistant",
+                            role="assistant" if is_content_event else None,
                             tool_calls=[tool_use] if tool_use else None,
                             provider_specific_fields=(provider_specific_fields if provider_specific_fields else None),
                             thinking_blocks=thinking_blocks,

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -4,10 +4,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 
+from litellm.litellm_core_utils.model_response_utils import is_model_response_stream_empty
 from litellm.llms.bedrock.chat.invoke_handler import (
     AWSEventStreamDecoder,
     make_call,
@@ -203,9 +202,26 @@ def test_bedrock_converse_streaming_consistent_id():
     expected_id = f"chatcmpl-{native_conversation_id}"
 
     for response in parsed_responses:
-        assert (
-            response.id == expected_id
-        ), "All chunk IDs must match the one captured from the messageStart event"
+        assert response.id == expected_id, "All chunk IDs must match the one captured from the messageStart event"
+
+
+def test_converse_metadata_chunk_is_empty_after_usage_is_stripped():
+    decoder = AWSEventStreamDecoder(model="test")
+
+    content_chunk = decoder.converse_chunk_parser({"delta": {"text": "Hello"}})
+    assert content_chunk.choices[0].delta.role == "assistant"
+
+    metadata_chunk = decoder.converse_chunk_parser(
+        {
+            "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+            "metrics": {"latencyMs": 100},
+        }
+    )
+    assert metadata_chunk.usage is not None
+    assert metadata_chunk.choices[0].delta.role is None
+
+    stripped_chunk = metadata_chunk.model_copy(update={"usage": None})
+    assert is_model_response_stream_empty(stripped_chunk)
 
 
 @pytest.mark.asyncio
@@ -292,4 +308,3 @@ def test_make_sync_call_honors_explicit_stream_chunk_size():
     )
 
     response.iter_bytes.assert_called_once_with(chunk_size=2048)
-

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 
-from litellm.litellm_core_utils.model_response_utils import is_model_response_stream_empty
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from litellm.llms.bedrock.chat.invoke_handler import (
     AWSEventStreamDecoder,
     make_call,
@@ -205,7 +205,7 @@ def test_bedrock_converse_streaming_consistent_id():
         assert response.id == expected_id, "All chunk IDs must match the one captured from the messageStart event"
 
 
-def test_converse_metadata_chunk_is_empty_after_usage_is_stripped():
+def test_converse_metadata_chunk_is_filtered_after_usage_is_stripped():
     decoder = AWSEventStreamDecoder(model="test")
 
     content_chunk = decoder.converse_chunk_parser({"delta": {"text": "Hello"}})
@@ -220,8 +220,28 @@ def test_converse_metadata_chunk_is_empty_after_usage_is_stripped():
     assert metadata_chunk.usage is not None
     assert metadata_chunk.choices[0].delta.role is None
 
-    stripped_chunk = metadata_chunk.model_copy(update={"usage": None})
-    assert is_model_response_stream_empty(stripped_chunk)
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {
+        "custom_llm_provider": "bedrock",
+        "litellm_params": {},
+    }
+    logging_obj.call_type = "completion"
+    logging_obj.stream_options = None
+    logging_obj.messages = [{"role": "user", "content": "Hello"}]
+    logging_obj.completion_start_time = None
+    logging_obj._llm_caching_handler = None
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=iter([content_chunk, metadata_chunk]),
+        model="test",
+        logging_obj=logging_obj,
+        custom_llm_provider="bedrock",
+    )
+    returned_chunks = list(wrapper)
+
+    assert len(returned_chunks) == 2
+    assert returned_chunks[0].choices[0].delta.content == "Hello"
+    assert returned_chunks[1].choices[0].finish_reason == "stop"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Converse streams emit content after the terminal chunk.
- Strict clients reject the extra assistant-role delta.

How it solves it:

- Metadata-only events no longer carry an assistant role.
- Existing empty-chunk filtering removes the stripped metadata carrier.

## User Flow

Before: a developer streaming Bedrock chat completions receives a protocol-invalid chunk after completion

1. They send `POST https://litellm-domain/v1/chat/completions` with a Bedrock model and `"stream": true`
2. They receive a `200` SSE stream containing the expected assistant tokens
3. They receive a chunk with `finish_reason: "stop"`, then an empty assistant-role delta
4. Their strict streaming client rejects the response as content after completion

After: the same developer's stream ends cleanly at the completion chunk

1. They send `POST https://litellm-domain/v1/chat/completions` with the same Bedrock model and `"stream": true`
2. They receive a `200` SSE stream containing the expected assistant tokens
3. They receive a chunk with `finish_reason: "stop"` and no later assistant-role delta
4. Their strict streaming client closes the response normally

## Relevant issues

Fixes #36767

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live AWS validation was not available locally. This deterministic no-mock reproduction feeds Bedrock's exact Converse event sequence through the production stream decoder and wrapper.

Before, staging base commit `09889e19`:

```text
chunk_count 4
1 'Hello' assistant None
2 ' world' None None
3 None None stop
4 '' assistant None
usage_banked [False, False, False, True]
hidden_usage True
```

After, commit `41044118`:

```text
chunk_count 3
1 'Hello' assistant None
2 ' world' None None
3 None None stop
usage_banked [False, False, False, True]
hidden_usage True
```

Validation:

- `uv run --no-sync pytest tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py -k metadata_chunk -q` — 1 passed
- `uv run --no-sync pytest tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py -q` — 9 passed
- `uv run --no-sync ruff format --check litellm/llms/bedrock/chat/invoke_handler.py tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py` — passed
- `uv run --no-sync ruff check litellm/llms/bedrock/chat/invoke_handler.py tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py` — passed

## Type

🐛 Bug Fix

✅ Test

## Caveats (if any)

- Live AWS validation was not run locally.

## QA runbook

N/A — unit regression only; no e2e test changed.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
