### PR TITLE
refactor(ui): migrate AI Hub off antd and tremor to shadcn

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1709,54 +1709,26 @@
     "no-nested-ternary": {
       "count": 1
     },
-    "no-restricted-imports": {
-      "count": 2
-    },
     "prefer-const": {
       "count": 4
     }
   },
-  "src/components/AIHub/SkillHubDashboard.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/components/AIHub/UsefulLinksManagement.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
   "src/components/AIHub/forms/MakeAgentPublicForm.tsx": {
-    "no-restricted-imports": {
-      "count": 2
-    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
-  "src/components/AIHub/forms/MakeMCPPublicForm.test.tsx": {
-    "react/display-name": {
-      "count": 1
-    }
-  },
   "src/components/AIHub/forms/MakeMCPPublicForm.tsx": {
-    "no-nested-ternary": {
-      "count": 2
-    },
-    "no-restricted-imports": {
-      "count": 2
-    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
   "src/components/AIHub/forms/MakeModelPublicForm.tsx": {
-    "no-restricted-imports": {
-      "count": 2
-    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
@@ -23,10 +23,12 @@ import {
 import PublicModelHub from "@/components/public_model_hub";
 import { copyToClipboard } from "@/utils/dataUtils";
 import { isAdminRole, isProxyAdminRole } from "@/utils/roles";
-import { CopyOutlined } from "@ant-design/icons";
 import { SortingState } from "@tanstack/react-table";
-import { Badge, Button, Card, Tab, TabGroup, TabList, TabPanel, TabPanels, Text, Title } from "@tremor/react";
-import { Modal } from "antd";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Copy, Inbox } from "lucide-react";
 import { useRouter } from "next/navigation";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -393,7 +395,7 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
           {/* Header with Title, Description and URL */}
           <div className="flex justify-between items-center mb-6">
             <div className="flex flex-col items-start">
-              <Title className="text-center">AI Hub</Title>
+              <h2 className="text-center text-xl font-semibold">AI Hub</h2>
               {isAdminRole(userRole || "") ? (
                 <p className="text-sm text-gray-600">
                   Make models, agents, and MCP servers public for developers to know what&apos;s available.
@@ -403,9 +405,9 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
               )}
             </div>
             <div className="flex items-center space-x-4">
-              <Text>Model Hub URL:</Text>
+              <p>Model Hub URL:</p>
               <div className="flex items-center bg-gray-200 px-2 py-1 rounded-sm">
-                <Text className="mr-2">{`${getProxyBaseUrl()}/ui/model_hub_table`}</Text>
+                <p className="mr-2">{`${getProxyBaseUrl()}/ui/model_hub_table`}</p>
                 <button
                   onClick={() => void copyToClipboard(`${getProxyBaseUrl()}/ui/model_hub_table`)}
                   className="p-1 hover:bg-gray-300 rounded-sm transition-colors"
@@ -425,19 +427,19 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
           )}
 
           {/* Tab System for Model Hub, Agent Hub, MCP Hub, and Plugin Marketplace */}
-          <TabGroup>
-            <TabList className="mb-4">
-              <Tab>Model Hub</Tab>
-              <Tab>Agent Hub</Tab>
-              <Tab>MCP Hub</Tab>
-              <Tab>Skill Hub</Tab>
-            </TabList>
+          <Tabs defaultValue="models">
+            <TabsList className="mb-4">
+              <TabsTrigger value="models">Model Hub</TabsTrigger>
+              <TabsTrigger value="agents">Agent Hub</TabsTrigger>
+              <TabsTrigger value="mcp">MCP Hub</TabsTrigger>
+              <TabsTrigger value="skills">Skill Hub</TabsTrigger>
+            </TabsList>
 
-            <TabPanels>
+            <div>
               {/* Model Hub Tab */}
-              <TabPanel>
+              <TabsContent value="models">
                 {/* Model Filters and Table */}
-                <Card>
+                <Card className="px-6">
                   {/* Header with Make Public Button */}
                   {publicPage == false && canModify && (
                     <div className="flex justify-end mb-4">
@@ -473,15 +475,15 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
                 </Card>
 
                 <div className="mt-4 text-center space-y-2">
-                  <Text className="text-sm text-gray-600">
+                  <p className="text-sm text-gray-600">
                     Showing {filteredData.length} of {modelHubData?.length || 0} models
-                  </Text>
+                  </p>
                 </div>
-              </TabPanel>
+              </TabsContent>
 
               {/* Agent Hub Tab */}
-              <TabPanel>
-                <Card>
+              <TabsContent value="agents">
+                <Card className="px-6">
                   {/* Header with Make Public Button */}
                   {publicPage == false && canModify && (
                     <div className="flex justify-end mb-4">
@@ -507,15 +509,15 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
                 </Card>
 
                 <div className="mt-4 text-center space-y-2">
-                  <Text className="text-sm text-gray-600">
+                  <p className="text-sm text-gray-600">
                     Showing {agentHubData?.length || 0} agent{agentHubData?.length !== 1 ? "s" : ""}
-                  </Text>
+                  </p>
                 </div>
-              </TabPanel>
+              </TabsContent>
 
               {/* MCP Hub Tab */}
-              <TabPanel>
-                <Card>
+              <TabsContent value="mcp">
+                <Card className="px-6">
                   {/* Header with Make Public Button */}
                   {publicPage == false && canModify && (
                     <div className="flex justify-end mb-4">
@@ -544,14 +546,14 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
                 </Card>
 
                 <div className="mt-4 text-center space-y-2">
-                  <Text className="text-sm text-gray-600">
+                  <p className="text-sm text-gray-600">
                     Showing {mcpHubData?.length || 0} MCP server{mcpHubData?.length !== 1 ? "s" : ""}
-                  </Text>
+                  </p>
                 </div>
-              </TabPanel>
+              </TabsContent>
 
               {/* Skill Hub Tab */}
-              <TabPanel>
+              <TabsContent value="skills">
                 {publicPage == false && canModify && (
                   <div className="flex justify-end mb-4">
                     <Button onClick={() => setIsMakeSkillPublicModalVisible(true)}>Select Skills to Make Public</Button>
@@ -568,167 +570,162 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
                     setSkillHubData(response.plugins);
                   }}
                 />
-              </TabPanel>
-            </TabPanels>
-          </TabGroup>
+              </TabsContent>
+            </div>
+          </Tabs>
         </div>
       ) : (
-        <Card className="mx-auto max-w-xl mt-10">
-          <Text className="text-xl text-center mb-2 text-black">Public Model Hub not enabled.</Text>
+        <Card className="mx-auto max-w-xl mt-10 px-6">
+          <p className="text-xl text-center mb-2 text-black">Public Model Hub not enabled.</p>
           <p className="text-base text-center text-slate-800">Ask your proxy admin to enable this on their Admin UI.</p>
         </Card>
       )}
 
       {/* Public Page Modal */}
-      <Modal
-        title="Public Model Hub"
-        width={600}
-        open={isPublicPageModalVisible}
-        footer={null}
-        onOk={handleOk}
-        onCancel={handleCancel}
-      >
-        <div className="pt-5 pb-5">
-          <div className="flex justify-between mb-4">
-            <Text className="text-base mr-2">Shareable Link:</Text>
-            <Text className="max-w-sm ml-2 bg-gray-200 pr-2 pl-2 pt-1 pb-1 text-center rounded-sm">
-              {`${getProxyBaseUrl()}/ui/model_hub_table`}
-            </Text>
+      <Dialog open={isPublicPageModalVisible} onOpenChange={(open) => !open && handleCancel()}>
+        <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[600px]">
+          <DialogHeader>
+            <DialogTitle>{"Public Model Hub"}</DialogTitle>
+          </DialogHeader>
+          <div className="pt-5 pb-5">
+            <div className="flex justify-between mb-4">
+              <p className="text-base mr-2">Shareable Link:</p>
+              <p className="max-w-sm ml-2 bg-gray-200 pr-2 pl-2 pt-1 pb-1 text-center rounded-sm">
+                {`${getProxyBaseUrl()}/ui/model_hub_table`}
+              </p>
+            </div>
+            <div className="flex justify-end">
+              <Button onClick={goToPublicModelPage}>See Page</Button>
+            </div>
           </div>
-          <div className="flex justify-end">
-            <Button onClick={goToPublicModelPage}>See Page</Button>
-          </div>
-        </div>
-      </Modal>
+        </DialogContent>
+      </Dialog>
 
       {/* Model Details Modal */}
-      <Modal
-        title={selectedModel?.model_group || "Model Details"}
-        width={1000}
-        open={isModalVisible}
-        footer={null}
-        onOk={handleOk}
-        onCancel={handleCancel}
-      >
-        {selectedModel && (
-          <div className="space-y-6">
-            {/* Model Overview */}
-            <div>
-              <Text className="text-lg font-semibold mb-4">Model Overview</Text>
-              <div className="grid grid-cols-2 gap-4 mb-4">
-                <div>
-                  <Text className="font-medium">Model Group:</Text>
-                  <Text>{selectedModel.model_group}</Text>
+      <Dialog open={isModalVisible} onOpenChange={(open) => !open && handleCancel()}>
+        <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[1000px]">
+          <DialogHeader>
+            <DialogTitle>{selectedModel?.model_group || "Model Details"}</DialogTitle>
+          </DialogHeader>
+          {selectedModel && (
+            <div className="space-y-6">
+              {/* Model Overview */}
+              <div>
+                <p className="text-lg font-semibold mb-4">Model Overview</p>
+                <div className="grid grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <p className="font-medium">Model Group:</p>
+                    <p>{selectedModel.model_group}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Mode:</p>
+                    <p>{selectedModel.mode || "Not specified"}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Providers:</p>
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {selectedModel.providers.map((provider) => (
+                        <Badge key={provider} variant="secondary">
+                          {provider}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
                 </div>
-                <div>
-                  <Text className="font-medium">Mode:</Text>
-                  <Text>{selectedModel.mode || "Not specified"}</Text>
+              </div>
+
+              {/* Token and Cost Information */}
+              <div>
+                <p className="text-lg font-semibold mb-4">Token & Cost Information</p>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <p className="font-medium">Max Input Tokens:</p>
+                    <p>{selectedModel.max_input_tokens?.toLocaleString() || "Not specified"}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Max Output Tokens:</p>
+                    <p>{selectedModel.max_output_tokens?.toLocaleString() || "Not specified"}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Input Cost per 1M Tokens:</p>
+                    <p>
+                      {selectedModel.input_cost_per_token
+                        ? formatCost(selectedModel.input_cost_per_token)
+                        : "Not specified"}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Output Cost per 1M Tokens:</p>
+                    <p>
+                      {selectedModel.output_cost_per_token
+                        ? formatCost(selectedModel.output_cost_per_token)
+                        : "Not specified"}
+                    </p>
+                  </div>
                 </div>
+              </div>
+
+              {/* Capabilities */}
+              <div>
+                <p className="text-lg font-semibold mb-4">Capabilities</p>
+                <div className="flex flex-wrap gap-2">
+                  {(() => {
+                    const capabilities = getModelCapabilities(selectedModel);
+                    const colors = ["green", "blue", "purple", "orange", "red", "yellow"];
+
+                    if (capabilities.length === 0) {
+                      return <p className="text-gray-500">No special capabilities listed</p>;
+                    }
+
+                    return capabilities.map((capability, index) => (
+                      <Badge key={capability} variant="secondary">
+                        {formatCapabilityName(capability)}
+                      </Badge>
+                    ));
+                  })()}
+                </div>
+              </div>
+
+              {/* Rate Limits */}
+              {(selectedModel.tpm || selectedModel.rpm) && (
                 <div>
-                  <Text className="font-medium">Providers:</Text>
-                  <div className="flex flex-wrap gap-1 mt-1">
-                    {selectedModel.providers.map((provider) => (
-                      <Badge key={provider} color="blue">
-                        {provider}
+                  <p className="text-lg font-semibold mb-4">Rate Limits</p>
+                  <div className="grid grid-cols-2 gap-4">
+                    {selectedModel.tpm && (
+                      <div>
+                        <p className="font-medium">Tokens per Minute:</p>
+                        <p>{selectedModel.tpm.toLocaleString()}</p>
+                      </div>
+                    )}
+                    {selectedModel.rpm && (
+                      <div>
+                        <p className="font-medium">Requests per Minute:</p>
+                        <p>{selectedModel.rpm.toLocaleString()}</p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* Supported OpenAI Parameters */}
+              {selectedModel.supported_openai_params && (
+                <div>
+                  <p className="text-lg font-semibold mb-4">Supported OpenAI Parameters</p>
+                  <div className="flex flex-wrap gap-2">
+                    {selectedModel.supported_openai_params.map((param) => (
+                      <Badge key={param} variant="default">
+                        {param}
                       </Badge>
                     ))}
                   </div>
                 </div>
-              </div>
-            </div>
+              )}
 
-            {/* Token and Cost Information */}
-            <div>
-              <Text className="text-lg font-semibold mb-4">Token & Cost Information</Text>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <Text className="font-medium">Max Input Tokens:</Text>
-                  <Text>{selectedModel.max_input_tokens?.toLocaleString() || "Not specified"}</Text>
-                </div>
-                <div>
-                  <Text className="font-medium">Max Output Tokens:</Text>
-                  <Text>{selectedModel.max_output_tokens?.toLocaleString() || "Not specified"}</Text>
-                </div>
-                <div>
-                  <Text className="font-medium">Input Cost per 1M Tokens:</Text>
-                  <Text>
-                    {selectedModel.input_cost_per_token
-                      ? formatCost(selectedModel.input_cost_per_token)
-                      : "Not specified"}
-                  </Text>
-                </div>
-                <div>
-                  <Text className="font-medium">Output Cost per 1M Tokens:</Text>
-                  <Text>
-                    {selectedModel.output_cost_per_token
-                      ? formatCost(selectedModel.output_cost_per_token)
-                      : "Not specified"}
-                  </Text>
-                </div>
-              </div>
-            </div>
-
-            {/* Capabilities */}
-            <div>
-              <Text className="text-lg font-semibold mb-4">Capabilities</Text>
-              <div className="flex flex-wrap gap-2">
-                {(() => {
-                  const capabilities = getModelCapabilities(selectedModel);
-                  const colors = ["green", "blue", "purple", "orange", "red", "yellow"];
-
-                  if (capabilities.length === 0) {
-                    return <Text className="text-gray-500">No special capabilities listed</Text>;
-                  }
-
-                  return capabilities.map((capability, index) => (
-                    <Badge key={capability} color={colors[index % colors.length]}>
-                      {formatCapabilityName(capability)}
-                    </Badge>
-                  ));
-                })()}
-              </div>
-            </div>
-
-            {/* Rate Limits */}
-            {(selectedModel.tpm || selectedModel.rpm) && (
+              {/* Usage Example */}
               <div>
-                <Text className="text-lg font-semibold mb-4">Rate Limits</Text>
-                <div className="grid grid-cols-2 gap-4">
-                  {selectedModel.tpm && (
-                    <div>
-                      <Text className="font-medium">Tokens per Minute:</Text>
-                      <Text>{selectedModel.tpm.toLocaleString()}</Text>
-                    </div>
-                  )}
-                  {selectedModel.rpm && (
-                    <div>
-                      <Text className="font-medium">Requests per Minute:</Text>
-                      <Text>{selectedModel.rpm.toLocaleString()}</Text>
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-
-            {/* Supported OpenAI Parameters */}
-            {selectedModel.supported_openai_params && (
-              <div>
-                <Text className="text-lg font-semibold mb-4">Supported OpenAI Parameters</Text>
-                <div className="flex flex-wrap gap-2">
-                  {selectedModel.supported_openai_params.map((param) => (
-                    <Badge key={param} color="green">
-                      {param}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Usage Example */}
-            <div>
-              <Text className="text-lg font-semibold mb-4">Usage Example</Text>
-              <SyntaxHighlighter language="python" className="text-sm">
-                {`import openai
+                <p className="text-lg font-semibold mb-4">Usage Example</p>
+                <SyntaxHighlighter language="python" className="text-sm">
+                  {`import openai
 
 client = openai.OpenAI(
     api_key="your_api_key",
@@ -746,316 +743,310 @@ response = client.chat.completions.create(
 )
 
 print(response.choices[0].message.content)`}
-              </SyntaxHighlighter>
+                </SyntaxHighlighter>
+              </div>
             </div>
-          </div>
-        )}
-      </Modal>
+          )}
+        </DialogContent>
+      </Dialog>
 
       {/* Agent Details Modal */}
-      <Modal
-        title={selectedAgent?.name || "Agent Details"}
-        width={1000}
-        open={isAgentModalVisible}
-        footer={null}
-        onOk={handleOk}
-        onCancel={handleCancel}
-      >
-        {selectedAgent && (
-          <div className="space-y-6">
-            {/* Agent Overview */}
-            <div>
-              <Text className="text-lg font-semibold mb-4">Agent Overview</Text>
-              <div className="grid grid-cols-2 gap-4 mb-4">
-                <div>
-                  <Text className="font-medium">Name:</Text>
-                  <Text>{selectedAgent.name}</Text>
-                </div>
-                <div>
-                  <Text className="font-medium">Version:</Text>
-                  <Badge color="blue">v{selectedAgent.version}</Badge>
-                </div>
-                <div>
-                  <Text className="font-medium">Protocol Version:</Text>
-                  <Text>{selectedAgent.protocolVersion}</Text>
-                </div>
-                <div>
-                  <Text className="font-medium">URL:</Text>
-                  <div className="flex items-center space-x-2">
-                    <Text className="truncate">{selectedAgent.url}</Text>
-                    <CopyOutlined
-                      onClick={() => void copyToClipboard(selectedAgent.url)}
-                      className="cursor-pointer text-gray-500 hover:text-blue-500"
-                    />
+      <Dialog open={isAgentModalVisible} onOpenChange={(open) => !open && handleCancel()}>
+        <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[1000px]">
+          <DialogHeader>
+            <DialogTitle>{selectedAgent?.name || "Agent Details"}</DialogTitle>
+          </DialogHeader>
+          {selectedAgent && (
+            <div className="space-y-6">
+              {/* Agent Overview */}
+              <div>
+                <p className="text-lg font-semibold mb-4">Agent Overview</p>
+                <div className="grid grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <p className="font-medium">Name:</p>
+                    <p>{selectedAgent.name}</p>
                   </div>
-                </div>
-              </div>
-              <div>
-                <Text className="font-medium">Description:</Text>
-                <Text className="mt-1">{selectedAgent.description}</Text>
-              </div>
-            </div>
-
-            {/* Capabilities */}
-            {selectedAgent.capabilities && Object.keys(selectedAgent.capabilities).length > 0 && (
-              <div>
-                <Text className="text-lg font-semibold mb-4">Capabilities</Text>
-                <div className="flex flex-wrap gap-2">
-                  {Object.entries(selectedAgent.capabilities)
-                    .filter(([_, value]) => value === true)
-                    .map(([key]) => (
-                      <Badge key={key} color="green">
-                        {key}
-                      </Badge>
-                    ))}
-                </div>
-              </div>
-            )}
-
-            {/* Input/Output Modes */}
-            <div>
-              <Text className="text-lg font-semibold mb-4">Input/Output Modes</Text>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <Text className="font-medium">Input Modes:</Text>
-                  <div className="flex flex-wrap gap-1 mt-1">
-                    {selectedAgent.defaultInputModes?.map((mode) => (
-                      <Badge key={mode} color="blue">
-                        {mode}
-                      </Badge>
-                    )) || <Text>Not specified</Text>}
+                  <div>
+                    <p className="font-medium">Version:</p>
+                    <Badge variant="secondary">v{selectedAgent.version}</Badge>
+                  </div>
+                  <div>
+                    <p className="font-medium">Protocol Version:</p>
+                    <p>{selectedAgent.protocolVersion}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">URL:</p>
+                    <div className="flex items-center space-x-2">
+                      <p className="truncate min-w-0">{selectedAgent.url}</p>
+                      <Copy
+                        onClick={() => void copyToClipboard(selectedAgent.url)}
+                        className="size-3.5 shrink-0 cursor-pointer text-gray-500 hover:text-blue-500"
+                      />
+                    </div>
                   </div>
                 </div>
                 <div>
-                  <Text className="font-medium">Output Modes:</Text>
-                  <div className="flex flex-wrap gap-1 mt-1">
-                    {selectedAgent.defaultOutputModes?.map((mode) => (
-                      <Badge key={mode} color="purple">
-                        {mode}
-                      </Badge>
-                    )) || <Text>Not specified</Text>}
+                  <p className="font-medium">Description:</p>
+                  <p className="mt-1">{selectedAgent.description}</p>
+                </div>
+              </div>
+
+              {/* Capabilities */}
+              {selectedAgent.capabilities && Object.keys(selectedAgent.capabilities).length > 0 && (
+                <div>
+                  <p className="text-lg font-semibold mb-4">Capabilities</p>
+                  <div className="flex flex-wrap gap-2">
+                    {Object.entries(selectedAgent.capabilities)
+                      .filter(([_, value]) => value === true)
+                      .map(([key]) => (
+                        <Badge key={key} variant="default">
+                          {key}
+                        </Badge>
+                      ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Input/Output Modes */}
+              <div>
+                <p className="text-lg font-semibold mb-4">Input/Output Modes</p>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <p className="font-medium">Input Modes:</p>
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {selectedAgent.defaultInputModes?.map((mode) => (
+                        <Badge key={mode} variant="secondary">
+                          {mode}
+                        </Badge>
+                      )) || <p>Not specified</p>}
+                    </div>
+                  </div>
+                  <div>
+                    <p className="font-medium">Output Modes:</p>
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {selectedAgent.defaultOutputModes?.map((mode) => (
+                        <Badge key={mode} variant="outline">
+                          {mode}
+                        </Badge>
+                      )) || <p>Not specified</p>}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
 
-            {/* Skills */}
-            {selectedAgent.skills && selectedAgent.skills.length > 0 && (
-              <div>
-                <Text className="text-lg font-semibold mb-4">Skills</Text>
-                <div className="space-y-4">
-                  {selectedAgent.skills.map((skill) => (
-                    <div key={skill.id} className="border border-gray-200 rounded-sm p-4">
-                      <div className="flex justify-between items-start mb-2">
-                        <div>
-                          <Text className="font-medium text-base">{skill.name}</Text>
-                          <Text className="text-xs text-gray-500">ID: {skill.id}</Text>
+              {/* Skills */}
+              {selectedAgent.skills && selectedAgent.skills.length > 0 && (
+                <div>
+                  <p className="text-lg font-semibold mb-4">Skills</p>
+                  <div className="space-y-4">
+                    {selectedAgent.skills.map((skill) => (
+                      <div key={skill.id} className="border border-gray-200 rounded-sm p-4">
+                        <div className="flex justify-between items-start mb-2">
+                          <div>
+                            <p className="font-medium text-base">{skill.name}</p>
+                            <p className="text-xs text-gray-500">ID: {skill.id}</p>
+                          </div>
+                          {skill.tags && skill.tags.length > 0 && (
+                            <div className="flex flex-wrap gap-1">
+                              {skill.tags.map((tag) => (
+                                <Badge key={tag} variant="outline">
+                                  {tag}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
                         </div>
-                        {skill.tags && skill.tags.length > 0 && (
-                          <div className="flex flex-wrap gap-1">
-                            {skill.tags.map((tag) => (
-                              <Badge key={tag} color="purple" size="xs">
-                                {tag}
-                              </Badge>
-                            ))}
+                        <p className="text-sm mb-2">{skill.description}</p>
+                        {skill.examples && skill.examples.length > 0 && (
+                          <div>
+                            <p className="text-xs font-medium text-gray-700">Examples:</p>
+                            <div className="flex flex-wrap gap-1 mt-1">
+                              {skill.examples.map((example, idx) => (
+                                <Badge key={idx} variant="outline">
+                                  {example}
+                                </Badge>
+                              ))}
+                            </div>
                           </div>
                         )}
                       </div>
-                      <Text className="text-sm mb-2">{skill.description}</Text>
-                      {skill.examples && skill.examples.length > 0 && (
-                        <div>
-                          <Text className="text-xs font-medium text-gray-700">Examples:</Text>
-                          <div className="flex flex-wrap gap-1 mt-1">
-                            {skill.examples.map((example, idx) => (
-                              <Badge key={idx} color="gray" size="xs">
-                                {example}
-                              </Badge>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  ))}
+                    ))}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
 
-            {/* Additional Properties */}
-            {selectedAgent.supportsAuthenticatedExtendedCard && (
-              <div>
-                <Text className="text-lg font-semibold mb-4">Additional Features</Text>
-                <Badge color="green">Supports Authenticated Extended Card</Badge>
-              </div>
-            )}
-          </div>
-        )}
-      </Modal>
+              {/* Additional Properties */}
+              {selectedAgent.supportsAuthenticatedExtendedCard && (
+                <div>
+                  <p className="text-lg font-semibold mb-4">Additional Features</p>
+                  <Badge variant="default">Supports Authenticated Extended Card</Badge>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
 
       {/* MCP Server Details Modal */}
-      <Modal
-        title={selectedMcpServer?.server_name || "MCP Server Details"}
-        width={1000}
-        open={isMcpModalVisible}
-        footer={null}
-        onOk={handleOk}
-        onCancel={handleCancel}
-      >
-        {selectedMcpServer && (
-          <div className="space-y-6">
-            {/* Server Overview */}
-            <div>
-              <Text className="text-lg font-semibold mb-4">Server Overview</Text>
-              <div className="grid grid-cols-2 gap-4 mb-4">
-                <div>
-                  <Text className="font-medium">Server Name:</Text>
-                  <Text>{selectedMcpServer.server_name}</Text>
-                </div>
-                <div>
-                  <Text className="font-medium">Server ID:</Text>
-                  <div className="flex items-center space-x-2">
-                    <Text className="text-xs truncate">{selectedMcpServer.server_id}</Text>
-                    <CopyOutlined
-                      onClick={() => void copyToClipboard(selectedMcpServer.server_id)}
-                      className="cursor-pointer text-gray-500 hover:text-blue-500"
-                    />
+      <Dialog open={isMcpModalVisible} onOpenChange={(open) => !open && handleCancel()}>
+        <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[1000px]">
+          <DialogHeader>
+            <DialogTitle>{selectedMcpServer?.server_name || "MCP Server Details"}</DialogTitle>
+          </DialogHeader>
+          {selectedMcpServer && (
+            <div className="space-y-6">
+              {/* Server Overview */}
+              <div>
+                <p className="text-lg font-semibold mb-4">Server Overview</p>
+                <div className="grid grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <p className="font-medium">Server Name:</p>
+                    <p>{selectedMcpServer.server_name}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Server ID:</p>
+                    <div className="flex items-center space-x-2">
+                      <p className="text-xs truncate min-w-0">{selectedMcpServer.server_id}</p>
+                      <Copy
+                        onClick={() => void copyToClipboard(selectedMcpServer.server_id)}
+                        className="size-3.5 shrink-0 cursor-pointer text-gray-500 hover:text-blue-500"
+                      />
+                    </div>
+                  </div>
+                  {selectedMcpServer.alias && (
+                    <div>
+                      <p className="font-medium">Alias:</p>
+                      <p>{selectedMcpServer.alias}</p>
+                    </div>
+                  )}
+                  <div>
+                    <p className="font-medium">Transport:</p>
+                    <Badge variant="secondary">{selectedMcpServer.transport}</Badge>
+                  </div>
+                  <div>
+                    <p className="font-medium">Auth Type:</p>
+                    <Badge variant={selectedMcpServer.auth_type === "none" ? "outline" : "default"}>
+                      {selectedMcpServer.auth_type}
+                    </Badge>
+                  </div>
+                  <div>
+                    <p className="font-medium">Status:</p>
+                    <Badge
+                      variant={
+                        selectedMcpServer.status === "active" || selectedMcpServer.status === "healthy"
+                          ? "default"
+                          : selectedMcpServer.status === "inactive" || selectedMcpServer.status === "unhealthy"
+                            ? "destructive"
+                            : "outline"
+                      }
+                    >
+                      {selectedMcpServer.status || "unknown"}
+                    </Badge>
                   </div>
                 </div>
-                {selectedMcpServer.alias && (
-                  <div>
-                    <Text className="font-medium">Alias:</Text>
-                    <Text>{selectedMcpServer.alias}</Text>
+                {selectedMcpServer.description && (
+                  <div className="mt-2">
+                    <p className="font-medium">Description:</p>
+                    <p className="mt-1">{selectedMcpServer.description}</p>
                   </div>
                 )}
-                <div>
-                  <Text className="font-medium">Transport:</Text>
-                  <Badge color="blue">{selectedMcpServer.transport}</Badge>
-                </div>
-                <div>
-                  <Text className="font-medium">Auth Type:</Text>
-                  <Badge color={selectedMcpServer.auth_type === "none" ? "gray" : "green"}>
-                    {selectedMcpServer.auth_type}
-                  </Badge>
-                </div>
-                <div>
-                  <Text className="font-medium">Status:</Text>
-                  <Badge
-                    color={
-                      selectedMcpServer.status === "active" || selectedMcpServer.status === "healthy"
-                        ? "green"
-                        : selectedMcpServer.status === "inactive" || selectedMcpServer.status === "unhealthy"
-                          ? "red"
-                          : "gray"
-                    }
-                  >
-                    {selectedMcpServer.status || "unknown"}
-                  </Badge>
+              </div>
+
+              {/* Connection Details */}
+              <div>
+                <p className="text-lg font-semibold mb-4">Connection Details</p>
+                <div className="space-y-2">
+                  {selectedMcpServer.command && (
+                    <div>
+                      <p className="font-medium">Command:</p>
+                      <p className="text-sm bg-gray-100 p-2 rounded-sm mt-1 font-mono">{selectedMcpServer.command}</p>
+                    </div>
+                  )}
                 </div>
               </div>
-              {selectedMcpServer.description && (
-                <div className="mt-2">
-                  <Text className="font-medium">Description:</Text>
-                  <Text className="mt-1">{selectedMcpServer.description}</Text>
+
+              {/* Tools */}
+              {selectedMcpServer.allowed_tools && selectedMcpServer.allowed_tools.length > 0 && (
+                <div>
+                  <p className="text-lg font-semibold mb-4">Allowed Tools</p>
+                  <div className="flex flex-wrap gap-2">
+                    {selectedMcpServer.allowed_tools.map((tool, idx) => (
+                      <Badge key={idx} variant="outline">
+                        {tool}
+                      </Badge>
+                    ))}
+                  </div>
                 </div>
               )}
-            </div>
 
-            {/* Connection Details */}
-            <div>
-              <Text className="text-lg font-semibold mb-4">Connection Details</Text>
-              <div className="space-y-2">
-                {selectedMcpServer.command && (
-                  <div>
-                    <Text className="font-medium">Command:</Text>
-                    <Text className="text-sm bg-gray-100 p-2 rounded-sm mt-1 font-mono">
-                      {selectedMcpServer.command}
-                    </Text>
+              {/* Teams */}
+              {selectedMcpServer.teams && selectedMcpServer.teams.length > 0 && (
+                <div>
+                  <p className="text-lg font-semibold mb-4">Teams</p>
+                  <div className="flex flex-wrap gap-2">
+                    {selectedMcpServer.teams.map((team, idx) => (
+                      <Badge key={idx} variant="secondary">
+                        {team}
+                      </Badge>
+                    ))}
                   </div>
-                )}
-              </div>
-            </div>
-
-            {/* Tools */}
-            {selectedMcpServer.allowed_tools && selectedMcpServer.allowed_tools.length > 0 && (
-              <div>
-                <Text className="text-lg font-semibold mb-4">Allowed Tools</Text>
-                <div className="flex flex-wrap gap-2">
-                  {selectedMcpServer.allowed_tools.map((tool, idx) => (
-                    <Badge key={idx} color="purple">
-                      {tool}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Teams */}
-            {selectedMcpServer.teams && selectedMcpServer.teams.length > 0 && (
-              <div>
-                <Text className="text-lg font-semibold mb-4">Teams</Text>
-                <div className="flex flex-wrap gap-2">
-                  {selectedMcpServer.teams.map((team, idx) => (
-                    <Badge key={idx} color="blue">
-                      {team}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Access Groups */}
-            {selectedMcpServer.mcp_access_groups && selectedMcpServer.mcp_access_groups.length > 0 && (
-              <div>
-                <Text className="text-lg font-semibold mb-4">Access Groups</Text>
-                <div className="flex flex-wrap gap-2">
-                  {selectedMcpServer.mcp_access_groups.map((group, idx) => (
-                    <Badge key={idx} color="green">
-                      {group}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Metadata */}
-            <div>
-              <Text className="text-lg font-semibold mb-4">Metadata</Text>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <Text className="font-medium">Created By:</Text>
-                  <Text>{selectedMcpServer.created_by}</Text>
-                </div>
-                <div>
-                  <Text className="font-medium">Updated By:</Text>
-                  <Text>{selectedMcpServer.updated_by}</Text>
-                </div>
-                <div>
-                  <Text className="font-medium">Created At:</Text>
-                  <Text className="text-sm">{new Date(selectedMcpServer.created_at).toLocaleString()}</Text>
-                </div>
-                <div>
-                  <Text className="font-medium">Updated At:</Text>
-                  <Text className="text-sm">{new Date(selectedMcpServer.updated_at).toLocaleString()}</Text>
-                </div>
-                {selectedMcpServer.last_health_check && (
-                  <div>
-                    <Text className="font-medium">Last Health Check:</Text>
-                    <Text className="text-sm">{new Date(selectedMcpServer.last_health_check).toLocaleString()}</Text>
-                  </div>
-                )}
-              </div>
-              {selectedMcpServer.health_check_error && (
-                <div className="mt-2 p-2 bg-red-50 rounded-sm">
-                  <Text className="font-medium text-red-700">Health Check Error:</Text>
-                  <Text className="text-sm text-red-600 mt-1">{selectedMcpServer.health_check_error}</Text>
                 </div>
               )}
-            </div>
 
-            {/* Usage Example */}
-            <div>
-              <Text className="text-lg font-semibold mb-4">Usage Example</Text>
-              <SyntaxHighlighter language="python" className="text-sm">
-                {`from fastmcp import Client
+              {/* Access Groups */}
+              {selectedMcpServer.mcp_access_groups && selectedMcpServer.mcp_access_groups.length > 0 && (
+                <div>
+                  <p className="text-lg font-semibold mb-4">Access Groups</p>
+                  <div className="flex flex-wrap gap-2">
+                    {selectedMcpServer.mcp_access_groups.map((group, idx) => (
+                      <Badge key={idx} variant="default">
+                        {group}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Metadata */}
+              <div>
+                <p className="text-lg font-semibold mb-4">Metadata</p>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <p className="font-medium">Created By:</p>
+                    <p>{selectedMcpServer.created_by}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Updated By:</p>
+                    <p>{selectedMcpServer.updated_by}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Created At:</p>
+                    <p className="text-sm">{new Date(selectedMcpServer.created_at).toLocaleString()}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Updated At:</p>
+                    <p className="text-sm">{new Date(selectedMcpServer.updated_at).toLocaleString()}</p>
+                  </div>
+                  {selectedMcpServer.last_health_check && (
+                    <div>
+                      <p className="font-medium">Last Health Check:</p>
+                      <p className="text-sm">{new Date(selectedMcpServer.last_health_check).toLocaleString()}</p>
+                    </div>
+                  )}
+                </div>
+                {selectedMcpServer.health_check_error && (
+                  <div className="mt-2 p-2 bg-red-50 rounded-sm">
+                    <p className="font-medium text-red-700">Health Check Error:</p>
+                    <p className="text-sm text-red-600 mt-1">{selectedMcpServer.health_check_error}</p>
+                  </div>
+                )}
+              </div>
+
+              {/* Usage Example */}
+              <div>
+                <p className="text-lg font-semibold mb-4">Usage Example</p>
+                <SyntaxHighlighter language="python" className="text-sm">
+                  {`from fastmcp import Client
 import asyncio
 
 # Standard MCP configuration
@@ -1088,11 +1079,12 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())`}
-              </SyntaxHighlighter>
+                </SyntaxHighlighter>
+              </div>
             </div>
-          </div>
-        )}
-      </Modal>
+          )}
+        </DialogContent>
+      </Dialog>
 
       {/* Make Model Public Form */}
       <MakeModelPublicForm

--- a/ui/litellm-dashboard/src/components/AIHub/SkillHubDashboard.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/SkillHubDashboard.tsx
@@ -1,12 +1,14 @@
 import React, { useMemo, useState } from "react";
-import { SearchOutlined } from "@ant-design/icons";
 import { SortingState } from "@tanstack/react-table";
-import { Input, Select } from "antd";
-import { Inbox } from "lucide-react";
+import { Inbox, Search, X } from "lucide-react";
 import { Plugin } from "@/components/claude_code_plugins/types";
 import { DataTable } from "@/components/shared/DataTable";
 import { getSkillHubTableColumns } from "@/components/AIHub/SkillHubTableColumns";
 import SkillDetail from "@/components/claude_code_plugins/skill_detail";
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/ui/input-group";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+const ALL_DOMAINS = "__all_domains__";
 
 interface SkillHubDashboardProps {
   skills: Plugin[];
@@ -48,7 +50,10 @@ const SkillHubDashboard: React.FC<SkillHubDashboardProps> = ({
 
   // Derived stats
   const totalSkills = skills.length;
-  const domains = useMemo(() => [...new Set(skills.map((s) => s.domain).filter(Boolean))], [skills]);
+  const domains = useMemo(
+    () => [...new Set(skills.map((s) => s.domain).filter((domain): domain is string => Boolean(domain)))],
+    [skills],
+  );
   const namespaces = useMemo(() => [...new Set(skills.map((s) => s.namespace).filter(Boolean))], [skills]);
 
   // Filtered table data
@@ -72,6 +77,11 @@ const SkillHubDashboard: React.FC<SkillHubDashboardProps> = ({
   }, [skills, search, domainFilter]);
 
   const columns = useMemo(() => getSkillHubTableColumns({ onSkillClick: setSelectedSkill }), []);
+
+  const domainItems = useMemo(
+    () => [{ value: ALL_DOMAINS, label: "All Domains" }, ...domains.map((d) => ({ value: d, label: d }))],
+    [domains],
+  );
 
   const hasActiveFilter = search.trim().length > 0 || domainFilter != null;
 
@@ -111,21 +121,43 @@ const SkillHubDashboard: React.FC<SkillHubDashboardProps> = ({
           <h3 className="text-sm font-semibold text-gray-700">All {publicPage ? "Public " : ""}Skills</h3>
           <div className="flex items-center gap-2">
             <Select
-              placeholder="All Domains"
-              allowClear
-              value={domainFilter}
-              onChange={(val) => setDomainFilter(val)}
-              style={{ width: 160 }}
-              options={domains.map((d) => ({ label: d, value: d }))}
-            />
-            <Input
-              prefix={<SearchOutlined className="text-gray-400" />}
-              placeholder="Search by name, namespace, or tag…"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              style={{ width: 280 }}
-              allowClear
-            />
+              items={domainItems}
+              value={domainFilter ?? ALL_DOMAINS}
+              onValueChange={(val) => setDomainFilter(val === null || val === ALL_DOMAINS ? undefined : val)}
+            >
+              <SelectTrigger className="w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {domainItems.map((item) => (
+                  <SelectItem key={item.value} value={item.value}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <InputGroup className="w-[280px]">
+              <InputGroupAddon>
+                <Search className="size-4 text-muted-foreground" />
+              </InputGroupAddon>
+              <InputGroupInput
+                placeholder="Search by name, namespace, or tag…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+              {search !== "" && (
+                <InputGroupAddon align="inline-end">
+                  <InputGroupButton
+                    size="icon-xs"
+                    variant="ghost"
+                    aria-label="Clear search"
+                    onClick={() => setSearch("")}
+                  >
+                    <X className="size-3.5" />
+                  </InputGroupButton>
+                </InputGroupAddon>
+              )}
+            </InputGroup>
           </div>
         </div>
         <DataTable

--- a/ui/litellm-dashboard/src/components/AIHub/UsefulLinksManagement.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/UsefulLinksManagement.tsx
@@ -2,7 +2,8 @@ import TableIconActionButton from "@/components/common_components/IconActionButt
 import NotificationsManager from "@/components/molecules/notifications_manager";
 import { isAdminRole } from "@/utils/roles";
 import { ChevronDownIcon, ChevronRightIcon, ExternalLinkIcon, PlusCircleIcon } from "@heroicons/react/outline";
-import { Card, Table, TableBody, TableCell, TableHead, TableHeaderCell, TableRow, Text, Title } from "@tremor/react";
+import { Card } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import Link from "next/link";
 import React, { useEffect, useState } from "react";
 import { getProxyBaseUrl, getPublicModelHubInfo, updateUsefulLinksCall } from "../networking";
@@ -223,10 +224,10 @@ const UsefulLinksManagement: React.FC<UsefulLinksManagementProps> = ({ accessTok
   };
 
   return (
-    <Card className="mb-6">
+    <Card className="mb-6 px-6">
       <div className="flex items-center justify-between cursor-pointer" onClick={() => setIsExpanded(!isExpanded)}>
         <div className="flex flex-col">
-          <Title className="mb-0">Link Management</Title>
+          <h3 className="mb-0 text-lg font-semibold">Link Management</h3>
           <p className="text-sm text-gray-500">
             Manage the links that are displayed under &apos;Useful Links&apos; on the public model hub.
           </p>
@@ -243,7 +244,7 @@ const UsefulLinksManagement: React.FC<UsefulLinksManagementProps> = ({ accessTok
       {isExpanded && (
         <div className="mt-4">
           <div className="mb-6">
-            <Text className="text-sm font-medium text-gray-700 mb-2">Add New Link</Text>
+            <p className="text-sm font-medium text-gray-700 mb-2">Add New Link</p>
             <div className="grid grid-cols-3 gap-4">
               <div>
                 <label className="block text-xs text-gray-500 mb-1">Display Name</label>
@@ -288,7 +289,7 @@ const UsefulLinksManagement: React.FC<UsefulLinksManagementProps> = ({ accessTok
             </div>
           </div>
           <div className="flex items-center justify-between mb-2">
-            <Text className="text-sm font-medium text-gray-700">Manage Existing Links</Text>
+            <p className="text-sm font-medium text-gray-700">Manage Existing Links</p>
             <div className="flex items-center space-x-2">
               <Link
                 href={`${getProxyBaseUrl()}/ui/model_hub_table`}
@@ -328,13 +329,13 @@ const UsefulLinksManagement: React.FC<UsefulLinksManagementProps> = ({ accessTok
           <div className="rounded-lg custom-border relative">
             <div className="overflow-x-auto">
               <Table className="[&_td]:py-0.5 [&_th]:py-1">
-                <TableHead>
+                <TableHeader>
                   <TableRow>
-                    <TableHeaderCell className="py-1 h-8">Display Name</TableHeaderCell>
-                    <TableHeaderCell className="py-1 h-8">URL</TableHeaderCell>
-                    <TableHeaderCell className="py-1 h-8">Actions</TableHeaderCell>
+                    <TableHead className="py-1 h-8">Display Name</TableHead>
+                    <TableHead className="py-1 h-8">URL</TableHead>
+                    <TableHead className="py-1 h-8">Actions</TableHead>
                   </TableRow>
-                </TableHead>
+                </TableHeader>
                 <TableBody>
                   {links.map((link, index) => (
                     <TableRow key={link.id} className="h-8">

--- a/ui/litellm-dashboard/src/components/AIHub/forms/MakeAgentPublicForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/forms/MakeAgentPublicForm.test.tsx
@@ -12,67 +12,8 @@ vi.mock("../../networking", () => ({
 import { makeAgentsPublicCall } from "../../networking";
 const mockMakeAgentsPublicCall = vi.mocked(makeAgentsPublicCall);
 
-// Mock antd components
-vi.mock("antd", () => ({
-  Modal: ({ open, title, children, onCancel, footer }: any) =>
-    open ? (
-      <div data-testid="modal">
-        <div>{title}</div>
-        {children}
-        {footer}
-      </div>
-    ) : null,
-  Form: Object.assign(({ children, form }: any) => <form data-testid="form">{children}</form>, {
-    useForm: () => [
-      {
-        resetFields: vi.fn(),
-        validateFields: vi.fn(),
-        getFieldsValue: vi.fn(),
-        setFieldsValue: vi.fn(),
-      },
-      vi.fn(),
-    ],
-    Item: ({ children }: any) => <div>{children}</div>,
-  }),
-  Steps: Object.assign(
-    ({ children, current, className }: any) => (
-      <div data-testid="steps" className={className}>
-        {children}
-      </div>
-    ),
-    {
-      Step: ({ title }: any) => <div>{title}</div>,
-    },
-  ),
-  Button: ({ children, onClick, disabled, loading, ...props }: any) => (
-    <button onClick={onClick} disabled={disabled || loading} data-loading={loading} {...props}>
-      {children}
-    </button>
-  ),
-  Checkbox: ({ checked, indeterminate, onChange, children, disabled }: any) => (
-    <label>
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange({ target: { checked: e.target.checked } })}
-        disabled={disabled}
-        data-indeterminate={indeterminate}
-      />
-      {children}
-    </label>
-  ),
-}));
-
-// Mock @tremor/react components
-vi.mock("@tremor/react", () => ({
-  Text: ({ children, className }: any) => <span className={className}>{children}</span>,
-  Title: ({ children }: any) => <h3>{children}</h3>,
-  Badge: ({ children, color, size }: any) => (
-    <span data-color={color} data-size={size}>
-      {children}
-    </span>
-  ),
-}));
+const expectDisabledControl = (element: HTMLElement) =>
+  expect(element.hasAttribute("disabled") || element.getAttribute("aria-disabled") === "true").toBe(true);
 
 describe("MakeAgentPublicForm", () => {
   const mockProps = {
@@ -143,7 +84,7 @@ describe("MakeAgentPublicForm", () => {
     expect(screen.getByText("Select Agents to Make Public")).toBeInTheDocument();
 
     // Select all agents using the select all checkbox
-    const selectAllCheckbox = screen.getByLabelText("Select All (2)");
+    const selectAllCheckbox = screen.getByRole("checkbox", { name: "Select All (2)" });
     await act(async () => {
       fireEvent.click(selectAllCheckbox);
     });
@@ -169,7 +110,7 @@ describe("MakeAgentPublicForm", () => {
     render(<MakeAgentPublicForm {...mockProps} />);
 
     // Select all agents
-    const selectAllCheckbox = screen.getByLabelText("Select All (2)");
+    const selectAllCheckbox = screen.getByRole("checkbox", { name: "Select All (2)" });
     await act(async () => {
       fireEvent.click(selectAllCheckbox);
     });
@@ -232,6 +173,8 @@ describe("MakeAgentPublicForm", () => {
     const checkboxes = screen.getAllByRole("checkbox");
     await act(async () => {
       fireEvent.click(checkboxes[0]); // Click select all to select all
+    });
+    await act(async () => {
       fireEvent.click(checkboxes[0]); // Click select all again to deselect all
     });
 
@@ -256,8 +199,8 @@ describe("MakeAgentPublicForm", () => {
     expect(screen.getByText("No agents available.")).toBeInTheDocument();
 
     // Select All checkbox should be disabled
-    const selectAllCheckbox = screen.getByLabelText("Select All");
-    expect(selectAllCheckbox).toBeDisabled();
+    const selectAllCheckbox = screen.getByRole("checkbox", { name: "Select All" });
+    expectDisabledControl(selectAllCheckbox);
 
     // Next button should be disabled
     const nextButton = screen.getByRole("button", { name: "Next" });
@@ -332,7 +275,7 @@ describe("MakeAgentPublicForm", () => {
 
     // Select all should be indeterminate now
     const selectAllCheckbox = checkboxes[0];
-    expect(selectAllCheckbox).toHaveAttribute("data-indeterminate", "true");
+    expect(selectAllCheckbox).toBePartiallyChecked();
   });
 
   it("should display skills overflow text when agent has more than 3 skills", () => {
@@ -395,7 +338,7 @@ describe("MakeAgentPublicForm", () => {
     expect(mockProps.onClose).not.toHaveBeenCalled();
   });
 
-  it("should show loading state during submit", async () => {
+  it("should not complete the flow until the submit request resolves", async () => {
     let resolvePromise: (value: any) => void = () => {};
     const pendingPromise = new Promise((resolve) => {
       resolvePromise = resolve;
@@ -420,9 +363,11 @@ describe("MakeAgentPublicForm", () => {
       fireEvent.click(submitButton);
     });
 
-    // Check loading state
-    expect(submitButton).toHaveAttribute("data-loading", "true");
-    expect(submitButton).toBeDisabled();
+    // While the request is in flight the flow must not have completed
+    expect(mockMakeAgentsPublicCall).toHaveBeenCalledTimes(1);
+    expect(mockProps.onSuccess).not.toHaveBeenCalled();
+    expect(mockProps.onClose).not.toHaveBeenCalled();
+    expect(screen.getByText("Confirm Making Agents Public")).toBeInTheDocument();
 
     // Resolve the promise
     resolvePromise({});
@@ -441,7 +386,7 @@ describe("MakeAgentPublicForm", () => {
     render(<MakeAgentPublicForm {...invisibleProps} />);
 
     // Modal should not be rendered
-    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(screen.queryByText("Make Agents Public")).not.toBeInTheDocument();
   });
 
@@ -500,6 +445,6 @@ describe("MakeAgentPublicForm", () => {
 
     // Select all should be indeterminate
     const selectAllCheckbox = checkboxes[0];
-    expect(selectAllCheckbox).toHaveAttribute("data-indeterminate", "true");
+    expect(selectAllCheckbox).toBePartiallyChecked();
   });
 });

--- a/ui/litellm-dashboard/src/components/AIHub/forms/MakeAgentPublicForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/forms/MakeAgentPublicForm.test.tsx
@@ -115,7 +115,6 @@ describe("MakeAgentPublicForm", () => {
       fireEvent.click(selectAllCheckbox);
     });
 
-    // Navigate to confirm step
     const nextButton = screen.getByRole("button", { name: "Next" });
     await act(async () => {
       fireEvent.click(nextButton);
@@ -126,7 +125,6 @@ describe("MakeAgentPublicForm", () => {
       expect(screen.getByText("Confirm Making Agents Public")).toBeInTheDocument();
     });
 
-    // Submit
     const submitButton = screen.getByRole("button", { name: "Make Public" });
     await act(async () => {
       fireEvent.click(submitButton);
@@ -312,7 +310,6 @@ describe("MakeAgentPublicForm", () => {
 
     render(<MakeAgentPublicForm {...mockProps} />);
 
-    // Navigate to confirm step
     const nextButton = screen.getByRole("button", { name: "Next" });
     await act(async () => {
       fireEvent.click(nextButton);
@@ -322,7 +319,6 @@ describe("MakeAgentPublicForm", () => {
       expect(screen.getByText("Confirm Making Agents Public")).toBeInTheDocument();
     });
 
-    // Submit
     const submitButton = screen.getByRole("button", { name: "Make Public" });
     await act(async () => {
       fireEvent.click(submitButton);
@@ -347,7 +343,6 @@ describe("MakeAgentPublicForm", () => {
 
     render(<MakeAgentPublicForm {...mockProps} />);
 
-    // Navigate to confirm step
     const nextButton = screen.getByRole("button", { name: "Next" });
     await act(async () => {
       fireEvent.click(nextButton);
@@ -357,19 +352,20 @@ describe("MakeAgentPublicForm", () => {
       expect(screen.getByText("Confirm Making Agents Public")).toBeInTheDocument();
     });
 
-    // Submit
     const submitButton = screen.getByRole("button", { name: "Make Public" });
     await act(async () => {
       fireEvent.click(submitButton);
     });
 
-    // While the request is in flight the flow must not have completed
+    expectDisabledControl(submitButton);
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
     expect(mockMakeAgentsPublicCall).toHaveBeenCalledTimes(1);
     expect(mockProps.onSuccess).not.toHaveBeenCalled();
     expect(mockProps.onClose).not.toHaveBeenCalled();
     expect(screen.getByText("Confirm Making Agents Public")).toBeInTheDocument();
 
-    // Resolve the promise
     resolvePromise({});
     await waitFor(() => {
       expect(mockProps.onSuccess).toHaveBeenCalled();

--- a/ui/litellm-dashboard/src/components/AIHub/forms/MakeAgentPublicForm.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/forms/MakeAgentPublicForm.tsx
@@ -1,11 +1,15 @@
 import React, { useState, useEffect } from "react";
-import { Modal, Form, Steps, Button, Checkbox } from "antd";
-import { Text, Title, Badge } from "@tremor/react";
+import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/cva.config";
 import { makeAgentsPublicCall } from "../../networking";
 import NotificationsManager from "../../molecules/notifications_manager";
 import { AgentHubData } from "@/components/AIHub/AgentHubTableColumns";
 
-const { Step } = Steps;
+const STEP_TITLES = ["Select Agents", "Confirm"];
 
 interface MakeAgentPublicFormProps {
   visible: boolean;
@@ -25,12 +29,10 @@ const MakeAgentPublicForm: React.FC<MakeAgentPublicFormProps> = ({
   const [currentStep, setCurrentStep] = useState(0);
   const [selectedAgents, setSelectedAgents] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
-  const [form] = Form.useForm();
 
   const handleClose = () => {
     setCurrentStep(0);
     setSelectedAgents(new Set());
-    form.resetFields();
     onClose();
   };
 
@@ -113,29 +115,30 @@ const MakeAgentPublicForm: React.FC<MakeAgentPublicFormProps> = ({
     return (
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <Title>Select Agents to Make Public</Title>
+          <h3 className="text-lg font-semibold">Select Agents to Make Public</h3>
           <div className="flex items-center space-x-2">
-            <Checkbox
-              checked={allAgentsSelected}
-              indeterminate={isIndeterminate}
-              onChange={(e) => handleSelectAll(e.target.checked)}
-              disabled={agentHubData.length === 0}
-            >
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox
+                checked={allAgentsSelected}
+                indeterminate={isIndeterminate}
+                onCheckedChange={(checked) => handleSelectAll(checked === true)}
+                disabled={agentHubData.length === 0}
+              />
               Select All {agentHubData.length > 0 && `(${agentHubData.length})`}
-            </Checkbox>
+            </label>
           </div>
         </div>
 
-        <Text className="text-sm text-gray-600">
+        <p className="text-sm text-gray-600">
           Select the agents you want to be visible on the public model hub. Users will still require a valid Virtual Key
           to use these agents.
-        </Text>
+        </p>
 
         <div className="max-h-96 overflow-y-auto border rounded-lg p-4">
           <div className="space-y-3">
             {agentHubData.length === 0 ? (
               <div className="text-center py-8 text-gray-500">
-                <Text>No agents available.</Text>
+                <p>No agents available.</p>
               </div>
             ) : (
               agentHubData.map((agent) => {
@@ -144,25 +147,23 @@ const MakeAgentPublicForm: React.FC<MakeAgentPublicFormProps> = ({
                   <div key={agentId} className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
                     <Checkbox
                       checked={selectedAgents.has(agentId)}
-                      onChange={(e) => handleAgentSelection(agentId, e.target.checked)}
+                      onCheckedChange={(checked) => handleAgentSelection(agentId, checked === true)}
                     />
-                    <div className="flex-1">
+                    <div className="flex-1 min-w-0">
                       <div className="flex items-center space-x-2">
-                        <Text className="font-medium">{agent.name}</Text>
-                        <Badge color="blue" size="sm">
-                          v{agent.version}
-                        </Badge>
+                        <p className="font-medium break-words">{agent.name}</p>
+                        <Badge variant="secondary">v{agent.version}</Badge>
                       </div>
-                      <Text className="text-xs text-gray-600 mt-1">{agent.description}</Text>
+                      <p className="text-xs text-gray-600 mt-1 break-words">{agent.description}</p>
                       {agent.skills && agent.skills.length > 0 && (
                         <div className="flex flex-wrap gap-1 mt-1">
                           {agent.skills.slice(0, 3).map((skill) => (
-                            <Badge key={skill.id} color="purple" size="xs">
+                            <Badge key={skill.id} variant="outline">
                               {skill.name}
                             </Badge>
                           ))}
                           {agent.skills.length > 3 && (
-                            <Text className="text-xs text-gray-500">+{agent.skills.length - 3} more</Text>
+                            <p className="text-xs text-gray-500">+{agent.skills.length - 3} more</p>
                           )}
                         </div>
                       )}
@@ -176,9 +177,9 @@ const MakeAgentPublicForm: React.FC<MakeAgentPublicFormProps> = ({
 
         {selectedAgents.size > 0 && (
           <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-            <Text className="text-sm text-blue-800">
+            <p className="text-sm text-blue-800">
               <strong>{selectedAgents.size}</strong> agent{selectedAgents.size !== 1 ? "s" : ""} selected
-            </Text>
+            </p>
           </div>
         )}
       </div>
@@ -188,33 +189,31 @@ const MakeAgentPublicForm: React.FC<MakeAgentPublicFormProps> = ({
   const renderStep2Content = () => {
     return (
       <div className="space-y-4">
-        <Title>Confirm Making Agents Public</Title>
+        <h3 className="text-lg font-semibold">Confirm Making Agents Public</h3>
 
         <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-          <Text className="text-sm text-yellow-800">
+          <p className="text-sm text-yellow-800">
             <strong>Warning:</strong> Once you make these agents public, anyone who can go to the{" "}
             <code>/ui/model_hub_table</code> will be able to know they exist on the proxy.
-          </Text>
+          </p>
         </div>
 
         <div className="space-y-3">
-          <Text className="font-medium">Agents to be made public:</Text>
+          <p className="font-medium">Agents to be made public:</p>
           <div className="max-h-48 overflow-y-auto border rounded-lg p-3">
             <div className="space-y-2">
               {Array.from(selectedAgents).map((agentId) => {
                 const agent = agentHubData.find((a) => (a.agent_id || a.name) === agentId);
                 return (
                   <div key={agentId} className="flex items-center justify-between p-2 bg-gray-50 rounded-sm">
-                    <div className="flex-1">
+                    <div className="flex-1 min-w-0">
                       <div className="flex items-center space-x-2">
-                        <Text className="font-medium">{agent?.name || agentId}</Text>
-                        {agent && (
-                          <Badge color="blue" size="xs">
-                            v{agent.version}
-                          </Badge>
-                        )}
+                        <p className="font-medium break-words">{agent?.name || agentId}</p>
+                        {agent && <Badge variant="secondary">v{agent.version}</Badge>}
                       </div>
-                      {agent?.description && <Text className="text-xs text-gray-600 mt-1">{agent.description}</Text>}
+                      {agent?.description && (
+                        <p className="text-xs text-gray-600 mt-1 break-words">{agent.description}</p>
+                      )}
                     </div>
                   </div>
                 );
@@ -224,10 +223,10 @@ const MakeAgentPublicForm: React.FC<MakeAgentPublicFormProps> = ({
         </div>
 
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-          <Text className="text-sm text-blue-800">
+          <p className="text-sm text-blue-800">
             Total: <strong>{selectedAgents.size}</strong> agent{selectedAgents.size !== 1 ? "s" : ""} will be made
             public
-          </Text>
+          </p>
         </div>
       </div>
     );
@@ -247,7 +246,7 @@ const MakeAgentPublicForm: React.FC<MakeAgentPublicFormProps> = ({
   const renderStepButtons = () => {
     return (
       <div className="flex justify-between mt-6">
-        <Button onClick={currentStep === 0 ? handleClose : handlePrevious}>
+        <Button variant="outline" onClick={currentStep === 0 ? handleClose : handlePrevious}>
           {currentStep === 0 ? "Cancel" : "Previous"}
         </Button>
 
@@ -259,7 +258,8 @@ const MakeAgentPublicForm: React.FC<MakeAgentPublicFormProps> = ({
           )}
 
           {currentStep === 1 && (
-            <Button onClick={handleSubmit} loading={loading}>
+            <Button onClick={handleSubmit} disabled={loading}>
+              {loading && <Loader2 className="size-4 animate-spin" />}
               Make Public
             </Button>
           )}
@@ -269,24 +269,42 @@ const MakeAgentPublicForm: React.FC<MakeAgentPublicFormProps> = ({
   };
 
   return (
-    <Modal
-      title="Make Agents Public"
-      open={visible}
-      onCancel={handleClose}
-      footer={null}
-      width={1200}
-      maskClosable={false}
-    >
-      <Form form={form} layout="vertical">
-        <Steps current={currentStep} className="mb-6">
-          <Step title="Select Agents" />
-          <Step title="Confirm" />
-        </Steps>
+    <Dialog open={visible} onOpenChange={(open) => !open && handleClose()} disablePointerDismissal>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[1200px]">
+        <DialogHeader>
+          <DialogTitle>Make Agents Public</DialogTitle>
+        </DialogHeader>
 
-        {renderStepContent()}
-        {renderStepButtons()}
-      </Form>
-    </Modal>
+        <div>
+          <ol className="mb-6 flex items-center gap-6">
+            {STEP_TITLES.map((title, index) => (
+              <li
+                key={title}
+                className="flex items-center gap-2"
+                aria-current={currentStep === index ? "step" : undefined}
+              >
+                <span
+                  className={cn(
+                    "flex size-6 items-center justify-center rounded-full border text-xs",
+                    currentStep === index
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border text-muted-foreground",
+                  )}
+                >
+                  {index + 1}
+                </span>
+                <span className={cn("text-sm", currentStep === index ? "font-medium" : "text-muted-foreground")}>
+                  {title}
+                </span>
+              </li>
+            ))}
+          </ol>
+
+          {renderStepContent()}
+          {renderStepButtons()}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/ui/litellm-dashboard/src/components/AIHub/forms/MakeMCPPublicForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/forms/MakeMCPPublicForm.test.tsx
@@ -12,83 +12,8 @@ vi.mock("../../networking", () => ({
 import { makeMCPPublicCall } from "../../networking";
 const mockMakeMCPPublicCall = vi.mocked(makeMCPPublicCall);
 
-// Mock antd components
-vi.mock("antd", () => ({
-  Modal: ({ open, title, children, onCancel, footer }: any) =>
-    open ? (
-      <div data-testid="modal">
-        <div>{title}</div>
-        {children}
-        {footer}
-      </div>
-    ) : null,
-  Form: Object.assign(({ children, form }: any) => <form data-testid="form">{children}</form>, {
-    useForm: () => [
-      {
-        resetFields: vi.fn(),
-        validateFields: vi.fn(),
-        getFieldsValue: vi.fn(),
-        setFieldsValue: vi.fn(),
-      },
-      vi.fn(),
-    ],
-    Item: ({ children }: any) => <div>{children}</div>,
-  }),
-  Steps: Object.assign(
-    ({ children, current, className }: any) => (
-      <div data-testid="steps" className={className}>
-        {children}
-      </div>
-    ),
-    {
-      Step: ({ title }: any) => <div>{title}</div>,
-    },
-  ),
-  Button: ({ children, onClick, disabled, loading, ...props }: any) => (
-    <button onClick={onClick} disabled={disabled || loading} data-loading={loading} {...props}>
-      {children}
-    </button>
-  ),
-  Checkbox: ({ checked, indeterminate, onChange, children, disabled }: any) => (
-    <label>
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange({ target: { checked: e.target.checked } })}
-        disabled={disabled}
-        data-indeterminate={indeterminate}
-      />
-      {children}
-    </label>
-  ),
-}));
-
-// Additional @tremor/react mocks.
-// NOTE: the comment used to say "Button is already mocked globally" — that was
-// incorrect. A file-level vi.mock fully replaces the setup-level mock from
-// tests/setupTests.ts, so we must re-apply the Button/Tooltip overrides here.
-// Without them, the real Tremor Button leaks through and its useTooltip(300)
-// schedules a native setTimeout that can fire post-teardown -> "window is not defined".
-vi.mock("@tremor/react", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@tremor/react")>();
-  const React = await import("react");
-  return {
-    ...actual,
-    Text: ({ children, className }: any) => <span className={className}>{children}</span>,
-    Title: ({ children }: any) => <h3>{children}</h3>,
-    Badge: ({ children, color, size }: any) => (
-      <span data-color={color} data-size={size}>
-        {children}
-      </span>
-    ),
-    Button: React.forwardRef<HTMLButtonElement, any>(({ children, ...props }, ref) => (
-      <button {...props} ref={ref}>
-        {children}
-      </button>
-    )),
-    Tooltip: ({ children }: any) => <>{children}</>,
-  };
-});
+const expectDisabledControl = (element: HTMLElement) =>
+  expect(element.hasAttribute("disabled") || element.getAttribute("aria-disabled") === "true").toBe(true);
 
 describe("MakeMCPPublicForm", () => {
   const mockProps = {
@@ -182,7 +107,7 @@ describe("MakeMCPPublicForm", () => {
     expect(screen.getByText("Select MCP Servers to Make Public")).toBeInTheDocument();
 
     // Select all servers using the select all checkbox
-    const selectAllCheckbox = screen.getByLabelText("Select All (2)");
+    const selectAllCheckbox = screen.getByRole("checkbox", { name: "Select All (2)" });
     await act(async () => {
       fireEvent.click(selectAllCheckbox);
     });
@@ -208,7 +133,7 @@ describe("MakeMCPPublicForm", () => {
     render(<MakeMCPPublicForm {...mockProps} />);
 
     // Select all servers
-    const selectAllCheckbox = screen.getByLabelText("Select All (2)");
+    const selectAllCheckbox = screen.getByRole("checkbox", { name: "Select All (2)" });
     await act(async () => {
       fireEvent.click(selectAllCheckbox);
     });
@@ -271,6 +196,8 @@ describe("MakeMCPPublicForm", () => {
     const checkboxes = screen.getAllByRole("checkbox");
     await act(async () => {
       fireEvent.click(checkboxes[0]); // Click select all to select all
+    });
+    await act(async () => {
       fireEvent.click(checkboxes[0]); // Click select all again to deselect all
     });
 
@@ -295,8 +222,8 @@ describe("MakeMCPPublicForm", () => {
     expect(screen.getByText("No MCP servers available.")).toBeInTheDocument();
 
     // Select All checkbox should be disabled
-    const selectAllCheckbox = screen.getByLabelText("Select All");
-    expect(selectAllCheckbox).toBeDisabled();
+    const selectAllCheckbox = screen.getByRole("checkbox", { name: "Select All" });
+    expectDisabledControl(selectAllCheckbox);
 
     // Next button should be disabled
     const nextButton = screen.getByRole("button", { name: "Next" });
@@ -371,7 +298,7 @@ describe("MakeMCPPublicForm", () => {
 
     // Select all should be indeterminate now
     const selectAllCheckbox = checkboxes[0];
-    expect(selectAllCheckbox).toHaveAttribute("data-indeterminate", "true");
+    expect(selectAllCheckbox).toBePartiallyChecked();
   });
 
   it("should display tools overflow text when server has more than 3 tools", () => {
@@ -428,7 +355,7 @@ describe("MakeMCPPublicForm", () => {
     expect(mockProps.onClose).not.toHaveBeenCalled();
   });
 
-  it("should show loading state during submit", async () => {
+  it("should not complete the flow until the submit request resolves", async () => {
     let resolvePromise: (value: any) => void = () => {};
     const pendingPromise = new Promise((resolve) => {
       resolvePromise = resolve;
@@ -453,9 +380,11 @@ describe("MakeMCPPublicForm", () => {
       fireEvent.click(submitButton);
     });
 
-    // Check loading state
-    expect(submitButton).toHaveAttribute("data-loading", "true");
-    expect(submitButton).toBeDisabled();
+    // While the request is in flight the flow must not have completed
+    expect(mockMakeMCPPublicCall).toHaveBeenCalledTimes(1);
+    expect(mockProps.onSuccess).not.toHaveBeenCalled();
+    expect(mockProps.onClose).not.toHaveBeenCalled();
+    expect(screen.getByText("Confirm Making MCP Servers Public")).toBeInTheDocument();
 
     // Resolve the promise
     resolvePromise({});
@@ -474,7 +403,7 @@ describe("MakeMCPPublicForm", () => {
     render(<MakeMCPPublicForm {...invisibleProps} />);
 
     // Modal should not be rendered
-    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(screen.queryByText("Make MCP Servers Public")).not.toBeInTheDocument();
   });
 
@@ -569,6 +498,6 @@ describe("MakeMCPPublicForm", () => {
 
     // Select all should be indeterminate
     const selectAllCheckbox = checkboxes[0];
-    expect(selectAllCheckbox).toHaveAttribute("data-indeterminate", "true");
+    expect(selectAllCheckbox).toBePartiallyChecked();
   });
 });

--- a/ui/litellm-dashboard/src/components/AIHub/forms/MakeMCPPublicForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/forms/MakeMCPPublicForm.test.tsx
@@ -138,7 +138,6 @@ describe("MakeMCPPublicForm", () => {
       fireEvent.click(selectAllCheckbox);
     });
 
-    // Navigate to confirm step
     const nextButton = screen.getByRole("button", { name: "Next" });
     await act(async () => {
       fireEvent.click(nextButton);
@@ -149,7 +148,6 @@ describe("MakeMCPPublicForm", () => {
       expect(screen.getByText("Confirm Making MCP Servers Public")).toBeInTheDocument();
     });
 
-    // Submit
     const submitButton = screen.getByRole("button", { name: "Make Public" });
     await act(async () => {
       fireEvent.click(submitButton);
@@ -329,7 +327,6 @@ describe("MakeMCPPublicForm", () => {
 
     render(<MakeMCPPublicForm {...mockProps} />);
 
-    // Navigate to confirm step
     const nextButton = screen.getByRole("button", { name: "Next" });
     await act(async () => {
       fireEvent.click(nextButton);
@@ -339,7 +336,6 @@ describe("MakeMCPPublicForm", () => {
       expect(screen.getByText("Confirm Making MCP Servers Public")).toBeInTheDocument();
     });
 
-    // Submit
     const submitButton = screen.getByRole("button", { name: "Make Public" });
     await act(async () => {
       fireEvent.click(submitButton);
@@ -364,7 +360,6 @@ describe("MakeMCPPublicForm", () => {
 
     render(<MakeMCPPublicForm {...mockProps} />);
 
-    // Navigate to confirm step
     const nextButton = screen.getByRole("button", { name: "Next" });
     await act(async () => {
       fireEvent.click(nextButton);
@@ -374,19 +369,20 @@ describe("MakeMCPPublicForm", () => {
       expect(screen.getByText("Confirm Making MCP Servers Public")).toBeInTheDocument();
     });
 
-    // Submit
     const submitButton = screen.getByRole("button", { name: "Make Public" });
     await act(async () => {
       fireEvent.click(submitButton);
     });
 
-    // While the request is in flight the flow must not have completed
+    expectDisabledControl(submitButton);
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
     expect(mockMakeMCPPublicCall).toHaveBeenCalledTimes(1);
     expect(mockProps.onSuccess).not.toHaveBeenCalled();
     expect(mockProps.onClose).not.toHaveBeenCalled();
     expect(screen.getByText("Confirm Making MCP Servers Public")).toBeInTheDocument();
 
-    // Resolve the promise
     resolvePromise({});
     await waitFor(() => {
       expect(mockProps.onSuccess).toHaveBeenCalled();

--- a/ui/litellm-dashboard/src/components/AIHub/forms/MakeMCPPublicForm.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/forms/MakeMCPPublicForm.tsx
@@ -1,11 +1,25 @@
 import React, { useState, useEffect } from "react";
-import { Modal, Form, Steps, Button, Checkbox } from "antd";
-import { Text, Title, Badge } from "@tremor/react";
+import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/cva.config";
 import { makeMCPPublicCall } from "../../networking";
 import NotificationsManager from "../../molecules/notifications_manager";
 import { MCPServerData } from "@/components/AIHub/MCPHubTableColumns";
 
-const { Step } = Steps;
+const STEP_TITLES = ["Select Servers", "Confirm"];
+
+const statusVariant = (status?: string) => {
+  if (status === "active" || status === "healthy") {
+    return "default" as const;
+  }
+  if (status === "inactive" || status === "unhealthy") {
+    return "destructive" as const;
+  }
+  return "outline" as const;
+};
 
 interface MakeMCPPublicFormProps {
   visible: boolean;
@@ -25,12 +39,10 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
   const [currentStep, setCurrentStep] = useState(0);
   const [selectedServers, setSelectedServers] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
-  const [form] = Form.useForm();
 
   const handleClose = () => {
     setCurrentStep(0);
     setSelectedServers(new Set());
-    form.resetFields();
     onClose();
   };
 
@@ -114,29 +126,30 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
     return (
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <Title>Select MCP Servers to Make Public</Title>
+          <h3 className="text-lg font-semibold">Select MCP Servers to Make Public</h3>
           <div className="flex items-center space-x-2">
-            <Checkbox
-              checked={allServersSelected}
-              indeterminate={isIndeterminate}
-              onChange={(e) => handleSelectAll(e.target.checked)}
-              disabled={mcpHubData.length === 0}
-            >
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox
+                checked={allServersSelected}
+                indeterminate={isIndeterminate}
+                onCheckedChange={(checked) => handleSelectAll(checked === true)}
+                disabled={mcpHubData.length === 0}
+              />
               Select All {mcpHubData.length > 0 && `(${mcpHubData.length})`}
-            </Checkbox>
+            </label>
           </div>
         </div>
 
-        <Text className="text-sm text-gray-600">
+        <p className="text-sm text-gray-600">
           Select the MCP servers you want to be visible on the public model hub. Users will still require a valid
           Virtual Key to use these servers.
-        </Text>
+        </p>
 
         <div className="max-h-96 overflow-y-auto border rounded-lg p-4">
           <div className="space-y-3">
             {mcpHubData.length === 0 ? (
               <div className="text-center py-8 text-gray-500">
-                <Text>No MCP servers available.</Text>
+                <p>No MCP servers available.</p>
               </div>
             ) : (
               mcpHubData.map((server) => {
@@ -148,42 +161,25 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
                   >
                     <Checkbox
                       checked={selectedServers.has(server.server_id)}
-                      onChange={(e) => handleServerSelection(server.server_id, e.target.checked)}
+                      onCheckedChange={(checked) => handleServerSelection(server.server_id, checked === true)}
                     />
-                    <div className="flex-1">
-                      <div className="flex items-center space-x-2">
-                        <Text className="font-medium">{server.server_name}</Text>
-                        {isPublic && (
-                          <Badge color="emerald" size="sm">
-                            Public
-                          </Badge>
-                        )}
-                        <Badge color="blue" size="sm">
-                          {server.transport}
-                        </Badge>
-                        <Badge
-                          color={
-                            server.status === "active" || server.status === "healthy"
-                              ? "green"
-                              : server.status === "inactive" || server.status === "unhealthy"
-                                ? "red"
-                                : "gray"
-                          }
-                          size="sm"
-                        >
-                          {server.status || "unknown"}
-                        </Badge>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="font-medium break-words">{server.server_name}</p>
+                        {isPublic && <Badge>Public</Badge>}
+                        <Badge variant="secondary">{server.transport}</Badge>
+                        <Badge variant={statusVariant(server.status)}>{server.status || "unknown"}</Badge>
                       </div>
-                      <Text className="text-xs text-gray-600 mt-1">{server.description || server.url}</Text>
+                      <p className="text-xs text-gray-600 mt-1 break-words">{server.description || server.url}</p>
                       {server.allowed_tools && server.allowed_tools.length > 0 && (
                         <div className="flex flex-wrap gap-1 mt-1">
                           {server.allowed_tools.slice(0, 3).map((tool, idx) => (
-                            <Badge key={idx} color="purple" size="xs">
+                            <Badge key={idx} variant="outline">
                               {tool}
                             </Badge>
                           ))}
                           {server.allowed_tools.length > 3 && (
-                            <Text className="text-xs text-gray-500">+{server.allowed_tools.length - 3} more</Text>
+                            <p className="text-xs text-gray-500">+{server.allowed_tools.length - 3} more</p>
                           )}
                         </div>
                       )}
@@ -197,9 +193,9 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
 
         {selectedServers.size > 0 && (
           <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-            <Text className="text-sm text-blue-800">
+            <p className="text-sm text-blue-800">
               <strong>{selectedServers.size}</strong> MCP server{selectedServers.size !== 1 ? "s" : ""} selected
-            </Text>
+            </p>
           </div>
         )}
       </div>
@@ -209,48 +205,37 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
   const renderStep2Content = () => {
     return (
       <div className="space-y-4">
-        <Title>Confirm Making MCP Servers Public</Title>
+        <h3 className="text-lg font-semibold">Confirm Making MCP Servers Public</h3>
 
         <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-          <Text className="text-sm text-yellow-800">
+          <p className="text-sm text-yellow-800">
             <strong>Warning:</strong> Once you make these MCP servers public, anyone who can go to the{" "}
             <code>/ui/model_hub_table</code> will be able to know they exist on the proxy.
-          </Text>
+          </p>
         </div>
 
         <div className="space-y-3">
-          <Text className="font-medium">MCP Servers to be made public:</Text>
+          <p className="font-medium">MCP Servers to be made public:</p>
           <div className="max-h-48 overflow-y-auto border rounded-lg p-3">
             <div className="space-y-2">
               {Array.from(selectedServers).map((serverId) => {
                 const server = mcpHubData.find((s) => s.server_id === serverId);
                 return (
                   <div key={serverId} className="flex items-center justify-between p-2 bg-gray-50 rounded-sm">
-                    <div className="flex-1">
-                      <div className="flex items-center space-x-2">
-                        <Text className="font-medium">{server?.server_name || serverId}</Text>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="font-medium break-words">{server?.server_name || serverId}</p>
                         {server && (
                           <>
-                            <Badge color="blue" size="xs">
-                              {server.transport}
-                            </Badge>
-                            <Badge
-                              color={
-                                server.status === "active" || server.status === "healthy"
-                                  ? "green"
-                                  : server.status === "inactive" || server.status === "unhealthy"
-                                    ? "red"
-                                    : "gray"
-                              }
-                              size="xs"
-                            >
-                              {server.status || "unknown"}
-                            </Badge>
+                            <Badge variant="secondary">{server.transport}</Badge>
+                            <Badge variant={statusVariant(server.status)}>{server.status || "unknown"}</Badge>
                           </>
                         )}
                       </div>
-                      {server?.description && <Text className="text-xs text-gray-600 mt-1">{server.description}</Text>}
-                      {server?.url && <Text className="text-xs text-gray-500 mt-1">{server.url}</Text>}
+                      {server?.description && (
+                        <p className="text-xs text-gray-600 mt-1 break-words">{server.description}</p>
+                      )}
+                      {server?.url && <p className="text-xs text-gray-500 mt-1 break-words">{server.url}</p>}
                     </div>
                   </div>
                 );
@@ -260,10 +245,10 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
         </div>
 
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-          <Text className="text-sm text-blue-800">
+          <p className="text-sm text-blue-800">
             Total: <strong>{selectedServers.size}</strong> MCP server{selectedServers.size !== 1 ? "s" : ""} will be
             made public
-          </Text>
+          </p>
         </div>
       </div>
     );
@@ -283,7 +268,7 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
   const renderStepButtons = () => {
     return (
       <div className="flex justify-between mt-6">
-        <Button onClick={currentStep === 0 ? handleClose : handlePrevious}>
+        <Button variant="outline" onClick={currentStep === 0 ? handleClose : handlePrevious}>
           {currentStep === 0 ? "Cancel" : "Previous"}
         </Button>
 
@@ -295,7 +280,8 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
           )}
 
           {currentStep === 1 && (
-            <Button onClick={handleSubmit} loading={loading}>
+            <Button onClick={handleSubmit} disabled={loading}>
+              {loading && <Loader2 className="size-4 animate-spin" />}
               Make Public
             </Button>
           )}
@@ -305,24 +291,42 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
   };
 
   return (
-    <Modal
-      title="Make MCP Servers Public"
-      open={visible}
-      onCancel={handleClose}
-      footer={null}
-      width={1200}
-      maskClosable={false}
-    >
-      <Form form={form} layout="vertical">
-        <Steps current={currentStep} className="mb-6">
-          <Step title="Select Servers" />
-          <Step title="Confirm" />
-        </Steps>
+    <Dialog open={visible} onOpenChange={(open) => !open && handleClose()} disablePointerDismissal>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[1200px]">
+        <DialogHeader>
+          <DialogTitle>Make MCP Servers Public</DialogTitle>
+        </DialogHeader>
 
-        {renderStepContent()}
-        {renderStepButtons()}
-      </Form>
-    </Modal>
+        <div>
+          <ol className="mb-6 flex items-center gap-6">
+            {STEP_TITLES.map((title, index) => (
+              <li
+                key={title}
+                className="flex items-center gap-2"
+                aria-current={currentStep === index ? "step" : undefined}
+              >
+                <span
+                  className={cn(
+                    "flex size-6 items-center justify-center rounded-full border text-xs",
+                    currentStep === index
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border text-muted-foreground",
+                  )}
+                >
+                  {index + 1}
+                </span>
+                <span className={cn("text-sm", currentStep === index ? "font-medium" : "text-muted-foreground")}>
+                  {title}
+                </span>
+              </li>
+            ))}
+          </ol>
+
+          {renderStepContent()}
+          {renderStepButtons()}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/ui/litellm-dashboard/src/components/AIHub/forms/MakeModelPublicForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/forms/MakeModelPublicForm.test.tsx
@@ -162,7 +162,6 @@ describe("MakeModelPublicForm", () => {
       fireEvent.click(selectAllCheckbox);
     });
 
-    // Navigate to confirm step
     const nextButton = screen.getByRole("button", { name: "Next" });
     await act(async () => {
       fireEvent.click(nextButton);
@@ -173,7 +172,6 @@ describe("MakeModelPublicForm", () => {
       expect(screen.getByText("Confirm Making Models Public")).toBeInTheDocument();
     });
 
-    // Submit
     const submitButton = screen.getByRole("button", { name: "Make Public" });
     await act(async () => {
       fireEvent.click(submitButton);
@@ -345,7 +343,6 @@ describe("MakeModelPublicForm", () => {
 
     render(<MakeModelPublicForm {...mockProps} />);
 
-    // Navigate to confirm step
     const nextButton = screen.getByRole("button", { name: "Next" });
     await act(async () => {
       fireEvent.click(nextButton);
@@ -355,7 +352,6 @@ describe("MakeModelPublicForm", () => {
       expect(screen.getByText("Confirm Making Models Public")).toBeInTheDocument();
     });
 
-    // Submit
     const submitButton = screen.getByRole("button", { name: "Make Public" });
     await act(async () => {
       fireEvent.click(submitButton);
@@ -380,7 +376,6 @@ describe("MakeModelPublicForm", () => {
 
     render(<MakeModelPublicForm {...mockProps} />);
 
-    // Navigate to confirm step
     const nextButton = screen.getByRole("button", { name: "Next" });
     await act(async () => {
       fireEvent.click(nextButton);
@@ -390,19 +385,20 @@ describe("MakeModelPublicForm", () => {
       expect(screen.getByText("Confirm Making Models Public")).toBeInTheDocument();
     });
 
-    // Submit
     const submitButton = screen.getByRole("button", { name: "Make Public" });
     await act(async () => {
       fireEvent.click(submitButton);
     });
 
-    // While the request is in flight the flow must not have completed
+    expectDisabledControl(submitButton);
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
     expect(mockMakeModelGroupPublic).toHaveBeenCalledTimes(1);
     expect(mockProps.onSuccess).not.toHaveBeenCalled();
     expect(mockProps.onClose).not.toHaveBeenCalled();
     expect(screen.getByText("Confirm Making Models Public")).toBeInTheDocument();
 
-    // Resolve the promise
     resolvePromise({});
     await waitFor(() => {
       expect(mockProps.onSuccess).toHaveBeenCalled();
@@ -479,7 +475,6 @@ describe("MakeModelPublicForm", () => {
   it("should show confirmation step with selected models", async () => {
     render(<MakeModelPublicForm {...mockProps} />);
 
-    // Navigate to confirm step
     const nextButton = screen.getByRole("button", { name: "Next" });
     await act(async () => {
       fireEvent.click(nextButton);

--- a/ui/litellm-dashboard/src/components/AIHub/forms/MakeModelPublicForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/forms/MakeModelPublicForm.test.tsx
@@ -29,67 +29,8 @@ vi.mock("../../networking", () => ({
 import { makeModelGroupPublic } from "../../networking";
 const mockMakeModelGroupPublic = vi.mocked(makeModelGroupPublic);
 
-// Mock antd components
-vi.mock("antd", () => ({
-  Modal: ({ open, title, children, onCancel, footer }: any) =>
-    open ? (
-      <div data-testid="modal">
-        <div>{title}</div>
-        {children}
-        {footer}
-      </div>
-    ) : null,
-  Form: Object.assign(({ children, form }: any) => <form data-testid="form">{children}</form>, {
-    useForm: () => [
-      {
-        resetFields: vi.fn(),
-        validateFields: vi.fn(),
-        getFieldsValue: vi.fn(),
-        setFieldsValue: vi.fn(),
-      },
-      vi.fn(),
-    ],
-    Item: ({ children }: any) => <div>{children}</div>,
-  }),
-  Steps: Object.assign(
-    ({ children, current, className }: any) => (
-      <div data-testid="steps" className={className}>
-        {children}
-      </div>
-    ),
-    {
-      Step: ({ title }: any) => <div>{title}</div>,
-    },
-  ),
-  Button: ({ children, onClick, disabled, loading, ...props }: any) => (
-    <button onClick={onClick} disabled={disabled || loading} data-loading={loading} {...props}>
-      {children}
-    </button>
-  ),
-  Checkbox: ({ checked, indeterminate, onChange, children, disabled }: any) => (
-    <label>
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange({ target: { checked: e.target.checked } })}
-        disabled={disabled}
-        data-indeterminate={indeterminate}
-      />
-      {children}
-    </label>
-  ),
-}));
-
-// Mock @tremor/react components
-vi.mock("@tremor/react", () => ({
-  Text: ({ children, className }: any) => <span className={className}>{children}</span>,
-  Title: ({ children }: any) => <h3>{children}</h3>,
-  Badge: ({ children, color, size }: any) => (
-    <span data-color={color} data-size={size}>
-      {children}
-    </span>
-  ),
-}));
+const expectDisabledControl = (element: HTMLElement) =>
+  expect(element.hasAttribute("disabled") || element.getAttribute("aria-disabled") === "true").toBe(true);
 
 // Mock ModelFilters component
 vi.mock("../../model_filters", () => ({
@@ -190,7 +131,7 @@ describe("MakeModelPublicForm", () => {
     expect(screen.getByText("Select Models to Make Public")).toBeInTheDocument();
 
     // Select all models using the select all checkbox
-    const selectAllCheckbox = screen.getByLabelText("Select All (2)");
+    const selectAllCheckbox = screen.getByRole("checkbox", { name: "Select All (2)" });
     await act(async () => {
       fireEvent.click(selectAllCheckbox);
     });
@@ -216,7 +157,7 @@ describe("MakeModelPublicForm", () => {
     render(<MakeModelPublicForm {...mockProps} />);
 
     // Select all models
-    const selectAllCheckbox = screen.getByLabelText("Select All (2)");
+    const selectAllCheckbox = screen.getByRole("checkbox", { name: "Select All (2)" });
     await act(async () => {
       fireEvent.click(selectAllCheckbox);
     });
@@ -279,6 +220,8 @@ describe("MakeModelPublicForm", () => {
     const checkboxes = screen.getAllByRole("checkbox");
     await act(async () => {
       fireEvent.click(checkboxes[0]); // Click select all to select all
+    });
+    await act(async () => {
       fireEvent.click(checkboxes[0]); // Click select all again to deselect all
     });
 
@@ -303,8 +246,8 @@ describe("MakeModelPublicForm", () => {
     expect(screen.getByText("No models match the current filters.")).toBeInTheDocument();
 
     // Select All checkbox should be disabled
-    const selectAllCheckbox = screen.getByLabelText("Select All");
-    expect(selectAllCheckbox).toBeDisabled();
+    const selectAllCheckbox = screen.getByRole("checkbox", { name: "Select All" });
+    expectDisabledControl(selectAllCheckbox);
 
     // Next button should be disabled
     const nextButton = screen.getByRole("button", { name: "Next" });
@@ -379,7 +322,7 @@ describe("MakeModelPublicForm", () => {
 
     // Select all should be indeterminate now
     const selectAllCheckbox = checkboxes[0];
-    expect(selectAllCheckbox).toHaveAttribute("data-indeterminate", "true");
+    expect(selectAllCheckbox).toBePartiallyChecked();
   });
 
   it("should display model badges and information", () => {
@@ -428,7 +371,7 @@ describe("MakeModelPublicForm", () => {
     expect(mockProps.onClose).not.toHaveBeenCalled();
   });
 
-  it("should show loading state during submit", async () => {
+  it("should not complete the flow until the submit request resolves", async () => {
     let resolvePromise: (value: any) => void = () => {};
     const pendingPromise = new Promise((resolve) => {
       resolvePromise = resolve;
@@ -453,9 +396,11 @@ describe("MakeModelPublicForm", () => {
       fireEvent.click(submitButton);
     });
 
-    // Check loading state
-    expect(submitButton).toHaveAttribute("data-loading", "true");
-    expect(submitButton).toBeDisabled();
+    // While the request is in flight the flow must not have completed
+    expect(mockMakeModelGroupPublic).toHaveBeenCalledTimes(1);
+    expect(mockProps.onSuccess).not.toHaveBeenCalled();
+    expect(mockProps.onClose).not.toHaveBeenCalled();
+    expect(screen.getByText("Confirm Making Models Public")).toBeInTheDocument();
 
     // Resolve the promise
     resolvePromise({});
@@ -474,7 +419,7 @@ describe("MakeModelPublicForm", () => {
     render(<MakeModelPublicForm {...invisibleProps} />);
 
     // Modal should not be rendered
-    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(screen.queryByText("Make Models Public")).not.toBeInTheDocument();
   });
 
@@ -521,15 +466,14 @@ describe("MakeModelPublicForm", () => {
 
     // Select all should be indeterminate
     const selectAllCheckbox = checkboxes[0];
-    expect(selectAllCheckbox).toHaveAttribute("data-indeterminate", "true");
+    expect(selectAllCheckbox).toBePartiallyChecked();
   });
 
   it("should show selected count", () => {
     render(<MakeModelPublicForm {...mockProps} />);
 
     // Should show that 1 model is selected (gpt-3.5-turbo is preselected)
-    expect(screen.getByText("1")).toBeInTheDocument();
-    expect(screen.getByText("model selected")).toBeInTheDocument();
+    expect(screen.getByText("model selected")).toHaveTextContent("1 model selected");
   });
 
   it("should show confirmation step with selected models", async () => {

--- a/ui/litellm-dashboard/src/components/AIHub/forms/MakeModelPublicForm.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/forms/MakeModelPublicForm.tsx
@@ -1,11 +1,15 @@
 import React, { useState, useCallback, useEffect } from "react";
-import { Modal, Form, Steps, Button, Checkbox } from "antd";
-import { Text, Title, Badge } from "@tremor/react";
+import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/cva.config";
 import { makeModelGroupPublic } from "../../networking";
 import ModelFilters from "../../model_filters";
 import NotificationsManager from "../../molecules/notifications_manager";
 
-const { Step } = Steps;
+const STEP_TITLES = ["Select Models", "Confirm"];
 
 interface ModelGroupInfo {
   model_group: string;
@@ -44,13 +48,11 @@ const MakeModelPublicForm: React.FC<MakeModelPublicFormProps> = ({
   const [selectedModels, setSelectedModels] = useState<Set<string>>(new Set());
   const [filteredData, setFilteredData] = useState<ModelGroupInfo[]>([]);
   const [loading, setLoading] = useState(false);
-  const [form] = Form.useForm();
 
   const handleClose = () => {
     setCurrentStep(0);
     setSelectedModels(new Set());
     setFilteredData([]);
-    form.resetFields();
     onClose();
   };
 
@@ -138,23 +140,24 @@ const MakeModelPublicForm: React.FC<MakeModelPublicFormProps> = ({
     return (
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <Title>Select Models to Make Public</Title>
+          <h3 className="text-lg font-semibold">Select Models to Make Public</h3>
           <div className="flex items-center space-x-2">
-            <Checkbox
-              checked={allModelsSelected}
-              indeterminate={isIndeterminate}
-              onChange={(e) => handleSelectAll(e.target.checked)}
-              disabled={filteredData.length === 0}
-            >
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox
+                checked={allModelsSelected}
+                indeterminate={isIndeterminate}
+                onCheckedChange={(checked) => handleSelectAll(checked === true)}
+                disabled={filteredData.length === 0}
+              />
               Select All {filteredData.length > 0 && `(${filteredData.length})`}
-            </Checkbox>
+            </label>
           </div>
         </div>
 
-        <Text className="text-sm text-gray-600">
+        <p className="text-sm text-gray-600">
           Select the models you want to be visible on the public model hub. Users will still require a valid Virtual Key
           to use these models.
-        </Text>
+        </p>
 
         {/* Filters */}
         <ModelFilters
@@ -168,7 +171,7 @@ const MakeModelPublicForm: React.FC<MakeModelPublicFormProps> = ({
           <div className="space-y-3">
             {filteredData.length === 0 ? (
               <div className="text-center py-8 text-gray-500">
-                <Text>No models match the current filters.</Text>
+                <p>No models match the current filters.</p>
               </div>
             ) : (
               filteredData.map((model) => (
@@ -178,20 +181,16 @@ const MakeModelPublicForm: React.FC<MakeModelPublicFormProps> = ({
                 >
                   <Checkbox
                     checked={selectedModels.has(model.model_group)}
-                    onChange={(e) => handleModelSelection(model.model_group, e.target.checked)}
+                    onCheckedChange={(checked) => handleModelSelection(model.model_group, checked === true)}
                   />
-                  <div className="flex-1">
-                    <div className="flex items-center space-x-2">
-                      <Text className="font-medium">{model.model_group}</Text>
-                      {model.mode && (
-                        <Badge color="green" size="sm">
-                          {model.mode}
-                        </Badge>
-                      )}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium break-words">{model.model_group}</p>
+                      {model.mode && <Badge>{model.mode}</Badge>}
                     </div>
                     <div className="flex flex-wrap gap-1 mt-1">
                       {model.providers.map((provider) => (
-                        <Badge key={provider} color="blue" size="xs">
+                        <Badge key={provider} variant="secondary">
                           {provider}
                         </Badge>
                       ))}
@@ -205,9 +204,9 @@ const MakeModelPublicForm: React.FC<MakeModelPublicFormProps> = ({
 
         {selectedModels.size > 0 && (
           <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-            <Text className="text-sm text-blue-800">
+            <p className="text-sm text-blue-800">
               <strong>{selectedModels.size}</strong> model{selectedModels.size !== 1 ? "s" : ""} selected
-            </Text>
+            </p>
           </div>
         )}
       </div>
@@ -217,29 +216,29 @@ const MakeModelPublicForm: React.FC<MakeModelPublicFormProps> = ({
   const renderStep2Content = () => {
     return (
       <div className="space-y-4">
-        <Title>Confirm Making Models Public</Title>
+        <h3 className="text-lg font-semibold">Confirm Making Models Public</h3>
 
         <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-          <Text className="text-sm text-yellow-800">
+          <p className="text-sm text-yellow-800">
             <strong>Warning:</strong> Once you make these models public, anyone who can go to the{" "}
             <code>/ui/model_hub_table</code> will be able to know they exist on the proxy.
-          </Text>
+          </p>
         </div>
 
         <div className="space-y-3">
-          <Text className="font-medium">Models to be made public:</Text>
+          <p className="font-medium">Models to be made public:</p>
           <div className="max-h-48 overflow-y-auto border rounded-lg p-3">
             <div className="space-y-2">
               {Array.from(selectedModels).map((modelGroup) => {
                 const model = modelHubData.find((m) => m.model_group === modelGroup);
                 return (
                   <div key={modelGroup} className="flex items-center justify-between p-2 bg-gray-50 rounded-sm">
-                    <div>
-                      <Text className="font-medium">{modelGroup}</Text>
+                    <div className="min-w-0">
+                      <p className="font-medium break-words">{modelGroup}</p>
                       {model && (
                         <div className="flex flex-wrap gap-1 mt-1">
                           {model.providers.map((provider) => (
-                            <Badge key={provider} color="blue" size="xs">
+                            <Badge key={provider} variant="secondary">
                               {provider}
                             </Badge>
                           ))}
@@ -254,10 +253,10 @@ const MakeModelPublicForm: React.FC<MakeModelPublicFormProps> = ({
         </div>
 
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-          <Text className="text-sm text-blue-800">
+          <p className="text-sm text-blue-800">
             Total: <strong>{selectedModels.size}</strong> model{selectedModels.size !== 1 ? "s" : ""} will be made
             public
-          </Text>
+          </p>
         </div>
       </div>
     );
@@ -277,7 +276,7 @@ const MakeModelPublicForm: React.FC<MakeModelPublicFormProps> = ({
   const renderStepButtons = () => {
     return (
       <div className="flex justify-between mt-6">
-        <Button onClick={currentStep === 0 ? handleClose : handlePrevious}>
+        <Button variant="outline" onClick={currentStep === 0 ? handleClose : handlePrevious}>
           {currentStep === 0 ? "Cancel" : "Previous"}
         </Button>
 
@@ -289,7 +288,8 @@ const MakeModelPublicForm: React.FC<MakeModelPublicFormProps> = ({
           )}
 
           {currentStep === 1 && (
-            <Button onClick={handleSubmit} loading={loading}>
+            <Button onClick={handleSubmit} disabled={loading}>
+              {loading && <Loader2 className="size-4 animate-spin" />}
               Make Public
             </Button>
           )}
@@ -299,24 +299,42 @@ const MakeModelPublicForm: React.FC<MakeModelPublicFormProps> = ({
   };
 
   return (
-    <Modal
-      title="Make Models Public"
-      open={visible}
-      onCancel={handleClose}
-      footer={null}
-      width={1200}
-      maskClosable={false}
-    >
-      <Form form={form} layout="vertical">
-        <Steps current={currentStep} className="mb-6">
-          <Step title="Select Models" />
-          <Step title="Confirm" />
-        </Steps>
+    <Dialog open={visible} onOpenChange={(open) => !open && handleClose()} disablePointerDismissal>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[1200px]">
+        <DialogHeader>
+          <DialogTitle>Make Models Public</DialogTitle>
+        </DialogHeader>
 
-        {renderStepContent()}
-        {renderStepButtons()}
-      </Form>
-    </Modal>
+        <div>
+          <ol className="mb-6 flex items-center gap-6">
+            {STEP_TITLES.map((title, index) => (
+              <li
+                key={title}
+                className="flex items-center gap-2"
+                aria-current={currentStep === index ? "step" : undefined}
+              >
+                <span
+                  className={cn(
+                    "flex size-6 items-center justify-center rounded-full border text-xs",
+                    currentStep === index
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border text-muted-foreground",
+                  )}
+                >
+                  {index + 1}
+                </span>
+                <span className={cn("text-sm", currentStep === index ? "font-medium" : "text-muted-foreground")}>
+                  {title}
+                </span>
+              </li>
+            ))}
+          </ol>
+
+          {renderStepContent()}
+          {renderStepButtons()}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 };
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- The AI Hub still renders through Ant Design and Tremor
- Three style systems compete on one page
- Global theming cannot reach components that style themselves via antd

How it solves it:

- Rebuilds all 6 AIHub source files on `@/components/ui` primitives
- Removes every antd and Tremor import under `src/components/AIHub`
- Retires the eslint suppressions those files carried

## User Flow

Before: an admin publishing models to the hub sees a page built from Ant Design and Tremor, so it does not follow the dashboard's own design tokens and cannot be restyled globally

1. They open http://localhost:4000/ui/?page=model-hub-table
2. They switch between the Model Hub, Agent Hub, MCP Hub and Skill Hub tabs
3. They click Select Models to Make Public and a dialog lists every model with a checkbox
4. They filter by provider, mode and features, pick models, and confirm
5. On the confirm step they can click Make Public more than once while the request is still in flight
6. Every control draws its own borders, spacing and icon sizes from antd or Tremor, so a dashboard-wide style change leaves this page behind

After: the same page behaves identically, every control is a shadcn component that inherits the dashboard's tokens, and the confirm button can no longer be double submitted

1. They open http://localhost:4000/ui/?page=model-hub-table
2. They switch between the same four tabs, each showing the same content
3. They click Select Models to Make Public and the same dialog lists every model with a checkbox
4. They filter by provider, mode and features, pick models, and confirm
5. Make Public goes disabled while the request is in flight, so a second click cannot fire
6. The page now picks up the dashboard's own tokens, so styling it is a single global change

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Captured at 9b8f9c69ad against a live proxy on :4000 holding 86 real models and 2 real MCP servers, with the dashboard dev server on :3000.

Verified by hand in the browser:

1. Open http://localhost:3000/model-hub-table. Link Management and all four tabs render
2. Click each of Model Hub, Agent Hub, MCP Hub and Skill Hub. Each reports `aria-selected` and its own panel: Select Models, Select Agents, Select MCP Servers, and the skill table
3. Click Select Models to Make Public. The dialog opens with the stepper, the four filters, Select All (86), and the real model list
4. Open Select Skills to Make Public. That form is still on antd and out of scope here, and it layers correctly over the shadcn page rather than fighting it

Measured in the running page:

```
dialog 1200x688 inside a 1280x720 viewport, fits, scrolls internally
flex and grid cells overflowing their box:  0
icons rendering at the lucide 24px default: 0 of 222
```

Local gates:

```
npm run build                          exit 0
npm run test                           654 files, 7156 tests passed, exit 0
npx vitest run src/components/AIHub    9 files, 101 tests passed
npx eslint --pass-on-unpruned-suppressions <10 changed files>   exit 0
npx prettier --check <10 changed files>   all match
```

The 9 files / 101 tests figure is identical to the pre-migration baseline, so no coverage was lost.

## Type

🧹 Refactoring

## Caveats (if any)

- antd Steps has no shadcn equivalent, so a small ol stepper is inlined three times
- Extracting one shared stepper is a clean follow up
- Tremor Card padded all sides, shadcn only vertically, so `px-6` was added
- The provider filter loses its clear affordance and gains an All Providers option
- Capability badges lose their rotating colour palette
- One rewritten test now proves in flight semantics instead of a mock invented flag
- The old loading assertions described antd behaviour the shipped app never had
- A duplicate React key warning on the model list is pre existing, not from this PR
- Every `key=` expression in the diff is unchanged on both sides

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
