### PR TITLE
fix(langfuse): log `custom_tool_call` items in Responses API output

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -206,6 +206,17 @@ class LangfuseOtelLogger(OpenTelemetry):
                             "arguments": arguments_obj,
                         }
                         output_items_data.append(langfuse_tool_call)
+                    elif item_type == "custom_tool_call":
+                        # Custom (freeform) tools carry a raw string `input` instead of JSON `arguments`
+                        output_items_data.append(
+                            {
+                                "id": getattr(item, "id", ""),
+                                "name": getattr(item, "name", ""),
+                                "call_id": getattr(item, "call_id", ""),
+                                "type": "custom_tool_call",
+                                "input": getattr(item, "input", ""),
+                            }
+                        )
             if output_items_data:
                 safe_set_attribute(
                     span,

--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -203,7 +203,9 @@ class LangfuseOtelLogger(OpenTelemetry):
                         else:
                             arguments_str = getattr(item, "arguments", "{}")
                             payload_key = "arguments"
-                            payload_value = json.loads(arguments_str) if isinstance(arguments_str, str) else arguments_str
+                            payload_value = (
+                                json.loads(arguments_str) if isinstance(arguments_str, str) else arguments_str
+                            )
                         langfuse_tool_call = {
                             "id": getattr(item, "id", ""),
                             "name": getattr(item, "name", ""),

--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -195,28 +195,23 @@ class LangfuseOtelLogger(OpenTelemetry):
                                 "content": getattr(getattr(item, "content", [{}])[0], "text", ""),
                             }
                         )
-                    elif item_type == "function_call":
-                        arguments_str = getattr(item, "arguments", "{}")
-                        arguments_obj = json.loads(arguments_str) if isinstance(arguments_str, str) else arguments_str
+                    elif item_type in ("function_call", "custom_tool_call"):
+                        # A custom (freeform) tool carries its payload as a raw string under `input`,
+                        # where a function call carries a JSON string under `arguments`.
+                        if item_type == "custom_tool_call":
+                            payload_key, payload_value = "input", getattr(item, "input", "")
+                        else:
+                            arguments_str = getattr(item, "arguments", "{}")
+                            payload_key = "arguments"
+                            payload_value = json.loads(arguments_str) if isinstance(arguments_str, str) else arguments_str
                         langfuse_tool_call = {
                             "id": getattr(item, "id", ""),
                             "name": getattr(item, "name", ""),
                             "call_id": getattr(item, "call_id", ""),
-                            "type": "function_call",
-                            "arguments": arguments_obj,
+                            "type": item_type,
+                            payload_key: payload_value,
                         }
                         output_items_data.append(langfuse_tool_call)
