### PR TITLE
feat(lint): exempt TypedDict-annotated dict literals from LIT002

### DIFF
--- a/scripts/check_type_discipline.py
+++ b/scripts/check_type_discipline.py
@@ -36,8 +36,10 @@ LIT002  Mutable-collection *construction*: a list/dict/set literal or comprehens
         disqualifies every name, since what it binds is statically invisible),
         every field it declares or inherits in-module must be
         `ReadOnly[...]`, only the display itself is exempt (nested mutables still
-        count), and a TypedDict imported from another module is out of reach,
-        exactly as in LIT012. Suppress with `# mutable-ok: <reason>`.
+        count), a TypedDict imported from another module is out of reach, exactly
+        as in LIT012, and a dotted annotation (`x: mod.Td = {...}`) never
+        matches, since it cannot name a local class. Suppress with
+        `# mutable-ok: <reason>`.
 LIT003  noqa suppression without rule codes or without a reason.
         Required shape: `# noqa: TID251  # <reason>`
 LIT004  pyright/mypy ignore without bracketed codes or without a reason.
@@ -499,10 +501,15 @@ def _frozen_argument_ids(tree: ast.AST) -> frozenset[int]:
 
 
 def _declared_type_name(annotation: ast.expr) -> str | None:
-    """The head name of an AnnAssign annotation, looking through a `Final[...]` wrapper."""
+    """The bare name an AnnAssign annotation spells, looking through a `Final[...]` wrapper.
+
+    Qualified annotations (`x: mod.Td`) yield None: a dotted name refers to another
+    module's attribute, which can never be a class defined in the file being checked,
+    so reducing it to its tail would let an imported type borrow a local one's name.
+    """
     if isinstance(annotation, ast.Subscript) and _head_name(annotation.value) == "Final":
-        return _head_name(annotation.slice)
-    return _head_name(annotation)
+        return annotation.slice.id if isinstance(annotation.slice, ast.Name) else None
+    return annotation.id if isinstance(annotation, ast.Name) else None
 
 
 def _binding_names(node: ast.AST) -> tuple[str, ...]:

--- a/scripts/check_type_discipline.py
+++ b/scripts/check_type_discipline.py
@@ -36,8 +36,9 @@ LIT002  Mutable-collection *construction*: a list/dict/set literal or comprehens
         disqualifies every name, since what it binds is statically invisible),
         every field it declares or inherits in-module must be
         `ReadOnly[...]`, only the display itself is exempt (nested mutables still
-        count), a TypedDict imported from another module is out of reach, exactly
-        as in LIT012, and a dotted annotation (`x: mod.Td = {...}`) never
+        count), a TypedDict imported from another module or nested inside a def
+        or class is out of reach (only ones defined at the module's top level
+        resolve file-wide), and a dotted annotation (`x: mod.Td = {...}`) never
         matches, since it cannot name a local class. Suppress with
         `# mutable-ok: <reason>`.
 LIT003  noqa suppression without rule codes or without a reason.
@@ -541,8 +542,11 @@ def _typeddict_assigned_value_ids(tree: ast.AST) -> frozenset[int]:
     `x: MyTd = {...}` is the literal spelling of the `MyTd(...)` call, which was
     never construction to begin with, so the display is a one-shot build -- provided
     the annotation provably names a frozen payload. Three conditions gate that:
