### PR TITLE
fix(anthropic): dedup trailing /v1 in api_base before appending /v1/messages

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -225,8 +225,6 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         stream: bool | None = None,
     ) -> str:
         api_base = AnthropicModelInfo.get_api_base(api_base) or "https://api.anthropic.com"
-        # Normalize like OpenAILikeAnthropicMessagesConfig: an api_base that
-        # already ends in /v1 must not become /v1/v1/messages.
         base = api_base.rstrip("/")
         if base.endswith("/v1/messages"):
             return base

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -225,9 +225,13 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         stream: bool | None = None,
     ) -> str:
         api_base = AnthropicModelInfo.get_api_base(api_base) or "https://api.anthropic.com"
-        if not api_base.endswith("/v1/messages"):
-            api_base = f"{api_base}/v1/messages"
-        return api_base
+        # Normalize like OpenAILikeAnthropicMessagesConfig: an api_base that
+        # already ends in /v1 must not become /v1/v1/messages.
+        base = api_base.rstrip("/")
+        if base.endswith("/v1/messages"):
+            return base
+        base = base.removesuffix("/v1")
+        return f"{base}/v1/messages"
 
     def validate_anthropic_messages_environment(
         self,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_get_complete_url.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_get_complete_url.py
@@ -13,24 +13,20 @@ def config() -> AnthropicMessagesConfig:
 @pytest.mark.parametrize(
     "api_base, expected",
     [
-        # default when no api_base is configured
         (None, "https://api.anthropic.com/v1/messages"),
-        # bases without a version suffix
         ("https://host", "https://host/v1/messages"),
         ("https://host/", "https://host/v1/messages"),
-        # bases that already carry /v1 must not become /v1/v1/messages
         ("https://host/v1", "https://host/v1/messages"),
         ("https://host/v1/", "https://host/v1/messages"),
         ("https://api.groq.com/openai/v1", "https://api.groq.com/openai/v1/messages"),
-        # full endpoint passes through untouched
         ("https://host/v1/messages", "https://host/v1/messages"),
-        # provider-prefixed path segments are preserved
         ("https://gateway.example.com/anthropic", "https://gateway.example.com/anthropic/v1/messages"),
         ("https://gateway.example.com/anthropic/v1", "https://gateway.example.com/anthropic/v1/messages"),
     ],
 )
 def test_get_complete_url_deduplicates_trailing_v1(config, api_base, expected, monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_BASE", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
     url = config.get_complete_url(
         api_base=api_base,
         api_key="sk-test",

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_get_complete_url.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_get_complete_url.py
@@ -1,0 +1,41 @@
+import pytest
+
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+    AnthropicMessagesConfig,
+)
+
+
+@pytest.fixture
+def config() -> AnthropicMessagesConfig:
+    return AnthropicMessagesConfig()
+
+
+@pytest.mark.parametrize(
+    "api_base, expected",
+    [
+        # default when no api_base is configured
+        (None, "https://api.anthropic.com/v1/messages"),
+        # bases without a version suffix
+        ("https://host", "https://host/v1/messages"),
+        ("https://host/", "https://host/v1/messages"),
+        # bases that already carry /v1 must not become /v1/v1/messages
+        ("https://host/v1", "https://host/v1/messages"),
+        ("https://host/v1/", "https://host/v1/messages"),
+        ("https://api.groq.com/openai/v1", "https://api.groq.com/openai/v1/messages"),
+        # full endpoint passes through untouched
+        ("https://host/v1/messages", "https://host/v1/messages"),
+        # provider-prefixed path segments are preserved
+        ("https://gateway.example.com/anthropic", "https://gateway.example.com/anthropic/v1/messages"),
+        ("https://gateway.example.com/anthropic/v1", "https://gateway.example.com/anthropic/v1/messages"),
+    ],
+)
+def test_get_complete_url_deduplicates_trailing_v1(config, api_base, expected, monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_BASE", raising=False)
+    url = config.get_complete_url(
+        api_base=api_base,
+        api_key="sk-test",
+        model="claude-sonnet-4-5",
+        optional_params={},
+        litellm_params={},
+    )
+    assert url == expected


### PR DESCRIPTION
## TLDR

Problem this solves:

- `api_base` ending in `/v1` produced `/v1/v1/messages` → provider 404
- Only the Anthropic messages config lacked the trailing-`/v1` dedup

How it solves it:

- Mirror `openai_like`/`deepseek` normalization: strip trailing `/v1` before appending
- Add parametrized URL tests matching the `openai_like` test table

## User Flow

Before: a developer pointing an `anthropic/`-prefixed model at an Anthropic-compatible gateway whose root ends in `/v1` gets a 404 on every call

1. They configure a model with `api_base: https://gateway.example.com/anthropic/v1` and send POST https://litellm-domain/v1/messages
2. The gateway replies 404 not_found — the request landed on `.../anthropic/v1/v1/messages`
3. The same `api_base` works fine when the model uses an `openai_like` route, which makes the failure look provider-specific

After: the same config works

1. They configure the same model with the same `api_base: https://gateway.example.com/anthropic/v1` and send POST https://litellm-domain/v1/messages
2. The request lands on `.../anthropic/v1/messages` and returns the model's response
3. Bases with or without `/v1`, with trailing slashes, or already ending in `/v1/messages` all resolve to the same correct endpoint

## Relevant issues

Fixes #36956
Real-world report: #36651 (Claude Code → LiteLLM → Groq/NIM, misconfigured `anthropic/` entries surface exactly this shape)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live request against the real Anthropic API through `anthropic_messages()` with `api_base="https://api.anthropic.com/v1"` (a base that already ends in `/v1`), debug logging on. No mocks — the outbound URL is what LiteLLM actually sent.

Before (`b77923fc8`, current main):

```
POST Request Sent from LiteLLM:
curl -X POST \
https://api.anthropic.com/v1/v1/messages \
```

After (`d0a63b472`, this PR):

```
POST Request Sent from LiteLLM:
curl -X POST \
https://api.anthropic.com/v1/messages \
```

(Anthropic's gateway authenticates before routing, so both requests return `authentication_error` with a throwaway key — the URL line is the discriminating evidence; against gateways that route first, the before-shape is a hard 404 as reported in #36651.)

Tests: `pytest tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_get_complete_url.py` — 9 passed (parametrized over no-base default, `/v1`, `/v1/`, full `/v1/messages`, and provider-prefixed bases); the full `experimental_pass_through` suite shows no new failures vs. unpatched main.

## Type

🐛 Bug Fix
