### PR TITLE
fix(responses): return 400 for invalid input types

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -465,7 +465,7 @@ async def aresponses(
         ) and litellm_logging_obj.should_run_prompt_management_hooks(prompt_id=prompt_id, non_default_params=kwargs):
             if isinstance(input, str):
                 client_input: list[AllMessageValues] = [{"role": "user", "content": input}]
-            elif not isinstance(input, list):  # pyright: ignore[reportUnnecessaryIsInstance]
+            elif not isinstance(input, list):  # pyright: ignore[reportUnnecessaryIsInstance]  # runtime input can come from untrusted client payload
                 raise litellm.BadRequestError(
                     message=f"'input' must be a string or list of input items, got {type(input).__name__}",
                     model=model,
@@ -585,7 +585,7 @@ def _apply_prompt_management_to_responses_call(
 
     if isinstance(input, str):
         client_input: list[AllMessageValues] = [{"role": "user", "content": input}]
-    elif not isinstance(input, list):  # pyright: ignore[reportUnnecessaryIsInstance]
+    elif not isinstance(input, list):  # pyright: ignore[reportUnnecessaryIsInstance]  # runtime input can come from untrusted client payload
         raise litellm.BadRequestError(
             message=f"'input' must be a string or list of input items, got {type(input).__name__}",
             model=model,

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -465,6 +465,12 @@ async def aresponses(
         ) and litellm_logging_obj.should_run_prompt_management_hooks(prompt_id=prompt_id, non_default_params=kwargs):
             if isinstance(input, str):
                 client_input: list[AllMessageValues] = [{"role": "user", "content": input}]
+            elif not isinstance(input, list):
+                raise litellm.BadRequestError(
+                    message=f"'input' must be a string or list of input items, got {type(input).__name__}",
+                    model=model,
+                    llm_provider=custom_llm_provider or "unknown",
+                )
             else:
                 client_input = [item for item in input if isinstance(item, dict) and "role" in item]
             (
@@ -579,6 +585,12 @@ def _apply_prompt_management_to_responses_call(
 
     if isinstance(input, str):
         client_input: list[AllMessageValues] = [{"role": "user", "content": input}]
+    elif not isinstance(input, list):
+        raise litellm.BadRequestError(
+            message=f"'input' must be a string or list of input items, got {type(input).__name__}",
+            model=model,
+            llm_provider=custom_llm_provider or "unknown",
+        )
     else:
         client_input = [item for item in input if isinstance(item, dict) and "role" in item]
 

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -465,7 +465,7 @@ async def aresponses(
         ) and litellm_logging_obj.should_run_prompt_management_hooks(prompt_id=prompt_id, non_default_params=kwargs):
             if isinstance(input, str):
                 client_input: list[AllMessageValues] = [{"role": "user", "content": input}]
-            elif not isinstance(input, list): # pyright: ignore[reportUnnecessaryIsInstance]
+            elif not isinstance(input, list):  # pyright: ignore[reportUnnecessaryIsInstance]
                 raise litellm.BadRequestError(
                     message=f"'input' must be a string or list of input items, got {type(input).__name__}",
                     model=model,

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -585,7 +585,7 @@ def _apply_prompt_management_to_responses_call(
 
     if isinstance(input, str):
         client_input: list[AllMessageValues] = [{"role": "user", "content": input}]
-    elif not isinstance(input, list): # pyright: ignore[reportUnnecessaryIsInstance]
+    elif not isinstance(input, list):  # pyright: ignore[reportUnnecessaryIsInstance]
         raise litellm.BadRequestError(
             message=f"'input' must be a string or list of input items, got {type(input).__name__}",
             model=model,

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -465,7 +465,7 @@ async def aresponses(
         ) and litellm_logging_obj.should_run_prompt_management_hooks(prompt_id=prompt_id, non_default_params=kwargs):
             if isinstance(input, str):
                 client_input: list[AllMessageValues] = [{"role": "user", "content": input}]
-            elif not isinstance(input, list):
+            elif not isinstance(input, list): # pyright: ignore[reportUnnecessaryIsInstance]
                 raise litellm.BadRequestError(
                     message=f"'input' must be a string or list of input items, got {type(input).__name__}",
                     model=model,
@@ -585,7 +585,7 @@ def _apply_prompt_management_to_responses_call(
 
     if isinstance(input, str):
         client_input: list[AllMessageValues] = [{"role": "user", "content": input}]
-    elif not isinstance(input, list):
+    elif not isinstance(input, list): # pyright: ignore[reportUnnecessaryIsInstance]
         raise litellm.BadRequestError(
             message=f"'input' must be a string or list of input items, got {type(input).__name__}",
             model=model,

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import litellm
 from litellm.integrations.anthropic_cache_control_hook import (
     AnthropicCacheControlHook,
 )
@@ -410,6 +411,23 @@ class TestResponsesAPIPromptManagement:
         assert handler_call_kwargs.get("custom_llm_provider") == "anthropic"
 
 
+    def test_invalid_input_type_raises_bad_request_error(self):
+        """Non-string, non-list input should raise BadRequestError."""
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=[],
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3]:
+            with pytest.raises(litellm.BadRequestError, match="input"):
+                litellm.responses(
+                    input=12345,
+                    model="gpt-4o",
+                    prompt_id="test-prompt",
+                    litellm_logging_obj=logging_obj,
+                )
+
 class TestAsyncResponsesAPIPromptManagement:
     """Tests for the async aresponses() prompt management path.
 
@@ -539,3 +557,21 @@ class TestAsyncResponsesAPIPromptManagement:
         assert sent_input[0]["cache_control"] == {"type": "ephemeral"}
         assert sent_input[1] == reasoning_item
         assert sent_input[2]["id"] == "msg_1"
+
+    @pytest.mark.asyncio
+    async def test_async_invalid_input_type_raises_bad_request_error(self):
+        """Non-string, non-list input should raise BadRequestError."""
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=[],
+        )
+        logging_obj.async_failure_handler = AsyncMock()
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3]:
+            with pytest.raises(litellm.BadRequestError, match="input"):
+                await litellm.aresponses(
+                    input=12345,
+                    model="gpt-4o",
+                    prompt_id="test-prompt",
+                    litellm_logging_obj=logging_obj,
+                )


### PR DESCRIPTION
## Summary

- Validate Responses API `input` before iterating over it in prompt management.
- Raise `BadRequestError` for non-string, non-list input instead of allowing `TypeError` to propagate as a 500.
- Added regression tests covering both `responses()` and `aresponses()`.

### Problem this solves:

When `input` is a non-string, non-list value such as an integer, float, boolean, `None`, or dictionary, the Responses API attempts to iterate over it during prompt management. This can raise a `TypeError`, which is subsequently surfaced as a 500 error instead of a client-side 400 validation error.

### How it solves it:

Validate the type of `input` before iterating over it. Invalid non-string, non-list values now raise `BadRequestError` with a descriptive message, resulting in a 400-level client error instead of a 500 server error.

## User Flow

Before: A client sends an invalid numeric `input` to the Responses API and receives a 500 error instead of a client validation error.

1. They send `POST https://litellm-domain/v1/responses` with `"input": 12345` and a valid model.
2. The request fails while processing the invalid `input` value.
3. The client receives a 500 response containing a `TypeError` rather than a 400 validation error.

After: The same invalid request is rejected as a client error with a descriptive validation message.

1. They send `POST https://litellm-domain/v1/responses` with `"input": 12345` and a valid model.
2. The request is rejected because `input` must be a string or list of input items.
3. The client receives a 400 response with an error message identifying the invalid `input` type.

## Relevant issues

Fixes #36923

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR