### PR TITLE
feat(ui): render request metrics on the /ui/chat surface

### DIFF
--- a/ui/litellm-dashboard/src/app/chat/page.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/chat/page.integration.test.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatHistory } from "@/components/chat/useChatHistory";
+import ChatConversationPage from "./page";
+
+const { mockMakeOpenAIResponsesRequest } = vi.hoisted(() => ({
+  mockMakeOpenAIResponsesRequest: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("@/components/llm_calls/fetch_models", () => ({
+  fetchAvailableModels: vi.fn(async () => [{ model_group: "gpt-5.4-mini" }]),
+}));
+
+vi.mock("@/components/llm_calls/responses_api", () => ({
+  makeOpenAIResponsesRequest: mockMakeOpenAIResponsesRequest,
+}));
+
+vi.mock("@/components/chat/MCPConnectPicker", () => ({
+  default: () => <div data-testid="mcp-connect-picker" />,
+}));
+
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
+vi.mock("remark-gfm", () => ({ default: () => undefined }));
+
+vi.mock("react-syntax-highlighter", () => ({
+  Prism: ({ children }: { children: string }) => <pre>{children}</pre>,
+}));
+
+vi.mock("react-syntax-highlighter/dist/esm/styles/prism", () => ({ coy: {} }));
+
+vi.mock("@/contexts/ChatShellContext", () => ({
+  useChatShell: () => {
+    const history = useChatHistory(null, "metrics-test-user");
+    return {
+      accessToken: "sk-test",
+      userId: "metrics-test-user",
+      userEmail: "tester@example.com",
+      userRole: "Admin",
+      premiumUser: false,
+      selectedMCPServers: [],
+      setSelectedMCPServers: vi.fn(),
+      conversations: history.conversations,
+      activeConversation: history.activeConversation,
+      activeConversationId: history.currentActiveId,
+      storageUnavailable: false,
+      staleId: false,
+      createConversation: history.createConversation,
+      appendMessage: history.appendMessage,
+      updateLastAssistantMessage: history.updateLastAssistantMessage,
+      truncateFromMessage: history.truncateFromMessage,
+      deleteConversation: vi.fn(),
+      renameConversation: vi.fn(),
+    };
+  },
+}));
+
+const ONE_TURN_ARG_COUNT = 25;
+const ON_TIMING_DATA_INDEX = 7;
+const ON_USAGE_DATA_INDEX = 8;
+const ON_TOTAL_LATENCY_INDEX = 24;
+
+async function sendOneMessage(): Promise<void> {
+  render(<ChatConversationPage />);
+  await waitFor(() => expect(screen.getByRole("button", { name: /gpt-5\.4-mini/ })).toBeInTheDocument());
+  fireEvent.change(screen.getByPlaceholderText("How can I help you today?"), {
+    target: { value: "How much did this cost?" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Send" }));
+  await waitFor(() => expect(mockMakeOpenAIResponsesRequest).toHaveBeenCalledTimes(1));
+}
+
+describe("/ui/chat request metrics", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockMakeOpenAIResponsesRequest.mockReset();
+  });
+
+  it("renders latency, TTFT, token counts and cost reported for the assistant turn", async () => {
+    mockMakeOpenAIResponsesRequest.mockImplementation(async (...args: unknown[]) => {
+      const updateTextUI = args[1] as (role: string, delta: string) => void;
+      const onTimingData = args[ON_TIMING_DATA_INDEX] as ((ttft: number) => void) | undefined;
+      const onUsageData = args[ON_USAGE_DATA_INDEX] as ((usage: Record<string, number>) => void) | undefined;
+      const onTotalLatency = args[ON_TOTAL_LATENCY_INDEX] as ((latency: number) => void) | undefined;
+
+      updateTextUI("assistant", "Sixty three microdollars.");
+      onTimingData?.(250);
+      onUsageData?.({ promptTokens: 12, completionTokens: 8, totalTokens: 20, cost: 0.000063 });
+      onTotalLatency?.(1200);
+    });
+
+    await sendOneMessage();
+
+    await waitFor(() => expect(screen.getByLabelText("Total: 20")).toBeInTheDocument());
+    expect(screen.getByLabelText("TTFT: 0.25s")).toBeInTheDocument();
+    expect(screen.getByLabelText("Total Latency: 1.20s")).toBeInTheDocument();
+    expect(screen.getByLabelText("In: 12")).toBeInTheDocument();
+    expect(screen.getByLabelText("Out: 8")).toBeInTheDocument();
+    expect(screen.getByLabelText("Cost: $0.000063")).toBeInTheDocument();
+  });
+
+  it("supplies the timing, usage and latency callbacks at the positional slots the Responses helper reads", async () => {
+    mockMakeOpenAIResponsesRequest.mockResolvedValue(undefined);
+
+    await sendOneMessage();
+
+    const call = mockMakeOpenAIResponsesRequest.mock.calls[0];
+    expect(call).toHaveLength(ONE_TURN_ARG_COUNT);
+    expect(typeof call[ON_TIMING_DATA_INDEX]).toBe("function");
+    expect(typeof call[ON_USAGE_DATA_INDEX]).toBe("function");
+    expect(typeof call[ON_TOTAL_LATENCY_INDEX]).toBe("function");
+  });
+
+  it("shows no metrics bar for a turn the provider reported no usage for", async () => {
+    mockMakeOpenAIResponsesRequest.mockImplementation(async (...args: unknown[]) => {
+      const updateTextUI = args[1] as (role: string, delta: string) => void;
+      updateTextUI("assistant", "No usage here.");
+    });
+
+    await sendOneMessage();
+
+    await waitFor(() => expect(screen.getByText("No usage here.")).toBeInTheDocument());
+    expect(document.querySelector(".response-metrics")).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/app/chat/page.tsx
+++ b/ui/litellm-dashboard/src/app/chat/page.tsx
@@ -15,6 +15,7 @@ import ChatMessages from "@/components/chat/ChatMessages";
 import MCPConnectPicker from "@/components/chat/MCPConnectPicker";
 import { fetchAvailableModels } from "@/components/llm_calls/fetch_models";
 import { makeOpenAIResponsesRequest } from "@/components/llm_calls/responses_api";
+import type { TokenUsage } from "@/components/chat_ui/ResponseMetrics";
 import type { MCPEvent } from "@/components/chat/types";
 import { getProviderLogoAndName } from "@/components/provider_info_helpers";
 
@@ -202,8 +203,8 @@ export default function ChatConversationPage() {
             accumulatedReasoning += rc;
             updateLastAssistantMessage(convId!, { reasoningContent: accumulatedReasoning });
           },
-          undefined,
-          undefined,
+          (timeToFirstToken: number) => updateLastAssistantMessage(convId!, { timeToFirstToken }),
+          (usage: TokenUsage) => updateLastAssistantMessage(convId!, { usage }),
           undefined,
           undefined,
           undefined,
@@ -216,6 +217,14 @@ export default function ChatConversationPage() {
             // one full localStorage write per MCP event during streaming.
             accumulatedMCPEvents.push(event);
           },
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          true,
+          (totalLatency: number) => updateLastAssistantMessage(convId!, { totalLatency }),
         );
         streamCompletedCleanly = true;
       } catch (err: unknown) {

--- a/ui/litellm-dashboard/src/components/chat/ChatMessages.tsx
+++ b/ui/litellm-dashboard/src/components/chat/ChatMessages.tsx
@@ -11,6 +11,7 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { coy } from "react-syntax-highlighter/dist/esm/styles/prism";
 import ReasoningContent from "@/components/chat_ui/ReasoningContent";
 import MCPEventsDisplay from "@/components/chat_ui/MCPEventsDisplay";
+import ResponseMetrics from "@/components/chat_ui/ResponseMetrics";
 import { ChatMessage } from "./types";
 
 const REDACTED_KEY_PATTERNS = /token|key|secret|password|auth/i;
@@ -248,6 +249,12 @@ function AssistantBubble({ message, isLastMessage, isStreaming, isTypingIndicato
           <MCPEventsDisplay events={mcpEvents} />
         </div>
       )}
+
+      <ResponseMetrics
+        timeToFirstToken={message.timeToFirstToken}
+        totalLatency={message.totalLatency}
+        usage={message.usage}
+      />
     </div>
   );
 }

--- a/ui/litellm-dashboard/src/components/chat/types.ts
+++ b/ui/litellm-dashboard/src/components/chat/types.ts
@@ -1,4 +1,5 @@
 import type { MCPEvent } from "../mcp_tools/types";
+import type { TokenUsage } from "../chat_ui/ResponseMetrics";
 export type { MCPEvent };
 
 export interface ChatMessage {
@@ -11,8 +12,15 @@ export interface ChatMessage {
   toolName?: string;
   toolArgs?: Record<string, unknown>;
   toolResult?: string;
+  timeToFirstToken?: number;
+  totalLatency?: number;
+  usage?: TokenUsage;
   timestamp: number;
 }
+
+export type AssistantMessageUpdate = Partial<
+  Pick<ChatMessage, "content" | "reasoningContent" | "mcpEvents" | "timeToFirstToken" | "totalLatency" | "usage">
+>;
 
 export interface Conversation {
   id: string;

--- a/ui/litellm-dashboard/src/components/chat/useChatHistory.ts
+++ b/ui/litellm-dashboard/src/components/chat/useChatHistory.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { ChatMessage, Conversation } from "./types";
+import { AssistantMessageUpdate, ChatMessage, Conversation } from "./types";
 
 const STORAGE_KEY_PREFIX = "litellm_chat_history_v1";
 const MAX_CONVERSATIONS = 100;
@@ -57,10 +57,7 @@ export function useChatHistory(
   staleId: boolean;
   createConversation: (model: string) => string;
   appendMessage: (conversationId: string, message: Omit<ChatMessage, "id" | "timestamp">) => void;
-  updateLastAssistantMessage: (
-    conversationId: string,
-    updates: Partial<Pick<ChatMessage, "content" | "reasoningContent" | "mcpEvents">>,
-  ) => void;
+  updateLastAssistantMessage: (conversationId: string, updates: AssistantMessageUpdate) => void;
   /** Remove the message with `messageId` and all subsequent messages from the conversation. */
   truncateFromMessage: (conversationId: string, messageId: string) => void;
   deleteConversation: (id: string) => void;
@@ -150,25 +147,22 @@ export function useChatHistory(
     });
   }, []);
 
-  const updateLastAssistantMessage = useCallback(
-    (conversationId: string, updates: Partial<Pick<ChatMessage, "content" | "reasoningContent" | "mcpEvents">>) => {
-      setConversations((prev) => {
-        const updated = prev.map((conv) => {
-          if (conv.id !== conversationId) return conv;
-          const messages = [...conv.messages];
-          const lastAssistantIndex = messages.reduceRight((found, msg, idx) => {
-            if (found !== -1) return found;
-            return msg.role === "assistant" ? idx : -1;
-          }, -1);
-          if (lastAssistantIndex === -1) return conv;
-          messages[lastAssistantIndex] = { ...messages[lastAssistantIndex], ...updates };
-          return { ...conv, messages, updatedAt: Date.now() };
-        });
-        return trimConversations(updated);
+  const updateLastAssistantMessage = useCallback((conversationId: string, updates: AssistantMessageUpdate) => {
+    setConversations((prev) => {
+      const updated = prev.map((conv) => {
+        if (conv.id !== conversationId) return conv;
+        const messages = [...conv.messages];
+        const lastAssistantIndex = messages.reduceRight((found, msg, idx) => {
+          if (found !== -1) return found;
+          return msg.role === "assistant" ? idx : -1;
+        }, -1);
+        if (lastAssistantIndex === -1) return conv;
+        messages[lastAssistantIndex] = { ...messages[lastAssistantIndex], ...updates };
+        return { ...conv, messages, updatedAt: Date.now() };
       });
-    },
-    [],
-  );
+      return trimConversations(updated);
+    });
+  }, []);
 
   const truncateFromMessage = useCallback((conversationId: string, messageId: string) => {
     setConversations((prev) => {

--- a/ui/litellm-dashboard/src/components/llm_calls/responses_api.test.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/responses_api.test.tsx
@@ -171,6 +171,57 @@ describe("responses_api", () => {
     expect(onTotalLatency).toHaveBeenLastCalledWith(expect.any(Number));
   });
 
+  it("should forward the cost the proxy reports on the streamed usage object", async () => {
+    async function* streamWithCost() {
+      yield { type: "response.output_text.delta", delta: "Hi" };
+      yield {
+        type: "response.completed",
+        response: {
+          id: "resp_cost",
+          usage: { output_tokens: 12, input_tokens: 12, total_tokens: 24, cost: 0.000063 },
+        },
+      };
+    }
+    mockResponsesCreate.mockResolvedValueOnce(streamWithCost());
+
+    const onUsageData = vi.fn();
+
+    await makeOpenAIResponsesRequest(
+      messages,
+      mockUpdateTextUI,
+      "gpt-4",
+      "test-token",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      onUsageData,
+    );
+
+    expect(onUsageData).toHaveBeenCalledWith(
+      { completionTokens: 12, promptTokens: 12, totalTokens: 24, cost: 0.000063 },
+      "",
+    );
+  });
+
+  it("should omit cost when the proxy reports none", async () => {
+    const onUsageData = vi.fn();
+
+    await makeOpenAIResponsesRequest(
+      messages,
+      mockUpdateTextUI,
+      "gpt-4",
+      "test-token",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      onUsageData,
+    );
+
+    expect(onUsageData).toHaveBeenCalledWith(expect.not.objectContaining({ cost: expect.anything() }), "");
+  });
+
   it("should replay MCP output items as events for a non-streaming response", async () => {
     mockResponsesCreate.mockResolvedValueOnce({
       id: "resp_789",

--- a/ui/litellm-dashboard/src/components/llm_calls/responses_api.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/responses_api.tsx
@@ -297,6 +297,10 @@ export async function makeOpenAIResponsesRequest(
               usageData.reasoningTokens = usage.completion_tokens_details.reasoning_tokens;
             }
 
+            if (usage.cost !== undefined && usage.cost !== null) {
+              usageData.cost = Number(usage.cost);
+            }
+
             onUsageData(usageData, mcpToolUsed);
           }
         }

--- a/ui/litellm-dashboard/src/contexts/ChatShellContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/ChatShellContext.tsx
@@ -3,7 +3,7 @@
 import React, { createContext, useContext, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useChatHistory } from "@/components/chat/useChatHistory";
-import type { ChatMessage, Conversation } from "@/components/chat/types";
+import type { AssistantMessageUpdate, ChatMessage, Conversation } from "@/components/chat/types";
 
 interface ChatShellContextValue {
   accessToken: string;
@@ -20,10 +20,7 @@ interface ChatShellContextValue {
   staleId: boolean;
   createConversation: (model: string) => string;
   appendMessage: (conversationId: string, message: Omit<ChatMessage, "id" | "timestamp">) => void;
-  updateLastAssistantMessage: (
-    conversationId: string,
-    updates: Partial<Pick<ChatMessage, "content" | "reasoningContent" | "mcpEvents">>,
-  ) => void;
+  updateLastAssistantMessage: (conversationId: string, updates: AssistantMessageUpdate) => void;
   truncateFromMessage: (conversationId: string, messageId: string) => void;
   deleteConversation: (id: string) => void;
   renameConversation: (id: string, newTitle: string) => void;


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/ui/chat` shows no latency, tokens or cost
- The usage reaches the browser and is discarded
- Users must leave for the Logs page

How it solves it:

- Supply the timing, usage and latency callbacks
- Keep those values on the assistant message
- Render the existing metrics bar under each answer
- Read the reported cost on the Responses path

## User Flow

Before: someone sizing up the gateway from the chat page gets no feedback on speed, tokens or cost

1. They open http://localhost:4000/ui/chat/ and pick a model in the picker at the bottom left
2. They type "Name three primary colours." and press Send
3. The answer streams in and nothing follows it: no time to first token, no latency, no token counts, no cost
4. To find out what that turn cost, they leave for http://localhost:4000/ui/chat/logs and look the request up by hand

After: the same turn on the same page carries a metrics line, matching what the playground has always shown

1. The proxy admin sets `include_cost_in_streaming_usage: true` so the gateway reports cost alongside tokens
2. They open http://localhost:4000/ui/chat/ and pick a model in the picker at the bottom left
3. They type "Name three primary colours." and press Send
4. As the first token lands, a `TTFT: 0.41s` chip appears under the answer
5. When the turn finishes the line fills out with `Total Latency`, `In`, `Out`, `Total` and `Cost: $0.000058`
6. The line stays on that message when they come back to the conversation, so the Logs page is no longer the only place to see it

## What was actually wrong

The ticket says usage is dropped before it can be shown, which reads as though something upstream loses it. Nothing upstream does. The provider returns usage, the gateway's streamed `response.completed` carries it, the browser receives those same bytes, and the Responses helper already parses them into a usage object. The browser then throws it away, because the chat page passes positional `undefined` where the timing, usage and total-latency callbacks sit. The drop is entirely client side, in the last hop, which is why nothing in the proxy changes here.

Two notes so the absences are not read as defects. `stream_options: {"include_usage": true}` does not apply on this route: that is a Chat Completions concept, and the Responses API always puts usage in `response.completed`, so nothing needs enabling for token counts. Cost is the exception and appears only when the operator sets `include_cost_in_streaming_usage`, exactly as on the playground's chat-completions path; without it the Cost chip is simply absent.

The call site omits nothing on streaming: it passes `streamingEnabled` as `true` explicitly, so `/ui/chat` always streams and the non-streaming response-cache conflation tracked in LIT-5533 cannot reach this surface.

Excluded on purpose and filed as LIT-5540: the Responses helper reads reasoning tokens from `completion_tokens_details.reasoning_tokens`, but that payload puts them under `output_tokens_details`, so the Reasoning chip is dead on this path today and stays dead for the playground too. Pre-existing, in a shared producer, and out of scope for a UI-threading change.

## Interaction with #36827

Verified rather than predicted. Merging this head with #36827's head `b3e833fd83` locally is clean, and on the merged tree `/ui/chat` renders `Cache Read: 6135` beside `In: 6141`, `Out: 4` and `Total: 6145` with no further change from either side. The two touch `responses_api.tsx` in the same function, six lines apart: #36827 spreads cache tokens into the usage literal, this adds cost after the reasoning block. `git merge-tree` and a real merge both report no conflict.

## Relevant issues

## Linear ticket

Resolves LIT-5519

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on port 4519 against real OpenAI, Postgres on 5519. Before captured at `262ed530f8`, after at `120c350b16`, which is the tree at head `15ea483f00` minus four comments in a test file that never reaches the browser bundle.

**1. The gateway is not the one dropping anything.** The exact request the chat page sends, streamed, with the usage the browser receives:

```
curl -s -N http://127.0.0.1:4519/v1/responses \
  -H "Authorization: Bearer sk-lit5519" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.4-mini","input":[{"role":"user","content":"Name three primary colours.","type":"message"}],"stream":true}' \
  | grep '"type":"response.completed"' | sed 's/^data: //' | python3 -m json.tool | grep -A 12 '"usage"'
```

```
"usage": {
    "input_tokens": 11,
    "input_tokens_details": {
        "cached_tokens": 0,
        "cache_write_tokens": 0
    },
    "output_tokens": 11,
    "output_tokens_details": {
        "reasoning_tokens": 0
    },
    "total_tokens": 22,
    "cost": 5.775000000000001e-05
},
```

The answer itself streamed back as `Red, blue, and yellow.` and the call is billed for real:

```
docker exec lit5519-pg psql -U litellm -d litellm -t -A -F' | ' \
  -c 'select model, prompt_tokens, completion_tokens, spend, call_type from "LiteLLM_SpendLogs" order by "startTime" desc limit 3;'
```

```
openai/gpt-5.4-mini | 11 | 11 | 5.775000000000001e-05 | aresponses
openai/gpt-5.4-mini | 12 | 12 | 6.3e-05 | aresponses
openai/gpt-5.4-mini | 7 | 12 | 5.925e-05 | acompletion
```

**2. The browser was throwing it away.** Same running proxy, same URL, before and after. This walks the chat page's own script bundle over HTTP rather than off disk, so it reports what the server actually served. `timeToFirstToken` is the property the page now writes onto the message:

```
served_chat_chunk() {
  html=$(curl -s -L http://127.0.0.1:4519/ui/chat/)
  for u in $(echo "$html" | grep -o '/litellm-asset-prefix/_next/static/chunks/[^"]*\.js' | sort -u); do
    body=$(curl -s "http://127.0.0.1:4519$u")
    case "$body" in *"How can I help you today?"*) echo "$u"; echo "$body" > /tmp/chunk.js; return;; esac
  done
}
served_chat_chunk; grep -c timeToFirstToken /tmp/chunk.js
```

Before, at `262ed530f8`:

```
/litellm-asset-prefix/_next/static/chunks/0kzod24rqslaj.js
0
```

After, at `120c350b16`:

```
/litellm-asset-prefix/_next/static/chunks/3j_wznoosx-vf.js
3
```

**3. The route is behind a flag.** `/ui/chat` is gated on the `enable_chat_ui` UI setting, which defaults to false. With it off the page returns 200 and then redirects to `/ui/`, and no Chat entry appears in the sidebar, which looks exactly like a missing route:

```
curl -s -X PATCH http://127.0.0.1:4519/update/ui_settings \
  -H "Authorization: Bearer sk-lit5519" -H "Content-Type: application/json" \
  -d '{"enable_chat_ui": true}'
```

```
{"message":"UI settings updated successfully","status":"success","settings":{"enable_chat_ui":true}}
```

**4. What renders.** With the flag on, open http://localhost:4519/ui/chat/, pick a model in the composer's picker, send anything, and the bar appears under the answer inside `div.response-metrics`. Each chip carries an `aria-label` of the same text: `TTFT: 0.41s`, `Total Latency: 1.20s`, `In: 12`, `Out: 8`, `Total: 20`, `Cost: $0.000058`. The bar persists on that message across a reload.

## Review notes

Greptile 4/5 raised one finding, positional-argument label comments in the new `responses_api.test.tsx` cases. Taken: the labels are gone at `15ea483f00`. The surrounding cases in that file predate this PR and keep theirs, since removing them would be an unrelated edit.

On lint budgets, measured rather than assumed: `responses_api.tsx` goes from 17 eslint warnings to 18, the one addition being `max-depth`, which sits at 56 of a 70 ceiling repo-wide. `complexity` is unchanged at 1. The alternative that avoids the extra warning is folding cost into the usage literal, which is the exact line #36827 edits, so it trades one budgeted warning for a merge conflict with a live PR. Kept the form that merges clean.

## Type

🆕 New Feature

## Caveats (if any)

- Cost chip needs `include_cost_in_streaming_usage: true`
- Provider cache chips land with #36827, no further change needed
- Reasoning chip stays dead here, wrong details key upstream

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
