### PR TITLE
fix(auth): carry team grants in lite login session tokens

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2556,6 +2556,8 @@ class ExperimentalUIJWTToken:
         user_info: LiteLLM_UserTable,
         team_id: str | None = None,
         team_alias: str | None = None,
+        team_models: Sequence[str] | None = None,
+        team_model_aliases: Mapping[str, str] | None = None,
         max_budget: float | None = None,
     ) -> str:
         """
@@ -2568,6 +2570,8 @@ class ExperimentalUIJWTToken:
             user_info: User information from the database
             team_id: Team ID for the user (optional, uses user's team if available)
             team_alias: Team alias for the selected team, if available
+            team_models: Model allowlist granted by the selected team
+            team_model_aliases: Team model aliases for the selected team
 
         Returns:
             Encrypted JWT token string
@@ -2606,7 +2610,9 @@ class ExperimentalUIJWTToken:
             user_id=user_info.user_id,
             team_id=_team_id,
             team_alias=team_alias,
-            models=user_info.models,
+            team_models=list(team_models) if team_models is not None else [],
+            team_model_aliases=dict(team_model_aliases) if team_model_aliases is not None else None,
+            models=[] if _team_id is not None else user_info.models,
             max_parallel_requests=None,
             user_role=LitellmUserRoles(user_info.user_role),
             is_session_token=True,

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -21,6 +21,7 @@ from copy import deepcopy
 from html import escape
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Final,
     Literal,
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
 import jwt
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, BeforeValidator, ConfigDict, TypeAdapter, ValidationError
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -185,6 +187,7 @@ class _PrismaTableActions(Protocol[_DbRecordT]):
     async def find_many(
         self,
         where: Mapping[str, object] | None = None,
+        include: Mapping[str, bool] | None = None,
     ) -> Sequence[_DbRecordT]: ...
 
     async def update(
@@ -239,6 +242,45 @@ class _HasTeamDetailTable(Protocol):
 
 def _team_detail_db(repo: "_HasTeamDetailTable") -> "_PrismaTableActions[_TeamDetailRow]":
     return repo.table
+
+
+_MODEL_ALIASES_ADAPTER: Final = TypeAdapter(dict[str, str])
+
+
+def _decode_model_aliases(value: object) -> object:
+    """``/team/new`` stores team model aliases as a JSON-encoded string in the Json column."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return _MODEL_ALIASES_ADAPTER.validate_json(value)
+    except ValidationError:
+        return None
+
+
+class _TeamModelAliasTable(BaseModel):
+    model_config = ConfigDict(protected_namespaces=())
+
+    model_aliases: Annotated[Mapping[str, str] | None, BeforeValidator(_decode_model_aliases)] = None
+
+
+class _TeamRowGrants(BaseModel):
+    team_id: str
+    team_alias: str | None = None
+    models: tuple[str, ...] = ()
+    litellm_model_table: _TeamModelAliasTable | None = None
+
+
+class _CliSsoTeamDetail(BaseModel):
+    """The per-team snapshot cached in the CLI SSO flow and echoed to the CLI on poll."""
+
+    team_id: str | None = None
+    team_alias: str | None = None
+    team_models: tuple[str, ...]
+    team_model_aliases: Mapping[str, str] | None = None
+
+
+_CLI_SSO_TEAM_DETAILS_ADAPTER: Final = TypeAdapter(tuple[_CliSsoTeamDetail, ...])
+_TEAMLESS_CLI_SSO_TEAM_DETAIL: Final = _CliSsoTeamDetail(team_models=())
 
 
 class _CustomSsoCall(Protocol):
@@ -2147,27 +2189,55 @@ async def _build_cli_sso_user_defined_values(
     )
 
 
+def _cli_sso_team_detail(team_row: Mapping[str, object]) -> _CliSsoTeamDetail:
+    team: Final = _TeamRowGrants.model_validate(team_row)
+    alias_table: Final = team.litellm_model_table
+    return _CliSsoTeamDetail(
+        team_id=team.team_id,
+        team_alias=team.team_alias,
+        team_models=team.models,
+        team_model_aliases=alias_table.model_aliases if alias_table is not None else None,
+    )
+
+
 async def _fetch_cli_sso_team_details(
     prisma_client: PrismaClient,
     teams: Sequence[str],
-) -> list[dict[str, object]]:
-    team_details: Final[list[dict[str, object]]] = []
+) -> tuple[_CliSsoTeamDetail, ...] | None:
+    """``None`` means the lookup itself failed, which is not the same as the user having no teams."""
+    if not teams:
+        return ()
     try:
