### PR TITLE
fix(langfuse): restrict trace steering keys to real langfuse trace fields

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -172,6 +172,7 @@ callbacks: List[
 callback_settings: Dict[str, Dict[str, Any]] = {}
 initialized_langfuse_clients: int = 0
 langfuse_default_tags: Optional[List[str]] = None
+langfuse_enable_update_trace_keys: bool = False
 langsmith_batch_size: Optional[int] = None
 prometheus_initialize_budget_metrics: Optional[bool] = False
 prometheus_latency_buckets: Optional[List[float]] = None

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -568,7 +568,10 @@ class LangFuseLogger:
             # This allows continuing an existing trace while still returning the correct trace_id
             if existing_trace_id is not None:
                 trace_id = existing_trace_id
-            update_trace_keys: Final = _as_steering_key_sequence(clean_metadata.pop("update_trace_keys", ()))
+            requested_trace_keys: Final = _as_steering_key_sequence(clean_metadata.pop("update_trace_keys", ()))
+            update_trace_keys: Final = (
+                requested_trace_keys if _as_steering_flag(litellm.langfuse_enable_update_trace_keys) else ()
+            )
             debug: Final = clean_metadata.pop("debug_langfuse", None)
             mask_input: Final = _as_steering_flag(clean_metadata.pop("mask_input", False))
             mask_output: Final = _as_steering_flag(clean_metadata.pop("mask_output", False))

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 import sys
 import types
@@ -1086,34 +1087,71 @@ def test_mask_input_from_the_request_body_is_unchanged(mask_input, expect_redact
     assert (trace_params["input"] == _LANGFUSE_REDACTED) is expect_redacted
 
 
-def test_update_trace_keys_header_applies_every_key():
+@pytest.mark.parametrize("flag", [True, "true"])
+def test_update_trace_keys_header_applies_every_key_when_enabled(flag):
     logger = _steering_logger()
 
-    trace_params, _ = _emit(
-        logger,
-        headers={
-            "langfuse_existing_trace_id": "trace-1",
-            "langfuse_update_trace_keys": "trace_release, trace_tail",
-            "langfuse_trace_release": "v1.2.3",
-            "langfuse_trace_tail": "last",
-        },
-    )
+    with patch.object(litellm, "langfuse_enable_update_trace_keys", flag):
+        trace_params, _ = _emit(
+            logger,
+            headers={
+                "langfuse_existing_trace_id": "trace-1",
+                "langfuse_update_trace_keys": "trace_release, trace_tail",
+                "langfuse_trace_release": "v1.2.3",
+                "langfuse_trace_tail": "last",
+            },
+        )
 
     assert trace_params["release"] == "v1.2.3"
     assert trace_params["tail"] == "last"
 
 
-def test_update_trace_keys_from_the_request_body_list_is_unchanged():
+def test_update_trace_keys_is_off_by_default():
+    """
+    The caller picks the key name, so while the feature is on they can name
+    user_api_key_auth and have the resolved auth object, including team callback
+    credentials, serialized onto the trace. It stays inert until an operator opts in.
+    """
     logger = _steering_logger()
 
     trace_params, _ = _emit(
         logger,
         metadata={
             "existing_trace_id": "trace-1",
-            "update_trace_keys": ["trace_release"],
+            "update_trace_keys": ["user_api_key_auth", "trace_release"],
+            "user_api_key_auth": {"team_metadata": {"logging": [{"callback_vars": {"secret": "sk-canary"}}]}},
             "trace_release": "v1.2.3",
         },
     )
+
+    assert "user_api_key_auth" not in trace_params
+    assert "release" not in trace_params
+    assert "sk-canary" not in json.dumps(trace_params, default=repr)
+
+
+def test_update_trace_keys_input_and_output_are_gated_too():
+    logger = _steering_logger()
+
+    off, _ = _emit(logger, metadata={"existing_trace_id": "trace-1", "update_trace_keys": ["input", "output"]})
+    with patch.object(litellm, "langfuse_enable_update_trace_keys", True):
+        on, _ = _emit(logger, metadata={"existing_trace_id": "trace-1", "update_trace_keys": ["input", "output"]})
+
+    assert "input" not in off and "output" not in off
+    assert "input" in on and "output" in on
+
+
+def test_update_trace_keys_from_the_request_body_list_applies_when_enabled():
+    logger = _steering_logger()
+
+    with patch.object(litellm, "langfuse_enable_update_trace_keys", True):
+        trace_params, _ = _emit(
+            logger,
+            metadata={
+                "existing_trace_id": "trace-1",
+                "update_trace_keys": ["trace_release"],
+                "trace_release": "v1.2.3",
+            },
+        )
 
     assert trace_params["release"] == "v1.2.3"
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- A team member can pull the team's Langfuse credentials out of a trace
- `update_trace_keys` lets the caller name any request-metadata key
- The named value is copied onto the trace unfiltered

How it solves it:

- `update_trace_keys` does nothing unless an operator enables it
- `langfuse_enable_update_trace_keys`, default off
- Enabling it restores the previous behaviour exactly

## User Flow

Before: any holder of a team key can read the team's Langfuse credentials out of a trace they create

1. They send POST https://litellm-domain/v1/chat/completions with `"metadata": {"existing_trace_id": "t-1", "update_trace_keys": ["user_api_key_auth"]}` and get a normal 200
2. They open that trace in the Langfuse project their team already logs to
3. The trace carries a `user_api_key_auth` field holding the resolved auth object, including the team's `callback_vars`, its hashed key token, budgets and team config
4. A member with no admin rights on the gateway now holds the team's logging destination credentials

After: the same request succeeds and copies nothing

1. They send the same POST and get the same 200
2. The trace is created or continued as before, with no `user_api_key_auth` field on it
3. An operator who wants trace continuation sets `langfuse_enable_update_trace_keys: true` under `litellm_settings`, and every previously documented key works again

## Relevant issues

## Linear ticket

Refs LIT-5484

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy, real Postgres, real Gemini calls, Langfuse pointed at a local sink that records the outbound bytes. A marker credential sits in the team row's `callback_vars`. The same request is sent to both legs, naming the auth object and a documented continuation key together.

```bash
curl -s -X POST http://127.0.0.1:4483/v1/chat/completions -H "Authorization: Bearer $TEAMKEY" \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"hi"}],
       "metadata":{"existing_trace_id":"t-1",
                   "update_trace_keys":["user_api_key_auth","trace_release"],
                   "trace_release":"v9"}}'
```

Default, at `3ec42fbad2`:

```
  HTTP 200
  auth_copied=False  release=None  secret_on_trace=False
```

With `litellm_settings: langfuse_enable_update_trace_keys: true`:

```
  HTTP 200
  auth_copied=True   release='v9'  secret_on_trace=True
```

The second leg is the old behaviour, unchanged, now reachable only by operator choice.

## Type

🐛 Bug Fix

## Caveats (if any)

- Trace continuation is off until an operator opts in
- Enabling it restores the credential exposure, by design
- Independent of #36744, which closes the same leak on the payload channel

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3ec42fbad2747568b9844310189c7189467bb0ee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->