### PR TITLE
ci: drop the CircleCI ui_build and ui_unit_tests jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2744,84 +2744,6 @@ jobs:
           file: ./coverage.xml
           flags: circleci
 
-  ui_build:
-    docker:
-      - image: cimg/node:24.19@sha256:8966565f07189a67d64d6808a2b127f31dafae566508e3547f55640e1070bfad
-        auth:
-          username: ${DOCKERHUB_USERNAME}
-          password: ${DOCKERHUB_PASSWORD}
-    resource_class: medium+
-    working_directory: ~/project
-    steps:
-      - checkout
-      - skip_if_unrelated_changes:
-          category: client
-      - setup_google_dns
-      - restore_cache:
-          keys:
-            - ui-build-deps-v1-{{ checksum "ui/litellm-dashboard/package-lock.json" }}
-            - ui-build-deps-v1-
-      - restore_cache:
-          keys:
-            - ui-nextjs-cache-v1-{{ checksum "ui/litellm-dashboard/package-lock.json" }}
-            - ui-nextjs-cache-v1-
-      - run:
-          name: Install dependencies
-          command: |
-            cd ui/litellm-dashboard
-            npm ci
-      - save_cache:
-          key: ui-build-deps-v1-{{ checksum "ui/litellm-dashboard/package-lock.json" }}
-          paths:
-            - ui/litellm-dashboard/node_modules
-      - run:
-          name: Build UI
-          command: |
-            cd ui/litellm-dashboard
-            source ./build_ui.sh
-      - save_cache:
-          key: ui-nextjs-cache-v1-{{ checksum "ui/litellm-dashboard/package-lock.json" }}
-          paths:
-            - ui/litellm-dashboard/.next/cache
-      - persist_to_workspace:
-          root: .
-          paths:
-            - litellm/proxy/_experimental/out
-
-  ui_unit_tests:
-    docker:
-      - image: cimg/node:24.19@sha256:8966565f07189a67d64d6808a2b127f31dafae566508e3547f55640e1070bfad
-        auth:
-          username: ${DOCKERHUB_USERNAME}
-          password: ${DOCKERHUB_PASSWORD}
-    resource_class: xlarge
-    working_directory: ~/project
-    steps:
-      - checkout
-      - skip_if_unrelated_changes:
-          category: client
-      - setup_google_dns
-      - restore_cache:
-          keys:
-            - ui-unit-deps-v1-{{ checksum "ui/litellm-dashboard/package-lock.json" }}
-            - ui-unit-deps-v1-
-      - run:
-          name: Install dependencies
-          command: |
-            cd ui/litellm-dashboard
-            npm ci
-      - save_cache:
-          key: ui-unit-deps-v1-{{ checksum "ui/litellm-dashboard/package-lock.json" }}
-          paths:
-            - ui/litellm-dashboard/node_modules
-      - run:
-          name: Run UI unit tests (Vitest)
-          command: |
-            cd ui/litellm-dashboard
-
-            CI=true npm run test -- --run \
-              --pool forks --poolOptions.forks.maxForks=6
-
   e2e_ui_testing:
     docker:
       - image: cimg/python:3.12-browsers@sha256:b432899af01c9a311bf74f4f22e9ada2e5306d4b1b4383f8d29e1228a5844ef2
@@ -3180,12 +3102,6 @@ workflows:
       - litellm_router_testing:
           filters: *main_branches
       - litellm_router_unit_testing:
-          filters: *main_branches
-      - ui_build:
-          filters: *main_branches
-      - ui_unit_tests:
-          requires:
-            - ui_build
           filters: *main_branches
       - auth_ui_unit_tests:
           filters: *main_branches


### PR DESCRIPTION
## TLDR

Problem this solves:

- CircleCI rebuilds and retests the UI that GHA already covers
- `ui_build` persists an artifact nothing ever reads
- Paid CI minutes on jobs that gate nothing

How it solves it:

- Delete the `ui_build` job
- Delete the `ui_unit_tests` job
- Leave the GHA equivalents as the only lanes

## User Flow

No end-user flow changes. This removes two CI jobs, so the effect is on contributors rather than on anyone calling the proxy

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

There is no runtime behavior to exercise against a proxy here, so the proof is that the config still parses, nothing dangles, and the diff is only the two jobs

The diff is a pure deletion, 84 lines and no additions:

```
$ git diff --stat
 .circleci/config.yml | 84 ----------------------------------------------------
 1 file changed, 84 deletions(-)
$ git diff | grep -c '^+[^+]'
0
```

The config still loads, both jobs are gone, the similarly-named Python job is untouched, and no workflow entry now points at a job that does not exist:

```
$ python3 -c '...load .circleci/config.yml, diff workflow refs against job defs...'
ui_build in jobs        : False
ui_unit_tests in jobs   : False
auth_ui_unit_tests kept : True
total jobs              : 47
workflow refs with no job definition: none
```

That last line is the one that matters: `ui_unit_tests` carried a `requires: [ui_build]` edge, so removing one without the other would have left a dangling dependency that fails config validation at pipeline start

On `ui_build` producing nothing: it persisted `litellm/proxy/_experimental/out` to the workspace, and the only job downstream of it was `ui_unit_tests`, whose steps are checkout, npm ci and vitest with no `attach_workspace`. The build output was written and discarded on every client-touching PR

`assert-ci-coverage` is green, but deliberately not offered as proof for the UI side. It walks `tests/**/test_*.py` only, so it cannot see vitest files:

```
$ python3 .github/scripts/assert_ci_coverage.py
OK: 2383 test files and 10 Dockerfiles are each invoked by at least one job or carry an explicit allowlist entry.
```

That says no Python test lost a runner. It is silent on the UI, which the caveat below covers instead

## Type

🚄 Infrastructure

## Caveats (if any)

- PR runs now cover UI tests reachable from the diff
- Full vitest suite still runs on staging pushes
- Deliberate: 248s of the 252s suite is one file
- `upload-coverage` left alone, it is not a duplicate

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
