### PR TITLE
fix(proxy): price streamed-usage cost injection against the routed deployment

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -2953,6 +2953,11 @@ class ProxyBaseLLMRequestProcessing:
         caps: Final = ProxyLogging._callback_capabilities()
         cost_injection_enabled: Final = bool(getattr(litellm, "include_cost_in_streaming_usage", False))
         fast_path = not caps.has_streaming_chunk_override and not caps.has_guardrail and not cost_injection_enabled
+        cost_model_name, cost_model_provider = (
+            ProxyBaseLLMRequestProcessing._resolve_cost_injection_model(request_data)
+            if cost_injection_enabled
+            else ("", None)
+        )
         debug_enabled: Final = verbose_proxy_logger.isEnabledFor(logging.DEBUG)
         stream_completed = False
         client_disconnected = False
@@ -2990,8 +2995,9 @@ class ProxyBaseLLMRequestProcessing:
                     elif isinstance(chunk, dict):
                         str_so_far += str(chunk.get("content", ""))
 
-                    model_name = request_data.get("model", "")
-                    chunk = ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(chunk, model_name)
+                    chunk = ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(
+                        chunk, cost_model_name, cost_model_provider
+                    )
 
                 # Set before the yield: an async generator suspends at the yield,
                 # so a GeneratorExit on client disconnect is raised there and any
@@ -3086,22 +3092,54 @@ class ProxyBaseLLMRequestProcessing:
             request=request,
         )
 
-    @overload
     @staticmethod
-    def _process_chunk_with_cost_injection(chunk: bytes, model_name: str) -> bytes: ...
+    def _resolve_cost_injection_model(request_data: dict) -> tuple[str, str | None]:
+        """Resolve the model that streamed-usage cost injection prices against.
+
+        The client-sent ``model`` is often a router model-group alias (e.g.
+        ``claude-opus-4-6``) whose name also exists as a direct-provider model,
+        so pricing the raw alias resolves the wrong provider and price table
+        and skips ``cost_discount_config``. Prefer the deployment the router
+        actually served (recorded on the logging object), then resolving the
+        alias through the router, and only then the raw request model.
+        """
+        requested_model: Final = str(request_data.get("model", "") or "")
+        deployment_model: Final = ProxyBaseLLMRequestProcessing._get_deployment_model_name(
+            request_data.get("litellm_logging_obj")
+        )
+        if deployment_model:
+            return deployment_model, None
+
+        from litellm.proxy.management_endpoints.cost_tracking_settings import (
+            _resolve_model_for_cost_lookup,  # pyright: ignore[reportPrivateUsage]  # the one alias-to-deployment resolver, shared with the cost-estimate endpoint
+        )
+
+        resolved: Final = _resolve_model_for_cost_lookup(requested_model)
+        return resolved.model, resolved.provider
 
     @overload
     @staticmethod
-    def _process_chunk_with_cost_injection(chunk: object, model_name: str) -> object: ...
+    def _process_chunk_with_cost_injection(
+        chunk: bytes, model_name: str, custom_llm_provider: str | None = None
+    ) -> bytes: ...
+
+    @overload
+    @staticmethod
+    def _process_chunk_with_cost_injection(
+        chunk: object, model_name: str, custom_llm_provider: str | None = None
+    ) -> object: ...
 
     @staticmethod
