### PR TITLE
fix: normalize Prometheus latency datetimes

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -8,7 +8,7 @@ import math
 import os
 import sys
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 import litellm
@@ -3990,7 +3990,11 @@ class PrometheusLogger(CustomLogger):
         otherwise returns None.
         """
         if isinstance(start_time, datetime) and isinstance(end_time, datetime):
-            return (end_time - start_time).total_seconds()
+            normalized_start: Final = (
+                start_time if start_time.tzinfo is not None else start_time.replace(tzinfo=timezone.utc)
+            )
+            normalized_end: Final = end_time if end_time.tzinfo is not None else end_time.replace(tzinfo=timezone.utc)
+            return (normalized_end - normalized_start).total_seconds()
         return None
 
     @staticmethod

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -3991,9 +3991,15 @@ class PrometheusLogger(CustomLogger):
         """
         if isinstance(start_time, datetime) and isinstance(end_time, datetime):
             normalized_start: Final = (
-                start_time if start_time.tzinfo is not None else start_time.replace(tzinfo=timezone.utc)
+                start_time
+                if start_time.tzinfo is not None
+                else start_time.replace(tzinfo=timezone.utc)
             )
-            normalized_end: Final = end_time if end_time.tzinfo is not None else end_time.replace(tzinfo=timezone.utc)
+            normalized_end: Final = (
+                end_time
+                if end_time.tzinfo is not None
+                else end_time.replace(tzinfo=timezone.utc)
+            )
             return (normalized_end - normalized_start).total_seconds()
         return None
 

--- a/tests/test_litellm/integrations/test_prometheus_overhead_with_guardrails.py
+++ b/tests/test_litellm/integrations/test_prometheus_overhead_with_guardrails.py
@@ -7,6 +7,7 @@ durations. During-call (moderation) guardrails run concurrently with the LLM
 call and are excluded so they don't inflate the overhead.
 """
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -158,6 +159,25 @@ def test_get_guardrail_overhead_seconds_counts_single_pre_call_dict():
         guardrail_information={"guardrail_mode": "pre_call", "duration": 0.3},
     )
     assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.3) < 1e-6
+
+
+@pytest.mark.parametrize(
+    ("start_time", "end_time"),
+    (
+        (
+            datetime(2026, 8, 14, 12, 0, 0, tzinfo=timezone.utc).replace(tzinfo=None),
+            datetime(2026, 8, 14, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2026, 8, 14, 14, 0, 0, tzinfo=timezone(timedelta(hours=2))),
+            datetime(2026, 8, 14, 12, 0, 1, tzinfo=timezone.utc).replace(tzinfo=None),
+        ),
+    ),
+)
+def test_safe_duration_seconds_normalizes_mixed_timezone_awareness(start_time, end_time):
+    logger = PrometheusLogger()
+
+    assert logger._safe_duration_seconds(start_time, end_time) == 1.0
 
 
 def _patch_label_factory(monkeypatch):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mixed timezone timestamps break Prometheus latency logging

How it solves it:

- Treats naive timestamps as UTC before subtraction
- Preserves offsets on timezone-aware timestamps

## User Flow

Before: a proxy operator applies a guardrail and sees a logging error after the request succeeds

1. They send POST https://litellm-domain/guardrails/apply_guardrail with a configured guardrail
2. The request returns 200, but logs show a naive/aware datetime TypeError
3. The Prometheus latency observation is missing for that request

After: the same successful request records its latency without a logging error

1. They send POST https://litellm-domain/guardrails/apply_guardrail with the same guardrail
2. The request returns 200 without the datetime TypeError
3. Prometheus receives the latency observation for that request

## Relevant issues

Fixes #36851

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy verification is pending while this PR remains a draft

## Type

Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check mixed timezone-awareness in both directions
