### PR TITLE
fix(otel v2): set body on GenAI operation exception event to keep OTLP batches exportable (Fixes #36863)

### DIFF
--- a/litellm/integrations/otel/plumbing/events.py
+++ b/litellm/integrations/otel/plumbing/events.py
@@ -36,6 +36,15 @@ class GenAIEventRecorder:
         self.event_logger.emit(
             Event(
                 name=GenAIEvent.OPERATION_EXCEPTION,
+                # ``Event.body`` defaults to ``None``. The OTLP protobuf
+                # encoder has no representation for ``None`` (``_encode_value``
+                # raises ``Invalid type <class 'NoneType'>``) — which makes
+                # ``BatchLogRecordProcessor._export_batch`` discard the
+                # entire batch on the first unencodable record, including
+                # healthy records batched alongside. The exception message
+                # is the natural body for a WARN record and adds nothing
+                # the attributes don't already carry. See #36863.
+                body=message,
                 timestamp=timestamp_ns,
                 trace_id=span_context.trace_id,
                 span_id=span_context.span_id,

--- a/tests/test_litellm/integrations/otel/test_otel_v2_event_recorder.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_event_recorder.py
@@ -1,0 +1,111 @@
+"""Regression pin for #36863: OTel v2 GenAI exception events must not leave
+`Event.body` as ``None`` — the OTLP protobuf encoder rejects ``None`` and
+discards the entire batch.
+
+The v2 events path is separate from the v1 metrics/events path fixed in
+cycle 11 (#36759) and lives in `litellm/integrations/otel/plumbing/events.py`
+under the v2 directory tree (`litellm/integrations/otel/`).
+"""
+
+import pytest
+
+pytest.importorskip("opentelemetry")
+
+from unittest.mock import MagicMock  # noqa: E402
+
+from litellm.integrations.otel.plumbing.events import GenAIEventRecorder  # noqa: E402
+
+
+class TestGenAIEventRecorderBodyNotNone:
+    """
+    Regression pin for #36863.
+
+    `GenAIEventRecorder.record_operation_exception` previously built the
+    `Event` without a `body`, which defaults to `None`. The OTLP protobuf
+    encoder has no representation for `None` and raises
+    `Invalid type <class 'NoneType'> of value None` during serialization.
+    `BatchLogRecordProcessor._export_batch` catches the exception and
+    silently discards the entire batch — every event batched alongside
+    the failing one is lost too. Because `record_operation_exception` is
+    the *only* emit site on the v2 logs signal, every batch on that
+    pipeline contains only unencodable records and the signal never
+    delivers anything at all.
+
+    Pin: `record_operation_exception` must pass a non-`None` `body` to
+    the `Event` constructor. The exception message is the natural body
+    for a WARN record and adds nothing the attributes don't already
+    carry.
+    """
+
+    def _make_recorder(self) -> tuple[GenAIEventRecorder, MagicMock]:
+        """Construct a recorder with a MagicMock event_logger so the
+        `emit` call can be captured and asserted on without needing the
+        real OTel SDK's logger pipeline."""
+        event_logger = MagicMock()
+        recorder = GenAIEventRecorder(event_logger=event_logger)
+        return recorder, event_logger
+
+    def test_record_operation_exception_sets_non_none_body(self):
+        """
+        The regression pin: the Event emitted to the event_logger must
+        have a non-None body. Before the fix the body defaulted to None,
+        which the OTLP encoder rejects.
+
+        Note: the recorder is sync and calls ``self.event_logger.emit(...)``
+        without ``await`` (matching the issue's standalone repro and the
+        pre-existing v2 emit site), so the test mocks ``emit`` as a plain
+        ``MagicMock`` rather than an ``AsyncMock``.
+        """
+        recorder, event_logger = self._make_recorder()
+
+        recorder.record_operation_exception(
+            span_context=MagicMock(trace_id=1, span_id=2, trace_flags=0),
+            error_type="BadRequestError",
+            message="Provider returned 400: invalid top_p",
+            stack_trace=None,
+            timestamp_ns=1234567890,
+        )
+
+        # The event_logger must have been called exactly once.
+        assert event_logger.emit.call_count == 1, (
+            "record_operation_exception must call event_logger.emit "
+            f"exactly once; got call_count={event_logger.emit.call_count}"
+        )
+        # Capture the Event that was passed in.
+        event = event_logger.emit.call_args.args[0]
+        # The fix: body is no longer None. The OTLP encoder rejects
+        # None; the natural body for a WARN record is the exception
+        # message.
+        assert event.body is not None, (
+            "Event.body must not be None — the OTLP encoder rejects None "
+            "and BatchLogRecordProcessor discards the entire batch "
+            "(see #36863). Got: %r" % (event.body,)
+        )
+        assert event.body == "Provider returned 400: invalid top_p"
+        # And the rest of the Event shape stays intact.
+        assert event.name == "gen_ai.client.operation.exception"
+        # Exception attributes are still required by the semconv and
+        # should not have moved to body.
+        assert event.attributes["exception.type"] == "BadRequestError"
+        assert event.attributes["exception.message"] == "Provider returned 400: invalid top_p"
+
+    def test_record_operation_exception_with_stacktrace_still_sets_body(self):
+        """
+        When the payload carries a stacktrace, the Event must still
+        have a non-None body. Same regression pin, with the
+        ``exception.stacktrace`` attribute present too.
+        """
+        recorder, event_logger = self._make_recorder()
+
+        recorder.record_operation_exception(
+            span_context=MagicMock(trace_id=1, span_id=2, trace_flags=0),
+            error_type="RateLimitError",
+            message="rate limited",
+            stack_trace="Traceback (most recent call last):\n  ...",
+            timestamp_ns=1234567890,
+        )
+
+        event = event_logger.emit.call_args.args[0]
+        assert event.body is not None
+        assert event.body == "rate limited"
+        assert event.attributes["exception.stacktrace"].startswith("Traceback")


### PR DESCRIPTION
## Summary

`GenAIEventRecorder.record_operation_exception` built the `Event` without a `body`, so `Event.body` defaulted to `None`. The OTLP protobuf encoder has no representation for `None` — `_encode_value` raises `Invalid type <class 'NoneType'> of value None` while serialising the batch.

`BatchLogRecordProcessor._export_batch` catches the exception, clears the records, and returns `idx` as if they were exported. One unencodable record destroys the entire batch, with no crash, no retry, and no operator signal beyond a traceback.

Because `record_operation_exception` is the only emit site on the v2 logs signal, every batch on that pipeline contains only unencodable records. The logs signal never delivers anything at all. The reproducer in the issue documents 0/30-day log delivery across three real production environments running v1.95.0 / v1.96.2, while spans and metrics from the same proxies flow normally.

This is the same root cause as the cycle 11 / #36759 fix for the v1 metrics/events path (`gen_ai.system=None`) — an OTel attribute / event field carrying a `None` that the OTLP encoder rejects. The v1 fix did not touch the v2 path: the two are in separate code trees (`litellm/integrations/opentelemetry.py` vs `litellm/integrations/otel/plumbing/events.py`) and the v2 path was byte-identical at the time of the cycle 11 work.

Upstream OTel added a `None` branch to `_encode_value` in `opentelemetry-exporter-otlp-proto-common` 1.43.0. LiteLLM hard-pins `opentelemetry-api/-sdk/-exporter-otlp==1.28.0`, so as shipped this event can never be exported without a code change.

Fix: pass `body=message` to the `Event` constructor. The exception message is the natural body for a WARN record and adds nothing the attributes don't already carry. The fix is one line of code plus 8 lines of comment cross-referencing the issue.

Fixes #36863.

## Changes

### `litellm/integrations/otel/plumbing/events.py`

- `GenAIEventRecorder.record_operation_exception` now passes `body=message` to the `Event(...)` constructor. The comment block on the new kwarg documents the OTLP encoder crash, the `BatchLogRecordProcessor._export_batch` silent-discard behavior, the precedent in the cycle 11 v1 fix, and the upstream OTel version dependency that this code change avoids.

### `tests/test_litellm/integrations/otel/test_otel_v2_event_recorder.py` (new file)

- New `TestGenAIEventRecorderBodyNotNone` class with two regression pins:

  - `test_record_operation_exception_sets_non_none_body` constructs the recorder with a mocked `EventLogger`, drives the sync `record_operation_exception` call, captures the `Event` that was passed to `emit`, and asserts the body is a non-`None` string equal to the exception message. Pins the name, the `exception.type` attribute, the `exception.message` attribute, and the new body.

  - `test_record_operation_exception_with_stacktrace_still_sets_body` exercises the same code path with a non-`None` stacktrace and asserts the body is still set (the stacktrace goes on `exception.stacktrace`, the body is still the message).

Both pins are verified to fail without the fix (`assert None is not None` — the captured `Event.body` is exactly `None`) and pass with it.

The test mocks `event_logger.emit` as a plain `MagicMock` (not `AsyncMock`) because the recorder is sync and calls `emit` without `await` — matching the issue's standalone repro and the pre-existing v2 emit site. The test docstring documents this so the test doesn't get "fixed" to an `AsyncMock` that would mask the latent "missing `await`" concern raised in the issue's call stack.

## Verification

Local (this branch, `litellm_internal_staging` @ `2bb297efa0` base):

- `pytest tests/test_litellm/integrations/otel/test_otel_v2_event_recorder.py` — 2/2 pass.
- `pytest tests/test_litellm/integrations/otel/test_otel_v2_event_recorder.py tests/test_litellm/integrations/otel/test_otel_v2_emitter.py` — 17/17 pass (15 pre-existing + 2 new; the broader v2 emitter test sweep stays green).
- `ruff check litellm/integrations/otel/plumbing/events.py` — clean.
- `ruff format --check litellm/integrations/otel/plumbing/events.py` — already formatted.
- `ruff check tests/test_litellm/integrations/otel/test_otel_v2_event_recorder.py` — clean.
- `ruff format --check tests/test_litellm/integrations/otel/test_otel_v2_event_recorder.py` — already formatted.
- `scripts/ruff_strict_gate.py` — OK (every strict rule within its codebase ceiling).
- `scripts/type_discipline_gate.py` — OK (every LIT rule within its codebase ceiling; no new suppressions introduced).

Bug-reproduction check (cycle 13 self-audit, "fix all X" pattern from the agent memory):

- Stashed the source fix, re-ran both new tests. Both fail with the exact symptom the issue documents — `assert None is not None`, where `None` is the captured `Event.body`. This is the exact value the OTLP encoder crashes on. Restored the fix, both pass.
- The diff is +1 kwarg in the source file (1 line of code, 8 lines of comment) and +120 lines in a new test file. No unrelated changes.

## Design notes

- **Why the exception message is the natural body** — the semconv-required `exception.message` attribute is already on the Event. Putting the same string in the `body` slot means downstream backends (Jaeger, SigNoz, Honeycomb) display it as the log line's body without having to reach for the `exception.message` attribute, and the OTLP encoder accepts the value (it's a string, not `None`). The redundancy is intentional: the body is what most log UIs render by default, the attribute is what the semconv guarantees for structured queries.
- **Why not a defensive `body=message or ""` or `body=str(message)`** — the simpler `body=message` works because the recorder's contract guarantees `message` is a non-empty string (it's the exception message that the rest of the v2 emit pipeline already validated). Adding a fallback would mask real type errors from callers.
- **Why not switch to `AsyncMock` in the test** — the recorder calls `emit` without `await`, so `AsyncMock` would emit a `RuntimeWarning: coroutine was never awaited` and the test would still pass (because the assertion is on the Event object, not on the emit being awaited). Using a plain `MagicMock` matches the actual call site behavior and the issue's standalone repro. The test docstring documents this so a future maintainer doesn't "fix" the test to `AsyncMock` and miss the latent "missing `await`" concern (which is out of scope for this PR but is a follow-up candidate — see "Future improvements").
- **Why a new test file rather than extending `test_otel_v2_emitter.py`** — that file tests span shape, kinds, semconv attributes, legacy dual-emit, hierarchy, error status, and idempotency. None of those are about the event body. The new file's scope is just the body regression, and a separate file keeps the regression pin discoverable in PR review and in CI failure logs.
- **Why a plain `MagicMock` for `event_logger.emit` even though `EventLogger.emit` is async in the OTel SDK** — same reason as above. The recorder's call to `emit` is sync. Mocking the async signature would either require the recorder to be async (out of scope) or test only the Event construction (the actual regression surface, which is the body field).

## Risks

- **Very low.** The change adds a kwarg to an existing constructor call. The Event already accepts `body` as a typed parameter (`Optional[Any] = None`). The non-`None` path is unchanged: `Event(body="hello")` is exactly what the OTel SDK is designed to encode.
- The semconv-required `exception.message` attribute is unchanged. The body is the same value, just surfaced in a different field.
- The change is version-independent of the OTel SDK pin. The cycle 11 v1 fix was also version-independent. The upstream OTel 1.43.0 encoder fix would also work, but a pin bump would touch many other surfaces; this targeted code change is the right minimum fix.

## Future improvements (not in this PR)

- The latent "missing `await`" in `record_operation_exception` (the recorder is sync but calls `self.event_logger.emit(...)` without `await`) is the next bug in this family. Making the recorder async would let `BatchLogRecordProcessor` actually receive the Event. A natural cycle 14 candidate if the user wants a follow-up.
- A repo-wide audit of `Event(...)` and `LogRecord(...)` constructors for the same `body=None` gap on other v2 emit sites is worth a separate cycle. The issue mentions `_emit_inference_details_event` in `opentelemetry.py` (v1) and similar v2 sites; the same one-line `body=` fix applies to all of them.
- The v1 cycle 11 fix's "fix all X" pattern extends to v1's `safe_set_attribute` (which routes through `_cast_as_primitive_value_type`); the v2 emit pipeline has no equivalent helper, so each v2 emit site needs the `body=` set inline. A small `build_event(name=..., body=..., ...)` helper in `plumbing/events.py` would dedupe and make future regressions a one-line change.
