### PR TITLE
fix(proxy): tolerate a concurrent creator when creating spend views

### DIFF
--- a/litellm/proxy/db/create_views.py
+++ b/litellm/proxy/db/create_views.py
@@ -10,6 +10,29 @@ _db = Any
 # 'undefined function' or 'column undefined_col referenced in query').
 _VIEW_NOT_FOUND_MARKERS: Final = ("does not exist", "no such table", "undefined table")
 
+# Markers for the inverse condition: another replica created the view between
+# our existence probe and our CREATE.
+_VIEW_ALREADY_EXISTS_MARKERS: Final = ("already exists", "duplicate object", "duplicate table")
+
+
+async def create_view_tolerating_race(db: _db, view_name: str, ddl: str) -> None:
+    """
+    Create a view, treating "a concurrent creator won" as success.
+
+    Every replica booting against the same fresh database observes the view as
+    absent and issues the CREATE; Postgres fails all but one with a
+    duplicate-object error. The desired end state is still reached, so losing
+    that race is success. Without this, the loser's exception propagates out of
+    a detached startup task and the remaining views are never created.
+    """
+    try:
+        await db.execute_raw(ddl)
+        verbose_logger.debug("%s Created!", view_name)
+    except Exception as e:
+        if not any(marker in str(e).lower() for marker in _VIEW_ALREADY_EXISTS_MARKERS):
+            raise
+        verbose_logger.debug("%s already created by a concurrent replica", view_name)
+
 
 async def create_missing_views(db: _db):
     """
@@ -34,7 +57,10 @@ async def create_missing_views(db: _db):
         if not any(marker in error_msg for marker in _VIEW_NOT_FOUND_MARKERS):
             raise
         # If an error occurs, the view does not exist, so create it
-        await db.execute_raw("""
+        await create_view_tolerating_race(
+            db,
+            "LiteLLM_VerificationTokenView",
+            """
                 CREATE VIEW "LiteLLM_VerificationTokenView" AS
                 SELECT
                 v.*,
@@ -46,9 +72,8 @@ async def create_missing_views(db: _db):
                 FROM "LiteLLM_VerificationToken" v
                 LEFT JOIN "LiteLLM_TeamTable" t ON v.team_id = t.team_id
                 LEFT JOIN "LiteLLM_ProjectTable" p ON v.project_id = p.project_id;
-            """)
-
-        verbose_logger.debug("LiteLLM_VerificationTokenView Created!")
+            """,
+        )
 
     try:
         await db.query_raw("""SELECT 1 FROM "MonthlyGlobalSpend" LIMIT 1""")
@@ -218,9 +243,7 @@ async def create_missing_views(db: _db):
         ORDER BY total_spend DESC
         LIMIT 100;
         """
-        await db.execute_raw(query=sql_query)
-
-        verbose_logger.debug("Last30dTopEndUsersSpend Created!")
+        await create_view_tolerating_race(db, "Last30dTopEndUsersSpend", sql_query)
 
 
 async def should_create_missing_views(db: _db) -> bool:

--- a/litellm/proxy/db/create_views.py
+++ b/litellm/proxy/db/create_views.py
@@ -94,9 +94,7 @@ async def create_missing_views(db: _db):
         GROUP BY 
         DATE("startTime");
         """
-        await db.execute_raw(query=sql_query)
-
-        verbose_logger.debug("MonthlyGlobalSpend Created!")
+        await create_view_tolerating_race(db, "MonthlyGlobalSpend", sql_query)
 
     try:
         await db.query_raw("""SELECT 1 FROM "Last30dKeysBySpend" LIMIT 1""")
@@ -125,9 +123,7 @@ async def create_missing_views(db: _db):
         ORDER BY
         total_spend DESC;
         """
-        await db.execute_raw(query=sql_query)
-
-        verbose_logger.debug("Last30dKeysBySpend Created!")
+        await create_view_tolerating_race(db, "Last30dKeysBySpend", sql_query)
 
     try:
         await db.query_raw("""SELECT 1 FROM "Last30dModelsBySpend" LIMIT 1""")
@@ -151,9 +147,7 @@ async def create_missing_views(db: _db):
         ORDER BY
         total_spend DESC;
         """
-        await db.execute_raw(query=sql_query)
-
-        verbose_logger.debug("Last30dModelsBySpend Created!")
+        await create_view_tolerating_race(db, "Last30dModelsBySpend", sql_query)
     try:
         await db.query_raw("""SELECT 1 FROM "MonthlyGlobalSpendPerKey" LIMIT 1""")
         verbose_logger.debug("MonthlyGlobalSpendPerKey Exists!")
@@ -175,9 +169,7 @@ async def create_missing_views(db: _db):
             DATE("startTime"),
             api_key;
         """
