### PR TITLE
fix(gemini-realtime): keep the client's voice on Vertex AI native-audio Live

### DIFF
--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -92,6 +92,10 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         """Google AI Studio Gemini 3.5+ accepts ``id`` on functionResponses; Vertex AI rejects it."""
         return True
 
+    def _strip_native_audio_speech_config(self) -> bool:
+        """Google AI Studio native-audio Live rejects ``speechConfig`` on setup; Vertex AI accepts it."""
+        return True
+
     @staticmethod
     def _usage_detail_alias(details: Any, defaults: dict[str, int]) -> dict[str, Any]:
         if not isinstance(details, dict):
@@ -382,8 +386,7 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         without_text: Final = [modality for modality in normalized if modality != "TEXT"]
         return without_text if without_text else ["AUDIO"]
 
-    @staticmethod
-    def _finalize_gemini_live_setup(model: str, setup: dict[str, Any]) -> dict[str, Any]:
+    def _finalize_gemini_live_setup(self, model: str, setup: dict[str, Any]) -> dict[str, Any]:
         """Drop fields Gemini Live native-audio rejects on ``setup``."""
         generation_config: Final = setup.get("generationConfig")
         if isinstance(generation_config, dict):
@@ -392,7 +395,7 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
                 generation_config["responseModalities"] = GeminiRealtimeConfig._coerce_response_modalities(
                     model, modalities
                 )
-            if GeminiRealtimeConfig._is_native_audio_model(model):
+            if self._strip_native_audio_speech_config() and GeminiRealtimeConfig._is_native_audio_model(model):
                 generation_config.pop("speechConfig", None)
         return setup
 

--- a/litellm/llms/vertex_ai/realtime/transformation.py
+++ b/litellm/llms/vertex_ai/realtime/transformation.py
@@ -35,6 +35,9 @@ class VertexAIRealtimeConfig(GeminiRealtimeConfig):
     def _include_function_response_id(self) -> bool:
         return False
 
+    def _strip_native_audio_speech_config(self) -> bool:
+        return False
+
     # ------------------------------------------------------------------
     # URL
     # ------------------------------------------------------------------

--- a/tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py
@@ -465,3 +465,53 @@ def test_vertex_function_call_output_omits_id():
     assert "id" not in function_response
     assert function_response["name"] == "terminate_call"
     assert function_response["response"] == {"status": "ok"}
