### PR TITLE
fix(batches): account a managed batch's cost exactly once

### DIFF
--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -51,6 +51,7 @@ class CheckBatchCost:
         # Cached after the first poll cycle. Once we know the column is absent we skip
         # the guaranteed-failing primary query on every subsequent cycle.
         self._has_batch_processed_column: bool = True
+        self.batch_processed_support_confirmed: bool = False
 
     async def _get_user_info(self, batch_id: str, user_id: Optional[str]) -> Dict[str, Any]:
         """
@@ -722,6 +723,7 @@ class CheckBatchCost:
                     take=MAX_OBJECTS_PER_POLL_CYCLE,
                     order={"created_at": "asc"},
                 )
+                self.batch_processed_support_confirmed = True
             except Exception as query_err:
                 if "batch_processed" not in str(query_err).lower() and "unknown column" not in str(query_err).lower() and "does not exist" not in str(query_err).lower():
                     raise

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -498,10 +498,11 @@ async def retrieve_batch(
             )
 
         if unified_batch_id and batch_cost_poller_is_active():
-            data["litellm_metadata"] = {
-                **(data.get("litellm_metadata") or {}),
-                "batch_ignore_default_logging": True,
-            }
+            litellm_metadata = data.get("litellm_metadata")
+            if not isinstance(litellm_metadata, dict):
+                litellm_metadata = {}  # mutable-ok: the suppression flag must live inside litellm_metadata for the success handler to read it, and this request carried no mapping to extend
+                data["litellm_metadata"] = litellm_metadata
+            litellm_metadata["batch_ignore_default_logging"] = True
 
         # Retrieve from provider (for non-terminal states or if DB lookup failed)
         # SCENARIO 1: Batch ID is encoded with model info

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -497,7 +497,8 @@ async def retrieve_batch(
                 "Batch %s is in non-terminal state %s, syncing with provider", batch_id, response.status
             )
 
-        if unified_batch_id and batch_cost_poller_is_active():
+        poller_owns_accounting: Final = bool(unified_batch_id) and batch_cost_poller_is_active()
+        if poller_owns_accounting:
             litellm_metadata = data.get("litellm_metadata")
             if not isinstance(litellm_metadata, dict):
                 litellm_metadata = {}  # mutable-ok: the suppression flag must live inside litellm_metadata for the success handler to read it, and this request carried no mapping to extend
@@ -581,6 +582,7 @@ async def retrieve_batch(
             verbose_proxy_logger=verbose_proxy_logger,
             db_batch_object=db_batch_object,
             operation="retrieve",
+            poller_owns_accounting=poller_owns_accounting,
         )
 
         ### CALL HOOKS ### - modify outgoing data

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -24,6 +24,7 @@ from litellm.proxy.common_utils.openai_endpoint_utils import (
 from litellm.proxy.openai_files_endpoints.common_utils import (
     _is_base64_encoded_unified_file_id,
     apply_team_provider_credentials,
+    batch_cost_poller_is_active,
     decode_model_from_file_id,
     encode_batch_response_ids,
     encode_file_id_with_model,
@@ -495,6 +496,12 @@ async def retrieve_batch(
             verbose_proxy_logger.debug(
                 "Batch %s is in non-terminal state %s, syncing with provider", batch_id, response.status
             )
+
+        if unified_batch_id and batch_cost_poller_is_active():
+            data["litellm_metadata"] = {
+                **(data.get("litellm_metadata") or {}),
+                "batch_ignore_default_logging": True,
+            }
 
         # Retrieve from provider (for non-terminal states or if DB lookup failed)
         # SCENARIO 1: Batch ID is encoded with model info

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -1233,11 +1233,16 @@ async def get_batch_from_database(
 
 def batch_cost_poller_is_active() -> bool:
     """
-    Whether the CheckBatchCost poller is running and will therefore account for a
-    managed batch's cost itself.
+    Whether the CheckBatchCost poller will account for a managed batch's cost itself.
 
