### PR TITLE
fix: preserve prompt_tokens_details when raw PromptTokensDetails reaches chunk aggregator

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -27,6 +27,7 @@ from litellm.types.utils import (
     ServerToolUse,
     Usage,
 )
+from openai.types.completion_usage import PromptTokensDetails
 from litellm.utils import print_verbose, token_counter
 
 if TYPE_CHECKING:
@@ -650,6 +651,8 @@ class ChunkProcessor:
                 prompt_tokens_details = PromptTokensDetailsWrapper(**usage_chunk.prompt_tokens_details)
             elif isinstance(usage_chunk.prompt_tokens_details, PromptTokensDetailsWrapper):
                 prompt_tokens_details = usage_chunk.prompt_tokens_details
+            elif isinstance(usage_chunk.prompt_tokens_details, PromptTokensDetails):
+                prompt_tokens_details = PromptTokensDetailsWrapper(**usage_chunk.prompt_tokens_details.model_dump())
 
         return {
             "prompt_tokens": prompt_tokens,

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -1076,6 +1076,27 @@ def test_prompt_tokens_details_survive_later_usage_chunk_without_details():
     assert usage.prompt_tokens_details.cache_write_tokens == 10
 
 
+def test_prompt_tokens_details_base_class_preserved_in_usage_chunk():
+    """Regression for #36882: when the raw streaming usage chunk carries a
+    base-class PromptTokensDetails (not PromptTokensDetailsWrapper), the
+    helper must still extract cached_tokens rather than silently dropping the
+    whole prompt_tokens_details field."""
+    from openai.types.completion_usage import PromptTokensDetails as RawPromptTokensDetails
+
+    from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProcessor
+    from litellm.types.utils import Usage
+
+    raw_details = RawPromptTokensDetails(cached_tokens=0)
+    usage_chunk = Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+    usage_chunk.prompt_tokens_details = raw_details  # type: ignore[assignment]
+
+    processor = ChunkProcessor.__new__(ChunkProcessor)
+    result = processor._usage_chunk_calculation_helper(usage_chunk)
+
+    assert result["prompt_tokens_details"] is not None
+    assert result["prompt_tokens_details"].cached_tokens == 0
+
+
 def test_get_combined_tool_content_custom_tool_call():
     from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProcessor
     from litellm.types.utils import ChatCompletionMessageCustomToolCall


### PR DESCRIPTION
## TLDR

Problem this solves:

- `prompt_tokens_details` (including `cached_tokens: 0`) was silently dropped from the final streaming usage chunk on some requests
- The helper that aggregates per-chunk usage only handled `dict` and `PromptTokensDetailsWrapper`; a raw openai-SDK `PromptTokensDetails` object was silently ignored

How it solves it:

- Add an `elif isinstance(..., PromptTokensDetails)` branch in `_usage_chunk_calculation_helper` to wrap the base class into a `PromptTokensDetailsWrapper`, matching the existing handling for dicts and wrapper instances

## User Flow

Before: a developer streaming chat completions through LiteLLM Proxy with `stream_options: {include_usage: true}` gets inconsistent usage chunks

1. They send POST https://litellm-proxy/v1/chat/completions with `"stream": true, "stream_options": {"include_usage": true}`
2. The final SSE usage chunk contains `prompt_tokens`, `completion_tokens`, `total_tokens` but no `prompt_tokens_details` field, even though the upstream provider returned `cached_tokens: 0`
3. Their cache-aware cost calculation must fail closed because `cached_tokens` is absent

After: the final SSE chunk always includes `prompt_tokens_details.cached_tokens` when the upstream provider returns it

1. They send the same POST https://litellm-proxy/v1/chat/completions
2. The final SSE usage chunk includes `"prompt_tokens_details": {"cached_tokens": 0}` as the upstream provider intended
3. Their cost calculation can use the field to compute effective input tokens

## Relevant issues

Fixes #36882

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Screenshots / Proof of Fix

The added unit test `test_prompt_tokens_details_base_class_preserved_in_usage_chunk` directly reproduces the failure: it sets `usage_chunk.prompt_tokens_details` to a raw `PromptTokensDetails(cached_tokens=0)` (simulating a chunk that bypasses litellm's `Usage.__init__`), calls `_usage_chunk_calculation_helper`, and asserts the result is not `None` and `cached_tokens == 0`. Before the fix this assertion fails; after, it passes.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR