### PR TITLE
feat(ui): show provider prompt cache tokens in chat response metrics

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/anthropic_messages.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/anthropic_messages.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeAnthropicMessagesRequest } from "./anthropic_messages";
+import type { TokenUsage } from "@/components/chat_ui/ResponseMetrics";
+
+vi.mock("@/components/networking", () => ({
+  getProxyBaseUrl: vi.fn(() => "https://example.com"),
+}));
+
+const mockMessagesStream = vi.fn();
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn(() => ({ messages: { stream: mockMessagesStream } })),
+}));
+
+describe("anthropic_messages prompt cache usage", () => {
+  const captureUsage = async (usage: Record<string, unknown>): Promise<TokenUsage> => {
+    async function* mockStream() {
+      yield {
+        type: "message_delta",
+        usage: { input_tokens: 5000, output_tokens: 2, ...usage },
+      };
+    }
+    mockMessagesStream.mockReturnValue(mockStream());
+
+    const onUsageData = vi.fn();
+    await makeAnthropicMessagesRequest(
+      [{ role: "user", content: "Hello" }],
+      vi.fn(),
+      "claude-haiku-4-5",
+      "test-token",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      onUsageData,
+    );
+
+    expect(onUsageData).toHaveBeenCalledTimes(1);
+    return onUsageData.mock.calls[0][0] as TokenUsage;
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("surfaces read and creation tokens from Anthropic-shape usage", async () => {
+    await expect(
+      captureUsage({ cache_read_input_tokens: 4695, cache_creation_input_tokens: 1234 }),
+    ).resolves.toMatchObject({ cacheReadTokens: 4695, cacheCreationTokens: 1234, promptTokens: 5000 });
+  });
+
+  it("omits cache fields entirely when Anthropic reports no prompt caching", async () => {
+    const usageData = await captureUsage({});
+
+    expect(usageData).not.toHaveProperty("cacheReadTokens");
+    expect(usageData).not.toHaveProperty("cacheCreationTokens");
+    expect(usageData.promptTokens).toBe(5000);
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/anthropic_messages.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/anthropic_messages.tsx
@@ -5,6 +5,7 @@ import { buildMcpToolBlocks } from "@/components/llm_calls/mcp_tool_blocks";
 import { MCPServer, MCPToolset } from "@/components/mcp_tools/types";
 import { getProxyBaseUrl } from "@/components/networking";
 import NotificationManager from "@/components/molecules/notifications_manager";
+import { extractPromptCacheTokens } from "@/utils/promptCacheUsage";
 
 export async function makeAnthropicMessagesRequest(
   messages: MessageType[],
@@ -109,6 +110,7 @@ export async function makeAnthropicMessagesRequest(
           completionTokens: usage.output_tokens,
           promptTokens: usage.input_tokens,
           totalTokens: usage.input_tokens + usage.output_tokens,
+          ...extractPromptCacheTokens(usage),
         };
         onUsageData(usageData);
       }

--- a/ui/litellm-dashboard/src/components/chat_ui/ResponseMetrics.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/ResponseMetrics.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import ResponseMetrics, { type TokenUsage } from "./ResponseMetrics";
+
+const baseUsage: TokenUsage = { promptTokens: 5000, completionTokens: 12, totalTokens: 5012 };
+
+describe("ResponseMetrics prompt cache chips", () => {
+  it("renders both cache chips when the provider reports reads and writes", () => {
+    render(<ResponseMetrics usage={{ ...baseUsage, cacheReadTokens: 4695, cacheCreationTokens: 1234 }} />);
+
+    expect(screen.getByText("Cache Read: 4695")).toBeInTheDocument();
+    expect(screen.getByText("Cache Write: 1234")).toBeInTheDocument();
+  });
+
+  it("renders only the read chip when the provider reports reads alone", () => {
+    render(<ResponseMetrics usage={{ ...baseUsage, cacheReadTokens: 4695 }} />);
+
+    expect(screen.getByText("Cache Read: 4695")).toBeInTheDocument();
+    expect(screen.queryByText(/Cache Write/)).not.toBeInTheDocument();
+  });
+
+  it("renders no cache chips for a provider that reports no cache fields", () => {
+    render(<ResponseMetrics usage={baseUsage} />);
+
+    expect(screen.getByText("In: 5000")).toBeInTheDocument();
+    expect(screen.queryByText(/Cache Read/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Cache Write/)).not.toBeInTheDocument();
+  });
+
+  it("renders no cache chips when the provider reports zero cache tokens", () => {
+    render(<ResponseMetrics usage={{ ...baseUsage, cacheReadTokens: 0, cacheCreationTokens: 0 }} />);
+
+    expect(screen.queryByText(/Cache Read/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Cache Write/)).not.toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/chat_ui/ResponseMetrics.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/ResponseMetrics.tsx
@@ -1,12 +1,25 @@
 import React from "react";
-import { ArrowDownToLine, ArrowUpFromLine, Clock, DollarSign, Hash, Lightbulb, Wrench } from "lucide-react";
+import {
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Clock,
+  Database,
+  DatabaseBackup,
+  DollarSign,
+  Hash,
+  Lightbulb,
+  Wrench,
+} from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { PROMPT_CACHE_CREATION_TOOLTIP, PROMPT_CACHE_READ_TOOLTIP } from "@/utils/promptCacheUsage";
 
 export interface TokenUsage {
   completionTokens?: number;
   promptTokens?: number;
   totalTokens?: number;
   reasoningTokens?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
   cost?: number;
 }
 
@@ -35,6 +48,33 @@ function MetricItem({ label, tooltip, icon, value }: MetricItemProps) {
       </TooltipTrigger>
       <TooltipContent>{tooltip}</TooltipContent>
     </Tooltip>
+  );
+}
+
+function PromptCacheChips({ usage }: { usage?: TokenUsage }) {
+  const readTokens = usage?.cacheReadTokens ?? 0;
+  const creationTokens = usage?.cacheCreationTokens ?? 0;
+
+  return (
+    <>
+      {readTokens > 0 && (
+        <MetricItem
+          label="Cache Read"
+          tooltip={PROMPT_CACHE_READ_TOOLTIP}
+          icon={<Database className="size-3" aria-hidden="true" />}
+          value={String(readTokens)}
+        />
+      )}
+
+      {creationTokens > 0 && (
+        <MetricItem
+          label="Cache Write"
+          tooltip={PROMPT_CACHE_CREATION_TOOLTIP}
+          icon={<DatabaseBackup className="size-3" aria-hidden="true" />}
+          value={String(creationTokens)}
+        />
+      )}
+    </>
   );
 }
 
@@ -69,6 +109,8 @@ const ResponseMetrics: React.FC<ResponseMetricsProps> = ({ timeToFirstToken, tot
           value={String(usage.promptTokens)}
         />
       )}
+
+      <PromptCacheChips usage={usage} />
 
       {usage?.completionTokens !== undefined && (
         <MetricItem

--- a/ui/litellm-dashboard/src/components/chat_ui/types.ts
+++ b/ui/litellm-dashboard/src/components/chat_ui/types.ts
@@ -1,3 +1,5 @@
+import type { TokenUsage } from "./ResponseMetrics";
+
 export interface VectorStoreSearchResult {
   score: number;
   content: Array<{ text: string; type: string }>;
@@ -33,13 +35,7 @@ export interface MessageType {
   reasoningContent?: string;
   timeToFirstToken?: number;
   totalLatency?: number;
-  usage?: {
-    completionTokens?: number;
-    promptTokens?: number;
-    totalTokens?: number;
-    reasoningTokens?: number;
-    cost?: number;
-  };
+  usage?: TokenUsage;
   toolName?: string;
   imagePreviewUrl?: string;
   image?: {

--- a/ui/litellm-dashboard/src/components/llm_calls/chat_completion.test.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/chat_completion.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeOpenAIChatCompletionRequest } from "./chat_completion";
+import type { TokenUsage } from "../chat_ui/ResponseMetrics";
 
 vi.mock("@/components/networking", () => ({
   getProxyBaseUrl: vi.fn(() => "https://example.com"),
@@ -392,5 +393,69 @@ describe("chat_completion", () => {
     expect(mockCreate).toHaveBeenCalledTimes(1);
     const callArgs = mockCreate.mock.calls[0][0];
     expect(callArgs).not.toHaveProperty("mock_testing_fallbacks");
+  });
+});
+
+describe("chat_completion prompt cache usage", () => {
+  const captureUsage = async (usage: Record<string, unknown>): Promise<TokenUsage> => {
+    async function* mockStream() {
+      yield {
+        choices: [{ delta: {}, index: 0 }],
+        model: "gpt-4",
+        usage: { completion_tokens: 2, prompt_tokens: 5000, total_tokens: 5002, ...usage },
+      };
+    }
+    mockCreate.mockResolvedValue(mockStream());
+
+    const onUsageData = vi.fn();
+    await makeOpenAIChatCompletionRequest(
+      [{ role: "user", content: "Hello" }],
+      vi.fn(),
+      "gpt-4",
+      "test-token",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      onUsageData,
+    );
+
+    expect(onUsageData).toHaveBeenCalledTimes(1);
+    return onUsageData.mock.calls[0][0] as TokenUsage;
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("surfaces read and creation tokens from Anthropic-shape usage", async () => {
+    await expect(
+      captureUsage({ cache_read_input_tokens: 4695, cache_creation_input_tokens: 1234 }),
+    ).resolves.toMatchObject({ cacheReadTokens: 4695, cacheCreationTokens: 1234 });
+  });
+
+  it("surfaces read tokens from OpenAI-shape prompt_tokens_details", async () => {
+    await expect(
+      captureUsage({ prompt_tokens_details: { cached_tokens: 4695, cache_write_tokens: 0 } }),
+    ).resolves.toMatchObject({ cacheReadTokens: 4695, promptTokens: 5000 });
+  });
+
+  it("omits cache fields entirely for a provider that reports none", async () => {
+    const usageData = await captureUsage({});
+
+    expect(usageData).not.toHaveProperty("cacheReadTokens");
+    expect(usageData).not.toHaveProperty("cacheCreationTokens");
+    expect(usageData.promptTokens).toBe(5000);
+  });
+
+  it("omits cache fields when the provider reports zeroes", async () => {
+    const usageData = await captureUsage({
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      prompt_tokens_details: { cached_tokens: 0 },
+    });
+
+    expect(usageData).not.toHaveProperty("cacheReadTokens");
+    expect(usageData).not.toHaveProperty("cacheCreationTokens");
   });
 });

--- a/ui/litellm-dashboard/src/components/llm_calls/chat_completion.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/chat_completion.tsx
@@ -4,6 +4,7 @@ import { TokenUsage } from "../chat_ui/ResponseMetrics";
 import { VectorStoreSearchResponse } from "../chat_ui/types";
 import { getProxyBaseUrl } from "@/components/networking";
 import { MCPServer, MCPToolset, type MCPEvent } from "@/components/mcp_tools/types";
+import { extractPromptCacheTokens } from "@/utils/promptCacheUsage";
 
 const completionAsSingleChunk = (completion: ChatCompletion): ChatCompletionChunk =>
   ({
@@ -226,6 +227,7 @@ export async function makeOpenAIChatCompletionRequest(
           completionTokens: chunkWithUsage.usage.completion_tokens,
           promptTokens: chunkWithUsage.usage.prompt_tokens,
           totalTokens: chunkWithUsage.usage.total_tokens,
+          ...extractPromptCacheTokens(chunkWithUsage.usage),
         };
 
         // Check for reasoning tokens

--- a/ui/litellm-dashboard/src/components/llm_calls/responses_api.test.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/responses_api.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeOpenAIResponsesRequest } from "./responses_api";
 import { MessageType } from "../chat_ui/types";
+import type { TokenUsage } from "../chat_ui/ResponseMetrics";
 
 vi.mock("@/components/networking", () => ({
   getProxyBaseUrl: vi.fn(() => "https://example.com"),
@@ -292,5 +293,60 @@ describe("responses_api", () => {
         allowed_tools: ["toolB", "toolC"],
       },
     ]);
+  });
+});
+
+describe("responses_api prompt cache usage", () => {
+  const captureUsage = async (usage: Record<string, unknown>): Promise<TokenUsage> => {
+    async function* mockStream() {
+      yield {
+        type: "response.completed",
+        response: {
+          id: "resp_cache",
+          usage: { output_tokens: 2, input_tokens: 5000, total_tokens: 5002, ...usage },
+        },
+      };
+    }
+    mockResponsesCreate.mockResolvedValue(mockStream());
+
+    const onUsageData = vi.fn();
+    await makeOpenAIResponsesRequest(
+      [{ role: "user", content: "Hello" }],
+      vi.fn(),
+      "gpt-4",
+      "test-token",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      onUsageData,
+    );
+
+    expect(onUsageData).toHaveBeenCalledTimes(1);
+    return onUsageData.mock.calls[0][0] as TokenUsage;
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("surfaces read tokens from Responses-shape input_tokens_details", async () => {
+    await expect(
+      captureUsage({ input_tokens_details: { cached_tokens: 4695, cache_write_tokens: 0 } }),
+    ).resolves.toMatchObject({ cacheReadTokens: 4695, promptTokens: 5000 });
+  });
+
+  it("surfaces creation tokens from Responses-shape cache writes", async () => {
+    await expect(
+      captureUsage({ input_tokens_details: { cached_tokens: 0, cache_write_tokens: 4695 } }),
+    ).resolves.toMatchObject({ cacheCreationTokens: 4695 });
+  });
+
+  it("omits cache fields entirely for a provider that reports none", async () => {
+    const usageData = await captureUsage({});
+
+    expect(usageData).not.toHaveProperty("cacheReadTokens");
+    expect(usageData).not.toHaveProperty("cacheCreationTokens");
+    expect(usageData.promptTokens).toBe(5000);
   });
 });

--- a/ui/litellm-dashboard/src/components/llm_calls/responses_api.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/responses_api.tsx
@@ -3,6 +3,7 @@ import { MessageType } from "../chat_ui/types";
 import { TokenUsage } from "../chat_ui/ResponseMetrics";
 import { getProxyBaseUrl } from "@/components/networking";
 import NotificationManager from "@/components/molecules/notifications_manager";
+import { extractPromptCacheTokens } from "@/utils/promptCacheUsage";
 import type { MCPEvent } from "@/components/mcp_tools/types";
 import { MCPServer, MCPToolset } from "@/components/mcp_tools/types";
 import {
@@ -290,6 +291,7 @@ export async function makeOpenAIResponsesRequest(
               completionTokens: usage.output_tokens,
               promptTokens: usage.input_tokens,
               totalTokens: usage.total_tokens,
+              ...extractPromptCacheTokens(usage),
             };
 
             // Add reasoning tokens if available

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
@@ -4,6 +4,7 @@ import { InfoCircleOutlined } from "@ant-design/icons";
 import moment from "moment";
 import { LogEntry } from "../columns";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
+import { PROMPT_CACHE_CREATION_TOOLTIP, PROMPT_CACHE_READ_TOOLTIP } from "@/utils/promptCacheUsage";
 import GuardrailViewer from "../GuardrailViewer/GuardrailViewer";
 import EvalViewer from "../EvalViewer/EvalViewer";
 import { CostBreakdownViewer } from "../CostBreakdownViewer";
@@ -285,10 +286,6 @@ function getUncachedInputTextTokens(metadata: Record<string, any>): number | und
 
 const RESPONSE_CACHE_TOOLTIP =
   "Whether this request was served from LiteLLM's response cache (e.g. Redis / in-memory), skipping the LLM provider call entirely. This is separate from provider prompt caching; a Miss here does not mean prompt caching failed.";
-const PROMPT_CACHE_READ_TOOLTIP =
-  "Input tokens read from the LLM provider's prompt cache (e.g. Anthropic / OpenAI), billed at a discounted rate. Reported by the provider.";
-const PROMPT_CACHE_CREATION_TOOLTIP =
-  "Input tokens written to the LLM provider's prompt cache for reuse by later requests.";
 const RESPONSE_CACHE_DOCS_URL = "https://docs.litellm.ai/docs/proxy/caching";
 const PROMPT_CACHE_DOCS_URL = "https://docs.litellm.ai/docs/completion/prompt_caching";
 

--- a/ui/litellm-dashboard/src/utils/promptCacheUsage.test.ts
+++ b/ui/litellm-dashboard/src/utils/promptCacheUsage.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { extractPromptCacheTokens } from "./promptCacheUsage";
+
+describe("extractPromptCacheTokens", () => {
+  it("reads the Anthropic Messages shape", () => {
+    expect(
+      extractPromptCacheTokens({ cache_read_input_tokens: 5678, cache_creation_input_tokens: 1234 }),
+    ).toStrictEqual({ cacheReadTokens: 5678, cacheCreationTokens: 1234 });
+  });
+
+  it("reads the chat completions shape", () => {
+    expect(
+      extractPromptCacheTokens({ prompt_tokens_details: { cached_tokens: 4695, cache_write_tokens: 0 } }),
+    ).toStrictEqual({ cacheReadTokens: 4695 });
+  });
+
+  it("reads the Responses API shape", () => {
+    expect(
+      extractPromptCacheTokens({ input_tokens_details: { cached_tokens: 0, cache_write_tokens: 4695 } }),
+    ).toStrictEqual({ cacheCreationTokens: 4695 });
+  });
+
+  it("returns nothing for usage without cache fields", () => {
+    expect(extractPromptCacheTokens({})).toStrictEqual({});
+    expect(extractPromptCacheTokens(undefined)).toStrictEqual({});
+    expect(extractPromptCacheTokens(null)).toStrictEqual({});
+  });
+
+  it("drops zero and non-finite counts so non-caching providers render nothing", () => {
+    expect(
+      extractPromptCacheTokens({
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: null,
+        prompt_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
+      }),
+    ).toStrictEqual({});
+    expect(extractPromptCacheTokens({ cache_read_input_tokens: Number.NaN })).toStrictEqual({});
+  });
+});

--- a/ui/litellm-dashboard/src/utils/promptCacheUsage.ts
+++ b/ui/litellm-dashboard/src/utils/promptCacheUsage.ts
@@ -1,0 +1,37 @@
+export const PROMPT_CACHE_READ_TOOLTIP =
+  "Input tokens read from the LLM provider's prompt cache (e.g. Anthropic / OpenAI), billed at a discounted rate. Reported by the provider.";
+export const PROMPT_CACHE_CREATION_TOOLTIP =
+  "Input tokens written to the LLM provider's prompt cache for reuse by later requests.";
+
+interface CachedTokenDetails {
+  cached_tokens?: number | null;
+  cache_write_tokens?: number | null;
+}
+
+export interface ProviderCacheUsage {
+  cache_read_input_tokens?: number | null;
+  cache_creation_input_tokens?: number | null;
+  prompt_tokens_details?: CachedTokenDetails | null;
+  input_tokens_details?: CachedTokenDetails | null;
+}
+
+export interface PromptCacheTokens {
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+}
+
+const positiveTokenCount = (value: number | null | undefined): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+
+export const extractPromptCacheTokens = (usage: ProviderCacheUsage | null | undefined): PromptCacheTokens => {
+  const details = usage?.prompt_tokens_details ?? usage?.input_tokens_details;
+  const cacheReadTokens =
+    positiveTokenCount(usage?.cache_read_input_tokens) ?? positiveTokenCount(details?.cached_tokens);
+  const cacheCreationTokens =
+    positiveTokenCount(usage?.cache_creation_input_tokens) ?? positiveTokenCount(details?.cache_write_tokens);
+
+  return {
+    ...(cacheReadTokens !== undefined && { cacheReadTokens }),
+    ...(cacheCreationTokens !== undefined && { cacheCreationTokens }),
+  };
+};


### PR DESCRIPTION
## TLDR

Problem this solves:

- Playground chat never showed provider prompt cache tokens
- Users could not tell whether prompt caching actually worked
- The counts existed, but only in the Logs drawer
- Three producers each parsed usage their own way

How it solves it:

- One shared helper normalizes all three usage shapes
- Two chips render cache read and cache write counts
- Chips reuse the Logs drawer's existing tooltip wording
- Absent or zero counts render nothing, as before

## User Flow

Before: an operator testing prompt caching in the playground gets no signal that it worked, and has to leave the page to find out

1. They open http://localhost:4000/ui/playground/, pick an OpenAI model, and paste a prompt of roughly 7,200 tokens
2. They send it once, then continue the conversation with a short follow-up
3. Under each reply the metrics bar reads `In: 7215   Out: 4   Total: 7219` next to the timings, with nothing about caching either time
4. Nothing on the page separates the follow-up, whose prefix the provider served from its prompt cache, from the first send, which paid full price for the same tokens
5. They leave the playground, open the Logs page, click that request, and only there see `Prompt Cache Read Tokens: 7,212`

After: the same two sends answer the question on the page the operator is already on

1. They open http://localhost:4000/ui/playground/, pick an OpenAI model, and paste the same prompt
2. They send it once. The metrics bar now reads `In: 7215   Cache Write: 7212   Out: 4   Total: 7219`
3. They continue the conversation. The metrics bar reads `In: 7234   Cache Read: 7212   Cache Write: 19   Out: 4   Total: 7238`, reading the warm prefix and writing only the new tail
4. Hovering `Cache Read` explains that these are input tokens read from the provider's prompt cache and billed at a discounted rate, the same wording the Logs drawer uses
5. With the proxy's own response cache turned on, and Stream responses left checked as it is by default, they clear the chat, send the prompt on its own, clear the chat again and send exactly the same thing. The response cache keys on the whole request body, so only that second standalone send is a repeat it recognises. It comes back in 0.22s against 1.19s, and the bar shows `In`, `Out` and `Total` with no cache chips at all, while the Logs drawer for it says `Response Cache: Hit`. A response-cache hit and a provider prompt-cache hit no longer read the same there
6. Switching Endpoint Type to /v1/responses and repeating shows the same two chips
7. On a model or provider that reports no cache tokens, the metrics bar is byte for byte what it was before

## Relevant issues

## Linear ticket

Resolves LIT-5513

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured against a local proxy on port 4513 hitting the real OpenAI and Anthropic APIs, costing real money, with its own Postgres and Redis. Latest model per family taken from `model_prices_and_context_window.json`: `gpt-5.6-luna` and `claude-haiku-4-5`

BEFORE, at `fa498391a4`. AFTER, at `b3e833fd83`

The before tree really does lack the fix rather than merely looking unchanged. On `fa498391a4` the metrics bar component contains no cache chip code, and in the shipped bundle every one of the four chunks that contains `TTFT`, the first label on the metrics bar, contains zero occurrences of `Cache Read` or `Cache Write`. After building this branch, the chunk the running server actually serves does contain them, confirmed over HTTP rather than off disk:

```
curl -s http://127.0.0.1:4513/ui/_next/static/chunks/3mvd-fiucq7h0.js | grep -c "Cache Read"
1
```

### In the playground

Leg 1, provider prompt caching, run with the response cache off so it cannot contaminate the result. A ~7.2k token prompt sent cold, then continued. Every chip below was asserted in the DOM before the screenshot was taken, so these are not eyeballed

First send, cold. The provider writes the prefix to its prompt cache, and only the write chip appears:

![Playground metrics bar after a cold send, showing Cache Write 7212 and no Cache Read](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit5513/01-cache-write.png)

```
TTFT: 1.87s   In: 7215   Cache Write: 7212   Out: 4   Total: 7219
```

Follow-up in the same conversation. The warm prefix is read and only the new tail is written, so both chips render at once and the 19 is the tail:

![Playground metrics bar on the follow-up, showing Cache Read 7212 and Cache Write 19](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit5513/02-cache-read.png)

```
In: 7234   Cache Read: 7212   Cache Write: 19   Out: 4   Total: 7238
```

Leg 2, the proxy's own response cache, same playground with Redis enabled. Sending the identical prompt from a cleared chat serves the repeat out of the response cache. No cache chip renders, asserted as `hasCacheRead=false hasCacheWrite=false`, and the latency gives it away: 0.22s against 1.19s for the real provider call on the same prompt:

![Playground metrics bar on a response-cache hit, showing In, Out and Total with no cache chips](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit5513/03-response-cache-hit.png)

```
TTFT: 0.22s   Total Latency: 0.23s   In: 6975   Out: 4   Total: 6979
```

The Logs drawer for that same request, which is where the response cache has always been reported and still is:

![Logs drawer showing Response Cache Hit and a cached cost of zero](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit5513/04-logs-response-cache-hit.png)

```
Response Cache: Hit        Cost: $0.00000000 (Cached)        Duration: 0.085s
```

So the two caches now read differently on the page itself: provider prompt caching puts a labelled token count on the bar, and a response-cache hit puts nothing there while the drawer says Hit

### At the API level

The same two legs driven by curl, plus the two other endpoints the shared helper normalizes. Token counts differ from the screenshots because these runs used their own prompts

Leg 1 over /v1/chat/completions, response cache off. Two byte-identical streaming sends, `stream_options.include_usage` set, which is exactly what the playground sends. The two response ids differ, so both are real provider calls:

```
--- send 1, cold prefix ---
  id: chatcmpl-ECXt7qb32VZQ1cqDaeNLVwI7Lm4VQ | prompt: 6378 | cached: 0    | write: 6375
--- send 2, identical ---
  id: chatcmpl-ECXtBopiyQOJAUoI8n8HXdr8bwlhK | prompt: 6378 | cached: 6375 | write: 0
```

Continuing that conversation instead of repeating it lights both chips at once, reading the warm prefix and writing only the new tail:

```
  prompt: 6397 | cached: 6375 | write: 19
```

Leg 2 over the same endpoint with Redis enabled. Same two byte-identical sends. The repeat comes back with the same response id, so it never reached the provider, and its usage carries no prompt cache details at all, which is why no cache chip renders for it:

```
--- send 1 ---
  id: chatcmpl-ECXwxliaW7A5FsLNERR2W8ggVP1zg
  usage: {"prompt_tokens": 6378, "completion_tokens": 4, "total_tokens": 6382,
          "prompt_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 6375}}
--- send 2, served from the response cache ---
  id: chatcmpl-ECXwxliaW7A5FsLNERR2W8ggVP1zg
  usage: {"prompt_tokens": 6378, "completion_tokens": 4, "total_tokens": 6382}
```

That is the distinction the ticket asks for, on the streaming path the playground uses by default: provider prompt caching shows a labelled token count, and a response-cache hit shows none. The non-streaming path is excluded and tracked, see the review notes

/v1/responses, the second shape the helper normalizes, same two legs:

```
--- leg 1 --- {"input_tokens": 6018, "input_tokens_details": {"cached_tokens": 0,    "cache_write_tokens": 6015}, "output_tokens": 5}
--- leg 2 --- {"input_tokens": 6018, "input_tokens_details": {"cached_tokens": 6015, "cache_write_tokens": 0},    "output_tokens": 5}
```

/v1/messages, the Anthropic-native shape, which needs an explicit `cache_control` breakpoint before Anthropic caches anything:

```
--- leg 1 --- {"input_tokens": 10, "cache_creation_input_tokens": 9446, "cache_read_input_tokens": 0,    "output_tokens": 4}
--- leg 2 --- {"input_tokens": 10, "cache_creation_input_tokens": 0,    "cache_read_input_tokens": 9446, "output_tokens": 4}
```

Anthropic caches nothing without that breakpoint, and the playground does not send one, so a plain pasted prompt against an Anthropic model reports flat zeros and renders no chips. To get the chips on an Anthropic model an operator fills in "Cache Control Injection Points" on the model itself, which is available both when adding a model and when editing an existing one, and which makes the proxy insert the breakpoint on their behalf. OpenAI needs none of this because its prompt caching is automatic, which is why the playground legs above use it

Coverage from the capture: read and write both proven live on all three endpoints, plus a response-cache hit proven to render no cache chips on the streaming path

## Type

🆕 New Feature

## Caveats (if any)

- The ticket's rename target does not exist on staging
- /ui/chat renders no metrics bar at all today
- Wiring /ui/chat is deliberately out of scope, tracked separately
- The non-streaming path is excluded, tracked as LIT-5533
- Anthropic needs cache control injection points set per model
- Two prompt-cache tooltip strings moved into the shared util

## Notes for the reviewer

The ticket asks to rename or explain a response-cache control in /ui/chat. That control does not exist. Grepping for "cache" across the playground, `src/app/chat` and `src/components/chat` returns nothing, and the labelling half of the ticket already shipped in #34138, which renamed the nav entry to "Response Cache", explained on the cache dashboard that the page covers LiteLLM's response cache rather than provider prompt caching, and added the three tooltips in the Logs drawer. What was left over is the customer's other ask, a way to see that caching worked, so that is what this PR does and that is why the diff is narrower than the ticket text

On surfaces: /ui/chat has no metrics bar at all right now. `ChatMessages.tsx` never renders `ResponseMetrics`, `ChatMessage` has no usage field, and `ChatShell.tsx` drops the usage callback before it could be rendered. The three places that do render the metrics bar are `playground/components/chat_ui/ChatMessageBubble.tsx`, `playground/components/compareUI/components/MessageDisplay.tsx` and `prompts/_components/prompt_editor_view/conversation_panel/MessageBubble.tsx`, and all three light up from this change. Giving /ui/chat a metrics bar would be a new UI element rather than two extra chips, so it is out of scope here and tracked on its own

This branch was rebased onto the playground shadcn migration in #36129, which moved `ResponseMetrics.tsx` off antd onto `@/components/ui/tooltip`, lucide icons and a shared `MetricItem`. The chips are expressed in that idiom rather than the antd one they were originally written in. They live in an extracted `PromptCacheChips` because inlining them pushes the metrics bar to a complexity of 25 against a ceiling of 20, where the file warns zero times on base; extracted, it still warns zero times and adds nothing to the repo-wide budget

Two things worth flagging in the diff. First, `PROMPT_CACHE_READ_TOOLTIP` and `PROMPT_CACHE_CREATION_TOOLTIP` moved out of `LogDetailContent.tsx` into the new shared util and are imported back, which is why a logs file appears in a chat PR. That makes wording drift between the two surfaces structurally impossible instead of merely unlikely. Second, OpenAI reports a creation-equivalent as `cache_write_tokens` rather than Anthropic's `cache_creation_input_tokens`, verified live on both API shapes, so the helper maps it and the write chip fires for OpenAI users too

One boundary is deliberately excluded, and it is a real one, tracked as LIT-5533 at High. Additional Model Settings carries a "Stream responses" checkbox, and unchecking it sends the request down the non-streaming branch of these same two producers, on this surface. There, a response-cache hit replays the stored body verbatim with its cache counts, and the chips render for it. Two byte-identical non-streaming sends return the same response id and the same `cache_write_tokens: 6135`, and driving the producer directly with `streamingEnabled: false` and that replayed body hands the bar `{ cacheCreationTokens: 6135, completionTokens: 4, promptTokens: 6141, totalTokens: 6145 }`, which is exactly the condition that draws the chip

Stated plainly, because it is worse than the inherited behaviour around it: on that path `Cache Write: 6135` asserts that the provider wrote 6135 tokens to its prompt cache, on a request that never reached the provider. The rest of the bar carries stale numbers from the original call, which is misleading; this carries a fabricated provider action, and it does so on the exact axis this ticket exists to fix

It is deferred because the correct fix is bar-level rather than chip-level. The entire bar replays on a response-cache hit, `In`, `Out`, `Total` and `Cost` included, and nothing on it can say the response was served from the response cache. The real defect is that missing indicator, and fixing it fixes the cost line and the token counts at the same time. Suppressing just these two chips would special-case two fields of a bar where every field has the same problem, and would leave a bespoke path for the proper fix to unwind. The replayed body carries no cache marker at all, so that fix has to read the `x-litellm-cache-key` response header in both producers and thread it through, which is a runtime change wanting its own capture. The distinction claim above is scoped to the streaming path for this reason

On the tests, the no-cache-fields assertions use `expect(usageData).not.toHaveProperty("cacheReadTokens")` rather than `toHaveBeenCalledWith`, because the latter ignores undefined properties and would pass even if every non-caching provider started rendering empty chips. Both chip guards were mutation checked against the rebased component, flipping each `> 0` to `>= 0` in turn; each mutation was asserted to have actually applied, and each was killed on its own

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
