### PR TITLE
fix(auth): stop the team fallback from widening model access

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2051,6 +2051,23 @@ async def _delete_cache_key_object(
         await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=key)
 
 
+class TeamNotFoundError(HTTPException):
+    """The team row is provably absent, as opposed to merely unreadable.
+
+    ``get_team_object`` reports every failure as a 404, so a deleted team and a
+    database that would not answer are indistinguishable to its callers. Callers
+    that must not treat a degraded read as a definitive answer, such as the
+    authorization fallback in ``user_api_key_auth``, key on this subclass. It
+    stays a 404 carrying the same detail, so every other caller is unaffected.
+    """
+
+    def __init__(self, team_id: str) -> None:
+        super().__init__(
+            status_code=404,
+            detail={"error": f"Team doesn't exist in db. Team={team_id}. Create team via `/team/new` call."},
+        )
+
+
 @log_db_metrics
 async def _get_team_db_check(
     team_id: str, prisma_client: PrismaClient, team_id_upsert: bool | None = None
@@ -2096,6 +2113,10 @@ async def _get_team_object_from_user_api_key_cache(
     )
     if should_check_db:
         response = await _get_team_db_check(team_id=team_id, prisma_client=prisma_client, team_id_upsert=team_id_upsert)
+        # The database answered and the row is not there. Distinct from every
+        # other failure here, which leaves the team's grant unknown.
+        if response is None:
+            raise TeamNotFoundError(team_id=team_id)
     else:
         response = None
 
@@ -2217,6 +2238,8 @@ async def get_team_object(
             key=key,
             team_id_upsert=team_id_upsert,
         )
+    except TeamNotFoundError:
+        raise
     except Exception:
         raise HTTPException(
             status_code=404,

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -34,6 +34,7 @@ from litellm.litellm_core_utils.dot_notation_indexing import get_nested_value
 from litellm.proxy._types import *
 from litellm.proxy.auth.auth_checks import (
     ExperimentalUIJWTToken,
+    TeamNotFoundError,
     _cache_key_object,
     _can_object_call_model,
     _check_end_user_budget,
@@ -85,6 +86,7 @@ from litellm.proxy.common_utils.http_parsing_utils import (
 )
 from litellm.proxy.common_utils.realtime_utils import _realtime_request_body
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 from litellm.proxy.utils import (
     PrismaClient,
@@ -2161,6 +2163,28 @@ def _team_obj_from_token(valid_token: UserAPIKeyAuth) -> LiteLLM_TeamTableCached
     )
 
 
+def _token_can_vouch_for_team(valid_token: UserAPIKeyAuth, lookup_error: BaseException) -> bool:
+    """Whether the token's own team fields may stand in for a team that failed to
+    resolve, without widening access.
+
+    A team that is provably gone is a definitive answer, not a degraded read, so
+    nothing may stand in for it and no setting may override that.
+
+    Otherwise the team's grant is merely unknown. A token carrying one may vouch,
+    since replaying a recorded grant cannot widen it and denying every team key
+    while the row is briefly unreadable would trade the widening for an outage. A
+    token carrying none may not: ``team_models=[]`` reads as every model and
+    ``team_blocked=False`` as unblocked. ``allow_requests_on_db_unavailable`` opts
+    back out, and is only consulted here because the failure is known by this
+    point to be a degraded read.
+    """
+    if isinstance(lookup_error, TeamNotFoundError):
+        return False
+    if valid_token.team_models:
+        return True
+    return PrismaDBExceptionHandler.should_allow_request_on_db_unavailable()
+
+
 @tracer.wrap()
 async def _run_centralized_common_checks(
     user_api_key_auth_obj: UserAPIKeyAuth,
@@ -2364,7 +2388,12 @@ async def _run_centralized_common_checks(
     if isinstance(team_result, BaseException):
         # Token-derived fallback only valid when a team_id is set;
         # _team_obj_from_token asserts that precondition.
-        team_object = _team_obj_from_token(user_api_key_auth_obj) if user_api_key_auth_obj.team_id is not None else None
+        if user_api_key_auth_obj.team_id is None:
+            team_object = None
+        elif _token_can_vouch_for_team(user_api_key_auth_obj, team_result):
+            team_object = _team_obj_from_token(user_api_key_auth_obj)
+        else:
+            raise team_result
     else:
         team_object = team_result
 

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -163,6 +163,7 @@ async def test_team_object_has_object_permission_id():
         token=hashed_key,
         last_refreshed_at=time.time(),
         team_object_permission_id=permission_id,
+        team_models=["gpt-4o"],
     )
     user_api_key_cache.set_cache(key=hashed_key, value=valid_token)
 
@@ -255,6 +256,7 @@ async def test_aaauser_personal_budgets(key_ownership):
             user_id=_user_id,
             team_id="my-special-team",
             team_max_budget=100,
+            team_models=["gpt-4o"],
             spend=20,
         )
 

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -2073,6 +2073,53 @@ async def test_get_team_object_raises_404_when_not_found():
     assert "Team doesn't exist in db" in str(exc_info.value.detail)
 
 
+def _mock_prisma_for_team_lookup(find_unique):
+    from unittest.mock import MagicMock
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_teamtable.find_unique = find_unique
+    return mock_prisma_client
+
+
+@pytest.mark.asyncio
+async def test_get_team_object_distinguishes_absent_team_from_unreadable_row():
+    """A deleted team and a database that would not answer both surface as a 404,
+    which leaves callers unable to tell a definitive answer from a degraded read.
+    Only the row being positively absent raises the subclass; anything else keeps
+    the plain 404 so every existing caller is unaffected."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from fastapi import HTTPException
+
+    from litellm.proxy.auth.auth_checks import TeamNotFoundError, get_team_object
+
+    mock_cache = MagicMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+
+    # The database answered, and the row is not there.
+    with pytest.raises(TeamNotFoundError) as absent_info:
+        await get_team_object(
+            team_id="absent-team-lit5522",
+            prisma_client=_mock_prisma_for_team_lookup(AsyncMock(return_value=None)),
+            user_api_key_cache=mock_cache,
+            check_db_only=True,
+        )
+    assert absent_info.value.status_code == 404
+    assert "Team doesn't exist in db" in str(absent_info.value.detail)
+
+    # The database did not answer. Same status and detail, but not the subclass,
+    # so a caller keying on it does not read this as proof the team is gone.
+    with pytest.raises(HTTPException) as unreadable_info:
+        await get_team_object(
+            team_id="unreadable-team-lit5522",
+            prisma_client=_mock_prisma_for_team_lookup(AsyncMock(side_effect=ConnectionError("db unreachable"))),
+            user_api_key_cache=mock_cache,
+            check_db_only=True,
+        )
+    assert unreadable_info.value.status_code == 404
+    assert not isinstance(unreadable_info.value, TeamNotFoundError)
+
+
 # Reject Client-Side Metadata Tags Tests
 
 

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -4369,6 +4369,212 @@ async def test_centralized_common_checks_team_404_does_not_zero_other_contexts()
 
 
 @pytest.mark.asyncio
+async def test_centralized_common_checks_unresolvable_team_without_grant_is_refused():
+    """The store restricts the team to gpt-4o-mini and the read of it fails, so the
+    only surviving team record is the token's own, which carries ``team_models=[]``
+    and reads as every model. The request must be refused with the original lookup
+    error. Pre-fix it was served."""
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from fastapi import HTTPException, Request
+    from starlette.datastructures import URL
+
+    # The key inherits its models from the team (models=[]), so the team object
+    # is the only gate on model access.
+    token = UserAPIKeyAuth(
+        api_key="sk-test",
+        team_id="restricted-team",
+        models=[],
+        team_models=[],
+    )
+    request = Request(scope={"type": "http"})
+    request._url = URL(url="/chat/completions")
+    request._body = json.dumps({"model": "gpt-4.1"}).encode()
+
+    team_read_failure = HTTPException(
+        status_code=404,
+        detail={"error": "Team doesn't exist in db. Team=restricted-team."},
+    )
+
+    attrs = _proxy_attrs_for_centralized_checks(user_custom_auth=None)
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        with patch(
+            "litellm.proxy.auth.user_api_key_auth.get_team_object",
+            new_callable=AsyncMock,
+            side_effect=team_read_failure,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _run_centralized_common_checks(
+                    user_api_key_auth_obj=token,
+                    request=request,
+                    request_data={"model": "gpt-4.1"},
+                    route="/chat/completions",
+                )
+        assert exc_info.value is team_read_failure
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("token_team_models", [[], ["gpt-4.1"]])
+async def test_centralized_common_checks_absent_team_refused_despite_db_unavailable_optout(token_team_models):
+    """A team that is provably gone is a definitive answer, not a degraded read.
+    ``allow_requests_on_db_unavailable`` is a static settings read, so without the
+    absent-versus-unreadable distinction it would hand a deleted team's key the
+    old permissive fallback while the database is perfectly healthy. Refused in
+    both token shapes, including the one whose grant would otherwise vouch.
+
+    Imported from the module under test rather than from ``auth_checks``: other
+    tests in this suite ``importlib.reload`` that module, which rebinds the class
+    and would leave this raising a type the guard has never seen."""
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from fastapi import HTTPException, Request
+    from starlette.datastructures import URL
+
+    from litellm.proxy.auth.user_api_key_auth import TeamNotFoundError
+
+    token = UserAPIKeyAuth(
+        api_key="sk-test",
+        team_id="deleted-team",
+        models=[],
+        team_models=token_team_models,
+    )
+    request = Request(scope={"type": "http"})
+    request._url = URL(url="/chat/completions")
+    request._body = json.dumps({"model": "gpt-4.1"}).encode()
+
+    team_absent = TeamNotFoundError(team_id="deleted-team")
+
+    attrs = _proxy_attrs_for_centralized_checks(user_custom_auth=None)
+    attrs["general_settings"] = {"allow_requests_on_db_unavailable": True}
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        with patch(
+            "litellm.proxy.auth.user_api_key_auth.get_team_object",
+            new_callable=AsyncMock,
+            side_effect=team_absent,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _run_centralized_common_checks(
+                    user_api_key_auth_obj=token,
+                    request=request,
+                    request_data={"model": "gpt-4.1"},
+                    route="/chat/completions",
+                )
+        assert exc_info.value is team_absent
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
+async def test_centralized_common_checks_unreadable_team_keeps_db_unavailable_optout():
+    """The counterpart: an unreadable team leaves the grant unknown rather than
+    answered, so an operator who has accepted degraded authorization during a
+    database fault still gets the fallback. Without this the fix would trade the
+    widening for a lockout with no way out."""
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from fastapi import HTTPException as _HTTPException
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    token = UserAPIKeyAuth(api_key="sk-test", team_id="unreadable-team", models=[], team_models=[])
+    request = Request(scope={"type": "http"})
+    request._url = URL(url="/chat/completions")
+    request._body = json.dumps({"model": "gpt-4.1"}).encode()
+
+    attrs = _proxy_attrs_for_centralized_checks(user_custom_auth=None)
+    attrs["general_settings"] = {"allow_requests_on_db_unavailable": True}
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        with (
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_team_object",
+                new_callable=AsyncMock,
+                side_effect=_HTTPException(status_code=404, detail={"error": "team unreadable"}),
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.common_checks",
+                new_callable=AsyncMock,
+            ) as mock_checks,
+        ):
+            await _run_centralized_common_checks(
+                user_api_key_auth_obj=token,
+                request=request,
+                request_data={"model": "gpt-4.1"},
+                route="/chat/completions",
+            )
+        mock_checks.assert_awaited_once()
+        assert mock_checks.call_args.kwargs["team_object"].team_id == "unreadable-team"
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "requested_model, is_granted",
+    [("gpt-4o-mini", True), ("gpt-4.1", False)],
+)
+async def test_centralized_common_checks_unresolvable_team_with_grant_enforces_it(requested_model, is_granted):
+    """Mirror of the refusal above: a token that does carry a team model grant keeps
+    the fallback, and the reconstructed team must still enforce that grant rather
+    than wave the request through."""
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from fastapi import HTTPException, Request
+    from starlette.datastructures import URL
+
+    from litellm.proxy._types import ProxyErrorTypes, ProxyException
+
+    token = UserAPIKeyAuth(
+        api_key="sk-test",
+        team_id="restricted-team",
+        models=[],
+        team_models=["gpt-4o-mini"],
+    )
+    request = Request(scope={"type": "http"})
+    request._url = URL(url="/chat/completions")
+    request._body = json.dumps({"model": requested_model}).encode()
+
+    attrs = _proxy_attrs_for_centralized_checks(user_custom_auth=None)
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        with patch(
+            "litellm.proxy.auth.user_api_key_auth.get_team_object",
+            new_callable=AsyncMock,
+            side_effect=HTTPException(status_code=404, detail={"error": "team unreadable"}),
+        ):
+            if is_granted:
+                await _run_centralized_common_checks(
+                    user_api_key_auth_obj=token,
+                    request=request,
+                    request_data={"model": requested_model},
+                    route="/chat/completions",
+                )
+            else:
+                with pytest.raises(ProxyException) as exc_info:
+                    await _run_centralized_common_checks(
+                        user_api_key_auth_obj=token,
+                        request=request,
+                        request_data={"model": requested_model},
+                        route="/chat/completions",
+                    )
+                assert exc_info.value.type == ProxyErrorTypes.team_model_access_denied
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
 async def test_centralized_common_checks_user_http_exception_isolates_to_user_only():
     """Per-fetch isolation, mirror of the team case: an HTTPException
     from get_user_object must zero only ``user_object``. The successfully


### PR DESCRIPTION
## TLDR

Problem this solves:

- A failed team lookup could grant models the team never allowed
- The same fallback also read an unresolvable team as unblocked

How it solves it:

- A team that is provably gone now refuses, with no override
- An unreadable team keeps the fallback, so nobody is locked out

## User Flow

Before: a developer's team key keeps working after its team can no longer be resolved, and it now reaches models the team never allowed

1. Their proxy admin creates a team limited to `gpt-4o-mini` and issues them a key that inherits the team's models
2. They send POST https://litellm-domain/v1/chat/completions with `"model": "gpt-4o-mini"` and get a 200 with a completion
3. They send the same POST with `"model": "gpt-4.1"` and get a 403 reading `team not allowed to access model. This team can only access models=['gpt-4o-mini']`
4. Their team is later removed while the key survives
5. They send POST https://litellm-domain/v1/chat/completions with `"model": "gpt-4.1"` again and now get a 200 with a real `gpt-4.1` completion
6. Anyone holding such a key can reach every model on the proxy, not only the ones their team was given

After: the same key stops at the point its team can no longer be resolved

1. Their proxy admin creates a team limited to `gpt-4o-mini` and issues them a key that inherits the team's models
2. They send POST https://litellm-domain/v1/chat/completions with `"model": "gpt-4o-mini"` and get a 200 with a completion
3. They send the same POST with `"model": "gpt-4.1"` and get a 403 reading `team not allowed to access model. This team can only access models=['gpt-4o-mini']`
4. Their team is later removed while the key survives
5. They send POST https://litellm-domain/v1/chat/completions with `"model": "gpt-4.1"` again and now get a 404 reading `Team doesn't exist in db`
6. Anyone holding such a key can no longer reach models their team was never given: the request is refused instead of upgraded

## Relevant issues

## Linear ticket

Resolves LIT-5522

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against a real Postgres and real OpenAI calls. One setup serves every leg: a team restricted to `gpt-4o-mini` with a key that inherits the team's allowlist, which is what the Admin UI produces by default, so the team object is the only gate on model access

```bash
curl -s -X POST http://127.0.0.1:4552/team/new \
  -H 'Authorization: Bearer sk-lit5522-master' -H 'Content-Type: application/json' \
  -d '{"team_alias":"lit5522-restricted","models":["gpt-4o-mini"]}'
# {"team_alias":"lit5522-restricted","team_id":"a2c35cd9-...","models":["gpt-4o-mini"]}

curl -s -X POST http://127.0.0.1:4552/key/generate \
  -H 'Authorization: Bearer sk-lit5522-master' -H 'Content-Type: application/json' \
  -d '{"team_id":"a2c35cd9-...","models":[],"key_alias":"lit5522-teamkey"}'
# key.models = []   key.team_id = a2c35cd9-...
```

Every request below is the same shape, varying only the key and the model

```bash
curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:4552/v1/chat/completions \
  -H "Authorization: Bearer $TEAM_KEY" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-4.1","messages":[{"role":"user","content":"reply with the single word lit5522"}],"max_tokens":10}'
```

Three team states are exercised. HEALTHY is the ordinary case. GONE is a team removed while its key survives, which is also what a partial restore leaves behind. UNREADABLE is a team whose row is present but will not load, which is what a database fault looks like from here

### Before, at commit `373a0fc506`

```
HEALTHY,    gpt-4o-mini  -> HTTP 200  {"id":"chatcmpl-ECZGbkjwswHSgiPmNaFtmVZ7AgcBf","model":"gpt-4o-mini",...,"content":"lit5522"}
HEALTHY,    gpt-4.1      -> HTTP 403  team not allowed to access model. This team can only access models=['gpt-4o-mini']
GONE,       gpt-4.1      -> HTTP 200  {"id":"chatcmpl-ECZGcTjdpHdPIfMYo7E8DG8vRIuVY","model":"gpt-4.1",...,"content":"lit5522"}
UNREADABLE, gpt-4.1      -> HTTP 200  {"id":"chatcmpl-ECZGeptFfBzipVOBgMmdVdNkWJqLl","model":"gpt-4.1",...,"content":"lit5522"}
```

The control succeeds outright and the ungranted model is refused, so the allowlist is demonstrably in force before anything is disturbed. The proxy log records the decision rather than leaving it to be inferred from where the request landed

```
LiteLLM Proxy:DEBUG: user_api_key_auth.py - centralized auth: team fetch failed
(HTTPException: 404: {'error': "Team doesn't exist in db. Team=a2c35cd9-... Create team via `/team/new` call."})
```

### After, at commit `a45fbba01a`

```
HEALTHY,    gpt-4o-mini  -> HTTP 200  {"id":"chatcmpl-ECZG5Slx1xBJkiXpwVs8Yqbsm9Wj8","model":"gpt-4o-mini",...,"content":"lit5522"}
HEALTHY,    gpt-4.1      -> HTTP 403  team not allowed to access model. This team can only access models=['gpt-4o-mini']
GONE,       gpt-4.1      -> HTTP 404  Team doesn't exist in db. Team=a2c35cd9-...
UNREADABLE, gpt-4.1      -> HTTP 404  Team doesn't exist in db. Team=5dc10382-...
```

The decisive pair, both with `allow_requests_on_db_unavailable: true`, same proxy and same request. A degraded read still serves, and a definitive answer still refuses

```
UNREADABLE, gpt-4.1, opt-in set -> HTTP 200  {"id":"chatcmpl-ECZFWlMXlWsofO7srFQOgmpx9s2Nr","model":"gpt-4.1",...,"content":"lit5522"}
GONE,       gpt-4.1, opt-in set -> HTTP 404  Team doesn't exist in db. Team=a2c35cd9-...
```

## Type

🐛 Bug Fix

## Review notes

Why the fix reaches into `get_team_object` rather than living entirely at the call site. That function reported a deleted team and a database that would not answer as the same 404, so the fallback had no way to tell a definitive answer from a degraded read. The first version of this PR tried to bound that with `allow_requests_on_db_unavailable`, which was wrong: that helper is `() -> bool` with no exception parameter, a static settings read, and every other caller in the tree pairs it with `is_database_connection_error(e)`. Using only the static half meant an operator who set it for outages would also have handed a deleted team's key the permissive fallback with the database perfectly healthy, which is the case this PR exists to close. An earlier revision of this description published that as proof the opt-out worked, when it was demonstrating the hole, and the GONE leg with the opt-in set is its corrected counterpart. The subclass is what makes consulting the setting legitimate, because by the time it is read the failure is known to be a degraded read

Who this denies, stated plainly rather than left qualitative. The refusal keys on the token carrying no team model grant, and a genuinely unrestricted team also records `models: []`, which is byte-identical to no grant. So the population that loses access is a key under an unrestricted team, and only while that team's row will not load. Unrestricted is a common team shape rather than an edge case, so this is a wider set than "a deleted team": any team created without an explicit model list looks the same to this check. It costs them nothing while the database is healthy, because the row resolves and this code never runs, and `allow_requests_on_db_unavailable` restores the previous behaviour for exactly that case, as the UNREADABLE legs show

The full CI matrix is itself the best evidence that the closed case holds no real traffic. Two legacy tests failed, and they are the only two places in the repo that exercise the widening state, and only because their database is a stub, so their team lookup always fails. Both were repaired by giving their team key a model grant, which is the realistic shape of a team key: that changes the fixture's realism, not the test's meaning, and every assertion in them is untouched

Test isolation worth knowing about: both mapped test files call `importlib.reload` on `auth_checks`, which rebinds the exception class, so a test importing it from there and injecting it into a patched lookup raises a type the guard has never seen. The new call-site tests import it from the module under test instead. Verified by running both files in one session in both orderings

Mutation check, five mutants, each run separately with bytecode cleared and a nonzero test count each time. Downgrading the subclass at the raise site, and dropping its pass-through in `get_team_object`, each kill the discriminator test. Removing the absent-team guard at the call site kills both parametrized refusal cases. Making the token grant always vouch, and making the opt-out never apply, each kill their own case. The first of those mutants SURVIVED an earlier revision, which is what exposed that the call-site tests were injecting the exception rather than provoking it, so a test that drives the real lookup was added

One typing note so it does not read as an oversight: this adds a single `reportUnknownMemberType` from reading `team_models`, which is annotated as a bare `list` on the shared token model. The rule's codebase ceiling is 39237 and the gate fails only when a rule is both over its limit and above base, so this is well inside it. Tightening that annotation would have turned a security fix into a change to a shared model, which is the wrong trade here

## Caveats (if any)

- A key whose team is provably gone is now refused outright
- An unreadable team still falls back, unless the token records no grant
- `allow_requests_on_db_unavailable` covers only the unreadable case

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
