### PR TITLE
fix(cli): launch agents as a child process on Windows

### DIFF
--- a/litellm/proxy/client/cli/commands/agents.py
+++ b/litellm/proxy/client/cli/commands/agents.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 import sys
 from collections.abc import Callable, Mapping, Sequence
 from typing import Final
@@ -142,8 +143,95 @@ def verify_proxy_key(
         )
 
 
-def _exec(path: str, args: Sequence[str], env: Mapping[str, str]) -> None:
-    os.execvpe(path, list(args), dict(env))
+_WINDOWS_SHIM_SUFFIXES: Final[frozenset[str]] = frozenset({".cmd", ".bat"})
+_CMD_PERCENT_GUARD: Final = "%%cd:~,%"
+_CMD_LINE_BREAKS: Final = ("\r", "\n")
+
+
+def _double_trailing_backslashes(segment: str) -> str:
+    bare: Final = segment.rstrip("\\")
+    return bare + "\\" * 2 * (len(segment) - len(bare))
+
+
+def _quote_for_cmd(token: str) -> str:
+    """Quote one token so both parsers that read it see the original text.
+
+    Follows the algorithm the Rust standard library settled on for batch files
+    after CVE-2024-24576. Two parsers see this token: cmd.exe, which ends a
+    quoted string on a lone `"` and so wants an embedded one doubled, and the
+    shim's own interpreter, which re-splits `%*` under C runtime rules where a
+    backslash escapes the quote that follows it, so every backslash run standing
+    before a quote is doubled. Quoting cannot stop cmd expanding `%VAR%`, so each
+    `%` is prefixed with `%%cd:~,`: the zero-length substring of the always
+    defined `cd` expands to nothing and leaves no `%` pair for cmd to match.
+    """
+    escaped: Final = '""'.join(_double_trailing_backslashes(part) for part in token.split('"'))
+    return '"' + escaped.replace("%", _CMD_PERCENT_GUARD) + '"'
+
+
+def _windows_command(path: str, args: Sequence[str]) -> str | tuple[str, ...]:
+    """Build what CreateProcess runs, routing batch shims through cmd.exe.
+
+    npm installs Claude Code as `claude.cmd`, which PATHEXT lets shutil.which
+    resolve but CreateProcess refuses to run (WinError 193), so a shim has to go
+    through the command processor. cmd.exe does not follow the C runtime quoting
+    that subprocess would apply to an argument list, and it would split on `&` or
+    `|` in a forwarded argument, so the shim case is emitted as one verbatim
+    command line with every token quoted. Every switch is load-bearing: `/s`
+    makes cmd strip only the outer pair, leaving each token quoted and its
+    metacharacters inert, `/e:on` keeps the command extensions that the percent
+    guard is built out of, `/v:off` keeps `!` from expanding, and `/d` keeps a
+    machine's AutoRun commands out of the launch. argv[0] carries the
+    caller-facing name on POSIX; Windows needs the resolved path there.
+
+    Raises AgentRunError for an argument holding a line break, which cmd would
+    read as the end of the command line and silently drop the rest of.
+    """
+    rest: Final = tuple(args[1:])
+    if os.path.splitext(path)[1].lower() not in _WINDOWS_SHIM_SUFFIXES:
+        return (path, *rest)
+    if any(brk in token for token in rest for brk in _CMD_LINE_BREAKS):
+        raise AgentRunError(
+            f"Cannot pass an argument containing a line break to `{os.path.basename(path)}` on "
+            "Windows: cmd.exe ends the command line there, so the agent would silently lose it."
+        )
+    inner: Final = " ".join(_quote_for_cmd(token) for token in (path, *rest))
+    return f'cmd.exe /d /e:on /v:off /s /c "{inner}"'
+
+
+def _spawn_and_wait(command: str | Sequence[str], env: Mapping[str, str]) -> int:
+    return subprocess.run(command, env=dict(env), check=False).returncode
+
+
+def _replace_process(
+    path: str,
+    args: Sequence[str],
+    env: Mapping[str, str],
+    *,
+    execvpe: Callable[..., None] = os.execvpe,
+) -> None:
+    execvpe(path, list(args), dict(env))
+
+
+def _hand_off(
+    path: str,
+    args: Sequence[str],
+    env: Mapping[str, str],
+    *,
+    platform: str = sys.platform,
+    replace: Callable[[str, Sequence[str], Mapping[str, str]], None] = _replace_process,
+    spawn: Callable[[str | Sequence[str], Mapping[str, str]], int] = _spawn_and_wait,
+) -> None:
+    """Replace this process with the agent; on Windows, run it as a child instead.
+
+    os.exec* has no process-replacement semantics on Windows: the C runtime
+    spawns a detached child and terminates the parent, so the shell reclaims the
+    console and the agent's TUI never gets one. Windows therefore waits on the
+    child and exits with its status.
+    """
+    if platform.startswith("win"):
+        raise SystemExit(spawn(_windows_command(path, args), env))
+    replace(path, list(args), dict(env))
 
 
 def _restore_controlling_terminal() -> None:
@@ -175,13 +263,14 @@ def run_agent(
     base_env: Mapping[str, str] | None = None,
     which: Callable[[str], str | None] = shutil.which,
     verify: Callable[[str, str], None] = verify_proxy_key,
-    launcher: Callable[[str, Sequence[str], Mapping[str, str]], None] = _exec,
+    launcher: Callable[[str, Sequence[str], Mapping[str, str]], None] = _hand_off,
     reattach_terminal: Callable[[], None] | None = None,
 ) -> None:
     """Validate, wire the environment, and hand off to the agent.
 
-    On success this replaces the current process and never returns. Raises
-    AgentRunError for missing binaries, an unreachable proxy, or a rejected key.
+    On success this never returns: POSIX replaces the current process, Windows
+    waits on the agent and exits with its status. Raises AgentRunError for
+    missing binaries, an unreachable proxy, or a rejected key.
     reattach_terminal, when given, runs just before handoff to restore stdin.
     """
     if not command:

--- a/tests/test_litellm/proxy/client/cli/test_agents.py
+++ b/tests/test_litellm/proxy/client/cli/test_agents.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import sys
 from unittest.mock import patch
@@ -14,6 +15,9 @@ sys.path.insert(
 
 from litellm.proxy.client.cli.commands.agents import (
     AgentRunError,
+    _hand_off,
+    _replace_process,
+    _spawn_and_wait,
     agent_commands,
     agent_launch_args,
     agent_profile,
@@ -29,9 +33,23 @@ def _agent_command(name):
     return next(c for c in agent_commands() if c.name == name)
 
 
+def _default_of(func, param):
+    return inspect.signature(func).parameters[param].default
+
+
 class _FakeResponse:
     def __init__(self, status_code):
         self.status_code = status_code
+
+
+class _Recorder:
+    def __init__(self, returns=None):
+        self.returns = returns
+        self.calls = []
+
+    def __call__(self, *args):
+        self.calls.append(args)
+        return self.returns
 
 
 class TestAgentProfile:
@@ -314,6 +332,267 @@ class TestRunAgent:
         assert order == ["launch"]
 
 
+_WINDOWS_CLAUDE_EXE = "C:\\Program Files\\Claude\\claude.exe"
+_WINDOWS_CLAUDE_CMD = "C:\\Users\\dev\\AppData\\Roaming\\npm\\claude.cmd"
+_AGENT_ENV = {"ANTHROPIC_BASE_URL": "http://localhost:4000"}
+_CMD_PREFIX = "cmd.exe /d /e:on /v:off /s /c "
+
+
+def _shim_command_line(*args):
+    spawn = _Recorder(returns=0)
+    with pytest.raises(SystemExit):
+        _hand_off(
+            _WINDOWS_CLAUDE_CMD,
+            ["claude", *args],
+            _AGENT_ENV,
+            platform="win32",
+            replace=_Recorder(),
+            spawn=spawn,
+        )
+    return spawn.calls[0][0]
+
+
+class TestHandOff:
+    def test_windows_spawns_child_instead_of_exec(self):
+        replace = _Recorder()
+        spawn = _Recorder(returns=0)
+
+        with pytest.raises(SystemExit) as excinfo:
+            _hand_off(
+                _WINDOWS_CLAUDE_EXE,
+                ["claude", "--resume"],
+                _AGENT_ENV,
+                platform="win32",
+                replace=replace,
+                spawn=spawn,
+            )
+
+        assert excinfo.value.code == 0
+        assert replace.calls == []
+        assert spawn.calls == [
+            ((_WINDOWS_CLAUDE_EXE, "--resume"), _AGENT_ENV),
+        ]
+
+    @pytest.mark.parametrize("code", [1, 42, 130])
+    def test_windows_propagates_child_exit_code(self, code):
+        with pytest.raises(SystemExit) as excinfo:
+            _hand_off(
+                _WINDOWS_CLAUDE_EXE,
+                ["claude"],
+                _AGENT_ENV,
+                platform="win32",
+                replace=_Recorder(),
+                spawn=_Recorder(returns=code),
+            )
+        assert excinfo.value.code == code
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            _WINDOWS_CLAUDE_CMD,
+            "C:\\shims\\claude.CMD",
+            "C:\\shims\\claude.bat",
+        ],
+    )
+    def test_windows_batch_shim_goes_through_cmd_exe(self, path):
+        spawn = _Recorder(returns=0)
+
+        with pytest.raises(SystemExit):
+            _hand_off(
+                path,
+                ["claude", "--resume"],
+                _AGENT_ENV,
+                platform="win32",
+                replace=_Recorder(),
+                spawn=spawn,
+            )
+
+        assert spawn.calls[0][0] == f'{_CMD_PREFIX}""{path}" "--resume""'
+
+    def test_windows_shim_quotes_a_path_containing_spaces(self):
+        spawn = _Recorder(returns=0)
+        path = "C:\\Program Files\\npm\\claude.cmd"
+
+        with pytest.raises(SystemExit):
+            _hand_off(
+                path,
+                ["claude", "-p", "hello world"],
+                _AGENT_ENV,
+                platform="win32",
+                replace=_Recorder(),
+                spawn=spawn,
+            )
+
+        expected = f'{_CMD_PREFIX}""C:\\Program Files\\npm\\claude.cmd" "-p" "hello world""'
+        assert spawn.calls[0][0] == expected
+
+    @pytest.mark.parametrize("payload", ["a&calc", "a|calc", "a>out", "a^b", "a&&calc"])
+    def test_windows_shim_never_leaves_a_metacharacter_unquoted(self, payload):
+        expected = f'{_CMD_PREFIX}""{_WINDOWS_CLAUDE_CMD}" "-p" "{payload}""'
+        assert _shim_command_line("-p", payload) == expected
+
+    def test_windows_shim_doubles_an_embedded_quote(self):
+        assert _shim_command_line("-p", 'say "hi"').endswith('"-p" "say ""hi""""')
+
+    @pytest.mark.parametrize(
+        "payload, quoted",
+        [
+            ("%PATH%", "%%cd:~,%PATH%%cd:~,%"),
+            ("100%", "100%%cd:~,%"),
+            ("%OS%%CD%", "%%cd:~,%OS%%cd:~,%%%cd:~,%CD%%cd:~,%"),
+        ],
+    )
+    def test_windows_shim_stops_cmd_expanding_a_percent_variable(self, payload, quoted):
+        assert _shim_command_line("-p", payload).endswith(f'"-p" "{quoted}""')
+
+    def test_windows_shim_guards_a_percent_in_the_shim_path(self):
+        spawn = _Recorder(returns=0)
+        path = "C:\\dev%HOME%\\claude.cmd"
+
+        with pytest.raises(SystemExit):
+            _hand_off(
+                path,
+                ["claude"],
+                _AGENT_ENV,
+                platform="win32",
+                replace=_Recorder(),
+                spawn=spawn,
+            )
+
+        assert spawn.calls[0][0] == f'{_CMD_PREFIX}""C:\\dev%%cd:~,%HOME%%cd:~,%\\claude.cmd""'
+
+    @pytest.mark.parametrize(
+        "payload, quoted",
+        [
+            ("C:\\dir\\", "C:\\dir\\\\"),
+            ('say \\"hi', 'say \\\\""hi'),
+            ('a\\\\"b', 'a\\\\\\\\""b'),
+        ],
+    )
+    def test_windows_shim_doubles_backslashes_that_precede_a_quote(self, payload, quoted):
+        assert _shim_command_line("-p", payload).endswith(f'"-p" "{quoted}""')
+
+    @pytest.mark.parametrize("payload", ["one\ntwo", "one\r\ntwo", "trailing\r"])
+    def test_windows_shim_refuses_an_argument_holding_a_line_break(self, payload):
+        with pytest.raises(AgentRunError, match="line break"):
+            _hand_off(
+                _WINDOWS_CLAUDE_CMD,
+                ["claude", "-p", payload],
+                _AGENT_ENV,
+                platform="win32",
+                replace=_Recorder(),
+                spawn=_Recorder(returns=0),
+            )
+
+    def test_windows_shim_keeps_the_switches_the_quoting_depends_on(self):
+        command = _shim_command_line("-p", "hi")
+        assert command.startswith("cmd.exe ")
+        switches = command.split(" /c ")[0].split()[1:]
+        assert switches == ["/d", "/e:on", "/v:off", "/s"]
+
+    def test_windows_exe_is_not_wrapped_in_cmd_exe(self):
+        spawn = _Recorder(returns=0)
+        with pytest.raises(SystemExit):
+            _hand_off(
+                _WINDOWS_CLAUDE_EXE,
+                ["claude"],
+                _AGENT_ENV,
+                platform="win32",
+                replace=_Recorder(),
+                spawn=spawn,
+            )
+        assert spawn.calls[0][0] == (_WINDOWS_CLAUDE_EXE,)
+
+    @pytest.mark.parametrize("platform", ["darwin", "linux", "freebsd8"])
+    def test_posix_still_replaces_the_process(self, platform):
+        replace = _Recorder()
+        spawn = _Recorder(returns=0)
+
+        _hand_off(
+            "/usr/local/bin/claude",
+            ["claude", "--resume"],
+            _AGENT_ENV,
+            platform=platform,
+            replace=replace,
+            spawn=spawn,
+        )
+
+        assert spawn.calls == []
+        assert replace.calls == [
+            ("/usr/local/bin/claude", ["claude", "--resume"], _AGENT_ENV),
+        ]
+        path, args, env = replace.calls[0]
+        assert isinstance(args, list)
+        assert isinstance(env, dict)
+
+    def test_replace_process_calls_execvpe_with_argv_and_env(self):
+        execvpe = _Recorder()
+
+        _replace_process(
+            "/usr/local/bin/claude",
+            ("claude", "--resume"),
+            _AGENT_ENV,
+            execvpe=execvpe,
+        )
+
+        assert execvpe.calls == [
+            ("/usr/local/bin/claude", ["claude", "--resume"], _AGENT_ENV),
+        ]
+        _path, argv, env = execvpe.calls[0]
+        assert isinstance(argv, list)
+        assert isinstance(env, dict)
+
+    def test_posix_default_replacement_is_execvpe(self):
+        assert _default_of(run_agent, "launcher") is _hand_off
+        assert _default_of(_hand_off, "replace") is _replace_process
+        assert _default_of(_replace_process, "execvpe") is os.execvpe
+        assert _default_of(_hand_off, "spawn") is _spawn_and_wait
+        assert _default_of(_hand_off, "platform") == sys.platform
+
+    def test_spawn_and_wait_blocks_until_the_child_is_done(self, tmp_path):
+        marker = tmp_path / "child-finished"
+        script = (
+            "import os, pathlib, time; time.sleep(0.5); "
+            "pathlib.Path(os.environ['MARKER']).write_text('done'); "
+            "raise SystemExit(int(os.environ['RC']))"
+        )
+
+        code = _spawn_and_wait(
+            [sys.executable, "-c", script],
+            {"RC": "7", "MARKER": str(marker), "PATH": os.environ.get("PATH", "")},
+        )
+
+        assert marker.read_text() == "done"
+        assert code == 7
+
+    def test_windows_run_agent_spawns_resolved_binary_with_proxy_args(self):
+        spawn = _Recorder(returns=3)
+        replace = _Recorder()
+
+        def launcher(path, args, env):
+            _hand_off(path, args, env, platform="win32", replace=replace, spawn=spawn)
+
+        with pytest.raises(SystemExit) as excinfo:
+            run_agent(
+                "http://localhost:4000",
+                "sk-key",
+                ["codex", "exec", "do a thing"],
+                skip_verify=True,
+                base_env={},
+                which=lambda name: _WINDOWS_CLAUDE_CMD.replace("claude", "codex"),
+                launcher=launcher,
+            )
+
+        assert excinfo.value.code == 3
+        assert replace.calls == []
+        command, env = spawn.calls[0]
+        shim = _WINDOWS_CLAUDE_CMD.replace("claude", "codex")
+        assert command.startswith(f'{_CMD_PREFIX}""{shim}" ')
+        assert command.endswith('"exec" "do a thing""')
+        assert '"model_provider=""litellm"""' in command
+        assert env["OPENAI_API_KEY"] == "sk-key"
+
+
 class TestAgentCommands:
     def setup_method(self):
         self.runner = CliRunner()
