### PR TITLE
fix(azure): rename max_tokens to max_completion_tokens for gpt-5-chat deployments

### DIFF
--- a/litellm/llms/azure/chat/gpt_transformation.py
+++ b/litellm/llms/azure/chat/gpt_transformation.py
@@ -112,6 +112,16 @@ class AzureOpenAIConfig(BaseConfig):
             "store",
         ]
 
+    @classmethod
+    def requires_max_completion_tokens(cls, model: str) -> bool:
+        """Whether Azure rejects the legacy ``max_tokens`` key for this deployment.
+
+        Deliberately wider than ``AzureOpenAIGPT5Config.is_model_gpt_5_model``: the whole gpt-5
+        name family needs the rename, including the ``gpt-5-chat*`` models that are excluded from
+        the reasoning path by https://github.com/BerriAI/litellm/issues/13781.
+        """
+        return "gpt-5" in model or "gpt5_series" in model
+
     def _is_response_format_supported_model(self, model: str) -> bool:
         """
         Determines if the model supports response_format.
@@ -160,6 +170,7 @@ class AzureOpenAIConfig(BaseConfig):
         api_version: str = "",
     ) -> dict:
         supported_openai_params: Final = self.get_supported_openai_params(model)
+        renames_max_tokens: Final = self.requires_max_completion_tokens(model)
         api_version_times: Final = api_version.split("-")
 
         if len(api_version_times) >= 3:
@@ -172,7 +183,9 @@ class AzureOpenAIConfig(BaseConfig):
             api_version_day = None
 
         for param, value in non_default_params.items():
-            if param == "tool_choice":
+            if param == "max_tokens" and renames_max_tokens:
+                optional_params.setdefault("max_completion_tokens", value)
+            elif param == "tool_choice":
                 """
                 This parameter requires API version 2023-12-01-preview or later
 

--- a/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
@@ -1,12 +1,21 @@
 import os
 import sys
+from typing import Final
+
+import pytest
+from pydantic import TypeAdapter
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
 )
 
+import litellm
 from litellm.litellm_core_utils.prompt_templates.common_utils import TOOL_RESULT_IMAGE_BOUNDARY
 from litellm.llms.azure.chat.gpt_transformation import AzureOpenAIConfig
+from litellm.utils import get_optional_params
+
+_MAPPED_PARAMS: Final = TypeAdapter(dict[str, object])
+_SUPPORTED_PARAMS: Final = TypeAdapter(list[str])
 
 
 class TestAzureOpenAIConfig:
@@ -91,3 +100,69 @@ def test_transform_request_hoists_tool_message_image():
         {"type": "text", "text": TOOL_RESULT_IMAGE_BOUNDARY},
         {"type": "image_url", "image_url": {"url": data_uri}},
     ]
+
+
+@pytest.mark.parametrize(
+    "model, emitted_key, absent_key",
+    [
+        ("gpt-5-chat", "max_completion_tokens", "max_tokens"),
+        ("gpt-5-chat-latest", "max_completion_tokens", "max_tokens"),
+        ("gpt-5-chat-2025-08-07", "max_completion_tokens", "max_tokens"),
+        ("gpt-5", "max_completion_tokens", "max_tokens"),
+        ("o3-mini", "max_completion_tokens", "max_tokens"),
+        ("gpt-4o", "max_tokens", "max_completion_tokens"),
+    ],
+)
+def test_azure_max_tokens_rename_covers_gpt_5_chat_family(model: str, emitted_key: str, absent_key: str) -> None:
+    """Azure rejects `max_tokens` for the whole gpt-5 name family, gpt-5-chat* included."""
+    mapped: Final = _MAPPED_PARAMS.validate_python(
+        get_optional_params(model=model, custom_llm_provider="azure", max_tokens=5)
+    )
+    assert mapped[emitted_key] == 5
+    assert absent_key not in mapped
+
+
+@pytest.mark.parametrize("model", ["gpt-5-chat", "gpt-5-chat-latest"])
+def test_azure_gpt_5_chat_stays_off_the_reasoning_path(model: str) -> None:
+    """https://github.com/BerriAI/litellm/issues/13781: gpt-5-chat* is a regular chat model."""
+    mapped: Final = _MAPPED_PARAMS.validate_python(
+        get_optional_params(
+            model=model,
+            custom_llm_provider="azure",
+            max_tokens=5,
+            temperature=0.3,
+            presence_penalty=0.1,
+            frequency_penalty=0.2,
+            stop=["stop"],
+            logit_bias={"1": 1},
+        )
+    )
+    supported: Final = _SUPPORTED_PARAMS.validate_python(
+        litellm.get_supported_openai_params(model=model, custom_llm_provider="azure")
+    )
+    assert mapped["temperature"] == 0.3
+    assert mapped["presence_penalty"] == 0.1
+    assert mapped["frequency_penalty"] == 0.2
+    assert mapped["stop"] == ["stop"]
+    assert mapped["logit_bias"] == {"1": 1}
+    assert "reasoning_effort" not in mapped
+    assert "reasoning_effort" not in supported
+
+
+def test_azure_gpt_5_takes_the_reasoning_path() -> None:
+    """Positive control for the predicate split: gpt-5 still drops chat-only params."""
+    mapped: Final = _MAPPED_PARAMS.validate_python(
+        get_optional_params(
+            model="gpt-5",
+            custom_llm_provider="azure",
+            presence_penalty=0.1,
+            logit_bias={"1": 1},
+            drop_params=True,
+        )
+    )
+    supported: Final = _SUPPORTED_PARAMS.validate_python(
+        litellm.get_supported_openai_params(model="gpt-5", custom_llm_provider="azure")
+    )
+    assert "presence_penalty" not in mapped
+    assert "logit_bias" not in mapped
+    assert "reasoning_effort" in supported


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure `gpt-5-chat` deployments 400 on every `max_tokens` request
- `/health` reports those deployments permanently unhealthy
- The rename that fixes it skipped the whole `gpt-5-chat` family

