### PR TITLE
fix(pricing): add the Vertex AI Gemini Live GA models and correct the preview

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18472,6 +18472,7 @@
     "gemini-live-2.5-flash": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 3e-06,
         "input_cost_per_token": 5e-07,
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_token": 2e-06,
@@ -18519,6 +18520,7 @@
     "vertex_ai/gemini-live-2.5-flash": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 3e-06,
         "input_cost_per_token": 5e-07,
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_token": 2e-06,
@@ -18566,6 +18568,7 @@
     "gemini-live-2.5-flash-native-audio": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 3e-06,
         "input_cost_per_token": 5e-07,
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_token": 2e-06,
@@ -18623,6 +18626,7 @@
     "vertex_ai/gemini-live-2.5-flash-native-audio": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 3e-06,
         "input_cost_per_token": 5e-07,
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_token": 2e-06,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18469,10 +18469,218 @@
         },
         "supports_image_size": false
     },
+    "gemini-live-2.5-flash": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "realtime",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/vertex_ai/live"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.035,
+            "search_context_size_medium": 0.035,
+            "search_context_size_high": 0.035
+        },
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_regions": [
+            "global"
+        ]
+    },
+    "vertex_ai/gemini-live-2.5-flash": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "litellm_provider": "vertex_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "realtime",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/vertex_ai/live"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.035,
+            "search_context_size_medium": 0.035,
+            "search_context_size_high": 0.035
+        },
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_regions": [
+            "global"
+        ]
+    },
+    "gemini-live-2.5-flash-native-audio": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "realtime",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/vertex_ai/live"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.035,
+            "search_context_size_medium": 0.035,
+            "search_context_size_high": 0.035
+        },
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supported_regions": [
+            "us-central1",
+            "us-east1",
+            "us-east4",
+            "us-east5",
+            "us-south1",
+            "us-west1",
+            "us-west4",
+            "europe-central2",
+            "europe-north1",
+            "europe-west1",
+            "europe-west4"
+        ],
+        "gemini_native_audio": true
+    },
+    "vertex_ai/gemini-live-2.5-flash-native-audio": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "litellm_provider": "vertex_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "realtime",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/vertex_ai/live"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.035,
+            "search_context_size_medium": 0.035,
+            "search_context_size_high": 0.035
+        },
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supported_regions": [
+            "us-central1",
+            "us-east1",
+            "us-east4",
+            "us-east5",
+            "us-south1",
+            "us-west1",
+            "us-west4",
+            "europe-central2",
+            "europe-north1",
+            "europe-west1",
+            "europe-west4"
+        ],
+        "gemini_native_audio": true
+    },
     "gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "vertex_ai-language-models",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
@@ -18491,7 +18699,6 @@
             "video"
         ],
         "supported_output_modalities": [
-            "text",
             "audio"
         ],
         "supports_audio_input": true,
@@ -18516,7 +18723,7 @@
     "gemini/gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
@@ -18536,7 +18743,6 @@
             "video"
         ],
         "supported_output_modalities": [
-            "text",
             "audio"
         ],
         "supports_audio_input": true,
@@ -45458,7 +45664,7 @@
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_token": 2.5e-06,
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
@@ -45483,7 +45689,7 @@
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_token": 2.5e-06,
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
@@ -45508,7 +45714,7 @@
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_token": 2.5e-06,
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
@@ -45535,7 +45741,7 @@
         "max_input_tokens": 131072,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_token": 4.5e-06,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
@@ -45566,7 +45772,7 @@
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_token": 2.5e-06,
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
@@ -45593,7 +45799,7 @@
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_token": 2.5e-06,
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
@@ -45620,7 +45826,7 @@
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_token": 2.5e-06,
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
@@ -45649,7 +45855,7 @@
         "max_input_tokens": 131072,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_token": 4.5e-06,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18472,6 +18472,7 @@
     "gemini-live-2.5-flash": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 3e-06,
         "input_cost_per_token": 5e-07,
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_token": 2e-06,
@@ -18519,6 +18520,7 @@
     "vertex_ai/gemini-live-2.5-flash": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 3e-06,
         "input_cost_per_token": 5e-07,
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_token": 2e-06,
@@ -18566,6 +18568,7 @@
     "gemini-live-2.5-flash-native-audio": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 3e-06,
         "input_cost_per_token": 5e-07,
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_token": 2e-06,
@@ -18623,6 +18626,7 @@
     "vertex_ai/gemini-live-2.5-flash-native-audio": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 3e-06,
         "input_cost_per_token": 5e-07,
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_token": 2e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18469,10 +18469,218 @@
         },
         "supports_image_size": false
     },
