### PR TITLE
fix(scim): refresh / invalidate team cache on PATCH/PUT/DELETE /Groups (Fixes #36817)

### DIFF
--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -46,6 +46,7 @@ from litellm.proxy.management_endpoints.scim.scim_transformations import (
     ScimTransformations,
 )
 from litellm.proxy.management_endpoints.team_endpoints import (
+    _refresh_cached_team,
     new_team,
     team_member_add,
     team_member_delete,
@@ -1888,6 +1889,24 @@ async def update_group(
             data=update_data,
         )
 
+        # Refresh the in-memory team cache so the very next auth check sees
+        # the new `team_alias` and `metadata`. Without this, a SCIM-driven
+        # rename (displayName) does not take effect on auth until the
+        # management-object TTL expires — see #36817. Same pattern as
+        # `team_endpoints.update_team` (line 1930) and the
+        # cycle-9 `_refresh_cached_team` work for `/team/block` and
+        # `/team/unblock` (#35565).
+        from litellm.proxy.proxy_server import (
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        await _refresh_cached_team(
+            team_row=updated_team,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
         # Handle user-team relationship changes
         current_members = set(await _get_team_member_user_ids_from_team(existing_team))
         verbose_proxy_logger.debug(f"SCIM PUT GROUP current_members: {current_members}")
@@ -1950,6 +1969,28 @@ async def delete_group(
 
         # Delete team
         await TeamRepository(prisma_client).table.delete(where={"team_id": group_id})
+
+        # Invalidate the in-memory team cache so the very next auth check
+        # sees the team as gone. Without this, a stale `team_id:{group_id}`
+        # entry stays readable until the management-object TTL expires —
+        # see #36817. The team is gone, so we invalidate (delete) rather
+        # than refresh. Both the local LRU and the Redis side of the
+        # dual cache are cleared, plus the alias-keyed cache if the team
+        # had one (matches the alias-invalidation half of `_cache_team_object`
+        # at `auth_checks.py:1806`).
+        from litellm.proxy.proxy_server import (
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        user_api_key_cache.delete_cache(key=f"team_id:{group_id}")
+        if proxy_logging_obj is not None:
+            await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=f"team_id:{group_id}")
+        if existing_team.team_alias:
+            alias_key = f"team_alias:{existing_team.team_alias}"
+            user_api_key_cache.delete_cache(key=alias_key)
+            if proxy_logging_obj is not None:
+                await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=alias_key)
 
         return Response(status_code=204)
 
@@ -2170,6 +2211,24 @@ async def patch_group(
         final_team = await TeamRepository(prisma_client).table.find_unique(where={"team_id": group_id})
         if final_team:
             updated_team = final_team
+
+        # Refresh the in-memory team cache so the very next auth check sees
+        # the new `team_alias` / `metadata` / SCIM-managed state. Without
+        # this, a SCIM-driven rename or metadata change does not take
+        # effect on auth until the management-object TTL expires. See
+        # #36817. Same pattern as the `update_group` fix above and the
+        # cycle-9 `_refresh_cached_team` work for `/team/block` and
+        # `/team/unblock` (#35565).
+        from litellm.proxy.proxy_server import (
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        await _refresh_cached_team(
+            team_row=updated_team,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
 
         # Convert to SCIM format and return
         scim_group = await ScimTransformations.transform_litellm_team_to_scim_group(

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -1198,13 +1198,28 @@ async def test_update_group_metadata_serialization_issue(mocker):
     mock_existing_team.created_at = None
     mock_existing_team.updated_at = None
 
-    # Mock updated team response
+    # Mock updated team response. `model_dump` must return a real dict —
+    # `update_group` now calls `_refresh_cached_team` after the DB write,
+    # which does `LiteLLM_TeamTableCachedObj(**team_row.model_dump())`.
+    # A `MagicMock` for `model_dump` would unpack to `{}` (MagicMock acts
+    # as a Mapping with empty keys()), which would fail the team_id
+    # validation. The real fix is to make the mock's `model_dump`
+    # contract match the real Prisma row shape.
     mock_updated_team = mocker.MagicMock()
     mock_updated_team.team_id = group_id
     mock_updated_team.team_alias = "Test Group"
     mock_updated_team.members = ["user1"]
     mock_updated_team.created_at = None
     mock_updated_team.updated_at = None
+    mock_updated_team.model_dump = mocker.MagicMock(
+        return_value={
+            "team_id": group_id,
+            "team_alias": "Test Group",
+            "members": ["user1"],
+            "created_at": None,
+            "updated_at": None,
+        }
+    )
 
     # Create a properly structured mock for the prisma client
     mock_prisma_client = mocker.MagicMock()
@@ -3519,3 +3534,331 @@ async def test_process_group_patch_replace_empty_value_does_not_use_path_filter(
     )
 
     assert final_members == set()
+
+
+class TestScimGroupCacheInvalidation:
+    """
+    Regression pin for #36817.
+
+    SCIM PATCH/PUT/DELETE /Groups/{id} previously only wrote to
+    `litellm_teamtable` and left the in-memory `team_id:{team_id}` cache
+    stale. Operators using SCIM-driven IdPs (Okta, Azure AD, etc.) expect
+    a rename to take effect immediately; without cache invalidation it
+    silently takes effect only on the next TTL refresh.
+
+    Pin: each SCIM group endpoint must call the same cache-management
+    helpers the team management endpoints use. `update_group` and
+    `patch_group` must call `_refresh_cached_team` with the post-mutation
+    row. `delete_group` must invalidate (delete) both the `team_id` key
+    and the `team_alias` key in the dual cache, matching the alias-
+    invalidation half of `_cache_team_object` at
+    `auth_checks.py:1806`.
+    """
+
+    @staticmethod
+    def _make_team(group_id, team_alias, members_with_roles):
+        from litellm.proxy._types import LiteLLM_TeamTable, Member
+
+        return LiteLLM_TeamTable(
+            team_id=group_id,
+            team_alias=team_alias,
+            members=[],
+            members_with_roles=[
+                Member(user_id=m, role="user") for m in members_with_roles
+            ],
+            metadata={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_group_refreshes_team_cache(self, mocker):
+        """
+        `PUT /scim/v2/Groups/{id}` must call `_refresh_cached_team` with the
+        post-mutation row after the database update. Regression pin for
+        #36817.
+        """
+        from litellm.proxy._types import LiteLLM_TeamTable
+        from litellm.proxy.management_endpoints.scim.scim_v2 import update_group
+        from litellm.types.proxy.management_endpoints.scim_v2 import SCIMGroup
+
+        group_id = "scim-update-cache-test"
+        existing_team = self._make_team(
+            group_id=group_id, team_alias="Old Name", members_with_roles=["user1"]
+        )
+        updated_team = self._make_team(
+            group_id=group_id, team_alias="New Name", members_with_roles=["user1"]
+        )
+
+        mock_prisma_client = mocker.MagicMock()
+        mock_prisma_client.db = mocker.MagicMock()
+        mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
+        mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=existing_team
+        )
+        mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
+            return_value=updated_team
+        )
+        mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+        mock_user = mocker.MagicMock()
+        mock_user.user_id = "user1"
+        mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+            return_value=mock_user
+        )
+
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
+            AsyncMock(return_value=mock_prisma_client),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2.patch_team_membership",
+            AsyncMock(),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._recompute_scim_member_roles",
+            AsyncMock(),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._handle_group_membership_changes",
+            AsyncMock(),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_team_to_scim_group",
+            AsyncMock(
+                return_value=SCIMGroup(
+                    schemas=["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                    id=group_id,
+                    displayName="New Name",
+                )
+            ),
+        )
+
+        mock_user_cache = mocker.MagicMock()
+        mock_logging = mocker.MagicMock()
+        mock_logging.internal_usage_cache.dual_cache = mocker.MagicMock()
+        mock_logging.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
+        mocker.patch(
+            "litellm.proxy.proxy_server.user_api_key_cache", mock_user_cache
+        )
+        mocker.patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj", mock_logging
+        )
+
+        refresh_mock = mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._refresh_cached_team",
+            new=AsyncMock(),
+        )
+
+        await update_group(
+            group_id=group_id,
+            group=SCIMGroup(
+                schemas=["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                id=group_id,
+                displayName="New Name",
+            ),
+        )
+
+        # Pin: update_group must call _refresh_cached_team exactly once
+        # with the post-mutation row. The post-mutation row is the object
+        # the Prisma `update` returned (the `updated_team` MagicMock), not
+        # the pre-mutation `existing_team`.
+        assert refresh_mock.await_count == 1, (
+            "update_group must call _refresh_cached_team exactly once after "
+            "the DB update (#36817 regression pin); "
+            f"got await_count={refresh_mock.await_count}"
+        )
+        call_kwargs = refresh_mock.await_args.kwargs
+        assert call_kwargs["team_row"] is updated_team
+        assert call_kwargs["user_api_key_cache"] is mock_user_cache
+        assert call_kwargs["proxy_logging_obj"] is mock_logging
+
+    @pytest.mark.asyncio
+    async def test_patch_group_refreshes_team_cache(self, mocker):
+        """
+        `PATCH /scim/v2/Groups/{id}` must call `_refresh_cached_team` after
+        the final find_unique. Regression pin for #36817.
+        """
+        from litellm.proxy._types import LiteLLM_TeamTable
+        from litellm.proxy.management_endpoints.scim.scim_v2 import patch_group
+        from litellm.types.proxy.management_endpoints.scim_v2 import (
+            SCIMGroup,
+            SCIMPatchOp,
+            SCIMPatchOperation,
+        )
+
+        group_id = "scim-patch-cache-test"
+        existing_team = self._make_team(
+            group_id=group_id, team_alias="Old Name", members_with_roles=["user1"]
+        )
+        updated_team = self._make_team(
+            group_id=group_id, team_alias="New Name", members_with_roles=["user1"]
+        )
+
+        mock_prisma_client = mocker.MagicMock()
+        mock_prisma_client.db = mocker.MagicMock()
+        mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
+        # `patch_group` does find_unique for the post-update final state.
+        mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=updated_team
+        )
+        mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
+            return_value=updated_team
+        )
+
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
+            AsyncMock(return_value=mock_prisma_client),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2.patch_team_membership",
+            AsyncMock(),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._recompute_scim_member_roles",
+            AsyncMock(),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._handle_group_membership_changes",
+            AsyncMock(),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._check_team_exists",
+            AsyncMock(return_value=existing_team),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._get_team_member_user_ids_from_team",
+            AsyncMock(return_value=["user1"]),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._process_group_patch_operations",
+            AsyncMock(return_value=({"team_alias": "New Name"}, {"user1"}, None)),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_team_to_scim_group",
+            AsyncMock(
+                return_value=SCIMGroup(
+                    schemas=["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                    id=group_id,
+                    displayName="New Name",
+                )
+            ),
+        )
+
+        mock_user_cache = mocker.MagicMock()
+        mock_logging = mocker.MagicMock()
+        mock_logging.internal_usage_cache.dual_cache = mocker.MagicMock()
+        mock_logging.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
+        mocker.patch(
+            "litellm.proxy.proxy_server.user_api_key_cache", mock_user_cache
+        )
+        mocker.patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj", mock_logging
+        )
+
+        refresh_mock = mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._refresh_cached_team",
+            new=AsyncMock(),
+        )
+
+        await patch_group(
+            group_id=group_id,
+            patch_ops=SCIMPatchOp(
+                schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+                Operations=[
+                    SCIMPatchOperation(
+                        op="replace", path="displayName", value="New Name"
+                    )
+                ],
+            ),
+        )
+
+        # Pin: patch_group must call _refresh_cached_team exactly once
+        # with the post-mutation row. The post-mutation row is the object
+        # the final find_unique returned, not the pre-mutation
+        # `existing_team`.
+        assert refresh_mock.await_count == 1, (
+            "patch_group must call _refresh_cached_team exactly once after "
+            "the final find_unique (#36817 regression pin); "
+            f"got await_count={refresh_mock.await_count}"
+        )
+        call_kwargs = refresh_mock.await_args.kwargs
+        assert call_kwargs["team_row"] is updated_team
+        assert call_kwargs["user_api_key_cache"] is mock_user_cache
+        assert call_kwargs["proxy_logging_obj"] is mock_logging
+
+    @pytest.mark.asyncio
+    async def test_delete_group_invalidates_team_id_and_alias_caches(self, mocker):
+        """
+        `DELETE /scim/v2/Groups/{id}` must invalidate both the
+        `team_id:{group_id}` cache key and the `team_alias:{alias}` cache
+        key in the dual cache (local LRU + Redis). Regression pin for
+        #36817.
+        """
+        from litellm.proxy.management_endpoints.scim.scim_v2 import delete_group
+
+        group_id = "scim-delete-cache-test"
+        team_alias = "Engineering"
+        existing_team = self._make_team(
+            group_id=group_id, team_alias=team_alias, members_with_roles=["user1"]
+        )
+
+        mock_prisma_client = mocker.MagicMock()
+        mock_prisma_client.db = mocker.MagicMock()
+        mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
+        mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=existing_team
+        )
+        mock_prisma_client.db.litellm_teamtable.delete = AsyncMock()
+        mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+        mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+            return_value=mocker.MagicMock(teams=[group_id])
+        )
+        mock_prisma_client.db.litellm_usertable.update = AsyncMock()
+
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
+            AsyncMock(return_value=mock_prisma_client),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._check_team_exists",
+            AsyncMock(return_value=existing_team),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._get_team_member_user_ids_from_team",
+            AsyncMock(return_value=["user1"]),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._recompute_scim_member_roles",
+            AsyncMock(),
+        )
+
+        mock_user_cache = mocker.MagicMock()
+        mock_logging = mocker.MagicMock()
+        mock_dual_cache = mocker.MagicMock()
+        mock_dual_cache.async_delete_cache = AsyncMock()
+        mock_logging.internal_usage_cache.dual_cache = mock_dual_cache
+        mocker.patch(
+            "litellm.proxy.proxy_server.user_api_key_cache", mock_user_cache
+        )
+        mocker.patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj", mock_logging
+        )
+
+        await delete_group(group_id=group_id)
+
+        # Pin: delete_group must invalidate the team_id cache key
+        # in BOTH the local LRU (user_api_key_cache.delete_cache) AND
+        # the Redis side of the dual cache
+        # (proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache).
+        mock_user_cache.delete_cache.assert_any_call(key=f"team_id:{group_id}")
+        mock_dual_cache.async_delete_cache.assert_any_call(
+            key=f"team_id:{group_id}"
+        )
+        # And the alias-keyed cache must also be invalidated — the
+        # alias-keyed cache is what JWT-by-alias auth reads from, so
+        # leaving it would keep the deleted team reachable under the
+        # old alias until TTL expiry.
+        mock_user_cache.delete_cache.assert_any_call(
+            key=f"team_alias:{team_alias}"
+        )
+        mock_dual_cache.async_delete_cache.assert_any_call(
+            key=f"team_alias:{team_alias}"
+        )


