### PR TITLE
test(ui): await the playground model combobox before clicking it

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -35,7 +35,7 @@ const STREAMING_ENABLED_ARG_INDEX = 25;
 
 async function openComboboxByPlaceholder(placeholder: string) {
   const user = userEvent.setup();
-  const combobox = screen.getByPlaceholderText(placeholder);
+  const combobox = await screen.findByPlaceholderText(placeholder);
   await user.click(combobox);
   return combobox;
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- A playground test fails at random in full-suite runs
- Its model-picker lookup does not wait for loading
- Retrying hid the flake instead of fixing it

How it solves it:

- The shared helper now awaits the model picker
- The lookup retries until loading finishes

## User Flow

This PR changes no runtime behavior, so there is no end-user flow to walk. The people who hit it are the ones running the dashboard unit suite, so the two lists below are written from that seat

Before: a contributor running the dashboard suite gets a red playground test they cannot reproduce

1. They run `npx vitest run` in `ui/litellm-dashboard`
2. The run reports `ChatUI > should show Simulate failure to test fallbacks in Model Settings when chat endpoint is selected` as failed, with `TestingLibraryElementError: Unable to find an element with the placeholder text of: Select a Model`
3. They re-run that one file and it passes every time, so the failure looks unreal
4. They re-run the whole suite and it comes back fully green, 646 files and 7019 tests
5. Nothing in the diff explains either result, so the run gets retried rather than fixed, and a genuine failure in that test would be waved through the same way

After: the same suite run is stable, so red means a real defect

1. They run `npx vitest run` in `ui/litellm-dashboard`
2. The playground test waits for the model picker to finish loading before it clicks it
3. The suite reports 646 files and 7019 tests passing, run after run
4. A failure in that test now points at behavior that actually broke

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR touches one line of one vitest file and no shipped code, so there is nothing to curl and no live-proxy behavior to capture. The proof is a deterministic red/green of the race instead

The model picker renders its own placeholder from the loading flag, so the text the helper searched for does not exist while models are loading:

```tsx
placeholder={isLoadingModels ? "Loading models..." : "Select a Model"}
disabled={isLoadingModels}
```

`isLoadingModels` starts `false`, but `render()` flushes the mount effect and the flag flips to `true` before the first `await` in the loader. The control the helper wants is therefore already gone when the test body starts, and only returns once the mocked fetch resolves. The `waitFor` for the page heading that precedes every call passes on its first tick, since that heading renders unconditionally, so it gates nothing

To make the window deterministic, I copied the failing test and changed only the mocked fetch, from resolving on a microtask to resolving on a macrotask, then flipped the helper line back and forth with everything else held identical

Before, at `e0f388cb5c`, with `screen.getByPlaceholderText`:

```
 × ChatUI flake repro > should show Simulate failure to test fallbacks in Model Settings when chat endpoint is selected 85ms
   → Unable to find an element with the placeholder text of: Select a Model
TestingLibraryElementError: Unable to find an element with the placeholder text of: Select a Model
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

After, at `f861af42c0`, with `await screen.findByPlaceholderText`:

```
 ✓ src/app/(dashboard)/playground/components/chat_ui/ChatUIFlakeRepro.test.tsx (1 test) 275ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

That reproduces the exact error text on the exact test that failed in the wild. The scratch copy was deleted afterwards and is not part of this diff

Single-file runs never showed the flake, so the check that counts is the whole dashboard suite. Two consecutive full runs at `f861af42c0`, both clean:

```
$ cd ui/litellm-dashboard && npx vitest run

 Test Files  646 passed (646)
      Tests  7019 passed (7019)
   Duration  255.87s
```

Those two runs predate the merge of `litellm_internal_staging` into this branch, which brought in dashboard changes of its own. On the merged tree I re-ran the playground file alone, 18 tests passing, and left the full-suite re-run to CI

## Type

✅ Test

## Caveats (if any)

- Test-only change, no shipped code touched
- Audited the file's other lookups, no second race

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
