### PR TITLE
feat(slack_alerting): add spend_report_include_tags to hide tag breakdown in spend reports

### DIFF
--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -1857,7 +1857,7 @@ Model Info:
                     _team_spend = round(float(spend["total_spend"]), 4)
                     _spend_message += f"Team: `{spend['team_alias']}` | Spend: `${_team_spend}`\n"
 
-            if spend_per_tag is not None:
+            if spend_per_tag is not None and self.alerting_args.spend_report_include_tags:
                 _spend_message += "\n*Tag Spend Report:*\n"
                 for spend in spend_per_tag:
                     _tag_spend = round(float(spend["total_spend"]), 4)
@@ -1920,7 +1920,7 @@ Model Info:
                     _team_spend = round(_team_spend, 4)
                     _spend_message += f"Team: `{spend['team_alias']}` | Spend: `${_team_spend}`\n"
 
-            if monthly_spend_per_tag is not None:
+            if monthly_spend_per_tag is not None and self.alerting_args.spend_report_include_tags:
                 _spend_message += "\n*Tag Spend Report:*\n"
                 for spend in monthly_spend_per_tag:
                     _tag_spend = spend["total_spend"]

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15243,7 +15243,7 @@ async def alerting_settings(
     Used by UI to generate 'alerting settings' page
     {
         field_name=field_name,
-        field_type=allowed_args[field_name]["type"], # string/int
+        field_type=allowed_args[field_name], # string/int
         field_description=field_info.description or "", # human-friendly description
         field_value=general_settings.get(field_name, None), # example value
     }
@@ -15294,6 +15294,7 @@ async def alerting_settings(
             "spend_anomaly_baseline_days": "Integer",
             "spend_anomaly_min_spend": "Float",
             "user_spend_check_interval": "Integer",
+            "spend_report_include_tags": "Boolean",
         }
     )
 

--- a/litellm/types/integrations/slack_alerting.py
+++ b/litellm/types/integrations/slack_alerting.py
@@ -125,6 +125,10 @@ class SlackAlertingArgs(LiteLLMPydanticObjectBase):
         ge=60,
         description="How often (in seconds) to check per-user spend thresholds and anomalies. Default is hourly.",
     )
+    spend_report_include_tags: bool = Field(
+        default=True,
+        description="If false, spend reports drop the per-tag breakdown and keep the per-team one. Tags stay tracked.",
+    )
 
 
 class DeploymentMetrics(LiteLLMPydanticObjectBase):

--- a/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
@@ -3,7 +3,9 @@ import datetime
 import json
 import time
 import unittest
-from typing import Final, List, Optional, Tuple
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Final, List, Literal, Optional, Tuple
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -419,3 +421,68 @@ async def test_send_alert_raises_when_no_webhook_url_configured(monkeypatch):
             alert_type=AlertType.budget_alerts,
             alerting_metadata={},
         )
