### PR TITLE
fix(gemini): map Gemini 3.7 and 3.8 Flash minimal thinking to low

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -862,9 +862,10 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         # Covers gemini-3-flash, gemini-3-flash-preview, gemini-3.1-flash, gemini-3.1-flash-lite-preview,
         # gemini-3.5-flash, and any future 3.x-flash variants.
         is_gemini3flash: Final = model and ("flash" in model.lower() and "gemini-3" in model.lower())
+        is_gemini37flash: Final = model and "gemini-3.7-flash" in model.lower()
         is_gemini31pro: Final = model and ("gemini-3.1-pro-preview" in model.lower())
         if reasoning_effort == "minimal":
-            if is_gemini3flash:
+            if is_gemini3flash and not is_gemini37flash:
                 return {"thinkingLevel": "minimal", "includeThoughts": True}
             else:
                 return {"thinkingLevel": "low", "includeThoughts": True}
@@ -879,13 +880,13 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             return {"thinkingLevel": "high", "includeThoughts": True}
         elif reasoning_effort == "disable":
             # Gemini 3 cannot fully disable thinking, so we use "minimal" for gemini-3-flash-preview, "low" for others
-            if is_gemini3flash:
+            if is_gemini3flash and not is_gemini37flash:
                 return {"thinkingLevel": "minimal", "includeThoughts": False}
             else:
                 return {"thinkingLevel": "low", "includeThoughts": False}
         elif reasoning_effort == "none":
             # For gemini-3-flash-preview, use "minimal" instead of "low"
-            if is_gemini3flash:
+            if is_gemini3flash and not is_gemini37flash:
                 return {"thinkingLevel": "minimal", "includeThoughts": False}
             else:
                 return {"thinkingLevel": "low", "includeThoughts": False}

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -862,10 +862,12 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         # Covers gemini-3-flash, gemini-3-flash-preview, gemini-3.1-flash, gemini-3.1-flash-lite-preview,
         # gemini-3.5-flash, and any future 3.x-flash variants.
         is_gemini3flash: Final = model and ("flash" in model.lower() and "gemini-3" in model.lower())
-        is_gemini37flash: Final = model and "gemini-3.7-flash" in model.lower()
+        requires_low_minimum_thinking: Final = model and (
+            "gemini-3.7-flash" in model.lower() or "gemini-3.8-flash" in model.lower()
+        )
         is_gemini31pro: Final = model and ("gemini-3.1-pro-preview" in model.lower())
         if reasoning_effort == "minimal":
-            if is_gemini3flash and not is_gemini37flash:
+            if is_gemini3flash and not requires_low_minimum_thinking:
                 return {"thinkingLevel": "minimal", "includeThoughts": True}
             else:
                 return {"thinkingLevel": "low", "includeThoughts": True}
@@ -880,13 +882,13 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             return {"thinkingLevel": "high", "includeThoughts": True}
         elif reasoning_effort == "disable":
             # Gemini 3 cannot fully disable thinking, so we use "minimal" for gemini-3-flash-preview, "low" for others
-            if is_gemini3flash and not is_gemini37flash:
+            if is_gemini3flash and not requires_low_minimum_thinking:
                 return {"thinkingLevel": "minimal", "includeThoughts": False}
             else:
                 return {"thinkingLevel": "low", "includeThoughts": False}
         elif reasoning_effort == "none":
             # For gemini-3-flash-preview, use "minimal" instead of "low"
-            if is_gemini3flash and not is_gemini37flash:
+            if is_gemini3flash and not requires_low_minimum_thinking:
                 return {"thinkingLevel": "minimal", "includeThoughts": False}
             else:
                 return {"thinkingLevel": "low", "includeThoughts": False}

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2666,6 +2666,18 @@ def test_reasoning_effort_maps_to_thinking_level_gemini_3():
     assert result["thinkingConfig"]["includeThoughts"] is False
 
 
+@pytest.mark.parametrize("reasoning_effort", ["minimal", "disable", "none"])
+def test_gemini_37_flash_uses_low_minimum_thinking_level(reasoning_effort: str):
+    result = VertexGeminiConfig().map_openai_params(
+        non_default_params={"reasoning_effort": reasoning_effort},
+        optional_params={},
+        model="vertex_ai/gemini-3.7-flash",
+        drop_params=False,
+    )
+
+    assert result["thinkingConfig"]["thinkingLevel"] == "low"
+
+
 def test_reasoning_effort_dict_format_gemini_3():
     """
     Test that reasoning_effort works when passed as dict format from OpenAI Agents SDK.

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2666,16 +2666,18 @@ def test_reasoning_effort_maps_to_thinking_level_gemini_3():
     assert result["thinkingConfig"]["includeThoughts"] is False
 
 
+@pytest.mark.parametrize("model", ["vertex_ai/gemini-3.7-flash", "vertex_ai/gemini-3.8-flash"])
 @pytest.mark.parametrize("reasoning_effort", ["minimal", "disable", "none"])
-def test_gemini_37_flash_uses_low_minimum_thinking_level(reasoning_effort: str):
+def test_gemini_flash_uses_low_minimum_thinking_level(model: str, reasoning_effort: str):
     result = VertexGeminiConfig().map_openai_params(
         non_default_params={"reasoning_effort": reasoning_effort},
         optional_params={},
-        model="vertex_ai/gemini-3.7-flash",
+        model=model,
         drop_params=False,
     )
 
     assert result["thinkingConfig"]["thinkingLevel"] == "low"
+    assert result["thinkingConfig"]["includeThoughts"] is (reasoning_effort == "minimal")
 
 
 def test_reasoning_effort_dict_format_gemini_3():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini 3.7 and 3.8 Flash rejects `minimal` thinking
- Three reasoning efforts can trigger provider HTTP 400

How it solves it:

- Detects Gemini 3.7 and 3.8 Flash in the existing mapping
- Uses `low` for `minimal`, `disable`, and `none`

Reference: [Gemini 3.8 Flash model documentation](https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash)

## User Flow

Before: a developer minimizing Gemini 3.7 and 3.8 Flash thinking gets HTTP 400

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "vertex_ai/gemini-3.8-flash"` and `"reasoning_effort": "none"`
2. They receive HTTP 400 with `Thinking level MINIMAL is not supported for this model`

After (expected): the same request returns a completion without the thinking-level error

1. They send the same POST https://litellm-domain/v1/chat/completions with `"model": "vertex_ai/gemini-3.8-flash"` and `"reasoning_effort": "none"`
2. They receive HTTP 200 with a chat completion instead of the thinking-level error

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The test file covering my change passes locally (157 passed)
- [ ] My PR passes all required CI/CD checks
- [x] My PR only solves one specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 for the latest commit

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Live provider verification has not been run for this revision

## Type

Bug Fix

## Caveats (if any)

### Low

- Live provider verification remains pending

## Final Attestation

- [x] The tests cover both models, affected efforts, and thought-summary flags
