### PR TITLE
fix(spend): give a batch's cost row a primary key of its own

### DIFF
--- a/basedpyright-code-budget.json
+++ b/basedpyright-code-budget.json
@@ -1,6 +1,6 @@
 {
   "reportAny": {
-    "limit": 22947
+    "limit": 22945
   },
   "reportArgumentType": {
     "limit": 2579
@@ -24,7 +24,7 @@
     "limit": 19
   },
   "reportExplicitAny": {
-    "limit": 7312
+    "limit": 7311
   },
   "reportFunctionMemberAccess": {
     "limit": 7

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -1,5 +1,3 @@
-import hashlib
-import json
 import os
 import re
 import secrets
@@ -28,6 +26,7 @@ from litellm.proxy._types import SpendLogsMetadata, SpendLogsPayload
 from litellm.proxy.spend_tracking.spend_log_error_logger import spend_log_error
 from litellm.proxy.utils import PrismaClient, hash_token
 from litellm.types.utils import (
+    CallTypes,
     CostBreakdown,
     StandardLoggingGuardrailInformation,
     StandardLoggingMCPToolCall,
@@ -144,36 +143,22 @@ def _get_spend_logs_metadata(
     return clean_metadata
 
 
-def generate_hash_from_response(response_obj: Any) -> str:
-    """
-    Generate a stable hash from a response object.
-
-    Args:
-        response_obj: The response object to hash (can be dict, list, etc.)
-
-    Returns:
-        A hex string representation of the MD5 hash
-    """
-    try:
-        # Create a stable JSON string of the entire response object
-        # Sort keys to ensure consistent ordering
-        json_str: Final = json.dumps(response_obj, sort_keys=True)
-
-        # Generate a hash of the response object
-        unique_hash: Final = hashlib.md5(json_str.encode()).hexdigest()
-        return unique_hash
-    except Exception:
-        # Return a fallback hash if serialization fails
-        return hashlib.md5(str(response_obj).encode()).hexdigest()
+BATCH_COST_REQUEST_ID_SUFFIX: Final = "_batch_cost"
 
 
 def get_spend_logs_id(call_type: str, response_obj: dict, kwargs: dict) -> str | None:
-    if call_type == "aretrieve_batch" or call_type == "acreate_file":
-        # Generate a hash from the response object
-        id: str | None = generate_hash_from_response(response_obj)
-    else:
-        id = cast(str | None, response_obj.get("id")) or cast(str | None, kwargs.get("litellm_call_id"))
-    return id
+    standard_logging_payload = kwargs.get("standard_logging_object")
+    candidate_ids: Final = (
+        response_obj.get("id"),
+        standard_logging_payload.get("id") if isinstance(standard_logging_payload, dict) else None,
+        kwargs.get("litellm_call_id"),
+    )
+    resolved_id: Final = next(
+        (candidate for candidate in candidate_ids if isinstance(candidate, str) and candidate), None
+    )
+    if resolved_id is not None and call_type == CallTypes.aretrieve_batch.value:
+        return f"{resolved_id}{BATCH_COST_REQUEST_ID_SUFFIX}"
+    return resolved_id
 
 
 def _extract_usage_for_ocr_call(response_obj: Any, response_obj_dict: dict) -> dict:

--- a/ruff-strict-budget.json
+++ b/ruff-strict-budget.json
@@ -24,7 +24,7 @@
     "limit": 133
   },
   "ANN401": {
-    "limit": 1342
+    "limit": 1341
   },
   "ASYNC230": {
     "limit": 11
@@ -57,7 +57,7 @@
     "limit": 3
   },
   "BLE001": {
-    "limit": 2924
+    "limit": 2923
   },
   "C401": {
     "limit": 8
@@ -147,7 +147,7 @@
     "limit": 3
   },
   "PLR1714": {
-    "limit": 257
+    "limit": 256
   },
   "PLW0127": {
     "limit": 57
@@ -249,7 +249,7 @@
     "limit": 113
   },
   "TRY300": {
-    "limit": 860
+    "limit": 859
   },
   "UP028": {
     "limit": 2

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -4,7 +4,7 @@ import json
 import os
 import sys
 from datetime import timezone
-from typing import Any, cast
+from typing import Any, Final, cast
 
 import pytest
 from fastapi.testclient import TestClient
@@ -2962,8 +2962,8 @@ def test_user_traffic_carries_no_internal_call_origin():
     assert metadata["internal_call_origin"] is None
 
 
-REDACTED_RESPONSE_PLACEHOLDER = {"text": "redacted-by-litellm"}
-CONSTANT_ID_FROM_HASHED_PLACEHOLDER = "00fcbef15a3b0097e14b0ca016ed30a0"
+REDACTED_RESPONSE_PLACEHOLDER: Final = {"text": "redacted-by-litellm"}
+CONSTANT_ID_FROM_HASHED_PLACEHOLDER: Final = "00fcbef15a3b0097e14b0ca016ed30a0"
 
 
 @pytest.mark.parametrize("call_type", ["aretrieve_batch", "acreate_file"])

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -37,6 +37,7 @@ from litellm.proxy.spend_tracking.spend_tracking_utils import (
     _sanitize_request_body_for_spend_logs_payload,
     _should_store_prompts_and_responses_in_spend_logs,
     get_logging_payload,
+    get_spend_logs_id,
 )
 from litellm.types.utils import (
     StandardLoggingHiddenParams,
@@ -2959,3 +2960,151 @@ def test_user_traffic_carries_no_internal_call_origin():
     )
     metadata = json.loads(payload["metadata"])
     assert metadata["internal_call_origin"] is None
+
+
+REDACTED_RESPONSE_PLACEHOLDER = {"text": "redacted-by-litellm"}
+CONSTANT_ID_FROM_HASHED_PLACEHOLDER = "00fcbef15a3b0097e14b0ca016ed30a0"
+
+
+@pytest.mark.parametrize("call_type", ["aretrieve_batch", "acreate_file"])
+def test_get_spend_logs_id_stays_unique_when_the_response_is_a_redaction_placeholder(call_type):
+    """request_id is the LiteLLM_SpendLogs primary key and the flush inserts with
+    skip_duplicates, so two calls must never derive the same id from identical response
+    content. Message redaction replaces every body it cannot redact with one fixed
+    placeholder, which is what a batch and a file body both become, so hashing the
+    response collapsed all of them onto a single id and silently dropped every row
+    after the first."""
+    suffix = "_batch_cost" if call_type == "aretrieve_batch" else ""
+    first = get_spend_logs_id(call_type, dict(REDACTED_RESPONSE_PLACEHOLDER), {"litellm_call_id": "call-id-1"})
+    second = get_spend_logs_id(call_type, dict(REDACTED_RESPONSE_PLACEHOLDER), {"litellm_call_id": "call-id-2"})
+
+    assert first == f"call-id-1{suffix}"
+    assert second == f"call-id-2{suffix}"
+    assert first != second
+    assert first != CONSTANT_ID_FROM_HASHED_PLACEHOLDER
+    assert second != CONSTANT_ID_FROM_HASHED_PLACEHOLDER
+
+
+@pytest.mark.parametrize("call_type", ["aretrieve_batch", "acreate_file"])
+def test_get_spend_logs_id_prefers_the_response_id_for_batch_and_file_calls(call_type):
+    """A batch or file response that survives redaction carries its own id, so the row
+    keys off that rather than the per-call id."""
+    expected = "batch_abc123_batch_cost" if call_type == "aretrieve_batch" else "batch_abc123"
+    assert get_spend_logs_id(call_type, {"id": "batch_abc123"}, {"litellm_call_id": "call-id-1"}) == expected
+
+
+def test_get_logging_payload_gives_redacted_batch_and_file_rows_distinct_request_ids():
+    """End to end at the payload level: a batch retrieve and a file create whose bodies
+    were both flattened to the same redaction placeholder must still produce two
+    insertable rows, each carrying its own spend."""
+    payloads = [
+        get_logging_payload(
+            kwargs={
+                "call_type": call_type,
+                "model": model,
+                "litellm_call_id": call_id,
+                "litellm_params": {"metadata": {"user_api_key": "test-key"}},
+            },
+            response_obj=dict(REDACTED_RESPONSE_PLACEHOLDER),
+            start_time=datetime.datetime.now(timezone.utc),
+            end_time=datetime.datetime.now(timezone.utc),
+        )
+        for call_type, model, call_id in (
+            ("aretrieve_batch", "global.anthropic.claude-haiku-4-5-20251001-v1:0", "call-id-batch"),
+            ("acreate_file", "vertex_ai/gemini-2.5-flash", "call-id-file"),
+        )
+    ]
+    request_ids = [payload["request_id"] for payload in payloads]
+
+    assert request_ids == ["call-id-batch_batch_cost", "call-id-file"]
+    assert len(set(request_ids)) == len(request_ids)
+    assert CONSTANT_ID_FROM_HASHED_PLACEHOLDER not in request_ids
+
+
+@pytest.mark.parametrize("call_type", ["aretrieve_batch", "acreate_file"])
+def test_get_spend_logs_id_keys_off_batch_identity_when_the_body_was_redacted(call_type):
+    """Retrieving one batch twice must produce one row, not two. Redaction strips the id
+    off the response body, so the identity has to come from the standard logging payload,
+    which is built from the unredacted response and keeps it. Falling through to the
+    per-call id here would write a second row carrying the same batch's full cost and
+    overstate spend by a multiple of how often the caller polled."""
+    standard_logging_object = {"id": "batch_abc123"}
+    first = get_spend_logs_id(
+        call_type,
+        dict(REDACTED_RESPONSE_PLACEHOLDER),
+        {"litellm_call_id": "call-id-1", "standard_logging_object": standard_logging_object},
+    )
+    second = get_spend_logs_id(
+        call_type,
+        dict(REDACTED_RESPONSE_PLACEHOLDER),
+        {"litellm_call_id": "call-id-2", "standard_logging_object": standard_logging_object},
+    )
+
+    expected = "batch_abc123_batch_cost" if call_type == "aretrieve_batch" else "batch_abc123"
+    assert first == second == expected
+    assert first != CONSTANT_ID_FROM_HASHED_PLACEHOLDER
+
+
+def test_get_spend_logs_id_separates_distinct_batches_whose_bodies_were_both_redacted():
+    """The flip side of idempotency: two different batches must not share a row just
+    because redaction flattened both bodies to the same placeholder."""
+    ids = [
+        get_spend_logs_id(
+            "aretrieve_batch",
+            dict(REDACTED_RESPONSE_PLACEHOLDER),
+            {"litellm_call_id": f"call-id-{index}", "standard_logging_object": {"id": batch_id}},
+        )
+        for index, batch_id in enumerate(("batch_first", "batch_second"))
+    ]
+
+    assert ids == ["batch_first_batch_cost", "batch_second_batch_cost"]
+
+
+def test_get_spend_logs_id_prefers_the_response_id_over_the_standard_logging_id():
+    """An unredacted response keeps deciding its own row key, so cache-hit ids and every
+    other call type behave exactly as they did before."""
+    assert (
+        get_spend_logs_id(
+            "acompletion",
+            {"id": "chatcmpl-from-response"},
+            {"litellm_call_id": "call-id-1", "standard_logging_object": {"id": "id-from-standard-payload"}},
+        )
+        == "chatcmpl-from-response"
+    )
+
+
+def test_batch_cost_row_does_not_collide_with_the_batch_creation_row():
+    """Creating a batch writes a row keyed by the batch's own id, so keying the cost row
+    the same way makes the insert a duplicate of it. request_id is the primary key and the
+    flush skips duplicates, so the cost row is dropped with no error and the batch is
+    billed nothing. Observed against a live proxy: the poller computed and flushed the
+    cost, and the only row carrying that id was the acreate_batch row written when the
+    batch was submitted."""
+    batch_id = "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDphYmM7bGxtX2JhdGNoX2lkOnh5eg"
+
+    creation_row_id = get_spend_logs_id("acreate_batch", {"id": batch_id}, {"litellm_call_id": "call-create"})
+    cost_row_id = get_spend_logs_id(
+        "aretrieve_batch",
+        dict(REDACTED_RESPONSE_PLACEHOLDER),
+        {"litellm_call_id": "call-poller", "standard_logging_object": {"id": batch_id}},
+    )
+
+    assert creation_row_id == batch_id
+    assert cost_row_id != creation_row_id
+    assert cost_row_id == f"{batch_id}_batch_cost"
+
+
+def test_batch_cost_row_id_is_stable_across_repeated_accounting():
+    """The cost row stays keyed to the batch, so accounting the same batch twice collapses
+    to one row instead of billing it twice."""
+    standard_logging_object = {"id": "batch_same"}
+    ids = [
+        get_spend_logs_id(
+            "aretrieve_batch",
+            dict(REDACTED_RESPONSE_PLACEHOLDER),
+            {"litellm_call_id": f"call-{index}", "standard_logging_object": standard_logging_object},
+        )
+        for index in range(2)
+    ]
+
+    assert ids[0] == ids[1] == "batch_same_batch_cost"

--- a/type-discipline-budget.json
+++ b/type-discipline-budget.json
@@ -15,7 +15,7 @@
     "limit": 0
   },
   "LIT006": {
-    "limit": 1074
+    "limit": 1072
   },
   "LIT007": {
     "limit": 0
@@ -27,7 +27,7 @@
     "limit": 0
   },
   "LIT010": {
-    "limit": 16716
+    "limit": 16715
   },
   "LIT011": {
     "limit": 5596


### PR DESCRIPTION
## TLDR

Problem this solves:

- Batch and file spend rows share one hardcoded primary key
- Message redaction makes that key a constant
- Every row after the first is silently dropped
- Batch cost never reaches /spend/logs or chargeback

How it solves it:

- Derive request_id from the response or call id
- Namespace a batch cost row away from its creation row

## User Flow

Before: a team running batch jobs through the gateway with message redaction on never sees a completed batch's cost in their spend logs

1. The proxy admin turns on message redaction (`litellm_settings: turn_off_message_logging: true`) and restarts the proxy
2. A developer uploads a JSONL file with POST https://litellm-domain/v1/files (`purpose: batch`, `target_model_names: <model>`) and gets back a gateway file id
3. They send POST https://litellm-domain/v1/batches with that `input_file_id` and get back a batch id with `status: validating`
4. They poll GET https://litellm-domain/v1/batches/{batch_id} until it returns `status: completed`
5. After the batch completes they GET https://litellm-domain/spend/logs (or open https://litellm-domain/ui/?page=logs) and find no entry for the completed batch at all: only the $0 batch creation row and the $0 file upload row, and the upload's request id is the same 32-character value (`00fcbef15a3b0097e14b0ca016ed30a0`) for every upload and every batch on the proxy, so the batch's tokens and cost never reach the key's or team's spend

After: the same batch lands in the spend logs as its own entry with its real cost

1. The proxy admin turns on message redaction (`litellm_settings: turn_off_message_logging: true`) and restarts the proxy
2. A developer uploads a JSONL file with POST https://litellm-domain/v1/files (`purpose: batch`, `target_model_names: <model>`) and gets back a gateway file id
3. They send POST https://litellm-domain/v1/batches with that `input_file_id` and get back a batch id with `status: validating`
4. They poll GET https://litellm-domain/v1/batches/{batch_id} until it returns `status: completed`
5. After the batch completes, GET https://litellm-domain/spend/logs (or https://litellm-domain/ui/?page=logs) shows an entry for the batch with `call_type: aretrieve_batch`, request id `{batch_id}_batch_cost`, and the batch's real token counts and cost, next to the batch creation row keyed by the batch id and the file upload row keyed by the provider's own file id instead of one fixed id shared with every other upload

## Relevant issues

Sibling finding from the same investigation as #36638, which fixed message redaction aborting success logging on a batch output body. Independent of it, since this bug predates that PR and neither fix depends on the other.

#36877 is the companion change that stops a batch's cost being accounted twice, or not at all when a caller's retrieve races the cost poller. That one decides whether the cost gets computed; this one decides whether the resulting row can be stored.

## Linear ticket

Resolves LIT-5621

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Same end-user flow run twice against live proxies, each on a fresh Postgres database, with message redaction on and a real OpenAI managed batch (`openai/gpt-5.4-nano`, two chat requests, real $). Config used by both:

```yaml
model_list:
  - model_name: gpt-5.4-nano
    litellm_params:
      model: openai/gpt-5.4-nano
      api_key: os.environ/OPENAI_API_KEY
litellm_settings:
  turn_off_message_logging: true
general_settings:
  proxy_batch_polling_interval: 20
```

```
$ cat input.jsonl
{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-5.4-nano", "messages": [{"role": "user", "content": "Say hello in one word"}], "max_completion_tokens": 200}}
{"custom_id": "req-2", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-5.4-nano", "messages": [{"role": "user", "content": "Name one color, one word"}], "max_completion_tokens": 200}}
```

**Before, at 6704a105ee (merge base), proxy on port 29010**

```
$ curl -sS http://127.0.0.1:29010/v1/files -H "Authorization: Bearer $KEY" -F purpose=batch -F target_model_names=gpt-5.4-nano -F file=@input.jsonl
{
    "id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07dW5pZmllZF9pZCw2ODk0MzJiMS1mMzA1LTRjYzktYTBkMy05NmMwOGZmYmUzMzU7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC01LjQtbmFubztsbG1fb3V0cHV0X2ZpbGVfaWQsZmlsZS1SWVZpTVRncU1pZUZFWVc0RGl0RHl6O2xsbV9vdXRwdXRfZmlsZV9tb2RlbF9pZCxkZjZhOGE3NmE1YTdmM2I2ZWI1YWMxZDM5M2I4MmExMjY2YzUyYjc4ZWUyZGE5NjkyYjhhZmZlNmQxZjZiYjlj",
    "object": "file",
    "purpose": "batch",
    "status": "uploaded",
    ...
}

$ curl -sS http://127.0.0.1:29010/v1/batches -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"input_file_id": "<file id above>", "endpoint": "/v1/chat/completions", "completion_window": "24h"}'
{
    "id": "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpkZjZhOGE3NmE1YTdmM2I2ZWI1YWMxZDM5M2I4MmExMjY2YzUyYjc4ZWUyZGE5NjkyYjhhZmZlNmQxZjZiYjljO2xsbV9iYXRjaF9pZDpiYXRjaF82YTgwYjU1YzhhNTA4MTkwYTU0ZjhlM2EwYWEyZGQ5OA",
    "object": "batch",
    "status": "validating",
    ...
}

$ while true; do curl -sS http://127.0.0.1:29010/v1/batches/$BATCH_ID -H "Authorization: Bearer $KEY" | jq -c '{status, request_counts}'; sleep 20; done   # until status is completed
11:52:13 {"status": "validating", "request_counts": {"completed": 0, "failed": 0, "total": 0}}
11:52:33 {"status": "validating", "request_counts": {"completed": 0, "failed": 0, "total": 0}}
11:52:53 {"status": "validating", "request_counts": {"completed": 0, "failed": 0, "total": 0}}
11:53:14 {"status": "validating", "request_counts": {"completed": 0, "failed": 0, "total": 0}}
11:53:34 {"status": "completed", "request_counts": {"completed": 2, "failed": 0, "total": 2}}

# 75s later, past the 20s polling interval plus jitter and the spend log flush
$ curl -sS "http://127.0.0.1:29010/spend/logs" -H "Authorization: Bearer $KEY" | jq -c '.[] | {request_id, call_type, model, spend, total_tokens, prompt_tokens, completion_tokens, startTime}'
{"request_id": "829dc768-cc0e-4f64-9bee-5b47ab6e4286", "call_type": "acreate_batch", "model": "openai/gpt-5.4-nano", "spend": 0.0, "total_tokens": 0, "prompt_tokens": 0, "completion_tokens": 0, "startTime": "2026-08-15T18:52:12.215000Z"}
{"request_id": "00fcbef15a3b0097e14b0ca016ed30a0", "call_type": "acreate_file", "model": "openai/gpt-5.4-nano", "spend": 0.0, "total_tokens": 0, "prompt_tokens": 0, "completion_tokens": 0, "startTime": "2026-08-15T18:52:10.989000Z"}

$ curl -sS "http://127.0.0.1:29010/spend/logs?request_id=${BATCH_ID}_batch_cost" -H "Authorization: Bearer $KEY" | jq -c '.[] | {request_id, call_type, model, spend, total_tokens}'
(no rows)

$ curl -sS "http://127.0.0.1:29010/spend/logs?request_id=00fcbef15a3b0097e14b0ca016ed30a0" -H "Authorization: Bearer $KEY" | jq -c '.[] | {request_id, call_type, model, spend}'
{"request_id": "00fcbef15a3b0097e14b0ca016ed30a0", "call_type": "acreate_file", "model": "openai/gpt-5.4-nano", "spend": 0.0}
```

No `aretrieve_batch` row anywhere. The proxy did compute and try to write the batch's cost, under the same fixed id the file upload already occupied, so the flush silently dropped it:

```
$ grep "Writing spend log to db" proxy_before.log
11:52:12 ... Writing spend log to db - request_id: 00fcbef15a3b0097e14b0ca016ed30a0, spend: 0.0
11:52:13 ... Writing spend log to db - request_id: 829dc768-cc0e-4f64-9bee-5b47ab6e4286, spend: 0.0
11:53:34 ... Writing spend log to db - request_id: 00fcbef15a3b0097e14b0ca016ed30a0, spend: 7.3e-06
```

**After, at 363e3f3f03 (this PR's tip), proxy on port 51449**

```
$ curl -sS http://127.0.0.1:51449/v1/files -H "Authorization: Bearer $KEY" -F purpose=batch -F target_model_names=gpt-5.4-nano -F file=@input.jsonl
{
    "id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07dW5pZmllZF9pZCwzMmMzMjQyNC03ODg4LTRlNmMtOGQ4NC03NWJiMzVhMzhiZmM7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC01LjQtbmFubztsbG1fb3V0cHV0X2ZpbGVfaWQsZmlsZS00NjFwNTVaQVd0eEp5QkdRa1dVWTZFO2xsbV9vdXRwdXRfZmlsZV9tb2RlbF9pZCxkZjZhOGE3NmE1YTdmM2I2ZWI1YWMxZDM5M2I4MmExMjY2YzUyYjc4ZWUyZGE5NjkyYjhhZmZlNmQxZjZiYjlj",
    "object": "file",
    "purpose": "batch",
    "status": "uploaded",
    ...
}

$ curl -sS http://127.0.0.1:51449/v1/batches -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"input_file_id": "<file id above>", "endpoint": "/v1/chat/completions", "completion_window": "24h"}'
{
    "id": "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpkZjZhOGE3NmE1YTdmM2I2ZWI1YWMxZDM5M2I4MmExMjY2YzUyYjc4ZWUyZGE5NjkyYjhhZmZlNmQxZjZiYjljO2xsbV9iYXRjaF9pZDpiYXRjaF82YTgwYjU1Yzg4NTg4MTkwOTA2YzBlNzQ2Yzc1YjdlYQ",
    "object": "batch",
    "status": "validating",
    ...
}

$ while true; do curl -sS http://127.0.0.1:51449/v1/batches/$BATCH_ID -H "Authorization: Bearer $KEY" | jq -c '{status, request_counts}'; sleep 20; done   # until status is completed
11:52:13 {"status": "validating", "request_counts": {"completed": 0, "failed": 0, "total": 0}}
11:52:33 {"status": "validating", "request_counts": {"completed": 0, "failed": 0, "total": 0}}
11:52:53 {"status": "validating", "request_counts": {"completed": 0, "failed": 0, "total": 0}}
11:53:14 {"status": "validating", "request_counts": {"completed": 0, "failed": 0, "total": 0}}
11:53:34 {"status": "in_progress", "request_counts": {"completed": 1, "failed": 0, "total": 2}}
11:53:54 {"status": "in_progress", "request_counts": {"completed": 1, "failed": 0, "total": 2}}
11:54:14 {"status": "in_progress", "request_counts": {"completed": 1, "failed": 0, "total": 2}}
11:54:35 {"status": "completed", "request_counts": {"completed": 2, "failed": 0, "total": 2}}

# 75s later, past the 20s polling interval plus jitter and the spend log flush
$ curl -sS "http://127.0.0.1:51449/spend/logs" -H "Authorization: Bearer $KEY" | jq -c '.[] | {request_id, call_type, model, spend, total_tokens, prompt_tokens, completion_tokens, startTime}'
{"request_id": "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpkZjZhOGE3NmE1YTdmM2I2ZWI1YWMxZDM5M2I4MmExMjY2YzUyYjc4ZWUyZGE5NjkyYjhhZmZlNmQxZjZiYjljO2xsbV9iYXRjaF9pZDpiYXRjaF82YTgwYjU1Yzg4NTg4MTkwOTA2YzBlNzQ2Yzc1YjdlYQ_batch_cost", "call_type": "aretrieve_batch", "model": "openai/gpt-5.4-nano", "spend": 7.3e-06, "total_tokens": 31, "prompt_tokens": 23, "completion_tokens": 8, "startTime": "2026-08-15T18:54:35.040000Z"}
{"request_id": "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpkZjZhOGE3NmE1YTdmM2I2ZWI1YWMxZDM5M2I4MmExMjY2YzUyYjc4ZWUyZGE5NjkyYjhhZmZlNmQxZjZiYjljO2xsbV9iYXRjaF9pZDpiYXRjaF82YTgwYjU1Yzg4NTg4MTkwOTA2YzBlNzQ2Yzc1YjdlYQ", "call_type": "acreate_batch", "model": "openai/gpt-5.4-nano", "spend": 0.0, "total_tokens": 0, "prompt_tokens": 0, "completion_tokens": 0, "startTime": "2026-08-15T18:52:12.210000Z"}
{"request_id": "file-461p55ZAWtxJyBGQkWUY6E", "call_type": "acreate_file", "model": "openai/gpt-5.4-nano", "spend": 0.0, "total_tokens": 0, "prompt_tokens": 0, "completion_tokens": 0, "startTime": "2026-08-15T18:52:10.982000Z"}

$ curl -sS "http://127.0.0.1:51449/spend/logs?request_id=${BATCH_ID}_batch_cost" -H "Authorization: Bearer $KEY" | jq -c '.[] | {request_id, call_type, model, spend, total_tokens}'
{"request_id": "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpkZjZhOGE3NmE1YTdmM2I2ZWI1YWMxZDM5M2I4MmExMjY2YzUyYjc4ZWUyZGE5NjkyYjhhZmZlNmQxZjZiYjljO2xsbV9iYXRjaF9pZDpiYXRjaF82YTgwYjU1Yzg4NTg4MTkwOTA2YzBlNzQ2Yzc1YjdlYQ_batch_cost", "call_type": "aretrieve_batch", "model": "openai/gpt-5.4-nano", "spend": 7.3e-06, "total_tokens": 31}

$ curl -sS "http://127.0.0.1:51449/spend/logs?request_id=00fcbef15a3b0097e14b0ca016ed30a0" -H "Authorization: Bearer $KEY" | jq -c '.[] | {request_id, call_type, model, spend}'
(no rows)
```

The batch cost row lands under `{batch_id}_batch_cost` with the batch's real usage (23 prompt, 8 completion tokens, the same $7.3e-06 the before proxy computed and lost), the batch creation row is keyed by the batch id, and the file upload row is keyed by the provider's file id. The seven in-progress polls wrote no spend row on either proxy, only the completed poll did:

```
$ grep "Writing spend log to db" proxy_after.log
11:52:12 ... Writing spend log to db - request_id: file-461p55ZAWtxJyBGQkWUY6E, spend: 0.0
11:52:13 ... Writing spend log to db - request_id: bGl0...YjdlYQ, spend: 0.0
11:54:35 ... Writing spend log to db - request_id: bGl0...YjdlYQ_batch_cost, spend: 7.3e-06
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Bedrock Converse batch output still logs $0 usage, tracked separately
- Relies on in-progress polls logging nothing, which they do today

## Changes

`get_spend_logs_id` no longer hashes the response. Every call type now derives its id the same way, preferring the response's own id, then the standard logging payload's id, then `litellm_call_id`.

The middle term is what keeps this correct under redaction. That payload is built from the unredacted response, so it still carries the batch id after redaction has flattened the body. Without it a redacted batch falls through to the per-call id, which writes a fresh row per retrieve, each carrying the same batch's full cost, and overstates spend by however many times the caller polled.

A batch cost row is namespaced with a `_batch_cost` suffix so it cannot collide with the `acreate_batch` row written when the batch was submitted. This follows the existing precedent for cache hits, which already suffix the id to avoid duplicating a request id.

Cost and usage themselves are unaffected by redaction and were verified to stay correct in both modes: the token columns fall back to the standard logging payload and spend comes from its `response_cost`, neither of which redaction touches. `generate_hash_from_response` had no other caller and is removed with it.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 363e3f3f03e959cb1242ced5f20dc051076fdd4e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
