### PR TITLE
fix(proxy/team): resolve member_delete cleanup by user id, not the addressed email

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -2311,7 +2311,7 @@ async def delete_user(
         fetch_all_teams = await TeamRepository(prisma_client).table.find_many(where={"team_id": {"in": user_row.teams}})
         teams_to_update = []
         for team in fetch_all_teams:
-            is_member_in_team, new_team_members = _cleanup_members_with_roles(
+            removed_team_members, new_team_members = _cleanup_members_with_roles(
                 existing_team_row=LiteLLM_TeamTable.model_validate(team.model_dump()),
                 data=TeamMemberDeleteRequest(
                     team_id=team.team_id,
@@ -2319,7 +2319,7 @@ async def delete_user(
                     user_email=user_row.user_email,
                 ),
             )
-            if is_member_in_team:
+            if removed_team_members:
                 _db_new_team_members: list[dict] = [m.model_dump() for m in new_team_members]
                 team.members_with_roles = json.dumps(_db_new_team_members)
                 teams_to_update.append(team)

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -3091,26 +3091,27 @@ async def team_member_add(
     )
 
 
+def _is_member_addressed_by(member: Member, data: TeamMemberDeleteRequest) -> bool:
+    return (data.user_id is not None and member.user_id is not None and data.user_id == member.user_id) or (
+        data.user_email is not None and member.user_email is not None and data.user_email == member.user_email
+    )
+
+
 def _cleanup_members_with_roles(
     existing_team_row: LiteLLM_TeamTable,
     data: TeamMemberDeleteRequest,
-) -> tuple[bool, list[Member]]:
-    """Cleanup members_with_roles list for a team."""
-    is_member_in_team = False
-    new_team_members: Final[list[Member]] = []
-    for m in existing_team_row.members_with_roles:
-        if (
-            data.user_id is not None
-            and m.user_id is not None
-            and data.user_id == m.user_id
-            or data.user_email is not None
-            and m.user_email is not None
-            and data.user_email == m.user_email
-        ):
-            is_member_in_team = True
-            continue
-        new_team_members.append(m)
-    return is_member_in_team, new_team_members
+) -> tuple[tuple[Member, ...], list[Member]]:
+    """Split a team's members_with_roles into the entries the request addresses and the ones that stay.
+
+    The addressed entries are returned rather than a bare found/not-found flag because they carry the
+    user_id the request may not have supplied, and every cleanup that keys off the user rather than
+    off the roster has to run against that id.
+    """
+    removed_team_members: Final = tuple(
+        m for m in existing_team_row.members_with_roles if _is_member_addressed_by(m, data)
+    )
+    new_team_members: Final = [m for m in existing_team_row.members_with_roles if not _is_member_addressed_by(m, data)]
+    return removed_team_members, new_team_members
 
 
 @router.post(
@@ -3182,12 +3183,12 @@ async def team_member_delete(
         )
 
     ## DELETE MEMBER FROM TEAM
-    is_member_in_team, new_team_members = _cleanup_members_with_roles(
+    removed_team_members, new_team_members = _cleanup_members_with_roles(
         existing_team_row=existing_team_row,
         data=data,
     )
 
-    if not is_member_in_team:
+    if not removed_team_members:
         raise HTTPException(status_code=400, detail={"error": "User not found in team"})
 
     existing_team_row.members_with_roles = new_team_members
@@ -3205,38 +3206,28 @@ async def team_member_delete(
 
     ## DELETE TEAM ID from USER ROW, IF EXISTS ##
     # get user row
-    key_val: Final = {}
-    if data.user_id is not None:
-        key_val["user_id"] = data.user_id
-    elif data.user_email is not None:
-        key_val["user_email"] = data.user_email
-    existing_user_rows: Final[Sequence[LiteLLM_UserTable] | None] = await UserRepository(prisma_client).table.find_many(
-        where=key_val
+    removed_user_ids: Final = frozenset(m.user_id for m in removed_team_members if m.user_id is not None)
+    key_val: Final[Mapping[str, object]] = (
+        {"user_id": {"in": sorted(removed_user_ids)}} if removed_user_ids else {"user_email": data.user_email}
     )
+    existing_user_rows: Final[Sequence[LiteLLM_UserTable]] = await _user_db(prisma_client).find_many(where=key_val)
 
-    if existing_user_rows is not None and (isinstance(existing_user_rows, list) and len(existing_user_rows) > 0):
-        for existing_user in existing_user_rows:
-            team_list = []
-            if data.team_id in existing_user.teams:
-                team_list = existing_user.teams
-                team_list.remove(data.team_id)
-                await _user_db(prisma_client).update(
-                    where={
-                        "user_id": existing_user.user_id,
-                    },
-                    data={"teams": {"set": team_list}},
-                )
+    for existing_user in existing_user_rows:
+        if data.team_id in existing_user.teams:
+            await _user_db(prisma_client).update(
+                where={
+                    "user_id": existing_user.user_id,
+                },
+                data={"teams": {"set": [team for team in existing_user.teams if team != data.team_id]}},
+            )
 
     # Also clean up any existing team membership rows for this user and team
-    user_ids_to_delete: Final = set[str]()
-    if data.user_id is not None:
-        user_ids_to_delete.add(data.user_id)
-    if existing_user_rows is not None and isinstance(existing_user_rows, list):
-        for existing_user in existing_user_rows:
-            if getattr(existing_user, "user_id", None):
-                user_ids_to_delete.add(existing_user.user_id)
+    user_ids_to_delete: Final = removed_user_ids.union(
+        (data.user_id,) if data.user_id is not None else (),
+        (user.user_id for user in existing_user_rows if user.user_id),
+    )
 
-    for _uid in user_ids_to_delete:
+    for _uid in sorted(user_ids_to_delete):
         await _team_membership_db(prisma_client).delete_many(where={"team_id": data.team_id, "user_id": _uid})
 
     ## DELETE KEYS CREATED BY USER FOR THIS TEAM
@@ -3248,7 +3239,7 @@ async def team_member_delete(
         # Fetch keys before deletion to persist them
         keys_to_delete: Final[list[LiteLLM_VerificationToken]] = await _tokens_db(prisma_client).find_many(
             where={
-                "user_id": {"in": list(user_ids_to_delete)},
+                "user_id": {"in": sorted(user_ids_to_delete)},
                 "team_id": data.team_id,
             }
         )
@@ -3263,7 +3254,7 @@ async def team_member_delete(
 
         await _tokens_db(prisma_client).delete_many(
             where={
-                "user_id": {"in": list(user_ids_to_delete)},
+                "user_id": {"in": sorted(user_ids_to_delete)},
                 "team_id": data.team_id,
             }
         )

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -4133,6 +4133,106 @@ async def test_team_member_delete_cleans_verification_tokens(
     )
 
 
+@pytest.mark.parametrize(
+    "roster_email",
+    ["Alice@Example.com", "alice-invited-as@example.com"],
+    ids=["case_variant_of_the_row_email", "email_the_row_never_carried"],
+)
+@pytest.mark.parametrize("user_row_exists", [True, False])
+@pytest.mark.asyncio
+async def test_team_member_delete_by_email_the_user_row_does_not_carry(
+    user_row_exists, roster_email, mock_db_client, mock_admin_auth
+):
+    """
+    Removing a member addressed by user_email drove its user-row and membership cleanup off that raw
+    email instead of off the user_id the roster entry already carries, so an email the user row does
+    not literally hold matched nothing and both cleanups silently no-opped behind a 200.
+
+    Both roster emails here are reachable over plain HTTP. /team/member_add resolves an email to a
+    user case-insensitively but stores the caller's casing in members_with_roles, which produces the
+    case variant; it also leaves an unmatched email on the entry when no user row carries it at all,
+    which produces the second. Both converge on the same lookup, so they are parametrized inputs
+    rather than separate paths, and each one has to detect the bug on its own.
+
+    The user table below is case-sensitive like Postgres, so only a lookup driven by the resolved
+    user_id finds the row. The user_row_exists=False leg pins the second half on its own: the
+    membership row has to go even when no user row is left to resolve it from.
+    """
+    from litellm.proxy._types import TeamMemberDeleteRequest
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_delete
+
+    test_team_id = "team-del-email-case-123"
+    test_user_id = "user-del-email-case-123"
+    user_row_email = "alice@example.com"
+
+    mock_team_row = MagicMock()
+    mock_team_row.model_dump.return_value = {
+        "team_id": test_team_id,
+        "members_with_roles": [
+            {"user_id": test_user_id, "user_email": roster_email, "role": "user"}
+        ],
+        "team_member_permissions": [],
+        "metadata": {},
+        "models": [],
+        "spend": 0.0,
+    }
+
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=mock_team_row
+    )
+    mock_db_client.db.litellm_teamtable.update = AsyncMock(return_value=mock_team_row)
+
+    mock_user_row = MagicMock()
+    mock_user_row.user_id = test_user_id
+    mock_user_row.user_email = user_row_email
+    mock_user_row.teams = [test_team_id]
+
+    async def find_user_rows(where):
+        if not user_row_exists:
+            return []
+        user_id_filter = where.get("user_id")
+        if isinstance(user_id_filter, dict) and test_user_id in user_id_filter.get(
+            "in", []
+        ):
+            return [mock_user_row]
+        if where.get("user_email") == user_row_email:
+            return [mock_user_row]
+        return []
+
+    mock_db_client.db.litellm_usertable.find_many = AsyncMock(
+        side_effect=find_user_rows
+    )
+    mock_db_client.db.litellm_usertable.update = AsyncMock(return_value=MagicMock())
+
+    mock_db_client.db.litellm_teammembership = MagicMock()
+    mock_db_client.db.litellm_teammembership.delete_many = AsyncMock(
+        return_value=MagicMock()
+    )
+
+    mock_db_client.db.litellm_verificationtoken = MagicMock()
+    mock_db_client.db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
+    mock_db_client.db.litellm_verificationtoken.delete_many = AsyncMock(
+        return_value=MagicMock()
+    )
+
+    await team_member_delete(
+        data=TeamMemberDeleteRequest(team_id=test_team_id, user_email=roster_email),
+        user_api_key_dict=mock_admin_auth,
+    )
+
+    if user_row_exists:
+        mock_db_client.db.litellm_usertable.update.assert_awaited_once_with(
+            where={"user_id": test_user_id},
+            data={"teams": {"set": []}},
+        )
+    else:
+        mock_db_client.db.litellm_usertable.update.assert_not_awaited()
+
+    mock_db_client.db.litellm_teammembership.delete_many.assert_awaited_once_with(
+        where={"team_id": test_team_id, "user_id": test_user_id}
+    )
+
+
 @pytest.mark.asyncio
 async def test_new_team_max_budget_exceeds_user_max_budget():
     """


### PR DESCRIPTION
## TLDR

Problem this solves:

- Removing a member by email leaves the team on their record
- Their per-member budget entry survives, orphaned
- The call still returns 200, so nothing surfaces it

How it solves it:

- Resolve the removed roster entry to its user id first
- Run both cleanups against that id, not the email

## User Flow

Before: an admin removes a teammate by the same email they were invited with, and the teammate keeps the team on their record

1. The admin invites the teammate with `POST /team/member_add` sending `{"team_id": "t-lit5520-before", "max_budget_in_team": 10, "member": {"user_email": "Alice-before@Example.com", "role": "user"}}`, and gets 200 with the teammate on the returned roster
2. The admin confirms the invite landed with `GET /user/info?user_id=u-lit5520-alice-before`, which reads `"teams": ["t-lit5520-before"]`
3. The admin removes the teammate with `POST /team/member_delete` sending `{"team_id": "t-lit5520-before", "user_email": "Alice-before@Example.com"}`, and gets 200 with a roster that no longer lists them
4. The admin re-reads `GET /user/info?user_id=u-lit5520-alice-before` and still sees `"teams": ["t-lit5520-before"]`
5. `GET /team/info?team_id=t-lit5520-before` shows a roster the teammate is absent from next to a $10 per-member budget entry the team still holds for them
6. The removed teammate still reads as a member of that team from their own record, so anything that trusts the user record over the roster keeps treating them as one

After: the same removal clears the team from every place the admin can read it

1. The admin invites the teammate with `POST /team/member_add` sending `{"team_id": "t-lit5520-after", "max_budget_in_team": 10, "member": {"user_email": "Alice-after@Example.com", "role": "user"}}`, and gets 200 with the teammate on the returned roster
2. The admin confirms the invite landed with `GET /user/info?user_id=u-lit5520-alice-after`, which reads `"teams": ["t-lit5520-after"]`
3. The admin removes the teammate with `POST /team/member_delete` sending `{"team_id": "t-lit5520-after", "user_email": "Alice-after@Example.com"}`, and gets 200 with a roster that no longer lists them
4. The admin re-reads `GET /user/info?user_id=u-lit5520-alice-after` and now sees `"teams": []`
5. `GET /team/info?team_id=t-lit5520-after` shows the same roster and no per-member budget entry left for them
6. The removed teammate reads as a non-member from both sides, so the two agree

## Relevant issues

## Linear ticket

Resolves LIT-5520

## Scope against the ticket

Taking LIT-5520's required-resolution bullets one at a time, rather than claiming the ticket wholesale:

- "Resolve the member to a user id first, then drive both the user-row and membership cleanup from that id" is closed here
- "The three cleanups either all apply or the call fails" is closed only on the success path: all three now apply where two used to be skipped. The all-or-nothing guarantee on the FAILURE path is not in this PR and is tracked as LIT-5541, because every write on this path goes through a repository helper that takes the `PrismaClient` wrapper rather than a transaction client, so a transaction here is a repository-layer refactor rather than a bug fix
- "Regression coverage for removal addressed by an email the user row does not carry" is closed, parametrized over both reachable ways a roster entry ends up holding an email the row does not have

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on a real Postgres, hitting the real Anthropic API. Each leg invites two users into a fresh team and removes them the same way, differing only in the casing of the email used.

Read Bob first. He is the control: he is addressed by the exact email his user record carries, and his removal is clean on BOTH builds. That is what rules out "removal is simply broken for everyone" and isolates the email casing as the one variable, so a leg where both users drifted alike would show up rather than read as a pass.

The most legible symptom is in step 6 of the before leg. `GET /team/info` reports an empty roster next to a $10 per-member budget entry the team still holds for someone it says is not a member, and every call that produced that state returned 200. An operator can see the money without knowing anything about identity resolution, and nothing in any response tells them a cleanup was skipped.

### Before, captured at `87736a767ca3b108866f498a43cc531596ba5ed5`

```console
########## 0. the proxy is live and serving a real model ##########
HTTP 200
{"model":"claude-sonnet-5","reply":"live","usage":{"completion_tokens":3,"prompt_tokens":14,"total_tokens":17,"completion_tokens_details":{"reasoning_tokens":0,"text_tokens":3},"prompt_tokens_details":{"cached_tokens":0,"text_tokens":14,"cache_write_tokens":0,"cache_creation_tokens":0,"cache_creation_token_details":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","service_tier":"standard"}}

########## 1. create the two users. Both user rows carry a LOWERCASE email ##########
HTTP 200
{"user_id":"u-lit5520-alice-before","user_email":"alice-before@example.com","teams":null}
HTTP 200
{"user_id":"u-lit5520-bob-before","user_email":"bob-before@example.com","teams":null}

########## 2. create the team ##########
HTTP 200
{"team_id":"t-lit5520-before","team_alias":"lit5520-before"}

########## 3. add alice by a MIXED-CASE email, bob by the exact email his row carries (control) ##########
HTTP 200
{"roster":[{"user_id":"default_user_id","user_email":null,"role":"admin"},{"user_id":"u-lit5520-alice-before","user_email":"Alice-before@Example.com","role":"user"}],"resolved_users":[{"user_id":"u-lit5520-alice-before","user_email":"alice-before@example.com"}]}
HTTP 200
{"roster":[{"user_id":"default_user_id","user_email":null,"role":"admin"},{"user_id":"u-lit5520-alice-before","user_email":"Alice-before@Example.com","role":"user"},{"user_id":"u-lit5520-bob-before","user_email":"bob-before@example.com","role":"user"}],"resolved_users":[{"user_id":"u-lit5520-bob-before","user_email":"bob-before@example.com"}]}

########## 4. after the adds: both users carry the team, both membership rows exist ##########
{"user_id":"u-lit5520-alice-before","user_email":"alice-before@example.com","teams":["t-lit5520-before"]}
{"user_id":"u-lit5520-bob-before","user_email":"bob-before@example.com","teams":["t-lit5520-before"]}
        user_id         |     team_id      
------------------------+------------------
 u-lit5520-alice-before | t-lit5520-before
 u-lit5520-bob-before   | t-lit5520-before
(2 rows)

{"roster":["default_user_id","u-lit5520-alice-before","u-lit5520-bob-before"],"per_member_budget_entries":[{"user_id":"u-lit5520-alice-before","max_budget":10.0},{"user_id":"u-lit5520-bob-before","max_budget":10.0}]}

########## 5. remove alice by that SAME mixed-case email, bob by his exact email ##########
HTTP 200
{"team_id":"t-lit5520-before","roster_after":[{"user_id":"default_user_id","user_email":null,"role":"admin"},{"user_id":"u-lit5520-bob-before","user_email":"bob-before@example.com","role":"user"}]}
HTTP 200
{"team_id":"t-lit5520-before","roster_after":[{"user_id":"default_user_id","user_email":null,"role":"admin"}]}

########## 6. after the removals ##########
--- the team id on each user record ---
        user_id         |       teams        
------------------------+--------------------
 u-lit5520-alice-before | {t-lit5520-before}
 u-lit5520-bob-before   | {}
(2 rows)

{"alice":"u-lit5520-alice-before","teams":["t-lit5520-before"]}
{"bob":"u-lit5520-bob-before","teams":[]}
--- membership rows still pointing at the team ---
        user_id         |     team_id      
------------------------+------------------
 u-lit5520-alice-before | t-lit5520-before
(1 row)

--- the team roster, and the per-member budget entries the team still holds ---
{"roster":["default_user_id"],"per_member_budget_entries":[{"user_id":"u-lit5520-alice-before","max_budget":10.0}]}
```

### After, captured at `74bc9b4cf54b9eddd2b275c92e4c14178793ec9e`

```console
########## 0. the proxy is live and serving a real model ##########
HTTP 200
{"model":"claude-sonnet-5","reply":"live","usage":{"completion_tokens":3,"prompt_tokens":14,"total_tokens":17,"completion_tokens_details":{"reasoning_tokens":0,"text_tokens":3},"prompt_tokens_details":{"cached_tokens":0,"text_tokens":14,"cache_write_tokens":0,"cache_creation_tokens":0,"cache_creation_token_details":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","service_tier":"standard"}}

########## 1. create the two users. Both user rows carry a LOWERCASE email ##########
HTTP 200
{"user_id":"u-lit5520-alice-after","user_email":"alice-after@example.com","teams":null}
HTTP 200
{"user_id":"u-lit5520-bob-after","user_email":"bob-after@example.com","teams":null}

########## 2. create the team ##########
HTTP 200
{"team_id":"t-lit5520-after","team_alias":"lit5520-after"}

########## 3. add alice by a MIXED-CASE email, bob by the exact email his row carries (control) ##########
HTTP 200
{"roster":[{"user_id":"default_user_id","user_email":null,"role":"admin"},{"user_id":"u-lit5520-alice-after","user_email":"Alice-after@Example.com","role":"user"}],"resolved_users":[{"user_id":"u-lit5520-alice-after","user_email":"alice-after@example.com"}]}
HTTP 200
{"roster":[{"user_id":"default_user_id","user_email":null,"role":"admin"},{"user_id":"u-lit5520-alice-after","user_email":"Alice-after@Example.com","role":"user"},{"user_id":"u-lit5520-bob-after","user_email":"bob-after@example.com","role":"user"}],"resolved_users":[{"user_id":"u-lit5520-bob-after","user_email":"bob-after@example.com"}]}

########## 4. after the adds: both users carry the team, both membership rows exist ##########
{"user_id":"u-lit5520-alice-after","user_email":"alice-after@example.com","teams":["t-lit5520-after"]}
{"user_id":"u-lit5520-bob-after","user_email":"bob-after@example.com","teams":["t-lit5520-after"]}
        user_id        |     team_id     
-----------------------+-----------------
 u-lit5520-alice-after | t-lit5520-after
 u-lit5520-bob-after   | t-lit5520-after
(2 rows)

{"roster":["default_user_id","u-lit5520-alice-after","u-lit5520-bob-after"],"per_member_budget_entries":[{"user_id":"u-lit5520-alice-after","max_budget":10.0},{"user_id":"u-lit5520-bob-after","max_budget":10.0}]}

########## 5. remove alice by that SAME mixed-case email, bob by his exact email ##########
HTTP 200
{"team_id":"t-lit5520-after","roster_after":[{"user_id":"default_user_id","user_email":null,"role":"admin"},{"user_id":"u-lit5520-bob-after","user_email":"bob-after@example.com","role":"user"}]}
HTTP 200
{"team_id":"t-lit5520-after","roster_after":[{"user_id":"default_user_id","user_email":null,"role":"admin"}]}

########## 6. after the removals ##########
--- the team id on each user record ---
        user_id        | teams 
-----------------------+-------
 u-lit5520-alice-after | {}
 u-lit5520-bob-after   | {}
(2 rows)

{"alice":"u-lit5520-alice-after","teams":[]}
{"bob":"u-lit5520-bob-after","teams":[]}
--- membership rows still pointing at the team ---
 user_id | team_id 
---------+---------
(0 rows)

--- the team roster, and the per-member budget entries the team still holds ---
{"roster":["default_user_id"],"per_member_budget_entries":[]}
```

## Review notes

Greptile scored this 4/5 on one finding: a single request carrying the `user_id` of one member and the `user_email` of another now cascades cleanup across both members. I kept the code as it stands, for a reason the live rig settles rather than argues.

The OR match that removes both roster entries is pre-existing and untouched here. On the base build that same conflicting request already strips both members from the roster, then cleans only the one named by id, leaving the other holding the team on their record, a live membership row and working team-scoped keys:

```console
########## setup: team with two distinct members ##########
HTTP 200
HTTP 200
HTTP 200
HTTP 200
HTTP 200
{"roster":["default_user_id","u-lit5520-conflict-a-base","u-lit5520-conflict-b-base"]}

########## one request naming member A by id and member B by email ##########
HTTP 200
{"roster_after":["default_user_id"]}

########## what each member is left holding ##########
          user_id          |           teams           
---------------------------+---------------------------
 u-lit5520-conflict-a-base | {}
 u-lit5520-conflict-b-base | {t-lit5520-conflict-base}
(2 rows)

          user_id          |         team_id         
---------------------------+-------------------------
 u-lit5520-conflict-b-base | t-lit5520-conflict-base
(1 row)

```

On this branch the roster outcome is identical and both members are cleaned:

```console
########## setup: team with two distinct members ##########
HTTP 200
HTTP 200
HTTP 200
HTTP 200
HTTP 200
{"roster":["default_user_id","u-lit5520-conflict-a-fixed","u-lit5520-conflict-b-fixed"]}

########## one request naming member A by id and member B by email ##########
HTTP 200
{"roster_after":["default_user_id"]}

########## what each member is left holding ##########
          user_id           | teams 
----------------------------+-------
 u-lit5520-conflict-a-fixed | {}
 u-lit5520-conflict-b-fixed | {}
(2 rows)

 user_id | team_id 
---------+---------
(0 rows)

```

So the change does not widen who gets removed, it makes the cleanup agree with the removal the endpoint already performs, and it closes the half where someone off the roster keeps team-scoped keys

Rejecting the ambiguous request outright was the alternative, and it is the obvious "why not just validate the input" answer, so to be explicit about why not: `delete_team` deliberately calls this endpoint once per member with both selectors read off a single roster entry, so a hard consistency check would add a new failure mode to team deletion for a request shape that is otherwise handled

## Type

🐛 Bug Fix

## Caveats (if any)

- Failure-path atomicity is out of scope, tracked as LIT-5541
- A roster entry with no user id still falls back to the email

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
