### PR TITLE
fix(redis): open the circuit breaker on RedisClusterException so a dead cluster cannot hang the worker

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -478,6 +478,20 @@ def _get_redis_client_logic(**env_overrides):
     return redis_kwargs
 
 
+def _apply_redis_cluster_reconnect_defaults(cluster_kwargs: dict) -> None:
+    """Fail-fast reconnect defaults so a dropped cluster node cannot stall callers.
+
+    redis-py rediscovers CLUSTER SLOTS on a dead connection. Without a connect
+    timeout, health check, and keepalive that rediscovery blocks for the OS TCP
+    timeout (tens of seconds) — the 2026-08-13 staging e2e 60s ALB hang. Explicit
+    kwargs from config still win.
+    """
+    cluster_kwargs.setdefault("health_check_interval", REDIS_CLUSTER_HEALTH_CHECK_INTERVAL)
+    cluster_kwargs.setdefault("socket_keepalive", True)
+    cluster_kwargs.setdefault("socket_timeout", REDIS_SOCKET_TIMEOUT)
+    cluster_kwargs.setdefault("socket_connect_timeout", cluster_kwargs["socket_timeout"])
+
+
 def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
     _redis_cluster_nodes_in_env: Final[str | None] = get_secret("REDIS_CLUSTER_NODES")
     if _redis_cluster_nodes_in_env is not None:
@@ -503,6 +517,7 @@ def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
         new_startup_nodes.append(ClusterNode(**item))
 
     cluster_kwargs.pop("startup_nodes", None)
+    _apply_redis_cluster_reconnect_defaults(cluster_kwargs)
     return redis.RedisCluster(startup_nodes=new_startup_nodes, **cluster_kwargs)
 
 
@@ -630,8 +645,7 @@ def get_redis_async_client(
         # by a cluster restart (e.g. ElastiCache Serverless maintenance) is revalidated and
         # reconnected before reuse instead of stalling in re-initialization; an explicit value
         # from config still wins.
-        cluster_kwargs.setdefault("health_check_interval", REDIS_CLUSTER_HEALTH_CHECK_INTERVAL)
-        cluster_kwargs.setdefault("socket_keepalive", True)
+        _apply_redis_cluster_reconnect_defaults(cluster_kwargs)
 
         # Create async RedisCluster with IAM token as password if available
         cluster_client: Final = async_redis.RedisCluster(

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -122,10 +122,14 @@ class RedisCircuitBreaker:
         failure_threshold: int,
         recovery_timeout: int,
         enabled: bool = True,
+        on_open: Callable[[], None] | None = None,
+        on_probe: Callable[[], None] | None = None,
     ) -> None:
         self.failure_threshold = failure_threshold
         self.recovery_timeout = recovery_timeout
         self.enabled = enabled
+        self._on_open = on_open
+        self._on_probe = on_probe
         self._failure_count = 0
         self._opened_at: float | None = None
         self._state = self.CLOSED
@@ -142,6 +146,10 @@ class RedisCircuitBreaker:
         if self._state == self.OPEN:
             if time.time() - (self._opened_at or 0) > self.recovery_timeout:
                 self._state = self.HALF_OPEN
+                # Drop the cached cluster client so the probe rediscovers
+                # CLUSTER SLOTS instead of reusing a wedged NodesManager.
+                if self._on_probe is not None:
+                    self._on_probe()
                 return False  # this caller is the designated probe
             return True
         return False
@@ -158,6 +166,8 @@ class RedisCircuitBreaker:
                     self._failure_count,
                     self.recovery_timeout,
                 )
+                if self._on_open is not None:
+                    self._on_open()
             self._state = self.OPEN
 
     def record_success(self) -> None:
@@ -338,6 +348,7 @@ class RedisCache(BaseCache):
         redis_kwargs.update(kwargs)
         self.redis_client = get_redis_client(**redis_kwargs)
         self.redis_async_client: async_redis_client | async_redis_cluster_client | None = None
+        self._async_client_generation = 0
         self.redis_kwargs = redis_kwargs
         self.async_redis_conn_pool = get_redis_connection_pool(**redis_kwargs)
 
@@ -360,6 +371,8 @@ class RedisCache(BaseCache):
             failure_threshold=REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
             recovery_timeout=REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT,
             enabled=REDIS_CIRCUIT_BREAKER_ENABLED,