-    MyTd is a class-form TypedDict in this module (imported ones are invisible,
-    exactly as in LIT012's base-class resolution); its name is bound exactly once
+    MyTd is a class-form TypedDict at the module's top level (imported ones are
+    invisible, exactly as in LIT012's base-class resolution, and one nested in a
+    def or class is skipped, since its name does not resolve outside the scope
+    that defines it, while a top-level one resolves everywhere); its name is
+    bound exactly once
     in the file (resolution here is scope-blind, so a name the file also binds in
     any other form, another def, an assignment or loop target, an import alias, a
     parameter, could resolve to something mutable at the annotation site, and a
@@ -553,7 +557,8 @@ def _typeddict_assigned_value_ids(tree: ast.AST) -> frozenset[int]:
     the display itself is exempt; anything mutable nested inside it still trips
     LIT002.
     """
-    classes = _typeddict_classes(tree)
+    top_level_ids = frozenset(id(stmt) for stmt in (tree.body if isinstance(tree, ast.Module) else ()))
+    classes = tuple(cls for cls in _typeddict_classes(tree) if id(cls) in top_level_ids)
     by_name = {cls.name: cls for cls in classes}
 
     def frozen_lineage(name: str, seen: frozenset[str]) -> bool:

--- a/scripts/check_type_discipline.py
+++ b/scripts/check_type_discipline.py
@@ -24,7 +24,13 @@ LIT002  Mutable-collection *construction*: a list/dict/set literal or comprehens
         `MappingProxyType(...)`) are not construction and pass, as does the value passed
         directly to a wrapper: it is frozen before it can escape, though anything
         mutable nested inside it still counts. Annotation-internal lists
-        (`Callable[[int], str]`) are exempt. Suppress with `# mutable-ok: <reason>`.
+        (`Callable[[int], str]`) are exempt, as is a dict display assigned directly
+        to a name annotated with a same-module TypedDict (`x: Final[MyTd] = {...}`,
+        bare or under `Final[...]`): it is the literal spelling of the `MyTd(...)`
+        call, which was never construction, and LIT012 keeps those fields ReadOnly.
+        Only the display itself is exempt (nested mutables still count), and a
+        TypedDict imported from another module is out of reach, exactly as in
+        LIT012. Suppress with `# mutable-ok: <reason>`.
 LIT003  noqa suppression without rule codes or without a reason.
         Required shape: `# noqa: TID251  # <reason>`
 LIT004  pyright/mypy ignore without bracketed codes or without a reason.
@@ -485,6 +491,33 @@ def _frozen_argument_ids(tree: ast.AST) -> frozenset[int]:
     )
 
 
+def _declared_type_name(annotation: ast.expr) -> str | None:
+    """The head name of an AnnAssign annotation, looking through a `Final[...]` wrapper."""
+    if isinstance(annotation, ast.Subscript) and _head_name(annotation.value) == "Final":
+        return _head_name(annotation.slice)
+    return _head_name(annotation)
+
+
+def _typeddict_assigned_value_ids(tree: ast.AST) -> frozenset[int]:
+    """ids() of every dict display assigned directly to a TypedDict-annotated name.
+
+    `x: MyTd = {...}` is the literal spelling of the `MyTd(...)` call, which was
+    never construction to begin with, and LIT012 keeps every same-module TypedDict
+    field ReadOnly, so neither spelling yields a payload the holder can grow. Only
+    the display itself is exempt; anything mutable nested inside it still trips
+    LIT002. A TypedDict imported from another module is invisible here, exactly as
+    in LIT012's base-class resolution.
+    """
+    typeddict_names = frozenset(cls.name for cls in _typeddict_classes(tree))
+    return frozenset(
+        id(node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.value, ast.Dict)
+        and _declared_type_name(node.annotation) in typeddict_names
+    )
+
+
 def _construction_kind(node: ast.expr) -> str | None:
     """Human label if `node` builds a mutable collection, else None."""
     if isinstance(node, ast.List):
@@ -509,10 +542,9 @@ def _construction_kind(node: ast.expr) -> str | None:
 
 
 def iter_construction_violations(path: Path, tree: ast.AST, comments: Comments) -> Iterator[Violation]:
-    in_annotation = _annotation_node_ids(tree)
-    frozen_arguments = _frozen_argument_ids(tree)
+    exempt = _annotation_node_ids(tree) | _frozen_argument_ids(tree) | _typeddict_assigned_value_ids(tree)
     for node in ast.walk(tree):
-        if not isinstance(node, ast.expr) or id(node) in in_annotation or id(node) in frozen_arguments:
+        if not isinstance(node, ast.expr) or id(node) in exempt:
             continue
         kind = _construction_kind(node)
         if kind is None or node.lineno in comments.mutable_ok_lines:
@@ -522,8 +554,10 @@ def iter_construction_violations(path: Path, tree: ast.AST, comments: Comments) 
             f"mutable {kind}: this builds a collection that can be grown or rewritten. "
             f"Build it in one shot and freeze it -- a tuple/frozenset wrapping a generator "
             f"(`tuple(f(x) for x in xs)`), a tuple literal, a frozen dataclass / NamedTuple "
-            f"/ ReadOnly TypedDict, or (if it really must be dynamic) a MappingProxyType "
-            f"wrapping a dict literal or comprehension (suppress: `# mutable-ok: <reason>`)",
+            f"/ ReadOnly TypedDict (a dict literal assigned to a name annotated with a "
+            f"same-module TypedDict is exempt), or (if it really must be dynamic) a "
+            f"MappingProxyType wrapping a dict literal or comprehension "
+            f"(suppress: `# mutable-ok: <reason>`)",
         )
  
  

--- a/scripts/check_type_discipline.py
+++ b/scripts/check_type_discipline.py
@@ -25,12 +25,17 @@ LIT002  Mutable-collection *construction*: a list/dict/set literal or comprehens
         directly to a wrapper: it is frozen before it can escape, though anything
         mutable nested inside it still counts. Annotation-internal lists
         (`Callable[[int], str]`) are exempt, as is a dict display assigned directly
-        to a name annotated with a same-module TypedDict (`x: Final[MyTd] = {...}`,
-        bare or under `Final[...]`): it is the literal spelling of the `MyTd(...)`
-        call, which was never construction, and LIT012 keeps those fields ReadOnly.
-        Only the display itself is exempt (nested mutables still count), and a
-        TypedDict imported from another module is out of reach, exactly as in
-        LIT012. Suppress with `# mutable-ok: <reason>`.
+        to a name annotated with a same-module all-ReadOnly TypedDict
+        (`x: Final[MyTd] = {...}`, bare or under `Final[...]`): it is the literal
+        spelling of the `MyTd(...)` call, which was never construction, and an
+        all-ReadOnly payload cannot be grown or rewritten. The exemption is
+        conservative: the TypedDict's name must be bound exactly once in the file
+        (a name also bound as a function, another class, an assignment target, or
+        an import alias might resolve to something mutable at the annotation
+        site), every field it declares or inherits in-module must be
+        `ReadOnly[...]`, only the display itself is exempt (nested mutables still
+        count), and a TypedDict imported from another module is out of reach,
+        exactly as in LIT012. Suppress with `# mutable-ok: <reason>`.
 LIT003  noqa suppression without rule codes or without a reason.
         Required shape: `# noqa: TID251  # <reason>`
 LIT004  pyright/mypy ignore without bracketed codes or without a reason.
@@ -498,23 +503,59 @@ def _declared_type_name(annotation: ast.expr) -> str | None:
     return _head_name(annotation)
 
 
+def _binding_names(node: ast.AST) -> tuple[str, ...]:
+    """The names a single statement binds: class, function, assignment target, import alias."""
+    if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+        return (node.name,)
+    if isinstance(node, (ast.Import, ast.ImportFrom)):
+        return tuple(alias.asname or alias.name.partition(".")[0] for alias in node.names)
+    if isinstance(node, ast.Assign):
+        return tuple(target.id for target in node.targets if isinstance(target, ast.Name))
+    if isinstance(node, (ast.AnnAssign, ast.AugAssign)) and isinstance(node.target, ast.Name):
+        return (node.target.id,)
+    return ()
+
+
 def _typeddict_assigned_value_ids(tree: ast.AST) -> frozenset[int]:
-    """ids() of every dict display assigned directly to a TypedDict-annotated name.
+    """ids() of every dict display assigned directly to a frozen-TypedDict-annotated name.
 
     `x: MyTd = {...}` is the literal spelling of the `MyTd(...)` call, which was
-    never construction to begin with, and LIT012 keeps every same-module TypedDict
-    field ReadOnly, so neither spelling yields a payload the holder can grow. Only
+    never construction to begin with, so the display is a one-shot build -- provided
+    the annotation provably names a frozen payload. Three conditions gate that:
+    MyTd is a class-form TypedDict in this module (imported ones are invisible,
+    exactly as in LIT012's base-class resolution); its name is bound exactly once
+    in the file (resolution here is scope-blind, so a name the file also binds as a
+    function, another class, an assignment target, or an import alias could resolve
+    to something mutable at the annotation site); and every field it declares or
+    inherits within the module is `ReadOnly[...]`, so no holder can statically
+    rewrite a key even where LIT012 was suppressed or is riding its budget. Only
     the display itself is exempt; anything mutable nested inside it still trips
-    LIT002. A TypedDict imported from another module is invisible here, exactly as
-    in LIT012's base-class resolution.
+    LIT002.
     """
-    typeddict_names = frozenset(cls.name for cls in _typeddict_classes(tree))
+    classes = _typeddict_classes(tree)
+    by_name = {cls.name: cls for cls in classes}
+
+    def frozen_lineage(name: str, seen: frozenset[str]) -> bool:
+        cls = by_name.get(name)
+        if cls is None or name in seen:
+            return False
+        if not all(_has_readonly_qualifier(field.annotation) for field in _class_fields(cls)):
+            return False
+        return all(
+            base == TYPEDDICT_BASE or frozen_lineage(base, seen | frozenset((name,)))
+            for base in _base_names(cls)
+        )
+
+    bindings = tuple(name for node in ast.walk(tree) for name in _binding_names(node))
+    frozen_names = frozenset(
+        cls.name for cls in classes if bindings.count(cls.name) == 1 and frozen_lineage(cls.name, frozenset())
+    )
     return frozenset(
         id(node.value)
         for node in ast.walk(tree)
         if isinstance(node, ast.AnnAssign)
         and isinstance(node.value, ast.Dict)
-        and _declared_type_name(node.annotation) in typeddict_names
+        and _declared_type_name(node.annotation) in frozen_names
     )
 
 
@@ -555,7 +596,7 @@ def iter_construction_violations(path: Path, tree: ast.AST, comments: Comments) 
             f"Build it in one shot and freeze it -- a tuple/frozenset wrapping a generator "
             f"(`tuple(f(x) for x in xs)`), a tuple literal, a frozen dataclass / NamedTuple "
             f"/ ReadOnly TypedDict (a dict literal assigned to a name annotated with a "
-            f"same-module TypedDict is exempt), or (if it really must be dynamic) a "
+            f"same-module all-ReadOnly TypedDict is exempt), or (if it really must be dynamic) a "
             f"MappingProxyType wrapping a dict literal or comprehension "
             f"(suppress: `# mutable-ok: <reason>`)",
         )

