### PR TITLE
fix(wandb): correct inference model pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -40143,7 +40143,8 @@
         "max_output_tokens": 161000,
         "max_tokens": 161000,
         "mode": "chat",
-        "output_cost_per_token": 5.4e-06
+        "output_cost_per_token": 5.4e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/deepseek-ai/DeepSeek-V3-0324": {
         "input_cost_per_token": 1.14e-06,
@@ -40152,7 +40153,8 @@
         "max_output_tokens": 161000,
         "max_tokens": 161000,
         "mode": "chat",
-        "output_cost_per_token": 2.75e-06
+        "output_cost_per_token": 2.75e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/deepseek-ai/DeepSeek-V3.1": {
         "input_cost_per_token": 5.5e-07,
@@ -40264,7 +40266,8 @@
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
-        "output_cost_per_token": 6.6e-07
+        "output_cost_per_token": 6.6e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/MiniMaxAI/MiniMax-M2.5": {
         "input_cost_per_token": 3e-07,
@@ -40297,7 +40300,8 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "output_cost_per_token": 3.5e-07
+        "output_cost_per_token": 3.5e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/moonshotai/Kimi-K2-Instruct": {
         "input_cost_per_token": 6e-07,
@@ -40414,7 +40418,8 @@
         "max_output_tokens": 262144,
         "max_tokens": 262144,
         "mode": "chat",
-        "output_cost_per_token": 1e-07
+        "output_cost_per_token": 1e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/Qwen/Qwen3-235B-A22B-Thinking-2507": {
         "input_cost_per_token": 1e-07,
@@ -40423,7 +40428,8 @@
         "max_output_tokens": 262144,
         "max_tokens": 262144,
         "mode": "chat",
-        "output_cost_per_token": 1e-07
+        "output_cost_per_token": 1e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/Qwen/Qwen3-30B-A3B-Instruct-2507": {
         "input_cost_per_token": 1e-07,
@@ -40483,7 +40489,8 @@
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 2e-06
+        "output_cost_per_token": 2e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/zai-org/GLM-5.1": {
         "cache_read_input_token_cost": 2.6e-07,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -40207,7 +40207,9 @@
         "max_tokens": 262000,
         "mode": "chat",
         "output_cost_per_token": 3.4e-07,
-        "source": "https://wandb.ai/site/pricing/tokens/"
+        "source": "https://wandb.ai/site/pricing/tokens/",
+        "supports_reasoning": true,
+        "supports_vision": true
     },
     "wandb/ibm-granite/granite-4.1-8b": {
         "input_cost_per_token": 5e-08,
@@ -40291,7 +40293,8 @@
         "max_tokens": 262000,
         "mode": "chat",
         "output_cost_per_token": 9.6e-07,
-        "source": "https://wandb.ai/site/pricing/tokens/"
+        "source": "https://wandb.ai/site/pricing/tokens/",
+        "supports_vision": true
     },
     "wandb/microsoft/Phi-4-mini-instruct": {
         "input_cost_per_token": 8e-08,
@@ -40336,7 +40339,9 @@
         "max_tokens": 262000,
         "mode": "chat",
         "output_cost_per_token": 3.41e-06,
-        "source": "https://wandb.ai/site/pricing/tokens/"
+        "source": "https://wandb.ai/site/pricing/tokens/",
+        "supports_reasoning": true,
+        "supports_vision": true
     },
     "wandb/moonshotai/Kimi-K2.7-Code": {
         "cache_read_input_token_cost": 1.5e-07,
@@ -40347,7 +40352,8 @@
         "max_tokens": 262000,
         "mode": "chat",
         "output_cost_per_token": 3.5e-06,
-        "source": "https://wandb.ai/site/pricing/tokens/"
+        "source": "https://wandb.ai/site/pricing/tokens/",
+        "supports_vision": true
     },
     "wandb/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
         "input_cost_per_token": 2e-07,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -40136,159 +40136,376 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
