### PR TITLE
test(proxy): stop monkeypatch.undo re-planting fixture-mocked prisma_client

### DIFF
--- a/tests/test_litellm/proxy/conftest.py
+++ b/tests/test_litellm/proxy/conftest.py
@@ -43,32 +43,51 @@ def disconnected_prisma() -> DisconnectedPrisma:
     return DisconnectedPrisma()
 
 
-@pytest.fixture(autouse=True)
-def _isolate_proxy_module_globals():
-    """
-    Snapshot and restore module-level globals on litellm.proxy.proxy_server
-    that tests sometimes mutate via raw setattr (not monkeypatch).
+_MODULE_GLOBAL_MISSING = object()
+_proxy_module_globals_snapshot = pytest.StashKey[Dict[str, object]]()
 
-    Without this, a leaked value — e.g. master_key set by a sibling test —
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_setup(item):
+    """
+    Snapshot module-level globals on litellm.proxy.proxy_server before any
+    fixture runs, and restore them in pytest_runtest_teardown after every
+    fixture finalizer has run.
+
+    Without this, a leaked value (e.g. master_key set by a sibling test)
     flips the auth short-circuit in user_api_key_auth and causes unrelated
     tests in the same xdist worker to return 401 instead of 200.
+
+    This must be a hook pair, not an autouse fixture: an autouse fixture in
+    the root conftest requests monkeypatch, so monkeypatch's undo stack
+    unwinds after every other fixture finalizer. A test that monkeypatches a
+    global while a fixture has it patched records the fixture's mock as the
+    "original", and monkeypatch.undo re-plants that mock after all restores
+    have run, poisoning the global for the rest of the xdist worker.
     """
     from litellm.proxy import proxy_server
 
-    sentinel = object()
-    snapshot = {
-        name: getattr(proxy_server, name, sentinel)
+    item.stash[_proxy_module_globals_snapshot] = {
+        name: getattr(proxy_server, name, _MODULE_GLOBAL_MISSING)
         for name in _PROXY_MODULE_GLOBALS_TO_ISOLATE
     }
-    try:
-        yield
-    finally:
-        for name, value in snapshot.items():
-            if value is sentinel:
-                if hasattr(proxy_server, name):
-                    delattr(proxy_server, name)
-            else:
-                setattr(proxy_server, name, value)
+    yield
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_teardown(item, nextitem):
+    yield
+    snapshot = item.stash.get(_proxy_module_globals_snapshot, None)
+    if snapshot is None:
+        return
+    from litellm.proxy import proxy_server
+
+    for name, value in snapshot.items():
+        if value is _MODULE_GLOBAL_MISSING:
+            if hasattr(proxy_server, name):
+                delattr(proxy_server, name)
+        else:
+            setattr(proxy_server, name, value)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1688,9 +1688,15 @@ class TestTemporaryMCPSessionEndpoints:
             expires_at=datetime.utcnow() - timedelta(seconds=30),
         )
         cache = {"expired": expired_entry}
-        with patch(
-            "litellm.proxy.management_endpoints.mcp_management_endpoints._temporary_mcp_servers",
-            cache,
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints._temporary_mcp_servers",
+                cache,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints._get_prisma_client_or_none",
+                return_value=None,
+            ),
         ):
             result = await get_cached_temporary_mcp_server("expired")
 
@@ -2274,6 +2280,10 @@ class TestTemporaryMCPSessionEndpoints:
                 "litellm.proxy.management_endpoints.mcp_management_endpoints._cache_temporary_mcp_server_in_redis",
                 AsyncMock(),
             ) as redis_cache_mock,
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints._get_prisma_client_or_none",
+                return_value=None,
+            ),
         ):
             response = await add_session_mcp_server(
                 payload=payload,
@@ -3418,6 +3428,10 @@ class TestTemporaryMCPSessionEndpoints:
                 patch(
                     "litellm.proxy.management_endpoints.mcp_management_endpoints.decrypt_value_helper",
                     return_value=serialized,
+                ),
+                patch(
+                    "litellm.proxy.management_endpoints.mcp_management_endpoints._get_prisma_client_or_none",
+                    return_value=None,
                 ),
             ):
                 result = await get_cached_temporary_mcp_server("from-redis")

--- a/tests/test_litellm/proxy/test_conftest.py
+++ b/tests/test_litellm/proxy/test_conftest.py
@@ -1,0 +1,31 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def fixture_planted_prisma_mock():
+    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()):
+        yield
+
+
+def test_monkeypatch_over_fixture_patched_prisma_client(
+    fixture_planted_prisma_mock, monkeypatch
+):
+    """
+    Mirrors the flake in test_team_endpoints.py: an autouse fixture patches
+    prisma_client, the test monkeypatches the same global, and monkeypatch
+    records the fixture's MagicMock as the value to restore. Its undo runs
+    after every other finalizer, so without hook-level isolation the mock
+    leaks and every later no-database test on the worker fails awaiting it.
+    """
+    import litellm.proxy.proxy_server as proxy_server
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", AsyncMock())
+    assert isinstance(proxy_server.prisma_client, AsyncMock)
+
+
+def test_prisma_client_did_not_leak_from_previous_test():
+    import litellm.proxy.proxy_server as proxy_server
+
+    assert not isinstance(proxy_server.prisma_client, MagicMock)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Required proxy-endpoints CI check flakes on unrelated PRs
- Three MCP management tests die on "MagicMock can't be used in 'await'"
- Failures survive the job's per-test reruns and full job reruns

How it solves it:

- Moves proxy_server global isolation from an autouse fixture to runtest hooks
- Hooks restore after every fixture finalizer, so monkeypatch.undo can't re-leak mocks
- Pins the three victim MCP tests to the no-database path
- Adds a regression pair that fails on the old conftest

The mechanism: the root conftest's autouse fixtures request monkeypatch, so monkeypatch's undo stack unwinds after every other fixture finalizer. test_team_endpoints.py has an autouse fixture that patches litellm.proxy.proxy_server.prisma_client with a MagicMock, and its delete_team tests monkeypatch that same global, recording the fixture's mock as the "original". At teardown the patch exits, the old isolation fixture restores the real value, and then monkeypatch.undo runs last and re-plants the MagicMock. Every later test's snapshot faithfully preserves it, so the worker is poisoned for the rest of the session and any later no-database MCP test that reads the global takes the database path and fails awaiting a MagicMock. With xdist loadscope this repeats whenever the team and MCP modules share a worker, which is why reruns fail identically

## User Flow

Before: a contributor's PR that never touches proxy code fails the required proxy-endpoints check, and re-running fails the same way

1. They open a PR touching only a lint script and its test, e.g. https://github.com/BerriAI/litellm/pull/36864
2. The required check Unit Tests: Proxy API Endpoints / proxy-endpoints / Run tests turns red after about 14 minutes
3. The run log at https://github.com/BerriAI/litellm/actions/runs/31763090709 shows three MCP server management tests they never touched failing with `TypeError: object MagicMock can't be used in 'await' expression`, having already survived the job's two automatic per-test retries
4. They re-run the failed job and the same three tests fail again, so the PR stays blocked

After: the same PR passes the proxy-endpoints check on the first run

1. They open the same PR touching only a lint script and its test
2. The required check Unit Tests: Proxy API Endpoints / proxy-endpoints / Run tests turns green
3. The PR is mergeable with no rerun roulette

## Relevant issues

Unblocks the required check failing on #36864

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR changes only test isolation, so the end-to-end surface is the CI job itself rather than a live proxy route. The failing check is deterministic CI evidence: https://github.com/BerriAI/litellm/actions/runs/31763090709 failed on the same three tests in the original run and again on a full rerun, on a PR touching only scripts/pre_commit_lint.sh and its test

Red-green on the regression pair, before at 86f2f16fd4 (staging tip conftest plus only the new test file):

```
$ pytest tests/test_litellm/proxy/test_conftest.py -q
FAILED tests/test_litellm/proxy/test_conftest.py::test_prisma_client_did_not_leak_from_previous_test
1 failed, 1 passed, 1 warning in 1.41s
```

After at a36ba05882:

```
$ pytest tests/test_litellm/proxy/test_conftest.py -q
2 passed, 1 warning in 1.58s
```

Full tests/test_litellm/proxy sweep on the same machine went from 7 failed, 7296 passed at the base to 4 failed, 7299 passed with the fix. The three recovered tests are exactly the three CI victims. The residual failures also fail identically at the base and are local environment artifacts: a machine-local sso settings failure, two tests needing the optional detect_secrets package, and one test reading a PROXY_BASE_URL left in the local .env

## Type

✅ Test

## Caveats (if any)

- Snapshot still covers only master_key and prisma_client, as before

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
