### PR TITLE
feat(cli): make the hidden `lite` command list configurable

### DIFF
--- a/litellm/proxy/client/cli/README.md
+++ b/litellm/proxy/client/cli/README.md
@@ -36,6 +36,17 @@ The base URL is resolved in this order of precedence:
 3. `base_url` from `~/.litellm/config.json`
 4. `http://localhost:4000`
 
+### Hiding commands from the listings
+
+Deployments that hand `lite` to end users often want to advertise only part of it. Store the commands to keep out of the listings, comma separated:
+
+```bash
+lite config set hidden_commands codex,opencode
+lite config unset hidden_commands   # list everything again
+```
+
+Hidden commands drop out of both `lite --help` and the interactive shell's "Available commands" block, and stay runnable so existing scripts keep working
+
 ## Global Options
 
 - `--version`, `-v`: Print the LiteLLM Proxy client and server version and exit.

--- a/litellm/proxy/client/cli/commands/agents.py
+++ b/litellm/proxy/client/cli/commands/agents.py
@@ -24,8 +24,6 @@ _KNOWN_AGENTS: Final[dict[str, tuple[str, frozenset[str]]]] = {
     "opencode": ("OpenCode", frozenset({PROFILE_OPENAI})),
 }
 
-_HIDDEN_AGENTS: Final[frozenset[str]] = frozenset({"codex", "opencode"})
-
 _INSTALL_DOCS: Final[dict[str, str]] = {
     "claude": "https://docs.claude.com/en/docs/claude-code/setup",
     "codex": "https://developers.openai.com/codex/cli",
@@ -258,12 +256,11 @@ def _launch(ctx: click.Context, binary: str, args: Sequence[str], *, skip_verify
         raise click.ClickException(str(e))
 
 
-def _make_agent_command(binary: str, display_name: str, *, hidden: bool) -> click.Command:
+def _make_agent_command(binary: str, display_name: str) -> click.Command:
     @click.command(
         name=binary,
         context_settings={"ignore_unknown_options": True},
         short_help=f"Run {display_name} through your LiteLLM proxy",
-        hidden=hidden,
     )
     @click.option("--skip-verify", is_flag=True, default=False, help=_SKIP_VERIFY_HELP)
     @click.argument("args", nargs=-1, type=click.UNPROCESSED)
@@ -281,15 +278,8 @@ def _make_agent_command(binary: str, display_name: str, *, hidden: bool) -> clic
 
 
 def agent_commands() -> tuple[click.Command, ...]:
-    """Build one top-level command per known agent, e.g. `lite claude`.
-
-    Agents in _HIDDEN_AGENTS stay invokable but are marked hidden so they drop
-    out of `lite --help` and the interactive shell's command listing.
-    """
-    return tuple(
-        _make_agent_command(binary, name, hidden=binary in _HIDDEN_AGENTS)
-        for binary, (name, _profiles) in _KNOWN_AGENTS.items()
-    )
+    """Build one top-level command per known agent, e.g. `lite claude`."""
+    return tuple(_make_agent_command(binary, name) for binary, (name, _profiles) in _KNOWN_AGENTS.items())
 
 
 __all__ = [

--- a/litellm/proxy/client/cli/commands/agents.py
+++ b/litellm/proxy/client/cli/commands/agents.py
@@ -24,6 +24,8 @@ _KNOWN_AGENTS: Final[dict[str, tuple[str, frozenset[str]]]] = {
     "opencode": ("OpenCode", frozenset({PROFILE_OPENAI})),
 }
 
+_HIDDEN_AGENTS: Final[frozenset[str]] = frozenset({"codex", "opencode"})
+
 _INSTALL_DOCS: Final[dict[str, str]] = {
     "claude": "https://docs.claude.com/en/docs/claude-code/setup",
     "codex": "https://developers.openai.com/codex/cli",
@@ -256,11 +258,12 @@ def _launch(ctx: click.Context, binary: str, args: Sequence[str], *, skip_verify
         raise click.ClickException(str(e))
 
 
-def _make_agent_command(binary: str, display_name: str) -> click.Command:
+def _make_agent_command(binary: str, display_name: str, *, hidden: bool) -> click.Command:
     @click.command(
         name=binary,
         context_settings={"ignore_unknown_options": True},
         short_help=f"Run {display_name} through your LiteLLM proxy",
+        hidden=hidden,
     )
     @click.option("--skip-verify", is_flag=True, default=False, help=_SKIP_VERIFY_HELP)
     @click.argument("args", nargs=-1, type=click.UNPROCESSED)
@@ -277,9 +280,16 @@ def _make_agent_command(binary: str, display_name: str) -> click.Command:
     return _command
 
 
-def agent_commands() -> list[click.Command]:
-    """Build one top-level command per known agent, e.g. `lite claude`."""
-    return [_make_agent_command(binary, name) for binary, (name, _profiles) in _KNOWN_AGENTS.items()]
+def agent_commands() -> tuple[click.Command, ...]:
+    """Build one top-level command per known agent, e.g. `lite claude`.
+
+    Agents in _HIDDEN_AGENTS stay invokable but are marked hidden so they drop
+    out of `lite --help` and the interactive shell's command listing.
+    """
+    return tuple(
+        _make_agent_command(binary, name, hidden=binary in _HIDDEN_AGENTS)
+        for binary, (name, _profiles) in _KNOWN_AGENTS.items()
+    )
 
 
 __all__ = [

--- a/litellm/proxy/client/cli/commands/config.py
+++ b/litellm/proxy/client/cli/commands/config.py
@@ -1,8 +1,9 @@
 import json
 import os
 import sys
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
+from types import MappingProxyType
 from typing import Final
 from urllib.parse import urlparse
 
@@ -11,7 +12,7 @@ from pydantic import TypeAdapter
 
 from .private_json import write_private_json
 
-ALLOWED_CONFIG_KEYS: Final[tuple[str, ...]] = ("base_url",)
+HIDDEN_COMMANDS_KEY: Final = "hidden_commands"
 
 _config_adapter: Final[TypeAdapter[Mapping[str, str]]] = TypeAdapter(Mapping[str, str])
 
@@ -49,6 +50,48 @@ def get_config_value(key: str) -> str | None:
     return load_config().get(key)
 
 
+def parse_hidden_commands(raw: str | None) -> frozenset[str]:
+    """Split a stored `hidden_commands` value, e.g. "codex, opencode"."""
+    return frozenset(name.strip() for name in (raw or "").split(",") if name.strip())
+
+
+def hidden_command_names() -> frozenset[str]:
+    """Top-level commands the operator chose to keep out of `lite`'s listings."""
+    return parse_hidden_commands(get_config_value(HIDDEN_COMMANDS_KEY))
+
+
+def _normalize_base_url(value: str) -> str:
+    parsed: Final = urlparse(value)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise click.UsageError("base_url must be a full http:// or https:// URL including a host")
+    if "?" in value or "#" in value:
+        raise click.UsageError("base_url must not include a query string or fragment")
+    return value.rstrip("/")
+
+
+def _normalize_hidden_commands(value: str) -> str:
+    names: Final = parse_hidden_commands(value)
+    if not names:
+        raise click.UsageError(
+            f"{HIDDEN_COMMANDS_KEY} must be a comma-separated list of command names, e.g. "
+            f"`lite config set {HIDDEN_COMMANDS_KEY} codex,opencode`. To list everything again, "
+            f"run `lite config unset {HIDDEN_COMMANDS_KEY}`"
+        )
+    if any(" " in name for name in names):
+        raise click.UsageError(f"{HIDDEN_COMMANDS_KEY} entries must be single command names, without spaces")
+    return ",".join(sorted(names))
+
+
+_NORMALIZERS: Final[Mapping[str, Callable[[str], str]]] = MappingProxyType(
+    {
+        "base_url": _normalize_base_url,
+        HIDDEN_COMMANDS_KEY: _normalize_hidden_commands,
+    }
+)
+
+ALLOWED_CONFIG_KEYS: Final[tuple[str, ...]] = tuple(_NORMALIZERS)
+
+
 @click.group(name="config")
 def config_commands() -> None:
     """Manage persistent CLI configuration (~/.litellm/config.json)"""
@@ -59,17 +102,11 @@ def config_commands() -> None:
 @click.argument("value")
 def set_config(key: str, value: str) -> None:
     """Set a config KEY to VALUE (e.g. `lite config set base_url https://your-proxy.example.com`)"""
-    if key not in ALLOWED_CONFIG_KEYS:
+    normalizer: Final = _NORMALIZERS.get(key)
+    if normalizer is None:
         raise click.UsageError(f"Unknown config key '{key}'. Allowed keys: {', '.join(ALLOWED_CONFIG_KEYS)}")
 
-    if key == "base_url":
-        parsed: Final = urlparse(value)
-        if parsed.scheme not in ("http", "https") or not parsed.netloc:
-            raise click.UsageError("base_url must be a full http:// or https:// URL including a host")
-        if "?" in value or "#" in value:
-            raise click.UsageError("base_url must not include a query string or fragment")
-
-    normalized_value: Final = value.rstrip("/")
+    normalized_value: Final = normalizer(value)
     save_config({**load_config(), key: normalized_value})
     click.echo(f"Set {key} = {normalized_value} in {get_config_file_path()}")
 

--- a/litellm/proxy/client/cli/interface.py
+++ b/litellm/proxy/client/cli/interface.py
@@ -89,7 +89,7 @@ def show_commands():
         ("teams", "Manage teams and team assignments"),
         ("users", "Manage users"),
     ]
-    commands += [(c.name, c.get_short_help_str()) for c in agent_commands()]
+    commands += [(c.name, c.get_short_help_str()) for c in agent_commands() if not c.hidden]
     commands += [
         ("version", "Show version information"),
         ("help", "Show this help message"),

--- a/litellm/proxy/client/cli/interface.py
+++ b/litellm/proxy/client/cli/interface.py
@@ -74,8 +74,9 @@ def styled_prompt():
 
 
 def show_commands():
-    """Display available commands."""
+    """Display available commands, minus any the operator chose to hide."""
     from .commands.agents import agent_commands
+    from .commands.config import hidden_command_names
 
     commands = [
         ("login", "Authenticate with the LiteLLM proxy server"),
@@ -89,16 +90,19 @@ def show_commands():
         ("teams", "Manage teams and team assignments"),
         ("users", "Manage users"),
     ]
-    commands += [(c.name, c.get_short_help_str()) for c in agent_commands() if not c.hidden]
+    commands += [(c.name, c.get_short_help_str()) for c in agent_commands()]
     commands += [
         ("version", "Show version information"),
         ("help", "Show this help message"),
         ("quit", "Exit the interactive session"),
     ]
 
+    hidden: Final = hidden_command_names()
+
     click.echo("Available commands:")
     for cmd, description in commands:
-        click.echo(f"  {cmd:<20} {description}")
+        if cmd not in hidden:
+            click.echo(f"  {cmd:<20} {description}")
     click.echo()
 
 

--- a/litellm/proxy/client/cli/main.py
+++ b/litellm/proxy/client/cli/main.py
@@ -12,7 +12,7 @@ from .commands.agents import agent_commands
 from .commands.auth import auth_group, get_stored_api_key, login, logout, whoami
 from .commands.autoroute.commands import autoroute_group
 from .commands.chat import chat
-from .commands.config import config_commands, get_config_value
+from .commands.config import config_commands, get_config_value, hidden_command_names
 from .commands.credentials import credentials
 from .commands.encryption import encryption
 from .commands.http import http
@@ -43,7 +43,21 @@ def print_version(base_url: str, api_key: str | None):
         click.echo(f"Could not retrieve server version: {e}")
 
 
-@click.group(invoke_without_command=True)
+class HideConfiguredCommandsGroup(click.Group):
+    """Group that omits operator-hidden commands from listings, still running them.
+
+    Deployments hand `lite` to users who should only see a curated subset of
+    commands (`lite config set hidden_commands codex,opencode`). Filtering the
+    listing rather than dropping the commands keeps anyone's existing scripts
+    working.
+    """
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        hidden: Final = hidden_command_names()
+        return [name for name in super().list_commands(ctx) if name not in hidden]
+
+
+@click.group(cls=HideConfiguredCommandsGroup, invoke_without_command=True)
 @click.option(
     "--version",
     "-v",

--- a/tests/test_litellm/proxy/client/cli/test_agents.py
+++ b/tests/test_litellm/proxy/client/cli/test_agents.py
@@ -12,6 +12,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 
+from litellm.proxy.client.cli import cli
 from litellm.proxy.client.cli.commands.agents import (
     AgentRunError,
     agent_commands,
@@ -21,6 +22,7 @@ from litellm.proxy.client.cli.commands.agents import (
     run_agent,
     verify_proxy_key,
 )
+from litellm.proxy.client.cli.interface import show_commands
 
 AGENTS_MODULE = "litellm.proxy.client.cli.commands.agents"
 
@@ -473,3 +475,41 @@ class TestAgentCommands:
             )
         assert result.exit_code == 0, result.output
         assert captured["reattach_terminal"] is None
+
+
+class TestUnsupportedAgentsAreHiddenButUsable:
+    def setup_method(self) -> None:
+        self.runner = CliRunner()
+
+    def test_top_level_help_lists_claude_but_not_codex_or_opencode(self) -> None:
+        result = self.runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "claude" in result.output
+        assert "codex" not in result.output
+        assert "opencode" not in result.output
+
+    def test_interactive_shell_listing_omits_codex_and_opencode(self, capsys: pytest.CaptureFixture[str]) -> None:
+        show_commands()
+        listing = capsys.readouterr().out
+        assert "claude" in listing
+        assert "codex" not in listing
+        assert "opencode" not in listing
+
+    def test_hidden_agents_are_still_invokable(self) -> None:
+        with patch(f"{AGENTS_MODULE}.run_agent") as run_agent_mock:
+            result = self.runner.invoke(
+                cli,
+                [
+                    "--base-url",
+                    "http://localhost:4000",
+                    "--api-key",
+                    "sk-key",
+                    "codex",
+                    "exec",
+                    "do a thing",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        _base_url, _api_key, command = run_agent_mock.call_args.args
+        assert list(command) == ["codex", "exec", "do a thing"]
+        assert "routing Codex through proxy" in result.output

--- a/tests/test_litellm/proxy/client/cli/test_agents.py
+++ b/tests/test_litellm/proxy/client/cli/test_agents.py
@@ -12,7 +12,6 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 
-from litellm.proxy.client.cli import cli
 from litellm.proxy.client.cli.commands.agents import (
     AgentRunError,
     agent_commands,
@@ -22,7 +21,6 @@ from litellm.proxy.client.cli.commands.agents import (
     run_agent,
     verify_proxy_key,
 )
-from litellm.proxy.client.cli.interface import show_commands
 
 AGENTS_MODULE = "litellm.proxy.client.cli.commands.agents"
 
@@ -475,41 +473,3 @@ class TestAgentCommands:
             )
         assert result.exit_code == 0, result.output
         assert captured["reattach_terminal"] is None
-
-
-class TestUnsupportedAgentsAreHiddenButUsable:
-    def setup_method(self) -> None:
-        self.runner = CliRunner()
-
-    def test_top_level_help_lists_claude_but_not_codex_or_opencode(self) -> None:
-        result = self.runner.invoke(cli, ["--help"])
-        assert result.exit_code == 0, result.output
-        assert "claude" in result.output
-        assert "codex" not in result.output
-        assert "opencode" not in result.output
-
-    def test_interactive_shell_listing_omits_codex_and_opencode(self, capsys: pytest.CaptureFixture[str]) -> None:
-        show_commands()
-        listing = capsys.readouterr().out
-        assert "claude" in listing
-        assert "codex" not in listing
-        assert "opencode" not in listing
-
-    def test_hidden_agents_are_still_invokable(self) -> None:
-        with patch(f"{AGENTS_MODULE}.run_agent") as run_agent_mock:
-            result = self.runner.invoke(
-                cli,
-                [
-                    "--base-url",
-                    "http://localhost:4000",
-                    "--api-key",
-                    "sk-key",
-                    "codex",
-                    "exec",
-                    "do a thing",
-                ],
-            )
-        assert result.exit_code == 0, result.output
-        _base_url, _api_key, command = run_agent_mock.call_args.args
-        assert list(command) == ["codex", "exec", "do a thing"]
-        assert "routing Codex through proxy" in result.output

--- a/tests/test_litellm/proxy/client/cli/test_config_commands.py
+++ b/tests/test_litellm/proxy/client/cli/test_config_commands.py
@@ -3,6 +3,7 @@ import os
 import stat
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
@@ -18,6 +19,7 @@ from litellm.proxy.client.cli.commands.config import (
     save_config,
 )
 from litellm.proxy.client.cli.commands.private_json import write_private_json
+from litellm.proxy.client.cli.interface import show_commands
 
 
 @pytest.fixture
@@ -177,6 +179,85 @@ class TestConfigUnset:
 
         assert result.exit_code == 0
         assert "not set" in result.output.lower()
+
+
+class TestHiddenCommands:
+    """`hidden_commands` lets a deployment curate what `lite` advertises.
+
+    Two listings exist and both must honor it: click's own `--help` table and the
+    hand-rolled block the interactive shell prints.
+    """
+
+    def test_nothing_is_hidden_by_default(self, cli_runner, isolated_home):
+        result = cli_runner.invoke(cli, ["--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "codex" in result.output
+        assert "opencode" in result.output
+
+    def test_configured_commands_drop_out_of_help(self, cli_runner, isolated_home):
+        assert cli_runner.invoke(cli, ["config", "set", "hidden_commands", "codex,opencode"]).exit_code == 0
+
+        result = cli_runner.invoke(cli, ["--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "claude" in result.output
+        assert "codex" not in result.output
+        assert "opencode" not in result.output
+
+    def test_configured_commands_drop_out_of_interactive_listing(self, capsys, isolated_home):
+        save_config({"hidden_commands": "codex,keys"})
+
+        show_commands()
+        listing = capsys.readouterr().out
+
+        assert "claude" in listing
+        assert "codex" not in listing
+        assert "keys" not in listing
+        assert "teams" in listing
+
+    def test_hidden_commands_are_still_invokable(self, cli_runner, isolated_home):
+        """Hiding is about the listing only; anyone already scripting the command keeps working."""
+        save_config({"hidden_commands": "codex"})
+
+        with patch("litellm.proxy.client.cli.commands.agents.run_agent") as run_agent_mock:
+            result = cli_runner.invoke(
+                cli,
+                ["--base-url", "http://localhost:4000", "--api-key", "sk-key", "codex", "exec", "do a thing"],
+            )
+
+        assert result.exit_code == 0, result.output
+        _base_url, _api_key, command = run_agent_mock.call_args.args
+        assert list(command) == ["codex", "exec", "do a thing"]
+
+    def test_unset_brings_the_commands_back(self, cli_runner, isolated_home):
+        assert cli_runner.invoke(cli, ["config", "set", "hidden_commands", "codex"]).exit_code == 0
+        assert cli_runner.invoke(cli, ["config", "unset", "hidden_commands"]).exit_code == 0
+
+        assert "codex" in cli_runner.invoke(cli, ["--help"]).output
+
+    def test_set_normalizes_whitespace_and_ordering(self, cli_runner, isolated_home):
+        result = cli_runner.invoke(cli, ["config", "set", "hidden_commands", " opencode , codex ,"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(_config_path(isolated_home).read_text()) == {"hidden_commands": "codex,opencode"}
+
+    @pytest.mark.parametrize("value", ["", " ", ",", " , "])
+    def test_set_empty_list_rejected(self, cli_runner, isolated_home, value):
+        """An empty value would silently hide nothing; point users at `config unset` instead."""
+        result = cli_runner.invoke(cli, ["config", "set", "hidden_commands", value])
+
+        assert result.exit_code != 0
+        assert "unset" in result.output
+        assert not _config_path(isolated_home).exists()
+
+    def test_set_space_separated_list_rejected(self, cli_runner, isolated_home):
+        """`lite config set hidden_commands "codex opencode"` would hide neither."""
+        result = cli_runner.invoke(cli, ["config", "set", "hidden_commands", "codex opencode"])
+
+        assert result.exit_code != 0
+        assert "without spaces" in result.output
+        assert not _config_path(isolated_home).exists()
 
 
 class TestConfigHelpers:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Deployments want `lite` to advertise only some commands
- The list of commands to hide is deployment specific
- Codex and OpenCode are supported, so hardcoding them was wrong

How it solves it:

- New `hidden_commands` key in `~/.litellm/config.json`
- Hidden commands leave both listings but stay invokable
- Nothing is hidden by default

## User Flow

Before: an admin rolling `lite` out to their org cannot trim what it advertises, so every user sees every command

1. The admin runs `lite config set hidden_commands codex,opencode` and gets `Error: Unknown config key 'hidden_commands'. Allowed keys: base_url`
2. Their users run `lite --help` and see the full command table, including the agents the org does not want them using
3. Their users run bare `lite` and the interactive shell's "Available commands" block lists the same set

After: the admin curates the listing once, per machine, and users see only what the org supports

1. The admin runs `lite config set hidden_commands codex,opencode` and gets `Set hidden_commands = codex,opencode in ~/.litellm/config.json`
2. Their users run `lite --help` and the command table shows `claude` with no `codex` or `opencode` row
3. Their users run bare `lite` and the "Available commands" block also shows only `claude`
4. Someone who already scripted `lite codex exec "..."` runs it unchanged and it still routes through the proxy
5. The admin runs `lite config unset hidden_commands` and both listings show everything again

## Relevant issues

## Linear ticket

Resolves LIT-4893

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The first revision of this PR hardcoded `codex` and `opencode` as hidden. That was wrong: both are wired through the proxy on purpose, Codex via `-c model_provider=litellm` overrides and OpenCode via `OPENAI_BASE_URL`, and both are documented as supported, so the hiding is now the operator's choice instead

There are two listings, and both had to honor the config: click's own `--help` table, and the hand-rolled "Available commands" block the interactive shell prints. Everything below is one run of the real `lite` entry point at `6bcd6adb50`, against `HOME=/tmp/litehome`, with no mocks

```
$ lite --help | sed -n '/Commands:/,$p'
Commands:
  auth          Manage CLI authentication (apiKeyHelper support, etc.)
  ...
  claude        Run Claude Code through your LiteLLM proxy
  codex         Run Codex through your LiteLLM proxy
  ...
  opencode      Run OpenCode through your LiteLLM proxy
  ...

$ lite config set hidden_commands codex,opencode
Set hidden_commands = codex,opencode in /tmp/litehome/.litellm/config.json

$ lite config get
hidden_commands = codex,opencode

$ lite --help | grep -E "claude|codex|opencode"
  claude        Run Claude Code through your LiteLLM proxy
  down          Restore ~/.claude/settings.json if a `lite up` session...

$ echo quit | lite | sed -n '/Available commands/,/quit/p'
Available commands:
  login                Authenticate with the LiteLLM proxy server
  ...
  users                Manage users
  claude               Run Claude Code through your LiteLLM proxy
  version              Show version information
  help                 Show this help message
  quit                 Exit the interactive session

$ lite --base-url http://localhost:4000 --api-key sk-nope codex --help | head -3
Usage: lite codex [OPTIONS] [ARGS]...

  Run Codex routed through your LiteLLM proxy.

$ lite config set hidden_commands "codex opencode"
Error: hidden_commands entries must be single command names, without spaces

$ lite config unset hidden_commands
Removed hidden_commands from /tmp/litehome/.litellm/config.json

$ lite --help | grep -E "claude|codex|opencode"
  claude        Run Claude Code through your LiteLLM proxy
  codex         Run Codex through your LiteLLM proxy
  down          Restore ~/.claude/settings.json if a `lite up` session...
  opencode      Run OpenCode through your LiteLLM proxy
```

A screen recording of the same flow, including the adversarial inputs, is posted in the [Slack thread](https://berriaillm.slack.com/archives/C0AE9HJQUHG/p1786660491055559?thread_ts=1786660491.055559&cid=C0AE9HJQUHG). Both the before behavior and the after behavior were captured at `6bcd6adb50`, the before by removing the config file rather than checking out the older revision, since nothing is hidden by default anymore

## Type

🆕 New Feature

## Caveats (if any)

- Hiding is cosmetic; hidden commands still run
- Config is per machine, so admins ship it with their rollout
- Matching is case sensitive, so `CODEX` hides nothing

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/699afc118c0b4f8bae39953f65e85865
Requested by: @yassin-berriai