### PR TITLE
fix(cost): carry image and video input tokens through the Responses usage bridge

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2664,8 +2664,10 @@ class LiteLLMCompletionResponsesConfig:
             if hasattr(prompt_details, "text_tokens") and prompt_details.text_tokens is not None:
                 input_details_dict["text_tokens"] = prompt_details.text_tokens
 
-            if hasattr(prompt_details, "audio_tokens") and prompt_details.audio_tokens is not None:
-                input_details_dict["audio_tokens"] = prompt_details.audio_tokens
+            for modality in ("audio_tokens", "image_tokens", "video_tokens"):
+                value = getattr(prompt_details, modality, None)
+                if value is not None:
+                    input_details_dict[modality] = value
 
             cache_write_tokens = getattr(prompt_details, "cache_write_tokens", None) or getattr(
                 prompt_details, "cache_creation_tokens", None

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -1130,6 +1130,7 @@ class ResponseAPILoggingUtils:
                     audio_tokens=getattr(response_api_usage.input_tokens_details, "audio_tokens", None),
                     text_tokens=getattr(response_api_usage.input_tokens_details, "text_tokens", None),
                     image_tokens=getattr(response_api_usage.input_tokens_details, "image_tokens", None),
+                    video_tokens=getattr(response_api_usage.input_tokens_details, "video_tokens", None),
                     cache_write_tokens=getattr(response_api_usage.input_tokens_details, "cache_write_tokens", None),
                 )
         completion_tokens_details: CompletionTokensDetailsWrapper | None = None

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1287,7 +1287,9 @@ class OutputTokensDetails(BaseLiteLLMOpenAIResponseObject):
 class InputTokensDetails(BaseLiteLLMOpenAIResponseObject):
     audio_tokens: int | None = None
     cached_tokens: int = 0
+    image_tokens: int | None = None
     text_tokens: int | None = None
+    video_tokens: int | None = None
 
     model_config = {"extra": "allow"}
 

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2585,6 +2585,39 @@ class TestUsageTransformation:
         assert response_usage.input_tokens_details.cached_tokens == 100
         assert getattr(response_usage.input_tokens_details, "cache_write_tokens", None) == 800
 
+    def test_transform_usage_preserves_input_modality_tokens(self):
+        """Regression: the bridge dropped image and video input tokens.
+
+        Vertex reports prompt tokens split by modality, so a Live session that sends
+        camera frames arrives with image_tokens set. InputTokensDetails declared only
+        audio/cached/text, so those tokens were folded into text and lost their
+        attribution, and any per-modality rate could never apply to them.
+        """
+        usage = Usage(
+            prompt_tokens=300,
+            completion_tokens=10,
+            total_tokens=310,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                text_tokens=20, audio_tokens=80, image_tokens=150, video_tokens=50, cached_tokens=0
+            ),
+            completion_tokens_details=CompletionTokensDetailsWrapper(text_tokens=10),
+        )
+
+        response_usage = LiteLLMCompletionResponsesConfig._transform_chat_completion_usage_to_responses_usage(
+            chat_completion_response=usage
+        )
+        details = response_usage.input_tokens_details
+        assert details is not None
+        assert getattr(details, "image_tokens", None) == 150
+        assert getattr(details, "video_tokens", None) == 50
+        assert getattr(details, "audio_tokens", None) == 80
+
+        from litellm.responses.utils import ResponseAPILoggingUtils
+
+        back = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(response_usage.model_dump())
+        assert back.prompt_tokens_details.image_tokens == 150
+        assert back.prompt_tokens_details.video_tokens == 50
+
     def test_transform_usage_with_reasoning_tokens_gemini(self):
         """Test that reasoning_tokens from Gemini are properly transformed to output_tokens_details"""
         # Setup: Simulate Gemini usage with thoughtsTokenCount


### PR DESCRIPTION
## TLDR

Problem this solves:

- Image and video input tokens vanish in the Responses usage bridge
- So no per-modality input rate can ever apply to them

How it solves it:

- Declare image and video on the input token details, and carry both
- Read `video_tokens` back out on the reverse transform

## User Flow