--- a/scripts/check_type_discipline.py
+++ b/scripts/check_type_discipline.py
@@ -504,15 +504,25 @@ def _declared_type_name(annotation: ast.expr) -> str | None:
 
 
 def _binding_names(node: ast.AST) -> tuple[str, ...]:
-    """The names a single statement binds: class, function, assignment target, import alias."""
+    """The names one node binds: def/class/import/parameter/global/except/match forms,
+    plus any Name stored or deleted, which covers every assignment, loop, walrus,
+    unpacking, comprehension, and `with` target."""
     if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
         return (node.name,)
     if isinstance(node, (ast.Import, ast.ImportFrom)):
         return tuple(alias.asname or alias.name.partition(".")[0] for alias in node.names)
-    if isinstance(node, ast.Assign):
-        return tuple(target.id for target in node.targets if isinstance(target, ast.Name))
-    if isinstance(node, (ast.AnnAssign, ast.AugAssign)) and isinstance(node.target, ast.Name):
-        return (node.target.id,)
+    if isinstance(node, (ast.Global, ast.Nonlocal)):
+        return tuple(node.names)
+    if isinstance(node, ast.arg):
+        return (node.arg,)
+    if isinstance(node, ast.ExceptHandler) and node.name is not None:
+        return (node.name,)
+    if isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name is not None:
+        return (node.name,)
+    if isinstance(node, ast.MatchMapping) and node.rest is not None:
+        return (node.rest,)
+    if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+        return (node.id,)
     return ()
 
 