-    def _process_chunk_with_cost_injection(chunk: object, model_name: str) -> object:
+    def _process_chunk_with_cost_injection(
+        chunk: object, model_name: str, custom_llm_provider: str | None = None
+    ) -> object:
         """
         Process a streaming chunk and inject cost information if enabled.
 
         Args:
             chunk: The streaming chunk (dict, str, bytes, or bytearray)
             model_name: Model name for cost calculation
+            custom_llm_provider: Provider of the resolved deployment, when known
 
         Returns:
             The processed chunk with cost information injected if applicable
@@ -3111,21 +3149,27 @@ class ProxyBaseLLMRequestProcessing:
 
         try:
             if isinstance(chunk, dict):
-                maybe_modified: Final = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(chunk, model_name)
+                maybe_modified: Final = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(
+                    chunk, model_name, custom_llm_provider
+                )
                 if maybe_modified is not None:
                     return maybe_modified
             elif isinstance(chunk, (bytes, bytearray)):
                 try:
                     s: Final = chunk.decode("utf-8")
                     if s.endswith(("\n\n", "\r\n\r\n")):
-                        maybe_mod = ProxyBaseLLMRequestProcessing._inject_cost_into_sse_frame_str(s, model_name)
+                        maybe_mod = ProxyBaseLLMRequestProcessing._inject_cost_into_sse_frame_str(
+                            s, model_name, custom_llm_provider
+                        )
                         if maybe_mod is not None:
                             return maybe_mod.encode("utf-8")
                 except Exception:
                     pass
             elif isinstance(chunk, str):
                 # Try to parse SSE frame and inject cost into the data line
-                maybe_mod = ProxyBaseLLMRequestProcessing._inject_cost_into_sse_frame_str(chunk, model_name)
+                maybe_mod = ProxyBaseLLMRequestProcessing._inject_cost_into_sse_frame_str(
+                    chunk, model_name, custom_llm_provider
+                )
                 if maybe_mod is not None:
                     # Ensure trailing frame separator
                     return maybe_mod if maybe_mod.endswith("\n\n") else (maybe_mod + "\n\n")
@@ -3136,13 +3180,16 @@ class ProxyBaseLLMRequestProcessing:
         return chunk
 
     @staticmethod
-    def _inject_cost_into_sse_frame_str(frame_str: str, model_name: str) -> str | None:
+    def _inject_cost_into_sse_frame_str(
+        frame_str: str, model_name: str, custom_llm_provider: str | None = None
+    ) -> str | None:
         """
         Inject cost information into an SSE frame string by modifying the JSON in the 'data:' line.
 
         Args:
             frame_str: SSE frame string that may contain multiple lines
             model_name: Model name for cost calculation
+            custom_llm_provider: Provider of the resolved deployment, when known
 
         Returns:
             Modified SSE frame string with cost injected, or None if no modification needed
@@ -3156,7 +3203,9 @@ class ProxyBaseLLMRequestProcessing:
                     json_part = stripped_ln.split("data:", 1)[1].strip()
                     if json_part and json_part != "[DONE]":
                         obj = json.loads(json_part)
-                        maybe_modified = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(obj, model_name)
+                        maybe_modified = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(
+                            obj, model_name, custom_llm_provider
+                        )
                         if maybe_modified is not None:
                             lines[idx] = "data: " + safe_dumps(maybe_modified) + ("\r" if ln.endswith("\r") else "")
                             return "\n".join(lines)
@@ -3223,24 +3272,38 @@ class ProxyBaseLLMRequestProcessing:
 
     @staticmethod
     def _completion_cost_or_none(
-        model_response: ModelResponse, model_name: str, service_tier: str | None
+        model_response: ModelResponse,
+        model_name: str,
+        service_tier: str | None,
+        custom_llm_provider: str | None = None,
     ) -> float | None:
         try:
             return litellm.completion_cost(
-                completion_response=model_response, model=model_name, service_tier=service_tier
+                completion_response=model_response,
+                model=model_name,
+                service_tier=service_tier,
+                custom_llm_provider=custom_llm_provider,
             )
         except Exception:
             return None
 
     @staticmethod
