### PR TITLE
fix(proxy): fail config load when a callbacks entry is not dispatchable

### DIFF
--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -1,7 +1,10 @@
 import copy
 import os
 from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING, Any, Final, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final, Literal, NoReturn, Optional, TypeAlias
+
+from typing_extensions import assert_never
 
 import litellm
 from litellm import get_secret
@@ -48,6 +51,66 @@ TRUSTED_PILLAR_RESPONSE_HEADERS_METADATA_KEY: Final = "_pillar_response_headers_
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
+
+
+@dataclass(frozen=True, slots=True)
+class _CallbackResolvedToClass:
+    entry: str
+    loaded: type
+    tag: Literal["resolved_to_class"] = "resolved_to_class"
+
+
+@dataclass(frozen=True, slots=True)
+class _CallbackNotDispatchable:
+    entry: str
+    loaded: object
+    tag: Literal["not_dispatchable"] = "not_dispatchable"
+
+
+_CallbackLoadError: TypeAlias = _CallbackResolvedToClass | _CallbackNotDispatchable
+
+
+def _classify_loaded_callback(entry: str, loaded: object) -> CustomLogger | Callable[..., object] | _CallbackLoadError:
+    """
+    Decide whether what a ``litellm_settings.callbacks`` dotted path resolved to can be dispatched.
+
+    A dotted path only ever runs as a ``CustomLogger`` instance or as a callback function. Anything
+    else (most commonly a class instead of an instance) used to load without complaint and then be
+    skipped on every request, with no log line and no error.
+    """
+    if isinstance(loaded, CustomLogger) or (callable(loaded) and not isinstance(loaded, type)):
+        return loaded
+    if isinstance(loaded, type):
+        return _CallbackResolvedToClass(entry=entry, loaded=loaded)
+    return _CallbackNotDispatchable(entry=entry, loaded=loaded)
+
+
+def _raise_callback_load_error(error: _CallbackLoadError) -> NoReturn:
+    """The one edge that raises: map a load error onto config load's failure contract."""
+    match error:
+        case _CallbackResolvedToClass():
+            module_path: Final = error.entry.rsplit(".", 1)[0] if "." in error.entry else error.entry
+            raise ValueError(
+                f"litellm_settings.callbacks entry '{error.entry}' resolved to the class "
+                f"{error.loaded.__module__}.{error.loaded.__qualname__}, which is neither a "
+                "CustomLogger instance nor a callable, so the proxy would never run it."
+                f" Point it at an instance instead, e.g. add `proxy_handler_instance = {error.loaded.__name__}()` to "
+                f'{module_path} and set `callbacks: ["{module_path}.proxy_handler_instance"]`.'
+            )
+        case _CallbackNotDispatchable():
+            raise ValueError(
+                f"litellm_settings.callbacks entry '{error.entry}' resolved to "
+                f"{type(error.loaded).__name__} {error.loaded!r}, which is neither a "
+                "CustomLogger instance nor a callable, so the proxy would never run it."
+            )
+    assert_never(error)
+
+
+def _loaded_callback_or_raise(entry: str, loaded: object) -> CustomLogger | Callable[..., object]:
+    resolved: Final = _classify_loaded_callback(entry=entry, loaded=loaded)
+    if isinstance(resolved, _CallbackResolvedToClass | _CallbackNotDispatchable):
+        _raise_callback_load_error(resolved)
+    return resolved
 
 
 def initialize_callbacks_on_proxy(
@@ -305,9 +368,12 @@ def initialize_callbacks_on_proxy(
                     "%s attempting to import custom calback=%s %s", blue_color_code, callback, reset_color_code
                 )
                 imported_list.append(
-                    get_instance_fn(
-                        value=callback,
-                        config_file_path=config_file_path,
+                    _loaded_callback_or_raise(
+                        entry=callback,
+                        loaded=get_instance_fn(
+                            value=callback,
+                            config_file_path=config_file_path,
+                        ),
                     )
                 )
         if isinstance(litellm.callbacks, list):
@@ -321,9 +387,12 @@ def initialize_callbacks_on_proxy(
             PrometheusLogger._mount_metrics_endpoint()
     else:
         litellm.callbacks = [
-            get_instance_fn(
-                value=value,
-                config_file_path=config_file_path,
+            _loaded_callback_or_raise(
+                entry=value,
+                loaded=get_instance_fn(
+                    value=value,
+                    config_file_path=config_file_path,
+                ),
             )
         ]
     verbose_proxy_logger.debug("%s Initialized Callbacks - %s %s", blue_color_code, litellm.callbacks, reset_color_code)

--- a/tests/test_litellm/proxy/common_utils/test_callback_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_callback_utils.py
@@ -21,6 +21,10 @@ from litellm.proxy.common_utils.callback_utils import (
     strip_callback_config,
 )
 import litellm
+from litellm.caching.caching import DualCache
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.utils import ProxyLogging
 
 from unittest.mock import patch
 from litellm.proxy.common_utils.callback_utils import process_callback
@@ -491,3 +495,163 @@ def test_strip_callback_config_drops_credential_bearing_slots():
 @pytest.mark.parametrize("value", [None, "not-a-dict", 42])
 def test_strip_callback_config_passes_through_non_dicts(value):
     assert strip_callback_config(value) is value
+
+
+# ---------------------------------------------------------------------------
+# initialize_callbacks_on_proxy: dotted-path entries must resolve to something
+# the request path can actually dispatch
+# ---------------------------------------------------------------------------
+
+_PROBE_MODULE_NAME = "custom_callback_probe"
+
+_PROBE_MODULE_SOURCE = '''
+from litellm.integrations.custom_logger import CustomLogger
+
+
+class FloorMaxTokens(CustomLogger):
+    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+        data["max_tokens"] = 16
+        return data
+
+
+class NotALogger:
+    pass
+
+
+def log_event_fn(kwargs, response_obj, start_time, end_time):
+    return None
+
+
+NOT_A_CALLBACK = "some-plain-string"
+
+proxy_handler_instance = FloorMaxTokens()
+'''
+
+
+@pytest.fixture
+def probe_config_path(tmp_path):
+    """Write a callback module next to a config.yaml, the layout get_instance_fn's file
+    branch expects, and restore every global the load + dispatch path touches.
+
+    ``ProxyLogging._callback_capabilities_cache`` is keyed on the id()s of the
+    litellm.callbacks members, so an entry left behind here can be read back by an
+    unrelated test whose (len, ids) signature happens to collide.
+    """
+    (tmp_path / f"{_PROBE_MODULE_NAME}.py").write_text(_PROBE_MODULE_SOURCE)
+
+    original_callbacks = (
+        list(litellm.callbacks) if isinstance(litellm.callbacks, list) else litellm.callbacks
+    )
+    litellm.callbacks = []
+    ProxyLogging._callback_capabilities_cache.clear()
+    try:
+        yield str(tmp_path / "config.yaml")
+    finally:
+        litellm.callbacks = original_callbacks
+        ProxyLogging._callback_capabilities_cache.clear()
+
+
+def _load_callbacks(value, config_file_path):
+    initialize_callbacks_on_proxy(
+        value=value,
+        premium_user=False,
+        config_file_path=config_file_path,
+        litellm_settings={},
+        callback_specific_params={},
+    )
+
+
+def test_initialize_callbacks_on_proxy_rejects_class_valued_entry(probe_config_path):
+    """A class path loads an object that fails the `isinstance(_callback, CustomLogger)`
+    dispatch gate in ProxyLogging.pre_call_hook, so the proxy used to boot clean and
+    silently never run the hook. Config load must fail instead."""
+    entry = f"{_PROBE_MODULE_NAME}.FloorMaxTokens"
+
+    with pytest.raises(ValueError) as exc_info:
+        _load_callbacks([entry], probe_config_path)
+
+    message = str(exc_info.value)
+    assert entry in message
+    assert "the class" in message
+    assert "FloorMaxTokens" in message
+    assert f"{_PROBE_MODULE_NAME}.proxy_handler_instance" in message
+    assert litellm.callbacks == []
+
+
+@pytest.mark.parametrize(
+    "attribute, expected_fragment",
+    [
+        ("NotALogger", "the class"),
+        ("NOT_A_CALLBACK", "str 'some-plain-string'"),
+    ],
+)
+def test_initialize_callbacks_on_proxy_rejects_non_dispatchable_values(
+    probe_config_path, attribute, expected_fragment
+):
+    entry = f"{_PROBE_MODULE_NAME}.{attribute}"
+
+    with pytest.raises(ValueError) as exc_info:
+        _load_callbacks([entry], probe_config_path)
+
+    message = str(exc_info.value)
+    assert entry in message
+    assert expected_fragment in message
+    assert litellm.callbacks == []
+
+
+def test_initialize_callbacks_on_proxy_rejects_class_valued_non_list_value(probe_config_path):
+    entry = f"{_PROBE_MODULE_NAME}.FloorMaxTokens"
+
+    with pytest.raises(ValueError) as exc_info:
+        _load_callbacks(entry, probe_config_path)
+
+    assert entry in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_initialize_callbacks_on_proxy_instance_entry_runs_pre_call_hook(probe_config_path):
+    """Positive control: the supported shape must still load AND still run. Drives the
+    real ProxyLogging.pre_call_hook, which is where a class-valued entry goes silent."""
+    _load_callbacks([f"{_PROBE_MODULE_NAME}.proxy_handler_instance"], probe_config_path)
+
+    assert len(litellm.callbacks) == 1
+    assert isinstance(litellm.callbacks[0], CustomLogger)
+
+    ProxyLogging._callback_capabilities_cache.clear()
+    proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+    data = await proxy_logging.pre_call_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-probe"),
+        data={
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 1,
+            "metadata": {},
+        },
+        call_type="acompletion",
+    )
+
+    assert data["max_tokens"] == 16
+
+
+def test_initialize_callbacks_on_proxy_keeps_known_string_callback(probe_config_path):
+    """Non-narrowing control: a known callback name never reaches get_instance_fn and
+    stays a plain string in litellm.callbacks."""
+    _load_callbacks(["langfuse"], probe_config_path)
+
+    assert litellm.callbacks == ["langfuse"]
+
+
+def test_initialize_callbacks_on_proxy_accepts_plain_function_callback(probe_config_path):
+    """Non-narrowing control: litellm.callbacks is typed
+    `Callable | <known name> | CustomLogger`, so a dotted path resolving to a plain
+    function is a supported shape and must keep loading."""
+    _load_callbacks([f"{_PROBE_MODULE_NAME}.log_event_fn"], probe_config_path)
+
+    assert [getattr(cb, "__name__", None) for cb in litellm.callbacks] == ["log_event_fn"]
+
+
+def test_initialize_callbacks_on_proxy_accepts_instance_non_list_value(probe_config_path):
+    _load_callbacks(f"{_PROBE_MODULE_NAME}.proxy_handler_instance", probe_config_path)
+
+    assert len(litellm.callbacks) == 1
+    assert isinstance(litellm.callbacks[0], CustomLogger)


### PR DESCRIPTION
## TLDR

Problem this solves:

- A `callbacks:` entry naming a class loads and never runs
- Proxy boots clean, no error, no log line
- Operator's guardrail or logger is silently ignored

How it solves it:

- Classify what the dotted path resolved to at load
- One mapper turns that error value into a startup failure
- Message names the entry, the resolution and the fix
- Instance and function entries keep loading unchanged

## User Flow

Before: an operator adds a custom handler to modify incoming requests, the proxy accepts the config, and the handler never runs

1. They write `custom_callbacks.py` with a handler that rewrites the messages on every request
2. They set `litellm_settings.callbacks: ["custom_callbacks.MyCustomHandler"]` and start the proxy
3. The proxy starts normally, printing nothing about the entry
4. They send POST http://0.0.0.0:4000/v1/chat/completions with their prompt and the model answers the original prompt, so the rewrite never happened
5. Nothing in the logs says why, and on a request that gets far enough the only signal is an unrelated 500 reading `CustomLogger.async_post_call_success_hook() missing 1 required positional argument: 'self'`

After: the same config is refused at startup with a message that says exactly what to change

1. They write the same `custom_callbacks.py`
2. They set `litellm_settings.callbacks: ["custom_callbacks.MyCustomHandler"]` and start the proxy
3. Startup fails with `litellm_settings.callbacks entry 'custom_callbacks.MyCustomHandler' resolved to the class custom_callbacks.MyCustomHandler, which is neither a CustomLogger instance nor a callable, so the proxy would never run it. Point it at an instance instead, e.g. add proxy_handler_instance = MyCustomHandler() to custom_callbacks and set callbacks: ["custom_callbacks.proxy_handler_instance"]`
4. They add `proxy_handler_instance = MyCustomHandler()` to the file, point the config at it and restart
5. They send the same POST http://0.0.0.0:4000/v1/chat/completions and the model answers the rewritten prompt, so the handler ran

## Upgrade note (breaking for one misconfiguration)

A `litellm_settings.callbacks` entry whose dotted path names a **class** now fails config load, so the proxy refuses to start. Those entries were accepted and silently inert before: the proxy booted, served traffic and never ran the hook, with no error and no log line.

This is reachable from our own documentation. `docs/proxy/agentic_loop_hook.md` shipped `callbacks: ["my_module.MyToolCallback"]`, a class path, directly under a python snippet that correctly registers an instance, so anyone who followed that page has a hook that has never fired once and will now see startup halt on upgrade. The docs PR fixes that page.

The fix is one line in the operator's callback module plus one in the config, and the startup error spells out both:

```python
proxy_handler_instance = MyCustomHandler()
```

```yaml
litellm_settings:
  callbacks: ["custom_callbacks.proxy_handler_instance"]
```

Instance paths, plain function paths and built-in callback names are unaffected.

## Review notes

**Why the ceremony next to four bare raises.** CLAUDE.md requires failures modelled as values, mapped onto the public exception contract by one function using an exhaustive match plus `assert_never`. `_classify_loaded_callback` returns the value or a tagged error, and `_raise_callback_load_error` is the single edge that raises. Four sibling validations in the same `load_config` (`coordination_redis` twice, `allowed_ips`, `router_settings`) raise a bare `ValueError` inline, and `initialize_callbacks_on_proxy` itself already holds 14 bare `raise Exception` premium gates. Those are legacy, not a licence, so the new code follows the rule.

**Why the failure is not threaded further out.** The repo has exactly one `raise_public`-style mapper, in `litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py`, and it maps a local `CredError` union onto `HTTPException` status codes. That is request-path machinery: config load runs in the FastAPI lifespan with no request to answer, and `CredError`'s tags do not model "operator's config named a class". No repo-wide mapper exists, and `litellm/exceptions.py` holds only LLM-API contracts (openai subclasses carrying model, llm_provider, status_code). Returning the failure to the callers instead would mean changing the contracts of `initialize_callbacks_on_proxy`, `load_config`, `initialize` and the startup event, and uvicorn halts startup only on an exception, so it would become a raise at the top anyway. The union stays local and no caller signature moves.

**Scope.** This covers `litellm_settings.callbacks` only. The sibling keys `success_callback`, `failure_callback` and `audit_log_callbacks` resolve their dotted paths through their own branches of `load_config`, so they are a separate surface and are deliberately untouched here, as is the `guardrail:` key, which legitimately names a class

**Config sweep for the narrowed shape.** Swept both repos for every dotted `callbacks:` value (yaml, yml, json, py, sh, tpl and all markdown here, plus all of litellm-docs). Nothing anywhere resolves a dotted path to a string, so the narrowing regresses no shipped example, doc or test config. Of the eight dotted sites, seven name an instance and exactly one names a class: the agentic loop hook page above.

## Relevant issues

## Linear ticket

Resolves LIT-5553

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on port 4553, real Anthropic calls, no mocks. The handler used in every leg rewrites the incoming messages to `Reply with exactly: HOOK_RAN`, so the model's answer is the evidence: `HOOK_RAN` means it ran, anything else means it did not.

`probe_handler.py`

```python
from litellm.integrations.custom_logger import CustomLogger


class RewriteMessagesHandler(CustomLogger):
    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
        data["messages"] = [{"role": "user", "content": "Reply with exactly: HOOK_RAN"}]
        data["max_tokens"] = 16
        return data


proxy_handler_instance = RewriteMessagesHandler()
```

### 1. Before the fix, class path, at e0f388cb5c

```yaml
litellm_settings:
  callbacks: ["probe_handler.RewriteMessagesHandler"]
```

```shell
$ python litellm/proxy/proxy_cli.py --config config_class.yaml --port 4553
$ curl -s http://127.0.0.1:4553/health/liveliness
"I'm alive!"
$ curl -s http://127.0.0.1:4553/v1/chat/completions \
    -H "Authorization: Bearer sk-lit5553-probe" -H "Content-Type: application/json" \
    -d '{"model":"probe-model","messages":[{"role":"user","content":"Reply with exactly: HOOK_DID_NOT_RUN"}],"max_tokens":16}'
{"error":{"message":"CustomLogger.async_post_call_success_hook() missing 1 required positional argument: 'self'","type":"None","param":"None","code":"500"}}
```

The proxy started clean. Rerunning the same leg with `--detailed_debug` shows the body that actually went upstream still carried the original prompt, so the pre-call hook never ran:

```shell
$ grep -c 'HOOK_DID_NOT_RUN' before_class_debug.log
14
18:29:57 - LiteLLM:DEBUG: utils.py:493 - Custom Logger - model call details: {..., 'input': [{'role': 'user', 'content': 'Reply with exactly: HOOK_DID_NOT_RUN'}], ..., 'custom_llm_provider': 'anthropic', 'api_base': 'https://api.anthropic.com/v1/messages', ...}
```

### 2. After the fix, class path, at eba41258fe

Same config. The proxy refuses to start:

```shell
$ python litellm/proxy/proxy_cli.py --config config_class.yaml --port 4553
  File "litellm/proxy/proxy_server.py", line 4788, in load_config
    initialize_callbacks_on_proxy(
  File "litellm/proxy/common_utils/callback_utils.py", line 112, in _loaded_callback_or_raise
    _raise_callback_load_error(resolved)
  File "litellm/proxy/common_utils/callback_utils.py", line 93, in _raise_callback_load_error
    raise ValueError(
ValueError: litellm_settings.callbacks entry 'probe_handler.RewriteMessagesHandler' resolved to the class probe_handler.RewriteMessagesHandler, which is neither a CustomLogger instance nor a callable, so the proxy would never run it. Point it at an instance instead, e.g. add `proxy_handler_instance = RewriteMessagesHandler()` to probe_handler and set `callbacks: ["probe_handler.proxy_handler_instance"]`.
ERROR:    Application startup failed. Exiting.
```

The process exits 3 and never binds the port, so `/health/liveliness` was never reachable for this leg.

### 3. Before the fix, instance path, at e0f388cb5c

```yaml
litellm_settings:
  callbacks: ["probe_handler.proxy_handler_instance"]
```

```shell
$ curl -s http://127.0.0.1:4553/health/liveliness
"I'm alive!"
$ curl -s http://127.0.0.1:4553/v1/chat/completions \
    -H "Authorization: Bearer sk-lit5553-probe" -H "Content-Type: application/json" \
    -d '{"model":"probe-model","messages":[{"role":"user","content":"Reply with exactly: HOOK_DID_NOT_RUN"}],"max_tokens":16}'
{"id":"chatcmpl-a590c179-28a5-49c2-a56d-afa1fe3ce96b","model":"probe-model","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"HOOK_RAN","role":"assistant"}}],"usage":{"completion_tokens":8,"prompt_tokens":16,"total_tokens":24}}
```

### 4. After the fix, instance path, at eba41258fe

Same config, same request, unchanged behavior:

```shell
$ curl -s http://127.0.0.1:4553/health/liveliness
"I'm alive!"
$ curl -s http://127.0.0.1:4553/v1/chat/completions \
    -H "Authorization: Bearer sk-lit5553-probe" -H "Content-Type: application/json" \
    -d '{"model":"probe-model","messages":[{"role":"user","content":"Reply with exactly: HOOK_DID_NOT_RUN"}],"max_tokens":16}'
{"id":"chatcmpl-e68aea60-998d-4abf-9c3e-72bf1eb30ec3","model":"probe-model","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"HOOK_RAN","role":"assistant"}}],"usage":{"completion_tokens":8,"prompt_tokens":16,"total_tokens":24}}
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Guard covers only the dotted-path branch
- Shapes kept: known callback names, the interception and guardrail names, enterprise names, a handler instance passed in code, and dotted paths resolving to an instance or a plain function
- Shape narrowed: a dotted path resolving to a string
- Custom guardrails still name a class under `guardrails:`, untouched
- Class entries now halt startup, see the upgrade note
- Docs: BerriAI/litellm-docs#892, merge this one first

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
