### PR TITLE
fix(vertex_ai): normalize tuple-form JSON Schema items before the Vertex transform

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -846,7 +846,7 @@ def _normalize_tuple_items(schema: dict[str, Any], depth: int = 0) -> None:
     tuple_items: Final = schema.get("items", None)
     if isinstance(tuple_items, list):
         if tuple_items:
-            schema["items"] = {"anyOf": tuple_items}
+            schema["items"] = {"anyOf": tuple_items}  # mutable-ok: the walkers below rewrite this subtree in place
         else:
             schema.pop("items")
 

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -846,7 +846,7 @@ def _normalize_tuple_items(schema: dict[str, Any], depth: int = 0) -> None:
     tuple_items: Final = schema.get("items", None)
     if isinstance(tuple_items, list):
         if tuple_items:
-            schema["items"] = {"anyOf": tuple_items}  # mutable-ok: every walker here rewrites the schema tree in place
+            schema["items"] = {"anyOf": tuple_items}
         else:
             schema.pop("items")
 

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -657,6 +657,8 @@ def _build_vertex_schema(parameters: dict, add_property_ordering: bool = False):
     # refs recursively and correctly detects/skips circular references.
     unpack_defs(parameters, defs)
 
+    _normalize_tuple_items(parameters)
+
     # 5. Nullable fields:
     #     * https://github.com/pydantic/pydantic/issues/1270
     #     * https://stackoverflow.com/a/58841311