-    "wandb/openai/gpt-oss-120b": {
-        "max_tokens": 131072,
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "input_cost_per_token": 0.015,
-        "output_cost_per_token": 0.06,
+    "wandb/deepseek-ai/DeepSeek-R1-0528": {
+        "input_cost_per_token": 1.35e-06,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 161000,
+        "max_output_tokens": 161000,
+        "max_tokens": 161000,
+        "mode": "chat",
+        "output_cost_per_token": 5.4e-06
     },
-    "wandb/openai/gpt-oss-20b": {
-        "max_tokens": 131072,
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "input_cost_per_token": 0.005,
-        "output_cost_per_token": 0.02,
+    "wandb/deepseek-ai/DeepSeek-V3-0324": {
+        "input_cost_per_token": 1.14e-06,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 161000,
+        "max_output_tokens": 161000,
+        "max_tokens": 161000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-06
     },
-    "wandb/zai-org/GLM-4.5": {
-        "max_tokens": 131072,
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "input_cost_per_token": 0.055,
-        "output_cost_per_token": 0.2,
+    "wandb/deepseek-ai/DeepSeek-V3.1": {
+        "input_cost_per_token": 5.5e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 161000,
+        "max_output_tokens": 161000,
+        "max_tokens": 161000,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/Qwen/Qwen3-235B-A22B-Instruct-2507": {
-        "max_tokens": 262144,
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "input_cost_per_token": 0.01,
-        "output_cost_per_token": 0.01,
+    "wandb/deepseek-ai/DeepSeek-V4-Flash": {
+        "cache_read_input_token_cost": 7e-08,
+        "input_cost_per_token": 1.4e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 1049000,
+        "max_output_tokens": 1049000,
+        "max_tokens": 1049000,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct": {
-        "max_tokens": 262144,
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "input_cost_per_token": 0.1,
-        "output_cost_per_token": 0.15,
+    "wandb/deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "cache_read_input_token_cost": 7e-08,
+        "input_cost_per_token": 1.3e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/Qwen/Qwen3-235B-A22B-Thinking-2507": {
-        "max_tokens": 262144,
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "input_cost_per_token": 0.01,
-        "output_cost_per_token": 0.01,
+    "wandb/deepseek-ai/DeepSeek-V4-Pro": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1.15e-06,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 1049000,
+        "max_output_tokens": 1049000,
+        "max_tokens": 1049000,
+        "mode": "chat",
+        "output_cost_per_token": 2.55e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/moonshotai/Kimi-K2-Instruct": {
-        "max_tokens": 128000,
+    "wandb/google/gemma-4-31B-it": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 3.4e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/ibm-granite/granite-4.1-8b": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 131000,
+        "max_output_tokens": 131000,
+        "max_tokens": 131000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/JetBrains/Mellum2-12B-A2.5B-Instruct": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 131000,
+        "max_output_tokens": 131000,
+        "max_tokens": 131000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/meta-llama/Llama-3.1-70B-Instruct": {
+        "input_cost_per_token": 8e-07,
+        "litellm_provider": "wandb",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 6e-07,
-        "output_cost_per_token": 2.5e-06,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 8e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/meta-llama/Llama-3.1-8B-Instruct": {
+        "input_cost_per_token": 2.2e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/meta-llama/Llama-3.3-70B-Instruct": {
+        "input_cost_per_token": 7.1e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 7.1e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+        "input_cost_per_token": 1.7e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 64000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 6.6e-07
+    },
+    "wandb/MiniMaxAI/MiniMax-M2.5": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 197000,
+        "max_output_tokens": 197000,
+        "max_tokens": 197000,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true
+    },
+    "wandb/MiniMaxAI/MiniMax-M3": {
+        "cache_read_input_token_cost": 5e-08,
+        "input_cost_per_token": 2.3e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 9.6e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/microsoft/Phi-4-mini-instruct": {
+        "input_cost_per_token": 8e-08,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3.5e-07
+    },
+    "wandb/moonshotai/Kimi-K2-Instruct": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06
     },
     "wandb/moonshotai/Kimi-K2.5": {
-        "max_tokens": 262144,
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 6e-07,
-        "output_cost_per_token": 3e-06,
         "litellm_provider": "wandb",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
         "mode": "chat",
+        "output_cost_per_token": 3e-06,
         "source": "https://wandb.ai/inference/coreweave/cw_moonshotai_Kimi-K2.5",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_vision": true
     },
-    "wandb/MiniMaxAI/MiniMax-M2.5": {
-        "max_tokens": 197000,
-        "max_input_tokens": 197000,
-        "max_output_tokens": 197000,
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
+    "wandb/moonshotai/Kimi-K2.6": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 6.5e-07,
         "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
         "mode": "chat",
-        "source": "https://wandb.ai/inference/coreweave/cw_MiniMaxAI_MiniMax-M2.5",
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true
+        "output_cost_per_token": 3.41e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/meta-llama/Llama-3.1-8B-Instruct": {
-        "max_tokens": 128000,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "input_cost_per_token": 0.022,
-        "output_cost_per_token": 0.022,
+    "wandb/moonshotai/Kimi-K2.7-Code": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 7.1e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 3.5e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/deepseek-ai/DeepSeek-V3.1": {
-        "max_tokens": 128000,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "input_cost_per_token": 0.055,
-        "output_cost_per_token": 0.165,
+    "wandb/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
+        "input_cost_per_token": 2e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 8e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/deepseek-ai/DeepSeek-R1-0528": {
-        "max_tokens": 161000,
-        "max_input_tokens": 161000,
-        "max_output_tokens": 161000,
-        "input_cost_per_token": 0.135,
-        "output_cost_per_token": 0.54,
+    "wandb/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 7.5e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/deepseek-ai/DeepSeek-V3-0324": {
-        "max_tokens": 161000,
-        "max_input_tokens": 161000,
-        "max_output_tokens": 161000,
-        "input_cost_per_token": 0.114,
-        "output_cost_per_token": 0.275,
+    "wandb/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B": {
+        "cache_read_input_token_cost": 5e-08,
+        "input_cost_per_token": 1e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/meta-llama/Llama-3.3-70B-Instruct": {
-        "max_tokens": 128000,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "input_cost_per_token": 0.071,
-        "output_cost_per_token": 0.071,
+    "wandb/openai/gpt-oss-120b": {
+        "input_cost_per_token": 3e-08,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 131000,
+        "max_output_tokens": 131000,
+        "max_tokens": 131000,
+        "mode": "chat",
+        "output_cost_per_token": 1.7e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/meta-llama/Llama-4-Scout-17B-16E-Instruct": {
-        "max_tokens": 64000,
-        "max_input_tokens": 64000,
-        "max_output_tokens": 64000,
-        "input_cost_per_token": 0.017,
-        "output_cost_per_token": 0.066,
+    "wandb/openai/gpt-oss-20b": {
+        "input_cost_per_token": 3e-08,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 131000,
+        "max_output_tokens": 131000,
+        "max_tokens": 131000,
+        "mode": "chat",
+        "output_cost_per_token": 1.3e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/microsoft/Phi-4-mini-instruct": {
-        "max_tokens": 128000,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "input_cost_per_token": 0.008,
-        "output_cost_per_token": 0.035,
+    "wandb/OpenPipe/Qwen3-14B-Instruct": {
+        "input_cost_per_token": 5e-08,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 32800,
+        "max_output_tokens": 32800,
+        "max_tokens": 32800,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/Qwen/Qwen3-235B-A22B-Instruct-2507": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07
+    },
+    "wandb/Qwen/Qwen3-235B-A22B-Thinking-2507": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07
+    },
+    "wandb/Qwen/Qwen3-30B-A3B-Instruct-2507": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/Qwen/Qwen3.5-35B-A3B": {
+        "input_cost_per_token": 2.5e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 1.25e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/Qwen/Qwen3.6-27B": {
+        "cache_read_input_token_cost": 1.2e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 3.6e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/Qwen/Qwen3.6-35B-A3B": {
+        "input_cost_per_token": 2.5e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 1.25e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/zai-org/GLM-4.5": {
+        "input_cost_per_token": 5.5e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06
+    },
+    "wandb/zai-org/GLM-5.1": {
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 203000,
+        "max_output_tokens": 203000,
+        "max_tokens": 203000,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/zai-org/GLM-5.2": {
+        "cache_read_input_token_cost": 1.4e-07,
+        "input_cost_per_token": 7.6e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 2.42e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "watsonx/ibm/granite-3-8b-instruct": {
         "input_cost_per_token": 2e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -40143,7 +40143,8 @@
         "max_output_tokens": 161000,
         "max_tokens": 161000,
         "mode": "chat",
-        "output_cost_per_token": 5.4e-06
+        "output_cost_per_token": 5.4e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/deepseek-ai/DeepSeek-V3-0324": {
         "input_cost_per_token": 1.14e-06,
@@ -40152,7 +40153,8 @@
         "max_output_tokens": 161000,
         "max_tokens": 161000,
         "mode": "chat",
-        "output_cost_per_token": 2.75e-06
+        "output_cost_per_token": 2.75e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/deepseek-ai/DeepSeek-V3.1": {
         "input_cost_per_token": 5.5e-07,
@@ -40264,7 +40266,8 @@
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
-        "output_cost_per_token": 6.6e-07
+        "output_cost_per_token": 6.6e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/MiniMaxAI/MiniMax-M2.5": {
         "input_cost_per_token": 3e-07,
@@ -40297,7 +40300,8 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "output_cost_per_token": 3.5e-07
+        "output_cost_per_token": 3.5e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/moonshotai/Kimi-K2-Instruct": {
         "input_cost_per_token": 6e-07,
@@ -40414,7 +40418,8 @@
         "max_output_tokens": 262144,
         "max_tokens": 262144,
         "mode": "chat",
-        "output_cost_per_token": 1e-07
+        "output_cost_per_token": 1e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/Qwen/Qwen3-235B-A22B-Thinking-2507": {
         "input_cost_per_token": 1e-07,
@@ -40423,7 +40428,8 @@
         "max_output_tokens": 262144,
         "max_tokens": 262144,
         "mode": "chat",
-        "output_cost_per_token": 1e-07
+        "output_cost_per_token": 1e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/Qwen/Qwen3-30B-A3B-Instruct-2507": {
         "input_cost_per_token": 1e-07,
@@ -40483,7 +40489,8 @@
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 2e-06
+        "output_cost_per_token": 2e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "wandb/zai-org/GLM-5.1": {
         "cache_read_input_token_cost": 2.6e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -40207,7 +40207,9 @@
         "max_tokens": 262000,
         "mode": "chat",
         "output_cost_per_token": 3.4e-07,
-        "source": "https://wandb.ai/site/pricing/tokens/"
+        "source": "https://wandb.ai/site/pricing/tokens/",
+        "supports_reasoning": true,
+        "supports_vision": true
     },
     "wandb/ibm-granite/granite-4.1-8b": {
         "input_cost_per_token": 5e-08,
@@ -40291,7 +40293,8 @@
         "max_tokens": 262000,
         "mode": "chat",
         "output_cost_per_token": 9.6e-07,
-        "source": "https://wandb.ai/site/pricing/tokens/"
+        "source": "https://wandb.ai/site/pricing/tokens/",
+        "supports_vision": true
     },
     "wandb/microsoft/Phi-4-mini-instruct": {
         "input_cost_per_token": 8e-08,
@@ -40336,7 +40339,9 @@
         "max_tokens": 262000,
         "mode": "chat",
         "output_cost_per_token": 3.41e-06,
-        "source": "https://wandb.ai/site/pricing/tokens/"
+        "source": "https://wandb.ai/site/pricing/tokens/",
+        "supports_reasoning": true,
+        "supports_vision": true
     },
     "wandb/moonshotai/Kimi-K2.7-Code": {
         "cache_read_input_token_cost": 1.5e-07,
@@ -40347,7 +40352,8 @@
         "max_tokens": 262000,
         "mode": "chat",
         "output_cost_per_token": 3.5e-06,
-        "source": "https://wandb.ai/site/pricing/tokens/"
+        "source": "https://wandb.ai/site/pricing/tokens/",
+        "supports_vision": true
     },
     "wandb/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
         "input_cost_per_token": 2e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -40136,159 +40136,376 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
-    "wandb/openai/gpt-oss-120b": {
-        "max_tokens": 131072,
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "input_cost_per_token": 0.015,
-        "output_cost_per_token": 0.06,
+    "wandb/deepseek-ai/DeepSeek-R1-0528": {
+        "input_cost_per_token": 1.35e-06,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 161000,
+        "max_output_tokens": 161000,
+        "max_tokens": 161000,
+        "mode": "chat",
+        "output_cost_per_token": 5.4e-06
     },
-    "wandb/openai/gpt-oss-20b": {
-        "max_tokens": 131072,
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "input_cost_per_token": 0.005,
-        "output_cost_per_token": 0.02,
+    "wandb/deepseek-ai/DeepSeek-V3-0324": {
+        "input_cost_per_token": 1.14e-06,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 161000,
+        "max_output_tokens": 161000,
+        "max_tokens": 161000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-06
     },
-    "wandb/zai-org/GLM-4.5": {
-        "max_tokens": 131072,
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "input_cost_per_token": 0.055,
-        "output_cost_per_token": 0.2,
+    "wandb/deepseek-ai/DeepSeek-V3.1": {
+        "input_cost_per_token": 5.5e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 161000,
+        "max_output_tokens": 161000,
+        "max_tokens": 161000,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/Qwen/Qwen3-235B-A22B-Instruct-2507": {
-        "max_tokens": 262144,
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "input_cost_per_token": 0.01,
-        "output_cost_per_token": 0.01,
+    "wandb/deepseek-ai/DeepSeek-V4-Flash": {
+        "cache_read_input_token_cost": 7e-08,
+        "input_cost_per_token": 1.4e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 1049000,
+        "max_output_tokens": 1049000,
+        "max_tokens": 1049000,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct": {
-        "max_tokens": 262144,
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "input_cost_per_token": 0.1,
-        "output_cost_per_token": 0.15,
+    "wandb/deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "cache_read_input_token_cost": 7e-08,
+        "input_cost_per_token": 1.3e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/Qwen/Qwen3-235B-A22B-Thinking-2507": {
-        "max_tokens": 262144,
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "input_cost_per_token": 0.01,
-        "output_cost_per_token": 0.01,
+    "wandb/deepseek-ai/DeepSeek-V4-Pro": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1.15e-06,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 1049000,
+        "max_output_tokens": 1049000,
+        "max_tokens": 1049000,
+        "mode": "chat",
+        "output_cost_per_token": 2.55e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/moonshotai/Kimi-K2-Instruct": {
-        "max_tokens": 128000,
+    "wandb/google/gemma-4-31B-it": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 3.4e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/ibm-granite/granite-4.1-8b": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 131000,
+        "max_output_tokens": 131000,
+        "max_tokens": 131000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/JetBrains/Mellum2-12B-A2.5B-Instruct": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 131000,
+        "max_output_tokens": 131000,
+        "max_tokens": 131000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/meta-llama/Llama-3.1-70B-Instruct": {
+        "input_cost_per_token": 8e-07,
+        "litellm_provider": "wandb",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 6e-07,
-        "output_cost_per_token": 2.5e-06,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 8e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/meta-llama/Llama-3.1-8B-Instruct": {
+        "input_cost_per_token": 2.2e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/meta-llama/Llama-3.3-70B-Instruct": {
+        "input_cost_per_token": 7.1e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 7.1e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+        "input_cost_per_token": 1.7e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 64000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 6.6e-07
+    },
+    "wandb/MiniMaxAI/MiniMax-M2.5": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 197000,
+        "max_output_tokens": 197000,
+        "max_tokens": 197000,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true
+    },
+    "wandb/MiniMaxAI/MiniMax-M3": {
+        "cache_read_input_token_cost": 5e-08,
+        "input_cost_per_token": 2.3e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 9.6e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/microsoft/Phi-4-mini-instruct": {
+        "input_cost_per_token": 8e-08,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3.5e-07
+    },
+    "wandb/moonshotai/Kimi-K2-Instruct": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06
     },
     "wandb/moonshotai/Kimi-K2.5": {
-        "max_tokens": 262144,
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 6e-07,
-        "output_cost_per_token": 3e-06,
         "litellm_provider": "wandb",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
         "mode": "chat",
+        "output_cost_per_token": 3e-06,
         "source": "https://wandb.ai/inference/coreweave/cw_moonshotai_Kimi-K2.5",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_vision": true
     },
-    "wandb/MiniMaxAI/MiniMax-M2.5": {
-        "max_tokens": 197000,
-        "max_input_tokens": 197000,
-        "max_output_tokens": 197000,
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
+    "wandb/moonshotai/Kimi-K2.6": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 6.5e-07,
         "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
         "mode": "chat",
-        "source": "https://wandb.ai/inference/coreweave/cw_MiniMaxAI_MiniMax-M2.5",
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true
+        "output_cost_per_token": 3.41e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/meta-llama/Llama-3.1-8B-Instruct": {
-        "max_tokens": 128000,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "input_cost_per_token": 0.022,
-        "output_cost_per_token": 0.022,
+    "wandb/moonshotai/Kimi-K2.7-Code": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 7.1e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 3.5e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/deepseek-ai/DeepSeek-V3.1": {
-        "max_tokens": 128000,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "input_cost_per_token": 0.055,
-        "output_cost_per_token": 0.165,
+    "wandb/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
+        "input_cost_per_token": 2e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 8e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/deepseek-ai/DeepSeek-R1-0528": {
-        "max_tokens": 161000,
-        "max_input_tokens": 161000,
-        "max_output_tokens": 161000,
-        "input_cost_per_token": 0.135,
-        "output_cost_per_token": 0.54,
+    "wandb/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 7.5e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/deepseek-ai/DeepSeek-V3-0324": {
-        "max_tokens": 161000,
-        "max_input_tokens": 161000,
-        "max_output_tokens": 161000,
-        "input_cost_per_token": 0.114,
-        "output_cost_per_token": 0.275,
+    "wandb/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B": {
+        "cache_read_input_token_cost": 5e-08,
+        "input_cost_per_token": 1e-07,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/meta-llama/Llama-3.3-70B-Instruct": {
-        "max_tokens": 128000,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "input_cost_per_token": 0.071,
-        "output_cost_per_token": 0.071,
+    "wandb/openai/gpt-oss-120b": {
+        "input_cost_per_token": 3e-08,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 131000,
+        "max_output_tokens": 131000,
+        "max_tokens": 131000,
+        "mode": "chat",
+        "output_cost_per_token": 1.7e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/meta-llama/Llama-4-Scout-17B-16E-Instruct": {
-        "max_tokens": 64000,
-        "max_input_tokens": 64000,
-        "max_output_tokens": 64000,
-        "input_cost_per_token": 0.017,
-        "output_cost_per_token": 0.066,
+    "wandb/openai/gpt-oss-20b": {
+        "input_cost_per_token": 3e-08,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 131000,
+        "max_output_tokens": 131000,
+        "max_tokens": 131000,
+        "mode": "chat",
+        "output_cost_per_token": 1.3e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
-    "wandb/microsoft/Phi-4-mini-instruct": {
-        "max_tokens": 128000,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "input_cost_per_token": 0.008,
-        "output_cost_per_token": 0.035,
+    "wandb/OpenPipe/Qwen3-14B-Instruct": {
+        "input_cost_per_token": 5e-08,
         "litellm_provider": "wandb",
-        "mode": "chat"
+        "max_input_tokens": 32800,
+        "max_output_tokens": 32800,
+        "max_tokens": 32800,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/Qwen/Qwen3-235B-A22B-Instruct-2507": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07
+    },
+    "wandb/Qwen/Qwen3-235B-A22B-Thinking-2507": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07
+    },
+    "wandb/Qwen/Qwen3-30B-A3B-Instruct-2507": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-07,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/Qwen/Qwen3.5-35B-A3B": {
+        "input_cost_per_token": 2.5e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 1.25e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/Qwen/Qwen3.6-27B": {
+        "cache_read_input_token_cost": 1.2e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 3.6e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/Qwen/Qwen3.6-35B-A3B": {
+        "input_cost_per_token": 2.5e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 1.25e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/zai-org/GLM-4.5": {
+        "input_cost_per_token": 5.5e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06
+    },
+    "wandb/zai-org/GLM-5.1": {
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 203000,
+        "max_output_tokens": 203000,
+        "max_tokens": 203000,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
+    },
+    "wandb/zai-org/GLM-5.2": {
+        "cache_read_input_token_cost": 1.4e-07,
+        "input_cost_per_token": 7.6e-07,
+        "litellm_provider": "wandb",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 262000,
+        "max_tokens": 262000,
+        "mode": "chat",
+        "output_cost_per_token": 2.42e-06,
+        "source": "https://wandb.ai/site/pricing/tokens/"
     },
     "watsonx/ibm/granite-3-8b-instruct": {
         "input_cost_per_token": 2e-07,

--- a/tests/test_litellm/test_wandb_model_metadata.py
+++ b/tests/test_litellm/test_wandb_model_metadata.py
@@ -49,6 +49,14 @@ CURRENT_PRICES_PER_MILLION_TOKENS: Final = MappingProxyType(
         "wandb/zai-org/GLM-5.2": (0.76, 2.42, 0.14),
     }
 )
+CONFIRMED_CAPABILITIES: Final = MappingProxyType(
+    {
+        "wandb/google/gemma-4-31B-it": ("supports_reasoning", "supports_vision"),
+        "wandb/MiniMaxAI/MiniMax-M3": ("supports_vision",),
+        "wandb/moonshotai/Kimi-K2.6": ("supports_reasoning", "supports_vision"),
+        "wandb/moonshotai/Kimi-K2.7-Code": ("supports_vision",),
+    }
+)
 
 
 @pytest.mark.parametrize("price_file", PRICE_FILES)
@@ -63,3 +71,12 @@ def test_current_wandb_pricing(price_file: Path) -> None:
             pytest.approx(cache_price / 1_000_000) if cache_price is not None else None
         )
         assert metadata["source"] == SOURCE
+
+
+@pytest.mark.parametrize("price_file", PRICE_FILES)
+def test_confirmed_wandb_model_capabilities(price_file: Path) -> None:
+    prices: Final = json.loads(price_file.read_text())
+
+    for model, capabilities in CONFIRMED_CAPABILITIES.items():
+        for capability in capabilities:
+            assert prices[model][capability] is True

--- a/tests/test_litellm/test_wandb_model_metadata.py
+++ b/tests/test_litellm/test_wandb_model_metadata.py
@@ -13,6 +13,8 @@ PRICE_FILES: Final = (
 SOURCE: Final = "https://wandb.ai/site/pricing/tokens/"
 CURRENT_PRICES_PER_MILLION_TOKENS: Final = MappingProxyType(
     {
+        "wandb/deepseek-ai/DeepSeek-R1-0528": (1.35, 5.40, None),
+        "wandb/deepseek-ai/DeepSeek-V3-0324": (1.14, 2.75, None),
         "wandb/deepseek-ai/DeepSeek-V3.1": (0.55, 1.65, None),
         "wandb/deepseek-ai/DeepSeek-V4-Flash": (0.14, 0.28, 0.07),
         "wandb/deepseek-ai/DeepSeek-V4-Flash-0731": (0.13, 0.28, 0.07),
@@ -23,6 +25,8 @@ CURRENT_PRICES_PER_MILLION_TOKENS: Final = MappingProxyType(
         "wandb/meta-llama/Llama-3.1-70B-Instruct": (0.80, 0.80, None),
         "wandb/meta-llama/Llama-3.1-8B-Instruct": (0.22, 0.22, None),
         "wandb/meta-llama/Llama-3.3-70B-Instruct": (0.71, 0.71, None),
+        "wandb/meta-llama/Llama-4-Scout-17B-16E-Instruct": (0.17, 0.66, None),
+        "wandb/microsoft/Phi-4-mini-instruct": (0.08, 0.35, None),
         "wandb/MiniMaxAI/MiniMax-M2.5": (0.30, 1.20, None),
         "wandb/MiniMaxAI/MiniMax-M3": (0.23, 0.96, 0.05),
         "wandb/moonshotai/Kimi-K2.6": (0.65, 3.41, 0.15),
@@ -33,11 +37,14 @@ CURRENT_PRICES_PER_MILLION_TOKENS: Final = MappingProxyType(
         "wandb/openai/gpt-oss-120b": (0.03, 0.17, None),
         "wandb/openai/gpt-oss-20b": (0.03, 0.13, None),
         "wandb/OpenPipe/Qwen3-14B-Instruct": (0.05, 0.22, None),
+        "wandb/Qwen/Qwen3-235B-A22B-Instruct-2507": (0.10, 0.10, None),
+        "wandb/Qwen/Qwen3-235B-A22B-Thinking-2507": (0.10, 0.10, None),
         "wandb/Qwen/Qwen3-30B-A3B-Instruct-2507": (0.10, 0.30, None),
         "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct": (1.00, 1.50, None),
         "wandb/Qwen/Qwen3.5-35B-A3B": (0.25, 1.25, None),
         "wandb/Qwen/Qwen3.6-27B": (0.60, 3.60, 0.12),
         "wandb/Qwen/Qwen3.6-35B-A3B": (0.25, 1.25, None),
+        "wandb/zai-org/GLM-4.5": (0.55, 2.00, None),
         "wandb/zai-org/GLM-5.1": (1.40, 4.40, 0.26),
         "wandb/zai-org/GLM-5.2": (0.76, 2.42, 0.14),
     }

--- a/tests/test_litellm/test_wandb_model_metadata.py
+++ b/tests/test_litellm/test_wandb_model_metadata.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+from types import MappingProxyType
+from typing import Final
+
+import pytest
+
+REPO_ROOT: Final = Path(__file__).parents[2]
+PRICE_FILES: Final = (
+    REPO_ROOT / "model_prices_and_context_window.json",
+    REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json",
+)
+SOURCE: Final = "https://wandb.ai/site/pricing/tokens/"
+CURRENT_PRICES_PER_MILLION_TOKENS: Final = MappingProxyType(
+    {
+        "wandb/deepseek-ai/DeepSeek-V3.1": (0.55, 1.65, None),
+        "wandb/deepseek-ai/DeepSeek-V4-Flash": (0.14, 0.28, 0.07),
+        "wandb/deepseek-ai/DeepSeek-V4-Flash-0731": (0.13, 0.28, 0.07),
+        "wandb/deepseek-ai/DeepSeek-V4-Pro": (1.15, 2.55, 0.20),
+        "wandb/google/gemma-4-31B-it": (0.10, 0.34, None),
+        "wandb/ibm-granite/granite-4.1-8b": (0.05, 0.10, None),
+        "wandb/JetBrains/Mellum2-12B-A2.5B-Instruct": (0.05, 0.10, None),
+        "wandb/meta-llama/Llama-3.1-70B-Instruct": (0.80, 0.80, None),
+        "wandb/meta-llama/Llama-3.1-8B-Instruct": (0.22, 0.22, None),
+        "wandb/meta-llama/Llama-3.3-70B-Instruct": (0.71, 0.71, None),
+        "wandb/MiniMaxAI/MiniMax-M2.5": (0.30, 1.20, None),
+        "wandb/MiniMaxAI/MiniMax-M3": (0.23, 0.96, 0.05),
+        "wandb/moonshotai/Kimi-K2.6": (0.65, 3.41, 0.15),
+        "wandb/moonshotai/Kimi-K2.7-Code": (0.71, 3.50, 0.15),
+        "wandb/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": (0.20, 0.80, None),
+        "wandb/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": (0.75, 2.75, 0.15),
+        "wandb/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B": (0.10, 0.25, 0.05),
+        "wandb/openai/gpt-oss-120b": (0.03, 0.17, None),
+        "wandb/openai/gpt-oss-20b": (0.03, 0.13, None),
+        "wandb/OpenPipe/Qwen3-14B-Instruct": (0.05, 0.22, None),
+        "wandb/Qwen/Qwen3-30B-A3B-Instruct-2507": (0.10, 0.30, None),
+        "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct": (1.00, 1.50, None),
+        "wandb/Qwen/Qwen3.5-35B-A3B": (0.25, 1.25, None),
+        "wandb/Qwen/Qwen3.6-27B": (0.60, 3.60, 0.12),
+        "wandb/Qwen/Qwen3.6-35B-A3B": (0.25, 1.25, None),
+        "wandb/zai-org/GLM-5.1": (1.40, 4.40, 0.26),
+        "wandb/zai-org/GLM-5.2": (0.76, 2.42, 0.14),
+    }
+)
+
+
+@pytest.mark.parametrize("price_file", PRICE_FILES)
+def test_current_wandb_pricing(price_file: Path) -> None:
+    prices: Final = json.loads(price_file.read_text())
+
+    for model, (input_price, output_price, cache_price) in CURRENT_PRICES_PER_MILLION_TOKENS.items():
+        metadata: Final = prices[model]
+        assert metadata["input_cost_per_token"] == pytest.approx(input_price / 1_000_000)
+        assert metadata["output_cost_per_token"] == pytest.approx(output_price / 1_000_000)
+        assert metadata.get("cache_read_input_token_cost") == (
+            pytest.approx(cache_price / 1_000_000) if cache_price is not None else None
+        )
+        assert metadata["source"] == SOURCE


### PR DESCRIPTION
## TLDR

Problem this solves:

- W&B prices used incorrect per-token units
- Current W&B models were missing

How it solves it:

- Uses official per-million-token prices
- Adds every currently listed W&B model
- Declares officially confirmed vision and reasoning capabilities
- Keeps the bundled catalog synchronized
- Covers every semantically changed W&B price in both catalogs

## User Flow

Before: a developer prices W&B inference usage and sees costs inflated by orders of magnitude

1. They send POST https://api.inference.wandb.ai/v1/chat/completions with model openai/gpt-oss-20b
2. The response reports 68 prompt tokens and 1 completion token
3. LiteLLM reports $0.34 input and $0.02 output cost

After: the same usage is priced using W&B's published token rates

1. They send POST https://api.inference.wandb.ai/v1/chat/completions with model openai/gpt-oss-20b
2. The response reports 68 prompt tokens and 1 completion token
3. LiteLLM reports $0.00000204 input and $0.00000013 output cost

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Before at 423b791:

    $ litellm.cost_per_token(model="wandb/openai/gpt-oss-20b", prompt_tokens=68, completion_tokens=1)
    (0.34, 0.02)

After at 16c151f, using a real W&B inference response:

    $ curl https://api.inference.wandb.ai/v1/chat/completions ...
    {"model":"openai/gpt-oss-20b","usage":{"prompt_tokens":68,"completion_tokens":1,"total_tokens":69}}

    $ LITELLM_LOCAL_MODEL_COST_MAP=True uv run python -c 'import litellm; print(litellm.cost_per_token(model="wandb/openai/gpt-oss-20b", prompt_tokens=68, completion_tokens=1))'
    (2.04e-06, 1.3e-07)

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0dcc8d4634f9bcf56eed61bd5e03b697290f31f3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->