-    def _inject_cost_into_usage_dict(obj: dict, model_name: str) -> dict | None:
+    def _inject_cost_into_usage_dict(obj: dict, model_name: str, custom_llm_provider: str | None = None) -> dict | None:
         """
         Inject cost information into the usage object of a streamed usage event
         (Anthropic ``message_delta`` or OpenAI ``chat.completion.chunk``).
 
+        Anthropic usage blocks carrying cache fields go through
+        ``AnthropicConfig.calculate_usage`` so ``prompt_tokens`` is
+        cache-inclusive like every other cost path; hand-building ``Usage``
+        from them left ``input_tokens`` uncached next to ``cached_tokens`` and
+        the calculator then billed ``input_tokens - cached_tokens`` fresh
+        tokens and the cache reads at the fresh-token rate.
+
         Args:
             obj: Dictionary containing the SSE event data
             model_name: Model name for cost calculation
+            custom_llm_provider: Provider of the resolved deployment, when known
 
         Returns:
             Modified dictionary with cost injected, or None if no modification needed
@@ -3251,11 +3314,17 @@ class ProxyBaseLLMRequestProcessing:
         usage_kwargs: Final = ProxyBaseLLMRequestProcessing._stream_usage_kwargs_for_event(obj, usage)
         if usage_kwargs is None:
             return None
+        usage_obj: Final = (
+            litellm.AnthropicConfig().calculate_usage(usage_object=usage, reasoning_content=None)
+            if obj.get("type") == "message_delta" and litellm.AnthropicConfig.is_anthropic_usage_object(usage)
+            else Usage(**usage_kwargs)
+        )
         service_tier: Final = obj.get("service_tier")
         cost_val: Final = ProxyBaseLLMRequestProcessing._completion_cost_or_none(
-            ModelResponse(usage=Usage(**usage_kwargs)),
+            ModelResponse(usage=usage_obj),
             model_name,
             service_tier if isinstance(service_tier, str) else None,
+            custom_llm_provider,
         )
         if cost_val is None:
             return None

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5876,3 +5876,138 @@ class TestProcessChunkWithCostInjection:
         )
 
         assert ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(chunk, "gpt-4o-mini") == chunk
+
+
+class TestStreamedUsageCostInjection:
+    """Streamed-usage cost injection must price the deployment the router
+    actually served, not the client-sent model-group alias, and must price
+    Anthropic cache reads instead of subtracting them from uncached input."""
+
+    @pytest.fixture
+    def local_model_cost_map(self, monkeypatch):
+        """Use the bundled cost map so price assertions match this branch."""
+        original = litellm.model_cost
+        monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+        litellm.get_model_info.cache_clear()
+        try:
+            yield
+        finally:
+            litellm.model_cost = original
+            litellm.get_model_info.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_streamed_cost_injection_prices_routed_deployment_not_client_alias(
+        self, local_model_cost_map, monkeypatch
+    ):
+        """A request sent with a router alias (claude-opus-4-6) that the router
+        serves on a Bedrock deployment must have its injected usage.cost priced
+        at the Bedrock deployment's rate with cost_discount_config applied, not
+        at the direct-Anthropic list price the raw alias resolves to."""
+        monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", True, raising=False)
+        monkeypatch.setattr(litellm, "cost_discount_config", {"bedrock": 0.20}, raising=False)
+
+        logging_obj = MagicMock()
+        logging_obj.litellm_params = {
+            "litellm_metadata": {"deployment": "bedrock/us.anthropic.claude-opus-4-6-v1"}
+        }
+        request_data = {"model": "claude-opus-4-6", "litellm_logging_obj": logging_obj}
+
+        frames = [
+            b'event: message_start\ndata: {"type": "message_start", "message": {"id": "m"}}\n\n',
+            (
+                b'event: message_delta\ndata: {"type": "message_delta",'
+                b' "delta": {"stop_reason": "end_turn"},'
+                b' "usage": {"input_tokens": 1000, "output_tokens": 10}}\n\n'
+            ),
+            b'event: message_stop\ndata: {"type": "message_stop"}\n\n',
+        ]
+
+        async def upstream(**kwargs):
+            for frame in frames:
+                yield frame
+
+        proxy_logging_obj = MagicMock(spec=ProxyLogging)
+        proxy_logging_obj.async_post_call_streaming_iterator_hook = upstream
+        proxy_logging_obj.async_post_call_streaming_hook = AsyncMock(
+            side_effect=lambda **kwargs: kwargs["response"]
+        )
+
+        with patch.object(
+            ProxyBaseLLMRequestProcessing,
+            "_finalize_streaming_generator_cleanup",
+            new=AsyncMock(),
+        ):
+            collected = []
+            async for out_chunk in ProxyBaseLLMRequestProcessing.async_sse_data_generator(
+                response=MagicMock(),
+                user_api_key_dict=ProxyUserAPIKeyAuth(api_key="hash", models=[]),
+                request_data=request_data,
+                proxy_logging_obj=proxy_logging_obj,
+            ):
+                collected.append(out_chunk)
+
+        delta_payloads = []
+        for out_chunk in collected:
+            text = out_chunk.decode("utf-8") if isinstance(out_chunk, bytes) else str(out_chunk)
+            for line in text.split("\n"):
+                if line.startswith("data:"):
+                    payload = json.loads(line.split("data:", 1)[1].strip())
+                    if payload.get("type") == "message_delta":
+                        delta_payloads.append(payload)
+
+        assert delta_payloads, "message_delta frame missing from streamed output"
+        injected_cost = delta_payloads[0]["usage"]["cost"]
+
+        bedrock_list_price = 1000 * 5.5e-06 + 10 * 2.75e-05
+        expected_cost = 0.80 * bedrock_list_price
+        assert injected_cost == pytest.approx(expected_cost, rel=1e-6)
+
+    def test_inject_cost_prices_cache_read_tokens_from_anthropic_usage(self, local_model_cost_map):
+        """Anthropic message_delta usage reports input_tokens EXCLUDING cache
+        reads. The injected cost must price cache reads at the cache-read rate
+        on top of the full uncached input, not subtract them from it."""
+        obj = {
+            "type": "message_delta",
+            "usage": {
+                "input_tokens": 10174,
+                "output_tokens": 500,
+                "cache_read_input_tokens": 9821,
+                "cache_creation_input_tokens": 0,
+            },
+        }
+
+        modified = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(
+            obj, "us.anthropic.claude-sonnet-4-6"
+        )
+
+        assert modified is not None
+        expected_cost = 10174 * 3.3e-06 + 9821 * 3.3e-07 + 500 * 1.65e-05
+        assert modified["usage"]["cost"] == pytest.approx(expected_cost, rel=1e-6)
+
+    def test_resolve_cost_injection_model_prefers_router_deployment(self):
+        logging_obj = MagicMock()
+        logging_obj.litellm_params = {
+            "metadata": {"deployment": "bedrock/us.anthropic.claude-opus-4-6-v1"}
+        }
+
+        model, provider = ProxyBaseLLMRequestProcessing._resolve_cost_injection_model(
+            {"model": "claude-opus-4-6", "litellm_logging_obj": logging_obj}
+        )
+
+        assert model == "bedrock/us.anthropic.claude-opus-4-6-v1"
+        assert provider is None
+
+    def test_resolve_cost_injection_model_falls_back_to_router_lookup(self):
+        from litellm.proxy.management_endpoints.cost_tracking_settings import ResolvedCostModel
+
+        with patch(
+            "litellm.proxy.management_endpoints.cost_tracking_settings._resolve_model_for_cost_lookup",
+            return_value=ResolvedCostModel("bedrock/us.anthropic.claude-opus-4-6-v1", "bedrock", None),
+        ) as mock_resolve:
+            model, provider = ProxyBaseLLMRequestProcessing._resolve_cost_injection_model(
+                {"model": "claude-opus-4-6"}
+            )
+
+        assert (model, provider) == ("bedrock/us.anthropic.claude-opus-4-6-v1", "bedrock")
+        mock_resolve.assert_called_once_with("claude-opus-4-6")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed `usage.cost` is priced from the raw client-sent model alias
- Aliases that also name direct-provider models resolve the wrong price table
- `cost_discount_config` is skipped because the provider resolves wrong
- Anthropic cache reads are subtracted from uncached input tokens

How it solves it:

- Price against the deployment the router actually served
- Fall back to router alias resolution, then the raw model
- Pass the resolved model and provider into the cost calculation
- Fold cache fields through the shared Anthropic usage calculation

## User Flow

Before: a developer streaming through a Bedrock-backed alias sees direct-API pricing in `usage.cost`, with the configured discount missing and cached calls almost free

1. The proxy admin registers model group `claude-opus-4-6` backed by `bedrock/us.anthropic.claude-opus-4-6-v1`, with `include_cost_in_streaming_usage: true` and `cost_discount_config: {bedrock: 0.20}`
2. The developer sends POST http://localhost:4000/v1/messages with `"model": "claude-opus-4-6"` and `"stream": true`
3. The final `message_delta` SSE event carries `usage.cost` at the direct Anthropic list rate (5.00 USD per 1M input tokens) with no discount, even though the call ran on Bedrock
4. On a prompt-cached call reporting 10,174 uncached plus 9,821 cache-read input tokens, `usage.cost` covers only 10,174 - 9,821 = 353 input tokens, and drops to zero input cost once cache reads exceed uncached input

After: the same stream reports the Bedrock deployment price with the discount applied and cache reads priced correctly

1. The proxy admin keeps the exact same config
2. The developer sends the same POST http://localhost:4000/v1/messages with `"model": "claude-opus-4-6"` and `"stream": true`
3. The final `message_delta` SSE event carries `usage.cost` at the Bedrock deployment rate (5.50 USD per 1M input tokens) with the 20 percent bedrock discount applied
4. The prompt-cached call is billed for all 10,174 uncached input tokens plus 9,821 cache reads at the cache-read rate

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live-proxy proof requires AWS Bedrock credentials with prompt caching enabled, which this environment does not have. Reproduction to run against a live proxy, before at base f6b9518ddb and after at d8505b7733, output to be attached before marking ready for review:

1. Start the proxy with a config containing the model group and settings from the User Flow section
2. Run the same streaming curl twice so the second call reads the prompt cache: `curl -N http://localhost:4000/v1/messages -H 'content-type: application/json' -H 'authorization: Bearer sk-1234' -d '{"model": "claude-opus-4-6", "max_tokens": 64, "stream": true, "system": [{"type": "text", "text": "<text over 1024 tokens>", "cache_control": {"type": "ephemeral"}}], "messages": [{"role": "user", "content": "hi"}]}'`
3. Compare `usage.cost` on the final `message_delta` event against the Bedrock deployment rate with the bedrock discount, and confirm the cached second call is not cheaper than its cache-read tokens warrant

## Type

🐛 Bug Fix

## Changes

`ProxyBaseLLMRequestProcessing.async_streaming_data_generator` now resolves the model to price against once per stream instead of passing `request_data["model"]` per chunk: the new `_resolve_cost_injection_model` prefers the deployment the router recorded for the request (the same `litellm_params` metadata the `x-litellm-model-name` header reads), falls back to `_resolve_model_for_cost_lookup` (the router resolution the cost-estimate endpoint already uses), and only then uses the raw request model. The resolved model and provider are passed through `_process_chunk_with_cost_injection` and `_inject_cost_into_sse_frame_str` into `_inject_cost_into_usage_dict`, whose `completion_cost` call now receives them, so both the price table and `cost_discount_config` match the routed deployment

`_inject_cost_into_usage_dict` also routes usage blocks carrying Anthropic cache fields through `AnthropicConfig.calculate_usage`, the same folding every other cost path uses. The previous hand-built `Usage` kept `input_tokens` uncached next to `cached_tokens`, so the calculator billed `input_tokens - cached_tokens` fresh tokens and priced cache reads at the fresh-token rate

Four regression tests in `tests/test_litellm/proxy/test_common_request_processing.py` (`TestStreamedUsageCostInjection`): an end-to-end stream through `async_sse_data_generator` asserting an aliased Bedrock deployment gets the discounted Bedrock price (fails before with the undiscounted direct-Anthropic price), a cache-read pricing test on `_inject_cost_into_usage_dict` (fails before with the 353-token cost), and two unit tests for the resolver's deployment-first and router-fallback behavior

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