@@ -524,10 +534,11 @@ def _typeddict_assigned_value_ids(tree: ast.AST) -> frozenset[int]:
     the annotation provably names a frozen payload. Three conditions gate that:
     MyTd is a class-form TypedDict in this module (imported ones are invisible,
     exactly as in LIT012's base-class resolution); its name is bound exactly once
-    in the file (resolution here is scope-blind, so a name the file also binds as a
-    function, another class, an assignment target, or an import alias could resolve
-    to something mutable at the annotation site); and every field it declares or
-    inherits within the module is `ReadOnly[...]`, so no holder can statically
+    in the file (resolution here is scope-blind, so a name the file also binds in
+    any other form, another def, an assignment or loop target, an import alias, a
+    parameter, could resolve to something mutable at the annotation site); and
+    every field it declares or inherits within the module is `ReadOnly[...]`, so
+    no holder can statically
     rewrite a key even where LIT012 was suppressed or is riding its budget. Only
     the display itself is exempt; anything mutable nested inside it still trips
     LIT002.

--- a/scripts/check_type_discipline.py
+++ b/scripts/check_type_discipline.py
@@ -30,9 +30,11 @@ LIT002  Mutable-collection *construction*: a list/dict/set literal or comprehens
         spelling of the `MyTd(...)` call, which was never construction, and an
         all-ReadOnly payload cannot be grown or rewritten. The exemption is
         conservative: the TypedDict's name must be bound exactly once in the file
-        (a name also bound as a function, another class, an assignment target, or
-        an import alias might resolve to something mutable at the annotation
-        site), every field it declares or inherits in-module must be
+        (a name also bound in any other form, another def, an assignment or loop
+        target, an import alias, a parameter, might resolve to something mutable
+        at the annotation site, and a `from x import *` anywhere in the file
+        disqualifies every name, since what it binds is statically invisible),
+        every field it declares or inherits in-module must be
         `ReadOnly[...]`, only the display itself is exempt (nested mutables still
         count), and a TypedDict imported from another module is out of reach,
         exactly as in LIT012. Suppress with `# mutable-ok: <reason>`.
@@ -536,9 +538,10 @@ def _typeddict_assigned_value_ids(tree: ast.AST) -> frozenset[int]:
     exactly as in LIT012's base-class resolution); its name is bound exactly once
     in the file (resolution here is scope-blind, so a name the file also binds in
     any other form, another def, an assignment or loop target, an import alias, a
-    parameter, could resolve to something mutable at the annotation site); and
-    every field it declares or inherits within the module is `ReadOnly[...]`, so
-    no holder can statically
+    parameter, could resolve to something mutable at the annotation site, and a
+    `from x import *` anywhere disqualifies every name in the file, since what it
+    binds is statically invisible); and every field it declares or inherits
+    within the module is `ReadOnly[...]`, so no holder can statically
     rewrite a key even where LIT012 was suppressed or is riding its budget. Only
     the display itself is exempt; anything mutable nested inside it still trips
     LIT002.