@@ -830,6 +832,39 @@ def filter_schema_fields(schema_dict: dict[str, object], valid_fields: set[str],
             result[key] = value
 
     return result
+
+
+def _normalize_tuple_items(schema: dict[str, Any], depth: int = 0) -> None:
+    """Rewrite tuple-form `items` (a list of sub-schemas) as `anyOf`.
+
+    JSON Schema allows it, Vertex's Schema type does not, and every walker below
+    reads `items` as a single sub-schema, so a list there crashes them.
+    """
+    if depth > DEFAULT_MAX_RECURSE_DEPTH:
+        raise ValueError(f"Max depth of {DEFAULT_MAX_RECURSE_DEPTH} exceeded while processing schema.")
+
+    tuple_items: Final = schema.get("items", None)
+    if isinstance(tuple_items, list):
+        if tuple_items:
+            schema["items"] = {"anyOf": tuple_items}  # mutable-ok: every walker here rewrites the schema tree in place
+        else:
+            schema.pop("items")
+
+    properties: Final = schema.get("properties", None)
+    if properties is not None:
+        for value in properties.values():
+            _normalize_tuple_items(value, depth=depth + 1)
+
+    items: Final = schema.get("items", None)
+    if items is not None:
+        _normalize_tuple_items(items, depth=depth + 1)
+
+    for key in ("anyOf", "oneOf", "allOf"):
+        values = schema.get(key, None)
+        if values is not None and isinstance(values, list):
+            for value in values:
+                if isinstance(value, dict):
+                    _normalize_tuple_items(value, depth=depth + 1)
 
 
 def convert_anyof_null_to_nullable(schema, depth=0):

--- a/tests/code_coverage_tests/recursive_detector.py
+++ b/tests/code_coverage_tests/recursive_detector.py
@@ -11,6 +11,7 @@ IGNORE_FUNCTIONS = [
     "clean_message",
     "unpack_defs",
     "convert_anyof_null_to_nullable",  # has a set max depth
+    "_normalize_tuple_items",  # has a set max depth
     "add_object_type",
     "strip_field",
     "_transform_prompt",

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -388,6 +388,70 @@ def test_build_vertex_schema_array_branch_missing_items_in_anyof():
         }, f"array branch must have items synthesized; got {branch}"
 
 
+def test_build_vertex_schema_tuple_form_items_become_anyof():
+    """
+    Regression: tuple-form `items` (`"items": [{...}, {...}]`, valid JSON Schema)
+    used to crash the transform with `'list' object has no attribute 'get'`,
+    surfacing as litellm.APIConnectionError on every vertex_ai request carrying
+    such a tool schema.
+    """
+    from litellm.llms.vertex_ai.common_utils import _build_vertex_schema
+
+    parameters = {
+        "type": "object",
+        "properties": {
+            "pair": {
+                "type": "array",
+                "items": [{"type": "integer"}, {"type": "string"}],
+            }
+        },
+    }
+
+    result = _build_vertex_schema(parameters)
+
+    assert result["properties"]["pair"]["items"] == {
+        "anyOf": [{"type": "integer"}, {"type": "string"}]
+    }
+
+
+def test_build_vertex_schema_tuple_form_items_nested_in_anyof_branch():
+    """Tuple-form `items` on an anyOf branch is reachable only if the walk
+    descends into anyOf, which is where the original crash was raised."""
+    from litellm.llms.vertex_ai.common_utils import _build_vertex_schema
+
+    parameters = {
+        "type": "object",
+        "properties": {
+            "pair": {
+                "anyOf": [
+                    {"type": "array", "items": [{"type": "integer"}]},
+                    {"type": "null"},
+                ]
+            }
+        },
+    }
+
+    result = _build_vertex_schema(parameters)
+
+    array_branch = result["properties"]["pair"]["anyOf"][0]
+    assert array_branch["items"] == {"anyOf": [{"type": "integer"}]}
+
+
+def test_build_vertex_schema_empty_tuple_form_items():
+    """An empty `items: []` has no branches to fold into anyOf, so it takes the
+    same path as `items: {}` rather than raising on a zero-length anyOf."""
+    from litellm.llms.vertex_ai.common_utils import _build_vertex_schema
+
+    parameters = {
+        "type": "object",
+        "properties": {"pair": {"type": "array", "items": []}},
+    }
+
+    result = _build_vertex_schema(parameters)
+
+    assert result["properties"]["pair"]["items"] == {"type": "object"}
+
+
 def test_vertex_ai_complex_response_schema():
     import json
     from copy import deepcopy


### PR DESCRIPTION
## TLDR

Problem this solves:

- Tuple-form `items` crashes every `vertex_ai/*` request carrying that tool
- Error surfaces as `APIConnectionError: 'list' object has no attribute 'get'`
- OpenAI-compatible clients and several MCP servers emit that shape

How it solves it:

- Rewrite `"items": [A, B]` as `"items": {"anyOf": [A, B]}` once, before the walkers
- Runs after `unpack_defs`, so `$ref`-expanded schemas are covered too
- `items: []` drops out and `process_items` synthesizes `{"type": "object"}`

## User Flow

Before: a developer whose tool schema declares a fixed-shape array gets a connection error from the gateway on every call, while the same tool works against other providers

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "vertex_ai/gemini-2.5-flash"` and a tool whose parameters contain `"a": {"type": "array", "items": [{"type": "integer"}, {"type": "string"}]}`
2. The gateway answers with `litellm.APIConnectionError: 'list' object has no attribute 'get'`, and no request ever reaches the model
3. They retry the identical body against an OpenAI-compatible provider and get a normal completion, so the tool schema itself is fine
4. Their only way forward is a pre-call shim that rewrites the tool schema before the gateway sees it

After: the same request is accepted and the tool reaches the model

1. They send the same POST https://litellm-domain/v1/chat/completions with the same tuple-form tool
2. The gateway forwards the tool to Vertex with that field typed as an array whose entries may be an integer or a string
3. They get a normal completion back, with a tool call if the model chooses to make one
4. The shim can come out of their stack

The array position that carried a fixed order is now an unordered union, which is the closest shape Vertex can express

## Relevant issues

Fixes #36848

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I do not have Vertex credentials, so there is no live provider run here. What I can show is that the failure is raised while building the request, before anything is sent, so it reproduces without a project or a key. Both runs below use the exact tool schema from the issue.

Before, at `423b791e` (the parent of this branch):

```
$ python -c "
from litellm.llms.vertex_ai.common_utils import _build_vertex_schema
print(_build_vertex_schema({'type':'object','properties':{'a':{'type':'array','items':[{'type':'integer'},{'type':'string'}]}}}))"
AttributeError: 'list' object has no attribute 'get'
```

After, at `f99823bf`:

```
$ python -c "
from litellm.llms.vertex_ai.common_utils import _build_vertex_schema
print(_build_vertex_schema({'type':'object','properties':{'a':{'type':'array','items':[{'type':'integer'},{'type':'string'}]}}}))"
{'type': 'object', 'properties': {'a': {'type': 'array', 'items': {'anyOf': [{'type': 'integer'}, {'type': 'string'}]}}}}
```

A maintainer with Vertex access can confirm the end to end path with the curl in the issue body, which is the same tool schema against a live `vertex_ai/*` deployment. Happy to add that run here if someone can share a sandbox project.

## Type

🐛 Bug Fix

## Caveats (if any)

- Positional constraints are lost; Vertex cannot express tuple arrays
- `additionalItems` is dropped, same as every other unsupported keyword
- Boolean sub-schemas (`items: [false]`) still crash, unchanged from today
- `prefixItems`, the 2020-12 spelling, is untouched and still ignored
- `_build_json_schema` still passes tuple `items` through unchanged

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

