### PR TITLE
fix(mcp): drop caller host and configured upstream headers from logged metadata

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -914,7 +914,12 @@ def _identity_header_names() -> frozenset[str]:
     """Lowercased header names the deployment reads the caller's identity out of. A name here
     is a claim about who the caller is rather than a secret, and ``get_user_from_headers``
     resolves it off the request this module reconstructs, so dropping one would lose end user
-    attribution on the MCP paths that leave ``end_user_id`` unset at connect time."""
+    attribution on the MCP paths that leave ``end_user_id`` unset at connect time.
+
+    ``user_header_mappings`` is accepted as a bare mapping as well as a list of them, matching
+    ``get_internal_user_header_from_mapping`` and ``get_customer_user_header_from_mapping``.
+    Iterating the bare form without normalizing yields its keys, which would silently exempt
+    nothing."""
     try:
         from litellm.proxy.proxy_server import general_settings
     except ImportError:
@@ -922,7 +927,8 @@ def _identity_header_names() -> frozenset[str]:
     if not general_settings:
         return frozenset()
     user_header: Final = general_settings.get("user_header_name")
-    mappings: Final = general_settings.get("user_header_mappings") or ()
+    configured: Final = general_settings.get("user_header_mappings")
+    mappings: Final = configured if isinstance(configured, list) else (configured,) if configured else ()
     mapped: Final = (mapping.get("header_name") for mapping in mappings if isinstance(mapping, Mapping))
     return frozenset(name.lower() for name in (user_header, *mapped) if isinstance(name, str) and name)
 

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -910,23 +910,43 @@ def _mcp_client_side_auth_header_name() -> str:
         return MCPRequestHandler.LITELLM_MCP_AUTH_HEADER_NAME
 
 
+def _identity_header_names() -> frozenset[str]:
+    """Lowercased header names the deployment reads the caller's identity out of. A name here
+    is a claim about who the caller is rather than a secret, and ``get_user_from_headers``
+    resolves it off the request this module reconstructs, so dropping one would lose end user
+    attribution on the MCP paths that leave ``end_user_id`` unset at connect time."""
+    try:
+        from litellm.proxy.proxy_server import general_settings
+    except ImportError:
+        return frozenset()
+    if not general_settings:
+        return frozenset()
+    user_header: Final = general_settings.get("user_header_name")
+    mappings: Final = general_settings.get("user_header_mappings") or ()
+    mapped: Final = (mapping.get("header_name") for mapping in mappings if isinstance(mapping, Mapping))
+    return frozenset(name.lower() for name in (user_header, *mapped) if isinstance(name, str) and name)
+
+
 def _forwarded_upstream_header_names() -> frozenset[str]:
     """Lowercased header names that a configured MCP server forwards upstream through its
     ``extra_headers`` allowlist. The names are chosen by the admin, so no prefix rule can
     recognize them, and a caller supplied value under one of them is an upstream credential.
 
-    ``authorization`` is left out because ``clean_headers`` already strips it, and adding it
+    ``authorization`` is left out because ``clean_headers`` already strips it, and claiming it
     here would change which header ``authenticated_with_header`` resolves to on the oauth
-    passthrough config, which lists it in ``extra_headers`` by design."""
+    passthrough config, which lists it in ``extra_headers`` by design. Identity headers are
+    left out for the same reason: naming one in ``extra_headers`` forwards the caller's
+    identity upstream, it does not turn that identity into a secret."""
     try:
         from .mcp_server_manager import global_mcp_server_manager
     except ImportError:
         return frozenset()
+    exempt: Final = _identity_header_names() | frozenset({"authorization"})
     return frozenset(
         name.lower()
         for server in global_mcp_server_manager.get_registry().values()
         for name in (server.extra_headers or ())
-        if isinstance(name, str) and name.lower() != "authorization"
+        if name.lower() not in exempt
     )
 
 