@@ -558,6 +561,8 @@ def _typeddict_assigned_value_ids(tree: ast.AST) -> frozenset[int]:
         )
 
     bindings = tuple(name for node in ast.walk(tree) for name in _binding_names(node))
+    if "*" in bindings:
+        return frozenset()
     frozen_names = frozenset(
         cls.name for cls in classes if bindings.count(cls.name) == 1 and frozen_lineage(cls.name, frozenset())
     )

--- a/tests/test_litellm/test_check_type_discipline.py
+++ b/tests/test_litellm/test_check_type_discipline.py
@@ -238,6 +238,16 @@ def test_typeddict_name_rebound_elsewhere_gets_no_exemption(tmp_path):
         tmp_path, _TYPEDDICT_PREFIX + "def scope():\n    Td = dict\n    return Td\nx: Td = {'a': 1}\n"
     )
     assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "from elsewhere import Td\nx: Td = {'a': 1}\n")
+    assert "LIT002" in _codes(
+        tmp_path, _TYPEDDICT_PREFIX + "def scope(seq):\n    for Td in seq:\n        pass\nx: Td = {'a': 1}\n"
+    )
+    assert "LIT002" in _codes(
+        tmp_path, _TYPEDDICT_PREFIX + "def scope(seq):\n    Td, other = seq\n    return other\nx: Td = {'a': 1}\n"
+    )
+    assert "LIT002" in _codes(
+        tmp_path, _TYPEDDICT_PREFIX + "def scope(v):\n    return (Td := v)\nx: Td = {'a': 1}\n"
+    )
+    assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "def scope(Td):\n    return Td\nx: Td = {'a': 1}\n")
 
 
 def test_dict_literal_annotated_as_imported_or_unknown_type_still_counts(tmp_path):