+
+
+_SPEND_PER_TEAM: Final = (MappingProxyType({"team_alias": "eng", "total_spend": 12.3456789}),)
+_SPEND_PER_TAG: Final = (MappingProxyType({"individual_request_tag": "prod", "total_spend": 4.2}),)
+_SPEND_REPORT_WEBHOOK: Final = "https://hooks.slack.example/spend-report"
+_SPEND_REPORT_BATCH_SIZE: Final = 2  # pins the flush threshold above 1 so DEFAULT_BATCH_SIZE can't trigger a real POST
+
+
+async def _delivered_spend_report(
+    monkeypatch: pytest.MonkeyPatch,
+    alerting_args: Mapping[str, bool],
+    report_type: Literal["weekly", "monthly"],
+) -> tuple[str, AsyncMock]:
+    monkeypatch.delenv("PROXY_BASE_URL", raising=False)  # send_alert appends it to the payload
+    slack_alerting: Final = SlackAlerting(
+        alerting=["slack"],
+        alert_types=[AlertType.spend_reports],
+        internal_usage_cache=DualCache(),
+        alerting_args=alerting_args,
+        default_webhook_url=_SPEND_REPORT_WEBHOOK,
+        batch_size=_SPEND_REPORT_BATCH_SIZE,
+    )
+    slack_alerting.periodic_started = True  # keeps send_alert from spawning an unawaited flush task
+    get_report: Final = AsyncMock(return_value=(_SPEND_PER_TEAM, _SPEND_PER_TAG))
+    with patch(  # test-quality-ok: lazily imported module function, no injection seam; the boundary is the DB
+        "litellm.proxy.spend_tracking.spend_management_endpoints._get_spend_report_for_time_range",
+        new=get_report,
+    ):
+        if report_type == "weekly":
+            await slack_alerting.send_weekly_spend_report()
+        else:
+            await slack_alerting.send_monthly_spend_report()
+
+    assert len(slack_alerting.log_queue) == 1
+    assert slack_alerting.log_queue[0]["url"] == _SPEND_REPORT_WEBHOOK
+    return slack_alerting.log_queue[0]["payload"]["text"], get_report
+
+
+@pytest.mark.parametrize("report_type", ("weekly", "monthly"))
+@pytest.mark.parametrize("alerting_args", (MappingProxyType({}), MappingProxyType({"spend_report_include_tags": True})))
+@pytest.mark.asyncio
+async def test_spend_report_includes_tag_breakdown_by_default(
+    monkeypatch: pytest.MonkeyPatch, report_type: Literal["weekly", "monthly"], alerting_args: Mapping[str, bool]
+) -> None:
+    message, _ = await _delivered_spend_report(monkeypatch, alerting_args, report_type)
+
+    assert "*Team Spend Report:*" in message
+    assert "Team: `eng` | Spend: `$12.3457`" in message
+    assert "*Tag Spend Report:*" in message
+    assert "Tag: `prod` | Spend: `$4.2`" in message
+
+
+@pytest.mark.parametrize("report_type", ("weekly", "monthly"))
+@pytest.mark.asyncio
+async def test_spend_report_omits_tag_breakdown_when_disabled(
+    monkeypatch: pytest.MonkeyPatch, report_type: Literal["weekly", "monthly"]
+) -> None:
+    message, get_report = await _delivered_spend_report(
+        monkeypatch, MappingProxyType({"spend_report_include_tags": False}), report_type
+    )
+
+    assert "*Team Spend Report:*" in message
+    assert "Team: `eng` | Spend: `$12.3457`" in message
+    assert "Tag" not in message
+    get_report.assert_awaited_once()

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -10050,6 +10050,51 @@ def test_get_config_list_includes_apply_user_budget_to_team_keys(monkeypatch):
         app.dependency_overrides.clear()
 
 
+def test_alerting_settings_exposes_spend_report_include_tags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Admin UI form rebuilds alerting_args from exactly the fields /alerting/settings returns,
+    and /config/field/update replaces the whole blob, so a field missing from allowed_args is
+    silently reset to its default the next time anyone saves that form."""
+    import types
+    from unittest.mock import AsyncMock, MagicMock
+
+    from fastapi.testclient import TestClient
+
+    import litellm.proxy.proxy_server as ps
+    from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.proxy_server import app
+
+    mock_prisma = MagicMock()
+    mock_config_table = MagicMock()
+    mock_config_table.find_first = AsyncMock(
+        return_value=types.SimpleNamespace(param_value={"alerting_args": {"spend_report_include_tags": False}})
+    )
+    mock_prisma.db = types.SimpleNamespace(litellm_config=mock_config_table)
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(
+        ps,
+        "proxy_logging_obj",
+        types.SimpleNamespace(
+            slack_alerting_instance=SlackAlerting(alerting_args={"spend_report_include_tags": False})
+        ),
+    )
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+    try:
+        client = TestClient(app)
+        resp = client.get("/alerting/settings")
+        assert resp.status_code == 200, resp.text
+        fields = {item["field_name"]: item for item in resp.json()}
+        assert "spend_report_include_tags" in fields
+        assert fields["spend_report_include_tags"]["field_type"] == "Boolean"
+        assert fields["spend_report_include_tags"]["field_value"] is False
+        assert fields["spend_report_include_tags"]["field_default_value"] is True
+        assert fields["spend_report_include_tags"]["stored_in_db"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
 def test_get_config_list_includes_budget_exceeded_throttle_percentage(monkeypatch):
     """The throttle fraction is a litellm_settings scalar surfaced on the General
     Settings table as a Float field so it sits with the other global limits; it


### PR DESCRIPTION
## TLDR

Problem this solves:

- Slack spend reports list spend for every request tag
- Auto User-Agent tagging alone adds dozens of tag lines per report
- The team table gets buried under the tag wall

How it solves it:

- New alerting arg spend_report_include_tags, default true keeps current behavior
- When false, weekly and monthly reports keep only the team breakdown
- Tag spend is still tracked and queryable, only the Slack message shrinks
- The toggle is also editable on the Admin UI alerting settings page

## User Flow

Before: the recurring spend report buries team spend under a wall of tag lines

