### PR TITLE
fix(vertex_ai): return a truncated choice when a Gemini candidate has no content

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -2219,6 +2219,29 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         for idx, candidate in enumerate(_candidates):
             if "content" not in candidate:
+                # Content-less candidate (e.g. thinking model out of budget):
+                # emit an empty choice with a mapped truncation reason, not an
+                # empty choices list. Non-streaming only.
+                if isinstance(model_response, ModelResponse):
+                    finish_reason = candidate.get("finishReason")
+                    mapped_finish_reason = (
+                        VertexGeminiConfig._check_finish_reason(None, finish_reason)
+                        if finish_reason is not None
+                        else "length"
+                    )
+                    empty_message: ChatCompletionResponseMessage = {
+                        "role": "assistant",
+                        "content": "",
+                    }
+                    model_response.choices.append(
+                        litellm.Choices(
+                            finish_reason=mapped_finish_reason,
+                            index=candidate.get("index", idx),
+                            message=empty_message,
+                            logprobs=None,
+                            enhancements=None,
+                        )
+                    )
                 continue
 
             # Extract metadata using helper function

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5606,3 +5606,28 @@ def test_vertex_ai_content_less_candidate_without_finish_reason_not_stop():
     assert model_response.choices[0].finish_reason == "length"
     assert model_response.choices[0].finish_reason != "stop"
     assert model_response.choices[0].message.content == ""
+
+
+def test_vertex_ai_multiple_content_less_candidates_each_rescued():
+    """Every content-less candidate is rescued independently, preserving each
+    candidate's index and mapping its own finishReason (MAX_TOKENS -> length,
+    SAFETY -> content_filter), rather than dropping any of them.
+    """
+    v = VertexGeminiConfig()
+    model_response = ModelResponse()
+    model_response.choices = []
+
+    v._process_candidates(
+        _candidates=[
+            {"finishReason": "MAX_TOKENS", "index": 0},
+            {"finishReason": "SAFETY", "index": 1},
+        ],
+        model_response=model_response,
+        standard_optional_params={},
+    )
+
+    assert len(model_response.choices) == 2
+    by_index = {c.index: c for c in model_response.choices}
+    assert by_index[0].finish_reason == "length"
+    assert by_index[1].finish_reason == "content_filter"
+    assert all(c.message.content == "" for c in model_response.choices)

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5553,3 +5553,56 @@ def test_accumulated_json_skips_non_dict_leading_value():
 
     assert len(out) == 1
     assert out[0].choices[0].delta.content == "a"
+
+
+def test_vertex_ai_content_less_candidate_rescued_as_length():
+    """A candidate with no "content" (e.g. a thinking model that spends its whole
+    token budget on reasoning -> finishReason=MAX_TOKENS, no content) must still
+    produce a choice, not be silently dropped. Dropping it leaves
+    model_response.choices empty and the caller hits IndexError on choices[0].
+    The rescued choice must carry empty content and finishReason mapped through
+    the SAME path the mainline uses (MAX_TOKENS -> "length"), never the raw
+    provider value.
+    """
+    v = VertexGeminiConfig()
+    model_response = ModelResponse()
+    model_response.choices = []
+
+    v._process_candidates(
+        _candidates=[
+            {
+                "finishReason": "MAX_TOKENS",
+                "index": 0,
+            }
+        ],
+        model_response=model_response,
+        standard_optional_params={},
+    )
+
+    assert len(model_response.choices) == 1
+    choice = model_response.choices[0]
+    # mapped, not the raw "MAX_TOKENS"
+    assert choice.finish_reason == "length"
+    assert choice.message.content == ""
+    assert choice.message.role == "assistant"
+
+
+def test_vertex_ai_content_less_candidate_without_finish_reason_not_stop():
+    """A content-less candidate with NO finishReason at all must not silently
+    become finish_reason="stop" (a false claim the model finished normally).
+    Budget-exhausted-with-no-marker is honestly reported as "length".
+    """
+    v = VertexGeminiConfig()
+    model_response = ModelResponse()
+    model_response.choices = []
+
+    v._process_candidates(
+        _candidates=[{"index": 0}],
+        model_response=model_response,
+        standard_optional_params={},
+    )
+
+    assert len(model_response.choices) == 1
+    assert model_response.choices[0].finish_reason == "length"
+    assert model_response.choices[0].finish_reason != "stop"
+    assert model_response.choices[0].message.content == ""


### PR DESCRIPTION
## Relevant issues
Fixes #36881

## Type
🐛 Bug Fix

## Changes

### TLDR
**Problem:** When Gemini returns a candidate with no content (a thinking model can spend its entire token budget on reasoning, so the candidate comes back with finishReason MAX_TOKENS and no content part), the Vertex handler skipped that candidate. If every candidate is content-less, the response ends up with an empty choices list and any caller reading the first choice gets an IndexError.

### How
Emit a choice for the content-less candidate with empty content and a truncation finish_reason instead of dropping it. The finishReason is mapped through the same path the normal branch uses (MAX_TOKENS becomes length), and a candidate with no finishReason at all is reported as length (budget exhausted) rather than a false stop. The streaming path is untouched; it has its own empty-choice recovery.

## Before / After (user flow)
**Before:** A request to a Gemini thinking model with a modest max-tokens limit uses the whole budget thinking and returns no visible text. Instead of a normal empty completion, the SDK raises IndexError on the first choice, an opaque crash unrelated to what actually happened.

**After:** The same request returns one choice with empty content and finish_reason "length", so the caller can see the response was truncated by the token limit and handle it (raise the limit, retry) instead of crashing.

## Testing
Two regression tests covering a MAX_TOKENS content-less candidate rescued as finish_reason "length", and a content-less candidate with no finishReason becoming "length", not "stop".