--- a/tests/test_litellm/test_check_type_discipline.py
+++ b/tests/test_litellm/test_check_type_discipline.py
@@ -250,6 +250,10 @@ def test_typeddict_name_rebound_elsewhere_gets_no_exemption(tmp_path):
     assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "def scope(Td):\n    return Td\nx: Td = {'a': 1}\n")
 
 
+def test_star_import_disqualifies_typeddict_exemption(tmp_path):
+    assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "from elsewhere import *\nx: Td = {'a': 1}\n")
+
+
 def test_dict_literal_annotated_as_imported_or_unknown_type_still_counts(tmp_path):
     assert "LIT002" in _codes(tmp_path, "from other_module import Td\nx: Td = {'a': 1}\n")
     assert "LIT002" in _codes(tmp_path, "from typing import Final\ny: Final = {'a': 1}\n")

--- a/tests/test_litellm/test_check_type_discipline.py
+++ b/tests/test_litellm/test_check_type_discipline.py
@@ -250,6 +250,17 @@ def test_typeddict_name_rebound_elsewhere_gets_no_exemption(tmp_path):
     assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "def scope(Td):\n    return Td\nx: Td = {'a': 1}\n")
 
 
+def test_nested_typeddict_gets_no_exemption(tmp_path):
+    assert "LIT002" in _codes(
+        tmp_path,
+        "from typing import ReadOnly, TypedDict\n"
+        "def scope():\n"
+        "    class Td(TypedDict):\n"
+        "        a: ReadOnly[int]\n"
+        "x: Td = {'a': 1}\n",
+    )
+
+
 def test_qualified_annotation_gets_no_exemption(tmp_path):
     assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "import elsewhere\nx: elsewhere.Td = {'a': 1}\n")
     assert "LIT002" in _codes(

--- a/tests/test_litellm/test_check_type_discipline.py
+++ b/tests/test_litellm/test_check_type_discipline.py
@@ -250,6 +250,13 @@ def test_typeddict_name_rebound_elsewhere_gets_no_exemption(tmp_path):
     assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "def scope(Td):\n    return Td\nx: Td = {'a': 1}\n")
 
 
+def test_qualified_annotation_gets_no_exemption(tmp_path):
+    assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "import elsewhere\nx: elsewhere.Td = {'a': 1}\n")
+    assert "LIT002" in _codes(
+        tmp_path, _TYPEDDICT_PREFIX + "import elsewhere\nx: Final[elsewhere.Td] = {'a': 1}\n"
+    )
+
+
 def test_star_import_disqualifies_typeddict_exemption(tmp_path):
     assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "from elsewhere import *\nx: Td = {'a': 1}\n")
 

--- a/tests/test_litellm/test_check_type_discipline.py
+++ b/tests/test_litellm/test_check_type_discipline.py
@@ -215,6 +215,31 @@ def test_mutable_nested_inside_typeddict_literal_still_counts(tmp_path):
     assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "x: Td = {'a': 1, 'b': str([1])}\n")
 
 