-        if teams:
-            prisma_teams: Final = await _team_detail_db(TeamRepository(prisma_client)).find_many(
-                where={"team_id": {"in": teams}}
-            )
-            for team_row in prisma_teams:
-                team_dict = team_row.model_dump()
-                team_details.append(
-                    {
-                        "team_id": team_dict.get("team_id"),
-                        "team_alias": team_dict.get("team_alias"),
-                    }
-                )
+        prisma_teams: Final = await _team_detail_db(TeamRepository(prisma_client)).find_many(
+            where={"team_id": {"in": teams}},
+            include={"litellm_model_table": True},
+        )
     except Exception as e:
         verbose_proxy_logger.error("Error fetching team details for CLI SSO session: %s", e)
-    return team_details
+        return None
+    return tuple(_cli_sso_team_detail(team_row.model_dump()) for team_row in prisma_teams)
+
+
+def _cli_sso_session_teams(team_details: Sequence[_CliSsoTeamDetail]) -> list[str]:
+    """The teams a login may bind to: only those whose row still exists.
+
+    A team deleted out from under a membership, which is what deleting an organization
+    leaves behind, can never resolve its grants, so offering it would refuse every
+    future login for that user with nothing they could do to recover.
+    """
+    return [detail.team_id for detail in team_details if detail.team_id is not None]
+
+
+def _selected_cli_sso_team_detail(team_details: object, team_id: str | None) -> _CliSsoTeamDetail | None:
+    """``None`` means the team's grants are unknown. An empty grant is a real value meaning unrestricted,
+    so an unknown one must not be minted as empty."""
+    if team_id is None:
+        return _TEAMLESS_CLI_SSO_TEAM_DETAIL
+    try:
+        details: Final = _CLI_SSO_TEAM_DETAILS_ADAPTER.validate_python(team_details)
+    except ValidationError:
+        return None
+    return next((detail for detail in details if detail.team_id == team_id), None)
 
 
 async def _complete_cli_sso_callback_session(
@@ -2210,6 +2280,12 @@ async def _complete_cli_sso_callback_session(
         teams = user_info.teams if isinstance(user_info.teams, list) else []
 
     team_details: Final = await _fetch_cli_sso_team_details(prisma_client=prisma_client, teams=teams)
+    if team_details is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Could not resolve team model grants for this login. Please try again",
+        )
+    resolved_teams: Final = _cli_sso_session_teams(team_details)
     attribution_metadata: Final = build_cli_sso_attribution_metadata(result=result)
     if attribution_metadata:
         await _persist_cli_sso_user_metadata(
@@ -2223,8 +2299,8 @@ async def _complete_cli_sso_callback_session(
         "user_role": user_info.user_role,
         "models": user_info.models if hasattr(user_info, "models") else [],
         "user_email": user_email,
-        "teams": teams,
-        "team_details": team_details,
+        "teams": resolved_teams,
+        "team_details": [detail.model_dump() for detail in team_details],
         "attribution_metadata": attribution_metadata,
     }
     flow["sso_complete"] = True
@@ -2233,7 +2309,10 @@ async def _complete_cli_sso_callback_session(
     _set_cli_sso_flow(login_id=key, cache=cli_sso_session_cache, flow=flow)
 
     verbose_proxy_logger.info(
-        "Stored CLI SSO session for user: %s, teams: %s, num_teams: %s", user_info.user_id, teams, len(teams)
+        "Stored CLI SSO session for user: %s, teams: %s, num_teams: %s",
+        user_info.user_id,
+        resolved_teams,
+        len(resolved_teams),
     )
     verify_url: Final = get_custom_url(
         request_base_url=str(request.base_url),
@@ -2401,11 +2480,14 @@ async def cli_poll_key(
                 # If no team_id provided and user has 0 or 1 team, use first team (or None)
                 team_id = user_teams[0] if len(user_teams) > 0 else None
 
-            team_alias = None
-            if team_id and isinstance(user_team_details, list):
-                team_alias = next(
-                    (team.get("team_alias") for team in user_team_details if team.get("team_id") == team_id),
-                    None,
+            selected_team: Final = _selected_cli_sso_team_detail(
+                team_details=user_team_details,
+                team_id=team_id,
+            )
+            if selected_team is None:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Could not resolve the model grants for team: {team_id}. Please run `lite login` again",
                 )
 
             user_info: Final = LiteLLM_UserTable(
@@ -2417,7 +2499,9 @@ async def cli_poll_key(
             jwt_token: Final = ExperimentalUIJWTToken.get_cli_jwt_auth_token(
                 user_info=user_info,
                 team_id=team_id,
-                team_alias=team_alias,
+                team_alias=selected_team.team_alias,
+                team_models=selected_team.team_models,
+                team_model_aliases=selected_team.team_model_aliases,
                 max_budget=None,
             )
 

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -155,6 +155,55 @@ def test_get_cli_jwt_auth_token_includes_team_alias(valid_sso_user_defined_value
     assert token_data["team_alias"] == "test-team"
 
 
+def test_get_cli_jwt_auth_token_carries_team_grants_not_user_allowlist(
+    valid_sso_user_defined_values,
+):
+    """A team-bound `lite login` session token must snapshot the team's grants.
+
+    Without team_models the /v1/models bail-out (`not key_models and not team_models`)
+    treats the session as unrestricted and lists the whole proxy; without
+    team_model_aliases a team alias never resolves on /chat/completions. The user's
+    personal allowlist must stay out of the key `models` slot, since a team-bound
+    credential is governed by the team grant, not by a per-user list.
+    """
+    token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(
+        valid_sso_user_defined_values,
+        team_id="team-123",
+        team_alias="test-team",
+        team_models=("claude-sonnet-4-5", "gpt-4.1"),
+        team_model_aliases={"team-fast": "gpt-4.1-mini"},
+    )
+
+    decrypted_token = decrypt_value_helper(
+        token, key="ui_hash_key", exception_type="debug"
+    )
+    assert decrypted_token is not None
+    token_data = json.loads(decrypted_token)
+
+    assert token_data["team_id"] == "team-123"
+    assert token_data["team_models"] == ["claude-sonnet-4-5", "gpt-4.1"]
+    assert token_data["team_model_aliases"] == {"team-fast": "gpt-4.1-mini"}
+    assert valid_sso_user_defined_values.models == ["gpt-3.5-turbo"]
+    assert token_data["models"] == []
+
+
+def test_get_cli_jwt_auth_token_keeps_user_allowlist_when_no_team(
+    valid_sso_user_defined_values,
+):
+    """A session token with no team bound still carries the user's own allowlist."""
+    token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(valid_sso_user_defined_values)
+
+    decrypted_token = decrypt_value_helper(
+        token, key="ui_hash_key", exception_type="debug"
+    )
+    assert decrypted_token is not None
+    token_data = json.loads(decrypted_token)
+
+    assert token_data.get("team_id") is None
+    assert token_data["models"] == ["gpt-3.5-turbo"]
+    assert token_data["team_models"] == []
+
+
 def test_get_experimental_ui_login_jwt_auth_token_uses_10_min_expiry(
     valid_sso_user_defined_values,
 ):

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -2847,6 +2847,19 @@ class TestCLIKeyRegenerationFlow:
             "user_code_verified": False,
             "session_data": None,
         }
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_teamtable.find_many = AsyncMock(
+            return_value=[
+                MagicMock(
+                    model_dump=lambda team_id=team_id: {
+                        "team_id": team_id,
+                        "team_alias": team_id,
+                        "models": [],
+                    }
+                )
+                for team_id in ("team1", "team2")
+            ]
+        )
         with (
             patch.dict(
                 os.environ,
@@ -2859,7 +2872,7 @@ class TestCLIKeyRegenerationFlow:
                 "litellm.proxy.management_endpoints.ui_sso.get_user_info_from_db",
                 return_value=mock_user_info,
             ),
-            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
             patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
             patch("litellm.proxy.proxy_server.cli_sso_session_cache", mock_cache),
             patch(
@@ -3156,9 +3169,9 @@ class TestCLIKeyRegenerationFlow:
             "user_role": "internal_user",
             "teams": ["team-a", "team-b", "team-c"],
             "team_details": [
-                {"team_id": "team-a", "team_alias": "Team A"},
-                {"team_id": "team-b", "team_alias": "Team B"},
-                {"team_id": "team-c", "team_alias": "Team C"},
+                {"team_id": "team-a", "team_alias": "Team A", "team_models": []},
+                {"team_id": "team-b", "team_alias": "Team B", "team_models": []},
+                {"team_id": "team-c", "team_alias": "Team C", "team_models": []},
             ],
             "models": ["gpt-4"],
             "user_email": "test@example.com",
@@ -3224,6 +3237,243 @@ class TestCLIKeyRegenerationFlow:
 
             # Verify session was deleted after JWT generation
             mock_cache.delete_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fetch_cli_sso_team_details_projects_team_grants(self):
+        """The cached team detail must carry the team's model grants.
+
+        The projection used to drop everything except team_id/team_alias, so the
+        minted CLI token had no team_models and no team_model_aliases to snapshot.
+        The joined alias table is stored JSON-encoded, so it has to be decoded here
+        too, otherwise alias lookup at request time is a substring match on a string.
+        """
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _fetch_cli_sso_team_details,
+        )
+
+        team_row = MagicMock()
+        team_row.model_dump.return_value = {
+            "team_id": "team-a",
+            "team_alias": "Team A",
+            "models": ["claude-sonnet-4-5", "gpt-4.1"],
+            "litellm_model_table": {
+                "id": 7,
+                "model_aliases": json.dumps({"team-fast": "gpt-4.1-mini"}),
+                "created_by": "admin",
+                "updated_by": "admin",
+            },
+        }
+        find_many = AsyncMock(return_value=[team_row])
+        prisma_client = MagicMock()
+        prisma_client.db.litellm_teamtable.find_many = find_many
+
+        details = await _fetch_cli_sso_team_details(
+            prisma_client=prisma_client, teams=["team-a"]
+        )
+
+        assert find_many.await_args.kwargs["include"] == {"litellm_model_table": True}
+        assert [detail.model_dump() for detail in details] == [
+            {
+                "team_id": "team-a",
+                "team_alias": "Team A",
+                "team_models": ("claude-sonnet-4-5", "gpt-4.1"),
+                "team_model_aliases": {"team-fast": "gpt-4.1-mini"},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_fetch_cli_sso_team_details_separates_lookup_failure_from_no_teams(self):
+        """A failed lookup must not look like a team that resolved to nothing.
+
+        Both used to return [], so a database blip was indistinguishable from a real
+        answer. The callback needs them apart: a blip has to fail the login, while a
+        real empty answer means the team rows are genuinely gone.
+        """
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _fetch_cli_sso_team_details,
+        )
+
+        failing_client = MagicMock()
+        failing_client.db.litellm_teamtable.find_many = AsyncMock(
+            side_effect=Exception("connection reset")
+        )
+        assert (
+            await _fetch_cli_sso_team_details(
+                prisma_client=failing_client, teams=["team-a"]
+            )
+            is None
+        )
+
+        empty_client = MagicMock()
+        empty_client.db.litellm_teamtable.find_many = AsyncMock(return_value=[])
+        assert (
+            await _fetch_cli_sso_team_details(
+                prisma_client=empty_client, teams=["team-a"]
+            )
+            == ()
+        )
+
+    @pytest.mark.asyncio
+    async def test_cli_poll_key_mints_jwt_with_selected_team_grants(self):
+        """The selected team's grants must reach the mint, not just its alias."""
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _hash_cli_sso_secret,
+            cli_poll_key,
+        )
+
+        session_data = {
+            "user_id": "grants-user",
+            "user_role": "internal_user",
+            "teams": ["team-a", "team-b"],
+            "team_details": [
+                {
+                    "team_id": "team-a",
+                    "team_alias": "Team A",
+                    "team_models": ["gpt-4.1"],
+                    "team_model_aliases": {"a-fast": "gpt-4.1-mini"},
+                },
+                {
+                    "team_id": "team-b",
+                    "team_alias": "Team B",
+                    "team_models": ["claude-sonnet-4-5"],
+                    "team_model_aliases": {"b-fast": "claude-haiku-4-5"},
+                },
+            ],
+            "models": ["personal-only"],
+            "user_email": "grants@example.com",
+        }
+        mock_cache = MagicMock(redis_cache=None)
+        mock_cache.get_cache.return_value = {
+            "poll_secret_hash": _hash_cli_sso_secret("poll-secret"),
+            "sso_complete": True,
+            "user_code_verified": True,
+            "session_data": session_data,
+        }
+
+        with (
+            patch("litellm.proxy.proxy_server.cli_sso_session_cache", mock_cache),
+            patch(
+                "litellm.proxy.auth.auth_checks.ExperimentalUIJWTToken.get_cli_jwt_auth_token",
+                return_value="minted-token",
+            ) as mock_get_jwt,
+        ):
+            result = await cli_poll_key(
+                key_id="cli-session-grants",
+                team_id="team-b",
+                x_litellm_cli_poll_secret="poll-secret",
+            )
+
+        assert result["status"] == "ready"
+        kwargs = mock_get_jwt.call_args.kwargs
+        assert kwargs["team_id"] == "team-b"
+        assert kwargs["team_alias"] == "Team B"
+        assert kwargs["team_models"] == ("claude-sonnet-4-5",)
+        assert kwargs["team_model_aliases"] == {"b-fast": "claude-haiku-4-5"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "team_details",
+        [
+            pytest.param(None, id="detail_fetch_failed"),
+            pytest.param(
+                [{"team_id": "team-other", "team_models": []}], id="selected_team_absent"
+            ),
+            pytest.param(
+                [{"team_id": "team-a", "team_alias": "Team A"}],
+                id="legacy_detail_without_grants",
+            ),
+        ],
+    )
+    async def test_cli_poll_key_refuses_to_mint_when_team_grants_are_unknown(
+        self, team_details
+    ):
+        """An unknown team grant must never be minted as an empty one.
+
+        get_complete_model_list falls through to the whole proxy model list when both
+        the key allowlist and the team allowlist are empty, and team-bound tokens carry
+        an empty key allowlist by design. So minting an unresolved team as empty would
+        hand a team-bound CLI session every model on the proxy.
+        """
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _hash_cli_sso_secret,
+            cli_poll_key,
+        )
+
+        mock_cache = MagicMock(redis_cache=None)
+        mock_cache.get_cache.return_value = {
+            "poll_secret_hash": _hash_cli_sso_secret("poll-secret"),
+            "sso_complete": True,
+            "user_code_verified": True,
+            "session_data": {
+                "user_id": "grants-user",
+                "user_role": "internal_user",
+                "teams": ["team-a"],
+                "team_details": team_details,
+                "models": ["personal-only"],
+                "user_email": "grants@example.com",
+            },
+        }
+
+        with (
+            patch("litellm.proxy.proxy_server.cli_sso_session_cache", mock_cache),
+            patch(
+                "litellm.proxy.auth.auth_checks.ExperimentalUIJWTToken.get_cli_jwt_auth_token",
+                return_value="minted-token",
+            ) as mock_get_jwt,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await cli_poll_key(
+                    key_id="cli-session-grants",
+                    team_id="team-a",
+                    x_litellm_cli_poll_secret="poll-secret",
+                )
+
+        assert exc_info.value.status_code == 500
+        assert "team-a" in str(exc_info.value.detail)
+        mock_get_jwt.assert_not_called()
+        mock_cache.delete_cache.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cli_poll_key_mints_teamless_session_without_team_grants(self):
+        """A user with no team still mints, keeping their personal allowlist in the key slot."""
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _hash_cli_sso_secret,
+            cli_poll_key,
+        )
+
+        mock_cache = MagicMock(redis_cache=None)
+        mock_cache.get_cache.return_value = {
+            "poll_secret_hash": _hash_cli_sso_secret("poll-secret"),
+            "sso_complete": True,
+            "user_code_verified": True,
+            "session_data": {
+                "user_id": "teamless-user",
+                "user_role": "internal_user",
+                "teams": [],
+                "team_details": [],
+                "models": ["personal-only"],
+                "user_email": "teamless@example.com",
+            },
+        }
+
+        with (
+            patch("litellm.proxy.proxy_server.cli_sso_session_cache", mock_cache),
+            patch(
+                "litellm.proxy.auth.auth_checks.ExperimentalUIJWTToken.get_cli_jwt_auth_token",
+                return_value="minted-token",
+            ) as mock_get_jwt,
+        ):
+            result = await cli_poll_key(
+                key_id="cli-session-teamless",
+                team_id=None,
+                x_litellm_cli_poll_secret="poll-secret",
+            )
+
+        assert result["status"] == "ready"
+        kwargs = mock_get_jwt.call_args.kwargs
+        assert kwargs["team_id"] is None
+        assert kwargs["team_models"] == ()
+        assert kwargs["user_info"].models == ["personal-only"]
 
     @pytest.mark.asyncio
     async def test_cli_poll_key_does_not_cap_session_when_user_has_budget(self):
@@ -3302,7 +3552,7 @@ class TestCLIKeyRegenerationFlow:
             "user_id": "unbudgeted-user",
             "user_role": "internal_user",
             "teams": ["team-x"],
-            "team_details": [{"team_id": "team-x", "team_alias": "Team X"}],
+            "team_details": [{"team_id": "team-x", "team_alias": "Team X", "team_models": []}],
             "models": ["gpt-4"],
             "user_email": "unbudgeted@example.com",
         }
@@ -6539,6 +6789,17 @@ class TestCliSsoAttributionMetadata:
             return_value=MagicMock(metadata={"auth_provider": "generic"})
         )
         mock_prisma.db.litellm_usertable.update_many = AsyncMock()
+        mock_prisma.db.litellm_teamtable.find_many = AsyncMock(
+            return_value=[
+                MagicMock(
+                    model_dump=lambda: {
+                        "team_id": "team1",
+                        "team_alias": "team1",
+                        "models": [],
+                    }
+                )
+            ]
+        )
 
         with (
             patch.dict(
@@ -7877,6 +8138,117 @@ async def test_cli_completion_persists_assertion_under_db_user_id():
 
     retain_mock.assert_awaited_once_with(user_id="cli-user-id", assertion=assertion)
     assert response.status_code == 200
+
+
+def _cli_callback_kwargs(flow):
+    return {
+        "request": _cli_callback_request(),
+        "key": "cli-login-id",
+        "flow": flow,
+        "result": {"sub": "raw-idp-subject"},
+        "parsed_openid_result": {
+            "user_id": "raw-idp-subject",
+            "user_email": "u@example.com",
+            "user_role": None,
+        },
+        "user_defined_values": None,
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": MagicMock(),
+        "cli_sso_session_cache": MagicMock(),
+        "proxy_logging_obj": MagicMock(),
+    }
+
+
+def _cli_callback_request():
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "http://localhost:4000/"
+    return mock_request
+
+
+def _cli_callback_user_info(teams):
+    user_info = MagicMock()
+    user_info.user_id = "cli-user-id"
+    user_info.user_role = "internal_user"
+    user_info.models = ["personal-only"]
+    user_info.teams = teams
+    return user_info
+
+
+@pytest.mark.asyncio
+async def test_cli_completion_drops_teams_whose_rows_no_longer_exist():
+    """A membership pointing at a deleted team must not be offered for selection.
+
+    Deleting an organization removes its team rows but leaves the user's membership
+    behind. If that dead team still reached the session, it would be auto-selected
+    for a single-team user, its grants could never resolve, and every future login
+    would be refused with no way for the user to recover.
+    """
+    from litellm.proxy.management_endpoints.ui_sso import (
+        _CliSsoTeamDetail,
+        _complete_cli_sso_callback_session,
+    )
+
+    live_detail = _CliSsoTeamDetail(
+        team_id="team-live", team_alias="Live", team_models=("gpt-4.1",)
+    )
+    flow = {}
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.get_user_info_from_db",
+            AsyncMock(return_value=_cli_callback_user_info(["team-live", "team-deleted"])),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso._fetch_cli_sso_team_details",
+            AsyncMock(return_value=(live_detail,)),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.build_cli_sso_attribution_metadata",
+            return_value={},
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.retain_sso_identity_assertion_for_ema",
+            AsyncMock(),
+        ),
+    ):
+        response = await _complete_cli_sso_callback_session(**_cli_callback_kwargs(flow))
+
+    assert response.status_code == 200
+    assert flow["session_data"]["teams"] == ["team-live"]
+    assert [d["team_id"] for d in flow["session_data"]["team_details"]] == ["team-live"]
+
+
+@pytest.mark.asyncio
+async def test_cli_completion_fails_the_login_when_team_lookup_fails():
+    """A lookup failure must fail the login instead of caching a teamless session.
+
+    Silently dropping every team here would hand a team-bound user a session with
+    their personal allowlist, which is the same "unknown grant treated as a real
+    grant" bug in a quieter form.
+    """
+    from litellm.proxy.management_endpoints.ui_sso import (
+        _complete_cli_sso_callback_session,
+    )
+
+    flow = {}
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.get_user_info_from_db",
+            AsyncMock(return_value=_cli_callback_user_info(["team-live"])),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso._fetch_cli_sso_team_details",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.retain_sso_identity_assertion_for_ema",
+            AsyncMock(),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await _complete_cli_sso_callback_session(**_cli_callback_kwargs(flow))
+
+    assert exc_info.value.status_code == 500
+    assert "session_data" not in flow
 
 
 class TestSameOriginReturnPath:


### PR DESCRIPTION
## TLDR

Problem this solves:

- `lite login` tokens carry a team but none of its grants
- `/v1/models` lists the whole proxy for team-bound CLI users
- Team model aliases never resolve on `/v1/chat/completions`
- The user's personal allowlist lands in the key slot

How it solves it:

- Team detail lookup now keeps the team's models and aliases
- Both are written onto the token when it is minted
- Team-bound tokens no longer copy the user's personal allowlist
- A team whose grants cannot be resolved is refused, not assumed

## User Flow

Before: a developer on a team runs `lite login`, then sees every model on the proxy and cannot call their team's alias

1. They run `lite login`, pick their team in the browser, and get a session token back
2. They send GET https://litellm-domain/v1/models with that token and the response lists every deployment on the proxy, including ones their team was never granted
3. They send POST https://litellm-domain/v1/chat/completions with `"model": "team-fast"`, the alias their team admin configured, and get 403 `team_model_access_denied` saying "This team can only access models=['team-granted-model']. Tried to access team-fast"

After: the same login lists only what the team was granted, and the team's alias works

1. They run `lite login`, pick their team in the browser, and get a session token back
2. They send GET https://litellm-domain/v1/models with that token and the response lists only `team-granted-model`, the model their team was granted
3. They send POST https://litellm-domain/v1/chat/completions with `"model": "team-fast"` and get 200 with the completion from the model the alias points at

Another user on a different team could already not call this team's models, since enforcement reads the team row live. What changed is that the session no longer advertises models it cannot use, and no longer refuses an alias it should honor

A second flow changed too. Before: a developer whose team was removed along with its organization runs `lite login` and gets a session tied to a team that no longer exists, which lists every model on the proxy. After: the same developer runs `lite login`, the removed team is not offered, and they get a session scoped to what they still have

## Relevant issues

## Linear ticket

Resolves LIT-4757

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Local proxy on port 4757 with its own Postgres and Redis, three live deployments (`team-granted-model` on anthropic/claude-haiku-4-5, `not-granted-model` and `alias-target-model` on openai/gpt-4.1-mini), a team granted only `team-granted-model` plus a model alias `team-fast -> alias-target-model`, and a team member whose personal allowlist is empty. Every leg runs the real `/sso/cli/start -> /sso/cli/complete -> /sso/cli/poll` sequence that `lite login` drives, and the completions are real billed calls to the provider. The only thing standing in for a real IdP is the browser redirect: the login session is built by the same team lookup the SSO callback calls, reading the same live Postgres

Setup, identical for both legs:

```
curl -sX POST http://127.0.0.1:4757/team/new -H "Authorization: Bearer sk-lit4757-master" -H 'Content-Type: application/json' \
  -d '{"team_id":"lit4757-team","team_alias":"LIT4757 Team","models":["team-granted-model"],"model_aliases":{"team-fast":"alias-target-model"}}'
curl -sX POST http://127.0.0.1:4757/user/new -H "Authorization: Bearer sk-lit4757-master" -H 'Content-Type: application/json' \
  -d '{"user_id":"lit4757-user","user_email":"lit4757@example.com","user_role":"internal_user","models":[],"teams":["lit4757-team"],"auto_create_key":false}'
```

Each leg then runs:

```
START=$(curl -sX POST http://127.0.0.1:4757/sso/cli/start)
# stands in for the browser IdP redirect only
curl -sX POST "http://127.0.0.1:4757/sso/cli/complete/$LOGIN_ID" --data-urlencode "user_code=$USER_CODE" --data-urlencode "browser_complete_token=$TOKEN"
POLL=$(curl -s "http://127.0.0.1:4757/sso/cli/poll/$LOGIN_ID?team_id=lit4757-team" -H "X-LiteLLM-CLI-Poll-Secret: $POLL_SECRET")
curl -s http://127.0.0.1:4757/v1/models -H "Authorization: Bearer $KEY"
curl -s -X POST http://127.0.0.1:4757/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"model":"team-fast","messages":[{"role":"user","content":"Reply with exactly: lit4757 alias resolved"}],"max_tokens":24}'
```

BEFORE, at `7fcca523aa`:

```
########## BEFORE: proxy is serving 7fcca523aa ##########
"I'm alive!"

########## BEFORE: lite login, step 1 of 3, POST /sso/cli/start ##########
login_id cli-m2gIZ3HI..., user_code QNDS-8PFA

########## BEFORE: standing in for the browser IdP redirect only ##########
user row teams: ["lit4757-team"]
team_details cached: [{"team_id": "lit4757-team", "team_alias": "LIT4757 Team"}]

########## BEFORE: lite login, step 2 of 3, POST /sso/cli/complete ##########
browser verification: HTTP 200

########## BEFORE: lite login, step 3 of 3, GET /sso/cli/poll ##########
poll status ready team_id lit4757-team

########## BEFORE: GET /v1/models as the lite login session ##########
HTTP 200 ['alias-target-model', 'not-granted-model', 'team-granted-model']
NOT-GRANTED MODEL VISIBLE: True

########## BEFORE: POST /v1/chat/completions with the team model alias 'team-fast' ##########
HTTP 403 {"error":{"message":"team not allowed to access model. This team can only access models=['team-granted-model']. Tried to access team-fast","type":"team_model_access_denied","param":"model","code":"403"}}
```

AFTER, at `38261a2291`:

```
########## AFTER: proxy is serving 38261a2291 ##########
"I'm alive!"

########## AFTER: lite login, step 1 of 3, POST /sso/cli/start ##########
login_id cli-_qbrzmF2..., user_code 9D73-ZHEV

########## AFTER: standing in for the browser IdP redirect only ##########
user row teams: ["lit4757-team"]
teams offered to the session: ["lit4757-team"]
team_details cached: [{"team_id": "lit4757-team", "team_alias": "LIT4757 Team", "team_models": ["team-granted-model"], "team_model_aliases": {"team-fast": "alias-target-model"}}]

########## AFTER: lite login, step 2 of 3, POST /sso/cli/complete ##########
browser verification: HTTP 200

########## AFTER: lite login, step 3 of 3, GET /sso/cli/poll ##########
poll status ready team_id lit4757-team

########## AFTER: GET /v1/models as the lite login session ##########
HTTP 200 ['team-granted-model']
NOT-GRANTED MODEL VISIBLE: False

########## AFTER: POST /v1/chat/completions with the team model alias 'team-fast' ##########
HTTP 200 {"id":"chatcmpl-ECYvVsr2uTDsyzuoad0uaN2rLAzZ6","created":1786662901,"model":"team-fast","object":"chat.completion","system_fingerprint":"fp_59a879beae","choices":[{"finish_reason":"stop","index":0,"message":{"content":"lit4757 alias resolved","role":"assistant","provider_specific_fields":{"refusal":null},"annotations":[]},"provider_specific_fields":{}}],"usage":{"completion_tokens":5,"prompt_tokens":16,"total_tokens":21,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}},"service_tier":"default"}
```

Deleting an organization removes its team rows and leaves the memberships behind, so that case is covered too. BEFORE, at `7fcca523aa`, the login binds the session to a team that is gone:

```
########## ORG DELETE, BEFORE at 7fcca523aa ##########
an admin deletes the organization that owns the user's only team
DELETE /organization/delete HTTP 200
the team row is gone, the membership is not:
  surviving team rows: 0   user still lists: {lit4757-orgteam}

user row teams: ["lit4757-orgteam"]
team_details cached: []
poll status ready | bound to team_id lit4757-orgteam

the session is bound to a team that no longer exists, and lists:
  GET /v1/models HTTP 200 ['alias-target-model', 'not-granted-model', 'team-granted-model']
```

AFTER, at `38261a2291`, the same user with the same leftover membership completes the login and is not pinned to the removed team:

```
########## ORG DELETE, AFTER at 38261a2291: same user, same stale membership ##########
  surviving team rows: 0   user still lists: {lit4757-orgteam}

user row teams: ["lit4757-orgteam"]
teams offered to the session: []
poll HTTP 200 | status ready | bound to team_id None | minted a key: True
```

And a login cached by the old build, then polled on the new one, is refused rather than completed on incomplete data, also at `38261a2291`:

```
########## LEGACY SESSION, AFTER at 38261a2291 ##########
team_details cached: [{"team_id": "lit4757-team", "team_alias": "LIT4757 Team"}]
poll: {"detail":"Could not resolve the model grants for team: lit4757-team. Please run `lite login` again"} HTTP 500
```

The before tree was verified to lack the fix (`grep -c "_selected_cli_sso_team_detail"` returned 0 on `7fcca523aa`), and every leg re-asserted `/health/liveliness` first

Every change was mutation tested on its own, each mutant applied to a clean tree and reverted before the next, and each one killed out of 459 tests:

- drop the joined alias table from the lookup -> `test_fetch_cli_sso_team_details_projects_team_grants`
- drop models and aliases from the projection -> same test
- stop decoding the JSON-encoded aliases -> same test
- restore the personal allowlist in the key slot -> `test_get_cli_jwt_auth_token_carries_team_grants_not_user_allowlist`
- drop the mint-time population -> same test
- stop passing the selected team's grants from the poll -> `test_cli_poll_key_mints_jwt_with_selected_team_grants` plus the teamless case
- treat an unresolved team as an empty grant -> `test_cli_poll_key_refuses_to_mint_when_team_grants_are_unknown[selected_team_absent]`, the one case that mutant reaches, since the other two routes go through validation
- report a failed team lookup as a real empty answer -> `test_fetch_cli_sso_team_details_separates_lookup_failure_from_no_teams`
- offer the raw membership instead of the teams that resolved -> `test_cli_completion_drops_teams_whose_rows_no_longer_exist`

On scope, so the decision stays visible: this is the narrow fix, populating the team's grants when the session token is minted. The durable alternative is to have the listing endpoints read the per-request team object instead of the token snapshot, and I deliberately did not do that here. It overlaps LIT-4755 and LIT-3803, and the ticket's assignee has scoping opinions on it, so it should be their call rather than something that rides along in this PR. The assignee should review

## Review notes

Both review bots flagged the same line, that a team whose grants could not be resolved was treated as though it had no restrictions. I agreed and fixed it, so this is a record of the reasoning rather than a rebuttal

The part worth naming is why the unresolved case could not simply be read as "deny". An empty team grant is a real, legitimate value meaning unrestricted, and it matches how the live team row is enforced, so unresolved and empty had to become two different values rather than one being reinterpreted as the other. The selection now returns a distinct unresolved, and the poll declines to mint on it

Refusing is only safe if it cannot become permanent, so I checked what happens when a team goes away. Deleting a team through `/team/delete` also clears the memberships, so that case settles itself on the next login. Deleting an organization does not: its team rows go but the memberships stay, and a user left holding only that membership would have been refused on every future login with no way to recover. So the login now offers only teams whose rows still exist, which also removes the older behavior of binding a session to a team that is gone. A lookup that fails outright fails the login instead, since quietly dropping every team would hand a team-bound user a session scoped to their personal allowlist, which is the same "assume rather than resolve" shape in a quieter form

Two pre-existing fixtures carried the older cached shape and were updated to what the writer now emits. Two others mocked the team lookup with a client that could not actually serve it, which the old code absorbed silently; they now use a working mock

## Type

🐛 Bug Fix

## Caveats (if any)

- Ticket assignee should review; this touches their area
- Narrow fix only: mint-time population, no resolver refactor
- Listing still reads the token snapshot, not the live team
- A team granting all models now lists all models
- Logins cached mid-rollout fail once and need a retry

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
