### PR TITLE
fix(responses-api): report real usage on guardrail-blocked replies

### DIFF
--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -93,6 +93,38 @@ def _normalize_tool_dialect(
     return {**data, **{key: value for key, value in replaceable if key in data}}  # mutable-ok: plain body dict
 
 
+def _blocked_responses_api_usage(original_response: Any | None) -> ResponseAPIUsage:
+    """
+    Token usage for a synthetic guardrail-blocked /v1/responses reply.
+
+    A post-call block replaces the LLM's response with the violation message,
+    but the upstream call already consumed tokens -- report that real usage
+    (carried on ``ModifyResponseException.original_response``) rather than
+    discarding it, mirroring ``_blocked_response_usage`` in proxy_server.py
+    for /v1/chat/completions. Pre-call blocks never invoked the LLM (no
+    original_response), so usage is zero.
+
+    original_response can be a native ResponsesAPIResponse (usage already in
+    input_tokens/output_tokens shape) or a bridged chat ModelResponse (usage
+    in prompt_tokens/completion_tokens shape, needing a field-name mapping).
+    """
+    usage: Final = getattr(original_response, "usage", None) if original_response is not None else None
+    if usage is None:
+        return ResponseAPIUsage(input_tokens=0, output_tokens=0, total_tokens=0)
+    if hasattr(usage, "input_tokens"):
+        return ResponseAPIUsage(
+            input_tokens=getattr(usage, "input_tokens", 0) or 0,
+            output_tokens=getattr(usage, "output_tokens", 0) or 0,
+            total_tokens=getattr(usage, "total_tokens", 0) or 0,
+        )
+    if hasattr(usage, "prompt_tokens"):
+        return ResponseAPIUsage(
+            input_tokens=getattr(usage, "prompt_tokens", 0) or 0,
+            output_tokens=getattr(usage, "completion_tokens", 0) or 0,
+            total_tokens=getattr(usage, "total_tokens", 0) or 0,
+        )
+    return ResponseAPIUsage(input_tokens=0, output_tokens=0, total_tokens=0)
+
 def _is_chat_completions_body(data: Mapping[str, Any]) -> bool:
     messages: Final = data.get("messages")
     if isinstance(messages, list) and messages:
@@ -415,7 +447,7 @@ async def responses_api(
             model=e.model or data.get("model"),
             output=cast(Any, [{"content": [{"type": "text", "text": violation_text}]}]),
             status="completed",
-            usage=ResponseAPIUsage(input_tokens=0, output_tokens=0, total_tokens=0),
+            usage=_blocked_responses_api_usage(e.original_response),
         )
         return response_obj
     except Exception as e:

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -1748,3 +1748,68 @@ class TestCursorGateRecognizesRoutingGroups:
         resolved = _resolve_cursor_model_variant(body, router)
         assert resolved["model"] == "grouped-thinking-high"
         assert "reasoning_effort" not in resolved
+
+class TestBlockedResponsesAPIUsage(unittest.TestCase):
+    """
+    Regression tests for https://github.com/BerriAI/litellm/issues/6022-style bug:
+    a guardrail-blocked /v1/responses reply must report the real upstream usage
+    carried on ModifyResponseException.original_response, not hardcoded zeros.
+    """
+
+    def test_none_original_response_returns_zero_usage(self):
+        """Pre-call block: no upstream call ever happened, so usage stays zero."""
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _blocked_responses_api_usage,
+        )
+
+        usage = _blocked_responses_api_usage(None)
+
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+        assert usage.total_tokens == 0
+
+    def test_responses_api_shaped_usage_passed_through(self):
+        """Post-call block on a native /v1/responses upstream call: usage is
+        already input_tokens/output_tokens-shaped and should be lifted directly.
+        """
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _blocked_responses_api_usage,
+        )
+
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 14
+        mock_usage.output_tokens = 20
+        mock_usage.total_tokens = 34
+        del mock_usage.prompt_tokens  # ensure hasattr(usage, "prompt_tokens") is False
+
+        mock_original_response = MagicMock()
+        mock_original_response.usage = mock_usage
+
+        usage = _blocked_responses_api_usage(mock_original_response)
+
+        assert usage.input_tokens == 14
+        assert usage.output_tokens == 20
+        assert usage.total_tokens == 34
+
+    def test_chat_shaped_usage_is_field_mapped(self):
+        """Post-call block on a bridged chat ModelResponse: prompt_tokens/
+        completion_tokens must map to input_tokens/output_tokens.
+        """
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _blocked_responses_api_usage,
+        )
+
+        mock_usage = MagicMock()
+        del mock_usage.input_tokens  # ensure the ResponseAPIUsage-shape branch is skipped
+        mock_usage.prompt_tokens = 14
+        mock_usage.completion_tokens = 18
+        mock_usage.total_tokens = 32
+
+        mock_original_response = MagicMock()
+        mock_original_response.usage = mock_usage
+
+        usage = _blocked_responses_api_usage(mock_original_response)
+
+        assert usage.input_tokens == 14
+        assert usage.output_tokens == 18
+        assert usage.total_tokens == 32


### PR DESCRIPTION
Fixes #36880

## Problem
When a guardrail blocks a request/response through the /v1/responses
endpoint, the returned violation message always reports zero usage
(`ResponseAPIUsage(input_tokens=0, output_tokens=0, total_tokens=0)`),
even for a post-call block where the upstream LLM call already happened
and consumed real tokens. Anything reading usage off that response
(billing, monitoring, budget checks) sees zero cost for a call that
actually cost money.

## Root cause
The `except ModifyResponseException as e:` handler in
litellm/proxy/response_api_endpoints/endpoints.py hardcodes zero usage
instead of reading `e.original_response`, which already carries the real
usage when the block happened post-call. The chat completions endpoint
already solves this correctly via `_blocked_response_usage()` in
proxy_server.py — the Responses API endpoint just never got the
equivalent handling.

## Fix
Added `_blocked_responses_api_usage()`, mirroring `_blocked_response_usage`'s
logic for the Responses API's usage shape:
- `original_response is None` (pre-call block, no upstream call happened) → zero usage
- `original_response.usage` already Responses-API-shaped (native /v1/responses
  upstream call) → passed through directly
- `original_response.usage` Chat-Completions-shaped (a bridged call under
  the hood) → field-mapped (prompt_tokens→input_tokens,
  completion_tokens→output_tokens)

## Testing
Added 3 unit tests covering all three branches (None, Responses-shaped,
Chat-shaped) directly against the new helper function. I wasn't able to
run these through the full pytest suite locally — the proxy test conftest
requires a generated `prisma` client, which needs a DB step outside this
change's scope — so I verified the exact same assertions via a standalone
script against the real function instead; all three pass. Happy to run
the full suite if a maintainer can point me to the quickest prisma-generate
path, or if CI covers it directly.