### PR TITLE
fix(transcription): stop a zero output rate from zeroing transcription cost

### DIFF
--- a/litellm/llms/openai/cost_calculation.py
+++ b/litellm/llms/openai/cost_calculation.py
@@ -109,15 +109,16 @@ def cost_per_second(model: str, custom_llm_provider: str | None, duration: float
     prompt_cost = 0.0
     completion_cost = 0.0
     ## Speech / Audio cost calculation
-    if "output_cost_per_second" in model_info and model_info["output_cost_per_second"] is not None:
+    output_cost_per_second: Final = model_info.get("output_cost_per_second")
+    if output_cost_per_second is not None and output_cost_per_second > 0:
         verbose_logger.debug(
             "For model=%s - output_cost_per_second: %s; duration: %s",
             model,
-            model_info.get("output_cost_per_second"),
+            output_cost_per_second,
             duration,
         )
         ## COST PER SECOND ##
-        completion_cost = model_info["output_cost_per_second"] * duration
+        completion_cost = output_cost_per_second * duration
     elif "input_cost_per_second" in model_info and model_info["input_cost_per_second"] is not None:
         verbose_logger.debug(
             "For model=%s - input_cost_per_second: %s; duration: %s",

--- a/tests/test_litellm/llms/openai/test_cost_calculation.py
+++ b/tests/test_litellm/llms/openai/test_cost_calculation.py
@@ -1,0 +1,83 @@
+"""Tests for per-second transcription cost calculation."""
+
+import pytest
+
+import litellm
+from litellm.llms.openai.cost_calculation import cost_per_second
+
+
+def _register_stt(name: str, **pricing: float) -> None:
+    litellm.register_model(
+        {
+            name: {
+                "mode": "audio_transcription",
+                "litellm_provider": "openai",
+                **pricing,
+            }
+        },
+        persist_across_reloads=False,
+    )
+
+
+def test_input_rate_bills_when_output_rate_is_zero():
+    """A declared-but-zero output rate must not suppress the real input rate."""
+    _register_stt(
+        "test-stt-zero-output",
+        input_cost_per_second=5e-05,
+        output_cost_per_second=0.0,
+    )
+
+    prompt_cost, completion_cost = cost_per_second(
+        model="test-stt-zero-output", custom_llm_provider="openai", duration=300.0
+    )
+
+    assert prompt_cost == pytest.approx(0.015)
+    assert completion_cost == 0.0
+
+
+def test_output_rate_takes_precedence_when_both_are_billable():
+    """Entries duplicating one rate into both fields must not be billed twice."""
+    _register_stt(
+        "test-stt-both-rates",
+        input_cost_per_second=1e-04,
+        output_cost_per_second=1e-04,
+    )
+
+    prompt_cost, completion_cost = cost_per_second(
+        model="test-stt-both-rates", custom_llm_provider="openai", duration=10.0
+    )
+
+    assert prompt_cost + completion_cost == pytest.approx(1e-03)
+
+
+def test_output_rate_alone_still_bills():
+    _register_stt("test-stt-output-only", output_cost_per_second=3e-05)
+
+    prompt_cost, completion_cost = cost_per_second(
+        model="test-stt-output-only", custom_llm_provider="openai", duration=60.0
+    )
+
+    assert prompt_cost == 0.0
+    assert completion_cost == pytest.approx(1.8e-03)
+
+
+@pytest.mark.parametrize(
+    "model, provider",
+    [
+        ("deepgram/nova-3", "deepgram"),
+        ("groq/whisper-large-v3", "groq"),
+        ("elevenlabs/scribe_v1", "elevenlabs"),
+        ("assemblyai/best", "assemblyai"),
+        ("whisper-1", "openai"),
+    ],
+)
+def test_shipped_per_second_models_bill_a_non_zero_cost(model, provider):
+    prompt_cost, completion_cost = cost_per_second(model=model, custom_llm_provider=provider, duration=60.0)
+
+    assert prompt_cost + completion_cost > 0.0
+
+
+def test_whisper_bills_its_documented_rate_once():
+    prompt_cost, completion_cost = cost_per_second(model="whisper-1", custom_llm_provider="openai", duration=30.0)
+
+    assert prompt_cost + completion_cost == pytest.approx(0.003)


### PR DESCRIPTION
## TLDR

Problem this solves:

- 43 of 55 per-second transcription models bill $0
- A zero output rate silently suppresses the real input rate
- Every deepgram, assemblyai, elevenlabs and groq entry is affected

How it solves it:

- Take the output branch only when that rate is billable
- A zero output rate now falls through to the input rate
- No pricing data edits and no existing test rewrites

## User Flow

Before: a developer transcribing audio through the proxy is billed nothing, so spend tracking and budgets never see the usage

1. They send POST https://litellm-domain/v1/audio/transcriptions with `"model": "deepgram/nova-3"` and a 60 second audio file
2. The transcript comes back correctly, so nothing looks wrong
3. They open https://litellm-domain/ui/?page=logs and the request is listed at $0.00 spend
4. They call GET https://litellm-domain/spend/logs and the entry reads `"spend": 0.0`
5. Their key budget never decrements, so transcription traffic is effectively free and unbounded

After: the same request records real spend, so logs and budgets reflect the audio actually transcribed

1. They send the same POST https://litellm-domain/v1/audio/transcriptions with `"model": "deepgram/nova-3"` and the same 60 second file
2. The transcript comes back identically
3. https://litellm-domain/ui/?page=logs now lists the request at $0.0043
4. GET https://litellm-domain/spend/logs returns `"spend": 0.0043` for that entry
5. The key budget decrements, so transcription traffic counts against limits like every other route

## Relevant issues

Fixes #19154

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy, real provider APIs, no mocks. Same config, same audio file (`tests/gettysburg.wav`, 17.58s), same two curls on both commits. `deepgram/nova-3` is one of the 43 affected models; `whisper-1` is the unaffected control that must not change

```bash
# proxy config (model_list excerpt)
#   - model_name: deepgram-nova-3
#     litellm_params: {model: deepgram/nova-3, api_key: os.environ/DEEPGRAM_API_KEY}
#   - model_name: whisper-1
#     litellm_params: {model: whisper-1, api_key: os.environ/OPENAI_API_KEY}

python litellm/proxy/proxy_cli.py --config proof-config.yaml --port 4010

for m in deepgram-nova-3 whisper-1; do
  curl -s -D - -o /dev/null http://localhost:4010/v1/audio/transcriptions \
    -H "Authorization: Bearer sk-1234" \
    -F "model=$m" -F "file=@tests/gettysburg.wav" | grep -iE "^HTTP|x-litellm-response-cost"
done
```

Before, at f03df1bb42 (latest litellm_internal_staging): the deepgram transcription succeeds but bills nothing, no cost header is returned at all

```text
=== deepgram-nova-3 ===
HTTP/1.1 200 OK
=== whisper-1 ===
HTTP/1.1 200 OK
x-litellm-response-cost: 0.001756999969482422
```
<img width="1394" height="314" alt="image" src="https://github.com/user-attachments/assets/9c237b10-f3ed-4184-bde7-98b6f3eaf25f" />

After, at 24406d68e0 (this PR): the same deepgram request now returns the real cost, and the control is byte-for-byte unchanged

```text
=== deepgram-nova-3 ===
HTTP/1.1 200 OK
x-litellm-response-cost: 0.0012597481052099998
=== whisper-1 ===
HTTP/1.1 200 OK
x-litellm-response-cost: 0.001756999969482422
```

<img width="1452" height="347" alt="image" src="https://github.com/user-attachments/assets/83b619e8-1587-47a9-8e5b-af03a1fbdc14" />

Sanity check: 17.577s of audio at deepgram/nova-3's `input_cost_per_second` of 7.167e-05 is 0.00125975, matching the returned header exactly. whisper-1 bills 17.57s at 0.0001/s on both commits, confirming the duplicate-rate entries keep billing exactly what they bill today

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

- Earlier fixes #19158 and #23842 were reverted (#19352, #24297)
- Follow-up: whisper spend still splits as output, not input
- groq whisper still bills $0: separate provider-stamping bug, filing it separately
