### PR TITLE
fix(databricks): surface provider usage, including prompt-cache counts, in streaming chunks

### DIFF
--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -733,6 +733,7 @@ class DatabricksChatResponseIterator(BaseModelResponseIterator):
                 created=chunk["created"],
                 model=chunk["model"],
                 choices=translated_choices,
+                usage=chunk.get("usage"),
             )
         except KeyError as e:
             raise DatabricksException(

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -423,3 +423,79 @@ def test_databricks_config_probes_capabilities_under_databricks_namespace():
     without this override they probed the ``anthropic`` cost-map namespace and
     ignored the exact ``databricks/databricks-claude-*`` entries."""
     assert DatabricksConfig().custom_llm_provider == "databricks"
+
+
+def _streaming_chunk(usage=None, choices=None):
+    base = {
+        "id": "chatcmpl-test",
+        "created": 1234567890,
+        "model": "databricks-claude-sonnet-5",
+        "choices": [{"delta": {"content": "hi"}}] if choices is None else choices,
+    }
+    return base if usage is None else {**base, "usage": usage}
+
+
+@pytest.mark.parametrize(
+    "cache_read, cache_creation, expected_cached, expected_written",
+    [
+        (12002, 0, 12002, 0),
+        (0, 12002, 0, 12002),
+    ],
+    ids=["warm_cache_read", "cold_cache_write"],
+)
+def test_chunk_parser_surfaces_prompt_cache_usage(cache_read, cache_creation, expected_cached, expected_written):
+    """Databricks returns Anthropic prompt-cache counts in the streaming usage object,
+    but chunk_parser dropped usage entirely, so cache-aware pricing never reached the
+    cost calculator and every streamed request was billed at the full input rate."""
+    iterator = DatabricksChatResponseIterator(streaming_response=None, sync_stream=True)
+
+    result = iterator.chunk_parser(
+        _streaming_chunk(
+            usage={
+                "prompt_tokens": 12011,
+                "completion_tokens": 8,
+                "total_tokens": 12019,
+                "cache_read_input_tokens": cache_read,
+                "cache_creation_input_tokens": cache_creation,
+            }
+        )
+    )
+
+    assert result.usage is not None
+    assert result.usage.prompt_tokens == 12011
+    assert result.usage.completion_tokens == 8
+    assert result.usage.prompt_tokens_details is not None
+    assert result.usage.prompt_tokens_details.cached_tokens == expected_cached
+    assert result.usage._cache_creation_input_tokens == expected_written
+
+
+def test_chunk_parser_surfaces_usage_only_final_chunk():
+    """stream_options={"include_usage": True} emits a trailing chunk whose choices
+    list is empty; usage must still reach the caller."""
+    iterator = DatabricksChatResponseIterator(streaming_response=None, sync_stream=True)
+
+    result = iterator.chunk_parser(
+        _streaming_chunk(
+            usage={
+                "prompt_tokens": 100,
+                "completion_tokens": 5,
+                "total_tokens": 105,
+                "cache_read_input_tokens": 90,
+            },
+            choices=[],
+        )
+    )
+
+    assert result.choices == []
+    assert result.usage is not None
+    assert result.usage.prompt_tokens_details.cached_tokens == 90
+
+
+def test_chunk_parser_without_usage_still_parses_content():
+    iterator = DatabricksChatResponseIterator(streaming_response=None, sync_stream=True)
+
+    result = iterator.chunk_parser(_streaming_chunk())
+
+    assert result.id == "chatcmpl-test"
+    assert result.model == "databricks-claude-sonnet-5"
+    assert result.choices[0]["delta"]["content"] == "hi"

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -444,9 +444,6 @@ def _streaming_chunk(usage=None, choices=None):
     ids=["warm_cache_read", "cold_cache_write"],
 )
 def test_chunk_parser_surfaces_prompt_cache_usage(cache_read, cache_creation, expected_cached, expected_written):
-    """Databricks returns Anthropic prompt-cache counts in the streaming usage object,
-    but chunk_parser dropped usage entirely, so cache-aware pricing never reached the
-    cost calculator and every streamed request was billed at the full input rate."""
     iterator = DatabricksChatResponseIterator(streaming_response=None, sync_stream=True)
 
     result = iterator.chunk_parser(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed Databricks chat responses discard the provider's `usage` object
- Token counts fall back to LiteLLM's own estimate, so streaming spend is wrong
- In the repro, prompt tokens understated 8x and completion tokens logged as 0
- Prompt-cache token counts never surface, so cache-aware pricing never applies
- Cached Databricks Claude requests bill at the full input rate

How it solves it:

- Pass the streaming chunk's usage object through to the caller

## User Flow

Before: a developer streaming any Databricks-served chat model gets LiteLLM's estimated token counts instead of the provider's, so spend and cache savings are wrong

1. They send POST https://litellm-domain/v1/chat/completions to a Databricks deployment such as `databricks-gpt-oss-120b` with `"stream": true` and `"stream_options": {"include_usage": true}`
2. The trailing SSE chunk reports `"prompt_tokens": 13, "completion_tokens": 0`, while the same request sent straight to Databricks reports `"prompt_tokens": 107, "completion_tokens": 20`
3. They send the same prompt as POST https://litellm-domain/v1/messages with `"stream": true` and the `message_delta` event reports `"input_tokens": 13, "output_tokens": 0`
4. GET https://litellm-domain/spend/logs?request_id=... shows both requests logged at prompt 13, completion 0
5. On a Databricks Claude deployment with a large system block marked for caching, the trailing usage chunk carries no cache breakdown on either the cold or the warm request, and https://litellm-domain/ui/?page=logs costs both at the full input rate

After: the same requests report the provider's own token counts and cache split, and spend follows them

1. They send the same POST https://litellm-domain/v1/chat/completions
2. The trailing SSE chunk now reports `"prompt_tokens": 107, "completion_tokens": 20, "total_tokens": 127`, matching Databricks
3. The same POST https://litellm-domain/v1/messages now reports `"input_tokens": 107, "output_tokens": 20` in `message_delta`
4. GET https://litellm-domain/spend/logs?request_id=... shows prompt 107, completion 20, and spend 14x higher than before
5. On the Databricks Claude deployment the cold request reports `cache_creation_input_tokens` and the warm one `cache_read_input_tokens`, and https://litellm-domain/ui/?page=logs costs the warm request at the cache-read rate

## Relevant issues

Fixes #36933

## Linear ticket

Resolves LIT-5284

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two proxies booted from clean branch checkouts, each with a fresh database, in front of Azure Databricks Foundation Model APIs serving `databricks-gpt-oss-120b`. Same config, same requests, real provider calls

Proxy config:

```yaml
model_list:
  - model_name: dbx-gpt-oss-120b
    litellm_params:
      model: databricks/databricks-gpt-oss-120b
      api_key: os.environ/DATABRICKS_API_KEY
      api_base: os.environ/DATABRICKS_API_BASE
general_settings:
  master_key: sk-1234
```

Ground truth from the provider, the same prompt sent straight to Databricks:

```sh
curl -sS -X POST "$DATABRICKS_API_BASE/databricks-gpt-oss-120b/invocations" \
  -H "Authorization: Bearer $DATABRICKS_API_KEY" -H "Content-Type: application/json" \
  -d '{"messages":[{"role":"user","content":"say hi in 3 words"}],"stream":true,"stream_options":{"include_usage":true},"max_tokens":20}' | grep '"usage"' | tail -1
```

```
data: {"id":"chatcmpl_0ef847a3-...","object":"chat.completion.chunk","created":1786819302,"model":"gpt-oss-120b-080525","choices":[{"index":0,"delta":{"content":""},"finish_reason":"length","logprobs":null}],"usage":{"prompt_tokens":107,"completion_tokens":20,"total_tokens":127}}
```

### Before (`423b791ee0`, merge base, port 35321)

#### /v1/chat/completions

1. Stream a completion and keep the trailing usage chunk:

    ```sh
    curl -sS -N -X POST http://localhost:$PORT/v1/chat/completions \
      -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
      -d '{"model":"dbx-gpt-oss-120b","messages":[{"role":"user","content":"say hi in 3 words"}],"stream":true,"stream_options":{"include_usage":true},"max_tokens":20}' | grep '"usage"' | tail -1
    ```

2. The chunk carries estimated counts, not the provider's:

    ```
    data: {"id":"chatcmpl_316a17de-6f17-41b6-844d-a298360d787f_ecd9a34e-92ea-4eb5-ae60-4057f0d9c770","created":1786819612,"model":"dbx-gpt-oss-120b","object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}],"usage":{"completion_tokens":0,"prompt_tokens":13,"total_tokens":13,"completion_tokens_details":{"reasoning_tokens":16}}}
    ```

3. prompt 13 vs Databricks' own 107, completion 0 vs 20, with `reasoning_tokens: 16` next to `completion_tokens: 0`

#### /spend/logs

1. Look up the spend row for that request:

    ```sh
    curl -sS "http://localhost:$PORT/spend/logs?request_id=$REQUEST_ID" -H "Authorization: Bearer sk-1234" \
      | jq -c '.[] | {model, prompt_tokens, completion_tokens, total_tokens, spend}'
    ```

2. The row logs the estimate:

    ```
    {"model":"databricks/databricks-gpt-oss-120b","prompt_tokens":13,"completion_tokens":0,"total_tokens":13,"spend":0.00000195013}
    ```

#### /v1/messages

1. Send the same prompt through the Anthropic-format endpoint:

    ```sh
    curl -sS -N -X POST http://localhost:$PORT/v1/messages \
      -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
      -d '{"model":"dbx-gpt-oss-120b","messages":[{"role":"user","content":"say hi in 3 words"}],"stream":true,"max_tokens":20}' | grep message_delta
    ```

2. The `message_delta` event reports the same estimate:

    ```
    data: {"type": "message_delta", "delta": {"stop_reason": "max_tokens"}, "usage": {"input_tokens": 13, "output_tokens": 0}}
    ```

#### Prompt-cache split on a Databricks Claude model

1. Send an 800-repetition system block marked `cache_control: ephemeral` to `system.ai.claude-opus-5`, cold then warm with the same body
2. Neither call carries `prompt_tokens_details`, so the warm call is indistinguishable from the cold one and bills at the full input rate:

    ```
    cold   {"completion_tokens":1,"prompt_tokens":10416,"total_tokens":10417,"completion_tokens_details":{"reasoning_tokens":0}}
    warm   {"completion_tokens":0,"prompt_tokens":10416,"total_tokens":10416,"completion_tokens_details":{"reasoning_tokens":0}}
    ```

### After (`732e23a4f9`, PR head, port 39163)

#### /v1/chat/completions

1. Run the same streaming curl as the before leg
2. The trailing chunk now matches the provider's ground truth exactly:

    ```
    data: {"id":"chatcmpl_aff90511-4682-4a73-9ce0-7d14e5da215a_63a51d16-57c6-4ebc-af72-2e8117a4bf7a","created":1786819614,"model":"dbx-gpt-oss-120b","object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}],"usage":{"completion_tokens":20,"prompt_tokens":107,"total_tokens":127,"completion_tokens_details":{"reasoning_tokens":17}}}
    ```

#### /spend/logs

1. Look up the spend row with the same command
2. The row logs the provider's counts, at 14x the before leg's spend for the same request:

    ```
    {"model":"databricks/databricks-gpt-oss-120b","prompt_tokens":107,"completion_tokens":20,"total_tokens":127,"spend":0.00002805047}
    ```

#### /v1/messages

1. Send the same Anthropic-format request
2. The `message_delta` event now reports the provider's counts:

    ```
    data: {"type": "message_delta", "delta": {"stop_reason": "max_tokens"}, "usage": {"input_tokens": 107, "output_tokens": 20}}
    ```

#### Prompt-cache split on a Databricks Claude model

1. Send the same cold-then-warm pair
2. The cold call now reports a cache write and the warm call a cache read of the same 17,603 tokens:

    ```
    cold   {"completion_tokens":4,"prompt_tokens":17613,"total_tokens":17617,"completion_tokens_details":{"reasoning_tokens":0},"prompt_tokens_details":{"cached_tokens":0,"cache_write_tokens":17603,"cache_creation_tokens":17603},"cache_creation_input_tokens":17603,"cache_read_input_tokens":0}
    warm   {"completion_tokens":4,"prompt_tokens":17613,"total_tokens":17617,"completion_tokens_details":{"reasoning_tokens":0},"prompt_tokens_details":{"cached_tokens":17603,"cache_write_tokens":0,"cache_creation_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":17603}
    ```

3. `prompt_tokens` also corrects from 10,416 to 17,613 on a byte-identical payload: without the provider's usage object, streamed Databricks spend was understated by roughly 41% on top of losing the cache split entirely

Cache-case capture note: those two cache legs are the author's run, before at unmodified `v1.96.0` (`8843766`) and after with this PR's single added line applied over a byte-identical copy of the module (`ce66cbc`, SHA-256 verified), because a full branch image build was impractical in that environment. The other three cases at the merge-base/PR-head hashes above exercise the same code path as a real branch build

/v1/responses is not covered by this change: LiteLLM routes Databricks `/v1/responses` requests to the provider's native Responses API, which returned `400 Responses API passthrough is not supported for model databricks-gpt-oss-120b` identically on both legs

Observations from the run:

- Databricks emits `usage` on every chunk regardless of `stream_options`
- `stream_options` is still not forwarded to Databricks; unchanged, not needed here
- `/v1/messages` `message_start` still reports `input_tokens: 0`; unchanged by this PR

## Type

🐛 Bug Fix

## Caveats (if any)

- Only affects the Databricks provider's streaming chat path
- Cache-split proof captured as a single-line overlay on v1.96.0, not a branch build
- `stream_options` still not forwarded to Databricks; usage arrives on every chunk anyway

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 732e23a4f91482cebdf2b05aad572a7ec001e0b7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