+def test_writable_typeddict_literal_gets_no_exemption(tmp_path):
+    src = "from typing import Final, TypedDict\nclass Wtd(TypedDict):\n    a: int\nx: Final[Wtd] = {'a': 1}\n"
+    assert "LIT002" in _codes(tmp_path, src)
+
+
+def test_typeddict_inheriting_writable_fields_gets_no_exemption(tmp_path):
+    loose_sub = _TYPEDDICT_PREFIX + "class Loose(Td):\n    c: int\nz: Final[Loose] = {'a': 1, 'c': 2}\n"
+    assert "LIT002" in _codes(tmp_path, loose_sub)
+    writable_base = (
+        "from typing import Final, ReadOnly, TypedDict\n"
+        "class W(TypedDict):\n    a: int\n"
+        "class S(W):\n    b: ReadOnly[int]\n"
+        "x: Final[S] = {'a': 1, 'b': 2}\n"
+    )
+    assert "LIT002" in _codes(tmp_path, writable_base)
+
+
+def test_typeddict_name_rebound_elsewhere_gets_no_exemption(tmp_path):
+    assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "class Td:\n    pass\nx: Td = {'a': 1}\n")
+    assert "LIT002" in _codes(
+        tmp_path, _TYPEDDICT_PREFIX + "def scope():\n    Td = dict\n    return Td\nx: Td = {'a': 1}\n"
+    )
+    assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "from elsewhere import Td\nx: Td = {'a': 1}\n")
+
+
 def test_dict_literal_annotated_as_imported_or_unknown_type_still_counts(tmp_path):
     assert "LIT002" in _codes(tmp_path, "from other_module import Td\nx: Td = {'a': 1}\n")
     assert "LIT002" in _codes(tmp_path, "from typing import Final\ny: Final = {'a': 1}\n")

--- a/tests/test_litellm/test_check_type_discipline.py
+++ b/tests/test_litellm/test_check_type_discipline.py
@@ -193,6 +193,37 @@ def test_lit002_fix_message_names_mappingproxytype(tmp_path):
     assert "MappingProxyType" in messages[0]
 
 
+_TYPEDDICT_PREFIX = (
+    "from typing import Final, NotRequired, ReadOnly, TypedDict\n"
+    "class Td(TypedDict):\n"
+    "    a: ReadOnly[int]\n"
+    "    b: NotRequired[ReadOnly[str]]\n"
+)
+
+
+def test_dict_literal_annotated_as_typeddict_is_exempt(tmp_path):
+    assert "LIT002" not in _codes(tmp_path, _TYPEDDICT_PREFIX + "x: Td = {'a': 1}\n")
+    assert "LIT002" not in _codes(tmp_path, _TYPEDDICT_PREFIX + "y: Final[Td] = {'a': 1, 'b': 's'}\n")
+
+
+def test_dict_literal_annotated_as_transitive_typeddict_subclass_is_exempt(tmp_path):
+    src = _TYPEDDICT_PREFIX + "class Sub(Td):\n    c: ReadOnly[int]\nz: Final[Sub] = {'a': 1, 'c': 2}\n"
+    assert "LIT002" not in _codes(tmp_path, src)
+
+
+def test_mutable_nested_inside_typeddict_literal_still_counts(tmp_path):
+    assert "LIT002" in _codes(tmp_path, _TYPEDDICT_PREFIX + "x: Td = {'a': 1, 'b': str([1])}\n")
+
+
+def test_dict_literal_annotated_as_imported_or_unknown_type_still_counts(tmp_path):
+    assert "LIT002" in _codes(tmp_path, "from other_module import Td\nx: Td = {'a': 1}\n")
+    assert "LIT002" in _codes(tmp_path, "from typing import Final\ny: Final = {'a': 1}\n")
+
+
+def test_typeddict_call_spelling_is_not_construction(tmp_path):
+    assert "LIT002" not in _codes(tmp_path, _TYPEDDICT_PREFIX + "x: Final[Td] = Td(a=1)\n")
+
+
 def test_mutable_ok_with_reason_suppresses_both_rules(tmp_path):
     codes = _codes(tmp_path, "x: dict[str, int] = {}  # mutable-ok: in-place buffer mutated hot path\n")
     assert "LIT001" not in codes


### PR DESCRIPTION
## TLDR

Problem this solves:

- LIT002 flags `x: MyTd = {...}` but not the `MyTd(...)` spelling
- Same value and type either way, so the count is a spelling tax
- TypedDicts with non-identifier keys can't use the call spelling at all

How it solves it:

- Exempts dict literals assigned to names annotated with a TypedDict defined at the file's top level
- Only if the name is bound exactly once in the file
- Only if every declared or inherited field is `ReadOnly`
- Only the outer display: nested mutable literals still count

## User Flow

Before: a contributor who builds a TypedDict payload as an annotated dict literal fails the lint gate and must respell or suppress