-        await db.execute_raw(query=sql_query)
-
-        verbose_logger.debug("MonthlyGlobalSpendPerKey Created!")
+        await create_view_tolerating_race(db, "MonthlyGlobalSpendPerKey", sql_query)
     try:
         await db.query_raw("""SELECT 1 FROM "MonthlyGlobalSpendPerUserPerKey" LIMIT 1""")
         verbose_logger.debug("MonthlyGlobalSpendPerUserPerKey Exists!")
@@ -201,9 +193,7 @@ async def create_missing_views(db: _db):
             "user",
             api_key;
         """
-        await db.execute_raw(query=sql_query)
-
-        verbose_logger.debug("MonthlyGlobalSpendPerUserPerKey Created!")
+        await create_view_tolerating_race(db, "MonthlyGlobalSpendPerUserPerKey", sql_query)
 
     try:
         await db.query_raw("""SELECT 1 FROM "DailyTagSpend" LIMIT 1""")
@@ -222,9 +212,7 @@ async def create_missing_views(db: _db):
         FROM "LiteLLM_SpendLogs" s
         GROUP BY individual_request_tag, DATE(s."startTime");
         """
-        await db.execute_raw(query=sql_query)
-
-        verbose_logger.debug("DailyTagSpend Created!")
+        await create_view_tolerating_race(db, "DailyTagSpend", sql_query)
 
     try:
         await db.query_raw("""SELECT 1 FROM "Last30dTopEndUsersSpend" LIMIT 1""")

--- a/litellm/proxy/db/create_views.py
+++ b/litellm/proxy/db/create_views.py
@@ -15,6 +15,7 @@ class SupportsExecuteRaw(Protocol):
 
     async def execute_raw(self, query: str, *args: object) -> int: ...
 
+
 # Markers that indicate a view/relation does not yet exist in the database.
 # Keeping these in one place avoids repeating the check across all view blocks
 # and prevents overly broad matches (e.g. bare 'undefined' would also match
