### PR TITLE
fix(ui): show zeroed auto-router usage stats when a window has no sessions

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
@@ -192,6 +192,7 @@ describe("AutoRouterBenchmarksTab", () => {
     expect(screen.getByText("97.7%")).toBeInTheDocument();
     expect(screen.getByText("24.3%")).toBeInTheDocument();
     expect(screen.getByText("81.6%")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Share of turns by bucket" })).not.toHaveClass("bg-muted");
   });
 
   it("summarizes the cache column from the bucketed turns, not the session turns", () => {
@@ -292,6 +293,7 @@ describe("AutoRouterBenchmarksTab", () => {
     expect(screen.getByText("0s")).toBeInTheDocument();
     expect(screen.getByText(/turns measured/)).toBeInTheDocument();
     expect(screen.getAllByText("0.0%").length).toBeGreaterThan(0);
+    expect(screen.getByRole("img", { name: "Share of turns by bucket" })).toHaveClass("bg-muted");
   });
 
   it("shows the savings delta as an unsigned zero when nothing was saved", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
@@ -66,6 +66,36 @@ const totals = (overrides: Partial<Totals> = {}): Totals => ({
   ...overrides,
 });
 
+const zeroBucket = { turns: 0, hits: 0, hit_rate_pct: 0 };
+
+const zeroCache: AutoRouterCacheStats = {
+  coverage_pct: 0,
+  hit_rate_pct: 0,
+  same_model: zeroBucket,
+  first_visit: zeroBucket,
+  return_to_tier: zeroBucket,
+  unordered_turns: 0,
+  return_misses_expired: 0,
+  return_misses_within_ttl: 0,
+  return_misses_unknown: 0,
+  ttl_5m_turns: 0,
+  ttl_1h_turns: 0,
+};
+
+const zeroTotals: Totals = {
+  sessions: 0,
+  turns: 0,
+  avg_turns_per_session: 0,
+  avg_session_seconds: 0,
+  avg_tokens_per_session: 0,
+  spend: 0,
+  saved_spend: 0,
+  baseline_spend: 0,
+  saved_pct: 0,
+  saved_per_session: 0,
+  cache: zeroCache,
+};
+
 const group = (overrides: Partial<AutoRouterBenchmarkGroup> = {}): AutoRouterBenchmarkGroup => ({
   router_name: "claude-auto",
   router_type: "complexity",
@@ -252,11 +282,24 @@ describe("AutoRouterBenchmarksTab", () => {
     expect(screen.getByText("Auto-router usage is unavailable right now")).toBeInTheDocument();
   });
 
-  it("says so when there are no auto-router sessions at all", () => {
-    mockHook({ data: response([]) });
+  it("renders the full dashboard with zeroed stats when the window has no sessions", () => {
+    mockHook({ data: response([], zeroTotals) });
     renderTab();
 
-    expect(screen.getByText("No auto-router sessions in this window yet")).toBeInTheDocument();
+    expect(screen.getByText("Total estimated savings")).toBeInTheDocument();
+    expect(screen.getAllByText("$0.00")).toHaveLength(4);
+    expect(screen.getByText("across 0 sessions")).toBeInTheDocument();
+    expect(screen.getByText("0s")).toBeInTheDocument();
+    expect(screen.getByText(/turns measured/)).toBeInTheDocument();
+    expect(screen.getAllByText("0.0%").length).toBeGreaterThan(0);
+  });
+
+  it("shows the savings delta as an unsigned zero when nothing was saved", () => {
+    mockHook({ data: response([], zeroTotals) });
+    renderTab();
+
+    expect(screen.getByText("0%")).toBeInTheDocument();
+    expect(screen.queryByText("-0%")).not.toBeInTheDocument();
   });
 
   it("requests the default thirty day window and widens or narrows it from the picker", () => {
@@ -303,7 +346,7 @@ describe("AutoRouterBenchmarksTab", () => {
   });
 
   it("keeps the window picker reachable while a window has no sessions", () => {
-    mockHook({ data: response([]) });
+    mockHook({ data: response([], zeroTotals) });
     renderTab();
 
     expect(screen.getByRole("tab", { name: "30d" })).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
@@ -64,7 +64,7 @@ const HeroCard: React.FC<{ view: BenchmarkView }> = ({ view }) => {
               variant="secondary"
               className={cheaper ? "bg-emerald-50 text-emerald-700" : "bg-red-50 text-destructive"}
             >
-              {cheaper ? "-" : "+"}
+              {stats.saved_spend !== 0 && (cheaper ? "-" : "+")}
               {Math.abs(stats.saved_pct).toFixed(0)}%
             </Badge>
           </div>
@@ -95,7 +95,7 @@ const StackedTurnBar: React.FC<{ buckets: BucketRow[] }> = ({ buckets }) => {
   return (
     <div className="flex flex-col gap-1">
       <div
-        className="flex h-2.5 w-full gap-0.5 overflow-hidden rounded-sm"
+        className={`flex h-2.5 w-full gap-0.5 overflow-hidden rounded-sm ${segments.length === 0 ? "bg-muted" : ""}`}
         role="img"
         aria-label="Share of turns by bucket"
       >
@@ -230,7 +230,6 @@ const BenchmarksBody: React.FC<BenchmarksBodyProps> = ({ isPending, error, data,
     return <Message>Auto-router usage is visible to proxy admin roles only</Message>;
   }
   if (error || !data) return <Message>Auto-router usage is unavailable right now</Message>;
-  if (data.groups.length === 0) return <Message>No auto-router sessions in this window yet</Message>;
 
   const view = viewFor(data, selectedKey);
   const stats = view.stats;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Auto-Router Usage tab collapsed to one line of text when a window had no sessions
- Admins read that as the page failing to load

How it solves it:

- Always renders the full dashboard, with every stat zeroed
- Savings badge shows an unsigned 0% instead of -0%
- Empty share-of-turns bar gets the muted track its sibling meters use

## User Flow

Before: an admin who just created their first auto-router opens the usage page and finds no dashboard at all

1. They open http://localhost:4000/ui/?page=cost-optimization and click the Auto-Router Usage tab
2. Instead of the dashboard, the page shows only the line "No auto-router sessions in this window yet"
3. They cannot see what the page will track or whether it is working, so it reads as broken

After: the same admin sees the complete dashboard reading zero, ready to fill in as traffic arrives

1. They open http://localhost:4000/ui/?page=cost-optimization and click the Auto-Router Usage tab
2. The savings hero shows $0.00 with a 0% badge, across 0 sessions, and the three session metrics read 0.0, 0s and 0.0
3. The prompt caching card shows a 0.0% hit rate, 0 turns measured, an empty muted bar and all three buckets at 0 turns
4. Once routed traffic lands, the same tiles show the real numbers

## Relevant issues

- Renders the Auto-Router Usage dashboard with zeroed stats when the window has no sessions, instead of replacing it with a one-line empty message
- Shows the hero savings badge as unsigned 0% when nothing was saved, so the zero state never reads -0%
- Gives the empty share-of-turns bar a muted track so it does not render as a blank strip

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix
<img width="1734" height="995" alt="image" src="https://github.com/user-attachments/assets/6788732a-b2d7-4d49-9be8-f4b5f4bf9eb4" />


UI change, screenshots to be posted after checkout. To reproduce at 5a12063fc5:

1. Start the proxy against a database with no auto-router sessions: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`
2. Start the dashboard dev server with `npm run dev` in ui/litellm-dashboard
3. Open http://localhost:4000/ui/?page=cost-optimization as a proxy admin and click the Auto-Router Usage tab
4. Before (parent commit 909a2e6232): the tab body is just the line "No auto-router sessions in this window yet"
5. After (5a12063fc5): the full dashboard renders zeroed: $0.00 savings with a 0% badge across 0 sessions, 0.0 avg turns, 0s avg session, 0.0 avg tokens, 0.0% cache hit rate with 0 turns measured
6. The 30d/7d/24h picker and the router dropdown stay usable, and a window that does have sessions still shows its real numbers

## Type

🐛 Bug Fix

## Caveats (if any)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5a12063fc5a14e869bb89a074e4b72ecc9e94501. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->