+            on_open=self._evict_redis_clients,
+            on_probe=self._evict_redis_clients,
         )
 
         self._setup_health_pings()
@@ -437,7 +450,29 @@ class RedisCache(BaseCache):
         sorted_kwargs: Final = sorted(self.redis_kwargs.items())
         kwargs_str: Final = json.dumps(sorted_kwargs, sort_keys=True)
         kwargs_hash: Final = hashlib.sha256(kwargs_str.encode()).hexdigest()[:16]
-        return f"async-redis-client-{kwargs_hash}"
+        return f"async-redis-client-{kwargs_hash}-g{self._async_client_generation}"
+
+    def _evict_redis_clients(self) -> None:
+        """Drop cached clients so the next Redis call rebuilds them.
+
+        redis-py's cluster NodesManager keeps a dead CLUSTER SLOTS map after
+        ElastiCache becomes unreachable. Reusing that client on HALF_OPEN
+        would probe the same wedged connection and never recover. Bumping
+        generation also invalidates Lua script executors keyed off this
+        cache key. Do not disconnect here — that can block the request that
+        just tripped the breaker.
+        """
+        self._async_client_generation += 1
+        self.redis_async_client = None
+        try:
+            from .._redis import get_redis_client
+
+            self.redis_client = get_redis_client(**self.redis_kwargs)
+        except Exception:
+            verbose_logger.debug(
+                "Redis circuit breaker: sync client rebuild failed; next call will retry",
+                exc_info=True,
+            )
 
     def init_async_client(
         self,

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -184,16 +184,20 @@ def _redis_health_error_types() -> tuple[type, ...]:
     a caller trip the shared breaker on demand, dropping rate limiting to per-process
     counters that spreading traffic across replicas can outrun.
 
-    RedisClusterException is the wrapper redis-py raises when CLUSTER SLOTS / startup
-    nodes are unreachable (``Redis Cluster cannot be connected ... Timeout connecting
-    to server``). It subclasses ``Exception`` directly, not TimeoutError/ConnectionError,
-    so omitting it leaves every cache write retrying a dead cluster and blocking the
-    request for the connect timeout — the 2026-08-13 staging e2e hang.
+    RedisClusterException is *not* in this tuple. redis-py uses that base for
+    command, slot-layout, and pipeline errors (SlotNotCoveredError,
+    CrossSlotTransactionError, InvalidPipelineStack, "db must be 0", …) against
+    a cluster that is still answering. Matching the base would open the breaker
+    and drop shared cache / rate-limit state to per-process counters.
+
+    The CLUSTER SLOTS / startup-node hang is detected in ``_is_redis_health_failure``
+    by walking ``__cause__`` (redis-py does ``raise RedisClusterException(...) from
+    TimeoutError``) and by the unreachable-node message when the cause was lost.
 
     Imported lazily because this module is reachable from a base ``import litellm`` while
     redis is not a base dependency.
     """
-    from redis.exceptions import BusyLoadingError, ClusterDownError, RedisClusterException
+    from redis.exceptions import BusyLoadingError, ClusterDownError
     from redis.exceptions import ConnectionError as RedisConnectionError
     from redis.exceptions import TimeoutError as RedisTimeoutError
 
@@ -202,16 +206,31 @@ def _redis_health_error_types() -> tuple[type, ...]:
         RedisTimeoutError,
         BusyLoadingError,
         ClusterDownError,
-        RedisClusterException,
         OSError,
         asyncio.TimeoutError,
     )
 
 
+# redis-py NodesManager.initialize: raise RedisClusterException(
+#   "Redis Cluster cannot be connected. Please provide at least one reachable node: …"
+# ) from exception
+_CLUSTER_UNREACHABLE_MARKER: Final = "redis cluster cannot be connected"
+
+
 def _is_redis_health_failure(exc: BaseException) -> bool:
     """True when ``exc`` indicates Redis is unreachable rather than the request being bad."""
     try:
-        return isinstance(exc, _redis_health_error_types())
+        types: Final = _redis_health_error_types()
+        seen: set[int] = set()
+        current: BaseException | None = exc
+        while current is not None and id(current) not in seen:
+            if isinstance(current, types):
+                return True
+            if _CLUSTER_UNREACHABLE_MARKER in str(current).lower():
+                return True
+            seen.add(id(current))
+            current = current.__cause__ if current.__cause__ is not None else current.__context__
+        return False
     except ImportError:
         return True
 

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -184,14 +184,28 @@ def _redis_health_error_types() -> tuple[type, ...]:
     a caller trip the shared breaker on demand, dropping rate limiting to per-process
     counters that spreading traffic across replicas can outrun.
 
+    RedisClusterException is the wrapper redis-py raises when CLUSTER SLOTS / startup
+    nodes are unreachable (``Redis Cluster cannot be connected ... Timeout connecting
+    to server``). It subclasses ``Exception`` directly, not TimeoutError/ConnectionError,
+    so omitting it leaves every cache write retrying a dead cluster and blocking the
+    request for the connect timeout — the 2026-08-13 staging e2e hang.
+
     Imported lazily because this module is reachable from a base ``import litellm`` while
     redis is not a base dependency.
     """
-    from redis.exceptions import BusyLoadingError, ClusterDownError
+    from redis.exceptions import BusyLoadingError, ClusterDownError, RedisClusterException
     from redis.exceptions import ConnectionError as RedisConnectionError
     from redis.exceptions import TimeoutError as RedisTimeoutError
 
-    return (RedisConnectionError, RedisTimeoutError, BusyLoadingError, ClusterDownError, OSError, asyncio.TimeoutError)
+    return (
+        RedisConnectionError,
+        RedisTimeoutError,
+        BusyLoadingError,
+        ClusterDownError,
+        RedisClusterException,
+        OSError,
+        asyncio.TimeoutError,
+    )
 
 
 def _is_redis_health_failure(exc: BaseException) -> bool:

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -582,9 +582,12 @@ async def test_concurrent_success_is_not_cancelled_by_another_calls_failure():
         pytest.param("ConnectionError", True, id="connection_refused_is_unhealthy"),
         pytest.param("TimeoutError", True, id="timeout_is_unhealthy"),
         pytest.param("BusyLoadingError", True, id="loading_is_unhealthy"),
-        pytest.param("RedisClusterException", True, id="cluster_unreachable_is_unhealthy"),
         pytest.param("ResponseError", False, id="wrong_type_command_is_not"),
         pytest.param("DataError", False, id="bad_data_is_not"),
+        pytest.param("SlotNotCoveredError", False, id="slot_layout_is_not_unhealthy"),
+        pytest.param("CrossSlotTransactionError", False, id="cross_slot_is_not_unhealthy"),
+        pytest.param("InvalidPipelineStack", False, id="pipeline_stack_is_not_unhealthy"),
+        pytest.param("RedisClusterException", False, id="generic_cluster_command_error_is_not"),
     ],
 )
 async def test_only_connectivity_failures_open_the_breaker(error, opens_breaker):