@@ -26,9 +27,7 @@ _VIEW_NOT_FOUND_MARKERS: Final = ("does not exist", "no such table", "undefined 
 _VIEW_ALREADY_EXISTS_MARKERS: Final = ("already exists", "duplicate object", "duplicate table")
 
 
-async def create_view_tolerating_race(
-    db: SupportsExecuteRaw, view_name: str, ddl: str
-) -> None:
+async def create_view_tolerating_race(db: SupportsExecuteRaw, view_name: str, ddl: str) -> None:
     """
     Create a view, treating "a concurrent creator won" as success.
 

--- a/litellm/proxy/db/create_views.py
+++ b/litellm/proxy/db/create_views.py
@@ -1,8 +1,19 @@
-from typing import Any, Final
+from typing import Any, Final, Protocol
 
 from litellm import verbose_logger
 
 _db = Any
+
+
+class SupportsExecuteRaw(Protocol):
+    """The one database operation create_view_tolerating_race needs.
+
+    Narrower than the `_db = Any` the rest of this module still uses, so the
+    helper's contract is checkable at its call sites without retyping every
+    function here.
+    """
+
+    async def execute_raw(self, query: str, *args: object) -> int: ...
 
 # Markers that indicate a view/relation does not yet exist in the database.
 # Keeping these in one place avoids repeating the check across all view blocks
@@ -15,7 +26,9 @@ _VIEW_NOT_FOUND_MARKERS: Final = ("does not exist", "no such table", "undefined 
 _VIEW_ALREADY_EXISTS_MARKERS: Final = ("already exists", "duplicate object", "duplicate table")
 
 
-async def create_view_tolerating_race(db: _db, view_name: str, ddl: str) -> None:
+async def create_view_tolerating_race(
+    db: SupportsExecuteRaw, view_name: str, ddl: str
+) -> None:
     """
     Create a view, treating "a concurrent creator won" as success.
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -106,6 +106,7 @@ from litellm.proxy.common_utils.config_sync_pubsub import publish_config_param_c
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 from litellm.proxy.db.create_views import (
     create_missing_views,
+    create_view_tolerating_race,
     should_create_missing_views,
 )
 from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
@@ -3273,7 +3274,10 @@ class PrismaClient:
                 ## check if required view exists ##
                 if ret[0]["view_names"] and required_view not in ret[0]["view_names"]:
                     await self.health_check()  # make sure we can connect to db
-                    await self.db.execute_raw("""
+                    await create_view_tolerating_race(
+                        self.db,
+                        "LiteLLM_VerificationTokenView",
+                        """
                             CREATE VIEW "LiteLLM_VerificationTokenView" AS
                             SELECT
                             v.*,
@@ -3283,9 +3287,8 @@ class PrismaClient:
                             t.rpm_limit AS team_rpm_limit
                             FROM "LiteLLM_VerificationToken" v
                             LEFT JOIN "LiteLLM_TeamTable" t ON v.team_id = t.team_id;
-                        """)
-
-                    verbose_proxy_logger.info("LiteLLM_VerificationTokenView Created in DB!")
+                        """,
+                    )
                 else:
                     should_create_views: Final = await should_create_missing_views(db=self.db)
                     if should_create_views:

--- a/tests/test_litellm/proxy/db/test_create_views.py
+++ b/tests/test_litellm/proxy/db/test_create_views.py
@@ -189,3 +189,55 @@ async def test_create_views_creates_view_on_undefined_table_error():
     await create_missing_views(mock_db)
 
     mock_db.execute_raw.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_views_tolerates_concurrent_creator_and_continues():
+    """A replica that loses the CREATE race must not abort the remaining views.
+
+    Regression: two proxy pods booting on a fresh DB both see every view as
+    absent and both issue the CREATE. Postgres fails the loser with a
+    duplicate-object error, which propagated out of create_missing_views and
+    left every later view (MonthlyGlobalSpend, DailyTagSpend, ...) uncreated,
+    so /global/spend* 500'd for the life of the deployment.
+    """
+    from litellm.proxy.db.create_views import create_missing_views
+
+    mock_db = MagicMock()
+    mock_db.query_raw = AsyncMock(side_effect=Exception("relation does not exist"))
+    mock_db.execute_raw = AsyncMock(
+        side_effect=[Exception('relation "LiteLLM_VerificationTokenView" already exists')]
+        + [None] * 20
+    )
+
+    await create_missing_views(mock_db)
+
+    assert mock_db.execute_raw.await_count > 1, (
+        "lost the race on the first view and stopped; later views were never created"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_views_reraises_genuine_ddl_error():
+    """An already-exists guard must not swallow real DDL failures."""
+    from litellm.proxy.db.create_views import create_missing_views
+
+    mock_db = MagicMock()
+    mock_db.query_raw = AsyncMock(side_effect=Exception("relation does not exist"))
+    mock_db.execute_raw = AsyncMock(side_effect=Exception("syntax error at or near"))
+
+    with pytest.raises(Exception, match="syntax error"):
+        await create_missing_views(mock_db)
+
+
+@pytest.mark.asyncio
+async def test_create_view_tolerating_race_swallows_only_already_exists():
+    from litellm.proxy.db.create_views import create_view_tolerating_race
+
+    mock_db = MagicMock()
+    mock_db.execute_raw = AsyncMock(side_effect=Exception("duplicate object"))
+    await create_view_tolerating_race(mock_db, "SomeView", "CREATE VIEW ...")
+
+    mock_db.execute_raw = AsyncMock(side_effect=Exception("permission denied"))
+    with pytest.raises(Exception, match="permission denied"):
+        await create_view_tolerating_race(mock_db, "SomeView", "CREATE VIEW ...")

--- a/tests/test_litellm/proxy/db/test_create_views.py
+++ b/tests/test_litellm/proxy/db/test_create_views.py
@@ -191,29 +191,40 @@ async def test_create_views_creates_view_on_undefined_table_error():
     mock_db.execute_raw.assert_called_once()
 
 
+# Every view create_missing_views is responsible for. Hard-coded rather than
+# derived from the module, so adding a view without guarding it fails here.
+EXPECTED_VIEW_COUNT = 8
+
+
 @pytest.mark.asyncio
-async def test_create_views_tolerates_concurrent_creator_and_continues():
-    """A replica that loses the CREATE race must not abort the remaining views.
+async def test_create_views_tolerates_a_concurrent_creator_on_every_view():
+    """A replica that loses the CREATE race must attempt every view regardless.
 
     Regression: two proxy pods booting on a fresh DB both see every view as
-    absent and both issue the CREATE. Postgres fails the loser with a
-    duplicate-object error, which propagated out of create_missing_views and
-    left every later view (MonthlyGlobalSpend, DailyTagSpend, ...) uncreated,
-    so /global/spend* 500'd for the life of the deployment.
+    absent and both issue the CREATE, and Postgres fails the loser with a
+    duplicate-object error on whichever views the winner got to first. Any
+    creation site still calling execute_raw unguarded re-raises that error and
+    aborts the rest of the function.
+
+    Every CREATE loses here, which is what pins the guard to all of them: an
+    earlier version of this fix converted only the first and the last site and
+    still died on MonthlyGlobalSpend against a real Postgres. Counting the
+    attempts is the assertion, because a partial fix simply stops early.
     """
     from litellm.proxy.db.create_views import create_missing_views
 
     mock_db = MagicMock()
     mock_db.query_raw = AsyncMock(side_effect=Exception("relation does not exist"))
     mock_db.execute_raw = AsyncMock(
-        side_effect=[Exception('relation "LiteLLM_VerificationTokenView" already exists')]
-        + [None] * 20
+        side_effect=Exception('relation "some_view" already exists')
     )
 
     await create_missing_views(mock_db)
 
-    assert mock_db.execute_raw.await_count > 1, (
-        "lost the race on the first view and stopped; later views were never created"
+    assert mock_db.execute_raw.await_count == EXPECTED_VIEW_COUNT, (
+        f"every view must still be attempted when the replica loses every race; "
+        f"got {mock_db.execute_raw.await_count} of {EXPECTED_VIEW_COUNT}, so a "
+        f"creation site is still unguarded and aborted the rest"
     )
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Concurrent replicas booting on a fresh DB: one crashes on view creation
- The crash escapes a detached startup task, so nothing surfaces it

How it solves it:

- Losing the CREATE race counts as success; genuine DDL errors still raise
- Applied to all 8 view creations, verified against a real Postgres

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Real Postgres 16, two processes calling `create_missing_views` through the real prisma client on one fresh schema, released from a barrier so both issue DDL at the same instant.

Before, on `litellm_internal_staging`:

```
  views before : 0
  A: [A] create_missing_views returned normally
  B: [B] RAISED RawQueryError: ERROR: relation "Last30dTopEndUsersSpend" already exists
  views after  : 8 / 8
  MISSING views: none
```

After, with this branch:

```
  views before : 0
  A: [A] create_missing_views returned normally
  B: [B] create_missing_views returned normally
  views after  : 8 / 8
  MISSING views: none
```

Reproduce it with a throwaway Postgres:

```
docker run -d --name pg -e POSTGRES_PASSWORD=x -e POSTGRES_USER=litellm -e POSTGRES_DB=litellm -p 55433:5432 postgres:16-alpine
export DATABASE_URL="postgresql://litellm:x@127.0.0.1:55433/litellm"
python -m prisma db push --schema schema.prisma --skip-generate --accept-data-loss
```

then run two processes that connect and call `create_missing_views` at the same moment, and check `select viewname from pg_views where schemaname='public'`.

## Correcting the original claim in this PR

I first wrote that the loser's exception left `MonthlyGlobalSpend` and `DailyTagSpend` uncreated and `/global/spend*` 500ing. **The run above shows that is not what happens with two replicas.** The loser aborts, but the winner is unaffected and goes on to create all 8 views, so the end state is complete either way. I have not been able to construct a two-replica interleaving that leaves a view missing, because whichever process wins the first CREATE is never interrupted afterwards.

What the run does show is the part worth fixing: on every concurrent boot one replica raises `RawQueryError` out of `create_missing_views`, which is called from a detached startup task, so it is an unhandled exception nothing reports. It also means that replica silently skips its remaining view checks, which is harmless only because a peer happens to be doing them.

The same live run also caught a real defect in my first attempt at this fix, which is why there are two commits: I had converted only the first and last of the 8 creation sites, so the loser simply moved its crash from `LiteLLM_VerificationTokenView` to `MonthlyGlobalSpend`. The unit test passed anyway because it mocked only the first call as failing. The test now makes every CREATE lose and asserts all 8 are still attempted, which fails against the partial fix.

Worth a separate look: `.buildkite/README.md` in project-releaser records this race as leaving those views missing on build 27 of the predecessor pipeline. That observation is real, but based on the above it needs another explanation.

## Type

🐛 Bug Fix

## Changes

`create_missing_views` probes each of 8 views with a `SELECT 1` and creates the ones the probe says are absent. With more than one replica, every pod makes that observation on a fresh database and every pod issues the `CREATE`. Postgres serialises them, so exactly one succeeds per view and the others get a duplicate-object error that propagated straight out of the function.

`create_view_tolerating_race` treats "someone else already created it" as success, since the intended end state has been reached either way, and re-raises anything else so a real DDL failure is still loud. All 8 creation sites use it. `PrismaClient.check_view_exists` uses the same helper for its own inline `LiteLLM_VerificationTokenView` create, which had the identical problem.

Three regression tests in the mapped test file: the all-8-lose case above, a genuine-DDL-error case pinning that the guard does not degrade into a blanket `except Exception`, and a direct test of the helper.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