+    "gemini-live-2.5-flash": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "realtime",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/vertex_ai/live"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.035,
+            "search_context_size_medium": 0.035,
+            "search_context_size_high": 0.035
+        },
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_regions": [
+            "global"
+        ]
+    },
+    "vertex_ai/gemini-live-2.5-flash": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "litellm_provider": "vertex_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "realtime",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/vertex_ai/live"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.035,
+            "search_context_size_medium": 0.035,
+            "search_context_size_high": 0.035
+        },
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_regions": [
+            "global"
+        ]
+    },
+    "gemini-live-2.5-flash-native-audio": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "realtime",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/vertex_ai/live"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.035,
+            "search_context_size_medium": 0.035,
+            "search_context_size_high": 0.035
+        },
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supported_regions": [
+            "us-central1",
+            "us-east1",
+            "us-east4",
+            "us-east5",
+            "us-south1",
+            "us-west1",
+            "us-west4",
+            "europe-central2",
+            "europe-north1",
+            "europe-west1",
+            "europe-west4"
+        ],
+        "gemini_native_audio": true
+    },
+    "vertex_ai/gemini-live-2.5-flash-native-audio": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "litellm_provider": "vertex_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "realtime",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/vertex_ai/live"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.035,
+            "search_context_size_medium": 0.035,
+            "search_context_size_high": 0.035
+        },
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supported_regions": [
+            "us-central1",
+            "us-east1",
+            "us-east4",
+            "us-east5",
+            "us-south1",
+            "us-west1",
+            "us-west4",
+            "europe-central2",
+            "europe-north1",
+            "europe-west1",
+            "europe-west4"
+        ],
+        "gemini_native_audio": true
+    },
     "gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "vertex_ai-language-models",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
@@ -18491,7 +18699,6 @@
             "video"
         ],
         "supported_output_modalities": [
-            "text",
             "audio"
         ],
         "supports_audio_input": true,
@@ -18516,7 +18723,7 @@
     "gemini/gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
@@ -18536,7 +18743,6 @@
             "video"
         ],
         "supported_output_modalities": [
-            "text",
             "audio"
         ],
         "supports_audio_input": true,
@@ -45458,7 +45664,7 @@
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_token": 2.5e-06,
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
@@ -45483,7 +45689,7 @@
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_token": 2.5e-06,
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
@@ -45508,7 +45714,7 @@
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_token": 2.5e-06,
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
@@ -45535,7 +45741,7 @@
         "max_input_tokens": 131072,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_token": 4.5e-06,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
@@ -45566,7 +45772,7 @@
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_token": 2.5e-06,
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
@@ -45593,7 +45799,7 @@
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_token": 2.5e-06,
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
@@ -45620,7 +45826,7 @@
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_token": 2.5e-06,
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
@@ -45649,7 +45855,7 @@
         "max_input_tokens": 131072,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_token": 4.5e-06,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Both GA Vertex Live models are absent, so sessions bill $0
- The existing preview entry under-prices text input by 40%
- Image input has no rate, so camera frames bill 6x under

How it solves it:

- Add `gemini-live-2.5-flash` and `gemini-live-2.5-flash-native-audio`
- Correct the preview to the published $0.50 input rate
- Set the $3.00 non-text input rate on the Live entries

## User Flow

Before: a developer running a voice session against a GA Live model is billed nothing at all, so the model looks free and no budget ever trips

1. They open a WebSocket to `wss://litellm-domain/v1/realtime?model=gemini-live-2.5-flash-native-audio` and speak into it
2. The model answers in audio and the session reports 16 prompt and 60 completion tokens
3. They open `https://litellm-domain/ui/?page=logs` and the request is logged at $0.000000
4. Their key's budget never advances, so a voice workload runs unmetered against any spend cap

After: the same session is billed at Google's published Live rates

1. They open a WebSocket to `wss://litellm-domain/v1/realtime?model=gemini-live-2.5-flash-native-audio` and speak into it
2. The model answers in audio and the session reports 16 prompt and 60 completion tokens
3. `https://litellm-domain/ui/?page=logs` now shows the request at $0.000668, with the audio share dominating
4. Their key's budget advances, so a spend cap applies to voice the way it already does to chat

## Relevant issues

Fixes #31087

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Vertex AI serves two GA Live models and neither had a cost map entry, so every Live session billed $0. This is the missing-entry half of #31087.

**Which models actually exist.** Probed by opening a real `BidiGenerateContent` socket and sending a `setup` per candidate, across 22 Vertex locations, with `definitely-not-a-real-model` as a negative control:

```
gemini-live-2.5-flash                 global only        (11 regional locations refuse it)
gemini-live-2.5-flash-native-audio    11 regions, not global
gemini-live-2.5-flash-preview-native-audio-09-2025   us-central1 only
definitely-not-a-real-model           absent everywhere
```