@@ -422,6 +701,15 @@ class TestAgentCommands:
         assert result.exit_code == 0, result.output
         assert captured["api_key"] == "sk-after-login"
         mock_get.assert_called_once_with(expected_base_url="http://localhost:4000")
+
+    def test_child_exit_code_reaches_the_shell(self):
+        with patch(f"{AGENTS_MODULE}.run_agent", side_effect=SystemExit(42)):
+            result = self.runner.invoke(
+                _agent_command("claude"),
+                [],
+                obj={"base_url": "http://localhost:4000", "api_key": "sk-key"},
+            )
+        assert result.exit_code == 42
 
     def test_agent_run_error_becomes_click_error(self):
         with patch(


### PR DESCRIPTION
## TLDR

Problem this solves:

- `lite claude` on Windows exits without ever launching Claude
- Windows has no exec, so the CLI just disappears
- An npm-installed `claude.cmd` cannot be exec'd at all

How it solves it:

- Windows now runs the agent as a child and waits
- The agent's exit code becomes the CLI's exit code
- Batch shims launch through `cmd.exe` with every token escaped
- Forwarded arguments reach the agent as the user typed them
- macOS and Linux keep the exact same exec handoff

## User Flow

Before: a developer on Windows gets their PowerShell prompt back instead of a Claude session

1. They run `lite login` against https://litellm-domain and finish the browser login
2. They run `lite claude`
3. `litellm: routing Claude Code through proxy at https://litellm-domain` prints
4. PowerShell returns to the prompt immediately, with no Claude session to type into
5. If Claude was installed from npm, they instead get a `[WinError 193] %1 is not a valid Win32 application` traceback
6. The same two commands on macOS or Linux open Claude normally, so the machine is the only difference

After: the same two commands open Claude Code in that same PowerShell window

1. They run `lite login` against https://litellm-domain and finish the browser login
2. They run `lite claude`
3. `litellm: routing Claude Code through proxy at https://litellm-domain` prints
4. Claude Code starts in that same window, reads their keystrokes, and its requests are served by the proxy
5. They leave Claude with `/exit`, and `$LASTEXITCODE` carries whatever code Claude itself returned
6. An npm-installed Claude starts the same way instead of raising `[WinError 193]`, including from a path with a space such as `C:\Program Files\npm`
7. `lite claude -p "what does %PATH% mean"` reaches Claude with that text intact, rather than with the machine's search path pasted into the question

## Relevant issues

## Linear ticket

Resolves LIT-4949

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

There are two defects behind the report, and both are fixed here on purpose

The silent exit: the handoff was `os.execvpe`, and `os.exec*` has no process-replacement semantics on Windows. The C runtime implements it as CreateProcess plus terminate-parent, so `lite` ends right after printing the routing line, PowerShell reclaims the console, and the detached Claude TUI has no console or stdin left to use. A native-installer `claude.exe` gives exactly the silent return the ticket describes

The `[WinError 193]`: `shutil.which` honors PATHEXT, so an npm install resolves to `claude.cmd`. CreateProcess cannot execute a batch file, and the resulting `OSError` is not an `AgentRunError`, so that install path raises a traceback rather than returning silently. Batch shims now go through the command processor

Going through `cmd.exe` brings its own trap, and this is exactly the ground CVE-2024-24576 covers, so the escaping follows the algorithm the Rust standard library settled on afterward rather than a local invention. The shim case is emitted as one verbatim command line, every token quoted, an embedded quote doubled the way cmd parses it, and any run of backslashes standing before a quote doubled so the shim's own re-parse under C runtime rules sees the token whole. Quoting alone cannot stop cmd expanding `%VAR%`, which is why each `%` also carries the `%%cd:~,` guard: a zero-length substring of the always-defined `cd` expands to nothing and leaves no `%` pair for cmd to match. An argument holding a line break is refused outright, since cmd would end the command line there and drop the rest without saying so. Every switch is load-bearing: `/s` makes cmd strip only the outer quote pair, `/e:on` keeps the command extensions the percent guard is built out of, `/v:off` keeps `!` from expanding, and `/d` keeps a machine's AutoRun commands out of the launch

Resolving the shim to its real interpreter instead was considered and rejected. An npm shim is a batch file whose interpreter can only be recovered by parsing it, and that file's shape differs across npm, yarn, and pnpm, so it would trade one quoting bug for a parsing bug that fails differently per package manager

Honest limitation up front, so nothing below is read as more than it is: every capture here ran on macOS, and no `cmd.exe` was involved in any of them. The user-visible Windows symptom cannot be reproduced on a Mac or under WSL, which is POSIX and will not show it. Proofs 3 and 4 therefore force the platform string and drive the real code through the launcher seam `run_agent` already takes, standing in for the two Windows C runtime entry points and recording exactly what CreateProcess would have been handed. The escaping shown is what this branch emits, not what a Windows box was observed doing with it. Everything above that seam in proof 3 is a real process, which is what makes the waiting and the exit code real rather than asserted. Final confirmation on a real Windows host is best done by the ticket assignee, who has the reporter's environment

Before runs captured at 7fcca523aa, the merge base. After runs captured at 8e5ea9f172

### Proof 1, POSIX is unchanged, real proxy and real spend

A proxy was run against a real upstream, and Claude Code was launched by `lite` and answered through it. The console script's shebang is stale in this checkout, so the entrypoint is invoked through the venv interpreter directly

```console
$ cat config.yaml
model_list:
  - model_name: "*"
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234

$ python litellm/proxy/proxy_cli.py --config config.yaml --port 4010
$ curl -s http://localhost:4010/health/readiness
{"status":"healthy","db":"Not connected"}

$ .venv/bin/python .venv/bin/lite --base-url http://localhost:4010 --api-key sk-1234 \
    claude -p "reply with exactly one word: pong"
litellm: routing Claude Code through proxy at http://localhost:4010
pong
lite exit code: 0
```

The proxy served that Claude Code session, and the spend is real

```console
$ grep "POST /v1/messages" litellm.log
INFO:     127.0.0.1:61069 - "POST /v1/messages?beta=true HTTP/1.1" 200 OK
INFO:     127.0.0.1:61069 - "POST /v1/messages?beta=true HTTP/1.1" 200 OK
```

### Proof 2, the before tree really is missing this

`run_agent` is the control here: it exists on both sides, so a `base=0` on the rest is a real absence rather than a broken grep

```console
$ BASE=$(git merge-base HEAD origin/litellm_internal_staging); echo $BASE
7fcca523aab19dbd5d4d5b5ff9a057d0110ecaaa
$ git show "${BASE}:litellm/proxy/client/cli/commands/agents.py" > /tmp/agents_base.py
$ for sym in run_agent _exec _hand_off _windows_command _CMD_PERCENT_GUARD; do
    printf '%-20s base=%s head=%s\n' "$sym" \
      "$(grep -c "$sym" /tmp/agents_base.py)" \
      "$(grep -c "$sym" litellm/proxy/client/cli/commands/agents.py)"
  done
run_agent            base=3 head=3
_exec                base=2 head=0
_hand_off            base=0 head=2
_windows_command     base=0 head=2
_CMD_PERCENT_GUARD   base=0 head=2
```

### Proof 3, before and after on a simulated Windows host

This is the whole stand-in, nothing else about the run is faked. The agent is a real child process that sleeps a second, writes a marker, and exits 42, so waiting or not waiting is observable rather than asserted

```console
$ cat > /tmp/windows_host.py <<'PY'
"""Stands in for the Windows C runtime on this Mac, at the seams run_agent already takes."""

import os
import subprocess
import sys

EXE = r"C:\Program Files\Claude\claude.exe"
SHIM = r"C:\Users\dev\AppData\Roaming\npm\claude.cmd"
STUB = (
    "import os,pathlib,time;"
    "time.sleep(1);"
    "pathlib.Path(os.environ['MARKER']).write_text('agent finished');"
    "raise SystemExit(42)"
)


def _start_agent(env):
    return subprocess.Popen([sys.executable, "-c", STUB], env=dict(env))


def windows_execvpe(path, args, env):
    """os.execvpe on Windows: CreateProcess a detached child, then terminate the parent."""
    if os.path.splitext(path)[1].lower() in (".cmd", ".bat"):
        raise OSError(193, "%1 is not a valid Win32 application", path)
    _start_agent(env)
    os._exit(0)


def windows_createprocess(command, env):
    """CreateProcess as subprocess.run reaches it on Windows: show the command line, then run and wait."""
    print("  CreateProcess:", command if isinstance(command, str) else tuple(command))
    return _start_agent(env).wait()
PY
$ export PYTHONPATH="$PWD:/tmp"
```

The base tree's `_exec` is nothing but `os.execvpe(path, list(args), dict(env))`, so passing `windows_execvpe` as the launcher is that same call with the Windows implementation of `os.execvpe` substituted in. On a Mac the real one would replace the process, which is precisely the behavior Windows does not have

Before, a native-installer `claude.exe`. `lite` is gone before Claude has done anything, and the 42 the agent eventually returns is lost

```console
$ cp /tmp/agents_base.py litellm/proxy/client/cli/commands/agents.py
$ rm -f /tmp/marker
$ MARKER=/tmp/marker python - <<'PY'
import os
from windows_host import EXE, windows_execvpe
from litellm.proxy.client.cli.commands.agents import run_agent
print("litellm: routing Claude Code through proxy at http://localhost:4000")
run_agent("http://localhost:4000", "sk-1234", ["claude", "-p", "say pong"],
          skip_verify=True, base_env=dict(os.environ),
          which=lambda name: EXE, launcher=windows_execvpe)
print("run_agent returned")
PY
litellm: routing Claude Code through proxy at http://localhost:4000
$ echo "lite exit code: $?"
lite exit code: 0
$ cat /tmp/marker || echo "marker absent, lite is gone and Claude is not on this console"
marker absent, lite is gone and Claude is not on this console
$ sleep 1.5; cat /tmp/marker
agent finished
```

`run_agent returned` never printed, and the marker landed a second after the shell had already taken the prompt back. That is the ticket

Before, an npm-installed `claude.cmd`

```console
$ MARKER=/tmp/marker python - <<'PY'
import os
from windows_host import SHIM, windows_execvpe
from litellm.proxy.client.cli.commands.agents import run_agent
run_agent("http://localhost:4000", "sk-1234", ["claude", "-p", "say pong"],
          skip_verify=True, base_env=dict(os.environ),
          which=lambda name: SHIM, launcher=windows_execvpe)
PY
  File "<stdin>", line 5, in <module>
  File "litellm/proxy/client/cli/commands/agents.py", line 209, in run_agent
    launcher(binary, [command[0], *extra_args, *command[1:]], env)
  File "/tmp/windows_host.py", line 24, in windows_execvpe
    raise OSError(193, "%1 is not a valid Win32 application", path)
OSError: [Errno 193] %1 is not a valid Win32 application: 'C:\\Users\\dev\\AppData\\Roaming\\npm\\claude.cmd'
$ echo "lite exit code: $?"
lite exit code: 1
```

After, the same two scenarios on this branch. `windows_execvpe` stays wired in as the replacement path, so a Windows run that still exec'd would fail exactly as it did above

```console
$ git restore litellm/proxy/client/cli/commands/agents.py
$ rm -f /tmp/marker
$ MARKER=/tmp/marker python - <<'PY'
import os
from windows_host import EXE, windows_createprocess, windows_execvpe
from litellm.proxy.client.cli.commands.agents import _hand_off, run_agent
print("litellm: routing Claude Code through proxy at http://localhost:4000")
run_agent("http://localhost:4000", "sk-1234", ["claude", "-p", "say pong"],
          skip_verify=True, base_env=dict(os.environ), which=lambda name: EXE,
          launcher=lambda p, a, e: _hand_off(p, a, e, platform="win32",
                                             replace=windows_execvpe, spawn=windows_createprocess))
PY
litellm: routing Claude Code through proxy at http://localhost:4000
  CreateProcess: ('C:\\Program Files\\Claude\\claude.exe', '-p', 'say pong')
$ echo "lite exit code: $?"
lite exit code: 42
$ cat /tmp/marker
agent finished
```

The marker is already there when `lite` returns, so it waited, and 42 came back out. Now the npm shim, with the two payloads that used to be dangerous. The `&` is the injection attempt and it stays inside quotes, and `%PATH%` reaches cmd with no `%` pair left to expand

```console
$ for payload in "say pong & calc" "what does %PATH% mean"; do
    rm -f /tmp/marker
    MARKER=/tmp/marker python - "$payload" <<'PY'
import os, sys
from windows_host import SHIM, windows_createprocess, windows_execvpe
from litellm.proxy.client.cli.commands.agents import _hand_off, run_agent
print("argument typed:", repr(sys.argv[1]))
run_agent("http://localhost:4000", "sk-1234", ["claude", "-p", sys.argv[1]],
          skip_verify=True, base_env=dict(os.environ), which=lambda name: SHIM,
          launcher=lambda p, a, e: _hand_off(p, a, e, platform="win32",
                                             replace=windows_execvpe, spawn=windows_createprocess))
PY
    echo "  lite exit code: $?"
    echo -n "  agent finished? "; cat /tmp/marker; echo
  done
argument typed: 'say pong & calc'
  CreateProcess: cmd.exe /d /e:on /v:off /s /c ""C:\Users\dev\AppData\Roaming\npm\claude.cmd" "-p" "say pong & calc""
  lite exit code: 42
  agent finished? agent finished
argument typed: 'what does %PATH% mean'
  CreateProcess: cmd.exe /d /e:on /v:off /s /c ""C:\Users\dev\AppData\Roaming\npm\claude.cmd" "-p" "what does %%cd:~,%PATH%%cd:~,% mean""
  lite exit code: 42
  agent finished? agent finished
```

### Proof 4, every hostile argument and the exact command line it produces

This is the artifact worth reading closely, since it is the whole contract in one place: what a user types on the left, what cmd would be handed on the right. The shim path is shortened to `C:\npm\claude.cmd` only to keep the lines readable

```console
$ python - <<'PY'
from litellm.proxy.client.cli.commands.agents import AgentRunError, _windows_command

SHIM = r"C:\npm\claude.cmd"
HOSTILE = [
    "say pong & calc",
    "a | calc",
    "start && calc",
    "a > out.txt",
    "what does %PATH% mean",
    "cost is 100%",
    'she said "hi"',
    "C:\\path\\",
    "one\ntwo",
]
for arg in HOSTILE:
    print(f"lite claude -p {arg!r}")
    try:
        print(f"  {_windows_command(SHIM, ['claude', '-p', arg])}")
    except AgentRunError as e:
        print(f"  refused: {e}")
    print()
PY
lite claude -p 'say pong & calc'
  cmd.exe /d /e:on /v:off /s /c ""C:\npm\claude.cmd" "-p" "say pong & calc""

lite claude -p 'a | calc'
  cmd.exe /d /e:on /v:off /s /c ""C:\npm\claude.cmd" "-p" "a | calc""

lite claude -p 'start && calc'
  cmd.exe /d /e:on /v:off /s /c ""C:\npm\claude.cmd" "-p" "start && calc""

lite claude -p 'a > out.txt'
  cmd.exe /d /e:on /v:off /s /c ""C:\npm\claude.cmd" "-p" "a > out.txt""

lite claude -p 'what does %PATH% mean'
  cmd.exe /d /e:on /v:off /s /c ""C:\npm\claude.cmd" "-p" "what does %%cd:~,%PATH%%cd:~,% mean""

lite claude -p 'cost is 100%'
  cmd.exe /d /e:on /v:off /s /c ""C:\npm\claude.cmd" "-p" "cost is 100%%cd:~,%""

lite claude -p 'she said "hi"'
  cmd.exe /d /e:on /v:off /s /c ""C:\npm\claude.cmd" "-p" "she said ""hi""""

lite claude -p 'C:\\path\\'
  cmd.exe /d /e:on /v:off /s /c ""C:\npm\claude.cmd" "-p" "C:\path\\""

lite claude -p 'one\ntwo'
  refused: Cannot pass an argument containing a line break to `C:\npm\claude.cmd` on Windows: cmd.exe ends the command line there, so the agent would silently lose it.
```

Reading down the right column: every metacharacter sits inside a quote pair, so cmd sees one token rather than a second command. `%PATH%` and the bare trailing `%` both come out with no `%` pair left to match. The embedded quote is doubled, which is what cmd parses, and the trailing backslash is doubled, which is what the shim's own re-parse needs so the closing quote is not escaped away. The line break is the one case with no safe encoding, so it is refused with a message the user can act on rather than quietly truncated

Each piece above is independently load-bearing, so each was mutated on its own and required to die on its own rather than in a batch, which would only have shown that at least one was covered. Seven runs, 71 tests collected in every one. Removing the percent guard fails only the three percent cases and the guarded-path case. Removing the backslash doubling fails only the three backslash cases. Removing the line-break check fails only the three line-break cases. The four `cmd.exe` switches were each dropped singly, and each drop fails the suite alone

The `/e:on` kill is weaker than the other four, and is worth saying so rather than counting it straight. It dies because these tests pin the emitted command line as an exact string, so dropping any switch breaks every assertion carrying that prefix. That proves the switch is emitted. It does not prove that command extensions are what make the percent guard work, because showing that means running `%cd:~,%` under a real cmd.exe with extensions off and watching the guard degrade, and no cmd.exe ran here. So `/e:on` is protected against being deleted by accident, and its necessity at runtime rests on the documented substring syntax plus Rust passing the same switch for the same reason

## Review notes

Greptile's 3/5 finding on the previous revision was correct and is fixed here rather than argued with: quoting a token does not stop cmd expanding `%VAR%` inside it, so an argument such as `-p "what does %PATH% mean"` did reach the agent with the search path substituted in. That is the same class of problem as CVE-2024-24576, so instead of inventing a guard the escaping now follows Rust's shipped `append_bat_arg`, which is the reference implementation for handing arguments to a batch file. Adopting it whole also closed the residual the previous description admitted to, since doubling backslash runs before a quote is exactly what the shim's own re-parse needs

What is genuinely still open is smaller and worth naming so it is not mistaken for covered ground. The escaping is now the same as a shipped standard library's, and the tests pin the emitted command line, but neither of us has run it against a real npm shim on a real Windows host, and Rust's own source carries a FIXME saying the same thing about arguments being reconstructed by the batch script. That is the check for the assignee

## Type

🐛 Bug Fix

## Caveats

- The Windows symptom still needs a Windows host to confirm
- The assignee has the reporter's environment and should verify there
- Escaping matches Rust's, unverified against a live npm shim

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
