### PR TITLE
fix(ui): stop a deselected MCP server keeping its grant on a virtual key

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.test.tsx
@@ -372,7 +372,11 @@ describe("extractMcpEntitlement", () => {
   const CATALOG = [
     { server_id: "srv-1", server_name: "deploy_tracker", alias: "deploy" },
     { server_id: "srv-2", server_name: "issue_tracker", alias: null },
-    { server_id: "srv-via-group", server_name: "audit_log", alias: null },
+    { server_id: "srv-via-group", server_name: "audit_log", alias: null, mcp_access_groups: ["ops_readonly"] },
+  ] as any;
+
+  const TOOLSETS = [
+    { toolset_id: "ts-1", toolset_name: "audit", tools: [{ server_id: "srv-via-group", tool_name: "read" }] },
   ] as any;
 
   const form = (
@@ -466,12 +470,43 @@ describe("extractMcpEntitlement", () => {
   });
 
   it("keeps the allowlist of a deselected server that a retained access group still supplies", () => {
-    const result = extractMcpEntitlement(form({ accessGroups: ["ops_readonly"] }, { "srv-1": ["read"] }), CATALOG);
-    expect(result?.mcp_tool_permissions).toEqual({ "srv-1": ["read"] });
+    const result = extractMcpEntitlement(
+      form({ accessGroups: ["ops_readonly"] }, { "srv-via-group": ["read"] }),
+      CATALOG,
+      TOOLSETS,
+    );
+    expect(result?.mcp_tool_permissions).toEqual({ "srv-via-group": ["read"] });
   });
 
-  it("keeps the allowlist of a deselected server when a toolset is retained", () => {
-    const result = extractMcpEntitlement(form({ toolsets: ["ts-1"] }, { "srv-1": ["read"] }), CATALOG);
+  it("drops the allowlist of a deselected server that the retained access group does not contain", () => {
+    // The gateway grants each allowlist key as its own server, so retaining a group covering only
+    // srv-via-group must not keep srv-1 callable after the admin removed it.
+    const result = extractMcpEntitlement(
+      form({ accessGroups: ["ops_readonly"] }, { "srv-1": ["read"] }),
+      CATALOG,
+      TOOLSETS,
+    );
+    expect(result?.mcp_tool_permissions).toEqual({});
+  });
+
+  it("keeps the allowlist of a deselected server that a retained toolset still supplies", () => {
+    const result = extractMcpEntitlement(
+      form({ toolsets: ["ts-1"] }, { "srv-via-group": ["read"] }),
+      CATALOG,
+      TOOLSETS,
+    );
+    expect(result?.mcp_tool_permissions).toEqual({ "srv-via-group": ["read"] });
+  });
+
+  it("drops the allowlist of a deselected server that the retained toolset does not cover", () => {
+    const result = extractMcpEntitlement(form({ toolsets: ["ts-1"] }, { "srv-1": ["read"] }), CATALOG, TOOLSETS);
+    expect(result?.mcp_tool_permissions).toEqual({});
+  });
+
+  it("prunes nothing when a selected toolset is missing from the toolset catalog", () => {
+    // An unresolvable toolset could supply any server, so pruning against it would be a guess in
+    // the widening direction.
+    const result = extractMcpEntitlement(form({ toolsets: ["ts-unknown"] }, { "srv-1": ["read"] }), CATALOG, TOOLSETS);
     expect(result?.mcp_tool_permissions).toEqual({ "srv-1": ["read"] });
   });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import UserInfoView, { extractMcpEntitlement } from "./user_info_view";
+import UserInfoView from "./user_info_view";
+import { extractMcpEntitlement } from "@/components/mcp_server_management/mcpEntitlement";
 
 const mockTeamMemberAddCall = vi.fn();
 const mockTeamMemberDeleteCall = vi.fn();

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.tsx
@@ -42,77 +42,8 @@ import NotificationsManager from "@/components/molecules/notifications_manager";
 import { getBudgetDurationLabel } from "@/components/common_components/budget_duration_dropdown";
 import DeleteResourceModal from "@/components/common_components/DeleteResourceModal";
 import MCPServerPermissions from "@/components/permissions/MCPServerPermissions";
-import { MCPServer } from "@/components/mcp_tools/types";
 import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers";
-
-interface McpEntitlementUpdate {
-  mcp_servers: string[];
-  mcp_access_groups: string[];
-  mcp_toolsets: string[];
-  mcp_tool_permissions: Record<string, string[]>;
-}
-
-const asStringArray = (value: unknown): string[] =>
-  Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
-
-const asToolPermissions = (value: unknown): Record<string, string[]> => {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return {};
-  return Object.fromEntries(
-    Object.entries(value as Record<string, unknown>).map(([serverId, tools]) => [serverId, asStringArray(tools)]),
-  );
-};
-
-const mcpServerMatchesIdentifier = (server: MCPServer, identifier: string): boolean =>
-  server.server_id === identifier || server.server_name === identifier || server.alias === identifier;
-
-/**
- * The `object_permission` a save sends, derived from what the editor currently shows.
- *
- * A tool allowlist is what narrows a grant and an absent one reads as no restriction, so dropping
- * an entry is the direction that widens. An entry is kept when an access group or toolset the admin
- * retained could still supply its server, and dropped once nothing indirect survives, which is what
- * makes removing a grant actually remove it.
- *
- * A tool-permission key may be a server id, a name or an alias: the gateway normalizes all three
- * before looking up the allowlist, so an entry written by the API or by config can use any of them.
- * `allServers` is what resolves a key to its servers, plural: names and aliases are not unique, and
- * the gateway unions such a key into EVERY server answering to it, so the entry is kept while any
- * one of them is still granted. Resolving to the first match instead would make the outcome depend
- * on catalog order and could drop a restriction that was also covering a server still granted. A key
- * that resolves to nothing is kept too, since a server we cannot identify is one we cannot confirm
- * was deselected; that also covers a catalog that has not loaded or failed to load, where every key
- * is unresolvable and nothing is pruned.
- */
-export const extractMcpEntitlement = (
-  formValues: Record<string, unknown>,
-  allServers: MCPServer[],
-): McpEntitlementUpdate | null => {
-  const selection = formValues.mcp_servers_and_groups;
-  if (selection === null || typeof selection !== "object") return null;
-
-  const { servers, accessGroups, toolsets } = selection as Record<string, unknown>;
-  const mcpServers = asStringArray(servers);
-  const mcpAccessGroups = asStringArray(accessGroups);
-  const mcpToolsets = asStringArray(toolsets);
-  const retainsIndirectGrant = mcpAccessGroups.length > 0 || mcpToolsets.length > 0;
-
-  const grantsServerNamedBy = (permissionKey: string): boolean => {
-    const named = allServers.filter((candidate) => mcpServerMatchesIdentifier(candidate, permissionKey));
-    if (named.length === 0) return true;
-    return named.some((server) => mcpServers.some((identifier) => mcpServerMatchesIdentifier(server, identifier)));
-  };
-
-  return {
-    mcp_servers: mcpServers,
-    mcp_access_groups: mcpAccessGroups,
-    mcp_toolsets: mcpToolsets,
-    mcp_tool_permissions: Object.fromEntries(
-      Object.entries(asToolPermissions(formValues.mcp_tool_permissions)).filter(
-        ([permissionKey]) => retainsIndirectGrant || grantsServerNamedBy(permissionKey),
-      ),
-    ),
-  };
-};
+import { extractMcpEntitlement } from "@/components/mcp_server_management/mcpEntitlement";
 
 interface UserInfoViewProps {
   userId: string;

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.tsx
@@ -43,6 +43,7 @@ import { getBudgetDurationLabel } from "@/components/common_components/budget_du
 import DeleteResourceModal from "@/components/common_components/DeleteResourceModal";
 import MCPServerPermissions from "@/components/permissions/MCPServerPermissions";
 import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers";
+import { useMCPToolsets } from "@/app/(dashboard)/hooks/mcpServers/useMCPToolsets";
 import { extractMcpEntitlement } from "@/components/mcp_server_management/mcpEntitlement";
 
 interface UserInfoViewProps {
@@ -95,6 +96,7 @@ export default function UserInfoView({
   const [selectedRole, setSelectedRole] = useState<string>("user");
   const [isLoadingTeams, setIsLoadingTeams] = useState(false);
   const { data: allMcpServers = [] } = useMCPServers();
+  const { data: allMcpToolsets = [] } = useMCPToolsets();
 
   React.useEffect(() => {
     setBaseUrl(getProxyBaseUrl());
@@ -296,7 +298,7 @@ export default function UserInfoView({
     try {
       if (!accessToken || !userData) return;
 
-      const mcpEntitlement = extractMcpEntitlement(formValues, allMcpServers);
+      const mcpEntitlement = extractMcpEntitlement(formValues, allMcpServers, allMcpToolsets);
       const userFields = Object.fromEntries(
         Object.entries(formValues).filter(
           ([field]) => field !== "mcp_servers_and_groups" && field !== "mcp_tool_permissions",

--- a/ui/litellm-dashboard/src/components/mcp_server_management/mcpEntitlement.ts
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/mcpEntitlement.ts
@@ -1,0 +1,72 @@
+import { ALL_PROXY_MCP_SERVERS_SENTINEL } from "@/components/mcp_tools/constants";
+import { MCPServer } from "@/components/mcp_tools/types";
+
+export interface McpEntitlementUpdate {
+  mcp_servers: string[];
+  mcp_access_groups: string[];
+  mcp_toolsets: string[];
+  mcp_tool_permissions: Record<string, string[]>;
+}
+
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+
+const asToolPermissions = (value: unknown): Record<string, string[]> => {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([serverId, tools]) => [serverId, asStringArray(tools)]),
+  );
+};
+
+const mcpServerMatchesIdentifier = (server: MCPServer, identifier: string): boolean =>
+  server.server_id === identifier || server.server_name === identifier || server.alias === identifier;
+
+/**
+ * The `object_permission` a save sends, derived from what the editor currently shows.
+ *
+ * A tool allowlist is what narrows a grant and an absent one reads as no restriction, so dropping
+ * an entry is the direction that widens. An entry is kept when an access group, a toolset, or the
+ * all-proxy grant the admin retained could still supply its server, and dropped once nothing
+ * indirect survives, which is what makes removing a grant actually remove it.
+ *
+ * A tool-permission key may be a server id, a name or an alias: the gateway normalizes all three
+ * before looking up the allowlist, so an entry written by the API or by config can use any of them.
+ * `allServers` is what resolves a key to its servers, plural: names and aliases are not unique, and
+ * the gateway unions such a key into EVERY server answering to it, so the entry is kept while any
+ * one of them is still granted. Resolving to the first match instead would make the outcome depend
+ * on catalog order and could drop a restriction that was also covering a server still granted. A key
+ * that resolves to nothing is kept too, since a server we cannot identify is one we cannot confirm
+ * was deselected; that also covers a catalog that has not loaded or failed to load, where every key
+ * is unresolvable and nothing is pruned.
+ */
+export const extractMcpEntitlement = (
+  formValues: Record<string, unknown>,
+  allServers: MCPServer[],
+): McpEntitlementUpdate | null => {
+  const selection = formValues.mcp_servers_and_groups;
+  if (selection === null || typeof selection !== "object") return null;
+
+  const { servers, accessGroups, toolsets } = selection as Record<string, unknown>;
+  const mcpServers = asStringArray(servers);
+  const mcpAccessGroups = asStringArray(accessGroups);
+  const mcpToolsets = asStringArray(toolsets);
+  const retainsIndirectGrant =
+    mcpAccessGroups.length > 0 || mcpToolsets.length > 0 || mcpServers.includes(ALL_PROXY_MCP_SERVERS_SENTINEL);
+
+  const grantsServerNamedBy = (permissionKey: string): boolean => {
+    const named = allServers.filter((candidate) => mcpServerMatchesIdentifier(candidate, permissionKey));
+    if (named.length === 0) return true;
+    return named.some((server) => mcpServers.some((identifier) => mcpServerMatchesIdentifier(server, identifier)));
+  };
+
+  return {
+    mcp_servers: mcpServers,
+    mcp_access_groups: mcpAccessGroups,
+    mcp_toolsets: mcpToolsets,
+    mcp_tool_permissions: Object.fromEntries(
+      Object.entries(asToolPermissions(formValues.mcp_tool_permissions)).filter(
+        ([permissionKey]) => retainsIndirectGrant || grantsServerNamedBy(permissionKey),
+      ),
+    ),
+  };
+};

--- a/ui/litellm-dashboard/src/components/mcp_server_management/mcpEntitlement.ts
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/mcpEntitlement.ts
@@ -1,5 +1,5 @@
 import { ALL_PROXY_MCP_SERVERS_SENTINEL } from "@/components/mcp_tools/constants";
-import { MCPServer } from "@/components/mcp_tools/types";
+import { MCPServer, MCPToolset } from "@/components/mcp_tools/types";
 
 export interface McpEntitlementUpdate {
   mcp_servers: string[];
@@ -25,9 +25,15 @@ const mcpServerMatchesIdentifier = (server: MCPServer, identifier: string): bool
  * The `object_permission` a save sends, derived from what the editor currently shows.
  *
  * A tool allowlist is what narrows a grant and an absent one reads as no restriction, so dropping
- * an entry is the direction that widens. An entry is kept when an access group, a toolset, or the
- * all-proxy grant the admin retained could still supply its server, and dropped once nothing
- * indirect survives, which is what makes removing a grant actually remove it.
+ * an entry is the direction that widens. An entry is kept while its own server is still reachable,
+ * directly or through a retained access group or toolset, and dropped once nothing reaches it, which
+ * is what makes removing a grant actually remove it. Reachability is resolved per server rather than
+ * per selection: the gateway treats every allowlist key as an independent server grant, so keeping
+ * every key because some unrelated group survived would leave a deselected server callable.
+ *
+ * The catalog carries `mcp_access_groups` on each server and `tools[].server_id` on each toolset,
+ * which is the same membership the gateway resolves against. A selected toolset missing from the
+ * catalog is unresolvable, so nothing is pruned in that save.
  *
  * A tool-permission key may be a server id, a name or an alias: the gateway normalizes all three
  * before looking up the allowlist, so an entry written by the API or by config can use any of them.
@@ -42,6 +48,7 @@ const mcpServerMatchesIdentifier = (server: MCPServer, identifier: string): bool
 export const extractMcpEntitlement = (
   formValues: Record<string, unknown>,
   allServers: MCPServer[],
+  allToolsets: MCPToolset[] = [],
 ): McpEntitlementUpdate | null => {
   const selection = formValues.mcp_servers_and_groups;
   if (selection === null || typeof selection !== "object") return null;
@@ -50,13 +57,25 @@ export const extractMcpEntitlement = (
   const mcpServers = asStringArray(servers);
   const mcpAccessGroups = asStringArray(accessGroups);
   const mcpToolsets = asStringArray(toolsets);
-  const retainsIndirectGrant =
-    mcpAccessGroups.length > 0 || mcpToolsets.length > 0 || mcpServers.includes(ALL_PROXY_MCP_SERVERS_SENTINEL);
+  const grantsEveryServer =
+    mcpServers.includes(ALL_PROXY_MCP_SERVERS_SENTINEL) ||
+    mcpToolsets.some((toolsetId) => !allToolsets.some((toolset) => toolset.toolset_id === toolsetId));
+
+  const toolsetServerIds = new Set(
+    allToolsets
+      .filter((toolset) => mcpToolsets.includes(toolset.toolset_id))
+      .flatMap((toolset) => toolset.tools.map((tool) => tool.server_id)),
+  );
+
+  const grants = (server: MCPServer): boolean =>
+    mcpServers.some((identifier) => mcpServerMatchesIdentifier(server, identifier)) ||
+    (server.mcp_access_groups ?? []).some((group) => mcpAccessGroups.includes(group)) ||
+    toolsetServerIds.has(server.server_id);
 
   const grantsServerNamedBy = (permissionKey: string): boolean => {
     const named = allServers.filter((candidate) => mcpServerMatchesIdentifier(candidate, permissionKey));
     if (named.length === 0) return true;
-    return named.some((server) => mcpServers.some((identifier) => mcpServerMatchesIdentifier(server, identifier)));
+    return named.some(grants);
   };
 
   return {
@@ -65,7 +84,7 @@ export const extractMcpEntitlement = (
     mcp_toolsets: mcpToolsets,
     mcp_tool_permissions: Object.fromEntries(
       Object.entries(asToolPermissions(formValues.mcp_tool_permissions)).filter(
-        ([permissionKey]) => retainsIndirectGrant || grantsServerNamedBy(permissionKey),
+        ([permissionKey]) => grantsEveryServer || grantsServerNamedBy(permissionKey),
       ),
     ),
   };

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
@@ -255,6 +255,11 @@ vi.mock("@/app/(dashboard)/hooks/uiSettings/useUISettings", () => ({
   useUISettings: vi.fn().mockReturnValue({ data: { values: {} }, isLoading: false }),
 }));
 
+// Mock useMCPServers hook (requires QueryClientProvider which is not available in this test)
+vi.mock("@/app/(dashboard)/hooks/mcpServers/useMCPServers", () => ({
+  useMCPServers: vi.fn().mockReturnValue({ data: [] }),
+}));
+
 // Mock useResetKeySpend hook (requires QueryClientProvider which is not available in this test)
 vi.mock("@/app/(dashboard)/hooks/keys/useResetKeySpend", () => ({
   useResetKeySpend: vi.fn().mockReturnValue({

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
@@ -260,6 +260,10 @@ vi.mock("@/app/(dashboard)/hooks/mcpServers/useMCPServers", () => ({
   useMCPServers: vi.fn().mockReturnValue({ data: [] }),
 }));
 
+vi.mock("@/app/(dashboard)/hooks/mcpServers/useMCPToolsets", () => ({
+  useMCPToolsets: vi.fn().mockReturnValue({ data: [] }),
+}));
+
 // Mock useResetKeySpend hook (requires QueryClientProvider which is not available in this test)
 vi.mock("@/app/(dashboard)/hooks/keys/useResetKeySpend", () => ({
   useResetKeySpend: vi.fn().mockReturnValue({

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -34,14 +34,23 @@ vi.mock("@/app/(dashboard)/hooks/projects/useProjects", () => ({
 
 const MCP_CATALOG = [
   { server_id: "srv-1", server_name: "deploy_tracker", alias: "deploy" },
-  { server_id: "srv-2", server_name: "incident_log", alias: "incidents" },
+  { server_id: "srv-2", server_name: "incident_log", alias: "incidents", mcp_access_groups: ["ops_readonly"] },
+];
+
+const MCP_TOOLSETS = [
+  { toolset_id: "ts-1", toolset_name: "incidents", tools: [{ server_id: "srv-2", tool_name: "write" }] },
 ];
 
 vi.mock("@/app/(dashboard)/hooks/mcpServers/useMCPServers", () => ({
   useMCPServers: vi.fn(() => ({ data: MCP_CATALOG })),
 }));
 
+vi.mock("@/app/(dashboard)/hooks/mcpServers/useMCPToolsets", () => ({
+  useMCPToolsets: vi.fn(() => ({ data: MCP_TOOLSETS })),
+}));
+
 import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers";
+import { useMCPToolsets } from "@/app/(dashboard)/hooks/mcpServers/useMCPToolsets";
 
 vi.mock("../networking", () => ({
   keyDeleteCall: vi.fn().mockResolvedValue({}),
@@ -928,6 +937,7 @@ describe("KeyInfoView", () => {
       vi.mocked(keyUpdateCall).mockClear();
       vi.mocked(keyUpdateCall).mockResolvedValue({});
       vi.mocked(useMCPServers).mockReturnValue({ data: MCP_CATALOG } as unknown as ReturnType<typeof useMCPServers>);
+      vi.mocked(useMCPToolsets).mockReturnValue({ data: MCP_TOOLSETS } as unknown as ReturnType<typeof useMCPToolsets>);
     });
 
     it("drops the allowlist of every deselected server instead of leaving it entitled", async () => {
@@ -964,6 +974,43 @@ describe("KeyInfoView", () => {
       });
 
       expect(submittedToolPermissions()).toEqual({ "srv-2": ["write"] });
+    });
+
+    it("drops an allowlist the retained access group does not reach", async () => {
+      await enterEditMode(KEY_WITH_TOOL_PERMISSIONS);
+      await editViewMocks.onSubmit!({
+        key: KEY_WITH_TOOL_PERMISSIONS.token,
+        token: KEY_WITH_TOOL_PERMISSIONS.token,
+        mcp_servers_and_groups: { servers: [], accessGroups: ["ops_readonly"], toolsets: [] },
+        mcp_tool_permissions: { "srv-1": ["read"], "srv-2": ["write"] },
+      });
+
+      expect(submittedToolPermissions()).toEqual({ "srv-2": ["write"] });
+    });
+
+    it("drops an allowlist the retained toolset does not cover", async () => {
+      await enterEditMode(KEY_WITH_TOOL_PERMISSIONS);
+      await editViewMocks.onSubmit!({
+        key: KEY_WITH_TOOL_PERMISSIONS.token,
+        token: KEY_WITH_TOOL_PERMISSIONS.token,
+        mcp_servers_and_groups: { servers: [], accessGroups: [], toolsets: ["ts-1"] },
+        mcp_tool_permissions: { "srv-1": ["read"], "srv-2": ["write"] },
+      });
+
+      expect(submittedToolPermissions()).toEqual({ "srv-2": ["write"] });
+    });
+
+    it("refuses to save a permission change while a selected toolset is unresolvable", async () => {
+      vi.mocked(useMCPToolsets).mockReturnValue({ data: undefined } as unknown as ReturnType<typeof useMCPToolsets>);
+      await enterEditMode(KEY_WITH_TOOL_PERMISSIONS);
+      await editViewMocks.onSubmit!({
+        key: KEY_WITH_TOOL_PERMISSIONS.token,
+        token: KEY_WITH_TOOL_PERMISSIONS.token,
+        mcp_servers_and_groups: { servers: [], accessGroups: [], toolsets: ["ts-1"] },
+        mcp_tool_permissions: { "srv-1": ["read"], "srv-2": ["write"] },
+      });
+
+      expect(keyUpdateCall).not.toHaveBeenCalled();
     });
 
     it("resolves a name-keyed allowlist against the server catalog", async () => {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -32,6 +32,17 @@ vi.mock("@/app/(dashboard)/hooks/projects/useProjects", () => ({
   useProjects: vi.fn().mockReturnValue({ data: [], isLoading: false }),
 }));
 
+const MCP_CATALOG = [
+  { server_id: "srv-1", server_name: "deploy_tracker", alias: "deploy" },
+  { server_id: "srv-2", server_name: "incident_log", alias: "incidents" },
+];
+
+vi.mock("@/app/(dashboard)/hooks/mcpServers/useMCPServers", () => ({
+  useMCPServers: vi.fn(() => ({ data: MCP_CATALOG })),
+}));
+
+import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers";
+
 vi.mock("../networking", () => ({
   keyDeleteCall: vi.fn().mockResolvedValue({}),
   keyUpdateCall: vi.fn().mockResolvedValue({}),
@@ -878,6 +889,144 @@ describe("KeyInfoView", () => {
       await editViewMocks.onSubmit!({ key: keyData.token, token: keyData.token, policies: [] });
 
       expect(keyUpdateCall).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ policies: [] }));
+    });
+  });
+
+  describe("MCP tool permissions on save", () => {
+    const KEY_WITH_TOOL_PERMISSIONS: KeyResponse = {
+      ...MOCK_KEY_DATA,
+      user_id: "proxy-admin-user",
+      object_permission: {
+        ...MOCK_KEY_DATA.object_permission,
+        mcp_servers: ["srv-1", "srv-2"],
+        mcp_access_groups: [],
+        mcp_tool_permissions: { "srv-1": ["read"], "srv-2": ["write"] },
+      },
+    } as KeyResponse;
+
+    const enterEditMode = async (keyData: KeyResponse) => {
+      vi.mocked(useAuthorized).mockReturnValue({
+        ...baseUseAuthorizedMock,
+        userId: "proxy-admin-user",
+        userRole: "proxy_admin",
+      });
+      renderWithProviders(
+        <KeyInfoView keyData={keyData} onClose={() => {}} keyId="test-key-id" onKeyDataUpdate={() => {}} teams={[]} />,
+      );
+      await userEvent.click(screen.getByRole("tab", { name: /settings/i }));
+      await userEvent.click(screen.getByRole("button", { name: /edit settings/i }));
+      await waitFor(() => expect(editViewMocks.onSubmit).toBeDefined());
+    };
+
+    const submittedToolPermissions = () => {
+      const payload = vi.mocked(keyUpdateCall).mock.calls.at(-1)?.[1] as Record<string, any>;
+      return payload.object_permission.mcp_tool_permissions;
+    };
+
+    beforeEach(() => {
+      editViewMocks.onSubmit = undefined;
+      vi.mocked(keyUpdateCall).mockClear();
+      vi.mocked(keyUpdateCall).mockResolvedValue({});
+      vi.mocked(useMCPServers).mockReturnValue({ data: MCP_CATALOG } as unknown as ReturnType<typeof useMCPServers>);
+    });
+
+    it("drops the allowlist of every deselected server instead of leaving it entitled", async () => {
+      await enterEditMode(KEY_WITH_TOOL_PERMISSIONS);
+      await editViewMocks.onSubmit!({
+        key: KEY_WITH_TOOL_PERMISSIONS.token,
+        token: KEY_WITH_TOOL_PERMISSIONS.token,
+        mcp_servers_and_groups: { servers: [], accessGroups: [], toolsets: [] },
+        mcp_tool_permissions: { "srv-1": ["read"], "srv-2": ["write"] },
+      });
+
+      expect(submittedToolPermissions()).toEqual({});
+    });
+
+    it("drops only the deselected server and keeps the one still granted", async () => {
+      await enterEditMode(KEY_WITH_TOOL_PERMISSIONS);
+      await editViewMocks.onSubmit!({
+        key: KEY_WITH_TOOL_PERMISSIONS.token,
+        token: KEY_WITH_TOOL_PERMISSIONS.token,
+        mcp_servers_and_groups: { servers: ["srv-1"], accessGroups: [], toolsets: [] },
+        mcp_tool_permissions: { "srv-1": ["read"], "srv-2": ["write"] },
+      });
+
+      expect(submittedToolPermissions()).toEqual({ "srv-1": ["read"] });
+    });
+
+    it("keeps an allowlist whose server is reachable through a retained access group", async () => {
+      await enterEditMode(KEY_WITH_TOOL_PERMISSIONS);
+      await editViewMocks.onSubmit!({
+        key: KEY_WITH_TOOL_PERMISSIONS.token,
+        token: KEY_WITH_TOOL_PERMISSIONS.token,
+        mcp_servers_and_groups: { servers: [], accessGroups: ["ops_readonly"], toolsets: [] },
+        mcp_tool_permissions: { "srv-2": ["write"] },
+      });
+
+      expect(submittedToolPermissions()).toEqual({ "srv-2": ["write"] });
+    });
+
+    it("resolves a name-keyed allowlist against the server catalog", async () => {
+      await enterEditMode(KEY_WITH_TOOL_PERMISSIONS);
+      await editViewMocks.onSubmit!({
+        key: KEY_WITH_TOOL_PERMISSIONS.token,
+        token: KEY_WITH_TOOL_PERMISSIONS.token,
+        mcp_servers_and_groups: { servers: ["srv-1"], accessGroups: [], toolsets: [] },
+        mcp_tool_permissions: { deploy_tracker: ["read"], incident_log: ["write"] },
+      });
+
+      expect(submittedToolPermissions()).toEqual({ deploy_tracker: ["read"] });
+    });
+
+    it("clears every allowlist when the admin picks the no-MCP-servers sentinel", async () => {
+      await enterEditMode(KEY_WITH_TOOL_PERMISSIONS);
+      await editViewMocks.onSubmit!({
+        key: KEY_WITH_TOOL_PERMISSIONS.token,
+        token: KEY_WITH_TOOL_PERMISSIONS.token,
+        mcp_servers_and_groups: { servers: ["no-mcp-servers"], accessGroups: [], toolsets: [] },
+        mcp_tool_permissions: { "srv-1": ["read"], "srv-2": ["write"] },
+      });
+
+      expect(submittedToolPermissions()).toEqual({});
+    });
+
+    it("keeps every allowlist when the admin grants all proxy servers", async () => {
+      await enterEditMode(KEY_WITH_TOOL_PERMISSIONS);
+      await editViewMocks.onSubmit!({
+        key: KEY_WITH_TOOL_PERMISSIONS.token,
+        token: KEY_WITH_TOOL_PERMISSIONS.token,
+        mcp_servers_and_groups: { servers: ["all-proxy-mcpservers"], accessGroups: [], toolsets: [] },
+        mcp_tool_permissions: { "srv-1": ["read"], "srv-2": ["write"] },
+      });
+
+      expect(submittedToolPermissions()).toEqual({ "srv-1": ["read"], "srv-2": ["write"] });
+    });
+
+    it("refuses to save a permission change it cannot compute without the server catalog", async () => {
+      vi.mocked(useMCPServers).mockReturnValue({ data: undefined } as ReturnType<typeof useMCPServers>);
+      await enterEditMode(KEY_WITH_TOOL_PERMISSIONS);
+      await editViewMocks.onSubmit!({
+        key: KEY_WITH_TOOL_PERMISSIONS.token,
+        token: KEY_WITH_TOOL_PERMISSIONS.token,
+        mcp_servers_and_groups: { servers: [], accessGroups: [], toolsets: [] },
+        mcp_tool_permissions: { "srv-1": ["read"], "srv-2": ["write"] },
+      });
+
+      expect(keyUpdateCall).not.toHaveBeenCalled();
+    });
+
+    it("preserves a vector-store edit made in the same save", async () => {
+      await enterEditMode(KEY_WITH_TOOL_PERMISSIONS);
+      await editViewMocks.onSubmit!({
+        key: KEY_WITH_TOOL_PERMISSIONS.token,
+        token: KEY_WITH_TOOL_PERMISSIONS.token,
+        vector_stores: ["vs-1"],
+        mcp_servers_and_groups: { servers: ["srv-1"], accessGroups: [], toolsets: [] },
+        mcp_tool_permissions: { "srv-1": ["read"] },
+      });
+
+      const payload = vi.mocked(keyUpdateCall).mock.calls.at(-1)?.[1] as Record<string, any>;
+      expect(payload.object_permission.vector_stores).toEqual(["vs-1"]);
     });
   });
 

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -24,6 +24,8 @@ import { useResetKeySpend } from "@/app/(dashboard)/hooks/keys/useResetKeySpend"
 import { useSetKeyBlockedState } from "@/app/(dashboard)/hooks/keys/useSetKeyBlockedState";
 import { keyKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
 import { useQueryClient } from "@tanstack/react-query";
+import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers";
+import { extractMcpEntitlement } from "../mcp_server_management/mcpEntitlement";
 import ObjectPermissionsView from "../object_permissions_view";
 import { RegenerateKeyModal } from "../organisms/RegenerateKeyModal";
 import { parseErrorMessage } from "../shared/errorUtils";
@@ -74,6 +76,7 @@ export default function KeyInfoView({
   const { teams: teamsData } = useTeams();
   const { data: projects } = useProjects();
   const { data: uiSettingsData } = useUISettings();
+  const { data: allMcpServers } = useMCPServers();
   const enableProjectsUI = Boolean(uiSettingsData?.values?.enable_projects_ui);
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -201,33 +204,21 @@ export default function KeyInfoView({
         delete formValues.vector_stores;
       }
 
-      if (formValues.mcp_servers_and_groups !== undefined) {
-        const { servers, accessGroups, toolsets } = formValues.mcp_servers_and_groups || {
-          servers: [],
-          accessGroups: [],
-          toolsets: [],
-        };
-        formValues.object_permission = {
-          ...currentKeyData.object_permission,
-          mcp_servers: servers || [],
-          mcp_access_groups: accessGroups || [],
-          mcp_toolsets: toolsets || [],
-        };
-        // Remove mcp_servers_and_groups from the top level as it should be in object_permission
-        delete formValues.mcp_servers_and_groups;
-      }
-
-      // Handle MCP tool permissions
-      if (formValues.mcp_tool_permissions !== undefined) {
-        const mcpToolPermissions = formValues.mcp_tool_permissions || {};
-        if (Object.keys(mcpToolPermissions).length > 0) {
-          formValues.object_permission = {
-            ...formValues.object_permission,
-            mcp_tool_permissions: mcpToolPermissions,
-          };
+      const mcpEntitlement = extractMcpEntitlement(formValues, allMcpServers ?? []);
+      if (mcpEntitlement) {
+        // Without the catalog every allowlist key is unresolvable, so nothing is pruned and a
+        // revocation would save as a no-op while reporting success. Refuse rather than mislead.
+        if (allMcpServers === undefined && Object.keys(mcpEntitlement.mcp_tool_permissions).length > 0) {
+          NotificationManager.error("MCP server list is unavailable, so MCP permissions cannot be saved yet. Retry.");
+          return;
         }
-        delete formValues.mcp_tool_permissions;
+        formValues.object_permission = {
+          ...(formValues.object_permission ?? currentKeyData.object_permission),
+          ...mcpEntitlement,
+        };
       }
+      delete formValues.mcp_servers_and_groups;
+      delete formValues.mcp_tool_permissions;
 
       // Handle agent permissions
       if (formValues.agents_and_groups !== undefined) {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -25,6 +25,7 @@ import { useSetKeyBlockedState } from "@/app/(dashboard)/hooks/keys/useSetKeyBlo
 import { keyKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers";
+import { useMCPToolsets } from "@/app/(dashboard)/hooks/mcpServers/useMCPToolsets";
 import { extractMcpEntitlement } from "../mcp_server_management/mcpEntitlement";
 import ObjectPermissionsView from "../object_permissions_view";
 import { RegenerateKeyModal } from "../organisms/RegenerateKeyModal";
@@ -77,6 +78,7 @@ export default function KeyInfoView({
   const { data: projects } = useProjects();
   const { data: uiSettingsData } = useUISettings();
   const { data: allMcpServers } = useMCPServers();
+  const { data: allMcpToolsets } = useMCPToolsets();
   const enableProjectsUI = Boolean(uiSettingsData?.values?.enable_projects_ui);
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -204,12 +206,19 @@ export default function KeyInfoView({
         delete formValues.vector_stores;
       }
 
-      const mcpEntitlement = extractMcpEntitlement(formValues, allMcpServers ?? []);
+      const mcpEntitlement = extractMcpEntitlement(formValues, allMcpServers ?? [], allMcpToolsets ?? []);
       if (mcpEntitlement) {
-        // Without the catalog every allowlist key is unresolvable, so nothing is pruned and a
-        // revocation would save as a no-op while reporting success. Refuse rather than mislead.
-        if (allMcpServers === undefined && Object.keys(mcpEntitlement.mcp_tool_permissions).length > 0) {
-          NotificationManager.error("MCP server list is unavailable, so MCP permissions cannot be saved yet. Retry.");
+        // Without a catalog the grants an allowlist key still has are unresolvable, so nothing is
+        // pruned and a revocation would save as a no-op while reporting success. Refuse instead.
+        const unresolvableSelection =
+          allMcpServers === undefined ||
+          mcpEntitlement.mcp_toolsets.some(
+            (toolsetId) => !(allMcpToolsets ?? []).some((toolset) => toolset.toolset_id === toolsetId),
+          );
+        if (unresolvableSelection && Object.keys(mcpEntitlement.mcp_tool_permissions).length > 0) {
+          NotificationManager.error(
+            "MCP server or toolset list is unavailable, so MCP permissions cannot be saved yet. Retry.",
+          );
           return;
         }
         formValues.object_permission = {


### PR DESCRIPTION

## TLDR

Problem this solves:

- Deselecting an MCP server on a key does not remove it
- Its stale tool allowlist keeps the key entitled
- Removing the granting access group leaves the same residue
- Clearing every allowlist would have been discarded too

How it solves it:

- Send the allowlist filtered against the servers still granted
- Keep an entry only while its own server stays reachable
- Resolve retained groups and toolsets to their member servers
- Set the map unconditionally so clearing takes effect
- Reuse the rule already shipped for internal users

## User Flow

Before: an admin removes an MCP server from a virtual key, the key keeps reaching that server

1. The admin opens the key at http://localhost:4512/ui/?page=virtual-keys, picks the key, and goes to Settings -> Edit Settings
2. Under "MCP Servers / Access Groups" the key lists two servers, and the tool matrix below shows one allowed tool on each
3. The admin removes the second server from the field and saves; the page reports the key updated
4. The key detail reloads showing only the first server, so the admin believes the second one is gone
5. Anything holding that key still lists the second server's tool and can still call it, so a server the admin revoked stays reachable
6. The same holds when the key keeps an access group or toolset that covers only the first server, so the revoked one survives every removal path

After: the same removal actually revokes the server

1. The admin opens the key at http://localhost:4512/ui/?page=virtual-keys, picks the key, and goes to Settings -> Edit Settings
2. Under "MCP Servers / Access Groups" the key lists two servers, and the tool matrix below shows one allowed tool on each
3. The admin removes the second server from the field and saves; the page reports the key updated
4. The key detail reloads showing only the first server
5. Anything holding that key now lists only the first server's tool, so the revoked server is no longer reachable
6. Keeping an access group or toolset that covers only the first server no longer keeps the second one callable, while removing a server the retained group does still cover leaves that one reachable, as it should

## Scope

The Linear ticket is a roll-up over ten issues, so state plainly which one this PR closes and which it does not, rather than letting the reader infer that a roll-up closing means all of it shipped. Status re-derived against staging rather than taken from the ticket's present tense:

| Roll-up item | State | Where |
|---|---|---|
| Inherited model grants in team and key-creation UI | Landed already | #36230 and #34211, both merged; #35846 closed as superseded |
| Inherited MCP servers and tools rendered for users and keys | Open, not this PR | #35154, and the internal-user call site is blocked behind it |
| Access-group changes stay synced with attached teams | Open, not this PR | #36825 |
| Indirect MCP grants editable and clearable without stale permissions | Team half open, key half is **this PR** | #35153 is the team half |

So this PR closes the key half of the fourth item only. The roll-up should stay open until #35153 and #35154 land.

## Relevant issues

## Linear ticket

Resolves LIT-5512

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

**There are no screenshots here on purpose, and the reason is the defect itself.** The stale grant is invisible in the UI by construction: `MCPServerPermissions` builds its list from `mcp_servers` and `mcp_access_groups`, then looks up `mcpToolPermissions[item.value]` only for servers already in that list, so an entry whose server is absent is never iterated and renders nowhere. The key detail page is therefore byte-identical before and after, and a before/after pair would be two identical screenshots. That invisibility is why this bug survived: it is a live grant the admin can neither see nor edit.

This PR also adds no rendered surface at all. The diff is a new helper module, a save handler and tests, and it is net negative inside the component, so the edit form looks the same either way. What changes is the entitlement the save produces, which is what the evidence below measures.

Live proxy against real Postgres and two real HTTP MCP servers, no mocks. Both legs run against the same proxy and the same database, from the same armed starting state, and differ only in the payload the key editor sends on save. That payload is the whole change, so the gateway is a fixed control here.

The gateway caches a key's resolved permissions for about a minute, so every read below is taken after a 75 second settle. Reading sooner returns the pre-save answer and makes both legs look identical, which is how this first read as "no difference".

Proof captured at `baf11a9399`, whose parent `262ed530f8` is the before tree. `git show 262ed530f8:ui/litellm-dashboard/src/components/templates/key_info_view.tsx | grep -c extractMcpEntitlement` returns 0, so the before tree genuinely lacks the fix.

Setup:

```bash
curl -s http://127.0.0.1:4512/v1/mcp/server -H "Authorization: Bearer sk-lit5512" \
  | python3 -c "import json,sys; [print(s['server_id'], s['server_name']) for s in json.load(sys.stdin)]"
```

```text
7c8775e9cc98547b6e054bb83d1bf54d lit5512_docs
4d0f9996f1bbf9733de3d7a4e7fedf57 lit5512_wiki
```

The key is granted both servers, with one allowed tool on each:

```bash
curl -s -X POST http://127.0.0.1:4512/key/generate \
  -H "Authorization: Bearer sk-lit5512" -H "Content-Type: application/json" \
  -d '{"key_alias":"lit5512-mcp-key","models":["lit5512-gpt"],
       "object_permission":{"mcp_servers":["7c8775e9cc98547b6e054bb83d1bf54d","4d0f9996f1bbf9733de3d7a4e7fedf57"],
       "mcp_access_groups":[],
       "mcp_tool_permissions":{"7c8775e9cc98547b6e054bb83d1bf54d":["read_wiki_structure"],
                               "4d0f9996f1bbf9733de3d7a4e7fedf57":["read_wiki_contents"]}}}'
```

Armed state, read as the key itself:

```bash
curl -s http://127.0.0.1:4512/mcp-rest/tools/list -H "Authorization: Bearer $KEY" \
  | python3 -c "import json,sys; d=json.load(sys.stdin); print(sorted({t['name'] for t in d['tools']}))"
```

```text
['read_wiki_contents', 'read_wiki_structure']
```

**Before.** The admin deselects `lit5512_wiki`. This is the save the unfixed editor sends, with the allowlist map passed through untouched:

```bash
curl -s -X POST http://127.0.0.1:4512/key/update \
  -H "Authorization: Bearer sk-lit5512" -H "Content-Type: application/json" \
  -d '{"key":"'"$KEY"'","object_permission":{"mcp_servers":["7c8775e9cc98547b6e054bb83d1bf54d"],
       "mcp_access_groups":[],"mcp_toolsets":[],
       "mcp_tool_permissions":{"7c8775e9cc98547b6e054bb83d1bf54d":["read_wiki_structure"],
                               "4d0f9996f1bbf9733de3d7a4e7fedf57":["read_wiki_contents"]}}}'
# HTTP 200, then sleep 75
```

```text
stored mcp_servers         : ['7c8775e9cc98547b6e054bb83d1bf54d']
stored mcp_tool_permissions: {"4d0f9996f1bbf9733de3d7a4e7fedf57": ["read_wiki_contents"],
                              "7c8775e9cc98547b6e054bb83d1bf54d": ["read_wiki_structure"]}
tools visible to the key   : ['read_wiki_contents', 'read_wiki_structure']
```

`lit5512_wiki` is gone from the granted servers, yet `read_wiki_contents` is still served: the leftover allowlist entry is itself a grant, so the revoked server is still reachable.

**After.** Same armed state, same admin action, and this is the save the fixed editor sends:

```bash
curl -s -X POST http://127.0.0.1:4512/key/update \
  -H "Authorization: Bearer sk-lit5512" -H "Content-Type: application/json" \
  -d '{"key":"'"$KEY"'","object_permission":{"mcp_servers":["7c8775e9cc98547b6e054bb83d1bf54d"],
       "mcp_access_groups":[],"mcp_toolsets":[],
       "mcp_tool_permissions":{"7c8775e9cc98547b6e054bb83d1bf54d":["read_wiki_structure"]}}}'
# HTTP 200, then sleep 75
```

```text
stored mcp_servers         : ['7c8775e9cc98547b6e054bb83d1bf54d']
stored mcp_tool_permissions: {"7c8775e9cc98547b6e054bb83d1bf54d": ["read_wiki_structure"]}
tools visible to the key   : ['read_wiki_structure']
```

The revocation now lands. The remaining server keeps exactly the allowlist the admin left on it.

Video of the UI legs, walked through the key editor against that same live proxy with two real MCP upstreams, is in the Slack thread: https://berriaillm.slack.com/archives/C0AE9HJQUHG/p1786662123427539?thread_ts=1786662123.427539&cid=C0AE9HJQUHG. It was captured at `dba4ea87f6`, the head at the time, while the curl legs above were captured before and after `baf11a9399`. A comment on this PR carries the same per-case output plus the screenshot.

The later commit that resolves retained groups and toolsets per server changes only which payload the editor computes, not how the proxy resolves it, so the same two legs above are the live evidence: the entitlement the second leg sends is exactly what the group case now produces once the retained group does not cover the removed server. That mapping is pinned by unit tests on both the helper and the save handler rather than re-curled.

## Type

🐛 Bug Fix

## Caveats (if any)

- Does not touch the team surface, tracked in #35153
- Key creation has the same gap, left for a follow-up
- A save is refused while a server or toolset list is unavailable
- A toolset missing from the catalog prunes nothing
- Granting all proxy servers retains every allowlist
- That sentinel is not selectable from the key editor today

## Review notes

Also fixed after the first pass, found by re-reading my own contract rather than from a review: the rule is meant to drop an entry only once its server is no longer granted, but selecting "All MCP Servers" left every allowlist key unresolvable against a catalog of real servers and dropped them all, widening tool access on servers that were already restricted. The all-proxy grant can supply any server, so it now retains entries exactly like an access group does.

Taken, from the first Greptile pass: the filter resolves each allowlist key against the MCP server catalog and keeps any key it cannot resolve, so an unavailable catalog made every key unresolvable, pruned nothing, and let a revocation save as a no-op while reporting success. I reproduced it before accepting it, with the catalog hook returning no data, and the save went through carrying both stale entries. The editor now refuses that save rather than reporting a success it did not perform. Keeping the unresolved-key fallback itself is deliberate: names and aliases are not unique and the gateway unions such a key into every server answering to it, so dropping an unresolvable entry could revoke a restriction still covering a granted server.

The ticket describes the clearing defect as an admin unticking the last tool, submitting an empty map that a `length > 0` guard then discards. That is not reachable: unticking the last tool submits `{server: []}`, which has length one and passes the guard, and the tool matrix never deletes a key from the map, so what the editor submits is always a superset of what was stored. The guard was dead code.

The two lines therefore have to change together, which is worth stating because a reviewer will not see the coupling: filtering alone leaves the clear path broken, and removing the guard alone prunes nothing. The regression tests pin the interaction rather than assuming it. Each line was mutated separately and each mutant dies on its own: reinstating the guard while keeping the filter fails only the deselect-everything test, and disabling the filter while keeping the guard removed fails three others.

Which hop loses the entries is worth stating, because the obvious reading is wrong and it is what makes this separate work from #35154. The entries are not lost on the read path: the resolver has them, the API returns them in `object_permission.mcp_tool_permissions`, and the page receives them. They are lost at RENDER, because the tool matrix filters to directly selected servers, and that is #35154's fix. The hop with the authorization consequence is the WRITE: the page sends those never-rendered entries straight back on save, and since a server named only under `mcp_tool_permissions` is entitled in the resolver, an entry the admin can neither see nor edit stays a live grant that survives the removal. Fixing the render hop alone would leave that in place.

Both directions of the defect were swept, since a one-directional sweep cannot see its own mirror image. Direction one, the UI reads something the API never resolves, is the models half and returned clean because it already shipped. Direction two, the API returns something the UI never renders, is what this PR fixes: the API returns `mcp_tool_permissions` entries for indirectly granted servers, the tool matrix never renders them because it filters to directly selected servers, and they are load-bearing grants in the resolver. Naming the clean direction matters, because a clean sweep reads like proof of absence when it may only be proof that nobody looked.

Sweeping the sibling surfaces: key creation builds `object_permission` from scratch rather than spreading stored state, so it cannot inherit a stale entry, but it never filters the allowlist either. Selecting a server, letting the matrix populate it, then deselecting it still leaves an entry, and a brand new key comes out entitled to a server the admin removed before saving. That surface omits empty fields to mean "unset", so the same helper does not drop in unchanged and forcing it there would change more than this fix should. Left for a follow-up rather than widened into this PR.

It stops being dead the moment the filter lands, because filtering out the last entry produces exactly the empty map the guard discarded, which would have defeated the fix in the one case it exists for. So both lines change together, which is the conclusion the ticket reached from a premise that does not hold.

### Inline findings

Three inline threads, adjudicated individually. Note that GitHub re-anchors `commit_id` to the current head, so a fixed finding reads as freshly filed against the very commit that fixes it; `original_commit_id` is the field that tells the truth.

**Unavailable catalog preserves revoked grants (P1, security).** Taken, and already fixed. Filed against `32d6228ca4`; the guard landed in `69ebe7300e` and is live at `key_info_view.tsx:211`. The editor now refuses a save it cannot compute rather than reporting a success it did not perform.

**Deselected server grant is retained when an unrelated group survives.** Taken, and now fixed here rather than deferred. Retention is resolved per server instead of per selection: an entry survives while its own server is directly selected, carries one of the retained access groups in `mcp_access_groups`, or appears as a `tools[].server_id` of a retained toolset, so a group covering only some other server no longer keeps a deselected server callable. My earlier reading that the editor cannot resolve membership was wrong. The catalog already carries both edges, `mcp_access_groups` per server and `server_id` per toolset tool, which is the same membership the gateway resolves against, so #35154's rendering work is not a prerequisite. The safe direction is preserved where information is genuinely missing: an unresolvable identifier still keeps its entry, since names and aliases are not unique, and a selected toolset absent from the catalog prunes nothing rather than guessing, because a missing entry reads as "no restriction" and over-pruning is the widening direction.

**Oversized comment and `Record<string, any>` in the test (P2).** Kept, on both halves. The comment is not narration of the implementation, it records which direction of a permission filter widens access and why an unresolvable key is retained, which is the "very complex business logic" carve-out in CLAUDE.md and is the reasoning a future editor most needs before touching this rule. It also moved verbatim from #35146 rather than being written here. The `any` sits in a test-local payload accessor in a file whose submit mock is already typed `Record<string, any>`; tightening one accessor against that would be inconsistent rather than safer, and the repo's no-explicit-any budget is unchanged by this PR.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR




Link to Devin session: https://app.devin.ai/sessions/81574b7220ed40419806ac0b41929672
Requested by: @yassin-berriai