No Gemini 3.x Live exists on Vertex in any location tested, which matches Google documenting 3.x Live as Developer-API only. The two endpoints are disjoint: the half-cascade model is global-only and the native-audio model is regional-only.

**Before**, dev gateway at `7c6ba0a990`, a real voice session on `vertex_ai/gemini-live-2.5-flash-native-audio` produced audio and a correct transcript, and its spend row read `$0.00000000` because the model resolved to no entry at all.

**After**, dev gateway at `ec9d9abfa2`, the same sessions on both GA models bill from `/spend/logs/v2`:

```
  vertex_ai/gemini-live-2.5-flash               (16 in / 30 out)  $0.000318
  vertex_ai/gemini-live-2.5-flash-native-audio  (16 in / 60 out)  $0.000668
```

**The preview correction.** The existing `gemini-live-2.5-flash-preview-native-audio-09-2025` entry prices text input at `3e-07`. That is `gemini-2.5-flash`'s rate, not the Live API's. Google publishes $0.50 per 1M for Live text input, and the entry's other three columns already match the Live table ($3 input audio, $2 output text, $12 output audio), so the one odd column reads as a copy from the wrong sibling. Corrected on that entry and its `gemini/` twin.

**The image rate.** These entries had no `input_cost_per_image_token`, so image tokens fell through to `input_cost_per_token` and billed at the $0.50/M text rate instead of $3.00/M. That matters more on Live than the name suggests, because Gemini reports a Live video stream as a sequence of frames under the IMAGE modality; VIDEO never appears in a Live session's usage, so a camera feed is billed entirely through this one field.

The rate is Google's non-text Live input price, published as "$3.00 (audio / video)" on `ai.google.dev/gemini-api/docs/pricing` and matching the audio rate already in these entries. An independent check lines up with it: Google documents video input as "roughly 258 tokens per second", and a single 128x128 JPEG frame measured exactly 258 tokens against Vertex, so one frame is one second of video for billing. A four-frame session reported 1032 image tokens, exactly 4 x 258.

Measured on a deployment carrying these entries, reading back from `/spend/logs/v2`, with `expected` computed independently from each session's own modality split:

```
mode     Vertex reported promptTokensDetails    billed        expected
image    [{TEXT 7}, {IMAGE 258}]                $0.00082550   $0.00082550
frames   [{TEXT 8}, {IMAGE 1032}]               $0.00313800   $0.00313800
```

At the text rate those same sessions would have billed $0.00014900 and $0.00052400, so the missing field was a 5.5x to 6x under-bill on any session carrying frames.

`supported_output_modalities` on the native-audio entries is now audio only, because Vertex closes the socket when `responseModalities` asks for TEXT on those models, verified directly:

```
native-audio, TEXT only     -> REJECTED close=1000
native-audio, TEXT + AUDIO  -> REJECTED close=1000
native-audio, AUDIO         -> ACCEPTED (setupComplete)
half-cascade, TEXT only     -> ACCEPTED (setupComplete)
```

`supported_regions` comes from those same probes, ordered so a caller in an unsupported region falls back to `us-central1` rather than an arbitrary first entry. Note it lists `us-west4`, which Google's own region table omits but which answers `setupComplete`, so the list is empirical rather than transcribed.

A live call is the proof here rather than `get_model_info` alone, since the failure mode was a billed-at-zero session rather than a lookup error.

## Type

🐛 Bug Fix

## Changes

Adds `gemini-live-2.5-flash` (half-cascade, global) and `gemini-live-2.5-flash-native-audio` (native audio, regional), each as a bare key and a `vertex_ai/` key, in both cost map files.

Corrects the 09-2025 preview entry and its `gemini/` twin: `input_cost_per_token` `3e-07` to `5e-07`, and `supported_output_modalities` to audio only.

Sets `input_cost_per_image_token` to `3e-06` on the four GA Live keys, matching the audio rate, so frames are priced at Google's non-text rate rather than falling back to text. Applied to both the bare and `vertex_ai/`-prefixed keys, since the prefixed one is what `get_model_info` resolves for `custom_llm_provider="vertex_ai"`.

Sets `mode` to `realtime` on the Gemini Live entries that said `chat` while listing only `/v1/realtime` in `supported_endpoints`, so health checks select the realtime probe. OpenAI's `gpt-audio` family is deliberately untouched: those genuinely also serve `/v1/chat/completions`, so `chat` is right for them. `gemini/gemini-robotics-er-2-streaming-preview` has the same `mode` mismatch and is left alone as out of scope.

No new test, per the cost-map convention; the existing cost suite is the verification.

## Caveats (if any)

- `input_cost_per_video_token` stays unset; Live never reports VIDEO
- `supported_regions` on a bare Vertex key is inert for routing
- The AI Studio `gemini/` image rate is out of scope here

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
