### PR TITLE
fix(mcp): tolerate invalid content blocks in tools/call results

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -35,6 +35,7 @@ from pydantic import AnyUrl
 
 from litellm._logging import verbose_logger
 from litellm.constants import MCP_CLIENT_TIMEOUT, MCP_NPM_CACHE_DIR
+from litellm.experimental_mcp_client.tolerant_result import TolerantClientSession
 from litellm.llms.custom_httpx.http_handler import get_ssl_configuration
 from litellm.types.llms.custom_http import VerifyTypes
 from litellm.types.mcp import (
@@ -373,7 +374,7 @@ class MCPClient:
                 session_kwargs["logging_callback"] = self._logging_callback
             # The SDK drops a response stream that ends without a JSON-RPC reply, so nothing else
             # ever fails the request.
-            session_ctx: Final = ClientSession(
+            session_ctx: Final = TolerantClientSession(
                 read_stream,
                 write_stream,
                 read_timeout_seconds=timedelta(seconds=self.timeout),

--- a/litellm/experimental_mcp_client/tolerant_result.py
+++ b/litellm/experimental_mcp_client/tolerant_result.py
@@ -13,8 +13,9 @@ survives.
 
 import base64
 import json
+from collections.abc import Mapping, Sequence
 from datetime import timedelta
-from typing import Any, Final, Literal, Mapping, Sequence, TypedDict
+from typing import Any, Final, Literal, TypedDict
 
 from mcp import ClientSession, types
 from mcp.shared.session import ProgressFnT
@@ -38,7 +39,7 @@ class _ResourcePayload(BaseModel):
 
     text: str | None = None
     blob: str | None = None
-    mimeType: str | None = None  # noqa: N815  # mirrors the MCP wire field name
+    mimeType: str | None = None
 
 
 class _TextContentBlock(TypedDict):

--- a/litellm/experimental_mcp_client/tolerant_result.py
+++ b/litellm/experimental_mcp_client/tolerant_result.py
@@ -1,0 +1,108 @@
+"""
+Tolerant parsing of ``tools/call`` results from non-spec-compliant upstream MCP servers.
+
+Some upstream MCP servers emit content blocks that fail SDK-side validation, e.g. an
+``EmbeddedResource`` whose ``uri`` is a relative path rather than a URI, or ``text/*``
+content shipped as a base64 ``blob`` instead of ``text``. The stock ``ClientSession``
+lets a single such block fail the entire ``tools/call`` result with a ``ValidationError``,
+discarding content the caller could otherwise use (litellm's own ``MCPClient.call_tool``
+degrades that into an opaque ``isError`` text block containing the pydantic traceback).
+Blocks that fail validation are degraded to text instead, so the rest of the result
+survives.
+"""
+
+import base64
+import json
+from datetime import timedelta
+from typing import Any, Final, Mapping, Sequence
+
+from mcp import ClientSession, types
+from mcp.shared.session import ProgressFnT
+from mcp.types import CallToolResult as MCPCallToolResult
+from pydantic import ValidationError, model_validator
+
+
+def _block_is_valid(block: object) -> bool:
+    try:
+        MCPCallToolResult.model_validate({"content": [block]})
+    except ValidationError:
+        return False
+    return True
+
+
+def _resource_text(resource: Mapping[str, Any]) -> str | None:
+    text: Final = resource.get("text")
+    if isinstance(text, str):
+        return text
+    blob: Final = resource.get("blob")
+    mime_type: Final = resource.get("mimeType")
+    if not isinstance(blob, str) or not isinstance(mime_type, str) or not mime_type.startswith("text/"):
+        return None
+    try:
+        return base64.b64decode(blob, validate=True).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+
+def _as_text_block(block: object) -> dict[str, Any]:
+    if isinstance(block, Mapping):
+        resource: Final = block.get("resource")
+        if isinstance(resource, Mapping):
+            text: Final = _resource_text(resource)
+            if text is not None:
+                return {"type": "text", "text": text}
+    return {"type": "text", "text": json.dumps(block, default=str)}
+
+
+class TolerantCallToolResult(MCPCallToolResult):
+    """``CallToolResult`` that degrades invalid content blocks to text instead of raising."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _degrade_invalid_content_blocks(cls, data: object) -> object:
+        if not isinstance(data, Mapping):
+            return data
+        content: Final = data.get("content")
+        if not isinstance(content, Sequence) or isinstance(content, (str, bytes)):
+            return data
+        if all(_block_is_valid(block) for block in content):
+            return data
+        return {
+            **data,
+            "content": [block if _block_is_valid(block) else _as_text_block(block) for block in content],
+        }
+
+
+class TolerantClientSession(ClientSession):
+    """``ClientSession`` that parses ``tools/call`` results with ``TolerantCallToolResult``.
+
+    ``ClientSession.call_tool`` hardcodes ``types.CallToolResult`` as the response type passed to
+    ``send_request`` with no seam to override just that argument, so this mirrors the mcp==1.28.1
+    method body verbatim (including the private ``_validate_tool_result`` call) rather than calling
+    ``super().call_tool()``. A future mcp release changing that method's signature or behavior would
+    not automatically propagate here.
+    """
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        read_timeout_seconds: timedelta | None = None,
+        progress_callback: ProgressFnT | None = None,
+        *,
+        meta: dict[str, Any] | None = None,
+    ) -> types.CallToolResult:
+        request_meta: Final = types.RequestParams.Meta(**meta) if meta is not None else None
+        result: Final = await self.send_request(
+            types.ClientRequest(
+                types.CallToolRequest(
+                    params=types.CallToolRequestParams(name=name, arguments=arguments, _meta=request_meta),
+                )
+            ),
+            TolerantCallToolResult,
+            request_read_timeout_seconds=read_timeout_seconds,
+            progress_callback=progress_callback,
+        )
+        if not result.isError:
+            await self._validate_tool_result(name, result)
+        return result

--- a/litellm/experimental_mcp_client/tolerant_result.py
+++ b/litellm/experimental_mcp_client/tolerant_result.py
@@ -15,17 +15,19 @@ import base64
 import json
 from collections.abc import Mapping, Sequence
 from datetime import timedelta
+from types import MappingProxyType
 from typing import Any, Final, Literal, TypedDict  # noqa: TID251  # matches ClientSession.call_tool's real signature
 
 from mcp import ClientSession, types
 from mcp.shared.session import ProgressFnT
 from mcp.types import CallToolResult as MCPCallToolResult
 from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
+from typing_extensions import ReadOnly
 
 
 def _block_is_valid(block: object) -> bool:
     try:
-        MCPCallToolResult.model_validate({"content": [block]})
+        MCPCallToolResult.model_validate(MappingProxyType({"content": (block,)}))
     except ValidationError:
         return False
     return True
@@ -43,8 +45,8 @@ class _ResourcePayload(BaseModel):
 
 
 class _TextContentBlock(TypedDict):
-    type: Literal["text"]
-    text: str
+    type: ReadOnly[Literal["text"]]
+    text: ReadOnly[str]
 
 
 def _resource_text(resource: _ResourcePayload) -> str | None:
@@ -73,8 +75,8 @@ def _as_text_block(block: object) -> _TextContentBlock:
             if resource is not None:
                 text: Final = _resource_text(resource)
                 if text is not None:
-                    return {"type": "text", "text": text}
-    return {"type": "text", "text": json.dumps(block, default=str)}
+                    return _TextContentBlock(type="text", text=text)
+    return _TextContentBlock(type="text", text=json.dumps(block, default=str))
 
 
 class TolerantCallToolResult(MCPCallToolResult):
@@ -90,10 +92,14 @@ class TolerantCallToolResult(MCPCallToolResult):
             return data
         if all(_block_is_valid(block) for block in content):
             return data
-        return {
-            **data,
-            "content": [block if _block_is_valid(block) else _as_text_block(block) for block in content],
-        }
+        return MappingProxyType(
+            {
+                **data,
+                "content": tuple(
+                    block if _block_is_valid(block) else _as_text_block(block) for block in content
+                ),
+            }
+        )
 
 
 class TolerantClientSession(ClientSession):

--- a/litellm/experimental_mcp_client/tolerant_result.py
+++ b/litellm/experimental_mcp_client/tolerant_result.py
@@ -14,12 +14,12 @@ survives.
 import base64
 import json
 from datetime import timedelta
-from typing import Any, Final, Mapping, Sequence
+from typing import Any, Final, Literal, Mapping, Sequence, TypedDict
 
 from mcp import ClientSession, types
 from mcp.shared.session import ProgressFnT
 from mcp.types import CallToolResult as MCPCallToolResult
-from pydantic import ValidationError, model_validator
+from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
 
 
 def _block_is_valid(block: object) -> bool:
@@ -30,27 +30,49 @@ def _block_is_valid(block: object) -> bool:
     return True
 
 
-def _resource_text(resource: Mapping[str, Any]) -> str | None:
-    text: Final = resource.get("text")
-    if isinstance(text, str):
-        return text
-    blob: Final = resource.get("blob")
-    mime_type: Final = resource.get("mimeType")
-    if not isinstance(blob, str) or not isinstance(mime_type, str) or not mime_type.startswith("text/"):
+class _ResourcePayload(BaseModel):
+    """Lenient shape of an ``EmbeddedResource.resource``: every field a non-compliant upstream
+    might have gotten wrong is optional, so this never itself fails to validate."""
+
+    model_config = ConfigDict(extra="allow")
+
+    text: str | None = None
+    blob: str | None = None
+    mimeType: str | None = None  # noqa: N815  # mirrors the MCP wire field name
+
+
+class _TextContentBlock(TypedDict):
+    type: Literal["text"]
+    text: str
+
+
+def _resource_text(resource: _ResourcePayload) -> str | None:
+    if resource.text is not None:
+        return resource.text
+    if resource.blob is None or resource.mimeType is None or not resource.mimeType.startswith("text/"):
         return None
     try:
-        return base64.b64decode(blob, validate=True).decode("utf-8")
+        return base64.b64decode(resource.blob, validate=True).decode("utf-8")
     except (ValueError, UnicodeDecodeError):
         return None
 
 
-def _as_text_block(block: object) -> dict[str, Any]:
+def _validate_resource(raw_resource: Mapping[str, object]) -> _ResourcePayload | None:
+    try:
+        return _ResourcePayload.model_validate(raw_resource)
+    except ValidationError:
+        return None
+
+
+def _as_text_block(block: object) -> _TextContentBlock:
     if isinstance(block, Mapping):
-        resource: Final = block.get("resource")
-        if isinstance(resource, Mapping):
-            text: Final = _resource_text(resource)
-            if text is not None:
-                return {"type": "text", "text": text}
+        raw_resource: Final = block.get("resource")
+        if isinstance(raw_resource, Mapping):
+            resource: Final = _validate_resource(raw_resource)
+            if resource is not None:
+                text: Final = _resource_text(resource)
+                if text is not None:
+                    return {"type": "text", "text": text}
     return {"type": "text", "text": json.dumps(block, default=str)}
 
 

--- a/litellm/experimental_mcp_client/tolerant_result.py
+++ b/litellm/experimental_mcp_client/tolerant_result.py
@@ -95,9 +95,7 @@ class TolerantCallToolResult(MCPCallToolResult):
         return MappingProxyType(
             {
                 **data,
-                "content": tuple(
-                    block if _block_is_valid(block) else _as_text_block(block) for block in content
-                ),
+                "content": tuple(block if _block_is_valid(block) else _as_text_block(block) for block in content),
             }
         )
 

--- a/litellm/experimental_mcp_client/tolerant_result.py
+++ b/litellm/experimental_mcp_client/tolerant_result.py
@@ -15,7 +15,7 @@ import base64
 import json
 from collections.abc import Mapping, Sequence
 from datetime import timedelta
-from typing import Any, Final, Literal, TypedDict
+from typing import Any, Final, Literal, TypedDict  # noqa: TID251  # matches ClientSession.call_tool's real signature
 
 from mcp import ClientSession, types
 from mcp.shared.session import ProgressFnT

--- a/tests/mcp_tests/test_mcp_client_unit.py
+++ b/tests/mcp_tests/test_mcp_client_unit.py
@@ -117,7 +117,7 @@ class TestMCPClientUnitTests:
 
     @pytest.mark.asyncio
     @patch.object(mcp_client_module, "streamable_http_client")
-    @patch.object(mcp_client_module, "ClientSession")
+    @patch.object(mcp_client_module, "TolerantClientSession")
     async def test_run_with_session(self, mock_session_class, mock_transport):
         """Test run_with_session establishes session with auth headers."""
         # Setup mocks
@@ -152,7 +152,7 @@ class TestMCPClientUnitTests:
 
     @pytest.mark.asyncio
     @patch.object(mcp_client_module, "streamable_http_client")
-    @patch.object(mcp_client_module, "ClientSession")
+    @patch.object(mcp_client_module, "TolerantClientSession")
     async def test_list_tools(self, mock_session_class, mock_transport):
         """Test listing tools from the server."""
         # Setup mocks
@@ -190,7 +190,7 @@ class TestMCPClientUnitTests:
 
     @pytest.mark.asyncio
     @patch.object(mcp_client_module, "streamable_http_client")
-    @patch.object(mcp_client_module, "ClientSession")
+    @patch.object(mcp_client_module, "TolerantClientSession")
     async def test_call_tool(self, mock_session_class, mock_transport):
         """Test calling a tool."""
         from mcp.types import CallToolRequestParams

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -78,7 +78,7 @@ class TestMCPClient:
 
     @pytest.mark.asyncio
     @patch("litellm.experimental_mcp_client.client.stdio_client")
-    @patch("litellm.experimental_mcp_client.client.ClientSession")
+    @patch("litellm.experimental_mcp_client.client.TolerantClientSession")
     async def test_mcp_client_stdio_connect_success(self, mock_session, mock_stdio_client):
         """Test successful stdio connection"""
         # Setup mocks - create proper async context manager
@@ -130,7 +130,7 @@ class TestMCPClient:
         mock_streamable_http_client.return_value = mock_http_ctx
 
         # Mock the session
-        with patch("litellm.experimental_mcp_client.client.ClientSession") as mock_session:
+        with patch("litellm.experimental_mcp_client.client.TolerantClientSession") as mock_session:
             mock_session_instance = AsyncMock()
             mock_session_instance.initialize = AsyncMock()
             mock_session_ctx = AsyncMock()
@@ -176,7 +176,7 @@ class TestMCPClient:
         mock_sse_client.return_value = mock_sse_ctx
 
         # Mock the session
-        with patch("litellm.experimental_mcp_client.client.ClientSession") as mock_session:
+        with patch("litellm.experimental_mcp_client.client.TolerantClientSession") as mock_session:
             mock_session_instance = AsyncMock()
             mock_session_instance.initialize = AsyncMock()
             mock_session_ctx = AsyncMock()
@@ -228,7 +228,7 @@ class TestMCPClient:
         mock_streamable_http_client.return_value = mock_http_ctx
 
         # Mock the session
-        with patch("litellm.experimental_mcp_client.client.ClientSession") as mock_session:
+        with patch("litellm.experimental_mcp_client.client.TolerantClientSession") as mock_session:
             mock_session_instance = AsyncMock()
             mock_session_instance.initialize = AsyncMock()
             mock_session_ctx = AsyncMock()
@@ -368,7 +368,7 @@ class TestMCPClientInstructionsCapture:
         assert client._last_initialize_instructions is None
 
     @pytest.mark.asyncio
-    @patch("litellm.experimental_mcp_client.client.ClientSession")
+    @patch("litellm.experimental_mcp_client.client.TolerantClientSession")
     async def test_captures_instructions_from_initialize(self, mock_session_cls):
         """Instructions from upstream initialize() are captured and stripped."""
         client = MCPClient(
@@ -397,7 +397,7 @@ class TestMCPClientInstructionsCapture:
         assert client._last_initialize_instructions == "upstream says hello"
 
     @pytest.mark.asyncio
-    @patch("litellm.experimental_mcp_client.client.ClientSession")
+    @patch("litellm.experimental_mcp_client.client.TolerantClientSession")
     async def test_none_instructions_stays_none(self, mock_session_cls):
         """When upstream returns no instructions the field stays None."""
         client = MCPClient(
@@ -487,7 +487,7 @@ class TestExecuteSessionOperationSurfacesTransportError:
         return transport_ctx
 
     @pytest.mark.asyncio
-    @patch("litellm.experimental_mcp_client.client.ClientSession")
+    @patch("litellm.experimental_mcp_client.client.TolerantClientSession")
     async def test_surfaces_connect_error_over_cancelled(self, mock_session_cls):
         client = MCPClient(server_url="http://example.com/mcp", transport_type="http")
         self._make_session(
@@ -504,7 +504,7 @@ class TestExecuteSessionOperationSurfacesTransportError:
             await client._execute_session_operation(transport_ctx, _op)
 
     @pytest.mark.asyncio
-    @patch("litellm.experimental_mcp_client.client.ClientSession")
+    @patch("litellm.experimental_mcp_client.client.TolerantClientSession")
     async def test_genuine_cancellation_is_not_replaced(self, mock_session_cls):
         client = MCPClient(server_url="http://example.com/mcp", transport_type="http")
         self._make_session(mock_session_cls, AsyncMock(side_effect=asyncio.CancelledError()))
@@ -517,7 +517,7 @@ class TestExecuteSessionOperationSurfacesTransportError:
             await client._execute_session_operation(transport_ctx, _op)
 
     @pytest.mark.asyncio
-    @patch("litellm.experimental_mcp_client.client.ClientSession")
+    @patch("litellm.experimental_mcp_client.client.TolerantClientSession")
     async def test_cleanup_error_after_success_is_swallowed(self, mock_session_cls):
         client = MCPClient(server_url="http://example.com/mcp", transport_type="http")
         init_result = MagicMock()
@@ -731,8 +731,9 @@ class _ScriptedUpstream:
     error, the shape an upstream application uses to report its own failure.
     """
 
-    def __init__(self, tools_list_error: ErrorData | None = None):
+    def __init__(self, tools_list_error: ErrorData | None = None, tools_call_result: dict | None = None):
         self._tools_list_error = tools_list_error
+        self._tools_call_result = tools_call_result
         self._to_client_tx, self._to_client_rx = anyio.create_memory_object_stream(10)
         self._from_client_tx, self._from_client_rx = anyio.create_memory_object_stream(10)
         self._task_group = None
@@ -769,18 +770,84 @@ class _ScriptedUpstream:
                 )
             elif method == "tools/list" and self._tools_list_error is not None:
                 await self._send(JSONRPCError(jsonrpc="2.0", id=request.id, error=self._tools_list_error))
+            elif method == "tools/call" and self._tools_call_result is not None:
+                # Sent as a raw dict, not built from CallToolResult, so a non-compliant upstream's
+                # actual wire bytes reach the client exactly as they would over a real connection.
+                await self._send(JSONRPCResponse(jsonrpc="2.0", id=request.id, result=self._tools_call_result))
 
 
 class _ScriptedClient(MCPClient):
     """An MCPClient whose transport is a scripted in-memory upstream instead of a real connection,
     so the real ``ClientSession`` and its real timeout machinery are what run."""
 
-    def __init__(self, *, timeout: float, tools_list_error: ErrorData | None = None):
+    def __init__(
+        self,
+        *,
+        timeout: float,
+        tools_list_error: ErrorData | None = None,
+        tools_call_result: dict | None = None,
+    ):
         super().__init__(server_url="http://upstream.local/mcp", timeout=timeout)
-        self._upstream = _ScriptedUpstream(tools_list_error=tools_list_error)
+        self._upstream = _ScriptedUpstream(tools_list_error=tools_list_error, tools_call_result=tools_call_result)
 
     def _create_transport_context(self):
         return self._upstream, None
+
+
+# A real payload captured from an upstream Azure DevOps MCP server's ``repo_file`` tool: an
+# ``EmbeddedResource`` with a repo-relative ``uri`` (the MCP spec requires a URI with a scheme) and
+# ``text/plain`` content shipped as a base64 ``blob`` instead of ``text``. mcp==1.28.1's
+# ``CallToolResult.model_validate`` raises a 14-error ``ValidationError`` on this exact payload.
+_MALFORMED_TOOLS_CALL_RESULT = {
+    "content": [
+        {
+            "type": "resource",
+            "resource": {
+                "uri": "/templates/ev.job/template/docker-compose.yml",
+                "mimeType": "text/plain",
+                "blob": "dmVyc2lvbjogJzIuNCcK",
+            },
+        }
+    ],
+    "isError": False,
+}
+
+
+class TestCallToolToleratesMalformedContentBlocks:
+    """A single content block that fails MCP-SDK validation must not fail the whole ``tools/call``
+    result. Driven through ``_ScriptedClient`` over real anyio streams and the real session class
+    the client actually wires in, so a change to which class gets constructed (not just the
+    validator logic in isolation) fails this test too.
+    """
+
+    @pytest.mark.asyncio
+    async def test_relative_uri_resource_degrades_to_text_instead_of_raising(self):
+        from mcp.types import CallToolRequestParams
+
+        client = _ScriptedClient(timeout=5, tools_call_result=_MALFORMED_TOOLS_CALL_RESULT)
+        params = CallToolRequestParams(name="repo_file", arguments={"action": "get_content"})
+
+        result = await asyncio.wait_for(client.call_tool(params, raise_on_error=True), timeout=10)
+
+        assert result.isError is False
+        assert len(result.content) == 1
+        assert result.content[0].type == "text"
+        assert result.content[0].text == "version: '2.4'\n"
+
+    @pytest.mark.asyncio
+    async def test_well_formed_result_is_unaffected(self):
+        from mcp.types import CallToolRequestParams
+
+        well_formed = {"content": [{"type": "text", "text": "ok"}], "isError": False}
+        client = _ScriptedClient(timeout=5, tools_call_result=well_formed)
+        params = CallToolRequestParams(name="some_tool", arguments={})
+
+        result = await asyncio.wait_for(client.call_tool(params, raise_on_error=True), timeout=10)
+
+        assert result.isError is False
+        assert len(result.content) == 1
+        assert result.content[0].type == "text"
+        assert result.content[0].text == "ok"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -731,9 +731,15 @@ class _ScriptedUpstream:
     error, the shape an upstream application uses to report its own failure.
     """
 
-    def __init__(self, tools_list_error: ErrorData | None = None, tools_call_result: dict | None = None):
+    def __init__(
+        self,
+        tools_list_error: ErrorData | None = None,
+        tools_call_result: dict | None = None,
+        tools_list_result: dict | None = None,
+    ):
         self._tools_list_error = tools_list_error
         self._tools_call_result = tools_call_result
+        self._tools_list_result = tools_list_result
         self._to_client_tx, self._to_client_rx = anyio.create_memory_object_stream(10)
         self._from_client_tx, self._from_client_rx = anyio.create_memory_object_stream(10)
         self._task_group = None
@@ -770,6 +776,8 @@ class _ScriptedUpstream:
                 )
             elif method == "tools/list" and self._tools_list_error is not None:
                 await self._send(JSONRPCError(jsonrpc="2.0", id=request.id, error=self._tools_list_error))
+            elif method == "tools/list" and self._tools_list_result is not None:
+                await self._send(JSONRPCResponse(jsonrpc="2.0", id=request.id, result=self._tools_list_result))
             elif method == "tools/call" and self._tools_call_result is not None:
                 # Sent as a raw dict, not built from CallToolResult, so a non-compliant upstream's
                 # actual wire bytes reach the client exactly as they would over a real connection.
@@ -786,9 +794,14 @@ class _ScriptedClient(MCPClient):
         timeout: float,
         tools_list_error: ErrorData | None = None,
         tools_call_result: dict | None = None,
+        tools_list_result: dict | None = None,
     ):
         super().__init__(server_url="http://upstream.local/mcp", timeout=timeout)
-        self._upstream = _ScriptedUpstream(tools_list_error=tools_list_error, tools_call_result=tools_call_result)
+        self._upstream = _ScriptedUpstream(
+            tools_list_error=tools_list_error,
+            tools_call_result=tools_call_result,
+            tools_list_result=tools_list_result,
+        )
 
     def _create_transport_context(self):
         return self._upstream, None
@@ -813,6 +826,13 @@ _MALFORMED_TOOLS_CALL_RESULT = {
 }
 
 
+# call_tool's private _validate_tool_result fetches the tool list (once per tool name, cached
+# after) to check the result's structuredContent against the tool's output schema. An empty list
+# means the tool isn't found, which _validate_tool_result treats as "nothing to validate against"
+# rather than an error, so it doesn't affect the content-degradation behavior under test here.
+_EMPTY_TOOLS_LIST_RESULT = {"tools": []}
+
+
 class TestCallToolToleratesMalformedContentBlocks:
     """A single content block that fails MCP-SDK validation must not fail the whole ``tools/call``
     result. Driven through ``_ScriptedClient`` over real anyio streams and the real session class
@@ -824,7 +844,11 @@ class TestCallToolToleratesMalformedContentBlocks:
     async def test_relative_uri_resource_degrades_to_text_instead_of_raising(self):
         from mcp.types import CallToolRequestParams
 
-        client = _ScriptedClient(timeout=5, tools_call_result=_MALFORMED_TOOLS_CALL_RESULT)
+        client = _ScriptedClient(
+            timeout=5,
+            tools_call_result=_MALFORMED_TOOLS_CALL_RESULT,
+            tools_list_result=_EMPTY_TOOLS_LIST_RESULT,
+        )
         params = CallToolRequestParams(name="repo_file", arguments={"action": "get_content"})
 
         result = await asyncio.wait_for(client.call_tool(params, raise_on_error=True), timeout=10)
@@ -839,7 +863,11 @@ class TestCallToolToleratesMalformedContentBlocks:
         from mcp.types import CallToolRequestParams
 
         well_formed = {"content": [{"type": "text", "text": "ok"}], "isError": False}
-        client = _ScriptedClient(timeout=5, tools_call_result=well_formed)
+        client = _ScriptedClient(
+            timeout=5,
+            tools_call_result=well_formed,
+            tools_list_result=_EMPTY_TOOLS_LIST_RESULT,
+        )
         params = CallToolRequestParams(name="some_tool", arguments={})
 
         result = await asyncio.wait_for(client.call_tool(params, raise_on_error=True), timeout=10)

--- a/tests/test_litellm/experimental_mcp_client/test_tolerant_result.py
+++ b/tests/test_litellm/experimental_mcp_client/test_tolerant_result.py
@@ -1,0 +1,57 @@
+import pytest
+from litellm.experimental_mcp_client.tolerant_result import (
+    TolerantCallToolResult,
+    _as_text_block,
+    _resource_text,
+    _ResourcePayload,
+    _validate_resource,
+)
+from pydantic import ValidationError
+
+
+def test_resource_text_returns_text_field_directly():
+    resource = _ResourcePayload(text="already text")
+    assert _resource_text(resource) == "already text"
+
+
+def test_resource_text_returns_none_when_nothing_decodable():
+    resource = _ResourcePayload(text=None, blob=None, mimeType=None)
+    assert _resource_text(resource) is None
+
+
+def test_resource_text_returns_none_on_undecodable_base64():
+    resource = _ResourcePayload(blob="not valid base64!!!", mimeType="text/plain")
+    assert _resource_text(resource) is None
+
+
+def test_resource_text_returns_none_on_non_utf8_bytes():
+    non_utf8_blob = b"\xff\xfe".hex()
+    import base64
+
+    resource = _ResourcePayload(blob=base64.b64encode(bytes.fromhex(non_utf8_blob)).decode(), mimeType="text/plain")
+    assert _resource_text(resource) is None
+
+
+def test_validate_resource_returns_none_for_wrong_typed_field():
+    assert _validate_resource({"mimeType": 12345}) is None
+
+
+def test_as_text_block_falls_back_to_json_dump_for_unrecognized_block():
+    block = _as_text_block({"type": "nonsense", "foo": "bar"})
+    assert block["type"] == "text"
+    assert block["text"] == '{"type": "nonsense", "foo": "bar"}'
+
+
+def test_degrade_invalid_content_blocks_passthrough_for_non_mapping_input():
+    with pytest.raises(ValidationError):
+        TolerantCallToolResult.model_validate("not a mapping at all")
+
+
+def test_degrade_invalid_content_blocks_passthrough_for_non_sequence_content():
+    with pytest.raises(ValidationError):
+        TolerantCallToolResult.model_validate({"content": 42, "isError": False})
+
+
+def test_degrade_invalid_content_blocks_passthrough_for_string_content():
+    with pytest.raises(ValidationError):
+        TolerantCallToolResult.model_validate({"content": "not-a-list-of-blocks", "isError": False})


### PR DESCRIPTION
## TLDR

Problem this solves:

- A single malformed content block fails an entire MCP `tools/call` result
- Client returns a raw `ValidationError` traceback instead of any content

How it solves it:

- Degrade only the invalid content block to text instead of raising
- Every valid content block in the result is left untouched

## User Flow

Before: a developer calling a tool on a non-compliant upstream MCP server through the gateway gets an error instead of the tool's real output

1. They send a `tools/call` JSON-RPC request for a tool backed by an Azure DevOps MCP server to the gateway's MCP endpoint
2. The upstream server's response includes a resource content item using a relative path instead of a full URI, which the MCP client library rejects
3. The gateway's response comes back with `"isError": true` and a single `text` block containing a raw pydantic `ValidationError` traceback, not the tool's actual output

After: the same call returns the tool's real output even though the upstream's response is still not fully spec-compliant

1. They send the same `tools/call` JSON-RPC request for the same tool to the same MCP endpoint
2. The upstream server's response still contains that same non-compliant resource content item
3. The gateway's response now comes back with `"isError": false` and the tool's actual output as `text` content

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

The lint/format/unit-test box is left unchecked deliberately: this repo's build backend (`maturin`, compiling `litellm-rust`) requires a local Rust toolchain that wasn't available in the environment this PR was written in, so `make lint` / `make test-unit` could not be run locally. The new test was verified with a standalone script exercising the same `mcp==1.28.1` model classes and the same `_ScriptedUpstream`/`_ScriptedClient` harness logic used in the actual test file, not through `pytest` itself. Flagging this explicitly rather than checking a box I couldn't verify; happy to fix anything CI turns up.

## Screenshots / Proof of Fix

This is not the live-proxy curl proof this template normally asks for. A local proxy could not be built for the same Rust-toolchain reason noted above. What follows is real evidence gathered against a live, non-compliant upstream MCP server, plus a real run of this fix's exact logic against that captured payload, at the commit above.

**Before (parent commit `423b791ee0395815050998dd73542445350ab792`): the real failure, captured live**

An MCP `tools/call` request for a `repo_file` tool backed by an Azure DevOps MCP server (`mcp.dev.azure.com`), sent with a real, valid upstream token, returns this content block verbatim:

```json
{"type":"resource","resource":{"uri":"/templates/ev.job/template/docker-compose.yml","mimeType":"text/plain","blob":"dmVyc2lvbjogJzIuNCcK..."}}
```

Feeding that exact block into `mcp==1.28.1`'s `CallToolResult.model_validate` (the same call `ClientSession.call_tool` makes internally) raises:

```
pydantic_core._pydantic_core.ValidationError: 14 validation errors for CallToolResult
content.0.TextContent.type
  Input should be 'text' [type=literal_error, input_value='resource', input_type=str]
...
content.0.EmbeddedResource.resource.TextResourceContents.uri
  Input should be a valid URL, relative URL without a base [type=url_parsing, input_value='/templates/ev.job/template/docker-compose.yml', input_type=str]
...
```

This is exactly the `ValidationError` that `MCPClient.call_tool`'s except-block turns into the `isError: true` text block described above.

**After (this PR, commit `3b7d9e74cbd8561bf62041c5888168ec64a0779c`): the same payload, run through the new model**

```
$ python -c "
from litellm.experimental_mcp_client.tolerant_result import TolerantCallToolResult
payload = {'content': [{'type': 'resource', 'resource': {
    'uri': '/templates/ev.job/template/docker-compose.yml',
    'mimeType': 'text/plain',
    'blob': 'dmVyc2lvbjogJzIuNCcK',
}}], 'isError': False}
result = TolerantCallToolResult.model_validate(payload)
print(result.content[0].type, repr(result.content[0].text))
"
text "version: '2.4'\n"
```

No exception. `isError` stays `False`. The content that used to be silently discarded behind a traceback comes through as the actual decoded text.

The new test in this PR, `TestCallToolToleratesMalformedContentBlocks::test_relative_uri_resource_degrades_to_text_instead_of_raising`, asserts this same outcome through the real `ClientSession`-derived class and real anyio streams via `_ScriptedUpstream`/`_ScriptedClient`, not a hand-built result object; it could not be executed via `pytest` here for the Rust-toolchain reason above, so this is not a substitute for CI actually running it, only evidence that the logic it exercises behaves as asserted.

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

- `make lint` / `make test-unit` not run locally; blocked on this repo's Rust/maturin build requirement
- `TolerantClientSession.call_tool` mirrors `mcp==1.28.1`'s method body verbatim (no override seam exists); a later `mcp` release changing that method won't automatically propagate
- Uses `Any`/`Mapping[str, Any]`/`object` for the genuinely untyped external data at this one boundary; flagging in case `reportAny` disagrees

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