-    False whenever the poller cannot be relied on: polling disabled by config, or the
-    job absent from the scheduler because the enterprise import failed.
+    False whenever the poller cannot be relied on: polling disabled by config, the job
+    absent from the scheduler because the enterprise import failed, or the poller not
+    yet having confirmed that the batch_processed column exists. That last condition
+    matters because the poller needs the column both to find outstanding batches and to
+    mark them accounted; without it the poller falls back to a query that excludes
+    terminal statuses, so a batch the retrieve path has already marked complete becomes
+    invisible to it. Defaulting to False until the poller confirms support keeps the
+    retrieve path accounting in exactly the cases the poller would drop the batch.
     """
     from litellm.constants import PROXY_BATCH_POLLING_ENABLED
 
@@ -1249,7 +1254,11 @@ def batch_cost_poller_is_active() -> bool:
         scheduler = getattr(proxy_server_module, "scheduler", None)
         if scheduler is None:
             return False
-        return scheduler.get_job("check_batch_cost_job") is not None
+        job = scheduler.get_job("check_batch_cost_job")
+        if job is None:
+            return False
+        poller = getattr(getattr(job, "func", None), "__self__", None)
+        return getattr(poller, "batch_processed_support_confirmed", False) is True
     except Exception:  # noqa: BLE001  # scheduler backends raise varied types from get_job; an unreadable scheduler means the poller cannot be relied on
         return False
 

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -1231,6 +1231,29 @@ async def get_batch_from_database(
         return None, None
 
 
+def batch_cost_poller_is_active() -> bool:
+    """
+    Whether the CheckBatchCost poller is running and will therefore account for a
+    managed batch's cost itself.
+
+    False whenever the poller cannot be relied on: polling disabled by config, or the
+    job absent from the scheduler because the enterprise import failed.
+    """
+    from litellm.constants import PROXY_BATCH_POLLING_ENABLED
+
+    if not PROXY_BATCH_POLLING_ENABLED:
+        return False
+    try:
+        import litellm.proxy.proxy_server as proxy_server_module
+
+        scheduler = getattr(proxy_server_module, "scheduler", None)
+        if scheduler is None:
+            return False
+        return scheduler.get_job("check_batch_cost_job") is not None
+    except Exception:  # noqa: BLE001  # scheduler backends raise varied types from get_job; an unreadable scheduler means the poller cannot be relied on
+        return False
+
+
 async def update_batch_in_database(
     batch_id: str,
     unified_batch_id: str | Literal[False],
@@ -1304,15 +1327,7 @@ async def update_batch_in_database(
             "updated_at": litellm.utils.get_utc_datetime(),
         }
 
-        # When a batch reaches completion, also mark batch_processed=True.
-        # The cost callback is enqueued asynchronously during the
-        # aretrieve_batch call that detected completion (via the @client
-        # decorator).  It is not awaited, so there is a theoretical window
-        # where the callback hasn't executed yet.  In practice the callback
-        # completes reliably.  Setting the flag here unblocks file deletion
-        # which queries batch_processed=False.  CheckBatchCost acts as a
-        # safety net for the rare case where the callback fails.
-        if db_status == "complete":
+        if db_status == "complete" and not batch_cost_poller_is_active():
             update_data["batch_processed"] = True
 
         try:

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -1273,6 +1273,7 @@ async def update_batch_in_database(
     db_batch_object=None,
     operation: str = "update",
     user_api_key_dict=None,
+    poller_owns_accounting: bool | None = None,
 ):
     """
     Update batch status and object in ManagedObjectTable.