1. They write `payload: Final[RequestKwargs] = {"model": m, "max_tokens": 128}` with `RequestKwargs` a TypedDict defined in the same module
2. They stage the change and run `make check`
3. The type-discipline gate fails: the line is reported as `LIT002 mutable dict literal` and the codebase count lands one over its ratcheted ceiling
4. To land the PR they respell the value as `RequestKwargs(model=m, max_tokens=128)` or add `# mutable-ok: <reason>`, though neither changes what the value is at runtime

After: the same literal passes the gate untouched

1. They write the same `payload: Final[RequestKwargs] = {"model": m, "max_tokens": 128}` line
2. They stage the change and run `make check`
3. The type-discipline gate passes: the literal now has the same standing as the `RequestKwargs(...)` call, and the LIT002 count is unchanged
4. When some other line does trip LIT002, its message now also names the annotated-literal spelling as a blessed fix

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Demo snippet `td_snip.py` (a TypedDict-annotated dict literal, the pattern this PR legalizes):

```python
from typing import Final, ReadOnly, TypedDict


class RequestKwargs(TypedDict):
    model: ReadOnly[str]
    max_tokens: ReadOnly[int]


payload: Final[RequestKwargs] = {"model": "gpt-5.5", "max_tokens": 128}
```

Before, at base commit 7fcca523aa:

```
$ python scripts/check_type_discipline.py td_snip.py
td_snip.py:9: LIT002 mutable dict literal: this builds a collection that can be grown or rewritten. ...

1 violation(s).
$ echo $?
1
```

After, at bbb5c9420d the same command prints nothing and exits 0

Gates and tests at bbb5c9420d, on top of `litellm_internal_staging`:

```
$ python scripts/type_discipline_gate.py
OK: every LIT rule is within its codebase ceiling (base origin/litellm_internal_staging)
$ python scripts/ruff_strict_gate.py
OK: every strict rule is within its codebase ceiling (base origin/litellm_internal_staging)
$ python scripts/type_check_gate.py
OK: every rule is within its basedpyright limit or no higher than base (145568 errors total)
$ pytest tests/test_litellm/test_check_type_discipline.py -q
97 passed in 0.29s
```

False-negative audit at bbb5c9420d: running the base checker and this branch's checker over `litellm/ tests/ enterprise/ scripts/` produces the identical set of 162,952 LIT002 lines, so no existing site gains the exemption today and `make lint-budget-update` moves no ceilings ("Ratcheted LIT-rule limits down by 0"). Exempted sites are also frozen by construction: the annotation must name a module-top-level TypedDict bound exactly once whose every declared and inherited field is `ReadOnly`, so a writable or `# writable-ok`'d TypedDict still counts

## Type

🚄 Infrastructure

## Caveats (if any)

- Top-level same-module TypedDicts only; imported ones still count, matching LIT012's reach, and one nested inside a def or class never qualifies since its name does not resolve outside its scope
- TypedDicts with any writable field still count, even where LIT012 was suppressed
- Names the file also binds in any other form (def, assignment, import, loop or walrus or unpacking target, parameter, capture) still count, and a `from x import *` anywhere in the file disqualifies every name in it
- Dotted annotations (`x: mod.Td = {...}`) never match, since they cannot name a local class
- String forward-reference annotations (`x: "MyTd"`) are not recognized

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only change to an internal checker with conservative guards and broad negative tests; no runtime or auth/data paths touched.
> 
> **Overview**
> **LIT002** no longer flags dict literals on annotated assignments when they are the same one-shot shape as a `TypedDict(...)` call. The type-discipline checker adds `_typeddict_assigned_value_ids` (plus helpers for annotation names and file-wide bindings) and unions that set into the existing LIT002 exemptions alongside annotation internals and freezing-wrapper arguments.
> 
> The exemption is **narrow**: module-top-level TypedDict whose name is bound exactly once, every field (including inherited) is `ReadOnly[...]`, bare or `Final[...]` annotation only—no dotted types, imported/nested TypedDicts, writable fields, `from x import *`, or rebound names. Nested mutables inside the literal still trip LIT002. Rule docs and the violation fix message now describe this path; tests cover happy paths and the conservative false-negative guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbb5c9420d267a22bdec3233a6dba2f6eec96af3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->