How it solves it:

- New `requires_max_completion_tokens` predicate covers every gpt-5 name
- Only the `max_tokens` rename keys off it, nothing else
- Reasoning params keep keying off `is_model_gpt_5_model`, so #13781 stays fixed

## User Flow

Before: a developer whose Azure deployment is named `gpt-5-chat` gets a 400 on every request that sets `max_tokens`, and the deployment sits red in `/health` forever

1. They send POST https://litellm-domain/v1/chat/completions with `{"model": "gpt-5-chat", "messages": [...], "max_tokens": 5}`
2. HTTP 400 comes back: `Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`
3. Their admin opens GET https://litellm-domain/health?model=gpt-5-chat and sees the deployment under `unhealthy_endpoints` with that same message, `healthy_count` 0
4. The synthetic monitor watching that endpoint pages on-call, and keeps paging

After: the same request succeeds and the same deployment reports healthy

1. They send the same POST https://litellm-domain/v1/chat/completions with `{"model": "gpt-5-chat", "messages": [...], "max_tokens": 5}`
2. HTTP 200 comes back with a normal chat completion
3. Their admin opens GET https://litellm-domain/health?model=gpt-5-chat and sees the deployment under `healthy_endpoints`, `unhealthy_count` 0
4. The monitor goes quiet

## Relevant issues

No upstream issue covers this defect. #13781 is the one this change is careful not to reopen: it reported `gpt-5-chat-latest` wrongly rejecting `temperature`, which is why the family was pulled off the GPT-5 reasoning path in the first place. #24779, closed as not planned, claims the same Azure error string for `azure/gpt-4o`

## Linear ticket

Resolves LIT-5549

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

There are no Azure credentials on the machine this was captured on, so the run below points a live proxy at a local HTTP server standing in for Azure. That server records the exact JSON body litellm puts on the wire and returns Azure's own 400 whenever `max_tokens` is present. The wire body is measured, the rejection is simulated, and the claim that Azure really rejects `max_tokens` for this family rests on a customer's production error plus Azure/azure-sdk-for-net#51844, which names `gpt-5-chat` among the deployments returning that exact string

Both runs use the same config, four Azure deployments (`gpt-5-chat`, `gpt-5`, `o3-mini`, `gpt-4o`) all pointed at the stand-in on 127.0.0.1:45550, proxy on 127.0.0.1:45549

