### PR TITLE
refactor(ui): move the model hub and model select onto shadcn primitives

### DIFF
--- a/tests/e2e/ui/tests/proxy-admin/teams.spec.ts
+++ b/tests/e2e/ui/tests/proxy-admin/teams.spec.ts
@@ -47,10 +47,10 @@ test.describe("Proxy Admin - Teams", () => {
     // Fill Team Name — the input has id="team_alias"
     await dialog.locator("#team_alias").fill(uniqueAlias);
 
-    // Select models — the models multi-select is inside the modal
-    // Click to open dropdown, select "All Proxy Models"
-    await dialog.locator(".ant-select-selection-overflow").first().click();
-    await page.locator(".ant-select-dropdown:visible").getByText("All Proxy Models").click();
+    // Select models — the models multi-select is inside the modal. Its popup is
+    // portaled to the body, so scope the option lookup to the page, not the dialog.
+    await dialog.getByTestId("create-team-models-select").getByRole("combobox").click();
+    await page.getByRole("option", { name: "All Proxy Models", exact: true }).click();
     await page.keyboard.press("Escape");
 
     // Submit — click the submit button inside the dialog (not the header button)
@@ -191,11 +191,11 @@ test.describe("Proxy Admin - Teams", () => {
       const modelsSelect = page.locator("[data-testid='models-select']");
       await expect(modelsSelect).toBeVisible({ timeout: 10_000 });
 
-      const anthropicTag = modelsSelect
-        .locator(".ant-select-selection-item")
+      const anthropicChip = modelsSelect
+        .locator('[data-slot="combobox-chip"]')
         .filter({ hasText: "fake-anthropic-claude" });
-      await expect(anthropicTag).toBeVisible({ timeout: 5_000 });
-      await anthropicTag.locator(".ant-select-selection-item-remove").click();
+      await expect(anthropicChip).toBeVisible({ timeout: 5_000 });
+      await anthropicChip.locator('[data-slot="combobox-chip-remove"]').click();
 
       await page.getByRole("button", { name: "Save Changes" }).click();
 

--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1830,9 +1830,6 @@
   "src/components/GuardrailsMonitor/LogViewer.tsx": {
     "no-nested-ternary": {
       "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "src/components/HelpLink.test.tsx": {
@@ -1841,11 +1838,6 @@
     }
   },
   "src/components/LicenseExpiryBanner.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/components/ModelSelect/ModelSelect.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -2341,9 +2333,6 @@
     }
   },
   "src/components/claude_code_plugins/MakeSkillPublicForm.tsx": {
-    "no-restricted-imports": {
-      "count": 2
-    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
@@ -2982,9 +2971,6 @@
     },
     "max-lines": {
       "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 2
     }
   },
   "src/components/query_param_input.tsx": {

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/LogViewer.tsx
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/LogViewer.tsx
@@ -1,8 +1,9 @@
-import { CheckCircleOutlined, CloseOutlined, DownOutlined, WarningOutlined } from "@ant-design/icons";
+import { CircleCheck, ChevronDown, TriangleAlert, X } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import moment from "moment";
-import { Button, Spin } from "antd";
 import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
 import { uiSpendLogsCall } from "@/components/networking";
 import { LogDetailsDrawer } from "@/components/view_logs/LogDetailsDrawer";
 import type { LogEntry as ViewLogsLogEntry } from "@/components/view_logs/columns";
@@ -13,21 +14,21 @@ const actionConfig: Record<
   { icon: React.ElementType; color: string; bg: string; border: string; label: string }
 > = {
   blocked: {
-    icon: CloseOutlined,
+    icon: X,
     color: "text-red-600",
     bg: "bg-red-50",
     border: "border-red-200",
     label: "Blocked",
   },
   passed: {
-    icon: CheckCircleOutlined,
+    icon: CircleCheck,
     color: "text-green-600",
     bg: "bg-green-50",
     border: "border-green-200",
     label: "Passed",
   },
   flagged: {
-    icon: WarningOutlined,
+    icon: TriangleAlert,
     color: "text-amber-600",
     bg: "bg-amber-50",
     border: "border-amber-200",
@@ -125,8 +126,8 @@ export function LogViewer({
                 {filters.map((f) => (
                   <Button
                     key={f}
-                    type={activeFilter === f ? "primary" : "default"}
-                    size="small"
+                    variant={activeFilter === f ? "default" : "outline"}
+                    size="sm"
                     onClick={() => setActiveFilter(f)}
                   >
                     {f.charAt(0).toUpperCase() + f.slice(1)}
@@ -139,8 +140,8 @@ export function LogViewer({
                 {sampleSizes.map((size) => (
                   <Button
                     key={size}
-                    type={sampleSize === size ? "primary" : "default"}
-                    size="small"
+                    variant={sampleSize === size ? "default" : "outline"}
+                    size="sm"
                     onClick={() => setSampleSize(size)}
                   >
                     {size}
@@ -154,7 +155,7 @@ export function LogViewer({
 
       {logsLoading && (
         <div className="flex items-center justify-center py-12">
-          <Spin />
+          <UiLoadingSpinner className="size-5" />
         </div>
       )}
       {!logsLoading && displayLogs.length === 0 && (
@@ -182,11 +183,11 @@ export function LogViewer({
                     </span>
                     <span className="text-xs text-gray-400">{log.timestamp}</span>
                     <span className="text-xs text-gray-400">·</span>
-                    {log.model && <span className="text-xs text-gray-500">{log.model}</span>}
+                    {log.model && <span className="min-w-0 text-xs break-words text-gray-500">{log.model}</span>}
                   </div>
                   <p className="text-sm text-gray-800 truncate">{log.input_snippet ?? log.input ?? "—"}</p>
                 </div>
-                <DownOutlined className="w-4 h-4 text-gray-400 shrink-0 mt-1" />
+                <ChevronDown className="w-4 h-4 text-gray-400 shrink-0 mt-1" />
               </button>
             );
           })}

--- a/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.test.tsx
+++ b/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.test.tsx
@@ -1,6 +1,6 @@
 import type { ProxyModel } from "@/app/(dashboard)/hooks/models/useModels";
 import type { Organization } from "@/components/networking";
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "../../../tests/test-utils";
@@ -21,64 +21,6 @@ vi.mock("@/app/(dashboard)/hooks/organizations/useOrganizations", () => ({
 vi.mock("@/app/(dashboard)/hooks/users/useCurrentUser", () => ({
   useCurrentUser: vi.fn(),
 }));
-
-vi.mock("antd", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("antd")>();
-  return {
-    ...actual,
-    Select: ({
-      value,
-      onChange,
-      options,
-      "data-testid": dataTestId,
-      allowClear,
-      maxTagCount,
-      maxTagPlaceholder,
-      mode,
-      ...props
-    }: any) => {
-      // Simulate maxTagCount responsive behavior - if value length > 5, call maxTagPlaceholder
-      const shouldShowPlaceholder = maxTagCount === "responsive" && Array.isArray(value) && value.length > 5;
-      const visibleValues = shouldShowPlaceholder ? value.slice(0, 5) : value;
-      const omittedValues = shouldShowPlaceholder ? value.slice(5).map((v: string) => ({ value: v, label: v })) : [];
-
-      return (
-        <div data-testid={dataTestId || "model-select"}>
-          <select
-            multiple={mode === "multiple"}
-            role="listbox"
-            value={visibleValues}
-            onChange={(e) => {
-              const selectedValues = Array.from(e.target.selectedOptions, (option) => option.value);
-              onChange(mode === "multiple" ? selectedValues : selectedValues[0]);
-            }}
-            {...props}
-          >
-            {options?.map((group: any) => (
-              <optgroup
-                key={group.label?.props?.children || group.title}
-                label={group.title || group.label?.props?.children}
-              >
-                {group.options?.map((option: any) => (
-                  <option key={option.value} value={option.value} disabled={option.disabled}>
-                    {typeof option.label === "string" ? option.label : option.label?.props?.children}
-                  </option>
-                ))}
-              </optgroup>
-            ))}
-          </select>
-          {shouldShowPlaceholder && maxTagPlaceholder && (
-            <div data-testid="max-tag-placeholder">{maxTagPlaceholder(omittedValues)}</div>
-          )}
-        </div>
-      );
-    },
-    Skeleton: {
-      Input: ({ active, block }: any) => <div data-testid="skeleton-input" data-active={active} data-block={block} />,
-    },
-    Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  };
-});
 
 import { useAllProxyModels } from "@/app/(dashboard)/hooks/models/useModels";
 import { useOrganization } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
@@ -107,6 +49,14 @@ const createMockOrganization = (models: string[]): Organization => ({
   users: null,
   members: null,
 });
+
+const openModelList = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getAllByRole("combobox")[0]);
+  await screen.findByRole("listbox");
+};
+
+const expectOffered = (label: string) => expect(screen.queryAllByText(label).length).toBeGreaterThan(0);
+const expectNotOffered = (label: string) => expect(screen.queryAllByText(label)).toHaveLength(0);
 
 describe("ModelSelect", () => {
   const mockProxyModels: ProxyModel[] = [
@@ -138,21 +88,26 @@ describe("ModelSelect", () => {
     } as any);
   });
 
-  it("should render with all option groups", async () => {
+  it("should offer every model and wildcard under its group heading", async () => {
+    const user = userEvent.setup();
     renderWithProviders(
       <ModelSelect onChange={mockOnChange} context="user" options={{ showAllProxyModelsOverride: true }} />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("model-select")).toBeInTheDocument();
-      expect(screen.getByText("gpt-4")).toBeInTheDocument();
-      expect(screen.getByText("claude-3")).toBeInTheDocument();
-      expect(screen.getByText("All Openai models")).toBeInTheDocument();
-      expect(screen.getByText("All Anthropic models")).toBeInTheDocument();
-    });
+    await openModelList(user);
+
+    expectOffered("Wildcard Options");
+    expectOffered("gpt-4");
+    expectOffered("claude-3");
+    expectOffered("All Openai models");
+    expectOffered("All Anthropic models");
   });
 
-  it("should show skeleton loader when any data is loading", () => {
+  it("should offer nothing to select while any dependency is loading", () => {
+    const { unmount: unmountReady } = renderWithProviders(<ModelSelect onChange={mockOnChange} context="user" />);
+    expect(screen.getAllByRole("combobox")).toHaveLength(1);
+    unmountReady();
+
     const loadingScenarios = [
       { hook: mockUseAllProxyModels, context: "user" as const },
       { hook: mockUseTeam, context: "team" as const, props: { teamID: "team-1" } },
@@ -168,30 +123,24 @@ describe("ModelSelect", () => {
 
       const { unmount } = renderWithProviders(<ModelSelect onChange={mockOnChange} context={context} {...props} />);
 
-      expect(screen.getByTestId("skeleton-input")).toBeInTheDocument();
+      expect(screen.queryAllByRole("combobox")).toHaveLength(0);
       unmount();
     });
   });
 
-  it("should handle model selection and onChange", async () => {
+  it("should report the picked model to onChange", async () => {
     const user = userEvent.setup();
     renderWithProviders(
       <ModelSelect onChange={mockOnChange} context="user" options={{ showAllProxyModelsOverride: true }} />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("model-select")).toBeInTheDocument();
-    });
+    await openModelList(user);
+    await user.click(screen.getAllByText("gpt-4")[0]);
 
-    const select = screen.getByRole("listbox");
-    await user.selectOptions(select, "gpt-4");
     expect(mockOnChange).toHaveBeenCalledWith(["gpt-4"]);
-
-    await user.selectOptions(select, ["gpt-4", "claude-3"]);
-    expect(mockOnChange).toHaveBeenCalled();
   });
 
-  it("should handle special options correctly", async () => {
+  it("should offer both special options when they are enabled", async () => {
     const user = userEvent.setup();
     mockUseOrganization.mockReturnValue({
       data: createMockOrganization(["all-proxy-models"]),
@@ -207,33 +156,32 @@ describe("ModelSelect", () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByText("All Proxy Models")).toBeInTheDocument();
-      expect(screen.getByText("No Default Models")).toBeInTheDocument();
-    });
+    await openModelList(user);
 
-    const select = screen.getByRole("listbox");
-    await user.selectOptions(select, ["all-proxy-models", "no-default-models"]);
-    expect(mockOnChange).toHaveBeenCalledWith(["no-default-models"]);
+    expectOffered("Special Options");
+    expectOffered("All Proxy Models");
+    expectOffered("No Default Models");
   });
 
-  it("should disable models when special option is selected", async () => {
+  it("should replace an existing selection when a special option is picked", async () => {
+    const user = userEvent.setup();
+
     renderWithProviders(
       <ModelSelect
         onChange={mockOnChange}
-        value={["all-proxy-models"]}
+        value={["gpt-4"]}
         context="user"
-        options={{ showAllProxyModelsOverride: true }}
+        options={{ showAllProxyModelsOverride: true, includeSpecialOptions: true }}
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole("option", { name: "gpt-4" })).toBeDisabled();
-      expect(screen.getByRole("option", { name: "All Openai models" })).toBeDisabled();
-    });
+    await openModelList(user);
+    await user.click(screen.getAllByText("No Default Models")[0]);
+
+    expect(mockOnChange).toHaveBeenCalledWith(["no-default-models"]);
   });
 
-  it("should filter models based on context", async () => {
+  it("should filter the offered models by context", async () => {
     const testCases = [
       {
         name: "user context with includeUserModels",
@@ -340,6 +288,7 @@ describe("ModelSelect", () => {
     ];
 
     for (const testCase of testCases) {
+      const user = userEvent.setup();
       testCase.setup();
       const { unmount } = renderWithProviders(
         <ModelSelect
@@ -350,14 +299,9 @@ describe("ModelSelect", () => {
         />,
       );
 
-      await waitFor(() => {
-        testCase.expectedVisible.forEach((model) => {
-          expect(screen.getByText(model)).toBeInTheDocument();
-        });
-        testCase.expectedHidden.forEach((model) => {
-          expect(screen.queryByText(model)).not.toBeInTheDocument();
-        });
-      });
+      await openModelList(user);
+      testCase.expectedVisible.forEach(expectOffered);
+      testCase.expectedHidden.forEach(expectNotOffered);
 
       unmount();
       vi.clearAllMocks();
@@ -368,7 +312,7 @@ describe("ModelSelect", () => {
     }
   });
 
-  it("should show All Proxy Models option based on conditions", async () => {
+  it("should offer All Proxy Models only when the context allows it", async () => {
     const testCases = [
       {
         name: "when showAllProxyModelsOverride is true",
@@ -426,6 +370,7 @@ describe("ModelSelect", () => {
     ];
 
     for (const testCase of testCases) {
+      const user = userEvent.setup();
       testCase.setup();
       const { unmount } = renderWithProviders(
         <ModelSelect
@@ -436,14 +381,13 @@ describe("ModelSelect", () => {
         />,
       );
 
-      await waitFor(() => {
-        if (testCase.shouldShow) {
-          expect(screen.getByText("All Proxy Models")).toBeInTheDocument();
-        } else {
-          expect(screen.queryByText("All Proxy Models")).not.toBeInTheDocument();
-          expect(screen.getByText("No Default Models")).toBeInTheDocument();
-        }
-      });
+      await openModelList(user);
+      if (testCase.shouldShow) {
+        expectOffered("All Proxy Models");
+      } else {
+        expectNotOffered("All Proxy Models");
+        expectOffered("No Default Models");
+      }
 
       unmount();
       vi.clearAllMocks();
@@ -452,27 +396,6 @@ describe("ModelSelect", () => {
         isLoading: false,
       } as any);
     }
-  });
-
-  it("should deduplicate models with same id", async () => {
-    const duplicateModels: ProxyModel[] = [
-      { id: "gpt-4", object: "model", created: 1234567890, owned_by: "openai" },
-      { id: "gpt-4", object: "model", created: 1234567890, owned_by: "openai" },
-    ];
-
-    mockUseAllProxyModels.mockReturnValue({
-      data: { data: duplicateModels },
-      isLoading: false,
-    } as any);
-
-    renderWithProviders(
-      <ModelSelect onChange={mockOnChange} context="user" options={{ showAllProxyModelsOverride: true }} />,
-    );
-
-    await waitFor(() => {
-      const gpt4Options = screen.getAllByText("gpt-4");
-      expect(gpt4Options.length).toBeGreaterThan(0);
-    });
   });
 
   it("should use custom dataTestId when provided", async () => {
@@ -485,12 +408,11 @@ describe("ModelSelect", () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("custom-test-id")).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId("custom-test-id")).toBeInTheDocument();
   });
 
   it("should return all proxy models for team context when organization has empty models array", async () => {
+    const user = userEvent.setup();
     mockUseTeam.mockReturnValue({
       data: { team_id: "team-1", team_alias: "Test Team", models: [] },
       isLoading: false,
@@ -503,52 +425,66 @@ describe("ModelSelect", () => {
 
     renderWithProviders(<ModelSelect onChange={mockOnChange} context="team" teamID="team-1" organizationID="org-1" />);
 
-    await waitFor(() => {
-      expect(screen.getByText("gpt-4")).toBeInTheDocument();
-      expect(screen.getByText("claude-3")).toBeInTheDocument();
-    });
+    await openModelList(user);
+
+    expectOffered("gpt-4");
+    expectOffered("claude-3");
   });
 
-  it("should disable No Default Models when all-proxy-models is selected", async () => {
-    mockUseOrganization.mockReturnValue({
-      data: createMockOrganization(["all-proxy-models"]),
-      isLoading: false,
-    } as any);
+  it("should not offer a special options group when includeSpecialOptions is omitted", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ModelSelect onChange={mockOnChange} context="global" />);
 
+    await openModelList(user);
+
+    expectNotOffered("Special Options");
+    expectNotOffered("All Proxy Models");
+    expectNotOffered("No Default Models");
+    expectOffered("Models");
+  });
+
+  it("should mark models and wildcards unselectable while a special option is selected", async () => {
+    const user = userEvent.setup();
     renderWithProviders(
       <ModelSelect
         onChange={mockOnChange}
         value={["all-proxy-models"]}
-        context="organization"
-        organizationID="org-1"
-        options={{ includeSpecialOptions: true }}
+        context="user"
+        options={{ showAllProxyModelsOverride: true, includeSpecialOptions: true }}
       />,
     );
 
-    await waitFor(() => {
-      const noDefaultOption = screen.getByRole("option", { name: "No Default Models" });
-      expect(noDefaultOption).toBeDisabled();
-    });
+    await openModelList(user);
+
+    expect(screen.getByRole("option", { name: "gpt-4" })).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("option", { name: "All Openai models" })).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("option", { name: "No Default Models" })).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("option", { name: "All Proxy Models" })).not.toHaveAttribute("aria-disabled", "true");
   });
 
-  it("should not render an empty optgroup when includeSpecialOptions is omitted", async () => {
-    renderWithProviders(<ModelSelect onChange={mockOnChange} context="global" />);
+  it("should list a duplicated proxy model only once", async () => {
+    const user = userEvent.setup();
+    mockUseAllProxyModels.mockReturnValue({
+      data: {
+        data: [
+          { id: "gpt-4", object: "model", created: 1234567890, owned_by: "openai" },
+          { id: "gpt-4", object: "model", created: 1234567890, owned_by: "openai" },
+        ],
+      },
+      isLoading: false,
+    } as any);
 
-    await waitFor(() => {
-      expect(screen.getByTestId("model-select")).toBeInTheDocument();
-    });
+    renderWithProviders(
+      <ModelSelect onChange={mockOnChange} context="user" options={{ showAllProxyModelsOverride: true }} />,
+    );
 
-    const optgroups = document.querySelectorAll("optgroup");
-    // Wildcard Options + Models — no blank leading group
-    expect(optgroups.length).toBe(2);
-    optgroups.forEach((g) => {
-      expect(g.getAttribute("label")).toBeTruthy();
-    });
+    await openModelList(user);
+
+    expect(screen.getAllByRole("option", { name: "gpt-4" })).toHaveLength(1);
   });
 
-  it("should render maxTagPlaceholder when many items are selected", async () => {
-    // Create many models to trigger maxTagCount responsive behavior
-    const manyModels: ProxyModel[] = Array.from({ length: 20 }, (_, i) => ({
+  it("should collapse selections past the chip limit into a labelled overflow count", async () => {
+    const manyModels: ProxyModel[] = Array.from({ length: 8 }, (_, i) => ({
       id: `model-${i}`,
       object: "model",
       created: 1234567890,
@@ -560,22 +496,18 @@ describe("ModelSelect", () => {
       isLoading: false,
     } as any);
 
-    const selectedValues = manyModels.slice(0, 10).map((m) => m.id);
-
     renderWithProviders(
       <ModelSelect
         onChange={mockOnChange}
-        value={selectedValues}
+        value={manyModels.map((m) => m.id)}
         context="user"
         options={{ showAllProxyModelsOverride: true }}
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("model-select")).toBeInTheDocument();
-      // Verify maxTagPlaceholder is rendered with omitted values
-      expect(screen.getByTestId("max-tag-placeholder")).toBeInTheDocument();
-      expect(screen.getByText(/\+5 more/)).toBeInTheDocument();
-    });
+    expect(await screen.findByText("+3 more")).toBeInTheDocument();
+    expect(screen.getByLabelText("model-0")).toBeInTheDocument();
+    expect(screen.getByLabelText("model-4")).toBeInTheDocument();
+    expect(screen.queryByLabelText("model-5")).not.toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.test.tsx
+++ b/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.test.tsx
@@ -140,6 +140,23 @@ describe("ModelSelect", () => {
     expect(mockOnChange).toHaveBeenCalledWith(["gpt-4"]);
   });
 
+  it("should append a second model to the existing selection", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ModelSelect
+        onChange={mockOnChange}
+        value={["gpt-4"]}
+        context="user"
+        options={{ showAllProxyModelsOverride: true }}
+      />,
+    );
+
+    await openModelList(user);
+    await user.click(screen.getAllByText("claude-3")[0]);
+
+    expect(mockOnChange).toHaveBeenCalledWith(["gpt-4", "claude-3"]);
+  });
+
   it("should offer both special options when they are enabled", async () => {
     const user = userEvent.setup();
     mockUseOrganization.mockReturnValue({

--- a/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.tsx
+++ b/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.tsx
@@ -2,7 +2,22 @@ import { ProxyModel, useAllProxyModels } from "@/app/(dashboard)/hooks/models/us
 import { useOrganization } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 import { useTeam } from "@/app/(dashboard)/hooks/teams/useTeams";
 import { useCurrentUser } from "@/app/(dashboard)/hooks/users/useCurrentUser";
-import { Select, Skeleton, Tooltip } from "antd";
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
+  ComboboxValue,
+} from "@/components/ui/combobox";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Organization, Team } from "../networking";
 import { splitWildcardModels } from "./modelUtils";
 
@@ -21,6 +36,8 @@ export const MODEL_SENTINEL_OPTIONS = [
   MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE,
 ] as const;
 
+const MAX_VISIBLE_MODEL_CHIPS = 5;
+
 export interface ModelSelectProps {
   teamID?: string;
   organizationID?: string;
@@ -36,6 +53,17 @@ export interface ModelSelectProps {
   onChange: (values: string[]) => void;
   style?: React.CSSProperties;
 }
+
+type ModelOption = {
+  label: string;
+  value: string;
+  disabled?: boolean;
+};
+
+type ModelOptionGroup = {
+  label: string;
+  items: ModelOption[];
+};
 
 type FilterContextArgs = {
   allProxyModels: string[];
@@ -109,10 +137,11 @@ export const ModelSelect = (props: ModelSelectProps) => {
     showAllProxyModelsOverride || (organizationHasAllProxyModels && includeSpecialOptions) || context === "global";
 
   if (isLoading) {
-    return <Skeleton.Input active block />;
+    return <Skeleton className="h-9 w-full" />;
   }
 
-  const handleChange = (values: string[]) => {
+  const handleChange = (selected: ModelOption[]) => {
+    const values = selected.map((option) => option.value);
     const specialValues = values.filter(isSpecialOption);
 
     let finalValues: string[];
@@ -133,85 +162,122 @@ export const ModelSelect = (props: ModelSelectProps) => {
   });
 
   const { wildcard, regular } = splitWildcardModels(filteredModels);
-  return (
-    <Select
-      data-testid={dataTestId}
-      value={value}
-      onChange={handleChange}
-      style={style}
-      options={[
-        ...(includeSpecialOptions
-          ? [
-              {
-                label: <span>Special Options</span>,
-                title: "Special Options",
-                options: [
-                  ...(shouldShowAllProxyModels
-                    ? [
-                        {
-                          label: <span>All Proxy Models</span>,
-                          value: MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
-                          disabled:
-                            value.length > 0 &&
-                            value.some(
-                              (v) => isSpecialOption(v) && v !== MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
-                            ),
-                          key: MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
-                        },
-                      ]
-                    : []),
-                  {
-                    label: <span>No Default Models</span>,
-                    value: MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value,
-                    disabled:
-                      value.length > 0 &&
-                      value.some((v) => isSpecialOption(v) && v !== MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value),
-                    key: MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value,
-                  },
-                ],
-              },
-            ]
-          : []),
-        ...(wildcard.length > 0
-          ? [
-              {
-                label: <span>Wildcard Options</span>,
-                title: "Wildcard Options",
-                options: wildcard.map((model) => {
-                  const provider = model.replace("/*", "");
-                  const capitalizedProvider = provider.charAt(0).toUpperCase() + provider.slice(1);
 
-                  return {
-                    label: <span>{`All ${capitalizedProvider} models`}</span>,
-                    value: model,
-                    disabled: hasSpecialOptionSelected,
-                  };
-                }),
+  const groups: ModelOptionGroup[] = [
+    ...(includeSpecialOptions
+      ? [
+          {
+            label: "Special Options",
+            items: [
+              ...(shouldShowAllProxyModels
+                ? [
+                    {
+                      label: MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.label,
+                      value: MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
+                      disabled:
+                        value.length > 0 &&
+                        value.some(
+                          (v) => isSpecialOption(v) && v !== MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
+                        ),
+                    },
+                  ]
+                : []),
+              {
+                label: MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.label,
+                value: MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value,
+                disabled:
+                  value.length > 0 &&
+                  value.some((v) => isSpecialOption(v) && v !== MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value),
               },
-            ]
-          : []),
-        {
-          label: <span>Models</span>,
-          title: "Models",
-          options: regular.map((model) => ({
-            label: <span>{model}</span>,
-            value: model,
-            disabled: hasSpecialOptionSelected,
-          })),
-        },
-      ]}
-      mode="multiple"
-      placeholder="Select Models"
-      allowClear
-      maxTagCount="responsive"
-      maxTagPlaceholder={(omittedValues) => (
-        <Tooltip
-          styles={{ root: { pointerEvents: "none" } }}
-          title={omittedValues.map(({ value }) => value).join(", ")}
-        >
-          <span>+{omittedValues.length} more</span>
-        </Tooltip>
-      )}
-    />
+            ],
+          },
+        ]
+      : []),
+    ...(wildcard.length > 0
+      ? [
+          {
+            label: "Wildcard Options",
+            items: wildcard.map((model) => {
+              const provider = model.replace("/*", "");
+              const capitalizedProvider = provider.charAt(0).toUpperCase() + provider.slice(1);
+
+              return {
+                label: `All ${capitalizedProvider} models`,
+                value: model,
+                disabled: hasSpecialOptionSelected,
+              };
+            }),
+          },
+        ]
+      : []),
+    {
+      label: "Models",
+      items: regular.map((model) => ({
+        label: model,
+        value: model,
+        disabled: hasSpecialOptionSelected,
+      })),
+    },
+  ];
+
+  const optionsByValue = new Map(groups.flatMap((group) => group.items).map((option) => [option.value, option]));
+  const selectedOptions = value.map((v) => optionsByValue.get(v) ?? { label: v, value: v });
+  const overflowOptions = selectedOptions.slice(MAX_VISIBLE_MODEL_CHIPS);
+
+  return (
+    <TooltipProvider>
+      <Combobox
+        multiple
+        items={groups}
+        value={selectedOptions}
+        onValueChange={handleChange}
+        isItemEqualToValue={(option: ModelOption, selected: ModelOption) => option.value === selected.value}
+        itemToStringLabel={(option: ModelOption) => option.label}
+      >
+        <ComboboxChips data-testid={dataTestId} style={style} className="w-full">
+          <ComboboxValue>
+            {(selected: ModelOption[]) => (
+              <>
+                {selected.slice(0, MAX_VISIBLE_MODEL_CHIPS).map((option) => (
+                  <ComboboxChip key={option.value} aria-label={option.label}>
+                    {option.label}
+                  </ComboboxChip>
+                ))}
+                {overflowOptions.length > 0 && (
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={<span className="px-1 text-xs text-muted-foreground" />}
+                    >{`+${overflowOptions.length} more`}</TooltipTrigger>
+                    <TooltipContent>{overflowOptions.map((option) => option.value).join(", ")}</TooltipContent>
+                  </Tooltip>
+                )}
+              </>
+            )}
+          </ComboboxValue>
+          <ComboboxChipsInput
+            placeholder="Select Models"
+            aria-label="Select Models"
+            className="h-5 min-w-24 flex-1 border-0 bg-transparent py-0 text-sm"
+          />
+        </ComboboxChips>
+        <ComboboxContent>
+          <ComboboxEmpty>No models found</ComboboxEmpty>
+          <ComboboxList>
+            {(group: ModelOptionGroup) => (
+              <ComboboxGroup key={group.label} items={group.items}>
+                <ComboboxLabel>{group.label}</ComboboxLabel>
+                <ComboboxCollection>
+                  {(option: ModelOption) => (
+                    <ComboboxItem key={option.value} value={option} disabled={option.disabled}>
+                      <span className="min-w-0 break-words">{option.label}</span>
+                    </ComboboxItem>
+                  )}
+                </ComboboxCollection>
+              </ComboboxGroup>
+            )}
+          </ComboboxList>
+        </ComboboxContent>
+      </Combobox>
+    </TooltipProvider>
   );
 };

--- a/ui/litellm-dashboard/src/components/claude_code_plugins/MakeSkillPublicForm.tsx
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/MakeSkillPublicForm.tsx
@@ -1,11 +1,15 @@
 import React, { useState, useEffect } from "react";
-import { Modal, Form, Steps, Button, Checkbox } from "antd";
-import { Text, Title, Badge } from "@tremor/react";
+import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/cva.config";
 import { enableClaudeCodePlugin, disableClaudeCodePlugin } from "../networking";
 import NotificationsManager from "../molecules/notifications_manager";
 import { Plugin } from "./types";
 
-const { Step } = Steps;
+const STEP_TITLES = ["Select Skills", "Confirm"];
 
 interface MakeSkillPublicFormProps {
   visible: boolean;
@@ -25,12 +29,10 @@ const MakeSkillPublicForm: React.FC<MakeSkillPublicFormProps> = ({
   const [currentStep, setCurrentStep] = useState(0);
   const [selectedSkills, setSelectedSkills] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
-  const [form] = Form.useForm();
 
   const handleClose = () => {
     setCurrentStep(0);
     setSelectedSkills(new Set());
-    form.resetFields();
     onClose();
   };
 
@@ -106,52 +108,44 @@ const MakeSkillPublicForm: React.FC<MakeSkillPublicFormProps> = ({
   const renderStep1 = () => (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <Title>Select Skills to Publish</Title>
-        <Checkbox
-          checked={allSelected}
-          indeterminate={isIndeterminate}
-          onChange={(e) => handleSelectAll(e.target.checked)}
-          disabled={skillsList.length === 0}
-        >
+        <h3 className="text-lg font-semibold">Select Skills to Publish</h3>
+        <label className="flex items-center gap-2 text-sm">
+          <Checkbox
+            checked={allSelected}
+            indeterminate={isIndeterminate}
+            onCheckedChange={(checked) => handleSelectAll(checked === true)}
+            disabled={skillsList.length === 0}
+          />
           Select All ({skillsList.length})
-        </Checkbox>
+        </label>
       </div>
 
-      <Text className="text-sm text-gray-600">
+      <p className="text-sm text-gray-600">
         Selected skills will be visible to all users in the Skill Hub. Deselected skills will be unpublished.
-      </Text>
+      </p>
 
       <div className="max-h-96 overflow-y-auto border rounded-lg p-4">
         <div className="space-y-3">
           {skillsList.length === 0 ? (
             <div className="text-center py-8 text-gray-500">
-              <Text>No skills registered yet.</Text>
+              <p>No skills registered yet.</p>
             </div>
           ) : (
             skillsList.map((skill) => (
               <div key={skill.name} className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
                 <Checkbox
+                  aria-label={skill.name}
                   checked={selectedSkills.has(skill.name)}
-                  onChange={(e) => handleSkillSelection(skill.name, e.target.checked)}
+                  onCheckedChange={(checked) => handleSkillSelection(skill.name, checked === true)}
                 />
-                <div className="flex-1">
+                <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
-                    <Text className="font-medium font-mono text-sm">{skill.name}</Text>
-                    {skill.enabled && (
-                      <Badge color="green" size="xs">
-                        Public
-                      </Badge>
-                    )}
+                    <p className="font-medium font-mono text-sm break-words">{skill.name}</p>
+                    {skill.enabled && <Badge variant="secondary">Public</Badge>}
                   </div>
-                  {skill.description && (
-                    <Text className="text-xs text-gray-500 truncate max-w-sm">{skill.description}</Text>
-                  )}
+                  {skill.description && <p className="text-xs text-gray-500 truncate max-w-sm">{skill.description}</p>}
                 </div>
-                {skill.domain && (
-                  <Badge color="blue" size="xs">
-                    {skill.domain}
-                  </Badge>
-                )}
+                {skill.domain && <Badge variant="outline">{skill.domain}</Badge>}
               </div>
             ))
           )}
@@ -160,9 +154,9 @@ const MakeSkillPublicForm: React.FC<MakeSkillPublicFormProps> = ({
 
       {selectedSkills.size > 0 && (
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-          <Text className="text-sm text-blue-800">
+          <p className="text-sm text-blue-800">
             <strong>{selectedSkills.size}</strong> skill{selectedSkills.size !== 1 ? "s" : ""} will be published
-          </Text>
+          </p>
         </div>
       )}
     </div>
@@ -170,29 +164,25 @@ const MakeSkillPublicForm: React.FC<MakeSkillPublicFormProps> = ({
 
   const renderStep2 = () => (
     <div className="space-y-4">
-      <Title>Confirm Publish to Skill Hub</Title>
+      <h3 className="text-lg font-semibold">Confirm Publish to Skill Hub</h3>
 
       <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-        <Text className="text-sm text-yellow-800">
+        <p className="text-sm text-yellow-800">
           <strong>Note:</strong> Published skills will be visible to all users in the Skill Hub tab. Skills not in the
           list below will be unpublished.
-        </Text>
+        </p>
       </div>
 
       <div className="space-y-3">
-        <Text className="font-medium">Skills to be published:</Text>
+        <p className="font-medium">Skills to be published:</p>
         <div className="max-h-48 overflow-y-auto border rounded-lg p-3">
           <div className="space-y-2">
             {Array.from(selectedSkills).map((name) => {
               const skill = skillsList.find((s) => s.name === name);
               return (
-                <div key={name} className="flex items-center justify-between p-2 bg-gray-50 rounded-sm">
-                  <Text className="font-mono text-sm">{name}</Text>
-                  {skill?.domain && (
-                    <Badge color="blue" size="xs">
-                      {skill.domain}
-                    </Badge>
-                  )}
+                <div key={name} className="flex items-center justify-between gap-2 p-2 bg-gray-50 rounded-sm">
+                  <p className="font-mono text-sm min-w-0 break-words">{name}</p>
+                  {skill?.domain && <Badge variant="outline">{skill.domain}</Badge>}
                 </div>
               );
             })}
@@ -201,49 +191,68 @@ const MakeSkillPublicForm: React.FC<MakeSkillPublicFormProps> = ({
       </div>
 
       <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-        <Text className="text-sm text-blue-800">
+        <p className="text-sm text-blue-800">
           Total: <strong>{selectedSkills.size}</strong> skill{selectedSkills.size !== 1 ? "s" : ""} will be published
-        </Text>
+        </p>
       </div>
     </div>
   );
 
   return (
-    <Modal
-      title="Publish to Skill Hub"
-      open={visible}
-      onCancel={handleClose}
-      footer={null}
-      width={700}
-      maskClosable={false}
-    >
-      <Form form={form} layout="vertical">
-        <Steps current={currentStep} className="mb-6">
-          <Step title="Select Skills" />
-          <Step title="Confirm" />
-        </Steps>
+    <Dialog open={visible} onOpenChange={(open) => !open && handleClose()} disablePointerDismissal>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[700px]">
+        <DialogHeader>
+          <DialogTitle>Publish to Skill Hub</DialogTitle>
+        </DialogHeader>
 
-        {currentStep === 0 ? renderStep1() : renderStep2()}
+        <div>
+          <ol className="mb-6 flex items-center gap-6">
+            {STEP_TITLES.map((title, index) => (
+              <li
+                key={title}
+                className="flex items-center gap-2"
+                aria-current={currentStep === index ? "step" : undefined}
+              >
+                <span
+                  className={cn(
+                    "flex size-6 items-center justify-center rounded-full border text-xs",
+                    currentStep === index
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border text-muted-foreground",
+                  )}
+                >
+                  {index + 1}
+                </span>
+                <span className={cn("text-sm", currentStep === index ? "font-medium" : "text-muted-foreground")}>
+                  {title}
+                </span>
+              </li>
+            ))}
+          </ol>
 
-        <div className="flex justify-between mt-6">
-          <Button onClick={currentStep === 0 ? handleClose : () => setCurrentStep(0)}>
-            {currentStep === 0 ? "Cancel" : "Previous"}
-          </Button>
-          <div className="flex space-x-2">
-            {currentStep === 0 && (
-              <Button onClick={handleNext} disabled={selectedSkills.size === 0}>
-                Next
-              </Button>
-            )}
-            {currentStep === 1 && (
-              <Button onClick={handleSubmit} loading={loading}>
-                Publish to Hub
-              </Button>
-            )}
+          {currentStep === 0 ? renderStep1() : renderStep2()}
+
+          <div className="flex justify-between mt-6">
+            <Button variant="outline" onClick={currentStep === 0 ? handleClose : () => setCurrentStep(0)}>
+              {currentStep === 0 ? "Cancel" : "Previous"}
+            </Button>
+            <div className="flex space-x-2">
+              {currentStep === 0 && (
+                <Button onClick={handleNext} disabled={selectedSkills.size === 0}>
+                  Next
+                </Button>
+              )}
+              {currentStep === 1 && (
+                <Button onClick={handleSubmit} disabled={loading}>
+                  {loading && <Loader2 className="size-4 animate-spin" />}
+                  Publish to Hub
+                </Button>
+              )}
+            </div>
           </div>
         </div>
-      </Form>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/ui/litellm-dashboard/src/components/public_model_hub.test.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.test.tsx
@@ -226,4 +226,19 @@ describe("public hub MCP details modal", () => {
     await screen.findByText("Server Overview");
     expect(screen.queryByText(PUBLIC_SERVER_URL)).not.toBeInTheDocument();
   });
+
+  it("closes the server details modal from its close control", async () => {
+    const networkingModule = await import("./networking");
+    vi.mocked(networkingModule.mcpHubPublicServersCall).mockResolvedValue([mockMcpServer]);
+
+    render(<PublicModelHub />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: /MCP Hub/i }));
+    fireEvent.click(await screen.findByRole("button", { name: "exa_test" }));
+    await screen.findByText("Server Overview");
+
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+
+    await waitFor(() => expect(screen.queryByText("Server Overview")).not.toBeInTheDocument());
+  });
 });

--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -1,10 +1,25 @@
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { ExternalLinkIcon, SearchIcon } from "@heroicons/react/outline";
 import { SortingState } from "@tanstack/react-table";
-import { Card, Text, Title } from "@tremor/react";
-import { Modal, Select, Tabs, Tag, Tooltip } from "antd";
 import { Copy, Inbox, Info } from "lucide-react";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxValue,
+} from "@/components/ui/combobox";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { MultiSelect } from "./shared/MultiSelect";
 import { DataTable } from "./shared/DataTable";
 import NotificationsManager from "./molecules/notifications_manager";
 import Navbar from "./navbar";
@@ -31,8 +46,6 @@ import { generateCodeSnippet } from "@/components/chat_ui/CodeSnippets";
 import { getEndpointType } from "@/components/chat_ui/mode_endpoint_mapping";
 import { MessageType } from "@/components/chat_ui/types";
 import { getProviderLogoAndName } from "./provider_info_helpers";
-
-const { TabPane } = Tabs;
 
 interface PublicModelHubProps {
   accessToken?: string | null;
@@ -397,11 +410,6 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
     setIsModalVisible(true);
   }, []);
 
-  const handleModalOk = () => {
-    setIsModalVisible(false);
-    setSelectedModel(null);
-  };
-
   const handleModalCancel = () => {
     setIsModalVisible(false);
     setSelectedModel(null);
@@ -412,11 +420,6 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
     setIsAgentModalVisible(true);
   }, []);
 
-  const handleAgentModalOk = () => {
-    setIsAgentModalVisible(false);
-    setSelectedAgent(null);
-  };
-
   const handleAgentModalCancel = () => {
     setIsAgentModalVisible(false);
     setSelectedAgent(null);
@@ -426,11 +429,6 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
     setSelectedMcpServer(server);
     setIsMcpModalVisible(true);
   }, []);
-
-  const handleMcpModalOk = () => {
-    setIsMcpModalVisible(false);
-    setSelectedMcpServer(null);
-  };
 
   const handleMcpModalCancel = () => {
     setIsMcpModalVisible(false);
@@ -468,758 +466,784 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
   const agentColumns = useMemo(() => getPublicAgentHubColumns({ onAgentClick: showAgentModal }), [showAgentModal]);
   const mcpColumns = useMemo(() => getPublicMCPHubColumns({ onServerClick: showMcpModal }), [showMcpModal]);
 
+  const hasAgents = Array.isArray(agentHubData) && agentHubData.length > 0;
+  const hasMcpServers = Array.isArray(mcpHubData) && mcpHubData.length > 0;
+
+  const providerOptions = useMemo(
+    () => (Array.isArray(modelHubData) ? getUniqueProviders(modelHubData) : []),
+    [modelHubData],
+  );
+  const modeOptions = useMemo(
+    () =>
+      Array.isArray(modelHubData) ? getUniqueModes(modelHubData).map((mode) => ({ label: mode, value: mode })) : [],
+    [modelHubData],
+  );
+  const featureOptions = useMemo(
+    () =>
+      Array.isArray(modelHubData)
+        ? getUniqueFeatures(modelHubData).map((feature) => ({ label: feature, value: feature }))
+        : [],
+    [modelHubData],
+  );
+  const agentSkillOptions = useMemo(
+    () =>
+      Array.isArray(agentHubData)
+        ? getUniqueAgentSkills(agentHubData).map((skill) => ({ label: skill, value: skill }))
+        : [],
+    [agentHubData],
+  );
+  const mcpTransportOptions = useMemo(
+    () =>
+      Array.isArray(mcpHubData)
+        ? getUniqueMcpTransports(mcpHubData).map((transport) => ({ label: transport, value: transport }))
+        : [],
+    [mcpHubData],
+  );
+
   return (
     <ThemeProvider accessToken={accessToken}>
-      <div className={isEmbedded ? "w-full" : "min-h-screen bg-white"}>
-        {/* Navigation - only show when not embedded */}
-        {!isEmbedded && <Navbar accessToken={accessToken || null} isPublicPage={true} />}
+      <TooltipProvider>
+        <div className={isEmbedded ? "w-full" : "min-h-screen bg-white"}>
+          {/* Navigation - only show when not embedded */}
+          {!isEmbedded && <Navbar accessToken={accessToken || null} isPublicPage={true} />}
 
-        <div className={isEmbedded ? "w-full p-6" : "w-full px-8 py-12"}>
-          {/* Embedded Explainer - only shown when embedded in dashboard */}
-          {isEmbedded && (
-            <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-              <p className="text-sm text-gray-700">
-                These are models, agents, and MCP servers your proxy admin has indicated are available in your company.
-              </p>
-            </div>
-          )}
-
-          {/* About Section - only shown when not embedded */}
-          {!isEmbedded && (
-            <Card className="mb-10 p-8 bg-white border border-gray-200 rounded-lg shadow-xs">
-              <Title className="text-2xl font-semibold mb-6 text-gray-900">About</Title>
-              <p className="text-gray-700 mb-6 text-base leading-relaxed">
-                {customDocsDescription ? customDocsDescription : "Proxy Server to call 100+ LLMs in the OpenAI format."}
-              </p>
-              <div className="flex items-center space-x-3 text-sm text-gray-600">
-                <span className="flex items-center">
-                  <span className="w-4 h-4 mr-2">🔧</span>
-                  Built with litellm: v{litellmVersion}
-                </span>
+          <div className={isEmbedded ? "w-full p-6" : "w-full px-8 py-12"}>
+            {/* Embedded Explainer - only shown when embedded in dashboard */}
+            {isEmbedded && (
+              <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                <p className="text-sm text-gray-700">
+                  These are models, agents, and MCP servers your proxy admin has indicated are available in your
+                  company.
+                </p>
               </div>
-            </Card>
-          )}
+            )}
 
-          {/* Useful Links - only shown when not embedded */}
-          {usefulLinks && Object.keys(usefulLinks).length > 0 && (
-            <Card className="mb-10 p-8 bg-white border border-gray-200 rounded-lg shadow-xs">
-              <Title className="text-2xl font-semibold mb-6 text-gray-900">Useful Links</Title>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {Object.entries(usefulLinks || {})
-                  .map(([title, value]) => {
-                    // Handle both old format (string) and new format ({url, index})
-                    const url = typeof value === "string" ? value : value.url;
-                    const index = typeof value === "string" ? 0 : value.index ?? 0;
-                    return { title, url, index };
-                  })
-                  .sort((a, b) => a.index - b.index)
-                  .map(({ title, url }) => (
-                    <button
-                      key={title}
-                      onClick={() => window.open(url, "_blank")}
-                      className="flex items-center space-x-3 text-blue-600 hover:text-blue-800 transition-colors p-3 rounded-lg hover:bg-blue-50 border border-gray-200"
-                    >
-                      <ExternalLinkIcon className="w-4 h-4" />
-                      <Text className="text-sm font-medium">{title}</Text>
-                    </button>
-                  ))}
-              </div>
-            </Card>
-          )}
-
-          {/* Health and Endpoint Status - only shown when not embedded */}
-          {!isEmbedded && (
-            <Card className="mb-10 p-8 bg-white border border-gray-200 rounded-lg shadow-xs">
-              <Title className="text-2xl font-semibold mb-6 text-gray-900">Health and Endpoint Status</Title>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <Text className="text-green-600 font-medium text-sm">Service status: {serviceStatus}</Text>
-              </div>
-            </Card>
-          )}
-
-          {/* Tabs for Models and Agents */}
-          <Card className="p-8 bg-white border border-gray-200 rounded-lg shadow-xs">
-            <Tabs activeKey={activeTab} onChange={setActiveTab} size="large" className="public-hub-tabs">
-              {/* Models Tab */}
-              <TabPane tab="Model Hub" key="models">
-                <div className="flex justify-between items-center mb-8">
-                  <Title className="text-2xl font-semibold text-gray-900">Available Models</Title>
+            {/* About Section - only shown when not embedded */}
+            {!isEmbedded && (
+              <Card className="mb-10 p-8 bg-white border border-gray-200 rounded-lg shadow-xs">
+                <h2 className="text-2xl font-semibold mb-6 text-gray-900">About</h2>
+                <p className="text-gray-700 mb-6 text-base leading-relaxed">
+                  {customDocsDescription
+                    ? customDocsDescription
+                    : "Proxy Server to call 100+ LLMs in the OpenAI format."}
+                </p>
+                <div className="flex items-center space-x-3 text-sm text-gray-600">
+                  <span className="flex items-center">
+                    <span className="w-4 h-4 mr-2">🔧</span>
+                    Built with litellm: v{litellmVersion}
+                  </span>
                 </div>
+              </Card>
+            )}
 
-                {/* Filters */}
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8 p-6 bg-gray-50 rounded-lg border border-gray-200">
-                  <div>
-                    <div className="flex items-center space-x-2 mb-3">
-                      <Text className="text-sm font-medium text-gray-700">Search Models:</Text>
-                      <Tooltip
-                        title="Smart search with relevance ranking - finds models containing your search terms, ranked by relevance. Try searching 'xai grok-4', 'claude-4', 'gpt-4', or 'sonnet'"
-                        placement="top"
+            {/* Useful Links - only shown when not embedded */}
+            {usefulLinks && Object.keys(usefulLinks).length > 0 && (
+              <Card className="mb-10 p-8 bg-white border border-gray-200 rounded-lg shadow-xs">
+                <h2 className="text-2xl font-semibold mb-6 text-gray-900">Useful Links</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {Object.entries(usefulLinks || {})
+                    .map(([title, value]) => {
+                      // Handle both old format (string) and new format ({url, index})
+                      const url = typeof value === "string" ? value : value.url;
+                      const index = typeof value === "string" ? 0 : value.index ?? 0;
+                      return { title, url, index };
+                    })
+                    .sort((a, b) => a.index - b.index)
+                    .map(({ title, url }) => (
+                      <button
+                        key={title}
+                        onClick={() => window.open(url, "_blank")}
+                        className="flex min-w-0 items-center space-x-3 text-blue-600 hover:text-blue-800 transition-colors p-3 rounded-lg hover:bg-blue-50 border border-gray-200"
                       >
-                        <Info className="w-4 h-4 text-gray-400 cursor-help" />
-                      </Tooltip>
-                    </div>
-                    <div className="relative">
-                      <SearchIcon className="w-4 h-4 text-gray-400 absolute left-3 top-1/2 transform -translate-y-1/2" />
-                      <input
-                        type="text"
-                        placeholder="Search model names... (smart search enabled)"
-                        value={searchTerm}
-                        onChange={(e) => setSearchTerm(e.target.value)}
-                        className="border border-gray-300 rounded-lg pl-10 pr-4 py-2 w-full text-sm focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white"
-                      />
-                    </div>
-                  </div>
-                  <div>
-                    <Text className="text-sm font-medium mb-3 text-gray-700">Provider:</Text>
-                    <Select
-                      mode="multiple"
-                      value={selectedProviders}
-                      onChange={(values) => setSelectedProviders(values)}
-                      placeholder="Select providers"
-                      className="w-full"
-                      size="large"
-                      allowClear
-                      optionRender={(option) => {
-                        const { logo } = getProviderLogoAndName(option.value as string);
-                        return (
-                          <div className="flex items-center space-x-2">
-                            {logo && (
-                              <img
-                                src={logo}
-                                alt={option.label as string}
-                                className="w-5 h-5 shrink-0 object-contain"
-                                onError={(e) => {
-                                  (e.target as HTMLImageElement).style.display = "none";
-                                }}
-                              />
-                            )}
-                            <span className="capitalize">{option.label}</span>
-                          </div>
-                        );
-                      }}
-                    >
-                      {modelHubData &&
-                        Array.isArray(modelHubData) &&
-                        getUniqueProviders(modelHubData).map((provider) => (
-                          <Select.Option key={provider} value={provider}>
-                            {provider}
-                          </Select.Option>
-                        ))}
-                    </Select>
-                  </div>
-                  <div>
-                    <Text className="text-sm font-medium mb-3 text-gray-700">Mode:</Text>
-                    <Select
-                      mode="multiple"
-                      value={selectedModes}
-                      onChange={(values) => setSelectedModes(values)}
-                      placeholder="Select modes"
-                      className="w-full"
-                      size="large"
-                      allowClear
-                    >
-                      {modelHubData &&
-                        Array.isArray(modelHubData) &&
-                        getUniqueModes(modelHubData).map((mode) => (
-                          <Select.Option key={mode} value={mode}>
-                            {mode}
-                          </Select.Option>
-                        ))}
-                    </Select>
-                  </div>
-                  <div>
-                    <Text className="text-sm font-medium mb-3 text-gray-700">Features:</Text>
-                    <Select
-                      mode="multiple"
-                      value={selectedFeatures}
-                      onChange={(values) => setSelectedFeatures(values)}
-                      placeholder="Select features"
-                      className="w-full"
-                      size="large"
-                      allowClear
-                    >
-                      {modelHubData &&
-                        Array.isArray(modelHubData) &&
-                        getUniqueFeatures(modelHubData).map((feature) => (
-                          <Select.Option key={feature} value={feature}>
-                            {feature}
-                          </Select.Option>
-                        ))}
-                    </Select>
-                  </div>
-                </div>
-
-                <DataTable
-                  data={filteredData}
-                  columns={modelColumns}
-                  getRowId={(model, index) => model.model_group || String(index)}
-                  sortingMode="client"
-                  sorting={modelSorting}
-                  onSortingChange={setModelSorting}
-                  isLoading={loading}
-                  loadingMessage="Loading models…"
-                  noDataMessage={
-                    <PublicHubEmptyState
-                      title={modelHubData?.length ? "No matching models" : "No models available"}
-                      body={
-                        modelHubData?.length
-                          ? "Adjust the search or filters to see more models."
-                          : "Models made public by the proxy admin will appear here."
-                      }
-                    />
-                  }
-                  size="compact"
-                />
-
-                <div className="mt-8 text-center">
-                  <Text className="text-sm text-gray-600">
-                    Showing {filteredData.length} of {modelHubData?.length || 0} models
-                  </Text>
-                </div>
-              </TabPane>
-
-              {/* Agents Tab */}
-              {agentHubData && Array.isArray(agentHubData) && agentHubData.length > 0 && (
-                <TabPane tab="Agent Hub" key="agents">
-                  <div className="flex justify-between items-center mb-8">
-                    <Title className="text-2xl font-semibold text-gray-900">Available Agents</Title>
-                  </div>
-
-                  {/* Filters */}
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8 p-6 bg-gray-50 rounded-lg border border-gray-200">
-                    <div>
-                      <div className="flex items-center space-x-2 mb-3">
-                        <Text className="text-sm font-medium text-gray-700">Search Agents:</Text>
-                        <Tooltip title="Search agents by name or description" placement="top">
-                          <Info className="w-4 h-4 text-gray-400 cursor-help" />
-                        </Tooltip>
-                      </div>
-                      <div className="relative">
-                        <SearchIcon className="w-4 h-4 text-gray-400 absolute left-3 top-1/2 transform -translate-y-1/2" />
-                        <input
-                          type="text"
-                          placeholder="Search agent names or descriptions..."
-                          value={agentSearchTerm}
-                          onChange={(e) => setAgentSearchTerm(e.target.value)}
-                          className="border border-gray-300 rounded-lg pl-10 pr-4 py-2 w-full text-sm focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white"
-                        />
-                      </div>
-                    </div>
-                    <div>
-                      <Text className="text-sm font-medium mb-3 text-gray-700">Skills:</Text>
-                      <Select
-                        mode="multiple"
-                        value={selectedAgentSkills}
-                        onChange={(values) => setSelectedAgentSkills(values)}
-                        placeholder="Select skills"
-                        className="w-full"
-                        size="large"
-                        allowClear
-                      >
-                        {agentHubData &&
-                          Array.isArray(agentHubData) &&
-                          getUniqueAgentSkills(agentHubData).map((skill) => (
-                            <Select.Option key={skill} value={skill}>
-                              {skill}
-                            </Select.Option>
-                          ))}
-                      </Select>
-                    </div>
-                  </div>
-
-                  <DataTable
-                    data={filteredAgentData}
-                    columns={agentColumns}
-                    getRowId={(agent, index) => agent.name || String(index)}
-                    sortingMode="client"
-                    sorting={agentSorting}
-                    onSortingChange={setAgentSorting}
-                    isLoading={agentLoading}
-                    loadingMessage="Loading agents…"
-                    noDataMessage={
-                      <PublicHubEmptyState
-                        title="No matching agents"
-                        body="Adjust the search or skill filter to see more agents."
-                      />
-                    }
-                    size="compact"
-                  />
-
-                  <div className="mt-8 text-center">
-                    <Text className="text-sm text-gray-600">
-                      Showing {filteredAgentData.length} of {agentHubData?.length || 0} agents
-                    </Text>
-                  </div>
-                </TabPane>
-              )}
-
-              {/* MCP Servers Tab */}
-              {mcpHubData && Array.isArray(mcpHubData) && mcpHubData.length > 0 && (
-                <TabPane tab="MCP Hub" key="mcp">
-                  <div className="flex justify-between items-center mb-8">
-                    <Title className="text-2xl font-semibold text-gray-900">Available MCP Servers</Title>
-                  </div>
-
-                  {/* Filters */}
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8 p-6 bg-gray-50 rounded-lg border border-gray-200">
-                    <div>
-                      <div className="flex items-center space-x-2 mb-3">
-                        <Text className="text-sm font-medium text-gray-700">Search MCP Servers:</Text>
-                        <Tooltip title="Search MCP servers by name or description" placement="top">
-                          <Info className="w-4 h-4 text-gray-400 cursor-help" />
-                        </Tooltip>
-                      </div>
-                      <div className="relative">
-                        <SearchIcon className="w-4 h-4 text-gray-400 absolute left-3 top-1/2 transform -translate-y-1/2" />
-                        <input
-                          type="text"
-                          placeholder="Search MCP server names or descriptions..."
-                          value={mcpSearchTerm}
-                          onChange={(e) => setMcpSearchTerm(e.target.value)}
-                          className="border border-gray-300 rounded-lg pl-10 pr-4 py-2 w-full text-sm focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white"
-                        />
-                      </div>
-                    </div>
-                    <div>
-                      <Text className="text-sm font-medium mb-3 text-gray-700">Transport:</Text>
-                      <Select
-                        mode="multiple"
-                        value={selectedMcpTransports}
-                        onChange={(values) => setSelectedMcpTransports(values)}
-                        placeholder="Select transport types"
-                        className="w-full"
-                        size="large"
-                        allowClear
-                      >
-                        {mcpHubData &&
-                          Array.isArray(mcpHubData) &&
-                          getUniqueMcpTransports(mcpHubData).map((transport) => (
-                            <Select.Option key={transport} value={transport}>
-                              {transport}
-                            </Select.Option>
-                          ))}
-                      </Select>
-                    </div>
-                  </div>
-
-                  <DataTable
-                    data={filteredMcpData}
-                    columns={mcpColumns}
-                    getRowId={(server, index) => server.server_id || String(index)}
-                    sortingMode="client"
-                    sorting={mcpSorting}
-                    onSortingChange={setMcpSorting}
-                    isLoading={mcpLoading}
-                    loadingMessage="Loading MCP servers…"
-                    noDataMessage={
-                      <PublicHubEmptyState
-                        title="No matching MCP servers"
-                        body="Adjust the search or transport filter to see more servers."
-                      />
-                    }
-                    size="compact"
-                  />
-
-                  <div className="mt-8 text-center">
-                    <Text className="text-sm text-gray-600">
-                      Showing {filteredMcpData.length} of {mcpHubData?.length || 0} MCP servers
-                    </Text>
-                  </div>
-                </TabPane>
-              )}
-
-              {/* Skill Hub Tab */}
-              <TabPane tab="Skill Hub" key="skills">
-                <SkillHubDashboard skills={skillHubData} isLoading={skillLoading} publicPage={true} />
-              </TabPane>
-            </Tabs>
-          </Card>
-        </div>
-
-        {/* Model Details Modal */}
-        <Modal
-          title={
-            <div className="flex items-center space-x-2">
-              <span>{selectedModel?.model_group || "Model Details"}</span>
-              {selectedModel && (
-                <Tooltip title="Copy model name">
-                  <Copy
-                    onClick={() => copyToClipboard(selectedModel.model_group)}
-                    className="cursor-pointer text-gray-500 hover:text-blue-500 w-4 h-4"
-                  />
-                </Tooltip>
-              )}
-            </div>
-          }
-          width={1000}
-          open={isModalVisible}
-          footer={null}
-          onOk={handleModalOk}
-          onCancel={handleModalCancel}
-        >
-          {selectedModel && (
-            <div className="space-y-6">
-              {/* Model Overview */}
-              <div>
-                <Text className="text-lg font-semibold mb-4">Model Overview</Text>
-                <div className="grid grid-cols-2 gap-4 mb-4">
-                  <div>
-                    <Text className="font-medium">Model Name:</Text>
-                    <Text>{selectedModel.model_group}</Text>
-                  </div>
-                  <div>
-                    <Text className="font-medium">Mode:</Text>
-                    <Text>{selectedModel.mode || "Not specified"}</Text>
-                  </div>
-                  <div>
-                    <Text className="font-medium">Providers:</Text>
-                    <div className="flex flex-wrap gap-1 mt-1">
-                      {(selectedModel.providers ?? []).map((provider) => {
-                        const { logo } = getProviderLogoAndName(provider);
-                        return (
-                          <Tag key={provider} color="blue">
-                            <div className="flex items-center space-x-1">
-                              {logo && (
-                                <img
-                                  src={logo}
-                                  alt={provider}
-                                  className="w-3 h-3 shrink-0 object-contain"
-                                  onError={(e) => {
-                                    (e.target as HTMLImageElement).style.display = "none";
-                                  }}
-                                />
-                              )}
-                              <span className="capitalize">{provider}</span>
-                            </div>
-                          </Tag>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-
-                {/* Wildcard Routing Note */}
-                {selectedModel.model_group.includes("*") && (
-                  <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-4">
-                    <div className="flex items-start space-x-2">
-                      <Info className="w-4 h-4 text-blue-600 mt-0.5 shrink-0" />
-                      <div>
-                        <Text className="font-medium text-blue-900 mb-2">Wildcard Routing</Text>
-                        <Text className="text-sm text-blue-800 mb-2">
-                          This model uses wildcard routing. You can pass any value where you see the{" "}
-                          <code className="bg-blue-100 px-1 py-0.5 rounded-sm text-xs">*</code> symbol.
-                        </Text>
-                        <Text className="text-sm text-blue-800">
-                          For example, with{" "}
-                          <code className="bg-blue-100 px-1 py-0.5 rounded-sm text-xs">
-                            {selectedModel.model_group}
-                          </code>
-                          , you can use any string (
-                          <code className="bg-blue-100 px-1 py-0.5 rounded-sm text-xs">
-                            {selectedModel.model_group.replaceAll("*", "my-custom-value")}
-                          </code>
-                          ) that matches this pattern.
-                        </Text>
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              {/* Token and Cost Information */}
-              <div>
-                <Text className="text-lg font-semibold mb-4">Token & Cost Information</Text>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Text className="font-medium">Max Input Tokens:</Text>
-                    <Text>{selectedModel.max_input_tokens?.toLocaleString() || "Not specified"}</Text>
-                  </div>
-                  <div>
-                    <Text className="font-medium">Max Output Tokens:</Text>
-                    <Text>{selectedModel.max_output_tokens?.toLocaleString() || "Not specified"}</Text>
-                  </div>
-                  <div>
-                    <Text className="font-medium">Input Cost per 1M Tokens:</Text>
-                    <Text>
-                      {selectedModel.input_cost_per_token
-                        ? formatCost(selectedModel.input_cost_per_token)
-                        : "Not specified"}
-                    </Text>
-                  </div>
-                  <div>
-                    <Text className="font-medium">Output Cost per 1M Tokens:</Text>
-                    <Text>
-                      {selectedModel.output_cost_per_token
-                        ? formatCost(selectedModel.output_cost_per_token)
-                        : "Not specified"}
-                    </Text>
-                  </div>
-                </div>
-              </div>
-
-              {/* Capabilities */}
-              <div>
-                <Text className="text-lg font-semibold mb-4">Capabilities</Text>
-                <div className="flex flex-wrap gap-2">
-                  {(() => {
-                    const capabilities = getModelCapabilities(selectedModel);
-                    const colors = ["green", "blue", "purple", "orange", "red", "yellow"];
-
-                    if (capabilities.length === 0) {
-                      return <Text className="text-gray-500">No special capabilities listed</Text>;
-                    }
-
-                    return capabilities.map((capability, index) => (
-                      <Tag key={capability} color={colors[index % colors.length]}>
-                        {formatCapabilityName(capability)}
-                      </Tag>
-                    ));
-                  })()}
-                </div>
-              </div>
-
-              {/* Rate Limits */}
-              {(selectedModel.tpm || selectedModel.rpm) && (
-                <div>
-                  <Text className="text-lg font-semibold mb-4">Rate Limits</Text>
-                  <div className="grid grid-cols-2 gap-4">
-                    {selectedModel.tpm && (
-                      <div>
-                        <Text className="font-medium">Tokens per Minute:</Text>
-                        <Text>{selectedModel.tpm.toLocaleString()}</Text>
-                      </div>
-                    )}
-                    {selectedModel.rpm && (
-                      <div>
-                        <Text className="font-medium">Requests per Minute:</Text>
-                        <Text>{selectedModel.rpm.toLocaleString()}</Text>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* Supported OpenAI Parameters */}
-              {selectedModel.supported_openai_params && selectedModel.supported_openai_params.length > 0 && (
-                <div>
-                  <Text className="text-lg font-semibold mb-4">Supported OpenAI Parameters</Text>
-                  <div className="flex flex-wrap gap-2">
-                    {selectedModel.supported_openai_params.map((param) => (
-                      <Tag key={param} color="green">
-                        {param}
-                      </Tag>
+                        <ExternalLinkIcon className="w-4 h-4 shrink-0" />
+                        <p className="text-sm font-medium break-words">{title}</p>
+                      </button>
                     ))}
-                  </div>
                 </div>
-              )}
+              </Card>
+            )}
 
-              {/* Usage Example */}
-              <div>
-                <Text className="text-lg font-semibold mb-4">Usage Example</Text>
-                <div className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto">
-                  <pre className="text-sm">
-                    {(() => {
-                      const codeSnippet = generateCodeSnippet({
-                        apiKeySource: "custom",
-                        accessToken: null,
-                        apiKey: "your_api_key",
-                        inputMessage: "Hello, how are you?",
-                        chatHistory: [{ role: "user", content: "Hello, how are you?", isImage: false } as MessageType],
-                        selectedTags: [],
-                        selectedVectorStores: [],
-                        selectedGuardrails: [],
-                        selectedPolicies: [],
-                        selectedMCPServers: [],
-                        endpointType: getEndpointType(selectedModel.mode || "chat"),
-                        selectedModel: selectedModel.model_group,
-                        selectedSdk: "openai",
-                      });
-                      return codeSnippet;
-                    })()}
-                  </pre>
+            {/* Health and Endpoint Status - only shown when not embedded */}
+            {!isEmbedded && (
+              <Card className="mb-10 p-8 bg-white border border-gray-200 rounded-lg shadow-xs">
+                <h2 className="text-2xl font-semibold mb-6 text-gray-900">Health and Endpoint Status</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <p className="text-green-600 font-medium text-sm">Service status: {serviceStatus}</p>
                 </div>
-                <div className="mt-2 text-right">
-                  <button
-                    onClick={() => {
-                      const codeSnippet = generateCodeSnippet({
-                        apiKeySource: "custom",
-                        accessToken: null,
-                        apiKey: "your_api_key",
-                        inputMessage: "Hello, how are you?",
-                        chatHistory: [{ role: "user", content: "Hello, how are you?", isImage: false } as MessageType],
-                        selectedTags: [],
-                        selectedVectorStores: [],
-                        selectedGuardrails: [],
-                        selectedPolicies: [],
-                        selectedMCPServers: [],
-                        endpointType: getEndpointType(selectedModel.mode || "chat"),
-                        selectedModel: selectedModel.model_group,
-                        selectedSdk: "openai",
-                      });
-                      copyToClipboard(codeSnippet);
-                    }}
-                    className="text-sm text-blue-600 hover:text-blue-800 cursor-pointer"
-                  >
-                    Copy to clipboard
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
-        </Modal>
+              </Card>
+            )}
 
-        {/* Agent Details Modal */}
-        <Modal
-          title={
-            <div className="flex items-center space-x-2">
-              <span>{selectedAgent?.name || "Agent Details"}</span>
-              {selectedAgent && (
-                <Tooltip title="Copy agent name">
-                  <Copy
-                    onClick={() => copyToClipboard(selectedAgent.name)}
-                    className="cursor-pointer text-gray-500 hover:text-blue-500 w-4 h-4"
-                  />
-                </Tooltip>
-              )}
-            </div>
-          }
-          width={1000}
-          open={isAgentModalVisible}
-          footer={null}
-          onOk={handleAgentModalOk}
-          onCancel={handleAgentModalCancel}
-        >
-          {selectedAgent && (
-            <div className="space-y-6">
-              {/* Agent Overview */}
-              <div>
-                <Text className="text-lg font-semibold mb-4">Agent Overview</Text>
-                <div className="grid grid-cols-2 gap-4 mb-4">
-                  <div>
-                    <Text className="font-medium">Name:</Text>
-                    <Text>{selectedAgent.name}</Text>
+            {/* Tabs for Models and Agents */}
+            <Card className="p-8 bg-white border border-gray-200 rounded-lg shadow-xs">
+              <Tabs value={activeTab} onValueChange={setActiveTab} className="public-hub-tabs">
+                <TabsList>
+                  <TabsTrigger value="models">Model Hub</TabsTrigger>
+                  {hasAgents && <TabsTrigger value="agents">Agent Hub</TabsTrigger>}
+                  {hasMcpServers && <TabsTrigger value="mcp">MCP Hub</TabsTrigger>}
+                  <TabsTrigger value="skills">Skill Hub</TabsTrigger>
+                </TabsList>
+
+                {/* Models Tab */}
+                <TabsContent value="models">
+                  <div className="flex justify-between items-center mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-900">Available Models</h2>
                   </div>
-                  <div>
-                    <Text className="font-medium">Version:</Text>
-                    <Text>{selectedAgent.version}</Text>
-                  </div>
-                  <div className="col-span-2">
-                    <Text className="font-medium">Description:</Text>
-                    <Text>{selectedAgent.description}</Text>
-                  </div>
-                  {selectedAgent.url && (
+
+                  {/* Filters */}
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8 p-6 bg-gray-50 rounded-lg border border-gray-200">
                     <div>
-                      <Text className="font-medium">URL:</Text>
-                      <a
-                        href={selectedAgent.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-blue-600 hover:text-blue-800 text-sm break-all"
-                      >
-                        {selectedAgent.url}
-                      </a>
+                      <div className="flex items-center space-x-2 mb-3">
+                        <p className="text-sm font-medium text-gray-700">Search Models:</p>
+                        <Tooltip>
+                          <TooltipTrigger render={<Info className="w-4 h-4 text-gray-400 cursor-help" />} />
+                          <TooltipContent side="top">
+                            Smart search with relevance ranking - finds models containing your search terms, ranked by
+                            relevance. Try searching &apos;xai grok-4&apos;, &apos;claude-4&apos;, &apos;gpt-4&apos;, or
+                            &apos;sonnet&apos;
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                      <div className="relative">
+                        <SearchIcon className="w-4 h-4 text-gray-400 absolute left-3 top-1/2 transform -translate-y-1/2" />
+                        <input
+                          type="text"
+                          placeholder="Search model names... (smart search enabled)"
+                          value={searchTerm}
+                          onChange={(e) => setSearchTerm(e.target.value)}
+                          className="border border-gray-300 rounded-lg pl-10 pr-4 py-2 w-full text-sm focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white"
+                        />
+                      </div>
                     </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Capabilities */}
-              {selectedAgent.capabilities && (
-                <div>
-                  <Text className="text-lg font-semibold mb-4">Capabilities</Text>
-                  <div className="flex flex-wrap gap-2">
-                    {Object.entries(selectedAgent.capabilities)
-                      .filter(([_, value]) => value === true)
-                      .map(([key]) => (
-                        <Tag key={key} color="green" className="capitalize">
-                          {key}
-                        </Tag>
-                      ))}
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium mb-3 text-gray-700">Provider:</p>
+                      <Combobox
+                        multiple
+                        items={providerOptions}
+                        value={selectedProviders}
+                        onValueChange={(values: string[]) => setSelectedProviders(values)}
+                      >
+                        <ComboboxChips className="min-h-8 w-full py-1 text-sm">
+                          <ComboboxValue>
+                            {(values: string[]) =>
+                              values.map((provider) => (
+                                <ComboboxChip key={provider} aria-label={provider}>
+                                  {provider}
+                                </ComboboxChip>
+                              ))
+                            }
+                          </ComboboxValue>
+                          <ComboboxChipsInput
+                            placeholder="Select providers"
+                            aria-label="Select providers"
+                            className="h-5 min-w-24 flex-1 border-0 bg-transparent py-0 text-sm"
+                          />
+                        </ComboboxChips>
+                        <ComboboxContent>
+                          <ComboboxEmpty>No providers found</ComboboxEmpty>
+                          <ComboboxList>
+                            {(provider: string) => {
+                              const { logo } = getProviderLogoAndName(provider);
+                              return (
+                                <ComboboxItem key={provider} value={provider}>
+                                  <span className="flex min-w-0 items-center space-x-2">
+                                    {logo && (
+                                      <img
+                                        src={logo}
+                                        alt={provider}
+                                        className="w-5 h-5 shrink-0 object-contain"
+                                        onError={(e) => {
+                                          (e.target as HTMLImageElement).style.display = "none";
+                                        }}
+                                      />
+                                    )}
+                                    <span className="capitalize break-words">{provider}</span>
+                                  </span>
+                                </ComboboxItem>
+                              );
+                            }}
+                          </ComboboxList>
+                        </ComboboxContent>
+                      </Combobox>
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium mb-3 text-gray-700">Mode:</p>
+                      <MultiSelect
+                        options={modeOptions}
+                        value={selectedModes}
+                        onValueChange={setSelectedModes}
+                        placeholder="Select modes"
+                        className="w-full"
+                      />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium mb-3 text-gray-700">Features:</p>
+                      <MultiSelect
+                        options={featureOptions}
+                        value={selectedFeatures}
+                        onValueChange={setSelectedFeatures}
+                        placeholder="Select features"
+                        className="w-full"
+                      />
+                    </div>
                   </div>
-                </div>
-              )}
 
-              {/* Skills */}
-              {selectedAgent.skills && selectedAgent.skills.length > 0 && (
-                <div>
-                  <Text className="text-lg font-semibold mb-4">Skills</Text>
-                  <div className="space-y-4">
-                    {selectedAgent.skills.map((skill, index) => (
-                      <div key={index} className="border border-gray-200 rounded-lg p-4">
-                        <div className="flex items-start justify-between mb-2">
+                  <DataTable
+                    data={filteredData}
+                    columns={modelColumns}
+                    getRowId={(model, index) => model.model_group || String(index)}
+                    sortingMode="client"
+                    sorting={modelSorting}
+                    onSortingChange={setModelSorting}
+                    isLoading={loading}
+                    loadingMessage="Loading models…"
+                    noDataMessage={
+                      <PublicHubEmptyState
+                        title={modelHubData?.length ? "No matching models" : "No models available"}
+                        body={
+                          modelHubData?.length
+                            ? "Adjust the search or filters to see more models."
+                            : "Models made public by the proxy admin will appear here."
+                        }
+                      />
+                    }
+                    size="compact"
+                  />
+
+                  <div className="mt-8 text-center">
+                    <p className="text-sm text-gray-600">
+                      Showing {filteredData.length} of {modelHubData?.length || 0} models
+                    </p>
+                  </div>
+                </TabsContent>
+
+                {/* Agents Tab */}
+                {hasAgents && (
+                  <TabsContent value="agents">
+                    <div className="flex justify-between items-center mb-8">
+                      <h2 className="text-2xl font-semibold text-gray-900">Available Agents</h2>
+                    </div>
+
+                    {/* Filters */}
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8 p-6 bg-gray-50 rounded-lg border border-gray-200">
+                      <div>
+                        <div className="flex items-center space-x-2 mb-3">
+                          <p className="text-sm font-medium text-gray-700">Search Agents:</p>
+                          <Tooltip>
+                            <TooltipTrigger render={<Info className="w-4 h-4 text-gray-400 cursor-help" />} />
+                            <TooltipContent side="top">Search agents by name or description</TooltipContent>
+                          </Tooltip>
+                        </div>
+                        <div className="relative">
+                          <SearchIcon className="w-4 h-4 text-gray-400 absolute left-3 top-1/2 transform -translate-y-1/2" />
+                          <input
+                            type="text"
+                            placeholder="Search agent names or descriptions..."
+                            value={agentSearchTerm}
+                            onChange={(e) => setAgentSearchTerm(e.target.value)}
+                            className="border border-gray-300 rounded-lg pl-10 pr-4 py-2 w-full text-sm focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white"
+                          />
+                        </div>
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium mb-3 text-gray-700">Skills:</p>
+                        <MultiSelect
+                          options={agentSkillOptions}
+                          value={selectedAgentSkills}
+                          onValueChange={setSelectedAgentSkills}
+                          placeholder="Select skills"
+                          className="w-full"
+                        />
+                      </div>
+                    </div>
+
+                    <DataTable
+                      data={filteredAgentData}
+                      columns={agentColumns}
+                      getRowId={(agent, index) => agent.name || String(index)}
+                      sortingMode="client"
+                      sorting={agentSorting}
+                      onSortingChange={setAgentSorting}
+                      isLoading={agentLoading}
+                      loadingMessage="Loading agents…"
+                      noDataMessage={
+                        <PublicHubEmptyState
+                          title="No matching agents"
+                          body="Adjust the search or skill filter to see more agents."
+                        />
+                      }
+                      size="compact"
+                    />
+
+                    <div className="mt-8 text-center">
+                      <p className="text-sm text-gray-600">
+                        Showing {filteredAgentData.length} of {agentHubData?.length || 0} agents
+                      </p>
+                    </div>
+                  </TabsContent>
+                )}
+
+                {/* MCP Servers Tab */}
+                {hasMcpServers && (
+                  <TabsContent value="mcp">
+                    <div className="flex justify-between items-center mb-8">
+                      <h2 className="text-2xl font-semibold text-gray-900">Available MCP Servers</h2>
+                    </div>
+
+                    {/* Filters */}
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8 p-6 bg-gray-50 rounded-lg border border-gray-200">
+                      <div>
+                        <div className="flex items-center space-x-2 mb-3">
+                          <p className="text-sm font-medium text-gray-700">Search MCP Servers:</p>
+                          <Tooltip>
+                            <TooltipTrigger render={<Info className="w-4 h-4 text-gray-400 cursor-help" />} />
+                            <TooltipContent side="top">Search MCP servers by name or description</TooltipContent>
+                          </Tooltip>
+                        </div>
+                        <div className="relative">
+                          <SearchIcon className="w-4 h-4 text-gray-400 absolute left-3 top-1/2 transform -translate-y-1/2" />
+                          <input
+                            type="text"
+                            placeholder="Search MCP server names or descriptions..."
+                            value={mcpSearchTerm}
+                            onChange={(e) => setMcpSearchTerm(e.target.value)}
+                            className="border border-gray-300 rounded-lg pl-10 pr-4 py-2 w-full text-sm focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white"
+                          />
+                        </div>
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium mb-3 text-gray-700">Transport:</p>
+                        <MultiSelect
+                          options={mcpTransportOptions}
+                          value={selectedMcpTransports}
+                          onValueChange={setSelectedMcpTransports}
+                          placeholder="Select transport types"
+                          className="w-full"
+                        />
+                      </div>
+                    </div>
+
+                    <DataTable
+                      data={filteredMcpData}
+                      columns={mcpColumns}
+                      getRowId={(server, index) => server.server_id || String(index)}
+                      sortingMode="client"
+                      sorting={mcpSorting}
+                      onSortingChange={setMcpSorting}
+                      isLoading={mcpLoading}
+                      loadingMessage="Loading MCP servers…"
+                      noDataMessage={
+                        <PublicHubEmptyState
+                          title="No matching MCP servers"
+                          body="Adjust the search or transport filter to see more servers."
+                        />
+                      }
+                      size="compact"
+                    />
+
+                    <div className="mt-8 text-center">
+                      <p className="text-sm text-gray-600">
+                        Showing {filteredMcpData.length} of {mcpHubData?.length || 0} MCP servers
+                      </p>
+                    </div>
+                  </TabsContent>
+                )}
+
+                {/* Skill Hub Tab */}
+                <TabsContent value="skills">
+                  <SkillHubDashboard skills={skillHubData} isLoading={skillLoading} publicPage={true} />
+                </TabsContent>
+              </Tabs>
+            </Card>
+          </div>
+
+          {/* Model Details Modal */}
+          <Dialog open={isModalVisible} onOpenChange={(open) => !open && handleModalCancel()}>
+            <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[1000px]">
+              <DialogHeader>
+                <DialogTitle className="flex min-w-0 items-center space-x-2">
+                  <span className="break-words">{selectedModel?.model_group || "Model Details"}</span>
+                  {selectedModel && (
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <Copy
+                            onClick={() => copyToClipboard(selectedModel.model_group)}
+                            className="cursor-pointer text-gray-500 hover:text-blue-500 w-4 h-4 shrink-0"
+                          />
+                        }
+                      />
+                      <TooltipContent>Copy model name</TooltipContent>
+                    </Tooltip>
+                  )}
+                </DialogTitle>
+              </DialogHeader>
+              {selectedModel && (
+                <div className="space-y-6">
+                  {/* Model Overview */}
+                  <div>
+                    <p className="text-lg font-semibold mb-4">Model Overview</p>
+                    <div className="grid grid-cols-2 gap-4 mb-4">
+                      <div>
+                        <p className="font-medium">Model Name:</p>
+                        <p>{selectedModel.model_group}</p>
+                      </div>
+                      <div>
+                        <p className="font-medium">Mode:</p>
+                        <p>{selectedModel.mode || "Not specified"}</p>
+                      </div>
+                      <div>
+                        <p className="font-medium">Providers:</p>
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {(selectedModel.providers ?? []).map((provider) => {
+                            const { logo } = getProviderLogoAndName(provider);
+                            return (
+                              <Badge key={provider} variant="secondary" className="min-w-0">
+                                <div className="flex items-center space-x-1">
+                                  {logo && (
+                                    <img
+                                      src={logo}
+                                      alt={provider}
+                                      className="w-3 h-3 shrink-0 object-contain"
+                                      onError={(e) => {
+                                        (e.target as HTMLImageElement).style.display = "none";
+                                      }}
+                                    />
+                                  )}
+                                  <span className="capitalize">{provider}</span>
+                                </div>
+                              </Badge>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Wildcard Routing Note */}
+                    {selectedModel.model_group.includes("*") && (
+                      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-4">
+                        <div className="flex items-start space-x-2">
+                          <Info className="w-4 h-4 text-blue-600 mt-0.5 shrink-0" />
                           <div>
-                            <Text className="font-medium text-base">{skill.name}</Text>
-                            <Text className="text-sm text-gray-600">{skill.description}</Text>
+                            <p className="font-medium text-blue-900 mb-2">Wildcard Routing</p>
+                            <p className="text-sm text-blue-800 mb-2">
+                              This model uses wildcard routing. You can pass any value where you see the{" "}
+                              <code className="bg-blue-100 px-1 py-0.5 rounded-sm text-xs">*</code> symbol.
+                            </p>
+                            <p className="text-sm text-blue-800">
+                              For example, with{" "}
+                              <code className="bg-blue-100 px-1 py-0.5 rounded-sm text-xs">
+                                {selectedModel.model_group}
+                              </code>
+                              , you can use any string (
+                              <code className="bg-blue-100 px-1 py-0.5 rounded-sm text-xs">
+                                {selectedModel.model_group.replaceAll("*", "my-custom-value")}
+                              </code>
+                              ) that matches this pattern.
+                            </p>
                           </div>
                         </div>
-                        {skill.tags && skill.tags.length > 0 && (
-                          <div className="flex flex-wrap gap-1 mt-2">
-                            {skill.tags.map((tag) => (
-                              <Tag key={tag} color="purple" className="text-xs">
-                                {tag}
-                              </Tag>
-                            ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Token and Cost Information */}
+                  <div>
+                    <p className="text-lg font-semibold mb-4">Token & Cost Information</p>
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <p className="font-medium">Max Input Tokens:</p>
+                        <p>{selectedModel.max_input_tokens?.toLocaleString() || "Not specified"}</p>
+                      </div>
+                      <div>
+                        <p className="font-medium">Max Output Tokens:</p>
+                        <p>{selectedModel.max_output_tokens?.toLocaleString() || "Not specified"}</p>
+                      </div>
+                      <div>
+                        <p className="font-medium">Input Cost per 1M Tokens:</p>
+                        <p>
+                          {selectedModel.input_cost_per_token
+                            ? formatCost(selectedModel.input_cost_per_token)
+                            : "Not specified"}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="font-medium">Output Cost per 1M Tokens:</p>
+                        <p>
+                          {selectedModel.output_cost_per_token
+                            ? formatCost(selectedModel.output_cost_per_token)
+                            : "Not specified"}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Capabilities */}
+                  <div>
+                    <p className="text-lg font-semibold mb-4">Capabilities</p>
+                    <div className="flex flex-wrap gap-2">
+                      {(() => {
+                        const capabilities = getModelCapabilities(selectedModel);
+
+                        if (capabilities.length === 0) {
+                          return <p className="text-gray-500">No special capabilities listed</p>;
+                        }
+
+                        return capabilities.map((capability) => (
+                          <Badge key={capability} variant="secondary">
+                            {formatCapabilityName(capability)}
+                          </Badge>
+                        ));
+                      })()}
+                    </div>
+                  </div>
+
+                  {/* Rate Limits */}
+                  {(selectedModel.tpm || selectedModel.rpm) && (
+                    <div>
+                      <p className="text-lg font-semibold mb-4">Rate Limits</p>
+                      <div className="grid grid-cols-2 gap-4">
+                        {selectedModel.tpm && (
+                          <div>
+                            <p className="font-medium">Tokens per Minute:</p>
+                            <p>{selectedModel.tpm.toLocaleString()}</p>
+                          </div>
+                        )}
+                        {selectedModel.rpm && (
+                          <div>
+                            <p className="font-medium">Requests per Minute:</p>
+                            <p>{selectedModel.rpm.toLocaleString()}</p>
                           </div>
                         )}
                       </div>
-                    ))}
+                    </div>
+                  )}
+
+                  {/* Supported OpenAI Parameters */}
+                  {selectedModel.supported_openai_params && selectedModel.supported_openai_params.length > 0 && (
+                    <div>
+                      <p className="text-lg font-semibold mb-4">Supported OpenAI Parameters</p>
+                      <div className="flex flex-wrap gap-2">
+                        {selectedModel.supported_openai_params.map((param) => (
+                          <Badge key={param} variant="secondary">
+                            {param}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Usage Example */}
+                  <div>
+                    <p className="text-lg font-semibold mb-4">Usage Example</p>
+                    <div className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto">
+                      <pre className="text-sm">
+                        {(() => {
+                          const codeSnippet = generateCodeSnippet({
+                            apiKeySource: "custom",
+                            accessToken: null,
+                            apiKey: "your_api_key",
+                            inputMessage: "Hello, how are you?",
+                            chatHistory: [
+                              { role: "user", content: "Hello, how are you?", isImage: false } as MessageType,
+                            ],
+                            selectedTags: [],
+                            selectedVectorStores: [],
+                            selectedGuardrails: [],
+                            selectedPolicies: [],
+                            selectedMCPServers: [],
+                            endpointType: getEndpointType(selectedModel.mode || "chat"),
+                            selectedModel: selectedModel.model_group,
+                            selectedSdk: "openai",
+                          });
+                          return codeSnippet;
+                        })()}
+                      </pre>
+                    </div>
+                    <div className="mt-2 text-right">
+                      <button
+                        onClick={() => {
+                          const codeSnippet = generateCodeSnippet({
+                            apiKeySource: "custom",
+                            accessToken: null,
+                            apiKey: "your_api_key",
+                            inputMessage: "Hello, how are you?",
+                            chatHistory: [
+                              { role: "user", content: "Hello, how are you?", isImage: false } as MessageType,
+                            ],
+                            selectedTags: [],
+                            selectedVectorStores: [],
+                            selectedGuardrails: [],
+                            selectedPolicies: [],
+                            selectedMCPServers: [],
+                            endpointType: getEndpointType(selectedModel.mode || "chat"),
+                            selectedModel: selectedModel.model_group,
+                            selectedSdk: "openai",
+                          });
+                          copyToClipboard(codeSnippet);
+                        }}
+                        className="text-sm text-blue-600 hover:text-blue-800 cursor-pointer"
+                      >
+                        Copy to clipboard
+                      </button>
+                    </div>
                   </div>
                 </div>
               )}
+            </DialogContent>
+          </Dialog>
 
-              {/* Input/Output Modes */}
-              <div>
-                <Text className="text-lg font-semibold mb-4">Input/Output Modes</Text>
-                <div className="grid grid-cols-2 gap-4">
+          {/* Agent Details Modal */}
+          <Dialog open={isAgentModalVisible} onOpenChange={(open) => !open && handleAgentModalCancel()}>
+            <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[1000px]">
+              <DialogHeader>
+                <DialogTitle className="flex min-w-0 items-center space-x-2">
+                  <span className="break-words">{selectedAgent?.name || "Agent Details"}</span>
+                  {selectedAgent && (
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <Copy
+                            onClick={() => copyToClipboard(selectedAgent.name)}
+                            className="cursor-pointer text-gray-500 hover:text-blue-500 w-4 h-4 shrink-0"
+                          />
+                        }
+                      />
+                      <TooltipContent>Copy agent name</TooltipContent>
+                    </Tooltip>
+                  )}
+                </DialogTitle>
+              </DialogHeader>
+              {selectedAgent && (
+                <div className="space-y-6">
+                  {/* Agent Overview */}
                   <div>
-                    <Text className="font-medium">Input Modes:</Text>
-                    <div className="flex flex-wrap gap-1 mt-1">
-                      {(selectedAgent.defaultInputModes ?? []).map((mode) => (
-                        <Tag key={mode} color="blue">
-                          {mode}
-                        </Tag>
-                      ))}
+                    <p className="text-lg font-semibold mb-4">Agent Overview</p>
+                    <div className="grid grid-cols-2 gap-4 mb-4">
+                      <div>
+                        <p className="font-medium">Name:</p>
+                        <p>{selectedAgent.name}</p>
+                      </div>
+                      <div>
+                        <p className="font-medium">Version:</p>
+                        <p>{selectedAgent.version}</p>
+                      </div>
+                      <div className="col-span-2">
+                        <p className="font-medium">Description:</p>
+                        <p>{selectedAgent.description}</p>
+                      </div>
+                      {selectedAgent.url && (
+                        <div>
+                          <p className="font-medium">URL:</p>
+                          <a
+                            href={selectedAgent.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-600 hover:text-blue-800 text-sm break-all"
+                          >
+                            {selectedAgent.url}
+                          </a>
+                        </div>
+                      )}
                     </div>
                   </div>
+
+                  {/* Capabilities */}
+                  {selectedAgent.capabilities && (
+                    <div>
+                      <p className="text-lg font-semibold mb-4">Capabilities</p>
+                      <div className="flex flex-wrap gap-2">
+                        {Object.entries(selectedAgent.capabilities)
+                          .filter(([_, value]) => value === true)
+                          .map(([key]) => (
+                            <Badge key={key} variant="secondary" className="capitalize">
+                              {key}
+                            </Badge>
+                          ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Skills */}
+                  {selectedAgent.skills && selectedAgent.skills.length > 0 && (
+                    <div>
+                      <p className="text-lg font-semibold mb-4">Skills</p>
+                      <div className="space-y-4">
+                        {selectedAgent.skills.map((skill, index) => (
+                          <div key={index} className="border border-gray-200 rounded-lg p-4">
+                            <div className="flex items-start justify-between mb-2">
+                              <div>
+                                <p className="font-medium text-base">{skill.name}</p>
+                                <p className="text-sm text-gray-600">{skill.description}</p>
+                              </div>
+                            </div>
+                            {skill.tags && skill.tags.length > 0 && (
+                              <div className="flex flex-wrap gap-1 mt-2">
+                                {skill.tags.map((tag) => (
+                                  <Badge key={tag} variant="secondary" className="text-xs">
+                                    {tag}
+                                  </Badge>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Input/Output Modes */}
                   <div>
-                    <Text className="font-medium">Output Modes:</Text>
-                    <div className="flex flex-wrap gap-1 mt-1">
-                      {(selectedAgent.defaultOutputModes ?? []).map((mode) => (
-                        <Tag key={mode} color="blue">
-                          {mode}
-                        </Tag>
-                      ))}
+                    <p className="text-lg font-semibold mb-4">Input/Output Modes</p>
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <p className="font-medium">Input Modes:</p>
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {(selectedAgent.defaultInputModes ?? []).map((mode) => (
+                            <Badge key={mode} variant="secondary">
+                              {mode}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                      <div>
+                        <p className="font-medium">Output Modes:</p>
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {(selectedAgent.defaultOutputModes ?? []).map((mode) => (
+                            <Badge key={mode} variant="secondary">
+                              {mode}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </div>
 
-              {/* Documentation */}
-              {selectedAgent.documentationUrl && (
-                <div>
-                  <Text className="text-lg font-semibold mb-4">Documentation</Text>
-                  <a
-                    href={selectedAgent.documentationUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 hover:text-blue-800 flex items-center space-x-2"
-                  >
-                    <ExternalLinkIcon className="w-4 h-4" />
-                    <span>View Documentation</span>
-                  </a>
-                </div>
-              )}
+                  {/* Documentation */}
+                  {selectedAgent.documentationUrl && (
+                    <div>
+                      <p className="text-lg font-semibold mb-4">Documentation</p>
+                      <a
+                        href={selectedAgent.documentationUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:text-blue-800 flex items-center space-x-2"
+                      >
+                        <ExternalLinkIcon className="w-4 h-4" />
+                        <span>View Documentation</span>
+                      </a>
+                    </div>
+                  )}
 
-              {/* A2A Usage Example */}
-              <div>
-                <Text className="text-lg font-semibold mb-4">Usage Example (A2A Protocol)</Text>
+                  {/* A2A Usage Example */}
+                  <div>
+                    <p className="text-lg font-semibold mb-4">Usage Example (A2A Protocol)</p>
 
-                {/* Step 1: Retrieve Agent Card */}
-                <div className="mb-4">
-                  <Text className="text-sm font-medium mb-2 text-gray-700">Step 1: Retrieve Agent Card</Text>
-                  <div className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto">
-                    <pre className="text-xs">
-                      {`base_url = '${selectedAgent.url}'
+                    {/* Step 1: Retrieve Agent Card */}
+                    <div className="mb-4">
+                      <p className="text-sm font-medium mb-2 text-gray-700">Step 1: Retrieve Agent Card</p>
+                      <div className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto">
+                        <pre className="text-xs">
+                          {`base_url = '${selectedAgent.url}'
 
 resolver = A2ACardResolver(
     httpx_client=httpx_client,
@@ -1251,12 +1275,12 @@ if _public_card.supports_authenticated_extended_card:
             f'Failed to fetch extended agent card: {e_extended}. Will proceed with public card.',
             exc_info=True,
         )`}
-                    </pre>
-                  </div>
-                  <div className="mt-2 text-right">
-                    <button
-                      onClick={() => {
-                        const codeSnippet = `from a2a.client import A2ACardResolver, A2AClient
+                        </pre>
+                      </div>
+                      <div className="mt-2 text-right">
+                        <button
+                          onClick={() => {
+                            const codeSnippet = `from a2a.client import A2ACardResolver, A2AClient
 from a2a.types import (
     AgentCard,
     MessageSendParams,
@@ -1300,21 +1324,21 @@ if _public_card.supports_authenticated_extended_card:
             f'Failed to fetch extended agent card: {e_extended}. Will proceed with public card.',
             exc_info=True,
         )`;
-                        copyToClipboard(codeSnippet);
-                      }}
-                      className="text-sm text-blue-600 hover:text-blue-800 cursor-pointer"
-                    >
-                      Copy to clipboard
-                    </button>
-                  </div>
-                </div>
+                            copyToClipboard(codeSnippet);
+                          }}
+                          className="text-sm text-blue-600 hover:text-blue-800 cursor-pointer"
+                        >
+                          Copy to clipboard
+                        </button>
+                      </div>
+                    </div>
 
-                {/* Step 2: Call the Agent */}
-                <div>
-                  <Text className="text-sm font-medium mb-2 text-gray-700">Step 2: Call the Agent</Text>
-                  <div className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto">
-                    <pre className="text-xs">
-                      {`client = A2AClient(
+                    {/* Step 2: Call the Agent */}
+                    <div>
+                      <p className="text-sm font-medium mb-2 text-gray-700">Step 2: Call the Agent</p>
+                      <div className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto">
+                        <pre className="text-xs">
+                          {`client = A2AClient(
     httpx_client=httpx_client, agent_card=final_agent_card_to_use
 )
 
@@ -1333,12 +1357,12 @@ request = SendMessageRequest(
 
 response = await client.send_message(request)
 print(response.model_dump(mode='json', exclude_none=True))`}
-                    </pre>
-                  </div>
-                  <div className="mt-2 text-right">
-                    <button
-                      onClick={() => {
-                        const codeSnippet = `client = A2AClient(
+                        </pre>
+                      </div>
+                      <div className="mt-2 text-right">
+                        <button
+                          onClick={() => {
+                            const codeSnippet = `client = A2AClient(
     httpx_client=httpx_client, agent_card=final_agent_card_to_use
 )
 
@@ -1357,89 +1381,92 @@ request = SendMessageRequest(
 
 response = await client.send_message(request)
 print(response.model_dump(mode='json', exclude_none=True))`;
-                        copyToClipboard(codeSnippet);
-                      }}
-                      className="text-sm text-blue-600 hover:text-blue-800 cursor-pointer"
-                    >
-                      Copy to clipboard
-                    </button>
+                            copyToClipboard(codeSnippet);
+                          }}
+                          className="text-sm text-blue-600 hover:text-blue-800 cursor-pointer"
+                        >
+                          Copy to clipboard
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          )}
-        </Modal>
-
-        {/* MCP Server Details Modal */}
-        <Modal
-          title={
-            <div className="flex items-center space-x-2">
-              <span>{selectedMcpServer?.server_name || "MCP Server Details"}</span>
-              {selectedMcpServer && (
-                <Tooltip title="Copy server name">
-                  <Copy
-                    onClick={() => copyToClipboard(selectedMcpServer.server_name)}
-                    className="cursor-pointer text-gray-500 hover:text-blue-500 w-4 h-4"
-                  />
-                </Tooltip>
               )}
-            </div>
-          }
-          width={1000}
-          open={isMcpModalVisible}
-          footer={null}
-          onOk={handleMcpModalOk}
-          onCancel={handleMcpModalCancel}
-        >
-          {selectedMcpServer && (
-            <div className="space-y-6">
-              {/* Server Overview */}
-              <div>
-                <Text className="text-lg font-semibold mb-4">Server Overview</Text>
-                <div className="grid grid-cols-2 gap-4 mb-4">
+            </DialogContent>
+          </Dialog>
+
+          {/* MCP Server Details Modal */}
+          <Dialog open={isMcpModalVisible} onOpenChange={(open) => !open && handleMcpModalCancel()}>
+            <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[1000px]">
+              <DialogHeader>
+                <DialogTitle className="flex min-w-0 items-center space-x-2">
+                  <span className="break-words">{selectedMcpServer?.server_name || "MCP Server Details"}</span>
+                  {selectedMcpServer && (
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <Copy
+                            onClick={() => copyToClipboard(selectedMcpServer.server_name)}
+                            className="cursor-pointer text-gray-500 hover:text-blue-500 w-4 h-4 shrink-0"
+                          />
+                        }
+                      />
+                      <TooltipContent>Copy server name</TooltipContent>
+                    </Tooltip>
+                  )}
+                </DialogTitle>
+              </DialogHeader>
+              {selectedMcpServer && (
+                <div className="space-y-6">
+                  {/* Server Overview */}
                   <div>
-                    <Text className="font-medium">Server Name:</Text>
-                    <Text>{selectedMcpServer.server_name}</Text>
+                    <p className="text-lg font-semibold mb-4">Server Overview</p>
+                    <div className="grid grid-cols-2 gap-4 mb-4">
+                      <div>
+                        <p className="font-medium">Server Name:</p>
+                        <p>{selectedMcpServer.server_name}</p>
+                      </div>
+                      <div>
+                        <p className="font-medium">Transport:</p>
+                        <Badge variant="secondary">{selectedMcpServer.transport}</Badge>
+                      </div>
+                      {selectedMcpServer.alias && (
+                        <div>
+                          <p className="font-medium">Alias:</p>
+                          <p>{selectedMcpServer.alias}</p>
+                        </div>
+                      )}
+                      <div>
+                        <p className="font-medium">Auth Type:</p>
+                        <Badge variant={selectedMcpServer.auth_type === "none" ? "outline" : "secondary"}>
+                          {selectedMcpServer.auth_type}
+                        </Badge>
+                      </div>
+                      <div className="col-span-2">
+                        <p className="font-medium">Description:</p>
+                        <p>{selectedMcpServer.mcp_info?.description || "-"}</p>
+                      </div>
+                    </div>
                   </div>
-                  <div>
-                    <Text className="font-medium">Transport:</Text>
-                    <Tag color="blue">{selectedMcpServer.transport}</Tag>
-                  </div>
-                  {selectedMcpServer.alias && (
+
+                  {/* Additional Info */}
+                  {selectedMcpServer.mcp_info && Object.keys(selectedMcpServer.mcp_info).length > 0 && (
                     <div>
-                      <Text className="font-medium">Alias:</Text>
-                      <Text>{selectedMcpServer.alias}</Text>
+                      <p className="text-lg font-semibold mb-4">Additional Information</p>
+                      <div className="bg-gray-50 p-4 rounded-lg">
+                        <pre className="text-xs overflow-x-auto">
+                          {JSON.stringify(selectedMcpServer.mcp_info, null, 2)}
+                        </pre>
+                      </div>
                     </div>
                   )}
+
+                  {/* Usage Example */}
                   <div>
-                    <Text className="font-medium">Auth Type:</Text>
-                    <Tag color={selectedMcpServer.auth_type === "none" ? "gray" : "green"}>
-                      {selectedMcpServer.auth_type}
-                    </Tag>
-                  </div>
-                  <div className="col-span-2">
-                    <Text className="font-medium">Description:</Text>
-                    <Text>{selectedMcpServer.mcp_info?.description || "-"}</Text>
-                  </div>
-                </div>
-              </div>
-
-              {/* Additional Info */}
-              {selectedMcpServer.mcp_info && Object.keys(selectedMcpServer.mcp_info).length > 0 && (
-                <div>
-                  <Text className="text-lg font-semibold mb-4">Additional Information</Text>
-                  <div className="bg-gray-50 p-4 rounded-lg">
-                    <pre className="text-xs overflow-x-auto">{JSON.stringify(selectedMcpServer.mcp_info, null, 2)}</pre>
-                  </div>
-                </div>
-              )}
-
-              {/* Usage Example */}
-              <div>
-                <Text className="text-lg font-semibold mb-4">Usage Example</Text>
-                <div className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto">
-                  <pre className="text-sm">
-                    {`# Using MCP Server with Python FastMCP
+                    <p className="text-lg font-semibold mb-4">Usage Example</p>
+                    <div className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto">
+                      <pre className="text-sm">
+                        {`# Using MCP Server with Python FastMCP
 
 from fastmcp import Client
 import asyncio
@@ -1474,12 +1501,12 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())`}
-                  </pre>
-                </div>
-                <div className="mt-2 text-right">
-                  <button
-                    onClick={() => {
-                      const codeSnippet = `# Using MCP Server with Python FastMCP
+                      </pre>
+                    </div>
+                    <div className="mt-2 text-right">
+                      <button
+                        onClick={() => {
+                          const codeSnippet = `# Using MCP Server with Python FastMCP
 
 from fastmcp import Client
 import asyncio
@@ -1514,18 +1541,20 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())`;
-                      copyToClipboard(codeSnippet);
-                    }}
-                    className="text-sm text-blue-600 hover:text-blue-800 cursor-pointer"
-                  >
-                    Copy to clipboard
-                  </button>
+                          copyToClipboard(codeSnippet);
+                        }}
+                        className="text-sm text-blue-600 hover:text-blue-800 cursor-pointer"
+                      >
+                        Copy to clipboard
+                      </button>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-          )}
-        </Modal>
-      </div>
+              )}
+            </DialogContent>
+          </Dialog>
+        </div>
+      </TooltipProvider>
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
## TLDR

Problem this solves:

- The public model hub and the model picker still render through antd and Tremor
- `ModelSelect` has seven consumers, so the mixed styling spreads widely
- Two teams e2e steps drive antd's Select through its internal classes

How it solves it:

- Rebuilds all four files on `@/components/ui` primitives
- Keeps every public prop signature identical, so no caller changes
- Repoints the e2e steps at the test id, role and data-slot

## User Flow

Before: someone browsing the gateway's model hub, and an admin picking a team's models, see controls built from Ant Design and Tremor, so they do not follow the dashboard's own design tokens and cannot be restyled globally

1. They open http://localhost:4000/ui/model_hub and pick the Model Hub tab
2. They filter by Provider and see each provider's logo beside its name
3. They click a model and read its overview, limits and a ready to paste code snippet
4. An admin opens http://localhost:4000/ui/?page=teams and creates a team
5. They pick several models, then pick All Proxy Models and watch the rest grey out
6. Every one of those controls draws its own borders, spacing and icon sizes from antd or Tremor, so a dashboard-wide style change leaves them behind

After: all of it behaves identically, and every control is a shadcn component that inherits the dashboard's tokens

1. They open http://localhost:4000/ui/model_hub and pick the same Model Hub tab
2. They filter by Provider, with the same logos, and the filter row's three controls now line up at the same height
3. They click a model and read the same overview, limits and code snippet
4. An admin opens http://localhost:4000/ui/?page=teams and creates a team
5. They pick several models, then pick All Proxy Models and the rest still grey out
6. The controls now pick up the dashboard's own tokens, so styling them is a single global change

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Captured at 0ee47a0028 against a live proxy on :4000 serving 86 models and 50 real teams, with the dashboard dev server on :3000.

Verified by hand in the browser, since jsdom has no layout engine:

1. Open http://localhost:3000/model_hub. Filter by Provider, click a model, read the details dialog
2. Open http://localhost:3000/teams, click Create Team, and drive the Models picker

The model hub's filter row, measured in the running page:

```
Provider / Mode / Features control height:  32, 32, 32
inner input border:                         none on all three
icons at the lucide 24px default:           0 of 17
page overflows horizontally:                no
```

Provider filtering, driven end to end:

```
open Provider:      2 options, each with a 20px logo
pick openai:        Showing 2 of 2 models -> Showing 1 of 2 models
remove the chip:    back to Showing 2 of 2 models
```

The model details dialog:

```
width:      1000px
name:       from its title, via aria-labelledby
icons:      16px, 16px
badges:     provider, Vision, Reasoning, Function Calling, and the supported params
snippet:    present
```

The team models picker, against the untouched antd Organization select beside it:

```
width:               635px both
height:              36px vs antd's 32px
nested input border: gone
pick 7 models:       5 chips plus "+1 more"
pick All Proxy Models: collapses to 1 chip, 87 of 88 options go aria-disabled
```

Local gates:

```
npm run build                                                exit 0
npx vitest run <the four files' folders>                     5 files, 124 tests passed
consumer test files (11)                                     232 tests passed, unchanged
npx eslint --pass-on-unpruned-suppressions <6 changed files> exit 0, 44 -> 37 warnings
npx prettier --check <6 changed files>                       all match
```

The 124 figure is the 122 pre-migration baseline plus a modal-close case and an appending-selection case, both proven before they were needed.

## Type

🧹 Refactoring

## Caveats (if any)

- `ModelSelect` caps visible chips at 5 and collapses the rest
- antd measured the available width instead, which Base UI cannot do
- The guardrail `LogViewer` was not reachable in the browser, no guardrail traffic
- `ModelHubTable`, which embeds the hub for admins, is still on Tremor
- `Teams`, `TeamInfo` and the other `ModelSelect` callers are still antd forms
- antd's clear-all control is gone, chips are removed one at a time
- Tremor's rotating badge palette flattens to one variant

## QA runbook

- tests/e2e/ui/tests/proxy-admin/teams.spec.ts - "Create a team" - a team created with All Proxy Models keeps its model selection
  - [ ] Open http://localhost:4000/ui/?page=teams and click Create Team
  - [ ] Fill Team Name, then click into the Models control and expect a popup listing Special Options, Wildcard Options and Models
  - [ ] Click All Proxy Models and expect one chip reading All Proxy Models, with every other option greyed out
  - [ ] Submit, expect a "Team created" toast, then GET /team/list and expect the new team's `models` to be non-empty
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/ui/tests/proxy-admin/teams.spec.ts - "Edit team model selection" - removing one model's chip persists on save
  - [ ] POST /team/update with the master key to seed the team's models as fake-openai-gpt-4 and fake-anthropic-claude
  - [ ] Open http://localhost:4000/ui/?page=teams, click that team, open Settings, click Edit Settings
  - [ ] Expect a chip reading fake-anthropic-claude in the Models control, and click its X
  - [ ] Click Save Changes, expect a settings-updated toast, then GET /team/info and expect fake-anthropic-claude gone
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

