### PR TITLE
fix(access groups): sync assigned_key_ids from the key write paths

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -88,6 +88,11 @@ from litellm.proxy.management_endpoints.common_utils import (
 from litellm.proxy.management_endpoints.model_management_endpoints import (
     _add_model_to_db,
 )
+from litellm.proxy.management_helpers.access_group_key_sync import (
+    sync_key_access_group_membership,
+    sync_key_regeneration_access_group_membership,
+    sync_key_update_access_group_membership,
+)
 from litellm.proxy.management_helpers.key_settings_audit import with_settings_updated_at
 from litellm.proxy.management_helpers.object_permission_utils import (
     _set_object_permission,
@@ -2347,6 +2352,17 @@ async def _process_single_key_update(
         proxy_logging_obj=proxy_logging_obj,
     )
 
+    # After the key's own cache entry is dropped, so a failure here cannot leave the key
+    # authenticating against the access groups it just lost.
+    await sync_key_update_access_group_membership(
+        prisma_client=prisma_client,
+        key_token=_hash_token_if_needed(
+            _resolve_token_to_update(data=update_key_request, existing_key_row=existing_key_row)
+        ),
+        data=update_key_request,
+        existing_key_row=existing_key_row,
+    )
+
     # Trigger async hook
     asyncio.create_task(
         KeyManagementEventHooks.async_key_updated_hook(
@@ -2826,6 +2842,15 @@ async def update_key_fn(
             hashed_token=_hash_token_if_needed(key),
             user_api_key_cache=user_api_key_cache,
             proxy_logging_obj=proxy_logging_obj,
+        )
+
+        # After the key's own cache entry is dropped, so a failure here cannot leave the key
+        # authenticating against the access groups it just lost.
+        await sync_key_update_access_group_membership(
+            prisma_client=prisma_client,
+            key_token=_hash_token_if_needed(key),
+            data=data,
+            existing_key_row=existing_key_row,
         )
 
         if data.spend is not None:
@@ -3771,7 +3796,7 @@ async def generate_key_helper_fn(
     auto_rotate: bool | None = None,
     rotation_interval: str | None = None,
     router_settings: dict | None = None,
-    access_group_ids: list | None = None,
+    access_group_ids: list[str] | None = None,
     budget_limits: list | None = None,  # multiple concurrent budget windows
 ):
     from litellm.proxy.proxy_server import premium_user, prisma_client
@@ -3979,6 +4004,14 @@ async def generate_key_helper_fn(
             create_key_response: Final = await prisma_client.insert_data(data=key_data, table_name="key")
 
             key_data["token_id"] = getattr(create_key_response, "token", None)
+            created_token_hash: Final = getattr(create_key_response, "token", None)
+            if isinstance(created_token_hash, str):
+                await sync_key_access_group_membership(
+                    prisma_client=prisma_client,
+                    key_token=created_token_hash,
+                    previous_access_group_ids=None,
+                    updated_access_group_ids=access_group_ids,
+                )
             key_data["litellm_budget_table"] = getattr(create_key_response, "litellm_budget_table", None)
             key_data["created_at"] = getattr(create_key_response, "created_at", None)
             key_data["updated_at"] = getattr(create_key_response, "updated_at", None)
@@ -4196,6 +4229,7 @@ async def delete_verification_tokens(
                 deleted_tokens = [key.token for key in authorized_keys]
                 if len(deleted_tokens) != len(tokens):
                     failed_tokens = [token for token in tokens if token not in deleted_tokens]
+
         else:
             raise Exception("DB not connected. prisma_client is None")
     except Exception as e:
@@ -4210,6 +4244,16 @@ async def delete_verification_tokens(
         # remove hash token from cache
         hashed_token = hash_token(cast(str, key))
         user_api_key_cache.delete_cache(hashed_token)
+
+    # After credential invalidation, so a failure here can never keep a deleted key alive.
+    for deleted_key in authorized_keys:
+        if deleted_key.token is not None:
+            await sync_key_access_group_membership(
+                prisma_client=prisma_client,
+                key_token=deleted_key.token,
+                previous_access_group_ids=deleted_key.access_group_ids,
+                updated_access_group_ids=None,
+            )
 
     return {
         "deleted_keys": deleted_tokens,
@@ -4725,6 +4769,15 @@ async def _execute_virtual_key_regeneration(
             user_api_key_cache=user_api_key_cache,
             proxy_logging_obj=proxy_logging_obj,
         )
+
+    # After credential invalidation, so a failure here can never keep the old key alive.
+    await sync_key_regeneration_access_group_membership(
+        prisma_client=prisma_client,
+        previous_key_token=hashed_api_key,
+        new_key_token=new_token_hash,
+        data=data,
+        existing_key_row=key_in_db,
+    )
 
     response: Final = GenerateKeyResponse.model_validate(updated_token_dict)
     asyncio.create_task(

--- a/litellm/proxy/management_helpers/access_group_key_sync.py
+++ b/litellm/proxy/management_helpers/access_group_key_sync.py
@@ -9,11 +9,14 @@ key only when the group lists the key's token (or the key's team). The access-gr
 endpoints maintain both halves already; this module is what the key write paths call
 so an edit from that side is mirrored back.
 
-Both writes are single guarded statements rather than read-modify-writes. Prisma has no
+Every write is a single guarded statement rather than a read-modify-write. Prisma has no
 atomic scalar-list removal (see `TeamRepository.remove_member`), and the read-modify-write
 it otherwise forces is not safe here: a lost update would put an already revoked token back
 into a group and restore its grants, or drop a grant an admin just made. The guards also
-make each statement idempotent, so a retry cannot duplicate an entry.
+make each statement idempotent, so a retry cannot duplicate an entry. Each statement covers
+every group the request touches at once, so the size of the caller's id list does not turn
+into a matching number of round trips, and returns the ids it actually moved so only those
+groups are dropped from cache.
 
 It deliberately lives outside `access_group_endpoints`, which is a lazily
 registered feature router (see `_lazy_features.LAZY_FEATURES`). Importing that
@@ -24,6 +27,8 @@ schema.
 
 from collections.abc import Sequence
 from typing import Final, Protocol
+
+from pydantic import BaseModel
 
 from litellm.proxy._types import (
     LiteLLM_VerificationToken,
@@ -36,20 +41,33 @@ from litellm.proxy.auth.auth_checks import (
 from litellm.repositories.table_repositories import AccessGroupRepository
 
 
+class _MovedGroupRow(BaseModel):
+    access_group_id: str
+
+
 class _RawExecutor(Protocol):
-    async def execute_raw(self, query: str, *args: str) -> int: ...
+    async def query_raw(self, query: str, *args: str | Sequence[str]) -> Sequence[object]: ...
 
 
 _ATTACH_KEY_SQL: Final = (
     'UPDATE "LiteLLM_AccessGroupTable" '
     'SET "assigned_key_ids" = array_append("assigned_key_ids", $1) '
-    'WHERE "access_group_id" = $2 AND NOT ($1 = ANY("assigned_key_ids"))'
+    'WHERE "access_group_id" = ANY($2::text[]) AND NOT ($1 = ANY("assigned_key_ids")) '
+    'RETURNING "access_group_id"'
 )
 
 _DETACH_KEY_SQL: Final = (
     'UPDATE "LiteLLM_AccessGroupTable" '
     'SET "assigned_key_ids" = array_remove("assigned_key_ids", $1) '
-    'WHERE "access_group_id" = $2 AND $1 = ANY("assigned_key_ids")'
+    'WHERE "access_group_id" = ANY($2::text[]) AND $1 = ANY("assigned_key_ids") '
+    'RETURNING "access_group_id"'
+)
+
+_REPOINT_KEY_SQL: Final = (
+    'UPDATE "LiteLLM_AccessGroupTable" '
+    'SET "assigned_key_ids" = array_append(array_remove(array_remove("assigned_key_ids", $1), $2), $2) '
+    'WHERE $1 = ANY("assigned_key_ids") '
+    'RETURNING "access_group_id"'
 )
 
 
@@ -74,11 +92,18 @@ async def _invalidate_access_group_cache(access_group_id: str) -> None:
     )
 
 
-async def _write_membership(prisma_client: object, sql: str, access_group_id: str, key_token: str) -> None:
-    """Run one guarded membership statement, invalidating the group's cache only if a row moved."""
-    rows_changed: Final = await _raw_executor(prisma_client).execute_raw(sql, key_token, access_group_id)
-    if rows_changed:
-        await _invalidate_access_group_cache(access_group_id)
+async def _invalidate_moved_groups(moved_rows: Sequence[object]) -> None:
+    for row in moved_rows:
+        await _invalidate_access_group_cache(_MovedGroupRow.model_validate(row).access_group_id)
+
+
+async def _write_membership(prisma_client: object, sql: str, access_group_ids: frozenset[str], key_token: str) -> None:
+    """Run one guarded membership statement for every listed group, dropping the cache of those it moved."""
+    if not access_group_ids:
+        return
+    await _invalidate_moved_groups(
+        await _raw_executor(prisma_client).query_raw(sql, key_token, sorted(access_group_ids))
+    )
 
 
 async def sync_key_access_group_membership(
@@ -90,13 +115,9 @@ async def sync_key_access_group_membership(
     """Mirror a key-side change to `access_group_ids` onto each access group's `assigned_key_ids`."""
     previous: Final = frozenset(previous_access_group_ids or ())
     updated: Final = frozenset(updated_access_group_ids or ())
-    added: Final = updated - previous
-    removed: Final = previous - updated
 
-    for access_group_id in added:
-        await _write_membership(prisma_client, _ATTACH_KEY_SQL, access_group_id, key_token)
-    for access_group_id in removed:
-        await _write_membership(prisma_client, _DETACH_KEY_SQL, access_group_id, key_token)
+    await _write_membership(prisma_client, _ATTACH_KEY_SQL, updated - previous, key_token)
+    await _write_membership(prisma_client, _DETACH_KEY_SQL, previous - updated, key_token)
 
 
 async def sync_key_update_access_group_membership(
@@ -135,22 +156,18 @@ async def sync_key_regeneration_access_group_membership(
 
     Regeneration replaces the token, which is the identity `assigned_key_ids` stores, so
     leaving the old hash behind both points the group at a row that no longer exists and
-    denies the regenerated key the group's grants.
+    denies the regenerated key the group's grants. The swap is driven by the groups that
+    hold the old token when the statement runs, not by the key row read earlier, so a group
+    edited in between is neither resurrected nor skipped. Removing the new token before
+    appending it keeps a re-run from duplicating it.
     """
-    regenerated_access_group_ids: Final = (
-        data.access_group_ids
-        if data is not None and "access_group_ids" in data.model_fields_set
-        else existing_key_row.access_group_ids
+    await _invalidate_moved_groups(
+        await _raw_executor(prisma_client).query_raw(_REPOINT_KEY_SQL, previous_key_token, new_key_token)
     )
-    await sync_key_access_group_membership(
-        prisma_client=prisma_client,
-        key_token=previous_key_token,
-        previous_access_group_ids=existing_key_row.access_group_ids,
-        updated_access_group_ids=None,
-    )
-    await sync_key_access_group_membership(
-        prisma_client=prisma_client,
-        key_token=new_key_token,
-        previous_access_group_ids=None,
-        updated_access_group_ids=regenerated_access_group_ids,
-    )
+    if data is not None:
+        await sync_key_update_access_group_membership(
+            prisma_client=prisma_client,
+            key_token=new_key_token,
+            data=data,
+            existing_key_row=existing_key_row,
+        )

--- a/litellm/proxy/management_helpers/access_group_key_sync.py
+++ b/litellm/proxy/management_helpers/access_group_key_sync.py
@@ -1,0 +1,156 @@
+"""
+Reverse sync for the key side of the key <-> access group relationship.
+
+`litellm_accessgrouptable.assigned_key_ids` and `litellm_verificationtoken.access_group_ids`
+are the two halves of one relationship and BOTH are read: the access group's
+attached-keys view reads the former, and so does the grant check in
+`auth_checks.get_authorized_resources_from_key_access_groups`, which authorizes a
+key only when the group lists the key's token (or the key's team). The access-group
+endpoints maintain both halves already; this module is what the key write paths call
+so an edit from that side is mirrored back.
+
+Both writes are single guarded statements rather than read-modify-writes. Prisma has no
+atomic scalar-list removal (see `TeamRepository.remove_member`), and the read-modify-write
+it otherwise forces is not safe here: a lost update would put an already revoked token back
+into a group and restore its grants, or drop a grant an admin just made. The guards also
+make each statement idempotent, so a retry cannot duplicate an entry.
+
+It deliberately lives outside `access_group_endpoints`, which is a lazily
+registered feature router (see `_lazy_features.LAZY_FEATURES`). Importing that
+module eagerly from `key_management_endpoints` would put it in `sys.modules`
+without its router ever being included, which drops its routes from the OpenAPI
+schema.
+"""
+
+from collections.abc import Sequence
+from typing import Final, Protocol
+
+from litellm.proxy._types import (
+    LiteLLM_VerificationToken,
+    RegenerateKeyRequest,
+    UpdateKeyRequest,
+)
+from litellm.proxy.auth.auth_checks import (
+    _delete_cache_access_object,  # pyright: ignore[reportPrivateUsage]  # the access-group endpoints reach for this same cache primitive
+)
+from litellm.repositories.table_repositories import AccessGroupRepository
+
+
+class _RawExecutor(Protocol):
+    async def execute_raw(self, query: str, *args: str) -> int: ...
+
+
+_ATTACH_KEY_SQL: Final = (
+    'UPDATE "LiteLLM_AccessGroupTable" '
+    'SET "assigned_key_ids" = array_append("assigned_key_ids", $1) '
+    'WHERE "access_group_id" = $2 AND NOT ($1 = ANY("assigned_key_ids"))'
+)
+
+_DETACH_KEY_SQL: Final = (
+    'UPDATE "LiteLLM_AccessGroupTable" '
+    'SET "assigned_key_ids" = array_remove("assigned_key_ids", $1) '
+    'WHERE "access_group_id" = $2 AND $1 = ANY("assigned_key_ids")'
+)
+
+
+def _raw_executor(prisma_client: object) -> _RawExecutor:
+    """Narrow the untyped Prisma client down to the raw-query call this module makes."""
+    return AccessGroupRepository(prisma_client).prisma_client.db  # pyright: ignore[reportAny]  # untyped Prisma client
+
+
+async def _invalidate_access_group_cache(access_group_id: str) -> None:
+    """
+    Drop an access group entry from both the in-memory and Redis caches.
+
+    Uses a lazy import of user_api_key_cache and proxy_logging_obj from proxy_server
+    to avoid circular imports, following the same pattern as key_management_endpoints.
+    """
+    from litellm.proxy.proxy_server import proxy_logging_obj, user_api_key_cache
+
+    await _delete_cache_access_object(
+        access_group_id=access_group_id,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
+    )
+
+
+async def _write_membership(prisma_client: object, sql: str, access_group_id: str, key_token: str) -> None:
+    """Run one guarded membership statement, invalidating the group's cache only if a row moved."""
+    rows_changed: Final = await _raw_executor(prisma_client).execute_raw(sql, key_token, access_group_id)
+    if rows_changed:
+        await _invalidate_access_group_cache(access_group_id)
+
+
+async def sync_key_access_group_membership(
+    prisma_client: object,
+    key_token: str,
+    previous_access_group_ids: Sequence[str] | None,
+    updated_access_group_ids: Sequence[str] | None,
+) -> None:
+    """Mirror a key-side change to `access_group_ids` onto each access group's `assigned_key_ids`."""
+    previous: Final = frozenset(previous_access_group_ids or ())
+    updated: Final = frozenset(updated_access_group_ids or ())
+    added: Final = updated - previous
+    removed: Final = previous - updated
+
+    for access_group_id in added:
+        await _write_membership(prisma_client, _ATTACH_KEY_SQL, access_group_id, key_token)
+    for access_group_id in removed:
+        await _write_membership(prisma_client, _DETACH_KEY_SQL, access_group_id, key_token)
+
+
+async def sync_key_update_access_group_membership(
+    prisma_client: object,
+    key_token: str,
+    data: UpdateKeyRequest | RegenerateKeyRequest,
+    existing_key_row: LiteLLM_VerificationToken,
+) -> None:
+    """
+    Mirror a key UPDATE onto the group side, honouring `exclude_unset` semantics.
+
+    The key row is written from `model_dump(exclude_unset=True)`, so a request that never
+    mentions `access_group_ids` leaves the key's own list alone and must leave the group's
+    copy alone too. Reading the attribute instead of `model_fields_set` would see None on
+    every unrelated edit and withdraw the token from every group it belongs to.
+    """
+    if "access_group_ids" not in data.model_fields_set:
+        return
+    await sync_key_access_group_membership(
+        prisma_client=prisma_client,
+        key_token=key_token,
+        previous_access_group_ids=existing_key_row.access_group_ids,
+        updated_access_group_ids=data.access_group_ids,
+    )
+
+
+async def sync_key_regeneration_access_group_membership(
+    prisma_client: object,
+    previous_key_token: str,
+    new_key_token: str,
+    data: RegenerateKeyRequest | None,
+    existing_key_row: LiteLLM_VerificationToken,
+) -> None:
+    """
+    Re-point every group's copy from the old token to the regenerated one.
+
+    Regeneration replaces the token, which is the identity `assigned_key_ids` stores, so
+    leaving the old hash behind both points the group at a row that no longer exists and
+    denies the regenerated key the group's grants.
+    """
+    regenerated_access_group_ids: Final = (
+        data.access_group_ids
+        if data is not None and "access_group_ids" in data.model_fields_set
+        else existing_key_row.access_group_ids
+    )
+    await sync_key_access_group_membership(
+        prisma_client=prisma_client,
+        key_token=previous_key_token,
+        previous_access_group_ids=existing_key_row.access_group_ids,
+        updated_access_group_ids=None,
+    )
+    await sync_key_access_group_membership(
+        prisma_client=prisma_client,
+        key_token=new_key_token,
+        previous_access_group_ids=None,
+        updated_access_group_ids=regenerated_access_group_ids,
+    )

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -791,6 +791,7 @@ async def test_generate_key_helper_fn_with_access_group_ids(monkeypatch):
     mock_prisma_client.db.litellm_objectpermissiontable.create = AsyncMock(
         return_value=MagicMock(object_permission_id=None)
     )
+    mock_prisma_client.db.execute_raw = AsyncMock(return_value=0)
 
     captured_key_data = {}
 
@@ -15703,3 +15704,543 @@ async def test_key_generate_omitted_budget_duration_still_filled_by_upperbound(m
 
     assert key_row["budget_duration"] == "30d"
     assert key_row["budget_reset_at"] is not None
+from litellm.proxy.management_helpers.access_group_key_sync import (
+    _ATTACH_KEY_SQL,
+    _DETACH_KEY_SQL,
+)
+
+ACCESS_GROUP_SYNC_TOKEN = "0d62f396c1317066f55a96086517047c737087c61eb2bf016b72e6298927b15b"
+
+
+def _access_group_table_mocks(monkeypatch, mock_prisma_client, access_groups):
+    """
+    Back the access group table with an in-memory dict so the sync's writes are observable.
+
+    The sync writes through two guarded SQL statements, so this emulates exactly what
+    Postgres does with them, including the guard that makes each one idempotent.
+    """
+
+    async def _execute_raw(query, *args):
+        key_token, access_group_id = args
+        stored = access_groups.get(access_group_id)
+        if stored is None:
+            return 0
+        current = stored["assigned_key_ids"]
+        if query == _ATTACH_KEY_SQL:
+            if key_token in current:
+                return 0
+            stored["assigned_key_ids"] = [*current, key_token]
+            return 1
+        assert query == _DETACH_KEY_SQL, f"unexpected statement: {query}"
+        if key_token not in current:
+            return 0
+        stored["assigned_key_ids"] = [t for t in current if t != key_token]
+        return 1
+
+    raw_mock = AsyncMock(side_effect=_execute_raw)
+    mock_prisma_client.db.execute_raw = raw_mock
+    return raw_mock
+
+
+async def _authorized_models_for_key(access_groups, token, key_access_group_ids):
+    """Run the real auth-time reader against the post-sync access group rows."""
+    from litellm.proxy._types import LiteLLM_AccessGroupTable, LiteLLM_TeamTable
+    from litellm.proxy.auth.auth_checks import (
+        get_authorized_resources_from_key_access_groups,
+    )
+
+    async def _get_access_object(*, access_group_id, **_kwargs):
+        stored = access_groups[access_group_id]
+        return LiteLLM_AccessGroupTable(
+            access_group_id=access_group_id,
+            access_group_name=access_group_id,
+            access_model_names=list(stored["access_model_names"]),
+            assigned_team_ids=[],
+            assigned_key_ids=list(stored["assigned_key_ids"]),
+        )
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_access_object",
+            new_callable=AsyncMock,
+            side_effect=_get_access_object,
+        ),
+    ):
+        return await get_authorized_resources_from_key_access_groups(
+            valid_token=UserAPIKeyAuth(
+                token=token,
+                models=[],
+                team_id="team-a",
+                access_group_ids=list(key_access_group_ids),
+            ),
+            team_object=LiteLLM_TeamTable(team_id="team-a", models=[]),
+            resource_field="access_model_names",
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_key_syncs_access_group_assigned_key_ids_in_both_directions(
+    monkeypatch,
+):
+    """
+    A key-side edit of `access_group_ids` must be mirrored onto every affected access
+    group's `assigned_key_ids`, in one operation, in both directions.
+
+    `assigned_key_ids` is not display-only. `get_authorized_resources_from_key_access_groups`
+    reads it as an authorization input and authorizes only when the group lists the key's
+    token, so a group the key just added must start granting its resources and a group the
+    key dropped must stop. A single-direction assertion would pass against a fix that only
+    ever adds (or only ever removes), so this covers add, remove, untouched, and the
+    authorization consequence of each.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        update_key_fn,
+    )
+
+    key_in_db = LiteLLM_VerificationToken(
+        token=ACCESS_GROUP_SYNC_TOKEN,
+        user_id="test-user",
+        access_group_ids=["ag-drop", "ag-keep"],
+    )
+    access_groups = {
+        "ag-drop": {
+            "assigned_key_ids": [ACCESS_GROUP_SYNC_TOKEN],
+            "access_model_names": ["dropped-model"],
+        },
+        "ag-keep": {
+            "assigned_key_ids": [ACCESS_GROUP_SYNC_TOKEN],
+            "access_model_names": ["kept-model"],
+        },
+        "ag-add": {"assigned_key_ids": [], "access_model_names": ["added-model"]},
+    }
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=key_in_db
+    )
+    mock_prisma_client.db.litellm_verificationtoken.find_first = AsyncMock(
+        return_value=None
+    )
+    mock_prisma_client.update_data = AsyncMock(return_value={"data": {}})
+    raw_mock = _access_group_table_mocks(
+        monkeypatch, mock_prisma_client, access_groups
+    )
+    _setup_update_key_mocks(monkeypatch, mock_prisma_client)
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_helpers.access_group_key_sync._invalidate_access_group_cache",
+            new_callable=AsyncMock,
+        ) as invalidate_cache,
+    ):
+        await update_key_fn(
+            request=MagicMock(),
+            data=UpdateKeyRequest(
+                key=ACCESS_GROUP_SYNC_TOKEN, access_group_ids=["ag-keep", "ag-add"]
+            ),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-admin",
+                user_id="admin-user",
+            ),
+            litellm_changed_by=None,
+        )
+
+    assert access_groups["ag-drop"]["assigned_key_ids"] == []
+    assert access_groups["ag-add"]["assigned_key_ids"] == [ACCESS_GROUP_SYNC_TOKEN]
+    assert access_groups["ag-keep"]["assigned_key_ids"] == [ACCESS_GROUP_SYNC_TOKEN]
+
+    # Both halves go out as single guarded statements. A read-modify-write here lets two
+    # admins editing one group lose each other's change: an attach can vanish, and a detach
+    # can put an already revoked token back and restore its grants.
+    assert sorted(call.args for call in raw_mock.call_args_list) == sorted(
+        [
+            (_ATTACH_KEY_SQL, ACCESS_GROUP_SYNC_TOKEN, "ag-add"),
+            (_DETACH_KEY_SQL, ACCESS_GROUP_SYNC_TOKEN, "ag-drop"),
+        ]
+    )
+    assert {call.args[0] for call in invalidate_cache.call_args_list} == {
+        "ag-drop",
+        "ag-add",
+    }
+
+    authorized_models = await _authorized_models_for_key(
+        access_groups,
+        ACCESS_GROUP_SYNC_TOKEN,
+        ["ag-drop", "ag-keep", "ag-add"],
+    )
+    assert sorted(authorized_models) == ["added-model", "kept-model"]
+
+
+@pytest.mark.asyncio
+async def test_update_key_leaves_access_groups_alone_when_field_is_unset(monkeypatch):
+    """
+    An update that never mentions `access_group_ids` must not touch the group rows.
+
+    `prepare_key_update_data` writes from `model_dump(exclude_unset=True)`, so an omitted
+    field leaves the key row's own list intact. Reading the request attribute instead of
+    its `model_fields_set` would see None and wipe every group's copy of the token on any
+    unrelated edit, e.g. a max_budget change.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        update_key_fn,
+    )
+
+    key_in_db = LiteLLM_VerificationToken(
+        token=ACCESS_GROUP_SYNC_TOKEN,
+        user_id="test-user",
+        access_group_ids=["ag-keep"],
+    )
+    access_groups = {
+        "ag-keep": {
+            "assigned_key_ids": [ACCESS_GROUP_SYNC_TOKEN],
+            "access_model_names": ["kept-model"],
+        },
+    }
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=key_in_db
+    )
+    mock_prisma_client.db.litellm_verificationtoken.find_first = AsyncMock(
+        return_value=None
+    )
+    mock_prisma_client.update_data = AsyncMock(return_value={"data": {}})
+    raw_mock = _access_group_table_mocks(
+        monkeypatch, mock_prisma_client, access_groups
+    )
+    _setup_update_key_mocks(monkeypatch, mock_prisma_client)
+
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+        new_callable=AsyncMock,
+    ):
+        await update_key_fn(
+            request=MagicMock(),
+            data=UpdateKeyRequest(key=ACCESS_GROUP_SYNC_TOKEN, max_budget=50.0),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-admin",
+                user_id="admin-user",
+            ),
+            litellm_changed_by=None,
+        )
+
+    raw_mock.assert_not_called()
+    assert access_groups["ag-keep"]["assigned_key_ids"] == [ACCESS_GROUP_SYNC_TOKEN]
+    assert await _authorized_models_for_key(
+        access_groups, ACCESS_GROUP_SYNC_TOKEN, ["ag-keep"]
+    ) == ["kept-model"]
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_keys_syncs_access_group_assigned_key_ids(monkeypatch):
+    """
+    /key/bulk_update and /team/keys/bulk_update reach the DB through
+    `_process_single_key_update`, which is a separate write path from /key/update's own
+    inline one. Both have to maintain the group's copy or a bulk attach grants nothing.
+    """
+    key_in_db = LiteLLM_VerificationToken(
+        token=ACCESS_GROUP_SYNC_TOKEN,
+        user_id="test-user",
+        access_group_ids=["ag-drop"],
+    )
+    access_groups = {
+        "ag-drop": {
+            "assigned_key_ids": [ACCESS_GROUP_SYNC_TOKEN],
+            "access_model_names": ["dropped-model"],
+        },
+        "ag-add": {"assigned_key_ids": [], "access_model_names": ["added-model"]},
+    }
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.update_data = AsyncMock(return_value={"data": {}})
+    _access_group_table_mocks(monkeypatch, mock_prisma_client, access_groups)
+    _setup_update_key_mocks(monkeypatch, mock_prisma_client)
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_helpers.access_group_key_sync._invalidate_access_group_cache",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.TeamMemberPermissionChecks.can_team_member_execute_key_management_endpoint",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await _process_single_key_update(
+            update_key_request=UpdateKeyRequest(
+                key=ACCESS_GROUP_SYNC_TOKEN, access_group_ids=["ag-add"]
+            ),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-admin",
+                user_id="admin-user",
+            ),
+            litellm_changed_by=None,
+            prisma_client=mock_prisma_client,
+            user_api_key_cache=AsyncMock(),
+            proxy_logging_obj=MagicMock(),
+            llm_router=None,
+            existing_key_row=key_in_db,
+        )
+
+    assert access_groups["ag-drop"]["assigned_key_ids"] == []
+    assert access_groups["ag-add"]["assigned_key_ids"] == [ACCESS_GROUP_SYNC_TOKEN]
+    assert await _authorized_models_for_key(
+        access_groups, ACCESS_GROUP_SYNC_TOKEN, ["ag-drop", "ag-add"]
+    ) == ["added-model"]
+
+
+@pytest.mark.asyncio
+async def test_delete_key_withdraws_token_from_its_access_groups(monkeypatch):
+    """
+    Deleting a key must withdraw its token from every group that lists it.
+
+    Without the withdrawal the group keeps a token that no longer resolves to a row, so
+    the access group page lists a key that does not exist and the list grows without bound.
+    """
+    key_in_db = LiteLLM_VerificationToken(
+        token=ACCESS_GROUP_SYNC_TOKEN,
+        user_id="test-user",
+        access_group_ids=["ag-keep"],
+    )
+    access_groups = {
+        "ag-keep": {
+            "assigned_key_ids": [ACCESS_GROUP_SYNC_TOKEN, "other-key"],
+            "access_model_names": ["kept-model"],
+        },
+    }
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_many = AsyncMock(
+        return_value=[key_in_db]
+    )
+    mock_prisma_client.delete_data = AsyncMock(return_value={"deleted_keys": 1})
+    mock_prisma_client.db.litellm_deletedverificationtoken.create_many = AsyncMock()
+    _access_group_table_mocks(monkeypatch, mock_prisma_client, access_groups)
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.prisma_client", mock_prisma_client
+    )
+
+    mock_cache = MagicMock()
+    mock_cache.delete_cache = MagicMock()
+
+    with patch(
+        "litellm.proxy.management_helpers.access_group_key_sync._invalidate_access_group_cache",
+        new_callable=AsyncMock,
+    ):
+        await delete_verification_tokens(
+            tokens=[ACCESS_GROUP_SYNC_TOKEN],
+            user_api_key_cache=mock_cache,
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-admin",
+                user_id="admin-user",
+            ),
+            litellm_changed_by="admin-user",
+        )
+
+    assert access_groups["ag-keep"]["assigned_key_ids"] == ["other-key"]
+
+
+@pytest.mark.asyncio
+async def test_generate_key_records_token_in_its_access_groups(monkeypatch):
+    """
+    /key/generate with `access_group_ids` must record the new token on the group side.
+
+    The key row's own list alone does not authorize: the group has to list the token back
+    or `get_authorized_resources_from_key_access_groups` contributes nothing, so a key
+    created against a group silently gets none of its models.
+    """
+    access_groups = {
+        "ag-add": {"assigned_key_ids": [], "access_model_names": ["added-model"]},
+    }
+
+    created_key = MagicMock()
+    created_key.token = ACCESS_GROUP_SYNC_TOKEN
+    created_key.litellm_budget_table = None
+    created_key.created_at = None
+    created_key.updated_at = None
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.insert_data = AsyncMock(return_value=created_key)
+    _access_group_table_mocks(monkeypatch, mock_prisma_client, access_groups)
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.prisma_client", mock_prisma_client
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+    monkeypatch.setattr("litellm.store_audit_logs", False)
+
+    with patch(
+        "litellm.proxy.management_helpers.access_group_key_sync._invalidate_access_group_cache",
+        new_callable=AsyncMock,
+    ):
+        await generate_key_helper_fn(
+            request_type="key",
+            access_group_ids=["ag-add"],
+            table_name="key",
+            user_id="test-user",
+        )
+
+    assert access_groups["ag-add"]["assigned_key_ids"] == [ACCESS_GROUP_SYNC_TOKEN]
+    assert await _authorized_models_for_key(
+        access_groups, ACCESS_GROUP_SYNC_TOKEN, ["ag-add"]
+    ) == ["added-model"]
+
+
+@pytest.mark.asyncio
+async def test_regenerate_key_repoints_access_group_assigned_key_ids(monkeypatch):
+    """
+    Regeneration replaces the key's token, which is the identity `assigned_key_ids` stores.
+
+    Leaving the old hash behind points the group at a token that no longer exists AND
+    denies the regenerated key the group's grants, so the group's copy has to be
+    re-pointed from the old hash to the new one in the same operation.
+    """
+    from litellm.proxy._types import RegenerateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _execute_virtual_key_regeneration,
+    )
+
+    from litellm.proxy.utils import hash_token
+
+    new_token_hash = hash_token("sk-newtoken1234ab12")
+    existing_key = LiteLLM_VerificationToken(
+        token="abc123",
+        user_id="user-1",
+        models=["gpt-4"],
+        access_group_ids=["ag-keep"],
+    )
+    access_groups = {
+        "ag-keep": {
+            "assigned_key_ids": ["abc123"],
+            "access_model_names": ["kept-model"],
+        },
+    }
+
+    mock_prisma_client = _make_regenerate_mock_prisma()
+    _access_group_table_mocks(monkeypatch, mock_prisma_client, access_groups)
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
+            new_callable=AsyncMock,
+            return_value="sk-newtoken1234ab12",
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.KeyManagementEventHooks.async_key_rotated_hook",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_helpers.access_group_key_sync._invalidate_access_group_cache",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await _execute_virtual_key_regeneration(
+            prisma_client=mock_prisma_client,
+            key_in_db=existing_key,
+            hashed_api_key="abc123",
+            key="abc123",
+            data=RegenerateKeyRequest(),
+            user_api_key_dict=_make_regenerate_user_api_key_dict(),
+            litellm_changed_by=None,
+            user_api_key_cache=MagicMock(),
+            proxy_logging_obj=MagicMock(),
+        )
+
+    assert access_groups["ag-keep"]["assigned_key_ids"] == [new_token_hash]
+    assert await _authorized_models_for_key(
+        access_groups, new_token_hash, ["ag-keep"]
+    ) == ["kept-model"]
+    assert (
+        await _authorized_models_for_key(access_groups, "abc123", ["ag-keep"]) == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_key_write_paths_revoke_the_key_cache_before_syncing_access_groups(
+    monkeypatch,
+):
+    """
+    Credential invalidation must not sit behind the group sync on any key write path.
+
+    The cached auth object still carries the key's old `access_group_ids`, so if the sync
+    raises first, the request fails with the key still authenticating against groups it
+    just lost, until that entry expires. Ordering it last means a failed sync degrades to
+    the stale listing this PR fixes rather than to a stale grant.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        update_key_fn,
+    )
+
+    order = []
+
+    key_in_db = LiteLLM_VerificationToken(
+        token=ACCESS_GROUP_SYNC_TOKEN,
+        user_id="test-user",
+        access_group_ids=["ag-drop"],
+    )
+    access_groups = {
+        "ag-drop": {
+            "assigned_key_ids": [ACCESS_GROUP_SYNC_TOKEN],
+            "access_model_names": ["dropped-model"],
+        },
+    }
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=key_in_db
+    )
+    mock_prisma_client.db.litellm_verificationtoken.find_first = AsyncMock(
+        return_value=None
+    )
+    mock_prisma_client.update_data = AsyncMock(return_value={"data": {}})
+    _access_group_table_mocks(monkeypatch, mock_prisma_client, access_groups)
+    mock_prisma_client.db.execute_raw = AsyncMock(
+        side_effect=lambda *a, **k: order.append("sync") or 1
+    )
+    _setup_update_key_mocks(monkeypatch, mock_prisma_client)
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+            new_callable=AsyncMock,
+            side_effect=lambda **kwargs: order.append("revoke_key_cache"),
+        ),
+        patch(
+            "litellm.proxy.management_helpers.access_group_key_sync._invalidate_access_group_cache",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await update_key_fn(
+            request=MagicMock(),
+            data=UpdateKeyRequest(key=ACCESS_GROUP_SYNC_TOKEN, access_group_ids=[]),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-admin",
+                user_id="admin-user",
+            ),
+            litellm_changed_by=None,
+        )
+
+    assert order == ["revoke_key_cache", "sync"]

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -791,7 +791,7 @@ async def test_generate_key_helper_fn_with_access_group_ids(monkeypatch):
     mock_prisma_client.db.litellm_objectpermissiontable.create = AsyncMock(
         return_value=MagicMock(object_permission_id=None)
     )
-    mock_prisma_client.db.execute_raw = AsyncMock(return_value=0)
+    mock_prisma_client.db.query_raw = AsyncMock(return_value=[])
 
     captured_key_data = {}
 
@@ -15707,6 +15707,7 @@ async def test_key_generate_omitted_budget_duration_still_filled_by_upperbound(m
 from litellm.proxy.management_helpers.access_group_key_sync import (
     _ATTACH_KEY_SQL,
     _DETACH_KEY_SQL,
+    _REPOINT_KEY_SQL,
 )
 
 ACCESS_GROUP_SYNC_TOKEN = "0d62f396c1317066f55a96086517047c737087c61eb2bf016b72e6298927b15b"
@@ -15716,29 +15717,63 @@ def _access_group_table_mocks(monkeypatch, mock_prisma_client, access_groups):
     """
     Back the access group table with an in-memory dict so the sync's writes are observable.
 
-    The sync writes through two guarded SQL statements, so this emulates exactly what
-    Postgres does with them, including the guard that makes each one idempotent.
+    The sync writes through guarded set-based SQL statements, so this emulates exactly what
+    Postgres does with them, including the guards that make each one idempotent and the
+    `RETURNING` clause that reports which groups actually moved.
     """
 
-    async def _execute_raw(query, *args):
-        key_token, access_group_id = args
-        stored = access_groups.get(access_group_id)
-        if stored is None:
-            return 0
-        current = stored["assigned_key_ids"]
-        if query == _ATTACH_KEY_SQL:
-            if key_token in current:
-                return 0
-            stored["assigned_key_ids"] = [*current, key_token]
-            return 1
-        assert query == _DETACH_KEY_SQL, f"unexpected statement: {query}"
-        if key_token not in current:
-            return 0
-        stored["assigned_key_ids"] = [t for t in current if t != key_token]
-        return 1
+    def _repoint(previous_token, new_token):
+        moved = [
+            group_id
+            for group_id, stored in access_groups.items()
+            if previous_token in stored["assigned_key_ids"]
+        ]
+        for group_id in moved:
+            current = access_groups[group_id]["assigned_key_ids"]
+            access_groups[group_id]["assigned_key_ids"] = [
+                *(t for t in current if t not in (previous_token, new_token)),
+                new_token,
+            ]
+        return moved
 
-    raw_mock = AsyncMock(side_effect=_execute_raw)
-    mock_prisma_client.db.execute_raw = raw_mock
+    def _attach(key_token, access_group_ids):
+        moved = [
+            group_id
+            for group_id in access_group_ids
+            if group_id in access_groups
+            and key_token not in access_groups[group_id]["assigned_key_ids"]
+        ]
+        for group_id in moved:
+            stored = access_groups[group_id]
+            stored["assigned_key_ids"] = [*stored["assigned_key_ids"], key_token]
+        return moved
+
+    def _detach(key_token, access_group_ids):
+        moved = [
+            group_id
+            for group_id in access_group_ids
+            if group_id in access_groups
+            and key_token in access_groups[group_id]["assigned_key_ids"]
+        ]
+        for group_id in moved:
+            stored = access_groups[group_id]
+            stored["assigned_key_ids"] = [
+                t for t in stored["assigned_key_ids"] if t != key_token
+            ]
+        return moved
+
+    async def _query_raw(query, *args):
+        if query == _REPOINT_KEY_SQL:
+            moved = _repoint(*args)
+        elif query == _ATTACH_KEY_SQL:
+            moved = _attach(*args)
+        else:
+            assert query == _DETACH_KEY_SQL, f"unexpected statement: {query}"
+            moved = _detach(*args)
+        return [{"access_group_id": group_id} for group_id in moved]
+
+    raw_mock = AsyncMock(side_effect=_query_raw)
+    mock_prisma_client.db.query_raw = raw_mock
     return raw_mock
 
 
@@ -15862,8 +15897,8 @@ async def test_update_key_syncs_access_group_assigned_key_ids_in_both_directions
     # can put an already revoked token back and restore its grants.
     assert sorted(call.args for call in raw_mock.call_args_list) == sorted(
         [
-            (_ATTACH_KEY_SQL, ACCESS_GROUP_SYNC_TOKEN, "ag-add"),
-            (_DETACH_KEY_SQL, ACCESS_GROUP_SYNC_TOKEN, "ag-drop"),
+            (_ATTACH_KEY_SQL, ACCESS_GROUP_SYNC_TOKEN, ["ag-add"]),
+            (_DETACH_KEY_SQL, ACCESS_GROUP_SYNC_TOKEN, ["ag-drop"]),
         ]
     )
     assert {call.args[0] for call in invalidate_cache.call_args_list} == {
@@ -16216,8 +16251,8 @@ async def test_key_write_paths_revoke_the_key_cache_before_syncing_access_groups
     )
     mock_prisma_client.update_data = AsyncMock(return_value={"data": {}})
     _access_group_table_mocks(monkeypatch, mock_prisma_client, access_groups)
-    mock_prisma_client.db.execute_raw = AsyncMock(
-        side_effect=lambda *a, **k: order.append("sync") or 1
+    mock_prisma_client.db.query_raw = AsyncMock(
+        side_effect=lambda *a, **k: order.append("sync") or []
     )
     _setup_update_key_mocks(monkeypatch, mock_prisma_client)
 
@@ -16244,3 +16279,168 @@ async def test_key_write_paths_revoke_the_key_cache_before_syncing_access_groups
         )
 
     assert order == ["revoke_key_cache", "sync"]
+
+
+@pytest.mark.asyncio
+async def test_update_key_syncs_many_access_groups_in_one_statement_per_direction(
+    monkeypatch,
+):
+    """
+    The number of groups on a request must not become a matching number of round trips.
+
+    Anyone allowed to assign access groups picks the size of `access_group_ids`, so a
+    per-group statement lets one /key/update hold a connection for hundreds of sequential
+    writes. Both halves are set-based, so the cost is two statements no matter the size.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        update_key_fn,
+    )
+
+    dropped = [f"ag-drop-{i}" for i in range(60)]
+    added = [f"ag-add-{i}" for i in range(60)]
+    key_in_db = LiteLLM_VerificationToken(
+        token=ACCESS_GROUP_SYNC_TOKEN,
+        user_id="test-user",
+        access_group_ids=dropped,
+    )
+    access_groups = {
+        **{
+            group_id: {
+                "assigned_key_ids": [ACCESS_GROUP_SYNC_TOKEN],
+                "access_model_names": [f"{group_id}-model"],
+            }
+            for group_id in dropped
+        },
+        **{
+            group_id: {"assigned_key_ids": [], "access_model_names": [f"{group_id}-model"]}
+            for group_id in added
+        },
+    }
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=key_in_db
+    )
+    mock_prisma_client.db.litellm_verificationtoken.find_first = AsyncMock(
+        return_value=None
+    )
+    mock_prisma_client.update_data = AsyncMock(return_value={"data": {}})
+    raw_mock = _access_group_table_mocks(
+        monkeypatch, mock_prisma_client, access_groups
+    )
+    _setup_update_key_mocks(monkeypatch, mock_prisma_client)
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_helpers.access_group_key_sync._invalidate_access_group_cache",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await update_key_fn(
+            request=MagicMock(),
+            data=UpdateKeyRequest(
+                key=ACCESS_GROUP_SYNC_TOKEN, access_group_ids=added
+            ),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-admin",
+                user_id="admin-user",
+            ),
+            litellm_changed_by=None,
+        )
+
+    assert [call.args[0] for call in raw_mock.call_args_list] == [
+        _ATTACH_KEY_SQL,
+        _DETACH_KEY_SQL,
+    ]
+    assert sorted(raw_mock.call_args_list[0].args[2]) == sorted(added)
+    assert sorted(raw_mock.call_args_list[1].args[2]) == sorted(dropped)
+    assert all(
+        access_groups[group_id]["assigned_key_ids"] == [ACCESS_GROUP_SYNC_TOKEN]
+        for group_id in added
+    )
+    assert all(access_groups[group_id]["assigned_key_ids"] == [] for group_id in dropped)
+
+
+@pytest.mark.asyncio
+async def test_regenerate_key_repoints_live_membership_not_the_key_row_it_read(
+    monkeypatch,
+):
+    """
+    Regeneration must move whatever the groups hold when it writes, not the key row's list.
+
+    That list is read before the new token exists, so replaying it re-adds the key to a
+    group an admin revoked in between and leaves the dead hash in a group an admin attached
+    in between, which silently restores one grant and drops another.
+    """
+    from litellm.proxy._types import RegenerateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _execute_virtual_key_regeneration,
+    )
+    from litellm.proxy.utils import hash_token
+
+    new_token_hash = hash_token("sk-newtoken1234ab12")
+    existing_key = LiteLLM_VerificationToken(
+        token="abc123",
+        user_id="user-1",
+        models=["gpt-4"],
+        access_group_ids=["ag-revoked-since"],
+    )
+    access_groups = {
+        "ag-revoked-since": {
+            "assigned_key_ids": [],
+            "access_model_names": ["revoked-model"],
+        },
+        "ag-attached-since": {
+            "assigned_key_ids": ["abc123"],
+            "access_model_names": ["attached-model"],
+        },
+    }
+
+    mock_prisma_client = _make_regenerate_mock_prisma()
+    _access_group_table_mocks(monkeypatch, mock_prisma_client, access_groups)
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
+            new_callable=AsyncMock,
+            return_value="sk-newtoken1234ab12",
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.KeyManagementEventHooks.async_key_rotated_hook",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_helpers.access_group_key_sync._invalidate_access_group_cache",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await _execute_virtual_key_regeneration(
+            prisma_client=mock_prisma_client,
+            key_in_db=existing_key,
+            hashed_api_key="abc123",
+            key="abc123",
+            data=RegenerateKeyRequest(),
+            user_api_key_dict=_make_regenerate_user_api_key_dict(),
+            litellm_changed_by=None,
+            user_api_key_cache=MagicMock(),
+            proxy_logging_obj=MagicMock(),
+        )
+
+    assert access_groups["ag-revoked-since"]["assigned_key_ids"] == []
+    assert access_groups["ag-attached-since"]["assigned_key_ids"] == [new_token_hash]
+    assert await _authorized_models_for_key(
+        access_groups, new_token_hash, ["ag-revoked-since", "ag-attached-since"]
+    ) == ["attached-model"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Attaching an access group to a key granted nothing
- The group's attached-keys list never learned about the key
- Regenerating or deleting a key left the list pointing at nothing

How it solves it:

- Key create, update, regenerate and delete now maintain the group's list
- Regeneration re-points the group from the old token to the new
- The group's cache entry is dropped on every such write
- Each direction is one statement, so group count adds no round trips

## User Flow

Before: an admin grants a team-restricted model to one key through an access group, the API accepts it, and the key still cannot call the model

1. They send POST https://litellm-domain/v1/access_group with `{"access_group_name": "premium", "access_model_names": ["claude-haiku-4-5"]}` and get back 201 with an `access_group_id`
2. They send POST https://litellm-domain/team/new for a team allowed only `gpt-4o-mini`, then POST https://litellm-domain/key/generate on that team, and get back a key
3. The developer sends POST https://litellm-domain/v1/chat/completions for `claude-haiku-4-5` with that key and gets 400 "team not allowed to access model", which is expected at this point
4. The admin sends POST https://litellm-domain/key/update with `{"key": "sk-...", "access_group_ids": ["<id>"]}` and gets 200 back showing the group attached
5. They send GET https://litellm-domain/v1/access_group/<id> and see `"assigned_key_ids": []`, so the access group page shows the group attached to no keys at all
6. The developer retries the same POST https://litellm-domain/v1/chat/completions for `claude-haiku-4-5` and gets the identical 400. The grant they were told they had never took effect
7. Another user on the same team is unaffected either way, because nobody gets the group's models: the per-key grant is inert no matter who holds the key

After: the same steps, and the key can call the model the group grants

1. Identical
2. Identical
3. Identical: still 400 "team not allowed to access model"
4. Identical: 200 back showing the group attached
5. GET https://litellm-domain/v1/access_group/<id> now shows `"assigned_key_ids"` carrying that key, so the access group page lists it
6. The developer retries POST https://litellm-domain/v1/chat/completions for `claude-haiku-4-5` and gets 200 with a real completion
7. Only the holder of that one key gains the model. Sending the same POST https://litellm-domain/key/update with `"access_group_ids": []` takes it away again, and the group's page stops listing the key

## Relevant issues

## Linear ticket

Resolves LIT-5521

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Same proxy, same Postgres, same commands on both legs, against real OpenAI and Anthropic APIs. The team is restricted to one model and the access group grants the other, so the only thing that can change the outcome is whether the group's own list learned about the key.

Before, captured at `262ed530f8` (staging without this commit, `grep -c sync_key_access_group_membership` returns 0):

```
$ curl -s -X POST $BASE/v1/access_group -H "$H_AUTH" -H "$H_JSON" \
  -d '{"access_group_name": "lit5521-before-group", "access_model_names": ["lit5521-restricted-model"]}'
{"access_group_id": "0de0ae02-996a-4a28-8b46-c8d7201947da", "access_model_names": ["lit5521-restricted-model"], "assigned_key_ids": []}

$ curl -s -X POST $BASE/team/new -H "$H_AUTH" -H "$H_JSON" \
  -d '{"team_alias": "lit5521-before-team", "models": ["lit5521-baseline-model"]}'
{"team_id": "2e5db877-afb1-4dac-bc1b-94ed50208b2d", "models": ["lit5521-baseline-model"]}

$ curl -s -X POST $BASE/key/generate -H "$H_AUTH" -H "$H_JSON" \
  -d '{"team_id": "2e5db877-afb1-4dac-bc1b-94ed50208b2d", "key_alias": "lit5521-before-key"}'
{"key": "sk-5LHEruUwFYn_Y3d-RFSt2Q", "token": "8350f0efb41d8efa2bbca84c2eb1c703d19ebc8c21f5bbd15209b7f55fb5d62b", "access_group_ids": []}

# CONTROL, real OpenAI call: the key works for the model its team allows
$ curl -s -X POST $BASE/v1/chat/completions -H "Authorization: Bearer $KEY" -H "$H_JSON" \
  -d '{"model": "lit5521-baseline-model", "messages": [{"role": "user", "content": "Say CONTROL-OK and nothing else"}], "max_tokens": 12}'
{"model":"lit5521-baseline-model","content":"CONTROL-OK"}

# the restriction bites before any group is attached
$ curl -s -X POST $BASE/v1/chat/completions -H "Authorization: Bearer $KEY" -H "$H_JSON" \
  -d '{"model": "lit5521-restricted-model", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 12}'
{"error":"team not allowed to access model. This team can only access models=['lit5521-baseline-model']. Tried to access lit5521-restricted-model"}

$ curl -s -X POST $BASE/key/update -H "$H_AUTH" -H "$H_JSON" \
  -d '{"key": "sk-5LHEruUwFYn_Y3d-RFSt2Q", "access_group_ids": ["0de0ae02-996a-4a28-8b46-c8d7201947da"]}'
{"key":"sk-5LHEruUwFYn_Y3d-RFSt2Q","access_group_ids":["0de0ae02-996a-4a28-8b46-c8d7201947da"]}

$ curl -s $BASE/v1/access_group/0de0ae02-996a-4a28-8b46-c8d7201947da -H "$H_AUTH"
{"access_group_id": "0de0ae02-996a-4a28-8b46-c8d7201947da", "assigned_key_ids": []}      <-- the key is missing

$ curl -s -X POST $BASE/v1/chat/completions -H "Authorization: Bearer $KEY" -H "$H_JSON" \
  -d '{"model": "lit5521-restricted-model", "messages": [{"role": "user", "content": "Say GRANTED and nothing else"}], "max_tokens": 12}'
{"error":"team not allowed to access model. This team can only access models=['lit5521-baseline-model']. Tried to access lit5521-restricted-model"}      <-- still denied
```

After, captured at `7f44000410`:

```
$ curl -s -X POST $BASE/v1/access_group -H "$H_AUTH" -H "$H_JSON" \
  -d '{"access_group_name": "lit5521-after5-group", "access_model_names": ["lit5521-restricted-model"]}'
{"access_group_id": "19be5069-a535-443f-b5fb-38c462e4021b", "access_model_names": ["lit5521-restricted-model"], "assigned_key_ids": []}

$ curl -s -X POST $BASE/team/new -H "$H_AUTH" -H "$H_JSON" \
  -d '{"team_alias": "lit5521-after5-team", "models": ["lit5521-baseline-model"]}'
{"team_id": "363a2af0-8924-4c4e-b895-794c7b2ed96c", "models": ["lit5521-baseline-model"]}

$ curl -s -X POST $BASE/key/generate -H "$H_AUTH" -H "$H_JSON" \
  -d '{"team_id": "363a2af0-8924-4c4e-b895-794c7b2ed96c", "key_alias": "lit5521-after5-key"}'
{"key": "sk--KARi_4H0_B2UQCQxtRvxg", "token": "e302f9ffbbfab1763b076f17bf9643596d4dbfad2446c0752128139587ecd8b8", "access_group_ids": []}

# CONTROL, same real OpenAI call, same result
$ curl -s -X POST $BASE/v1/chat/completions -H "Authorization: Bearer $KEY" -H "$H_JSON" \
  -d '{"model": "lit5521-baseline-model", "messages": [{"role": "user", "content": "Say CONTROL-OK and nothing else"}], "max_tokens": 12}'
{"model":"lit5521-baseline-model","content":"CONTROL-OK"}

# same denial before any group is attached
$ curl -s -X POST $BASE/v1/chat/completions -H "Authorization: Bearer $KEY" -H "$H_JSON" \
  -d '{"model": "lit5521-restricted-model", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 12}'
{"error":"team not allowed to access model. This team can only access models=['lit5521-baseline-model']. Tried to access lit5521-restricted-model"}

$ curl -s -X POST $BASE/key/update -H "$H_AUTH" -H "$H_JSON" \
  -d '{"key": "sk--KARi_4H0_B2UQCQxtRvxg", "access_group_ids": ["19be5069-a535-443f-b5fb-38c462e4021b"]}'
{"key":"sk--KARi_4H0_B2UQCQxtRvxg","access_group_ids":["19be5069-a535-443f-b5fb-38c462e4021b"]}

$ curl -s $BASE/v1/access_group/19be5069-a535-443f-b5fb-38c462e4021b -H "$H_AUTH"
{"access_group_id": "19be5069-a535-443f-b5fb-38c462e4021b",
 "assigned_key_ids": ["e302f9ffbbfab1763b076f17bf9643596d4dbfad2446c0752128139587ecd8b8"]}      <-- the key is there

# real Anthropic call, now allowed
$ curl -s -X POST $BASE/v1/chat/completions -H "Authorization: Bearer $KEY" -H "$H_JSON" \
  -d '{"model": "lit5521-restricted-model", "messages": [{"role": "user", "content": "Say GRANTED and nothing else"}], "max_tokens": 12}'
{"model":"lit5521-restricted-model","content":"GRANTED"}

# detaching withdraws it again
$ curl -s -X POST $BASE/key/update -H "$H_AUTH" -H "$H_JSON" \
  -d '{"key": "sk--KARi_4H0_B2UQCQxtRvxg", "access_group_ids": []}'
{"key":"sk--KARi_4H0_B2UQCQxtRvxg","access_group_ids":[]}

$ curl -s $BASE/v1/access_group/19be5069-a535-443f-b5fb-38c462e4021b -H "$H_AUTH"
{"access_group_id": "19be5069-a535-443f-b5fb-38c462e4021b", "assigned_key_ids": []}
```

The other three write paths, same proxy and same commit, so the group's list is verified live through the whole key lifecycle rather than only through /key/update:

```
# create with the group already attached
$ curl -s -X POST $BASE/key/generate -H "$H_AUTH" -H "$H_JSON" \
  -d '{"key_alias": "lit5521-lifecycle-key", "access_group_ids": ["cd451f9d-cca8-4008-b2a4-519bcde5709c"]}'
{"key":"sk-1uIfps2YYXEpAdkPsFjW0Q","token":"0de2591bde17a0b1c6a844bbf6404ee29d05eaa6a8538e394dbafb1633812c6d","access_group_ids":["cd451f9d-cca8-4008-b2a4-519bcde5709c"]}

$ curl -s $BASE/v1/access_group/cd451f9d-cca8-4008-b2a4-519bcde5709c -H "$H_AUTH"
{"assigned_key_ids":["0de2591bde17a0b1c6a844bbf6404ee29d05eaa6a8538e394dbafb1633812c6d"]}

# attaching a group the key already has changes nothing, no duplicate entry
$ curl -s -X POST $BASE/key/update -H "$H_AUTH" -H "$H_JSON" \
  -d '{"key": "sk-1uIfps2YYXEpAdkPsFjW0Q", "access_group_ids": ["cd451f9d-cca8-4008-b2a4-519bcde5709c"]}'
{"access_group_ids":["cd451f9d-cca8-4008-b2a4-519bcde5709c"]}

$ curl -s $BASE/v1/access_group/cd451f9d-cca8-4008-b2a4-519bcde5709c -H "$H_AUTH"
{"assigned_key_ids":["0de2591bde17a0b1c6a844bbf6404ee29d05eaa6a8538e394dbafb1633812c6d"]}

# regenerate: the group follows the new token instead of keeping the old hash
$ curl -s -X POST $BASE/key/sk-1uIfps2YYXEpAdkPsFjW0Q/regenerate -H "$H_AUTH" -H "$H_JSON" -d '{}'
{"key":"sk-vA8eGEhz9UBUNJ7c3LUgHQ","token_id":"3dc3de3e57e585496192941c3bd1ed4afc633f510416baca6afb6d81ff6bb343"}

$ curl -s $BASE/v1/access_group/cd451f9d-cca8-4008-b2a4-519bcde5709c -H "$H_AUTH"
{"assigned_key_ids":["3dc3de3e57e585496192941c3bd1ed4afc633f510416baca6afb6d81ff6bb343"]}

# delete: the token is withdrawn
$ curl -s -X POST $BASE/key/delete -H "$H_AUTH" -H "$H_JSON" -d '{"keys": ["sk-vA8eGEhz9UBUNJ7c3LUgHQ"]}'
{"deleted_keys":["sk-vA8eGEhz9UBUNJ7c3LUgHQ"]}

$ curl -s $BASE/v1/access_group/cd451f9d-cca8-4008-b2a4-519bcde5709c -H "$H_AUTH"
{"assigned_key_ids":[]}
```

Re-run at `17a1b6ce12`, the commit that batches the writes and drops the regeneration snapshot. Same live proxy and Postgres, real Anthropic calls, team restricted to `anthropic-haiku-4-5` and the group granting `anthropic-sonnet-4-5`. Attach still grants on the very next request, a cache-warmed detach still denies on the very next request with no restart, and create, re-attach, regenerate and delete all still behave as above. What is new is the cost and the concurrency case.

Five groups attached and detached in one /key/update each way, with `log_statement=all` showing one statement per direction carrying all five ids in a single array parameter:

```
$ curl -s -X POST $BASE/key/update -H "$H_AUTH" -H "$H_JSON" \
  -d '{"key":"sk-sYhPEsYoDwNQm89P89rTnA","access_group_ids":["1971eee9-...","f3dda0ab-...","4f2a1a4d-...","4b52fb94-...","acd37a5f-..."]}'
HTTP 200
1971eee9-... -> ['abf8b3e50f999969b6004f5bef887f1fffc72f3bd012c0d6952b13e0a678d9be']
f3dda0ab-... -> ['abf8b3e50f999969b6004f5bef887f1fffc72f3bd012c0d6952b13e0a678d9be']
4f2a1a4d-... -> ['abf8b3e50f999969b6004f5bef887f1fffc72f3bd012c0d6952b13e0a678d9be']
4b52fb94-... -> ['abf8b3e50f999969b6004f5bef887f1fffc72f3bd012c0d6952b13e0a678d9be']
acd37a5f-... -> ['abf8b3e50f999969b6004f5bef887f1fffc72f3bd012c0d6952b13e0a678d9be']

$ curl -s -X POST $BASE/v1/chat/completions -H "Authorization: Bearer $KEY" -H "$H_JSON" \
  -d '{"model":"anthropic-sonnet-4-5","messages":[{"role":"user","content":"hi"}],"max_tokens":10}'
HTTP 200

$ curl -s -X POST $BASE/key/update -H "$H_AUTH" -H "$H_JSON" -d '{"key":"sk-sYhPEsYoDwNQm89P89rTnA","access_group_ids":[]}'
HTTP 200
# all five back to [], and the next sonnet call is HTTP 403 team_model_access_denied

# postgresql log, one statement each way for all five groups
LOG: execute s135: UPDATE "LiteLLM_AccessGroupTable" SET "assigned_key_ids" = array_append("assigned_key_ids", $1)
       WHERE "access_group_id" = ANY($2::text[]) AND NOT ($1 = ANY("assigned_key_ids")) RETURNING "access_group_id"
DETAIL: parameters: $1 = 'abf8b3e5...', $2 = '{1971eee9-...,4b52fb94-...,4f2a1a4d-...,acd37a5f-...,f3dda0ab-...}'
LOG: execute s53: UPDATE "LiteLLM_AccessGroupTable" SET "assigned_key_ids" = array_remove("assigned_key_ids", $1)
       WHERE "access_group_id" = ANY($2::text[]) AND $1 = ANY("assigned_key_ids") RETURNING "access_group_id"
DETAIL: parameters: $1 = 'abf8b3e5...', $2 = '{1971eee9-...,4b52fb94-...,4f2a1a4d-...,acd37a5f-...,f3dda0ab-...}'
```

Regeneration against a group edited out of band, run twice with only the helper swapped, so the difference is the fix and nothing else. The key row still lists G1 while the old hash has been moved into G2 directly in Postgres, then the key is regenerated:

```
# state going in, both legs
G1 (what the key row says) -> {}
G2 (what actually holds the old hash) -> {1b27a3ff...OLD}
key row access_group_ids -> {G1}

# at 17a1b6ce12
$ curl -s -X POST $BASE/key/sk-Y-EpBy0aSiIuJBKV4kLHUQ/regenerate -H "$H_AUTH" -H "$H_JSON" -d '{}'
G1 -> {}                          correct, the revoked group is not resurrected
G2 -> {955fe043...NEW}            correct, the live holder follows the new token

# same script, pre-fix helper from 055f0e6035 copied in, proxy restarted
G1 -> {70cbb873...NEW}            wrong, the snapshot puts the key back into a group that had dropped it
G2 -> {9e34e865...OLD}            wrong, the live holder is stranded on a token that no longer exists

# regenerating with access_group_ids set applies the delta after the repoint
$ curl -s -X POST $BASE/key/sk-d9mE4BW0KI45i4bNPAKORQ/regenerate -H "$H_AUTH" -H "$H_JSON" -d '{"access_group_ids": ["b3d391d3-..."]}'
G2 -> {94178c23...NEWEST}, key row -> {G2}, sonnet HTTP 200, old key HTTP 401
```

## Type

🐛 Bug Fix

## Caveats

- Deriving the list at read time was rejected, see below
- Cascade deletes of keys via /team/delete and /user/delete stay uncovered
- Every membership write is raw SQL, so Postgres only
- /key/bulk_update cannot carry access_group_ids today
- Redis and multi-worker cache invalidation untested

## Review notes

Why the value is recorded rather than derived. The group's list and the key's list are two halves of one handshake, not a denormalized cache: a key is authorized only when it names the group AND the group names the key. Deriving the group's half from "every key naming this group" collapses that to a single side and grants strictly more than today. `tests/proxy_unit_tests/test_auth_checks.py` pins the case a derivation would break, a key naming a group whose own list excludes that key's token, and asserts denial.

Where the ticket and the code disagree. LIT-5521 says a key detached from the key side keeps receiving the group's grants. It does not: every reader gates on the key's own `access_group_ids` first, so a detach revokes immediately, and the leftover entry is a stale listing rather than a live grant. The authorization defect runs the other way, on attach, which is what the proof above captures. The detach direction is still fixed here, for the listing and so a regenerated or deleted key stops leaving entries behind.

What is covered and what is not. Every key write path that can change membership is covered: create (which serves /key/generate, /key/service_account/generate and the key /user/new mints), update (one shared helper reached by /key/update and by both bulk routes through `_process_single_key_update`), regenerate, and delete. Three cascade paths delete key rows in bulk without going through the key delete helper, /team/delete, /user/delete, and the org path behind it, and they still leave stale token hashes. There is no authorization consequence there, the key row is gone so the token cannot authenticate, and deleting the access group already self-heals out-of-sync entries. Worth a follow-up, deliberately not folded in here.

Greptile's non-atomic membership finding, taken. I reproduced it against a real Postgres 16 rather than reasoning about it, and the result changed what the fix should be: two concurrent read-modify-writes on the same row lose one membership even when both run inside a transaction, because under READ COMMITTED the second write is derived from a value read before the first committed. So wrapping the two writes in a transaction would have looked like a fix without being one. The same two writes expressed as a single `array_append` keep both. Both halves are now single guarded statements, `array_append ... WHERE NOT (token = ANY(...))` and `array_remove ... WHERE token = ANY(...)`, which is what `TeamRepository.remove_member` already tells you to reach for when the read-modify-write matters. It matters here: a lost detach puts an already revoked token back into a group and restores its grants, and a lost attach silently drops a grant an admin just made. The `WHERE` guards also make each statement idempotent, which a check-then-push cannot be. I measured all three shapes on Postgres 16 before choosing: two concurrent read-modify-writes leave `{keyA}` and lose the other, two guarded appends of different tokens leave `{keyA,keyB}`, and two concurrent appends of the SAME token leave `{tok}` guarded versus `{tok,tok}` when the check and the append are separate statements. Tests pin both write shapes, so a regression to array replacement in either direction fails, and the mocked executor emulates the guards rather than assuming them. On partial failure the group write throwing after the key row commits leaves exactly the pre-PR state and surfaces as an error to the caller, so nothing is newly corrupted, and `delete_access_group` already reconciles out-of-sync entries by unioning both sides.

Greptile's revocation-ordering finding, taken. The sync ran before credential-cache invalidation on both delete and regenerate, so a failure inside it would have returned an error with the old key still authenticating from cache. All four call sites now run after invalidation, update and bulk update included, so nothing fallible sits between changing a key and revoking what it had. The cached auth object still carries the key's old `access_group_ids`, so syncing first meant a failed sync returned an error with the key still authenticating against groups it had just lost. A test pins the ordering.

veria's unbounded-work finding, taken. The caller picks the size of `access_group_ids`, and one statement per group let a single /key/update hold a worker and a connection for as many sequential writes as the list is long, even for ids that do not exist. Both directions are now set-based, `WHERE access_group_id = ANY($2::text[])`, so the cost is one statement for the attaches and one for the detaches whatever the list size, with the guards and idempotence unchanged. Each statement returns the ids it actually moved, so cache invalidation stays scoped to the groups that changed rather than every id in the request. A cardinality cap was the other option and it is strictly worse here: it puts an arbitrary number in the request schema, breaks callers legitimately assigning many groups, and would still leave the per-group loop behind it. A test drives 60 attaches and 60 detaches through /key/update and asserts exactly two statements, so a regression to per-group writes fails.

Greptile's regeneration-transition finding, taken. Regeneration was replaying the key row it read before the new token existed, so an access-group edit landing in between was either resurrected, the group had dropped the key and the replay put the new token back, or lost, the group had just attached the key and kept the dead hash. It now swaps in place from whatever the rows hold at write time, `SET assigned_key_ids = array_append(array_remove(array_remove(assigned_key_ids, $1), $2), $2) WHERE $1 = ANY(assigned_key_ids)`, which needs no snapshot and no lock, and the double `array_remove` keeps a retry from duplicating the new token. A regenerate request that also changes `access_group_ids` still applies that delta afterwards, since that intent is expressed against the key's own list. The test sets the group rows to disagree with the key row in both directions and asserts the revoked group stays empty while the newly attached one follows the new token.

Consistency with the team-side fix. This mirrors PR #36825 field for field: same helper module shape, same previous/updated delta signature, same cache invalidation, and the same reason for living outside `access_group_endpoints.py`, which is a lazily registered feature router that must not be imported eagerly. It does not import from that PR's module, so the two can merge in either order.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR



Link to Devin session: https://app.devin.ai/sessions/d4faac79f9a84e0fba54b0c90f2265fc
Requested by: @yassin-berriai