Before, at e0f388cb5c92118dbf0d86acc8607980d14bfc22 (this branch's base):

```
$ curl -s http://127.0.0.1:45549/health/liveliness
"I'm alive!"

$ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:45549/v1/chat/completions \
    -H 'Authorization: Bearer sk-lit5549' -H 'Content-Type: application/json' \
    -d '{"model":"gpt-5-chat","messages":[{"role":"user","content":"hi"}],"max_tokens":5}'
{"error":{"message":"litellm.BadRequestError: AzureException BadRequestError - Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.. Received Model Group=gpt-5-chat\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":"max_tokens","code":"400"}}
HTTP 400

body litellm put on the wire to Azure:
{"path": "/openai/deployments/gpt-5-chat/chat/completions?api-version=2024-12-01-preview", "body": {"messages": [{"role": "user", "content": "hi"}], "model": "gpt-5-chat", "max_tokens": 5, "stream": false}}

$ curl -s "http://127.0.0.1:45549/health?model=gpt-5-chat" -H 'Authorization: Bearer sk-lit5549'
{"healthy_endpoints":[],"unhealthy_endpoints":[{"api_base":"http://127.0.0.1:45550","model":"azure/gpt-5-chat","max_tokens":5,"error":"litellm.BadRequestError: AzureException BadRequestError - Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead. ...","exception_status":400}],"healthy_count":0,"unhealthy_count":1}

body litellm put on the wire to Azure:
{"path": "/openai/deployments/gpt-5-chat/chat/completions?api-version=2024-12-01-preview", "body": {"messages": [{"role": "user", "content": "What's 1 + 1?"}], "model": "gpt-5-chat", "max_tokens": 5}}

controls, same request shape:
  gpt-5   -> HTTP 200  wire: {"model": "gpt-5", "max_completion_tokens": 5, ...}
  o3-mini -> HTTP 200  wire: {"model": "o3-mini", "max_completion_tokens": 5, ...}
  gpt-4o  -> HTTP 400  wire: {"model": "gpt-4o", "max_tokens": 5, ...}
```

After, at 1e877f2421a4eeb8e610d9aabe83f15d78090169, since rebased onto e1f3d6e158, then 29d8bedcc481b82cd8abd232f6bcf9404f2f7c11, and now 5b0ea66b331cb36fd6ef43b2dc08a1ddfb42182b (this PR). The capture is still the code at the current head: `litellm/llms/azure/chat/gpt_transformation.py` carries a byte-identical contribution at every one of those commits, and the latest rebase only merged a neighbouring test from #34462 into the test file:

```
$ curl -s http://127.0.0.1:45549/health/liveliness
"I'm alive!"

$ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:45549/v1/chat/completions \
    -H 'Authorization: Bearer sk-lit5549' -H 'Content-Type: application/json' \
    -d '{"model":"gpt-5-chat","messages":[{"role":"user","content":"hi"}],"max_tokens":5}'
{"id":"chatcmpl-lit5549","created":1,"model":"gpt-5-chat","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant"}}],"usage":{"completion_tokens":1,"prompt_tokens":1,"total_tokens":2}}
HTTP 200

body litellm put on the wire to Azure:
{"path": "/openai/deployments/gpt-5-chat/chat/completions?api-version=2024-12-01-preview", "body": {"messages": [{"role": "user", "content": "hi"}], "model": "gpt-5-chat", "max_completion_tokens": 5, "stream": false}}

$ curl -s "http://127.0.0.1:45549/health?model=gpt-5-chat" -H 'Authorization: Bearer sk-lit5549'
{"healthy_endpoints":[{"api_base":"http://127.0.0.1:45550","model":"azure/gpt-5-chat","max_tokens":5,"model_id":"2f92a5a8f85a34351a0b0e03034c389e3cab56c3101e47e6cbf1cd0f2c3ac4f5"}],"unhealthy_endpoints":[],"healthy_count":1,"unhealthy_count":0}

body litellm put on the wire to Azure:
{"path": "/openai/deployments/gpt-5-chat/chat/completions?api-version=2024-12-01-preview", "body": {"messages": [{"role": "user", "content": "What's 1 + 1?"}], "model": "gpt-5-chat", "max_completion_tokens": 5}}

controls, same request shape:
  gpt-5   -> HTTP 200  wire: {"model": "gpt-5", "max_completion_tokens": 5, ...}
  o3-mini -> HTTP 200  wire: {"model": "o3-mini", "max_completion_tokens": 5, ...}
  gpt-4o  -> HTTP 400  wire: {"model": "gpt-4o", "max_tokens": 5, ...}
```

The `gpt-5` and `o3-mini` rows are the load-bearing part of the before run: the same harness prints `max_completion_tokens` whenever litellm emits it, so `max_tokens` on the `gpt-5-chat` row means the code picked that key rather than the fixture never carrying the alternative. `gpt-4o` is unchanged on purpose and its 400 only shows that the stand-in rejects `max_tokens` from everyone

## Type

🐛 Bug Fix

## Caveats (if any)

- `azure/gpt-4o` still sends `max_tokens`; #24779 is out of scope
- Widening the predicate there needs checking against current Azure behaviour
- The Azure 400 is simulated locally; the request body is real

## Review notes

Greptile scored this 4/5 on 1e877f2421 with two findings it framed as non-blocking follow-ups. I looked into both and am deliberately not changing the code for either

On the predicate being hardcoded rather than read from the model cost map: no such flag exists. I enumerated every `support*` key present anywhere in `model_prices_and_context_window.json`, 40 of them across roughly three thousand entries, and none expresses "this deployment rejects the legacy `max_tokens` key". The nearest neighbours are `supports_reasoning`, `supports_sampling_params` and the `supports_*_reasoning_effort` family, which all answer the reasoning question instead. `supports_reasoning` is the worst of them to borrow here: `azure/gpt-5-chat` carries `supports_reasoning: true` today, so keying the rename off it would rebuild the exact conflation of two independent questions that caused this bug. The map also already spends the name `max_tokens` on the output-token ceiling, so a capability flag named around it would read as a collision. Model naming is the only source of truth for this capability at present, and all three pre-existing renames in the tree agree: `llms/openai/chat/o_series_transformation.py:99` keys off `is_o_series_model`, and `llms/openai/chat/gpt_5_transformation.py:200` and `:256` key off `is_model_gpt_5_search_model` and `is_model_gpt_5_model`. Introducing a flag would mean populating it correctly across the whole gpt-5 and o-series families before it could be trusted, which is a far larger and riskier change than this defect justifies

On the new branch introducing another parameter mutation: `optional_params` is a local accumulator here, not caller-owned state. It is created as a fresh `{}` inside `pre_process_optional_params` (`utils.py:3855`), returned into `get_optional_params`, and threaded through the provider `map_openai_params` chain with the return value reassigned at every hop, which is the contract `BaseConfig.map_openai_params` declares. Filling it is what the function is for, and every other branch of the same loop fills it the same way. The new branch is actually the least mutating of the four renames in the tree, since the three cited above each call `non_default_params.pop("max_tokens")` and reach into the caller's dict, while this one writes only into the accumulator and pops nothing

The automated security review raised a Medium, that a request carrying both `max_tokens=1` and `max_completion_tokens=10000` reserves one output token while the provider receives ten thousand, and asked for the conflicting fields to be rejected or normalised before the pre-call rate-limit hooks run. The under-reservation is real and worth fixing. It is being fixed in #37001, in the limiter, and deliberately not here. Three measurements, each of which independently rules out doing it in this file

Ordering. The reservation is taken by `_estimate_tokens_for_request` at `proxy/hooks/parallel_request_limiter_v3.py:607`, reading `data.get("max_tokens") or data.get("max_completion_tokens")` straight off the raw request body inside `async_pre_call_hook`, which fires at `proxy/common_request_processing.py:1471` before routing and long before any provider transformation. Driven directly, that body reserves 2 tokens where the same body carrying only `max_completion_tokens` reserves 10001. Nothing in `map_openai_params` can move those numbers, because the reservation is already written by the time the transformation runs. Rejecting there would convert a bypass into a 400 after the fact rather than reserve correctly, which is not the same thing

Reach. This is not introduced here. At this branch's merge-base, the same request already drops `max_tokens: 1` and emits `max_completion_tokens: 10000` for `azure/gpt-5`, `azure/o3-mini`, `openai/gpt-5` and `openai/o3-mini`. On a live proxy at base, `azure/gpt-5` with both fields returns HTTP 200 with ten thousand on the wire, which is exactly what `azure/gpt-5-chat` does after this change. Closing it inside `AzureOpenAIConfig` would shut one of five doors while implying the corridor was secured

Blast radius. Rejecting the combination would break a working configuration. `LiteLLM_Params` sets `extra="allow"` and the router merges deployment params underneath client kwargs, so an operator's deployment-level `max_tokens` default and a client's `max_completion_tokens` arrive together by design. Run end to end through the router, a deployment carrying `max_tokens: 4096` with a client sending `max_completion_tokens: 100` returns HTTP 200 and puts `{"max_completion_tokens": 100}` on the wire, the client value correctly winning. A conflict error would fail every operator in that shape

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