-                    elif item_type == "custom_tool_call":
-                        # Custom (freeform) tools carry a raw string `input` instead of JSON `arguments`
-                        output_items_data.append(
-                            {
-                                "id": getattr(item, "id", ""),
-                                "name": getattr(item, "name", ""),
-                                "call_id": getattr(item, "call_id", ""),
-                                "type": "custom_tool_call",
-                                "input": getattr(item, "input", ""),
-                            }
-                        )
             if output_items_data:
                 safe_set_attribute(
                     span,

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -134,6 +134,10 @@ def _redact_responses_api_output(output_items):
         if hasattr(output_item, "type") and output_item.type == "function_call" and hasattr(output_item, "arguments"):
             output_item.arguments = "redacted-by-litellm"
 
+        # Custom (freeform) tools carry their prompt-derived payload as a raw string under `input`.
+        if hasattr(output_item, "type") and output_item.type == "custom_tool_call" and hasattr(output_item, "input"):
+            output_item.input = "redacted-by-litellm"
+
 
 def _redact_responses_api_output_dict(output_items, redacted_str: str):
     """Helper to redact ResponsesAPIResponse output items in dict form."""
@@ -156,6 +160,9 @@ def _redact_responses_api_output_dict(output_items, redacted_str: str):
 
         if output_item.get("type") == "function_call" and "arguments" in output_item:
             output_item["arguments"] = redacted_str
+
+        if output_item.get("type") == "custom_tool_call" and "input" in output_item:
+            output_item["input"] = redacted_str
 
 
 def _redact_standard_logging_object(model_call_details: dict):

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -933,6 +933,65 @@ class TestLangfuseOtelResponsesAPI:
             assert output_data[0]["arguments"]["location"] == "San Francisco"
             assert output_data[0]["arguments"]["unit"] == "celsius"
 
+    def test_responses_api_with_custom_tool_calls(self):
+        """Test Langfuse OTEL logger with Responses API custom_tool_call output."""
+        from litellm.types.integrations.langfuse_otel import LangfuseSpanAttributes
+        from litellm.types.responses.main import CustomToolCallOutputItem
+
+        # Create Responses API response with a custom (freeform) tool call
+        response_obj = ResponsesAPIResponse(
+            id="response-790",
+            created_at=1625247700,
+            output=[
+                CustomToolCallOutputItem(
+                    id="ctc-123",
+                    type="custom_tool_call",
+                    name="exec",
+                    call_id="call-def",
+                    input="console.log('hello')",
+                    status="completed",
+                )
+            ],
+        )
+
+        kwargs = {
+            "call_type": "responses",
+            "messages": [{"role": "user", "content": "Print hello"}],
+            "model": "gpt-4o",
+            "optional_params": {},
+        }
+
+        mock_span = MagicMock()
+
+        with patch(
+            "litellm.integrations.arize._utils.safe_set_attribute"
+        ) as mock_safe_set_attribute:
+            LangfuseOtelLogger._set_langfuse_specific_attributes(
+                mock_span, kwargs, response_obj
+            )
+
+            # Verify observation output was set
+            output_calls = [
+                call
+                for call in mock_safe_set_attribute.call_args_list
+                if call.args[1] == LangfuseSpanAttributes.OBSERVATION_OUTPUT.value
+            ]
+
+            assert len(output_calls) > 0, "observation.output should be set"
+            output_json = output_calls[0].args[2]
+            output_data = json.loads(output_json)
+
+            # Verify output contains the custom tool call
+            assert isinstance(output_data, list)
+            assert len(output_data) == 1
+
+            # Verify custom tool call details
+            assert output_data[0]["type"] == "custom_tool_call"
+            assert output_data[0]["id"] == "ctc-123"
+            assert output_data[0]["name"] == "exec"
+            assert output_data[0]["call_id"] == "call-def"
+            assert output_data[0]["input"] == "console.log('hello')"
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -490,6 +490,35 @@ class TestPerformRedaction:
         assert redacted["output"][0]["arguments"] == "redacted-by-litellm"
         assert redacted["output"][0]["name"] == "get_weather"
 
+    def test_redacts_responses_api_custom_tool_call_input_dict(self):
+        result = {
+            "output": [
+                {
+                    "type": "custom_tool_call",
+                    "name": "submit_report",
+                    "input": "sensitive freeform payload",
+                    "call_id": "call_1",
+                }
+            ]
+        }
+
+        redacted = perform_redaction({}, result)
+
+        assert redacted["output"][0]["input"] == "redacted-by-litellm"
+        assert redacted["output"][0]["name"] == "submit_report"
+
+    def test_redacts_responses_api_custom_tool_call_input_object(self):
+        output_items = [
+            SimpleNamespace(type="custom_tool_call", name="submit_report", input="sensitive freeform payload"),
+            SimpleNamespace(type="function_call", name="get_weather", arguments='{"city": "sensitive-city"}'),
+        ]
+
+        _redact_responses_api_output(output_items)
+
+        assert output_items[0].input == "redacted-by-litellm"
+        assert output_items[0].name == "submit_report"
+        assert output_items[1].arguments == "redacted-by-litellm"
+
     def test_redacts_response_output_objects_with_top_level_text(self):
         output_items = [
             SimpleNamespace(text="top-level output"),


### PR DESCRIPTION
## TLDR

Problem this solves:

- Langfuse drops Responses API custom tool calls
- Custom tool input needs the existing message-redaction protection

How it solves it:

- Records custom tool identifiers and raw input
- Redacts custom input in both response representations
- Preserves staging's safe parsing of function arguments

## User Flow

Before: a developer reviewing a freeform tool call cannot see its payload in Langfuse

1. Send POST http://localhost:47431/v1/responses with an `exec` custom tool and `tool_choice: "required"`
2. Receive HTTP 200 with a `custom_tool_call` containing JavaScript
3. Open the corresponding Langfuse generation: the custom call is missing, even when an accompanying text message appears

After: the same call appears in Langfuse and respects message redaction

1. Send POST http://localhost:47432/v1/responses with the same tool and payload
2. Receive HTTP 200 with a `custom_tool_call` containing JavaScript
3. Open the corresponding Langfuse generation: the custom call is present; with `x-litellm-enable-message-redaction: true`, its input is `redacted-by-litellm`

## Relevant issues

Fixes #37430

## Affected release

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 on the current tip

Validation at `8926f645f5`: both affected test files pass, **86 passed**. The four new cases fail against merge base `252c71c0b2`. Changed executable lines have **100% coverage**. Ruff, type-discipline and test-quality budgets pass without budget changes; the current CI lint passes too

```sh
LITELLM_LOCAL_MODEL_COST_MAP=True PYTHONPATH=. python -m pytest \
  tests/test_litellm/integrations/test_langfuse_otel.py \
  tests/test_litellm/litellm_core_utils/test_redact_messages.py -q
# 86 passed
```

## Screenshots / Proof of Fix

Captured 2026-09-16 against two isolated proxies, the merge base on port 47431 and the current tip on 47432. Both used the same live `gpt-6-astra` deployment and self-hosted Langfuse, with actual provider calls and no mocks. The same request on each proxy returned HTTP 200. The observations below belong to these test proxies, identified separately from the upstream gateway's traces

Shared config, with credentials supplied through environment variables:

```yaml
model_list:
  - model_name: gpt-6-astra
    litellm_params:
      model: openai/gpt-6-astra
      api_base: http://127.0.0.1:4000/v1
      api_key: os.environ/UPSTREAM_API_KEY
    model_info:
      mode: responses
litellm_settings:
  callbacks: [langfuse_otel]
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

Set `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST` and `LANGFUSE_OTEL_HOST` for the test project. Save this as `custom.json`:

```json
{"model":"gpt-6-astra","input":"Use the exec tool to print 6*7 in JavaScript.","tools":[{"type":"custom","name":"exec","description":"Run JavaScript and return stdout"}],"tool_choice":"required","store":false,"reasoning":{"effort":"low"},"max_output_tokens":1024}
```

For `function.json`, replace `tools` with:

```json
[{"type":"function","name":"exec","description":"Run JavaScript","parameters":{"type":"object","properties":{"code":{"type":"string"}},"required":["code"],"additionalProperties":false},"strict":true}]
```

For `text.json`, remove `tools` and `tool_choice`, and set `input` to `Reply with exactly: 42`

### Before (252c71c0b2)

#### Custom tool output

1. Send the request and inspect the returned item types

   ```sh
   curl -sS http://localhost:47431/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' --data-binary @custom.json -o response.json -w 'http=%{http_code}\n'
   jq '[.output[].type]' response.json
   # http=200
   # ["message","custom_tool_call"]
   ```

2. Read the test proxy's generation from Langfuse

   ```sh
   curl -sS -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" "$LANGFUSE_HOST/api/public/observations/a57c0dc37adb3d3f" | jq '{id, output}'
   ```

   ```json
   {"id":"a57c0dc37adb3d3f","output":[{"role":"assistant","content":"I’ll print `6 * 7` using JavaScript."}]}
   ```

#### Custom tool with redaction

1. Send the request and inspect the returned item types

   ```sh
   curl -sS http://localhost:47431/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -H 'x-litellm-enable-message-redaction: true' --data-binary @custom.json -o response.json -w 'http=%{http_code}\n'
   jq '[.output[].type]' response.json
   # http=200
   # ["message","custom_tool_call"]
   ```

2. Read the test proxy's generation from Langfuse

   ```sh
   curl -sS -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" "$LANGFUSE_HOST/api/public/observations/1b1af6edb86ebe19" | jq '{id, output}'
   ```

   ```json
   {"id":"1b1af6edb86ebe19","output":[{"role":"assistant","content":"redacted-by-litellm"}]}
   ```

#### Function tool with redaction

1. Send the request and inspect the returned item types

   ```sh
   curl -sS http://localhost:47431/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -H 'x-litellm-enable-message-redaction: true' --data-binary @function.json -o response.json -w 'http=%{http_code}\n'
   jq '[.output[].type]' response.json
   # http=200
   # ["message","function_call"]
   ```

2. Read the test proxy's generation from Langfuse

   ```sh
   curl -sS -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" "$LANGFUSE_HOST/api/public/observations/82a77dafb63966fb" | jq '{id, output}'
   ```

   ```json
   {"id":"82a77dafb63966fb","output":[{"role":"assistant","content":"redacted-by-litellm"},{"id":"fc_0e0d2eb388296538016aaa107e4b4487d091d700512679d1fe","name":"exec","call_id":"call_3KBeE9ARgEAlGLh6cHfgFge4","type":"function_call","arguments":{}}]}
   ```

#### Plain text control

1. Send the request and inspect the returned item types

   ```sh
   curl -sS http://localhost:47431/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' --data-binary @text.json -o response.json -w 'http=%{http_code}\n'
   jq '[.output[].type]' response.json
   # http=200
   # ["message"]
   ```

2. Read the test proxy's generation from Langfuse

   ```sh
   curl -sS -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" "$LANGFUSE_HOST/api/public/observations/5e79a56489ba83b5" | jq '{id, output}'
   ```

   ```json
   {"id":"5e79a56489ba83b5","output":[{"role":"assistant","content":"42"}]}
   ```

### After (8926f645f5)

#### Custom tool output

1. Send the request and inspect the returned item types

   ```sh
   curl -sS http://localhost:47432/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' --data-binary @custom.json -o response.json -w 'http=%{http_code}\n'
   jq '[.output[].type]' response.json
   # http=200
   # ["message","custom_tool_call"]
   ```

2. Read the test proxy's generation from Langfuse

   ```sh
   curl -sS -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" "$LANGFUSE_HOST/api/public/observations/ed115755387c8d3e" | jq '{id, output}'
   ```

   ```json
   {"id":"ed115755387c8d3e","output":[{"role":"assistant","content":"I’ll print `6 * 7` using JavaScript."},{"id":"ctc_0ce2f9b6c75257ef016aaa107d8c6487d09fa29987888eb375","name":"exec","call_id":"call_ASagu9uv36LxaL7eGBiGIJBH","type":"custom_tool_call","input":"console.log(6 * 7);\n"}]}
   ```

#### Custom tool with redaction

1. Send the request and inspect the returned item types

   ```sh
   curl -sS http://localhost:47432/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -H 'x-litellm-enable-message-redaction: true' --data-binary @custom.json -o response.json -w 'http=%{http_code}\n'
   jq '[.output[].type]' response.json
   # http=200
   # ["message","custom_tool_call"]
   ```

2. Read the test proxy's generation from Langfuse

   ```sh
   curl -sS -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" "$LANGFUSE_HOST/api/public/observations/3ff3f0b2c3e3af99" | jq '{id, output}'
   ```

   ```json
   {"id":"3ff3f0b2c3e3af99","output":[{"role":"assistant","content":"redacted-by-litellm"},{"id":"ctc_09d3b2412d2168e6016aaa107dd4e887d0ab33b52e9bcc9197","name":"exec","call_id":"call_i4IBJFyHMCJYtLPnQ9CvaEzC","type":"custom_tool_call","input":"redacted-by-litellm"}]}
   ```

#### Function tool with redaction

1. Send the request and inspect the returned item types

   ```sh
   curl -sS http://localhost:47432/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -H 'x-litellm-enable-message-redaction: true' --data-binary @function.json -o response.json -w 'http=%{http_code}\n'
   jq '[.output[].type]' response.json
   # http=200
   # ["message","function_call"]
   ```

2. Read the test proxy's generation from Langfuse

   ```sh
   curl -sS -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" "$LANGFUSE_HOST/api/public/observations/8fd048d8e23cae6c" | jq '{id, output}'
   ```

   ```json
   {"id":"8fd048d8e23cae6c","output":[{"role":"assistant","content":"redacted-by-litellm"},{"id":"fc_0166aa94101ea74d016aaa107e643087d0a8172ab47e56255f","name":"exec","call_id":"call_j7pPUZBOLEVI6hkiWLjTc1Ft","type":"function_call","arguments":{}}]}
   ```

#### Plain text control

1. Send the request and inspect the returned item types

   ```sh
   curl -sS http://localhost:47432/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' --data-binary @text.json -o response.json -w 'http=%{http_code}\n'
   jq '[.output[].type]' response.json
   # http=200
   # ["message"]
   ```

2. Read the test proxy's generation from Langfuse

   ```sh
   curl -sS -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" "$LANGFUSE_HOST/api/public/observations/8efb4e3ca9b850f1" | jq '{id, output}'
   ```

   ```json
   {"id":"8efb4e3ca9b850f1","output":[{"role":"assistant","content":"42"}]}
   ```

## Type

Bug Fix

## Caveats (if any)

### Low

- Vertex CI has four identical failures on the target branch
- The auth prefetch test hits an existing cache-expiry flake tracked in #41278
- Re-running the auth job requires repository admin rights; the rerun API returned HTTP 403

At `8926f645f5`, 82 checks succeeded, two failed and one was skipped. Lint, integrations and core-utils passed. Greptile scored the current tip 5/5, Cursor Bugbot and Veria succeeded, and both review threads are resolved

The [target branch's Vertex job](https://github.com/BerriAI/litellm/actions/runs/35015014880/job/104536142917) and [this PR's Vertex job](https://github.com/BerriAI/litellm/actions/runs/35052509431/job/104655750301) fail the same four embedding-pricing assertions, with the same observed and expected values. They are outside the four files changed here

The [proxy-behavior job](https://github.com/BerriAI/litellm/actions/runs/35052509306/job/104655749816) fails `test_join_binds_the_membership_to_the_requested_team` with `TypeError: object MagicMock can't be used in 'await' expression` after the five-second prefetch cache expires. The affected test and implementation are unchanged by this PR; #41278 fixes the test clock on the same target branch

## Final Attestation

- [x] The tests cover raw custom output, redacted custom output, both redaction representations, and the existing function-call behavior
