### PR TITLE
fix(scripts): end make check with a ran/skipped summary and verdict

### DIFF
--- a/scripts/pre_commit_lint.sh
+++ b/scripts/pre_commit_lint.sh
@@ -281,4 +281,30 @@ if [ -n "${gen_pid:-}" ]; then
     cat "$gen_log"; rm -f "$gen_log"
 fi
 
+summary_item() {
+    local check_name=$1 triggered=$2 skip_reason=$3
+    if [ -n "$triggered" ]; then
+        echo "    ran:     $check_name"
+    else
+        echo "    skipped: $check_name ($skip_reason)"
+    fi
+}
+
+echo "check: summary"
+summary_item "Python lint (make lint)" "$litellm_py_files" "no litellm/ Python files in scope"
+summary_item "tests/e2e checks (basedpyright + raw HTTP client ban)" "$e2e_py_files" "no tests/e2e Python files in scope"
+summary_item "dashboard lint (prettier + eslint + lint budgets)" "$ui_prettier_changed$ui_eslint_changed" "no dashboard files in scope"
+summary_item "dashboard API-type sync (npm run gen:api)" "$spec_files" "no litellm/proxy, litellm/types, or generator files in scope"
+
+if [ -z "$litellm_py_files$e2e_py_files$ui_prettier_changed$ui_eslint_changed$spec_files" ]; then
+    echo "check: NOTE - no gating lint check matches the files in scope, so nothing ran:" >&2
+    printf '%s\n' "$scope" | sed 's/^/    /' >&2
+    echo "  A pass here is a no-op, not a lint verdict." >&2
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "check: PASS"
+else
+    echo "check: FAIL"
+fi
 exit $status

--- a/scripts/pre_commit_lint.sh
+++ b/scripts/pre_commit_lint.sh
@@ -55,11 +55,13 @@ else
     merge_base=$(git merge-base origin/litellm_internal_staging HEAD 2>/dev/null) || {
         echo "check: cannot resolve the merge base with origin/litellm_internal_staging." >&2
         echo "  Fix: git fetch origin litellm_internal_staging" >&2
+        echo "check: FAIL"
         exit 1
     }
     scope=$(printf '%s\n' "$(git diff --name-only --diff-filter=ACMRD "$merge_base")" "$untracked" | sed '/^$/d' | sort -u)
     if [ -z "$scope" ]; then
         echo "check: nothing to check (no staged files, no working-tree changes, no branch changes vs origin/litellm_internal_staging)"
+        echo "check: PASS"
         exit 0
     fi
     echo "check: nothing staged; scoping to the working tree's diff against the merge base with origin/litellm_internal_staging:"

--- a/tests/test_litellm/test_pre_commit_lint.py
+++ b/tests/test_litellm/test_pre_commit_lint.py
@@ -384,3 +384,43 @@ def test_a_failing_block_fails_the_whole_run(tmp_path: Path, fail: str, message:
     proc = _run(repo, bin_dir, {"STUB_FAIL": fail})
     assert proc.returncode == 1
     assert message in proc.stdout + proc.stderr
+
+
+def test_run_ends_with_a_summary_of_ran_and_skipped_blocks(tmp_path: Path) -> None:
+    repo, bin_dir = _sandbox(tmp_path)
+    proc = _run(repo, bin_dir, {})
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "check: summary" in proc.stdout
+    assert "ran:     Python lint (make lint)" in proc.stdout
+    assert "ran:     dashboard lint (prettier + eslint + lint budgets)" in proc.stdout
+    assert "ran:     dashboard API-type sync (npm run gen:api)" in proc.stdout
+    assert "skipped: tests/e2e checks (basedpyright + raw HTTP client ban) (no tests/e2e Python files in scope)" in proc.stdout
+    assert "check: PASS" in proc.stdout
+    assert "check: FAIL" not in proc.stdout
+
+
+def test_staged_files_matching_no_check_print_an_explicit_noop_note_and_nonempty_log(tmp_path: Path) -> None:
+    repo, bin_dir = _sandbox(tmp_path)
+    _commit_all(repo, "base")
+    tests_dir = repo / "tests" / "test_litellm"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "test_x.py").write_text("def test_x() -> None: ...\n")
+    subprocess.run(["git", "add", "tests"], cwd=repo, check=True)
+    proc = _run(repo, bin_dir, {})
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "no gating lint check matches the files in scope, so nothing ran" in proc.stdout
+    assert "tests/test_litellm/test_x.py" in proc.stdout
+    assert "a no-op, not a lint verdict" in proc.stdout
+    assert "check: PASS" in proc.stdout
+    assert "linting Python" not in proc.stdout
+    log = (repo / ".git" / "pre_commit_lint.log").read_text()
+    assert "check: summary" in log
+    assert "skipped: Python lint (make lint) (no litellm/ Python files in scope)" in log
+
+
+def test_failing_run_ends_with_a_fail_verdict(tmp_path: Path) -> None:
+    repo, bin_dir = _sandbox(tmp_path)
+    proc = _run(repo, bin_dir, {"STUB_FAIL": "make-lint"})
+    assert proc.returncode == 1
+    assert "check: FAIL" in proc.stdout
+    assert "check: PASS" not in proc.stdout