@@ -1287,6 +1288,12 @@ async def update_batch_in_database(
         db_batch_object: Optional existing database object; fetched by unified_object_id when omitted
         operation: Description of operation ("update", "cancel", etc.)
         user_api_key_dict: Optional auth context for creating managed file IDs
+        poller_owns_accounting: Whether the caller already decided that the cost poller
+            owns this batch's accounting. Callers that suppress their own inline
+            accounting must pass the same decision they acted on, because re-deciding
+            here can observe a poller that became usable in between and leave the batch
+            unmarked after it was already accounted for, billing it twice. Left None by
+            callers that record no cost themselves.
     """
     import litellm.utils
 
@@ -1336,7 +1343,10 @@ async def update_batch_in_database(
             "updated_at": litellm.utils.get_utc_datetime(),
         }
 
-        if db_status == "complete" and not batch_cost_poller_is_active():
+        poller_owns: Final = (
+            batch_cost_poller_is_active() if poller_owns_accounting is None else poller_owns_accounting
+        )
+        if db_status == "complete" and not poller_owns:
             update_data["batch_processed"] = True
 
         try:

--- a/tests/proxy_unit_tests/test_check_batch_cost.py
+++ b/tests/proxy_unit_tests/test_check_batch_cost.py
@@ -143,6 +143,11 @@ class TestCheckBatchCost:
         assert "complete" not in not_in
         assert "completed" not in not_in
         assert find_call[1]["where"]["batch_processed"] is False
+        # A successful filtered query is the only proof the column exists. The retrieve
+        # path reads this to decide whether handing accounting to the poller is safe:
+        # without the column the poller's fallback query excludes complete/completed, so
+        # a batch already marked complete would never be accounted by anyone.
+        assert check_batch_cost_instance.batch_processed_support_confirmed is True
 
     @pytest.mark.asyncio
     async def test_fallback_query_used_when_batch_processed_missing(
@@ -171,6 +176,7 @@ class TestCheckBatchCost:
         assert calls[1][1]["take"] == MAX_OBJECTS_PER_POLL_CYCLE
         # Column absence is now cached — next call should go straight to fallback
         assert check_batch_cost_instance._has_batch_processed_column is False
+        assert check_batch_cost_instance.batch_processed_support_confirmed is False
 
     @pytest.mark.asyncio
     async def test_column_absence_cached_across_cycles(

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -2406,3 +2406,47 @@ async def test_cancel__unified_batch_id_allowed_when_managed_files_required(canc
         await call_cancel(cancel_harness, _unified_batch_id())
 
     assert cancel_harness.router_acancel.call_count == 1
+
+
+# =========================================================================== #
+# Retrieve - who accounts for a managed batch's cost. Retrieving a batch and
+# the CheckBatchCost poller both computed it, so whichever observed completion
+# first won and the other either double counted or was locked out.
+# =========================================================================== #
+
+
+@pytest.mark.asyncio
+async def test_retrieve__managed_batch_defers_cost_to_the_poller_when_it_is_running(retrieve_harness):
+    """With the poller running it is the single accountant, so the retrieve must not also
+    record cost. Without this the same batch is billed once per retrieve, and a caller
+    polling its own batch inflates spend by however many times it looked."""
+    with patch.object(endpoints, "batch_cost_poller_is_active", MagicMock(return_value=True)):
+        await call_retrieve(retrieve_harness, _unified_batch_id())
+
+    assert retrieve_harness.router.aretrieve_batch.await_count == 1
+    metadata = retrieve_harness.router.aretrieve_batch.await_args.kwargs.get("litellm_metadata") or {}
+    assert metadata.get("batch_ignore_default_logging") is True
+
+
+@pytest.mark.asyncio
+async def test_retrieve__managed_batch_still_accounts_inline_without_a_poller(retrieve_harness):
+    """No poller means nothing else will ever account for this batch, so the retrieve has
+    to keep doing it. Suppressing here unconditionally would lose batch cost entirely on
+    any proxy running with batch polling disabled."""
+    with patch.object(endpoints, "batch_cost_poller_is_active", MagicMock(return_value=False)):
+        await call_retrieve(retrieve_harness, _unified_batch_id())
+
+    assert retrieve_harness.router.aretrieve_batch.await_count == 1
+    metadata = retrieve_harness.router.aretrieve_batch.await_args.kwargs.get("litellm_metadata") or {}
+    assert metadata.get("batch_ignore_default_logging") is None
+
+
+@pytest.mark.asyncio
+async def test_retrieve__raw_batch_id_is_untouched_by_the_poller_handoff(retrieve_harness):
+    """An unmanaged batch has no managed object row and so no poller queue entry. It must
+    keep accounting inline whatever the poller is doing."""
+    with patch.object(endpoints, "batch_cost_poller_is_active", MagicMock(return_value=True)):
+        await call_retrieve(retrieve_harness, "batch-raw-xyz")
+
+    metadata = retrieve_harness.litellm_aretrieve.await_args.kwargs.get("litellm_metadata") or {}
+    assert metadata.get("batch_ignore_default_logging") is None

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_common_utils.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_common_utils.py
@@ -106,19 +106,44 @@ class _FakeScheduler:
         return self._job
 
 
+class _FakePoller:
+    def __init__(self, confirmed):
+        self.batch_processed_support_confirmed = confirmed
+
+    def check_batch_cost(self):
+        return None
+
+
+def _job_for(poller):
+    if poller is None:
+        return None
+    job = MagicMock()
+    job.func = poller.check_batch_cost
+    return job
+
+
 @pytest.mark.parametrize(
     "polling_enabled, job, expected",
     [
-        (True, object(), True),
+        (True, _job_for(_FakePoller(confirmed=True)), True),
+        (True, _job_for(_FakePoller(confirmed=False)), False),
         (True, None, False),
-        (False, object(), False),
+        (False, _job_for(_FakePoller(confirmed=True)), False),
     ],
-    ids=["poller-running", "job-absent-enterprise-import-failed", "polling-disabled-by-config"],
+    ids=[
+        "poller-running-and-column-confirmed",
+        "poller-running-but-column-unconfirmed",
+        "job-absent-enterprise-import-failed",
+        "polling-disabled-by-config",
+    ],
 )
 def test_batch_cost_poller_is_active(monkeypatch, polling_enabled, job, expected):
     """The predicate must only claim the poller when it can actually be relied on, so a
-    proxy with polling switched off or without the enterprise job keeps accounting for
-    batch cost on the retrieve path."""
+    proxy with polling switched off, without the enterprise job, or whose poller has not
+    confirmed batch_processed support keeps accounting for batch cost on the retrieve
+    path. The unconfirmed case is the one that matters for legacy schemas: without the
+    column the poller falls back to a query excluding terminal statuses, so a batch the
+    retrieve path already marked complete would never be accounted by anyone."""
     import litellm.constants
     import litellm.proxy.proxy_server as proxy_server_module
     from litellm.proxy.openai_files_endpoints.common_utils import (
@@ -206,3 +231,98 @@ async def test_retrieving_a_completed_batch_still_marks_processed_without_a_cost
 
     assert data["batch_processed"] is True
     assert data["status"] == "complete"
+
+
+def test_batch_cost_poller_is_active_is_false_when_the_job_has_no_bound_poller(monkeypatch):
+    """A scheduler that hands back a plain function rather than a bound method leaves no
+    poller to interrogate, so the predicate stays conservative instead of assuming the
+    column is supported."""
+    import litellm.constants
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy.openai_files_endpoints.common_utils import (
+        batch_cost_poller_is_active,
+    )
+
+    def unbound_check_batch_cost():
+        return None
+
+    job = MagicMock()
+    job.func = unbound_check_batch_cost
+
+    monkeypatch.setattr(litellm.constants, "PROXY_BATCH_POLLING_ENABLED", True, raising=False)
+    monkeypatch.setattr(proxy_server_module, "scheduler", _FakeScheduler(job), raising=False)
+
+    assert batch_cost_poller_is_active() is False
+
+
+def test_batch_cost_poller_is_active_is_false_when_get_job_raises(monkeypatch):
+    """Scheduler backends raise varied types; an unreadable scheduler must not be read as
+    a working poller."""
+    import litellm.constants
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy.openai_files_endpoints.common_utils import (
+        batch_cost_poller_is_active,
+    )
+
+    class _ExplodingScheduler:
+        def get_job(self, job_id):
+            raise RuntimeError("scheduler not started")
+
+    monkeypatch.setattr(litellm.constants, "PROXY_BATCH_POLLING_ENABLED", True, raising=False)
+    monkeypatch.setattr(proxy_server_module, "scheduler", _ExplodingScheduler(), raising=False)
+
+    assert batch_cost_poller_is_active() is False
+
+
+
+@pytest.mark.asyncio
+async def test_retrieving_a_batch_whose_status_is_unchanged_writes_nothing(monkeypatch):
+    """A caller polling an already-complete batch must not write at all, so repeated polls
+    cannot flip batch_processed or disturb whichever component owns accounting."""
+    import litellm.proxy.openai_files_endpoints.common_utils as cu
+
+    monkeypatch.setattr(cu, "batch_cost_poller_is_active", lambda: False)
+    monkeypatch.setattr(cu, "ensure_batch_response_managed_file_ids", AsyncMock())
+
+    prisma_client = MagicMock()
+    update_mock = AsyncMock()
+    prisma_client.db.litellm_managedobjecttable.update = update_mock
+
+    db_batch_object = MagicMock()
+    db_batch_object.status = "completed"
+
+    await cu.update_batch_in_database(
+        batch_id="unified-batch-id",
+        unified_batch_id="unified-batch-id",
+        response=_completed_batch(),
+        managed_files_obj=MagicMock(),
+        prisma_client=prisma_client,
+        verbose_proxy_logger=MagicMock(),
+        db_batch_object=db_batch_object,
+        operation="retrieve",
+    )
+
+    update_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_batch_in_database_is_a_noop_for_unmanaged_batches(monkeypatch):
+    """Batches with no managed object row have neither the flag nor a poller queue entry, so
+    this path must leave them alone entirely."""
+    import litellm.proxy.openai_files_endpoints.common_utils as cu
+
+    prisma_client = MagicMock()
+    update_mock = AsyncMock()
+    prisma_client.db.litellm_managedobjecttable.update = update_mock
+
+    await cu.update_batch_in_database(
+        batch_id="batch-raw-xyz",
+        unified_batch_id=False,
+        response=_completed_batch(),
+        managed_files_obj=MagicMock(),
+        prisma_client=prisma_client,
+        verbose_proxy_logger=MagicMock(),
+        operation="retrieve",
+    )
+
+    update_mock.assert_not_awaited()

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_common_utils.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_common_utils.py
@@ -95,3 +95,114 @@ def test_apply_unified_file_ids_swaps_all_three_ids():
         "unified-out",
         "unified-err",
     )
+
+
+class _FakeScheduler:
+    def __init__(self, job):
+        self._job = job
+
+    def get_job(self, job_id):
+        assert job_id == "check_batch_cost_job"
+        return self._job
+
+
+@pytest.mark.parametrize(
+    "polling_enabled, job, expected",
+    [
+        (True, object(), True),
+        (True, None, False),
+        (False, object(), False),
+    ],
+    ids=["poller-running", "job-absent-enterprise-import-failed", "polling-disabled-by-config"],
+)
+def test_batch_cost_poller_is_active(monkeypatch, polling_enabled, job, expected):
+    """The predicate must only claim the poller when it can actually be relied on, so a
+    proxy with polling switched off or without the enterprise job keeps accounting for
+    batch cost on the retrieve path."""
+    import litellm.constants
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy.openai_files_endpoints.common_utils import (
+        batch_cost_poller_is_active,
+    )
+
+    monkeypatch.setattr(litellm.constants, "PROXY_BATCH_POLLING_ENABLED", polling_enabled, raising=False)
+    monkeypatch.setattr(proxy_server_module, "scheduler", _FakeScheduler(job), raising=False)
+
+    assert batch_cost_poller_is_active() is expected
+
+
+def test_batch_cost_poller_is_active_is_false_when_no_scheduler_exists(monkeypatch):
+    import litellm.constants
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy.openai_files_endpoints.common_utils import (
+        batch_cost_poller_is_active,
+    )
+
+    monkeypatch.setattr(litellm.constants, "PROXY_BATCH_POLLING_ENABLED", True, raising=False)
+    monkeypatch.setattr(proxy_server_module, "scheduler", None, raising=False)
+
+    assert batch_cost_poller_is_active() is False
+
+
+def _completed_batch() -> LiteLLMBatch:
+    return LiteLLMBatch(
+        id="batch-done",
+        completion_window="24h",
+        created_at=1234567890,
+        endpoint="/v1/chat/completions",
+        input_file_id="file-in",
+        object="batch",
+        status="completed",
+        output_file_id="file-out",
+    )
+
+
+async def _run_update(monkeypatch, poller_active: bool) -> dict:
+    import litellm.proxy.openai_files_endpoints.common_utils as cu
+
+    monkeypatch.setattr(cu, "batch_cost_poller_is_active", lambda: poller_active)
+    monkeypatch.setattr(cu, "ensure_batch_response_managed_file_ids", AsyncMock())
+
+    prisma_client = MagicMock()
+    update_mock = AsyncMock()
+    prisma_client.db.litellm_managedobjecttable.update = update_mock
+
+    db_batch_object = MagicMock()
+    db_batch_object.status = "in_progress"
+
+    await cu.update_batch_in_database(
+        batch_id="unified-batch-id",
+        unified_batch_id="unified-batch-id",
+        response=_completed_batch(),
+        managed_files_obj=MagicMock(),
+        prisma_client=prisma_client,
+        verbose_proxy_logger=MagicMock(),
+        db_batch_object=db_batch_object,
+        operation="retrieve",
+    )
+
+    assert update_mock.await_count == 1
+    return update_mock.await_args.kwargs["data"]
+
+
+@pytest.mark.asyncio
+async def test_retrieving_a_completed_batch_leaves_batch_processed_to_the_cost_poller(monkeypatch):
+    """batch_processed is what removes a batch from CheckBatchCost's queue, which selects
+    batch_processed=False. Retrieving a batch records no cost when the poller is active, so
+    setting the flag here retired the poller on behalf of work nobody had done: a cost
+    callback that then failed lost the batch's cost permanently with no retry left. The
+    status update must still happen so callers see the terminal state."""
+    data = await _run_update(monkeypatch, poller_active=True)
+
+    assert "batch_processed" not in data
+    assert data["status"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_retrieving_a_completed_batch_still_marks_processed_without_a_cost_poller(monkeypatch):
+    """With no poller to hand off to, this path is the only accountant, so it keeps setting
+    the flag. Otherwise a proxy with polling disabled would never unblock file deletion."""
+    data = await _run_update(monkeypatch, poller_active=False)
+
+    assert data["batch_processed"] is True
+    assert data["status"] == "complete"

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_common_utils.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_common_utils.py
@@ -326,3 +326,72 @@ async def test_update_batch_in_database_is_a_noop_for_unmanaged_batches(monkeypa
     )
 
     update_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_the_caller_s_accounting_decision_wins_over_a_later_poller_transition(monkeypatch):
+    """The ownership decision is made before the provider retrieval and acted on there, so
+    re-deciding afterwards can observe a poller that only just became usable. That split
+    left the retrieve accounting inline while the row stayed unmarked, so the poller
+    accounted for the same batch again and billed it twice. Passing the decision through
+    makes both halves agree even when the poller transitions mid-flight."""
+    import litellm.proxy.openai_files_endpoints.common_utils as cu
+
+    # The predicate now reports an active poller, i.e. it flipped during the retrieval.
+    monkeypatch.setattr(cu, "batch_cost_poller_is_active", lambda: True)
+    monkeypatch.setattr(cu, "ensure_batch_response_managed_file_ids", AsyncMock())
+
+    prisma_client = MagicMock()
+    update_mock = AsyncMock()
+    prisma_client.db.litellm_managedobjecttable.update = update_mock
+    db_batch_object = MagicMock()
+    db_batch_object.status = "in_progress"
+
+    await cu.update_batch_in_database(
+        batch_id="unified-batch-id",
+        unified_batch_id="unified-batch-id",
+        response=_completed_batch(),
+        managed_files_obj=MagicMock(),
+        prisma_client=prisma_client,
+        verbose_proxy_logger=MagicMock(),
+        db_batch_object=db_batch_object,
+        operation="retrieve",
+        poller_owns_accounting=False,
+    )
+
+    data = update_mock.await_args.kwargs["data"]
+    assert data["batch_processed"] is True
+    assert data["status"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_a_caller_that_handed_off_accounting_still_leaves_the_marker_alone(monkeypatch):
+    """The mirror case: a caller that suppressed its own accounting must leave the marker
+    for the poller even if the predicate has since stopped reporting one, otherwise the
+    batch is retired without anyone having accounted for it."""
+    import litellm.proxy.openai_files_endpoints.common_utils as cu
+
+    monkeypatch.setattr(cu, "batch_cost_poller_is_active", lambda: False)
+    monkeypatch.setattr(cu, "ensure_batch_response_managed_file_ids", AsyncMock())
+
+    prisma_client = MagicMock()
+    update_mock = AsyncMock()
+    prisma_client.db.litellm_managedobjecttable.update = update_mock
+    db_batch_object = MagicMock()
+    db_batch_object.status = "in_progress"
+
+    await cu.update_batch_in_database(
+        batch_id="unified-batch-id",
+        unified_batch_id="unified-batch-id",
+        response=_completed_batch(),
+        managed_files_obj=MagicMock(),
+        prisma_client=prisma_client,
+        verbose_proxy_logger=MagicMock(),
+        db_batch_object=db_batch_object,
+        operation="retrieve",
+        poller_owns_accounting=True,
+    )
+
+    data = update_mock.await_args.kwargs["data"]
+    assert "batch_processed" not in data
+    assert data["status"] == "complete"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Retrieving a batch and the cost poller both compute cost
- Whoever sees completion first locks the other out
- A failed callback loses that batch's cost permanently
- Repeated retrieves bill the same batch again

How it solves it:

- Only whoever recorded the cost marks it accounted
- The poller owns accounting whenever it is running

## User Flow

Before: a team running batch jobs through the gateway sees a completed batch billed once per status check, or not at all when the first check that sees completion fails to read the output

1. They upload a JSONL file with POST https://litellm-domain/v1/files (`purpose: batch`, `target_model_names: <model>`) and get back a gateway file id
2. They send POST https://litellm-domain/v1/batches with that `input_file_id` and get back a batch id with `status: validating`
3. They poll GET https://litellm-domain/v1/batches/{batch_id} until it returns `status: completed`, then keep polling a few more times (dashboards, retries, several workers)
4. They open https://litellm-domain/ui/?page=logs (or GET https://litellm-domain/spend/logs) and see one spend entry per completed-status poll for that single batch, so three polls bill three times its real cost
5. When the first completed-status poll fails to read the batch output, no spend entry ever appears for that batch and no later poll adds one

After: the same batch is billed exactly once, however many times its status is checked

1. They upload a JSONL file with POST https://litellm-domain/v1/files (`purpose: batch`, `target_model_names: <model>`) and get back a gateway file id
2. They send POST https://litellm-domain/v1/batches with that `input_file_id` and get back a batch id with `status: validating`
3. They poll GET https://litellm-domain/v1/batches/{batch_id} until it returns `status: completed`, then keep polling a few more times (dashboards, retries, several workers)
4. https://litellm-domain/ui/?page=logs (or GET https://litellm-domain/spend/logs) shows nothing for those polls; within one polling interval a single spend entry appears for the batch with its real cost and token counts
5. Further polls add nothing, and a poll that fails to read the output no longer leaves the batch unbilled, since the gateway's own poller still picks it up

## Relevant issues

Found alongside #36876, the spend log primary key fix, which is a prerequisite for a batch cost row to land at all. The two are independent changes in different subsystems and can merge in either order.

## Linear ticket

Resolves LIT-5622

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`batch_processed` is what removes a managed batch from `CheckBatchCost`'s queue, since it selects `batch_processed=False`, and it also unblocks file deletion. Retrieving a batch that had reached completion set that flag, claiming the cost had been accounted for on behalf of a callback that had not run yet and is never awaited.

**Before, at 3864e12415.** On a live proxy, a caller polling its own batches over HTTP destroyed two completed batches' cost. The cost callback failed inside the logging worker, and the same retrieve set the flag one second later, retiring the poller with no retry left:

```
04:27:05  LoggingWorker error: Output file id is None cannot retrieve file content
04:27:06  LoggingWorker error: No such object: <provider output path>
04:27:06  Updating batch <unified batch id> status
```

Both batches ended terminal, marked accounted, with no spend row and no way to recover them:

```
SELECT model_object_id, status, batch_processed FROM "LiteLLM_ManagedObjectTable" ORDER BY created_at DESC LIMIT 2;
 <vertex batch>   | completed | t
 <bedrock batch>  | completed | t

SELECT count(*) FROM "LiteLLM_SpendLogs" WHERE call_type='aretrieve_batch';
 0
```

Nothing logged at error level for the batches themselves, and the poller stopped querying them entirely from that point on.

The over-count is the same race in the other direction. Three retrieves of one completed batch, driven against a proxy at this commit, each recorded that batch's full cost:

```
3 retrieves of ONE batch (true cost $0.0221875)
  spend on user counter : $0.0665625   3.0x
```

**After, at 43a1fe2d40.** Same proxy, five HTTP retrieves that each *discover* completion, which is the dangerous poll. Every one leaves the flag alone and records nothing:

```
retrieve 1: status=completed batch_processed=f cost_rows=0
retrieve 2: status=completed batch_processed=f cost_rows=0
retrieve 3: status=completed batch_processed=f cost_rows=0
retrieve 4: status=completed batch_processed=f cost_rows=0
retrieve 5: status=completed batch_processed=f cost_rows=0
```

The poller then claims it and accounts it exactly once, with its real cost and usage read from the batch's real provider output:

```
17:00:47Z cost_rows=1 processed=t

SELECT count(*) AS rows, sum(spend) AS total_spend, sum(total_tokens) AS tokens
FROM "LiteLLM_SpendLogs" WHERE call_type='aretrieve_batch' AND model LIKE '%haiku%';
 rows | total_spend | tokens
------+-------------+--------
    1 |   0.0221875 |  42375
```

The same holds on live traffic rather than a driven reproduction. Fresh batches were submitted to a proxy at this commit, one per provider, while a client polled each batch's status over HTTP every five minutes straddling completion, which is the pattern that destroyed the two batches above. Both completed batches were accounted, once each:

```
aretrieve_batch rows : 3
distinct request_ids : 3

  gemini-2.5-flash    spend=$0.0009078   tokens=2664
  claude-haiku-4-5    spend=$0.0221875   tokens=42375
  amazon.nova-lite    spend=$0.0         tokens=0
```

Three batches, three rows, one each. The `$0` is an unrelated Bedrock Converse usage parsing defect tracked separately, not a symptom of this change.

With batch polling switched off, behavior is unchanged: the retrieve remains the only accountant and still sets the flag, so a proxy running without the poller does not lose batch cost.

## Type

🐛 Bug Fix

## Changes

`batch_processed` now means what its name says, and only the component that actually recorded the cost sets it.

A new `batch_cost_poller_is_active` reports whether `CheckBatchCost` can be relied on for this batch. It is false when polling is disabled by config, when the job is absent from the scheduler because the enterprise import failed, and when the poller has not yet confirmed that the `batch_processed` column exists. When it is true the poller owns accounting: retrieving a managed batch passes `batch_ignore_default_logging` so no cost is recorded on the retrieve, and `update_batch_in_database` leaves the flag for the poller to set after it has computed the cost. When it is false the retrieve path is the only accountant and behaves exactly as before.

That last condition is what keeps a schema without the column safe. There the poller can neither filter on it nor set it, so it falls back to a query excluding `complete` and `completed`; a batch the retrieve path had already marked complete would be invisible to the poller forever, and suppressing the retrieve's own accounting would leave nobody accounting for it at all. The poller therefore publishes `batch_processed_support_confirmed` only once a filtered query has actually succeeded, and the handoff requires it. Defaulting to unconfirmed also covers the window before the poller's first cycle, during which behavior matches this PR's parent rather than assuming a capability nothing has demonstrated yet.

Batches with no managed object row are untouched either way, since neither the flag nor the poller queue applies to them.

The ownership question is asked once per retrieve and the answer is carried forward. Asking it again after the provider call would let the two halves disagree, because the poller can complete its first successful filtered query in between: the retrieve would account inline having seen no usable poller, then leave the marker unset having seen one, and the poller would account for the same batch again. `update_batch_in_database` therefore takes the decision its caller already acted on and only derives its own when the caller records no cost, which leaves the cancel path unchanged.

Three consequences worth calling out. Cost now appears up to one `proxy_batch_polling_interval` after a batch completes rather than at the moment some caller happens to retrieve it; the retrieve response never carried cost to the client, so nothing user-facing changes.

The scheduler's interval trigger fires its first run one interval after startup, so until then the retrieve keeps ownership. That is deliberate: during that window this behaves as it did before the change, which is never worse than today, and the handoff begins only once the poller has proven it can both find outstanding batches and mark them done. Operators wanting the handoff sooner after a restart can lower `proxy_batch_polling_interval`.

And a batch whose deployment id no longer resolves, which happens when a model group is removed or renamed while batches are in flight, will not be accounted at all, because the poller cannot route it and the retrieve no longer accounts for it. That case was already unreliable, since the retrieve's own callback had to succeed for the cost to land, and it is left as is here rather than widened into this change.

## Caveats (if any)

- Cost lands up to one polling interval after completion, not at retrieve time
- Until the poller's first cycle after startup, the retrieve still accounts as before
- Batches whose deployment no longer resolves stay unaccounted, as they already were

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c9e9c279fe6270132079db6da41b69c7d8809169. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->