### PR TITLE
fix(files): read the file extension from the URL path, not the query string

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1468,7 +1468,12 @@ def infer_content_type_from_url_and_content(
 
     # Try to infer from URL extension
     if url:
-        extension: Final = url.split(".")[-1].lower().split("?")[0]  # Remove query params
+        # Strip the query string before taking the extension, the way
+        # _get_image_mime_type_from_url does: splitting on "." first takes the
+        # last dot-segment of the query instead, so "report.pdf?v=1.0" reads as "0".
+        from urllib.parse import urlparse
+
+        extension: Final = urlparse(url).path.split(".")[-1].lower()
         inferred_type: Final = extension_to_mime.get(extension)
         if inferred_type:
             return inferred_type

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -1554,3 +1554,37 @@ class TestRequestContainsImageContent:
         for _ in range(50):
             nested = {"type": "tool_result", "content": [nested]}
         assert request_contains_image_content([{"role": "user", "content": [nested]}]) is False
+
+class TestInferContentTypeQueryString:
+    """A dot in the query string must not be mistaken for the file extension."""
+
+    def _infer(self, url: str, content: bytes):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            infer_content_type_from_url_and_content,
+        )
+
+        return infer_content_type_from_url_and_content(
+            url=url, content=content, current_content_type="binary/octet-stream"
+        )
+
+    @pytest.mark.parametrize(
+        "url, content, expected",
+        [
+            # No query string, and a query string without a dot, both already worked.
+            ("https://bucket.s3.amazonaws.com/report.pdf", b"%PDF-1.7", "application/pdf"),
+            ("https://bucket.s3.amazonaws.com/report.pdf?v=1", b"%PDF-1.7", "application/pdf"),
+            # A dotted query string is the regression: the extension used to be
+            # read out of the query, so these raised ValueError.
+            ("https://bucket.s3.amazonaws.com/report.pdf?v=1.0", b"%PDF-1.7", "application/pdf"),
+            ("https://bucket.s3.amazonaws.com/data.csv?X-Amz-Expires=3.6", b"a,b\n1,2", "text/csv"),
+            ("https://cdn.example.com/page.html?cb=1.2.3", b"<html>", "text/html"),
+        ],
+    )
+    def test_extension_is_read_from_the_path_not_the_query(self, url, content, expected):
+        assert self._infer(url, content) == expected
+
+    def test_a_url_with_no_usable_extension_still_raises(self):
+        # The fallback is unchanged: non-image bytes with no known extension
+        # have nothing left to infer from.
+        with pytest.raises(ValueError):
+            self._infer("https://cdn.example.com/download?id=1.2", b"not-an-image")

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -1586,5 +1586,5 @@ class TestInferContentTypeQueryString:
     def test_a_url_with_no_usable_extension_still_raises(self):
         # The fallback is unchanged: non-image bytes with no known extension
         # have nothing left to infer from.
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Unable to determine content type from URL"):
             self._infer("https://cdn.example.com/download?id=1.2", b"not-an-image")


### PR DESCRIPTION
## TLDR

Problem this solves:

- A dot in a URL's query string breaks file-type detection
- Presigned S3 and CDN document URLs fail with a hard `ValueError`
- Same URL without the dotted query works, so it looks intermittent

How it solves it:

- Take the extension from `urlparse(url).path`, not the raw URL
- Matches `_get_image_mime_type_from_url`, which already does this

## User Flow

Before: a developer sending a Bedrock request with a presigned S3 document URL gets a hard error instead of an answer

1. They upload `report.pdf` to S3 and get back a presigned URL ending `?...&X-Amz-Expires=3.6`
2. They send POST `https://litellm-domain/v1/chat/completions` to a Bedrock Converse model, with that URL as a document part
3. The call fails with `500` and `Unable to determine content type from URL: https://bucket.s3.amazonaws.com/report.pdf?...`
4. They retry the same file with a URL that has no dot in the query and it succeeds, so the failure reads as flaky

After: the same request is accepted, because the type is read from the path

1. They upload `report.pdf` to S3 and get back the same presigned URL ending `?...&X-Amz-Expires=3.6`
2. They send the same POST `https://litellm-domain/v1/chat/completions` with that URL as a document part
3. The document is recognised as `application/pdf` and the call returns a normal completion
4. Removing the dot from the query changes nothing, because the query is no longer read

## Relevant issues

None open that I could find. I searched `infer_content_type_from_url_and_content` across issues and PRs; the only hit is closed #24900, a different mismatch on the Anthropic path.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

I cannot give the live-proxy, real-spend proof this section asks for: I have no provider credentials to hit Bedrock with, and I am not able to make paid calls. What follows is the closest honest substitute, exercising the real function directly. Captured at `185c32e8`; the "before" numbers are the same commit with only `common_utils.py` reverted.

```
$ python3 -c "from litellm.litellm_core_utils.prompt_templates.common_utils import \
    infer_content_type_from_url_and_content as f; ..."

                                                          before              after
https://bucket.s3.amazonaws.com/report.pdf                 application/pdf    application/pdf
https://bucket.s3.amazonaws.com/report.pdf?v=1             application/pdf    application/pdf
https://bucket.s3.amazonaws.com/report.pdf?v=1.0           ValueError         application/pdf
https://bucket.s3.amazonaws.com/data.csv?X-Amz-Expires=3.6 ValueError         text/csv
https://cdn.example.com/page.html?cb=1.2.3                 ValueError         text/html
```

The caller that turns this into a user-visible failure is `BedrockImageProcessor._post_call_image_processing` in `prompt_templates/factory.py`. Images usually survive because `get_image_type()` recognises their magic bytes; PDFs, CSVs, HTML and Office documents have no such fallback, so they raise.

## Type

🐛 Bug Fix

## Caveats (if any)

- Pre-existing unrelated failure in the same directory, see below
- No live-proxy proof: no provider credentials available

## Tests

`TestInferContentTypeQueryString`, six cases, in the module's existing test file.

```
                                                       before        after
TestInferContentTypeQueryString                        3 failed      6 passed
                                                       3 passed
```

The three that pass either way are deliberate: they pin the no-query and dot-free-query cases the change could have broken, plus a case that must still raise when there is genuinely nothing to infer from.

Whole directory, `pytest tests/test_litellm/litellm_core_utils/prompt_templates/`: **196 passed / 1 failed** on a clean tree and **196 passed / 1 failed** with this change (new tests deselected for the comparison), so this introduces no regression.

That one pre-existing failure is `test_bedrock_converse_messages_pt_document_various_formats`, and it is a **different** bug in the opposite direction: `get_file_extension_from_mime_type` has no entry for `text/markdown` even though `md` is in its own supported list, so it raises `No supported extensions for MIME type: text/markdown. Supported formats: [... 'md']`. I have left it alone to keep this PR to one problem, but flagging it since it sits in the adjacent code.

`ruff check` reports the same 15 findings before and after on both touched files.