+
+
+def test_vertex_native_audio_keeps_requested_voice(patch_native_audio_cost_map_entry):
+    """Regression: Vertex Live accepts speechConfig on native audio, so the client's voice must survive.
+
+    Stripping it silently dropped voice selection for every Vertex native-audio
+    session. TEXT is still coerced away, which Vertex does reject.
+    """
+    cfg = VertexAIRealtimeConfig(
+        access_token="tok", project="my-proj", location="us-central1"
+    )
+    session_update = {
+        "type": "session.update",
+        "session": {
+            "output_modalities": ["text"],
+            "audio": {"output": {"voice": "Aoede"}},
+        },
+    }
+
+    messages = cfg.transform_realtime_request(
+        json.dumps(session_update),
+        _NATIVE_AUDIO_MODEL,
+        session_configuration_request=None,
+    )
+
+    generation_config = json.loads(messages[0])["setup"]["generationConfig"]
+    assert generation_config["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Aoede"
+    assert generation_config["responseModalities"] == ["AUDIO"]
+
+
+def test_google_ai_studio_native_audio_still_strips_voice(patch_native_audio_cost_map_entry):
+    """Google AI Studio's own native-audio Live is untouched: only Vertex was verified to accept speechConfig."""
+    from litellm.llms.gemini.realtime.transformation import GeminiRealtimeConfig
+
+    messages = GeminiRealtimeConfig().transform_realtime_request(
+        json.dumps(
+            {
+                "type": "session.update",
+                "session": {
+                    "output_modalities": ["audio"],
+                    "audio": {"output": {"voice": "Aoede"}},
+                },
+            }
+        ),
+        _NATIVE_AUDIO_MODEL,
+        session_configuration_request=None,
+    )
+
+    generation_config = json.loads(messages[0])["setup"]["generationConfig"]
+    assert "speechConfig" not in generation_config


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex AI Live silently discards the voice a client asks for
- The strip was justified by a rejection Vertex does not actually do

How it solves it:

- Keep `speechConfig` on Vertex, still strip it for Google AI Studio
- Overridable predicate, matching the existing `_include_function_response_id`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`_finalize_gemini_live_setup` pops `speechConfig` for any model flagged `gemini_native_audio`. The constant that introduced it says those models "reject a `speechConfig` on `setup` with a 1007 invalid-argument error". That premise does not hold on Vertex AI.

**Vertex's own answer, before the fix**, talking straight to `BidiGenerateContent` so no LiteLLM code is in the path. Same socket, same setup, only `speechConfig` varies:

```
direct to Vertex, valid voice Aoede   -> setupComplete
direct to Vertex, bogus voice         -> closed code=1000
direct to Vertex, no speechConfig     -> setupComplete
```

Vertex accepts a valid voice and rejects an invalid one, which means it reads the field rather than refusing it. That is the opposite of what the strip assumes, and it is also what makes the invalid voice a usable probe: if `speechConfig` reaches Vertex, a bogus voice cannot succeed.

**Before**, dev gateway at `53cec79d55`, a real Live session over `/v1/realtime` on `gemini-live-2.5-flash-native-audio`:

```
A real voice name  (Aoede)          -> ok, 10 audio deltas
A bogus voice name (NotARealVoice1) -> ok, 10 audio deltas
```

The bogus voice sails through, so the voice never left the proxy.

**After**, dev gateway at `ec9d9abfa2`, same request shape:

```
  voice=Aoede            -> OK, 10 audio deltas
  voice=Puck             -> OK, 10 audio deltas
  voice=None             -> OK, 9 audio deltas
  voice=NotARealVoice1   -> TIMEOUT (no response.done)
```

Valid voices work and only the invalid one fails, so the client's `speechConfig` is now reaching Vertex.

Two things worth stating plainly rather than leaving for a reviewer to trip over. First, these captures were taken with `gemini_live_defer_setup` enabled, because with the default auto-setup LiteLLM sends its own `setup` on connect and the client's later `session.update` is dropped before it can carry a voice at all, so the strip is unreachable on that path. Second, Vertex's rejection of the invalid voice surfaces to the client as a timeout rather than an error, because the backend close is not propagated. Both are separate problems from this one and neither is introduced here.

Google AI Studio was never verified to accept `speechConfig`, so its behaviour is deliberately unchanged and a test pins that.

## Type

🐛 Bug Fix

## Changes

`GeminiRealtimeConfig` gains `_strip_native_audio_speech_config`, returning `True` so Google AI Studio keeps today's behaviour. `VertexAIRealtimeConfig` overrides it to `False`. `_finalize_gemini_live_setup` becomes an instance method so the override applies; both call sites already used `self`.

The `responseModalities` TEXT to AUDIO coercion is untouched, since Vertex genuinely does reject TEXT on these models.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime session setup for Vertex native-audio (voice forwarding) while preserving AI Studio stripping; scope is narrow but affects live audio behavior customers rely on.
> 
> **Overview**
> Vertex AI native-audio Live sessions were losing the client's chosen output voice because **`speechConfig` was always removed** from the Gemini Live `setup` for `gemini_native_audio` models—behavior meant for Google AI Studio, not Vertex.
> 
> This PR adds **`_strip_native_audio_speech_config()`** (parallel to **`_include_function_response_id`**) so **Google AI Studio still strips `speechConfig`**, while **`VertexAIRealtimeConfig` overrides it to keep voice settings**. **`_finalize_gemini_live_setup`** is now an instance method so that override applies on both providers.
> 
> **TEXT → AUDIO `responseModalities` coercion** for native-audio models is unchanged. Tests assert Vertex preserves **`Aoede`** in setup and that AI Studio still omits **`speechConfig`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fec5eaab9590c9d0affb206939ae33c554cfa83a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->