@@ -1019,7 +1039,8 @@ def logging_safe_mcp_headers(raw_headers: Mapping[str, str] | None) -> Mapping[s
     too: these headers are read back out of the metadata to change proxy behaviour, so
     leaving one in place would let any MCP client turn off the redaction an admin
     configured. This path carries no key or team object to authorize an opt-out with, so
-    it always strips them."""
+    it always strips them. ``host`` goes too, so that a caller cannot name the deployment in
+    the guardrail payload and the spend row the way it could once name the request URL."""
     from starlette.datastructures import Headers
 
     from litellm.proxy.litellm_pre_call_utils import (
@@ -1031,6 +1052,7 @@ def logging_safe_mcp_headers(raw_headers: Mapping[str, str] | None) -> Mapping[s
     excluded: Final = (
         _upstream_credential_headers(raw_headers.keys() if raw_headers else ())
         | UNTRUSTED_REQUEST_HEADER_CONTROL_FIELDS
+        | frozenset({"host"})
     )
     cleaned: Final = clean_headers(
         Headers(raw_headers),

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -880,7 +880,9 @@ _HOP_BY_HOP_HEADERS: Final = frozenset(
     }
 )
 
-_SYNTHETIC_REQUEST_EXCLUDED_HEADERS: Final = _HOP_BY_HOP_HEADERS | frozenset({"content-type", "x-forwarded-for"})
+_SYNTHETIC_REQUEST_EXCLUDED_HEADERS: Final = _HOP_BY_HOP_HEADERS | frozenset(
+    {"content-type", "host", "x-forwarded-for"}
+)
 
 _SYNTHETIC_REQUEST_SERVER: Final = ("127.0.0.1", 4000)
 
@@ -908,10 +910,31 @@ def _mcp_client_side_auth_header_name() -> str:
         return MCPRequestHandler.LITELLM_MCP_AUTH_HEADER_NAME
 
 
+def _forwarded_upstream_header_names() -> frozenset[str]:
+    """Lowercased header names that a configured MCP server forwards upstream through its
+    ``extra_headers`` allowlist. The names are chosen by the admin, so no prefix rule can
+    recognize them, and a caller supplied value under one of them is an upstream credential.
+
+    ``authorization`` is left out because ``clean_headers`` already strips it, and adding it
+    here would change which header ``authenticated_with_header`` resolves to on the oauth
+    passthrough config, which lists it in ``extra_headers`` by design."""
+    try:
+        from .mcp_server_manager import global_mcp_server_manager
+    except ImportError:
+        return frozenset()
+    return frozenset(
+        name.lower()
+        for server in global_mcp_server_manager.get_registry().values()
+        for name in (server.extra_headers or ())
+        if isinstance(name, str) and name.lower() != "authorization"
+    )
+
+
 def _upstream_credential_headers(header_names: Iterable[str]) -> frozenset[str]:
     """Lowercased names of the headers in ``header_names`` that carry an upstream MCP
-    credential rather than request context: the configured client side auth header and
-    the per-server ``x-mcp-{alias}-{header}`` family. ``clean_headers`` only knows the
+    credential rather than request context: the configured client side auth header, any
+    header name a configured server forwards upstream via ``extra_headers``, and the
+    per-server ``x-mcp-{alias}-{header}`` family. ``clean_headers`` only knows the
     credential headers of the chat completions path, so these are dropped on top of it.
     """
     from .auth.user_api_key_auth_mcp import MCPRequestHandler
@@ -923,10 +946,13 @@ def _upstream_credential_headers(header_names: Iterable[str]) -> frozenset[str]:
         }
     )
     client_side_auth: Final = _mcp_client_side_auth_header_name().lower()
+    forwarded_upstream: Final = _forwarded_upstream_header_names()
     return frozenset(
         name
         for name in (raw_name.lower() for raw_name in header_names)
-        if name == client_side_auth or (name.startswith(_MCP_SERVER_AUTH_HEADER_PREFIX) and name not in non_credential)
+        if name == client_side_auth
+        or name in forwarded_upstream
+        or (name.startswith(_MCP_SERVER_AUTH_HEADER_PREFIX) and name not in non_credential)
     )
 
 
@@ -944,7 +970,9 @@ def build_synthetic_mcp_request(
     ``proxy_server_request``, header-based tags, guardrails and trace correlation
     exactly as on the chat completions path. Hop-by-hop headers describe the
     original HTTP framing rather than the logical request, so they are dropped, and
-    ``x-forwarded-for`` comes from the resolved ``client_ip`` to avoid spoofing. Upstream
+    ``x-forwarded-for`` comes from the resolved ``client_ip`` to avoid spoofing. ``host`` is
+    dropped for the same reason: it is what ``Request.url`` is built from, so forwarding it
+    would let a caller choose the URL every logging callback records. Upstream
     MCP credentials and the deployment's proxy key header, including a custom
     ``litellm_key_header_name``, are dropped so they cannot reach a callback or a guardrail
     through the derived metadata even when a caller omits ``general_settings``.

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_utils.py
@@ -4,12 +4,32 @@ import pytest
 from fastapi import HTTPException
 
 from litellm.proxy._experimental.mcp_server.utils import (
+    _upstream_credential_headers,
     build_synthetic_mcp_request,
     logging_safe_mcp_headers,
     validate_and_normalize_mcp_server_payload,
     validate_tool_display_names,
 )
 from litellm.proxy._types import NewMCPServerRequest
+from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+
+def _server_forwarding(*header_names: str) -> MCPServer:
+    return MCPServer(
+        server_id="srv-1",
+        name="deepwiki",
+        transport="http",
+        url="https://mcp.example.com/mcp",
+        extra_headers=list(header_names),
+    )
+
+
+def _configured_servers(*servers: MCPServer):
+    return patch.dict(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager.config_mcp_servers",
+        {server.server_id: server for server in servers},
+        clear=False,
+    )
 
 
 class TestValidateToolDisplayNames:
@@ -114,6 +134,28 @@ class TestLoggingSafeMcpHeaders:
 
         assert safe == {"x-nuid": "nuid-1"}
 
+    def test_strips_headers_a_server_forwards_upstream(self):
+        """mcp_servers.<name>.extra_headers names the headers the proxy relays upstream, so a
+        caller supplied value under one of them is an upstream credential no prefix rule can spot.
+        Config is written in canonical casing while the wire header arrives lowercased."""
+        with _configured_servers(_server_forwarding("X-GitHub-Token", "X-Tenant")):
+            safe = logging_safe_mcp_headers({"x-github-token": "ghp_secret", "x-tenant": "acct-1", "x-nuid": "nuid-1"})
+
+        assert safe == {"x-nuid": "nuid-1"}
+
+    def test_keeps_authorization_classification_for_oauth_passthrough(self):
+        """clean_headers already strips authorization, and claiming it here would change which
+        header authenticated_with_header resolves to on a config that lists it by design."""
+        with _configured_servers(_server_forwarding("Authorization", "X-GitHub-Token")):
+            assert "authorization" not in _upstream_credential_headers(["authorization", "x-github-token"])
+            assert "x-github-token" in _upstream_credential_headers(["authorization", "x-github-token"])
+
+    def test_keeps_headers_when_no_server_forwards_them(self):
+        with _configured_servers(_server_forwarding("x-github-token")):
+            safe = logging_safe_mcp_headers({"x-other-token": "not-forwarded", "x-nuid": "nuid-1"})
+
+        assert safe == {"x-other-token": "not-forwarded", "x-nuid": "nuid-1"}
+
 
 class TestBuildSyntheticMcpRequest:
     def test_forwards_client_headers_without_upstream_credentials(self):
@@ -147,3 +189,25 @@ class TestBuildSyntheticMcpRequest:
 
         assert request.headers.get("x-nuid") == "nuid-1"
         assert "x-company-key" not in request.headers
+
+    def test_drops_caller_host_so_the_logged_url_is_not_client_steerable(self):
+        """add_litellm_data_to_request records str(request.url) as proxy_server_request.url, and
+        Request.url is built from the host header, so forwarding it hands the caller that value."""
+        request = build_synthetic_mcp_request(
+            path="/mcp/tools/call",
+            raw_headers={"host": "evil.attacker.example", "x-nuid": "nuid-1"},
+        )
+
+        assert "evil.attacker.example" not in str(request.url)
+        assert "host" not in request.headers
+        assert request.headers.get("x-nuid") == "nuid-1"
+
+    def test_drops_headers_a_server_forwards_upstream(self):
+        with _configured_servers(_server_forwarding("x-github-token")):
+            request = build_synthetic_mcp_request(
+                path="/mcp/tools/call",
+                raw_headers={"x-github-token": "ghp_secret", "x-nuid": "nuid-1"},
+            )
+
+        assert "x-github-token" not in request.headers
+        assert request.headers.get("x-nuid") == "nuid-1"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_utils.py
@@ -143,6 +143,26 @@ class TestLoggingSafeMcpHeaders:
 
         assert safe == {"x-nuid": "nuid-1"}
 
+    def test_strips_caller_asserted_host(self):
+        """This mapping reaches the guardrail payload and the list_tools spend row, so a caller
+        must not be able to name the deployment there either."""
+        safe = logging_safe_mcp_headers({"host": "evil.attacker.example", "x-nuid": "nuid-1"})
+
+        assert safe == {"x-nuid": "nuid-1"}
+
+    def test_keeps_identity_header_a_server_also_forwards(self):
+        """get_user_from_headers resolves end user attribution off this same request, so a header
+        the deployment reads identity from stays even when a server forwards it upstream."""
+        with patch.dict(
+            "litellm.proxy.proxy_server.general_settings",
+            {"user_header_name": "x-user-email"},
+            clear=False,
+        ):
+            with _configured_servers(_server_forwarding("x-user-email", "x-github-token")):
+                safe = logging_safe_mcp_headers({"x-user-email": "alice@corp.example", "x-github-token": "ghp_secret"})
+
+        assert safe == {"x-user-email": "alice@corp.example"}
+
     def test_keeps_authorization_classification_for_oauth_passthrough(self):
         """clean_headers already strips authorization, and claiming it here would change which
         header authenticated_with_header resolves to on a config that lists it by design."""
@@ -211,3 +231,19 @@ class TestBuildSyntheticMcpRequest:
 
         assert "x-github-token" not in request.headers
         assert request.headers.get("x-nuid") == "nuid-1"
+
+    def test_keeps_identity_header_so_end_user_attribution_survives(self):
+        """add_litellm_data_to_request reads user_header_name off this request to fill
+        end_user_id, so forwarding that header upstream must not remove it here."""
+        with patch.dict(
+            "litellm.proxy.proxy_server.general_settings",
+            {"user_header_name": "x-user-email"},
+            clear=False,
+        ):
+            with _configured_servers(_server_forwarding("x-user-email")):
+                request = build_synthetic_mcp_request(
+                    path="/mcp/tools/call",
+                    raw_headers={"x-user-email": "alice@corp.example"},
+                )
+
+        assert request.headers.get("x-user-email") == "alice@corp.example"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_utils.py
@@ -163,6 +163,28 @@ class TestLoggingSafeMcpHeaders:
 
         assert safe == {"x-user-email": "alice@corp.example"}
 
+    @pytest.mark.parametrize(
+        "configured",
+        [
+            [{"header_name": "X-User", "litellm_user_role": "customer"}],
+            {"header_name": "X-User", "litellm_user_role": "customer"},
+        ],
+        ids=["list-of-mappings", "bare-mapping"],
+    )
+    def test_keeps_identity_header_from_user_header_mappings(self, configured):
+        """get_internal_user_header_from_mapping and get_customer_user_header_from_mapping both
+        accept a bare mapping as well as a list, and config_settings.md documents the key as a
+        dict, so the exemption has to read both shapes."""
+        with patch.dict(
+            "litellm.proxy.proxy_server.general_settings",
+            {"user_header_mappings": configured},
+            clear=False,
+        ):
+            with _configured_servers(_server_forwarding("X-User", "X-GitHub-Token")):
+                safe = logging_safe_mcp_headers({"x-user": "alice", "x-github-token": "ghp_secret"})
+
+        assert safe == {"x-user": "alice"}
+
     def test_keeps_authorization_classification_for_oauth_passthrough(self):
         """clean_headers already strips authorization, and claiming it here would change which
         header authenticated_with_header resolves to on a config that lists it by design."""

--- a/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
+++ b/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
@@ -28,6 +28,7 @@ def _setup_mcp_call_environment(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", proxy_module)
 
     fake_manager = types.SimpleNamespace(
+        get_registry=MagicMock(return_value={}),
         call_tool=AsyncMock(return_value=_DummyMCPResult()),
         # Newer logging path calls this to enrich spend logs metadata
         _get_mcp_server_from_tool_name=MagicMock(return_value=None),
@@ -373,6 +374,7 @@ async def test_execute_tool_calls_logs_failure_via_post_call_failure_hook(monkey
     post_call_failure_hook = _setup_proxy_logging(monkeypatch)
 
     fake_manager = types.SimpleNamespace(
+        get_registry=MagicMock(return_value={}),
         call_tool=AsyncMock(side_effect=HTTPException(status_code=500, detail="boom"))
     )
     monkeypatch.setattr(
@@ -464,6 +466,7 @@ async def test_get_mcp_tools_from_manager_enables_list_tools_logging(monkeypatch
 
     # Patch manager methods used by _get_mcp_tools_from_manager to avoid needing full UserAPIKeyAuth fields.
     fake_manager = types.SimpleNamespace(
+        get_registry=MagicMock(return_value={}),
         get_allowed_mcp_servers=AsyncMock(return_value=[]),
         get_mcp_servers_from_ids=MagicMock(return_value=[]),
         get_mcp_server_by_name=MagicMock(return_value=None),
@@ -516,6 +519,7 @@ async def test_get_mcp_tools_from_manager_forwards_request_tags(monkeypatch):
         mock_get_tools,
     )
     fake_manager = types.SimpleNamespace(
+        get_registry=MagicMock(return_value={}),
         get_allowed_mcp_servers=AsyncMock(return_value=[]),
         get_mcp_servers_from_ids=MagicMock(return_value=[]),
         get_mcp_server_by_name=MagicMock(return_value=None),

--- a/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
+++ b/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
@@ -69,6 +69,7 @@ def _mock_mcp_environment(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     """Patch the MCP tool-call plumbing so _execute_tool_calls can run in tests."""
     call_tool = AsyncMock(return_value=CallToolResult(content=[TextContent(type="text", text="ok")], isError=False))
     fake_manager = types.SimpleNamespace(
+        get_registry=MagicMock(return_value={}),
         call_tool=call_tool,
         _get_mcp_server_from_tool_name=MagicMock(return_value=None),
         get_mcp_server_by_name=MagicMock(return_value=None),


### PR DESCRIPTION
## TLDR

Problem this solves:

- An MCP caller picked the request URL every logging callback recorded
- Headers a server forwards upstream reached logging metadata in cleartext

How it solves it:

- Drop `host` from the synthetic MCP request, so the URL is the proxy's own
- Treat configured `extra_headers` names as upstream credentials, minus identity ones

## User Flow

Before: anyone who can reach the MCP gateway writes attacker chosen data into the operator's logs, and a token the gateway relays upstream is stored beside it in the clear

1. A proxy admin configures an MCP server with `extra_headers: ["x-github-token"]` so their users can bring their own upstream token
2. A user calls `POST http://litellm-domain/mcp/` with `x-github-token: <their token>` and a forged `Host: evil.attacker.example`, and gets a normal `200` with the tool result
3. The admin opens their logging destination and the row for that call shows `url` and `endpoint` as `http://evil.attacker.example/mcp/tools/call`, a hostname that has nothing to do with their deployment
4. The same row carries `headers["x-github-token"]` with the user's token spelled out, and `proxy_server_request.headers` repeats it
5. Any operator, vendor or downstream system that can read those logs now holds that user's upstream token, and can be pointed at an attacker chosen hostname when correlating traffic

After: the same call still works and still reaches the upstream server with the token, but the logs describe the deployment instead of the caller

1. The admin keeps the same `extra_headers: ["x-github-token"]` configuration
2. The user sends the same request with the same forged `Host` and the same token, and gets the same `200` with the same tool result
3. The logged row shows `url` and `endpoint` as `http://127.0.0.1:4000/mcp/tools/call`, which no caller can influence
4. `headers` and `proxy_server_request.headers` no longer contain `x-github-token` at all
5. The upstream MCP server still receives `x-github-token` on `tools/list` and `tools/call`, so bring-your-own-token keeps working; a reader of the logs can no longer recover the token or be steered to a hostname of the caller's choosing

## Relevant issues

## Linear ticket

Refs LIT-5480

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxies, real MCP server (`https://mcp.deepwiki.com/mcp`), no mocks. Before runs at `a6f00b93b2`, which is byte identical to staging for both touched files; after runs at this PR's head. A `CustomLogger` records what each callback actually receives.

Config used on both sides:

```yaml
mcp_servers:
  deepwiki:
    transport: "http"
    url: "https://mcp.deepwiki.com/mcp"
    allow_all_keys: true
    extra_headers: ["x-github-token"]
```

The MCP python client sets `Host` itself and will not let you override it, so the host leg is driven with raw JSON-RPC over httpx. Note `/mcp` 307-redirects, so the trailing slash matters:

```
FORGED_HOST=evil.attacker.example python3 raw_host.py http://127.0.0.1:<port>/mcp/
HDRS='{"Authorization":"Bearer sk-1234","x-github-token":"<token>"}' python mcp_call2.py http://127.0.0.1:<port>/mcp/
```

Before, at `a6f00b93b2`, both calls return `200` with the real DeepWiki result, and the callback payloads carry:

```
attacker host in payloads : 10
upstream token in payloads: 9
post_mcp_tool_call_hook  url='http://evil.attacker.example/mcp/tools/call'
success                  url='http://evil.attacker.example/mcp/tools/call'
```

with `metadata.endpoint` matching:

```
post_mcp_tool_call_hook  endpoint='http://evil.attacker.example/mcp/tools/call'
success                  endpoint='http://evil.attacker.example/mcp/tools/call'
```

After, at `b4c0313ecc`, the same two calls still return `200` with the same result:

```
attacker host in payloads : 0
upstream token in payloads: 0
post_mcp_tool_call_hook  url='http://127.0.0.1:4000/mcp/tools/call'
success                  url='http://127.0.0.1:4000/mcp/tools/call'
post_mcp_tool_call_hook  endpoint='http://127.0.0.1:4000/mcp/tools/call'
```

The first revision left the forged hostname in the sanitized header mapping, which feeds the guardrail payload and the list_tools spend row, so it read 1 rather than 0 there. Dropping `host` in that helper as well is what takes it to 0

Stopping the leak is only half the claim, so a second rig points the gateway at a local MCP server that records the headers it is handed, to prove `extra_headers` still does its job. Same client call, both sides:

```
upstream requests that RECEIVED the token:
  initialize, notifications/initialized, tools/list, initialize, notifications/initialized, tools/call, tools/list
token in this proxy's logged payloads: before 9, after 0
```

So the credential still reaches the upstream server on `tools/list` and `tools/call` and no longer reaches the logging path.

Attribution is unaffected, and that is load bearing rather than incidental. `get_user_from_headers` resolves the end user off this same reconstructed request and only fills `end_user_id` when auth left it unset, so a deployment that both reads identity from a header and forwards it upstream would lose attribution if the header were claimed as a credential. Configured identity headers are therefore exempt. With `general_settings.user_header_name: x-user-email` and that same header named in `extra_headers`:

```
before: end_user_id='alice@corp.example'
after : end_user_id='alice@corp.example', header still present in metadata
```

## Type

🐛 Bug Fix

## Caveats (if any)

- `/mcp-rest` uses the real request, so it is unchanged and still logs both
- That REST exposure predates the synthetic request; verified at `6209b8928d`
- A2A `extra_headers` has the same shape and is untouched here
- Logged MCP url is now the synthetic server constant, not a real address
- Chat completions still builds its url from an unvalidated Host, proxy wide
- MCP `metadata.headers` is now narrower than the chat path's for the same client

## Behavior changes

An `extra_headers` name is dropped from the synthetic request, not only from the logged copy, so it stops reaching anything that reads request headers on MCP paths. That is intended for a credential and surprising for anything else, and `extra_headers` is documented as general header forwarding rather than as a secret list. Concretely, if an admin names one of these in `extra_headers`, its effect disappears on MCP paths only:

- a litellm control header (`x-litellm-tags`, `x-litellm-timeout`, `x-litellm-num-retries`, `x-litellm-spend-logs-metadata`, `x-litellm-agent-id`), which for tags also means per-tag budget and tag routing stop seeing it
- a name also listed in `litellm_settings.extra_spend_tag_headers`, which loses that spend tag
- any `x-` prefixed name, which leaves `requester_custom_headers` in the enterprise logging payload

Identity headers are exempt, so `user_header_name` and `user_header_mappings` names keep working; both the list and bare mapping shapes are handled. `authorization` is exempt too.

Dropping `host` also takes it out of the payload the `generic_guardrail_api` guardrail sends to its policy engine, which allowlists `host` by value today. That value was caller controlled, so a policy keyed on it was never trustworthy, but a deployment doing so will see the field go away rather than change.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2fe4af76b72faedbb09c612548e4bac61ee1406e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->