### PR TITLE
fix(openai,azure): return a length-truncated 200 when the output budget fits no token

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -10,6 +10,7 @@ from openai import (
     AsyncAzureOpenAI,
     AsyncOpenAI,
     AzureOpenAI,
+    BadRequestError,
     OpenAI,
 )
 
@@ -37,6 +38,10 @@ from litellm.utils import (
 
 from ...types.llms.openai import HttpxBinaryResponseContent
 from ..base import BaseLLM
+from ..openai.common_utils import (
+    build_output_token_limit_response,
+    is_output_token_limit_error,
+)
 from .common_utils import (
     AzureOpenAIError,
     BaseAzureLLM,
@@ -147,6 +152,10 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             headers: Final = dict(raw_response.headers)
             response: Final = raw_response.parse()
             return headers, response
+        except BadRequestError as e:
+            if not is_output_token_limit_error(e):
+                raise
+            return build_output_token_limit_response(e=e, data=data, is_async=False)
         except Exception as e:
             raise e
 
@@ -175,6 +184,10 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             time_delta: Final = round(end_time - start_time, 2)
             e.message += f" - timeout value={timeout}, time taken={time_delta} seconds"
             raise e
+        except BadRequestError as e:
+            if not is_output_token_limit_error(e):
+                raise
+            return build_output_token_limit_response(e=e, data=data, is_async=True)
         except Exception as e:
             raise e
 

--- a/litellm/llms/openai/common_utils.py
+++ b/litellm/llms/openai/common_utils.py
@@ -7,16 +7,25 @@ import inspect
 import json
 import os
 import ssl
+import time
+import uuid
+from collections.abc import AsyncIterator, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Optional
 
 import httpx
 import openai
 from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
+from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
+from openai.types.chat.chat_completion_chunk import ChoiceDelta
+from openai.types.completion_usage import CompletionUsage
 
 if TYPE_CHECKING:
     from aiohttp import ClientSession
 
 import litellm
+from litellm.litellm_core_utils.token_counter import token_counter
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.custom_httpx.http_handler import (
     _DEFAULT_TTL_FOR_HTTPX_CLIENTS,
@@ -109,6 +118,79 @@ def drop_params_from_unprocessable_entity_error(
     new_data: Final = {k: v for k, v in data.items() if k not in invalid_params}
 
     return new_data
+
+
+_OUTPUT_TOKEN_LIMIT_ERROR_MARKER: Final[str] = (
+    "could not finish the message because max_tokens or model output limit was reached"
+)
+
+
+def is_output_token_limit_error(e: openai.BadRequestError) -> bool:
+    """
+    True when OpenAI/Azure rejected a chat request because the output budget could not fit a single visible token.
+
+    GPT-5.x turns that case into a 400 while returning a length-truncated 200 for marginally larger budgets, so the
+    match has to stay pinned to the full provider sentence to avoid swallowing genuine bad requests.
+    """
+    return _OUTPUT_TOKEN_LIMIT_ERROR_MARKER in e.message.lower()
+
+
+def _output_token_limit_completion(model: str, prompt_tokens: int) -> ChatCompletion:
+    return ChatCompletion(
+        id=f"chatcmpl-{uuid.uuid4()}",
+        choices=(
+            Choice(
+                index=0,
+                finish_reason="length",
+                message=ChatCompletionMessage(role="assistant", content=""),
+            ),
+        ),
+        created=int(time.time()),
+        model=model,
+        object="chat.completion",
+        usage=CompletionUsage(completion_tokens=0, prompt_tokens=prompt_tokens, total_tokens=prompt_tokens),
+    )
+
+
+def _output_token_limit_chunk(model: str) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id=f"chatcmpl-{uuid.uuid4()}",
+        choices=(
+            ChunkChoice(
+                index=0,
+                finish_reason="length",
+                delta=ChoiceDelta(role="assistant", content=""),
+            ),
+        ),
+        created=int(time.time()),
+        model=model,
+        object="chat.completion.chunk",
+    )
+
+
+def _iter_once(chunk: ChatCompletionChunk) -> Iterator[ChatCompletionChunk]:
+    yield chunk
+
+
+async def _aiter_once(chunk: ChatCompletionChunk) -> AsyncIterator[ChatCompletionChunk]:
+    yield chunk
+
+
+def build_output_token_limit_response(
+    e: openai.BadRequestError, data: Mapping[str, object], is_async: bool
+) -> tuple[httpx.Headers, ChatCompletion | Iterator[ChatCompletionChunk] | AsyncIterator[ChatCompletionChunk]]:
+    """Synthesize the length-truncated response the provider itself returns for slightly larger output budgets.
+
+    The provider billed the prompt it processed but sends no usage object with the 400, so the prompt is estimated
+    the way every other usage-less path estimates it: reporting zero would spend input tokens against no budget.
+    """
+    model: Final[str] = str(data.get("model", ""))
+    messages: Final = data.get("messages")
+    prompt_tokens: Final = token_counter(model=model, messages=messages) if isinstance(messages, list) else 0
+    if not data.get("stream"):
+        return e.response.headers, _output_token_limit_completion(model, prompt_tokens)
+    chunk: Final = _output_token_limit_chunk(model)
+    return e.response.headers, (_aiter_once(chunk) if is_async else _iter_once(chunk))
 
 
 class BaseOpenAILLM:

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -46,7 +46,9 @@ from .chat.o_series_transformation import OpenAIOSeriesConfig
 from .common_utils import (
     BaseOpenAILLM,
     OpenAIError,
+    build_output_token_limit_response,
     drop_params_from_unprocessable_entity_error,
+    is_output_token_limit_error,
 )
 
 openaiOSeriesConfig: Final = OpenAIOSeriesConfig()
@@ -436,6 +438,10 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             time_delta: Final = round(end_time - start_time, 2)
             e.message += f" - timeout value={timeout}, time taken={time_delta} seconds"
             raise e
+        except openai.BadRequestError as e:
+            if not is_output_token_limit_error(e):
+                raise
+            return build_output_token_limit_response(e=e, data=data, is_async=True)
         except Exception as e:
             raise e
 
@@ -469,6 +475,10 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             return headers, response
         except OpenAIError:
             raise
+        except openai.BadRequestError as e:
+            if not is_output_token_limit_error(e):
+                raise
+            return build_output_token_limit_response(e=e, data=data, is_async=False)
         except Exception as e:
             if raw_response is not None:
                 raise Exception(

--- a/tests/test_litellm/llms/openai/test_openai_common_utils.py
+++ b/tests/test_litellm/llms/openai/test_openai_common_utils.py
@@ -2,6 +2,8 @@ import os
 import sys
 from unittest.mock import MagicMock, call, patch
 
+import httpx
+import openai
 import pytest
 
 sys.path.insert(
@@ -9,6 +11,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 import litellm
+from litellm.litellm_core_utils.token_counter import token_counter
 from litellm.llms.openai.common_utils import BaseOpenAILLM
 
 # Test parameters for different API functions
@@ -247,3 +250,145 @@ def test_a_client_litellm_built_its_own_http_client_for_is_still_closed(monkeypa
     closer.reap()
 
     assert wrapper.is_closed() is True
+
+
+OUTPUT_LIMIT_400_MESSAGE = (
+    "Could not finish the message because max_tokens or model output limit was reached. "
+    "Please try again with higher max_tokens."
+)
+GENUINE_400_MESSAGE = "Invalid value for 'max_tokens': integer above maximum value. Expected <= 128000, got 999999999."
+LONG_PROMPT = "please summarise the following notes for me: " + ("token " * 200)
+
+CALL_KWARGS_BY_PROVIDER = {
+    "openai": {"model": "gpt-5.6-sol", "api_key": "sk-not-a-real-key"},
+    "azure": {
+        "model": "azure/gpt-5.6-sol",
+        "api_key": "not-a-real-key",
+        "api_base": "https://not-a-real-resource.openai.azure.com",
+        "api_version": "2024-10-21",
+    },
+}
+
+
+def _transport(message: str) -> httpx.MockTransport:
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": {"message": message, "type": "invalid_request_error"}})
+
+    return httpx.MockTransport(_handler)
+
+
+def _sync_client_raising(provider: str, message: str):
+    http_client = httpx.Client(transport=_transport(message))
+    if provider == "azure":
+        return openai.AzureOpenAI(
+            api_key="not-a-real-key",
+            azure_endpoint="https://not-a-real-resource.openai.azure.com",
+            api_version="2024-10-21",
+            http_client=http_client,
+        )
+    return openai.OpenAI(api_key="sk-not-a-real-key", http_client=http_client)
+
+
+def _async_client_raising(provider: str, message: str):
+    http_client = httpx.AsyncClient(transport=_transport(message))
+    if provider == "azure":
+        return openai.AsyncAzureOpenAI(
+            api_key="not-a-real-key",
+            azure_endpoint="https://not-a-real-resource.openai.azure.com",
+            api_version="2024-10-21",
+            http_client=http_client,
+        )
+    return openai.AsyncOpenAI(api_key="sk-not-a-real-key", http_client=http_client)
+
+
+def _completion_kwargs(provider: str, client, **overrides) -> dict:
+    return {
+        **CALL_KWARGS_BY_PROVIDER[provider],
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 1,
+        "client": client,
+        **overrides,
+    }
+
+
+@pytest.mark.parametrize("provider", ["openai", "azure"])
+def test_sync_output_limit_400_maps_to_length_truncated_response(provider):
+    response = litellm.completion(
+        **_completion_kwargs(provider, _sync_client_raising(provider, OUTPUT_LIMIT_400_MESSAGE))
+    )
+
+    assert response.choices[0].finish_reason == "length"
+    assert response.choices[0].message.content == ""
+    assert response.usage.completion_tokens == 0
+
+
+@pytest.mark.parametrize("provider", ["openai", "azure"])
+def test_mapped_response_still_bills_the_prompt_the_provider_processed(provider):
+    messages = [{"role": "user", "content": LONG_PROMPT}]
+    expected_prompt_tokens = token_counter(model="gpt-5.6-sol", messages=messages)
+    assert expected_prompt_tokens > 100, "the fixture prompt must be big enough for a zeroed count to stand out"
+
+    response = litellm.completion(
+        **_completion_kwargs(provider, _sync_client_raising(provider, OUTPUT_LIMIT_400_MESSAGE), messages=messages)
+    )
+
+    assert response.usage.prompt_tokens == expected_prompt_tokens
+    assert response.usage.completion_tokens == 0
+    assert litellm.completion_cost(completion_response=response) > 0
+
+
+@pytest.mark.parametrize("provider", ["openai", "azure"])
+@pytest.mark.asyncio
+async def test_async_output_limit_400_maps_to_length_truncated_response(provider):
+    response = await litellm.acompletion(
+        **_completion_kwargs(provider, _async_client_raising(provider, OUTPUT_LIMIT_400_MESSAGE))
+    )
+
+    assert response.choices[0].finish_reason == "length"
+    assert response.choices[0].message.content == ""
+    assert response.usage.completion_tokens == 0
+
+
+@pytest.mark.parametrize("provider", ["openai", "azure"])
+def test_sync_streaming_output_limit_400_maps_to_length_truncated_stream(provider):
+    stream = litellm.completion(
+        **_completion_kwargs(provider, _sync_client_raising(provider, OUTPUT_LIMIT_400_MESSAGE), stream=True)
+    )
+    chunks = list(stream)
+
+    assert [c.choices[0].finish_reason for c in chunks].count("length") == 1
+    assert all(not c.choices[0].delta.content for c in chunks)
+
+
+@pytest.mark.parametrize("provider", ["openai", "azure"])
+@pytest.mark.asyncio
+async def test_async_streaming_output_limit_400_maps_to_length_truncated_stream(provider):
+    stream = await litellm.acompletion(
+        **_completion_kwargs(provider, _async_client_raising(provider, OUTPUT_LIMIT_400_MESSAGE), stream=True)
+    )
+    chunks = [chunk async for chunk in stream]
+
+    assert [c.choices[0].finish_reason for c in chunks].count("length") == 1
+    assert all(not c.choices[0].delta.content for c in chunks)
+
+
+@pytest.mark.parametrize("provider", ["openai", "azure"])
+@pytest.mark.parametrize("stream", [False, True])
+def test_sync_genuine_bad_request_still_raises(provider, stream):
+    with pytest.raises(litellm.BadRequestError):
+        result = litellm.completion(
+            **_completion_kwargs(provider, _sync_client_raising(provider, GENUINE_400_MESSAGE), stream=stream)
+        )
+        list(result)
+
+
+@pytest.mark.parametrize("provider", ["openai", "azure"])
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.asyncio
+async def test_async_genuine_bad_request_still_raises(provider, stream):
+    with pytest.raises(litellm.BadRequestError):
+        result = await litellm.acompletion(
+            **_completion_kwargs(provider, _async_client_raising(provider, GENUINE_400_MESSAGE), stream=stream)
+        )
+        async for _ in result:
+            pass


### PR DESCRIPTION
## TLDR

Problem this solves:

- GPT-5.x 400s when `max_tokens` fits no visible token
- Same models return a 200 at `max_tokens` 4
- Agent probes that send `max_tokens: 1` read that as "model unavailable"
- Direct `/v1/chat/completions` callers hit it too

How it solves it:

- Recognise the provider's own output-limit sentence on a 400
- Return `finish_reason: "length"`, empty content, zero completion tokens
- Estimate the prompt tokens so spend is still charged
- Applied at the four OpenAI and Azure chat request helpers
- Any other 400 still raises, and no budget is raised

## User Flow

Before: a developer switching models in an agent client that validates a model with a one token ping is told the model does not exist

1. The agent sends POST https://litellm-domain/v1/chat/completions with `{"model": "gpt-5.6-sol", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 1}`
2. The gateway answers 400 with `litellm.BadRequestError: OpenAIException - Could not finish the message because max_tokens or model output limit was reached. Please try again with higher max_tokens.`
3. The agent treats the 400 as "this model is unavailable" and refuses the switch, even though the same model answers normally at `max_tokens: 16`
4. Raising the ping to `max_tokens: 4` on the same route returns 200 with `finish_reason: "length"` and empty content, so the 400 band is one or two tokens wide

After: the same ping comes back as an ordinary truncated turn, and the model switch goes through

1. The agent sends the same POST https://litellm-domain/v1/chat/completions with `"max_tokens": 1`
2. The gateway answers 200 with `"finish_reason": "length"`, `"content": ""`, and `"completion_tokens": 0`
3. `"prompt_tokens"` reports the prompt the provider actually processed, so the request is charged to the key and the team as usual
4. The agent reads a successful response and allows the switch
5. `max_tokens: 4`, `8` and `16` behave exactly as before, so nothing above the 400 band moves
6. A genuine bad request, for example `max_tokens` above the model ceiling, still comes back as a 400 with the provider's message

## Relevant issues

Related to #35061

## Linear ticket

Resolves LIT-5328

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Every capture below was taken at `d3a44fdfe4`, against the merge base `e0f388cb5c92118dbf0d86acc8607980d14bfc22` that this branch sat on at the time. The branch has since been rebased onto current staging and the head is now `10058fbe41`, so those two hashes name real commits but are no longer the head or the merge base. The rebase was clean, carried no behaviour change, and left the diff byte-identical at the same 4 files and 250 added lines, so the numbers stand as measured. They are labelled with the hashes they were actually captured at rather than relabelled to the new head, since nothing was re-run against it.

Two live proxies on real OpenAI traffic against `gpt-5.6-sol`, one serving the merge base (before) and one serving this branch (after). Liveliness was re-asserted immediately before and after each capture leg, and the before tree was built from `git show <merge-base>:<path>` with `grep -c is_output_token_limit_error` returning 0 on all three changed source files.

The provider behaviour this maps, straight from OpenAI with no gateway in the path:

```bash
curl -sS https://api.openai.com/v1/chat/completions \
  -H "Authorization: Bearer $OPENAI_API_KEY" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"hi"}],"max_completion_tokens":1}'
```

```json
{"error":{"message":"Could not finish the message because max_tokens or model output limit was reached. Please try again with higher max_tokens.","type":"invalid_request_error","param":null,"code":null}}
```

The same request at `max_completion_tokens: 16` returns 200 with `"content": "Hi! How can I help?"`, so the key and the model are healthy.

### `/v1/chat/completions`

```bash
for n in 1 2 4 8 16; do
  curl -sS -X POST http://127.0.0.1:15328/v1/chat/completions \
    -H "Content-Type: application/json" -H "Authorization: Bearer sk-lit5328" \
    -d "{\"model\":\"gpt-5.6-sol\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":$n}"
done
```

| `max_tokens` | before (`e0f388cb5c`) | after (`d3a44fdfe4`) |
| -- | -- | -- |
| 1 | 400 `OpenAIException - Could not finish the message because max_tokens or model output limit was reached.` | 200 `finish_reason='length' content='' completion_tokens=0` |
| 2 | 400, same message | 200 `finish_reason='length' content='' completion_tokens=0` |
| 4 | 200 `finish_reason='length' content='' completion_tokens=4` | 200 `finish_reason='length' content='' completion_tokens=4` |
| 8 | 200 `finish_reason='length' content='' completion_tokens=8` | 200 `finish_reason='length' content='' completion_tokens=8` |
| 16 | 200 `finish_reason='stop' content='Hi! How can I help?' completion_tokens=10` | 200 `finish_reason='stop' content='Hi! How can I help?' completion_tokens=10` |

### `/v1/messages`

On the default configuration this route sends OpenAI models to the Responses API, which has carried a sixteen token floor since #33098, so it never reaches the 400 and both legs return 200 with full content at `max_tokens: 1`. The route reaches the chat completions bridge when an operator sets `litellm_settings.use_chat_completions_url_for_anthropic_messages: true`, and that is where the defect shows up. Same two proxies, that flag on:

```bash
for n in 1 2 4 8 16; do
  curl -sS -X POST http://127.0.0.1:15330/v1/messages \
    -H "Content-Type: application/json" -H "x-api-key: sk-lit5328" -H "anthropic-version: 2023-06-01" \
    -d "{\"model\":\"gpt-5.6-sol\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":$n}"
done
```

| `max_tokens` | before (`e0f388cb5c`) | after (`d3a44fdfe4`) |
| -- | -- | -- |
| 1 | 400 `OpenAIException - Could not finish the message because max_tokens or model output limit was reached.` | 200 `stop_reason='max_tokens' content='' output_tokens=0` |
| 2 | 400, same message | 200 `stop_reason='max_tokens' content='' output_tokens=0` |
| 4 | 200 `stop_reason='max_tokens' content='' output_tokens=4` | 200 `stop_reason='max_tokens' content='' output_tokens=4` |
| 8 | 200 `stop_reason='max_tokens' content='' output_tokens=8` | 200 `stop_reason='max_tokens' content='' output_tokens=8` |
| 16 | 200 `stop_reason='end_turn' content='Hi! How can I help?' output_tokens=10` | 200 `stop_reason='end_turn' content='Hi! How can I help?' output_tokens=10` |

### Streaming

Same sweep with `"stream": true` at `max_tokens` 1 and 4. OpenAI does not raise the 400 on its streaming surface, so both legs already return `HTTP 200` with a single `finish_reason: "length"` and the fix changes nothing here. Reported so nobody reads the streaming seam as live-verified: it is covered by the tests in this PR, which drive a transport that returns the provider's 400 on the stream create call, and it exists so Azure and any provider that does raise on stream create lands in the same place.

```
before: HTTP 200 chunks=4 finish_reasons=['length']   after: HTTP 200 chunks=4 finish_reasons=['length']
```

### Usage on the mapped response

The provider processes and bills the prompt before it decides the output budget fits nothing, but it sends no usage object with the 400, so the prompt tokens are estimated with the same `token_counter` every other usage-less path in litellm uses. Reporting zero there would have let a caller send an arbitrarily large prompt with `max_tokens: 1` and be charged nothing, since the cost pipeline trusts a usage object when one is present and never reaches its estimator.

Same long prompt, same proxy pair, `max_tokens` 1 against `max_tokens` 4, so our estimate can be read against OpenAI's own count for an identical prompt:

| `max_tokens` | before (`e0f388cb5c`) | after (`d3a44fdfe4`) |
| -- | -- | -- |
| 1 | 400, nothing recorded | 200 `finish_reason='length' prompt_tokens=217 completion_tokens=0` |
| 4 | 200 `finish_reason='length' prompt_tokens=216 completion_tokens=4` | 200 `finish_reason='length' prompt_tokens=216 completion_tokens=4` |

The estimate lands at 217 against the provider's 216 for the same prompt, one token high, and the row is now charged instead of being free. The streaming path never had this hole: it carries no usage object either way, and litellm's existing stream accounting already estimates the prompt, measured at the same 414 tokens as the non-streaming estimate on a shared fixture. No usage object is attached to the synthetic stream chunk, since real OpenAI sends one only when the caller sets `stream_options.include_usage`.

One diagnostic comes with this. The `token_counter` call adds a single `reportUnknownArgumentType`, because the request dict is typed `Mapping[str, object]` and an `isinstance` check narrows the messages only as far as `list[Unknown]`. It is under its ceiling and the type gate is green. A Pydantic `TypeAdapter` would clear it, and it was rejected deliberately: validating the message list against the `AllMessageValues` union can raise, so a legal but unusual message shape would turn a mapped 200 back into a 500, reintroducing a failure through the machinery added to prevent one. A typed accessor was the other option, and its `list[...]` return annotation trips LIT001.

### Relationship to #35063

That PR fixes the same defect with the same shape, a tight match on the provider sentence plus a synthesized length-truncated turn, but only inside the Anthropic messages adapter, so it leaves direct `/v1/chat/completions` callers on the 400. This PR moves the recognition and the synthesized response down to the four OpenAI and Azure chat request helpers, which every chat surface funnels through, so the messages bridge is covered as a consequence rather than as a special case. It also picks up Azure, which #35063 does not reach, and the streaming path. #35063 should be superseded rather than merged alongside, since two mappings of the same string on the same request would be redundant.

## Type

🐛 Bug Fix

## Caveats (if any)

- The only signal is the provider's error sentence, which can change
- Match is pinned to the full sentence, with a test for genuine 400s
- No Azure credentials here, so Azure stays customer-reported and OpenAI-verified
- Prompt tokens are estimated locally since the 400 carries no usage, and completion tokens are zero

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