@@ -599,7 +602,10 @@ async def test_only_connectivity_failures_open_the_breaker(error, opens_breaker)
     from litellm.caching.redis_cache import RedisCircuitBreaker, _run_under_circuit_breaker
 
     breaker = RedisCircuitBreaker(failure_threshold=3, recovery_timeout=60)
-    raised = getattr(redis.exceptions, error)("boom")
+    error_cls = getattr(redis.exceptions, error, None)
+    if error_cls is None:
+        pytest.skip(f"{error} is not in this redis-py")
+    raised = error_cls("boom")
 
     async def failing_call():
         raise raised
@@ -609,6 +615,41 @@ async def test_only_connectivity_failures_open_the_breaker(error, opens_breaker)
             await _run_under_circuit_breaker(breaker, "op", failing_call)
 
     assert breaker.is_open() is opens_breaker
+
+
+@pytest.mark.asyncio
+async def test_redis_cluster_exception_subclasses_do_not_open_the_breaker():
+    """Slot/pipeline/command errors share the RedisClusterException base.
+
+    Matching that base (isinstance) would let a covered-slot miss or a
+    cross-slot pipeline trip the shared breaker and degrade rate limits to
+    per-process counters while Redis is still answering.
+    """
+    from redis.exceptions import RedisClusterException
+
+    from litellm.caching.redis_cache import (
+        RedisCircuitBreaker,
+        _is_redis_health_failure,
+        _run_under_circuit_breaker,
+    )
+
+    class SlotLayoutError(RedisClusterException):
+        pass
+
+    class PipelineStackError(RedisClusterException):
+        pass
+
+    for raised in (SlotLayoutError("slot"), PipelineStackError("pipeline")):
+        assert _is_redis_health_failure(raised) is False
+        breaker = RedisCircuitBreaker(failure_threshold=3, recovery_timeout=60)
+
+        async def failing_call(exc=raised):
+            raise exc
+
+        for _ in range(breaker.failure_threshold + 1):
+            with pytest.raises(RedisClusterException):
+                await _run_under_circuit_breaker(breaker, "op", failing_call)
+        assert breaker.is_open() is False
 
 
 @pytest.mark.asyncio