Before: a developer sending an image to a Gemini model on `/v1/responses` gets no image token count back, so their per-modality accounting reads zero images

1. They send POST https://litellm-domain/v1/responses with a Gemini model and one image part
2. The reply's `usage.input_tokens` reads 270, but `usage.input_tokens_details` reads `{"text_tokens": 12}` with no image entry
3. They repeat it with a video part and get `usage.input_tokens` 527 against `{"text_tokens": 11}`, again with nothing for the video
4. All 270 and all 527 tokens look like text, so a rate they set for image or video input has nothing to attach to

After: the same two requests come back with the modality broken out

1. They send the same POST https://litellm-domain/v1/responses with a Gemini model and one image part
2. `usage.input_tokens` still reads 270, and `usage.input_tokens_details` now reads `{"text_tokens": 12, "image_tokens": 258}`
3. The video request now reads `{"text_tokens": 11, "video_tokens": 516}` against the same 527 total
4. An image or video input rate now has real token counts to price

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: one dev gateway, one config, one Vertex-backed Gemini model group, only the commit differing between the two runs. Each call sends a single image part or a single video part and reads `usage.input_tokens_details` straight off the `/v1/responses` reply

### Before (53cec79d55)

#### image part on /v1/responses

1. POST /v1/responses with one image part
2. `input_tokens` 270, `input_tokens_details` `{text_tokens 12, image_tokens null}`

#### video part on /v1/responses

1. POST /v1/responses with one video part
2. `input_tokens` 527, `input_tokens_details` `{text_tokens 11, video_tokens null}`

### After (ec9d9abfa2)

#### image part on /v1/responses

1. POST /v1/responses with one image part
2. `input_tokens` 270, `input_tokens_details` `{text_tokens 12, image_tokens 258}`

#### video part on /v1/responses

1. POST /v1/responses with one video part
2. `input_tokens` 527, `input_tokens_details` `{text_tokens 11, video_tokens 516}`

Both after-values reconcile: 12 + 258 = 270 and 11 + 516 = 527, so the modality tokens are attributed rather than merely present

One clarification, since an earlier revision of this description had it wrong: `get_model_info` does surface `input_cost_per_image_token` for Vertex models. It resolves `custom_llm_provider/model` before the bare key, so a rate set only on the bare key is ignored when a `vertex_ai/`-prefixed key also exists. Put the field on the key that resolves and the calculator picks it up

## Type

🐛 Bug Fix

## Changes

The forward transform's input branch loops over `audio_tokens`, `image_tokens` and `video_tokens` instead of handling audio alone, and the input token details type declares the two new fields rather than leaning on pydantic extras. The reverse transform already read `image_tokens`, so `video_tokens` joins it, matching a field the wrapper type has declared all along

The output half of this PR is gone. #38457 (`449c091391`) landed the same `audio_tokens` addition on the output token details type, with its own end-to-end coverage, and it always sets the output details with `reasoning_tokens` defaulting to 0. That structure is kept exactly as written upstream, so what is left here is the input side only

## Caveats

### Low

- The billed amount does not move yet. The calculator already falls back to `input_cost_per_token` when no per-modality rate is set, so these tokens were charged at the text rate rather than dropped from the bill. They have to survive the bridge before any per-modality rate can apply
- The proof above was captured before this PR was rebased onto current staging. The input hunk is byte-identical to what ran in that capture, and the only edits since were dropping the output half and alphabetizing the two new fields, so a fresh capture would read the same

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow usage-mapping change with tests; no auth or request-path behavior changes beyond richer usage metadata on `/v1/responses`.
> 
> **Overview**
> Fixes the Responses API usage bridge so **input** token breakdowns keep **image** and **video** counts instead of collapsing them into text-only `input_tokens_details`.
> 
> `InputTokensDetails` now declares `image_tokens` and `video_tokens`. The chat-completion → Responses transform copies `audio_tokens`, `image_tokens`, and `video_tokens` from `prompt_tokens_details` in one loop. The reverse path in `ResponseAPILoggingUtils` maps `video_tokens` back into `PromptTokensDetailsWrapper` (image was already read). A regression test covers forward and round-trip preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ab56b8fe5ac787c2e26f6900116d36d1891c573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->