--- a/tests/test_litellm/test_pre_commit_lint.py
+++ b/tests/test_litellm/test_pre_commit_lint.py
@@ -224,6 +224,7 @@ def test_nothing_staged_and_no_changes_is_an_explicit_no_op(tmp_path: Path) -> N
     proc = _run(repo, bin_dir, {})
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert "nothing to check" in proc.stdout
+    assert "check: PASS" in proc.stdout
     assert "linting Python" not in proc.stdout
 
 
@@ -234,6 +235,7 @@ def test_nothing_staged_without_a_base_ref_fails_with_a_fetch_hint(tmp_path: Pat
     assert proc.returncode == 1
     assert "cannot resolve the merge base" in proc.stdout
     assert "git fetch origin litellm_internal_staging" in proc.stdout
+    assert "check: FAIL" in proc.stdout
 
 
 def test_partial_staging_warns_which_checks_were_skipped(tmp_path: Path) -> None:


### PR DESCRIPTION
## TLDR

Problem this solves:

- make check could exit 0 printing nothing, leaving a zero-byte log
- staged files matching no check looked identical to a crashed run
- devs re-ran it, then read the script, to learn nothing ran

How it solves it:

- every run now ends naming each check as ran or skipped
- when nothing matches, a NOTE lists the in-scope files and says the pass is a no-op
- a final check: PASS or check: FAIL line mirrors the exit code
- early informational exits (nothing to check, no merge base) print the verdict too

## User Flow

Before: a contributor whose staged files match no lint check gets a silent exit 0 and a zero-byte log, indistinguishable from the script dying early

1. They stage a cost-map JSON and a tests/test_litellm test file with git add, then run make check
2. The terminal prints only "check: logging full output to .git/pre_commit_lint.log" and "check: full log: ..." with nothing in between, and exits 0
3. They open the log file and find it empty, so a clean pass looks exactly like a run that silently broke
4. They re-run make check a few times, then have to read scripts/pre_commit_lint.sh itself to learn that nothing was ever supposed to run

After: the same run ends with a per-check ran/skipped summary, the reason nothing ran, and an explicit verdict

1. They stage a cost-map JSON and a tests/test_litellm test file with git add, then run make check
2. The terminal prints the same first log line, then a "check: summary" block naming all four checks as skipped with the reason, like "no litellm/ Python files in scope"
3. A NOTE lists the staged files, says no gating lint check matches them, and that the pass is a no-op, not a lint verdict
4. The run ends with "check: PASS" ("check: FAIL" on a red run), and the log file holds that same summary instead of being empty

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Scenario from the bug report: a file no gating check covers (a tests/test_litellm Python file) is the only thing staged, in a bootstrapped worktree

Before, running the script as of the merge base 9d069f21dc:

```
$ git show origin/litellm_internal_staging:scripts/pre_commit_lint.sh > /tmp/base_pre_commit_lint.sh && chmod +x /tmp/base_pre_commit_lint.sh
$ git add tests/test_litellm/tmp_proof_scratch.py
$ /tmp/base_pre_commit_lint.sh; echo "exit=$?"
check: logging full output to /Users/mateo/Development/litellm/.git/worktrees/litellm-wt-check-summary/pre_commit_lint.log
check: full log: /Users/mateo/Development/litellm/.git/worktrees/litellm-wt-check-summary/pre_commit_lint.log
exit=0
$ wc -c /Users/mateo/Development/litellm/.git/worktrees/litellm-wt-check-summary/pre_commit_lint.log
       0 /Users/mateo/Development/litellm/.git/worktrees/litellm-wt-check-summary/pre_commit_lint.log
```

After, same staged file at cfbd43172a:

```
$ scripts/pre_commit_lint.sh; echo "exit=$?"
check: logging full output to /Users/mateo/Development/litellm/.git/worktrees/litellm-wt-check-summary/pre_commit_lint.log
check: summary
    skipped: Python lint (make lint) (no litellm/ Python files in scope)
    skipped: tests/e2e checks (basedpyright + raw HTTP client ban) (no tests/e2e Python files in scope)
    skipped: dashboard lint (prettier + eslint + lint budgets) (no dashboard files in scope)
    skipped: dashboard API-type sync (npm run gen:api) (no litellm/proxy, litellm/types, or generator files in scope)
check: NOTE - no gating lint check matches the files in scope, so nothing ran:
    tests/test_litellm/tmp_proof_scratch.py
  A pass here is a no-op, not a lint verdict.
check: PASS
check: full log: /Users/mateo/Development/litellm/.git/worktrees/litellm-wt-check-summary/pre_commit_lint.log
exit=0
$ wc -c /Users/mateo/Development/litellm/.git/worktrees/litellm-wt-check-summary/pre_commit_lint.log
     584 /Users/mateo/Development/litellm/.git/worktrees/litellm-wt-check-summary/pre_commit_lint.log
```

Early-exit verdict at 3fbe40c9b1, in a clean detached worktree at the staging tip with nothing staged and no changes:

```
$ scripts/pre_commit_lint.sh; echo "exit=$?"
check: logging full output to /Users/mateo/Development/litellm/.git/worktrees/litellm-wt-clean-tip/pre_commit_lint.log
check: nothing to check (no staged files, no working-tree changes, no branch changes vs origin/litellm_internal_staging)
check: PASS
check: full log: /Users/mateo/Development/litellm/.git/worktrees/litellm-wt-clean-tip/pre_commit_lint.log
exit=0
```

And a run at cfbd43172a where checks are in scope (this PR's own files staged plus the scripts change exercised via make check before committing) ended the same way with the ran/skipped split and a verdict, per the new tests which also cover the FAIL path

## Type

🐛 Bug Fix

## Caveats (if any)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the local pre-commit lint script and its unit tests; no production runtime, auth, or data paths are touched.
> 
> **Overview**
> **`make check`** (`scripts/pre_commit_lint.sh`) no longer finishes with a silent exit 0 and an empty log when nothing runs. Every run now ends with a **`check: summary`** block that labels each of the four gating checks as **ran** or **skipped** (with a short reason).
> 
> When staged or scoped files match **no** lint gate, the script prints a **NOTE** listing those paths and stating the pass is a **no-op, not a lint verdict**. Early exits (nothing to check vs. cannot resolve merge base) also print **`check: PASS`** or **`check: FAIL`** so the outcome matches the exit code.
> 
> Tests in **`test_pre_commit_lint.py`** assert the new verdict lines and add coverage for the summary, the no-match no-op path (including a non-empty log), and failing runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fbe40c9b10ff8fcd47a06a8101526c32e5a59ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->