@@ -629,16 +670,31 @@ async def test_cluster_connect_timeout_swallowed_set_opens_breaker():
         _run_under_circuit_breaker,
     )
 
-    production = RedisClusterException(
+    from redis.exceptions import TimeoutError as RedisTimeoutError
+
+    timeout = RedisTimeoutError("Timeout connecting to server")
+    try:
+        raise RedisClusterException(
+            "Redis Cluster cannot be connected. Please provide at least one reachable node: "
+            "Timeout connecting to server"
+        ) from timeout
+    except RedisClusterException as production:
+        wrapped = production
+
+    # Cause lost (message only) still counts — redis-py stringifies the timeout
+    # into the RedisClusterException text even if __cause__ is stripped.
+    message_only = RedisClusterException(
         "Redis Cluster cannot be connected. Please provide at least one reachable node: "
         "Timeout connecting to server"
     )
-    assert _is_redis_health_failure(production) is True
+    assert _is_redis_health_failure(wrapped) is True
+    assert _is_redis_health_failure(message_only) is True
+    assert _is_redis_health_failure(RedisClusterException("Argument 'db' must be 0")) is False
 
     breaker = RedisCircuitBreaker(failure_threshold=3, recovery_timeout=60)
 
     async def swallowed_cluster_timeout():
-        _record_swallowed_redis_failure(breaker, production)
+        _record_swallowed_redis_failure(breaker, wrapped)
         return None
 
     for _ in range(breaker.failure_threshold):

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -704,3 +704,71 @@ async def test_cluster_connect_timeout_swallowed_set_opens_breaker():
 
     with pytest.raises(Exception, match="circuit breaker is open"):
         await _run_under_circuit_breaker(breaker, "async_set_cache", swallowed_cluster_timeout)
+
+
+def test_breaker_on_open_fires_once_on_transition():
+    """on_open drops the wedged cluster client; it must not fire on every later miss."""
+    from litellm.caching.redis_cache import RedisCircuitBreaker
+
+    opened = []
+    cb = RedisCircuitBreaker(
+        failure_threshold=3,
+        recovery_timeout=60,
+        on_open=lambda: opened.append("open"),
+    )
+    for _ in range(3):
+        cb.record_failure()
+    assert opened == ["open"]
+    cb.record_failure()
+    cb.record_failure()
+    assert opened == ["open"]
+
+
+def test_breaker_on_probe_fires_when_half_open_starts():
+    """HALF_OPEN rebuilds the client so CLUSTER SLOTS is rediscovered."""
+    import time as time_mod
+
+    from litellm.caching.redis_cache import RedisCircuitBreaker
+
+    probes = []
+    cb = RedisCircuitBreaker(
+        failure_threshold=3,
+        recovery_timeout=60,
+        on_probe=lambda: probes.append("probe"),
+    )
+    cb._state = cb.OPEN
+    cb._opened_at = time_mod.time() - 9999
+    assert cb.is_open() is False
+    assert cb._state == cb.HALF_OPEN
+    assert probes == ["probe"]
+    assert cb.is_open() is True
+    assert probes == ["probe"]
+
+
+def test_redis_cache_evicts_clients_when_breaker_opens(monkeypatch, redis_no_ping):
+    """A HALF_OPEN probe must not reuse the NodesManager that just hung."""
+    import time as time_mod
+
+    monkeypatch.setenv("REDIS_HOST", "127.0.0.1")
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    cache = RedisCache(host="127.0.0.1", port=1, socket_timeout=0.1)
+    key_before = cache._get_async_client_cache_key()
+    gen_before = cache._async_client_generation
+    sentinel = object()
+    cache.redis_async_client = sentinel
+
+    for _ in range(cache._circuit_breaker.failure_threshold):
+        cache._circuit_breaker.record_failure()
+
+    assert cache._async_client_generation == gen_before + 1
+    assert cache.redis_async_client is None
+    assert cache._get_async_client_cache_key() != key_before
+
+    cache._circuit_breaker.record_failure()
+    assert cache._async_client_generation == gen_before + 1
+
+    cache.redis_async_client = sentinel
+    cache._circuit_breaker._opened_at = time_mod.time() - 9999
+    assert cache._circuit_breaker.is_open() is False
+    assert cache.redis_async_client is None
+    assert cache._async_client_generation == gen_before + 2

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -582,6 +582,7 @@ async def test_concurrent_success_is_not_cancelled_by_another_calls_failure():
         pytest.param("ConnectionError", True, id="connection_refused_is_unhealthy"),
         pytest.param("TimeoutError", True, id="timeout_is_unhealthy"),
         pytest.param("BusyLoadingError", True, id="loading_is_unhealthy"),
+        pytest.param("RedisClusterException", True, id="cluster_unreachable_is_unhealthy"),
         pytest.param("ResponseError", False, id="wrong_type_command_is_not"),
         pytest.param("DataError", False, id="bad_data_is_not"),
     ],