1. The proxy admin runs LiteLLM with alerting: ["slack"] and a database, so spend reports land in their Slack channel
2. Slack posts "Spend Report for `08-07-2026 - 08-14-2026` (7 days)" with a short Team Spend Report list
3. Right below, a Tag Spend Report list follows with 50+ lines like Tag: `User-Agent: OpenAI/Python 2.30.0` | Spend: `$309.29`
4. Channel members scroll past the tag wall every week to compare team spend

After: the same report arrives with the team table only

1. The proxy admin adds spend_report_include_tags: false under general_settings.alerting_args and restarts the proxy
2. Slack posts the same "Spend Report for ... (7 days)" with the Team Spend Report list
3. The message ends after the team list, no Tag Spend Report section appears
4. GET http://localhost:4000/spend/tags with the master key still returns per-tag spend, so tag tracking is unaffected

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both runs captured at a650aa8fac against a live proxy: Postgres 17 in Docker, a real OpenAI-compatible endpoint serving gpt-5.4-nano (base URL and key redacted, passed via env vars), and alerting_args.log_to_console: true so the exact Slack payload is printed to the proxy console. SLACK_WEBHOOK_URL points at a syntactically valid placeholder, so the POST to hooks.slack.com really fires and is rejected; delivery is untouched by this PR, only the message body changes

Config used for the "after" run (the "before" run is identical minus the spend_report_include_tags line):

```yaml
model_list:
  - model_name: gpt-5.4-nano
    litellm_params:
      model: openai/openai/gpt-5.4-nano
      api_key: os.environ/OPENAI_API_KEY
      api_base: os.environ/OPENAI_API_BASE

general_settings:
  master_key: sk-1234
  alerting: ["slack"]
  alerting_args:
    log_to_console: true
    spend_report_include_tags: false
```

Seeding real spend (all against the live proxy, real provider calls):

```
$ curl -X POST http://localhost:4010/team/new -H "Authorization: Bearer sk-1234" \
    -d '{"team_alias": "backend-team"}'
team_id: 380ab6d5-da51-4502-ae30-6063130d6897

$ curl -X POST http://localhost:4010/key/generate -H "Authorization: Bearer sk-1234" \
    -d '{"team_id": "380ab6d5-da51-4502-ae30-6063130d6897", "key_alias": "backend-team-key"}'
key: sk-NxgUw...

$ curl -X POST http://localhost:4010/v1/chat/completions -H "Authorization: Bearer sk-NxgUw..." \
    -d '{"model": "gpt-5.4-nano", "messages": [{"role": "user", "content": "Write a 300 word essay about container gardening"}], "metadata": {"tags": ["nightly-batch"]}}'
usage: 373 total tokens   (ran twice)

$ psql ... -c 'SELECT round(SUM(spend)::numeric, 6) FROM "LiteLLM_SpendLogs"'
0.000458
```

Before (spend_report_include_tags unset, default): trigger the reports and read the payload the proxy printed

```
$ curl 'http://localhost:4010/health/services?service=slack' -H "Authorization: Bearer sk-1234"

[Num Alerts: 2]

Alert type: `spend_reports`
Level: `Low`
Timestamp: `18:10:17`

Message: *💸 Monthly Spend Report for `08-01-2026 - 08-31-2026` *

*Team Spend Report:*
Team: `backend-team` | Spend: `$0.0005`

*Tag Spend Report:*
Tag: `User-Agent: curl/8.7.1` | Spend: `$0.0005`
Tag: `User-Agent: curl` | Spend: `$0.0005`
Tag: `nightly-batch` | Spend: `$0.0005`
```

After (spend_report_include_tags: false): same DB, same trigger, proxy restarted with the flag

```
$ curl 'http://localhost:4010/health/services?service=slack' -H "Authorization: Bearer sk-1234"

[Num Alerts: 2]

Alert type: `spend_reports`
Level: `Low`
Timestamp: `18:08:22`

Message: *💸 Monthly Spend Report for `08-01-2026 - 08-31-2026` *

*Team Spend Report:*
Team: `backend-team` | Spend: `$0.0005`
```

The [Num Alerts: 2] prefix is the pre-existing batcher squashing the weekly and monthly reports (same alert type, same webhook) into one payload that shows the first message; both report types go through the same gate and both are covered by the unit tests

## Type

🆕 New Feature

## Caveats (if any)

- A misspelled arg name fails silently, pydantic drops unknown keys
- The per-tag DB query still runs when hidden, only formatting changes

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
