### PR TITLE
fix(vertex_ai): surface the google-auth install hint on the async token path

### DIFF
--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -37,6 +37,15 @@ else:
     GoogleCredentialsObject = Any
 
 
+def _import_token_state() -> "type[TokenState]":
+    try:
+        from google.auth.credentials import TokenState
+    except ImportError:
+        raise ImportError(GOOGLE_IMPORT_ERROR_MESSAGE)
+
+    return TokenState
+
+
 class VertexBase:
     def __init__(self) -> None:
         super().__init__()
@@ -397,7 +406,7 @@ class VertexBase:
         Look up cached credentials and return (token, project_id) if the token
         is FRESH. Returns None if not cached or not fresh.
         """
-        from google.auth.credentials import TokenState
+        TokenState: Final = _import_token_state()
 
         creds, cached_project_id = self._unpack_cached_credentials(credential_cache_key)
         if (
@@ -423,7 +432,7 @@ class VertexBase:
         credentials object so the caller can schedule a background refresh
         without holding the per-key async lock.
         """
-        from google.auth.credentials import TokenState
+        TokenState: Final = _import_token_state()
 
         creds, cached_project_id = self._unpack_cached_credentials(credential_cache_key)
         if creds is None:
@@ -457,7 +466,7 @@ class VertexBase:
         Falls back to expired/valid checks if token_state is unavailable
         (e.g. older google-auth versions or mock objects in tests).
         """
-        from google.auth.credentials import TokenState as _TokenState
+        _TokenState: Final = _import_token_state()
 
         token_state: Final = getattr(credentials, "token_state", None)
         if isinstance(token_state, _TokenState):
@@ -978,7 +987,7 @@ class VertexBase:
         only one coroutine refreshes while others wait on the lock. Uses native
         async refresh for service_account and authorized_user credentials.
         """
-        from google.auth.credentials import TokenState
+        TokenState: Final = _import_token_state()
 
         cache_credentials: Final = json.dumps(credentials) if isinstance(credentials, dict) else credentials
         credential_cache_key: Final = (cache_credentials, project_id)

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -2088,3 +2088,33 @@ class TestVertexBase:
 
             assert token == "cached-token"
             assert not mock_get_lock.called, "Fast path should not acquire lock"
+
+    @pytest.mark.asyncio
+    async def test_missing_google_auth_raises_actionable_import_error(self):
+        """Test that a missing google-auth surfaces the install hint, not a raw ModuleNotFoundError"""
+        vertex_base = VertexBase()
+
+        with patch.dict("sys.modules", {"google.auth.credentials": None}):
+            with pytest.raises(ImportError, match="Google Cloud SDK not found"):
+                await vertex_base._ensure_access_token_async(
+                    credentials={"type": "service_account", "project_id": "project-1"},
+                    project_id="project-1",
+                    custom_llm_provider="vertex_ai",
+                )
+
+    @pytest.mark.parametrize(
+        "call_helper",
+        [
+            lambda vb: vb._try_get_cached_token(("key", None), "project-1"),
+            lambda vb: vb._try_get_usable_cached_token(("key", None), "project-1"),
+            lambda vb: vb._get_token_state(MagicMock()),
+        ],
+        ids=["try_get_cached_token", "try_get_usable_cached_token", "get_token_state"],
+    )
+    def test_token_state_helpers_raise_actionable_import_error(self, call_helper):
+        """Test that every TokenState call site surfaces the install hint"""
+        vertex_base = VertexBase()
+
+        with patch.dict("sys.modules", {"google.auth.credentials": None}):
+            with pytest.raises(ImportError, match="Google Cloud SDK not found"):
+                call_helper(vertex_base)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex requests fail with a raw `No module named 'google'`
- The install hint exists here, but four imports skipped it
- Those four are the only ones the async path reaches

How it solves it:

- All four now route through one guarded import helper
- Reuses the existing message; adds no dependency

## User Flow

Before: a developer pointing the proxy at a Vertex model gets an error naming nothing they can install

1. They `pip install "litellm[proxy]"` and configure `model: vertex_ai/gemini-2.5-flash`
2. They start the proxy on port 4000; it comes up clean, no warning
3. They POST `http://localhost:4000/v1/chat/completions` with that model
4. A 500 comes back reading `litellm.APIConnectionError: No module named 'google'`
5. No package is named, so they guess at what to install

After: the same request names the package

1. They `pip install "litellm[proxy]"` and configure `model: vertex_ai/gemini-2.5-flash`
2. They start the proxy on port 4000; it comes up clean, no warning
3. They POST `http://localhost:4000/v1/chat/completions` with that model
4. A 500 comes back reading `Google Cloud SDK not found. Install it with: pip install 'litellm[google]'`
5. They run that command and the request reaches real credential checks

## Relevant issues

Relates to #30320

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Built from this repo's `uv.lock` with exactly `--extra proxy`: 110 packages, no `google-auth`.
Only the patch differs between the two runs.

```
=== 2. google-auth must be ABSENT; this is the packaging gap the issue reports ===
google-auth NOT INSTALLED (expected)
packages in closure: 110

=== 4. BEFORE: base version of the file, google-auth absent ===       # 6704a105ee
APIConnectionError: litellm.APIConnectionError: No module named 'google'

=== 5. AFTER: the patch, google-auth still absent ===                 # b461a67d97
APIConnectionError: litellm.APIConnectionError: Google Cloud SDK not found. Install it with: pip install 'litellm[google]' or pip install google-cloud-aiplatform
```

Installing `google-auth` makes the guard transparent; the request then fails on credentials:

```
=== 6. install google-auth; the guard must become transparent ===
google-auth: 2.56.3
  File ".../vertex_llm_base.py", line 265, in _credentials_from_default_auth
    return google_auth.default(scopes=scopes)
google.auth.exceptions.DefaultCredentialsError: Your default credentials were not found.
```

A real billed Gemini call, unaffected:

```
{"model": "gemini-2.5-flash", "content": "proxy healthy",
 "usage": {"completion_tokens": 26, "prompt_tokens": 7, "total_tokens": 33}}
```

## Type

🐛 Bug Fix

## Changes

`GOOGLE_IMPORT_ERROR_MESSAGE` was already raised at seven import sites here. Four `TokenState`
imports were not, and all four sit only on the async path, so proxy requests got a bare
`ModuleNotFoundError` while sync callers got the hint. Sharing one helper also keeps
`get_access_token_async` under its complexity ceiling. Both new tests fail on unpatched code.

## Caveats (if any)

- Does not add `google-auth` to the `proxy` extra
- The issue's startup-validation ask stays open
- A too-old `google-auth` now also reports "not found"
- Matches the seven guarded sites already here

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b461a67d97b1559669bb149389a2163d44d9bc6f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->