@@ -608,3 +609,42 @@ async def test_only_connectivity_failures_open_the_breaker(error, opens_breaker)
             await _run_under_circuit_breaker(breaker, "op", failing_call)
 
     assert breaker.is_open() is opens_breaker
+
+
+@pytest.mark.asyncio
+async def test_cluster_connect_timeout_swallowed_set_opens_breaker():
+    """Staging 2026-08-13: redis-py wraps connect timeouts as RedisClusterException.
+
+    ``async_set_cache`` swallows the error so a dead cluster degrades instead of
+    500ing. The breaker must still open — RedisClusterException subclasses
+    Exception, not TimeoutError — otherwise every later request retries CLUSTER
+    SLOTS and the worker hangs for the connect timeout (the 60s ALB read timeout).
+    """
+    from redis.exceptions import RedisClusterException
+
+    from litellm.caching.redis_cache import (
+        RedisCircuitBreaker,
+        _is_redis_health_failure,
+        _record_swallowed_redis_failure,
+        _run_under_circuit_breaker,
+    )
+
+    production = RedisClusterException(
+        "Redis Cluster cannot be connected. Please provide at least one reachable node: "
+        "Timeout connecting to server"
+    )
+    assert _is_redis_health_failure(production) is True
+
+    breaker = RedisCircuitBreaker(failure_threshold=3, recovery_timeout=60)
+
+    async def swallowed_cluster_timeout():
+        _record_swallowed_redis_failure(breaker, production)
+        return None
+
+    for _ in range(breaker.failure_threshold):
+        await _run_under_circuit_breaker(breaker, "async_set_cache", swallowed_cluster_timeout)
+
+    assert breaker.is_open() is True
+
+    with pytest.raises(Exception, match="circuit breaker is open"):
+        await _run_under_circuit_breaker(breaker, "async_set_cache", swallowed_cluster_timeout)

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -12,7 +12,7 @@ from litellm._redis import (
     get_redis_connection_pool,
     get_redis_url_from_environment,
 )
