### PR TITLE
test(e2e): assert the model allow-list permits, not only denies

### DIFF
--- a/tests/e2e/access_control/access_control_client.py
+++ b/tests/e2e/access_control/access_control_client.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pydantic import BaseModel, ValidationError
+
 from proxy_client import ProxyClient
 from e2e_http import StreamingResponse
 from models import (
@@ -17,6 +19,24 @@ from models import (
 
 MODEL_ACCESS_DENIED_MARKER = "key_model_access_denied"
 ROUTE_NOT_ALLOWED_MARKER = "not allowed to call this route"
+
+
+class ApiErrorDetail(BaseModel):
+    message: str | None = None
+    type: str | None = None
+    code: str | int | None = None
+
+
+class ApiErrorEnvelope(BaseModel):
+    error: ApiErrorDetail
+
+
+def error_envelope(body: str) -> ApiErrorEnvelope | None:
+    """The OpenAI-shaped `{"error": {...}}` a client parses, or None if absent."""
+    try:
+        return ApiErrorEnvelope.model_validate_json(body)
+    except ValidationError:
+        return None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/e2e/access_control/test_access_control_e2e.py
+++ b/tests/e2e/access_control/test_access_control_e2e.py
@@ -13,19 +13,18 @@ management route).
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from access_control_client import (
     AccessControlClient,
     MODEL_ACCESS_DENIED_MARKER,
     ROUTE_NOT_ALLOWED_MARKER,
+    error_envelope,
 )
 from e2e_config import unique_marker
 from e2e_http import Success, UnauthorizedError, UnknownApiError, unwrap
 from lifecycle import ResourceManager
-from models import ChatBody, ChatMessage, LiteLLMParamsBody
+from models import ChatBody, ChatMessage, ChatResponse, LiteLLMParamsBody
 from proxy_client import ProxyClient
 
 pytestmark = pytest.mark.e2e
@@ -35,16 +34,28 @@ DISALLOWED_MODEL = "gpt-5.5"
 VIRTUAL_KEY_BACKEND = "anthropic/claude-haiku-4-5-20251001"
 
 
-def _is_json(body: str) -> bool:
-    try:
-        json.loads(body)
-        return True
-    except ValueError:
-        return False
-
-
-
 class TestAccessControl:
+    def test_allowed_model_is_permitted(
+        self, client: AccessControlClient, resources: ResourceManager
+    ) -> None:
+        """The allow-list's positive half.
+
+        Without this, every other case in this class passes just as happily
+        against a gateway that denies the allowed model too, because they only
+        ever assert that something was refused.
+        """
+        key = resources.key(models=[ALLOWED_MODEL])
+        result = client.chat_status(
+            key, ALLOWED_MODEL, f"capital of France? {unique_marker()}"
+        )
+        assert result.status_code == 200, (
+            f"key allow-listed for {ALLOWED_MODEL!r} must be able to call it, got "
+            f"{result.status_code}: {result.body[:300]}"
+        )
+        assert ChatResponse.model_validate_json(result.body).choices, (
+            f"200 must carry a real completion, not an error envelope: {result.body[:300]}"
+        )
+
     def test_disallowed_model_is_denied_403(
         self, client: AccessControlClient, resources: ResourceManager
     ) -> None:
@@ -85,7 +96,13 @@ class TestAccessControl:
             f"unknown model must be rejected 400 before forwarding, got "
             f"{result.status_code}: {result.body[:300]}"
         )
-        assert _is_json(result.body), f"400 body must be valid JSON: {result.body[:300]}"
+        envelope = error_envelope(result.body)
+        assert envelope is not None, (
+            f"400 body must be an OpenAI-shaped error envelope, got: {result.body[:300]}"
+        )
+        assert envelope.error.message, (
+            f"400 error must carry a message a client can surface: {result.body[:300]}"
+        )
 
 
 class TestVirtualKeyAuth:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Access-control tests only ever asserted denials
- The 400 body check passed on any JSON, including `{}`

How it solves it:

- Adds the allow-list's positive case, with a real completion
- Asserts the OpenAI error envelope carries a usable message

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This changes tests only, so the proof is running the assertions by hand against a live proxy. The QA runbook below is that sequence, and it maps 1:1 to what the two tests assert. I have not run it against a live proxy myself in this change.

## Type

✅ Test

## Changes

`tests/e2e/access_control/` only ever asserted refusals. Every case in `TestAccessControl` checked that something was denied, which means the class passes just as happily against a gateway that denies the allow-listed model too. This adds the positive half: a key allow-listed for a model can call it and gets a real completion back, not an error envelope carrying a 200.

The unknown-model case is tightened at the same time. It asserted that the 400 body parsed as JSON, which is true of any JSON at all including `{}`. It now asserts the OpenAI-shaped `{"error": {...}}` envelope a client actually parses, and that the message is non-empty, so a 400 no caller can surface fails the test.

`error_envelope` is a small typed helper on the suite's client rather than an inline `json.loads`, because the shape is the contract being asserted.

This is the test half of work staged on a branch that was used to prove the e2e gate reports red. It was never landed on its own. That branch also carried a deliberately broken assertion and its revert, which cancel out and are not included here.

## QA runbook

- tests/e2e/access_control/test_access_control_e2e.py::TestAccessControl::test_allowed_model_is_permitted - a key allow-listed for gemini-2.5-flash can actually call it and gets a real completion
  - [x] Generate a scoped key: `curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"models": ["gemini-2.5-flash"]}'`
  - [x] Call the allow-listed model with it: `curl -sS -o /dev/stderr -w '%{http_code}\n' -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer <key>" -H "Content-Type: application/json" -d '{"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "capital of France?"}]}'`
  - [x] Expect 200 and a body whose `choices[0].message.content` is a real answer, not an `error` object
  - [x] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/access_control/test_access_control_e2e.py::TestAccessControl::test_unknown_model_returns_400 - a request naming a model that does not exist is refused with an error a client can surface
  - [x] Reuse the key above, or any key, and name a model that does not exist: `curl -sS -o /dev/stderr -w '%{http_code}\n' -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer <key>" -H "Content-Type: application/json" -d '{"model": "nonexistent-model-abc123", "messages": [{"role": "user", "content": "hi this is a test"}]}'`
  - [x] Expect 400, and a body shaped `{"error": {"message": "...", ...}}` with a non-empty message naming the model
  - [x] Confirm the old assertion would not have caught a regression here: a body of `{}` is valid JSON and would have passed before this change
  - [x] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

Prerequisites: a proxy on `localhost:4000` with `gemini-2.5-flash` configured and Gemini credentials in the environment; `sk-1234` stands in for your master key.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