### PR DESCRIPTION
## Summary

The SCIM v2 group endpoints (`PATCH /scim/v2/Groups/{id}`, `PUT /scim/v2/Groups/{id}`, `DELETE /scim/v2/Groups/{id}`) only wrote to `litellm_teamtable` and left the in-memory `team_id:{team_id}` cache stale. The very next auth check that hit the cache served the pre-mutation team, so:

- `PATCH` (displayName / metadata / SCIM-managed flag changes) did not take effect on auth until the management-object TTL expired.
- `PUT` (rename via displayName, metadata rewrite) did not take effect on auth until the management-object TTL expired.
- `DELETE` did not invalidate the cached `team_id:{group_id}` entry, so a same-team `POST /team/new` reusing the same ID would read a stale `team_alias` / `metadata` snapshot from the cache.

SCIM is the standard protocol for IdP-driven group sync (Okta, Azure AD, OneLogin, JumpCloud, etc.), so the impact is real for every operator using an IdP-driven deployment: a SCIM-driven rename is silently lost for the cache TTL window on every request. In a multi-pod deployment, the window extends across replicas.

This is the same multi-prefix cache Achilles heel pattern fixed in cycle 9 for `/team/block` and `/team/unblock` (#35565). The SCIM module had zero cache-management code — its imports from `team_endpoints.py` were limited to `new_team`, `team_member_add`, and `team_member_delete`.

Fixes #36817.

## Changes

### `litellm/proxy/management_endpoints/scim/scim_v2.py`

- Added `_refresh_cached_team` to the existing import block from `litellm.proxy.management_endpoints.team_endpoints`.
- `update_group` (PUT): call `await _refresh_cached_team(updated_team, user_api_key_cache, proxy_logging_obj)` after the database update, mirroring `team_endpoints.update_team` (line 1930). `user_api_key_cache` and `proxy_logging_obj` are imported lazily from `litellm.proxy.proxy_server` to match the file's import-time-cycle-avoidance style.
- `patch_group` (PATCH): call `await _refresh_cached_team(updated_team, user_api_key_cache, proxy_logging_obj)` after the final `find_unique`, mirroring the same pattern. The post-mutation row is the row returned by the final `find_unique`, not the pre-mutation `existing_team`.
- `delete_group` (DELETE): invalidate the cache (not refresh, since the team no longer exists). Clear both the local LRU (`user_api_key_cache.delete_cache`) and the Redis side (`proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache`). Also invalidate the `team_alias:{alias}` key if the team had an alias, matching the alias-invalidation half of `_cache_team_object` at `auth_checks.py:1806`.

### `tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py`

- New `TestScimGroupCacheInvalidation` class with three regression pins.

  - `test_update_group_refreshes_team_cache` drives `update_group` end-to-end with mocked Prisma + cache + `_refresh_cached_team`, and asserts the refresh was awaited exactly once with the post-mutation row, the local cache, and the proxy logging handles. Pins the post-mutation `team_row` identity (the object returned by the Prisma `update`, not the pre-mutation `existing_team`).

  - `test_patch_group_refreshes_team_cache` does the same for `patch_group`, mocking the helper stack (`_process_group_patch_operations`, `_check_team_exists`, `_get_team_member_user_ids_from_team`, `_handle_group_membership_changes`, `_recompute_scim_member_roles`) to drive the full PATCH flow. The same `await_count == 1` + `team_row` identity pin applies.

  - `test_delete_group_invalidates_team_id_and_alias_caches` drives `delete_group` and asserts `user_api_key_cache.delete_cache` and `dual_cache.async_delete_cache` were each called with `key=f"team_id:{group_id}"` AND `key=f"team_alias:{team_alias}"`. Both halves of the dual cache (local LRU + Redis) must be invalidated for the fix to be correct.

- Latent-bug fix in `test_update_group_metadata_serialization_issue`: the pre-existing test mocked `mock_updated_team.model_dump` to return a `MagicMock`, which silently unpacked to `{}` via `**` (MagicMock acts as a Mapping with empty keys()). With the cache refresh now calling `LiteLLM_TeamTableCachedObj(**team_row.model_dump())`, the latent bug became a real one (the empty dict fails the `team_id` field validation). Updated the mock to give `model_dump` a real dict return so the mock's contract matches the real Prisma row shape.

## Verification

Local (this branch, `litellm_internal_staging` @ `2bb297efa0` base):

- `pytest tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py::TestScimGroupCacheInvalidation` — 3/3 pass.
- `pytest tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py` — 85/85 pass (82 pre-existing + 3 new).
- `pytest tests/test_litellm/proxy/management_endpoints/scim/test_scim_transformations.py` — 19/19 pass (sanity check on adjacent file; untouched by this PR).
- `ruff check litellm/proxy/management_endpoints/scim/scim_v2.py` — clean.
- `ruff format --check litellm/proxy/management_endpoints/scim/scim_v2.py` — already formatted.
- `scripts/ruff_strict_gate.py` — OK (every strict rule within its codebase ceiling).
- `scripts/type_discipline_gate.py` — OK (every LIT rule within its codebase ceiling; no new suppressions introduced).

Bug-reproduction check (cycle 12 self-audit, "fix all X" pattern from the agent memory):

- Stashed the source fix, re-ran all 3 new tests. All 3 fail with the exact symptom the issue documents (the `update_group` and `patch_group` ones fail because the `_refresh_cached_team` import is missing; the `delete_group` one fails because the cache invalidation calls are missing). Restored the fix, all 3 pass.
- The pre-existing test regression in `test_update_group_metadata_serialization_issue` was a real symptom of the bug (the mock's `model_dump` was returning a `MagicMock` that silently unpacked to `{}`), not a test design flaw on my side. Updated the mock to return a real dict.

## Design notes

- **Why `_refresh_cached_team` for PUT/PATCH and inline cache invalidation for DELETE** — `_refresh_cached_team` writes a fresh `LiteLLM_TeamTableCachedObj` to the cache, which is the right shape for the post-mutation `get_team_object` read path. For DELETE the team no longer exists, so writing a stale-shaped object is wrong; the right shape is to invalidate (delete) the cache keys. The two helpers serve different invariants.
- **Why import `user_api_key_cache` and `proxy_logging_obj` lazily inside the function** — the file already does this for `prisma_client` (the existing `from litellm.proxy.proxy_server import prisma_client` calls live inside the function bodies, not at module top, to avoid the import-time cycle between `proxy_server` and the management endpoints). Following the same pattern keeps the cycle intact.
- **Why pin the `team_row` identity in the regression tests** — both `update_group` and `patch_group` have a pre-mutation `existing_team` and a post-mutation `updated_team` in the test fixtures. The only way to prove the cache refresh is reading from the post-mutation state is to assert the `team_row` argument identity matches the post-mutation row. Sharing `team_id` between the two rows would let a buggy refresh against the pre-mutation row slip through the assertion.
- **Why inline the cache invalidation for `delete_group` rather than import a helper** — there is no `_delete_cache_team_object` helper in the codebase. The alias-invalidation half of `_cache_team_object` at `auth_checks.py:1806` is the closest existing pattern, and that's what the inline code mirrors. A dedicated helper would be a separate refactor (cycle 13+ candidate) and would touch every existing call site; that's out of scope for the regression pin.
- **Why fix the pre-existing test mock** — `test_update_group_metadata_serialization_issue` is checking the metadata-serialization behavior, not the cache refresh. The mock's `model_dump` was a `MagicMock` because the previous test never read it (it never called `model_dump` on the result). With the cache refresh now reading it, the latent bug became a real one. The right fix is to give the mock a real `model_dump` return value, not to add a defensive try/except in `_refresh_cached_team`. A defensive try/except would mask real schema-validation failures in production.
- **Why three regression tests instead of one parametrized** — the three endpoints have different cache-management shapes (refresh + delete for PUT/PATCH, pure delete for DELETE), and the delete shape has to assert on both halves of the dual cache. A parametrized test would either spread the assertion over multiple cases or hide the DELETE-specific dual-cache assertion. Three explicit tests read more clearly.

## Risks

- **Low.** The change adds cache writes / invalidations that should already be happening. The dict shape, the `LiteLLM_TeamTableCachedObj` model, the cache key prefix (`team_id:{id}` / `team_alias:{alias}`), and the dual-cache pattern are all unchanged from the established team-management-endpoint contract. The same helper (`_refresh_cached_team`) is reused verbatim.
- The pre-existing test `test_update_group_metadata_serialization_issue` had to be updated to give the mock a real `model_dump` return. The metadata-serialization behavior the test was checking is unchanged.
- The `delete_group` cache invalidation is best-effort: if the dual-cache calls fail, the function still returns 204 (the DB delete succeeded). The stale cache entry will expire on the management-object TTL.

## Future improvements (not in this PR)

- A `_delete_cache_team_object(team_id, team_alias=None)` helper would deduplicate the `delete_group` cache-invalidation code with the alias-invalidation half of `_cache_team_object`. The helper would also let the `prisma_client.delete_data(table_name="team", ...)` path in `proxy/utils.py:4235` (called from `/team/delete`) get the same treatment, which it currently doesn't. That's a separate cycle.
- The SCIM `/Users` endpoints (POST/PUT/DELETE) and the `patch_user_membership` path also mutate durable state, and the user cache key prefix is `user_id:{id}`. A similar audit is a natural cycle 13 candidate.
- The `_handle_group_membership_changes` path in `scim_v2.py` calls `patch_team_membership`, which already calls `_refresh_cached_team` internally for each member add/remove (cycle 9 work). No additional fix needed there.