-from litellm.constants import REDIS_CLUSTER_HEALTH_CHECK_INTERVAL
+from litellm.constants import REDIS_CLUSTER_HEALTH_CHECK_INTERVAL, REDIS_SOCKET_TIMEOUT
 from litellm._redis_credential_provider import (
     GCPIAMCredentialProvider,
     _token_cache,
@@ -195,6 +195,25 @@ def test_async_cluster_sets_reconnect_defaults(mock_cluster_cls):
     assert call_kwargs["health_check_interval"] == REDIS_CLUSTER_HEALTH_CHECK_INTERVAL
     assert call_kwargs["health_check_interval"] > 0
     assert call_kwargs["socket_keepalive"] is True
+    assert call_kwargs["socket_timeout"] == REDIS_SOCKET_TIMEOUT
+    assert call_kwargs["socket_connect_timeout"] == REDIS_SOCKET_TIMEOUT
+
+
+@patch("litellm._redis.redis.RedisCluster")
+def test_sync_cluster_sets_reconnect_defaults(mock_cluster_cls):
+    """Sync RedisCluster must get the same fail-fast reconnect defaults as async.
+
+    init_redis_cluster used to skip them, so a dropped ElastiCache Serverless
+    connection stalled the (often event-loop) caller in CLUSTER SLOTS rediscovery.
+    """
+    get_redis_client(startup_nodes=[{"host": "cluster-node", "port": 6379}])
+
+    mock_cluster_cls.assert_called_once()
+    call_kwargs = mock_cluster_cls.call_args[1]
+    assert call_kwargs["health_check_interval"] == REDIS_CLUSTER_HEALTH_CHECK_INTERVAL
+    assert call_kwargs["socket_keepalive"] is True
+    assert call_kwargs["socket_timeout"] == REDIS_SOCKET_TIMEOUT
+    assert call_kwargs["socket_connect_timeout"] == REDIS_SOCKET_TIMEOUT
 
 
 @patch("litellm._redis.async_redis.RedisCluster")


### PR DESCRIPTION
## TLDR

Problem this solves:

- A dead Redis Cluster left the proxy accepting HTTP but never responding
- Staging e2e on 2026-08-13: 72 tests died on 60s ALB read timeouts
- redis-py wraps connect timeouts as RedisClusterException (not TimeoutError), so the breaker never opened

How it solves it:

- Count RedisClusterException as a Redis health failure so the breaker opens
- After 5 misses, later requests skip Redis and return instead of retrying CLUSTER SLOTS
- Apply fail-fast connect timeout / keepalive / health check on sync and async cluster clients

## User Flow

<img width="1480" height="1000" alt="image" src="https://github.com/user-attachments/assets/ffcb548d-a844-4324-9574-1877395ed1af" />


Before: a caller whose proxy uses ElastiCache Serverless (cluster mode) hits a node that is not answering, and every request hangs until their client times out

1. They send POST https://litellm-domain/v1/chat/completions (or POST /model/new) with a valid key
2. The TCP connection is accepted; no HTTP status comes back
3. After 60s their client raises a read timeout; /health/liveliness still returns 200
4. The next request does the same hang — the proxy never takes Redis out of the path

After: the same dead cluster fails fast; the proxy keeps answering

1. They send the same POST https://litellm-domain/v1/chat/completions or POST /model/new
2. The first few Redis attempts fail in seconds (connect timeout), not the OS TCP timeout
3. After consecutive cluster-unreachable errors, later requests skip Redis and return a normal HTTP response (chat 200 / management 2xx, using in-memory state)
4. /health/liveliness stays 200; the worker is not wedged

## Relevant issues

Staging e2e 2026-08-13 (`litellm-e2e-1-0-0-main-20260813122400-h6rhc`, rev `09889e1986faa7b97d1d213040aa442b2aa393f6`): 72 failed, 442 passed, 57 skipped in 13105.79s. Every captured traceback was `Read timed out. (read timeout=60.0)` against `internal-k8s-litellm-litellm-e7f4afb143-1355079179.us-east-1.elb.amazonaws.com`. Gateway/backend logs after the window still showed `Redis Cluster cannot be connected … Timeout connecting to server` with zero `circuit breaker OPENED` lines.

Follows the hole left by #35273 / #31577 (LIT-4083): those covered TimeoutError/ConnectionError and async reconnect defaults, not RedisClusterException or the sync cluster client.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Unit proof at `342cdf628e` (this commit), twice:

```
pytest tests/test_litellm/caching/test_redis_cache.py::test_cluster_connect_timeout_swallowed_set_opens_breaker \
       tests/test_litellm/caching/test_redis_cache.py::test_only_connectivity_failures_open_the_breaker \
       tests/test_litellm/test_redis.py::test_async_cluster_sets_reconnect_defaults \
       tests/test_litellm/test_redis.py::test_sync_cluster_sets_reconnect_defaults \
       tests/test_litellm/test_redis.py::test_async_cluster_reconnect_defaults_are_overridable
```

10 passed in 0.56s. The new test constructs the production exception text (`Redis Cluster cannot be connected … Timeout connecting to server`), asserts it is a health failure, opens the breaker, and asserts the next call is skipped immediately.

A full staging e2e re-run is not in this PR. Redis itself was still unreachable on stage after the suite; this change only stops that from freezing the worker.

## Type

🐛 Bug Fix

## Caveats (if any)

- Does not fix ElastiCache reachability (TLS / SG / serverless). Budget/RPM/spend e2e that need a live Redis can still fail, but as assertions, not 60s hangs.
- Stage was 1 replica × NUM_WORKERS=1 during the incident; that is litellm-ops, not this PR.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7ee0b70d58dd34b3919cc834198aa5e47eb2e562. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->