### PR TITLE
feat(xai): day-0 pricing for grok-4.6

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -40889,6 +40889,27 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "xai/grok-4.6": {
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 1e-06,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_200k_tokens": 4e-06,
+        "litellm_provider": "xai",
+        "max_input_tokens": 500000,
+        "max_output_tokens": 500000,
+        "max_tokens": 500000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "output_cost_per_token_above_200k_tokens": 1.2e-05,
+        "source": "https://docs.x.ai/developers/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "xai/grok-beta": {
         "input_cost_per_token": 5e-06,
         "litellm_provider": "xai",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -40889,6 +40889,27 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "xai/grok-4.6": {
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 1e-06,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_200k_tokens": 4e-06,
+        "litellm_provider": "xai",
+        "max_input_tokens": 500000,
+        "max_output_tokens": 500000,
+        "max_tokens": 500000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "output_cost_per_token_above_200k_tokens": 1.2e-05,
+        "source": "https://docs.x.ai/developers/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "xai/grok-beta": {
         "input_cost_per_token": 5e-06,
         "litellm_provider": "xai",

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -2943,3 +2943,51 @@ def test_generic_cost_per_token_gemini_37_flash(_local_model_cost_map):
     )
     assert prompt_cost == pytest.approx(0.00075)
     assert completion_cost == pytest.approx(0.001875)
+
+
+def test_grok_46_launch_pricing(_local_model_cost_map):
+    model_cost_map = litellm.model_cost["xai/grok-4.6"]
+    assert model_cost_map["input_cost_per_token"] == 2e-06
+    assert model_cost_map["output_cost_per_token"] == 6e-06
+    assert model_cost_map["cache_read_input_token_cost"] == 5e-07
+    assert model_cost_map["input_cost_per_token_above_200k_tokens"] == 4e-06
+    assert model_cost_map["output_cost_per_token_above_200k_tokens"] == 1.2e-05
+    assert model_cost_map["cache_read_input_token_cost_above_200k_tokens"] == 1e-06
+    assert model_cost_map["mode"] == "chat"
+    assert model_cost_map["supports_reasoning"] is True
+    assert model_cost_map["supports_function_calling"] is True
+    assert model_cost_map["max_input_tokens"] == 500000
+
+
+def test_generic_cost_per_token_grok_46(_local_model_cost_map):
+    usage = Usage(
+        prompt_tokens=1_000,
+        completion_tokens=500,
+        total_tokens=1_500,
+        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=1_000),
+    )
+    prompt_cost, completion_cost = generic_cost_per_token(
+        model="grok-4.6",
+        usage=usage,
+        custom_llm_provider="xai",
+    )
+    assert prompt_cost == pytest.approx(1_000 * 2e-06)
+    assert completion_cost == pytest.approx(500 * 6e-06)
+
+
+def test_generic_cost_per_token_grok_46_long_context(_local_model_cost_map):
+    usage = Usage(
+        prompt_tokens=250_000,
+        completion_tokens=1_000,
+        total_tokens=251_000,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=50_000, text_tokens=200_000
+        ),
+    )
+    prompt_cost, completion_cost = generic_cost_per_token(
+        model="grok-4.6",
+        usage=usage,
+        custom_llm_provider="xai",
+    )
+    assert prompt_cost == pytest.approx(200_000 * 4e-06 + 50_000 * 1e-06)
+    assert completion_cost == pytest.approx(1_000 * 1.2e-05)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Grok 4.6 launched Aug 12 with no cost map entry
- Calls to `xai/grok-4.6` succeed but track $0 spend

How it solves it:

- Adds `xai/grok-4.6` with base, cached, and above-200k pricing
- Prices verified against xAI's live pricing API and real billed cost

## User Flow

Before: a proxy admin adds Grok 4.6 the day it launches, and every call logs at zero spend

1. They add a `grok-4.6` deployment backed by `xai/grok-4.6` to their proxy and send POST https://litellm-domain/v1/chat/completions with `{"model": "grok-4.6", "messages": [...]}`
2. The response comes back 200 with the model's answer and real token usage
3. No `x-litellm-response-cost` header is present, and https://litellm-domain/ui/?page=logs shows the request at $0 spend, so budgets and per-key limits never see the real cost

After: the same request comes back fully cost tracked at xAI's launch prices

1. They add the same `grok-4.6` deployment and send the same POST https://litellm-domain/v1/chat/completions with `{"model": "grok-4.6", "messages": [...]}`
2. The response comes back 200 with the answer and an `x-litellm-response-cost` header carrying the dollar cost of the call
3. That number matches what xAI itself bills for the request, and https://litellm-domain/ui/?page=logs shows the request at real spend

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy booted with `LITELLM_LOCAL_MODEL_COST_MAP=true` and this config, hitting the real xAI API:

```yaml
model_list:
  - model_name: grok-4.6
    litellm_params:
      model: xai/grok-4.6
      api_key: os.environ/XAI_API_KEY
```

Before (base `9d069f21dc`, proxy on :24818): the call succeeds but no cost is tracked

```bash
curl -s -D - http://localhost:24818/v1/chat/completions \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"model": "grok-4.6", "messages": [{"role": "user", "content": "Reply with exactly: grok 4.6 via litellm"}]}'
```

```
content: grok 4.6 via litellm
usage tokens: 441
NO x-litellm-response-cost HEADER
```

After (this PR `928dfab65c`, proxy on :24817): same call, cost tracked

```bash
curl -s -D - http://localhost:24817/v1/chat/completions \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"model": "grok-4.6", "messages": [{"role": "user", "content": "Reply with exactly: grok 4.6 via litellm"}]}'
```

```
"content": "grok 4.6 via litellm"
"usage": {"completion_tokens": 116, "prompt_tokens": 220, "total_tokens": 336,
          "prompt_tokens_details": {"cached_tokens": 128, ...},
          "cost_in_usd_ticks": 9440000}

x-litellm-model-name: xai/grok-4.6
x-litellm-response-cost: 0.000944
```

xAI's own usage block bills the call at 9440000 ticks, which is $0.000944, exactly the cost LiteLLM computed: 92 uncached prompt tokens at $2/M plus 128 cached at $0.50/M plus 116 completion tokens at $6/M

## Type

🆕 New Feature

## Caveats (if any)

- No `grok-4.6-latest` entry since xAI publishes no alias for it yet

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 928dfab65c59b86317a8b4336734ed6177b2d9c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->