### PR TITLE
fix(cost): apply a deployment's pricing override to realtime sessions

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1594,6 +1594,7 @@ def completion_cost(
                         litellm_model_name=model,
                         data_residency=data_residency,
                         litellm_logging_obj=litellm_logging_obj,
+                        custom_pricing_model=selected_model if custom_pricing else None,
                     )
                 elif call_type == _MCP_CALL_TYPE:
                     from litellm.proxy._experimental.mcp_server.cost_calculator import (
@@ -2522,6 +2523,7 @@ def handle_realtime_stream_cost_calculation(
     litellm_model_name: str,
     data_residency: str | None = None,
     litellm_logging_obj: LitellmLoggingObject | None = None,
+    custom_pricing_model: str | None = None,
 ) -> float:
     """
     Handles the cost calculation for realtime stream responses.
@@ -2530,9 +2532,11 @@ def handle_realtime_stream_cost_calculation(
 
     Args:
         results: A list of OpenAIRealtimeStreamBaseObject objects
+        custom_pricing_model: deployment-scoped pricing key, tried ahead of the
+            model the session reported so a config override is not ignored
     """
     received_model = None
-    potential_model_names: Final = []
+    potential_model_names: Final = [custom_pricing_model]
     for result in results:
         if result["type"] == "session.created":
             received_model = cast(OpenAIRealtimeStreamSessionEvents, result)["session"].get("model", None)
@@ -2550,6 +2554,7 @@ def handle_realtime_stream_cost_calculation(
             results=results,
             custom_llm_provider=custom_llm_provider,
             litellm_model_name=litellm_model_name,
+            custom_pricing_model=custom_pricing_model,
         )
         if any(r.get("type") == _TRANSCRIPTION_COMPLETED_EVENT_TYPE for r in results)
         else 0.0
@@ -2573,6 +2578,7 @@ def handle_realtime_transcription_cost_calculation(
     results: OpenAIRealtimeStreamList,
     custom_llm_provider: str,
     litellm_model_name: str,
+    custom_pricing_model: str | None = None,
 ) -> float:
     """
     Cost for realtime transcription sessions (e.g. gpt-realtime-whisper).
@@ -2590,15 +2596,15 @@ def handle_realtime_transcription_cost_calculation(
         return 0.0
 
     model_name: Final = _get_transcription_model_name_from_results(results) or litellm_model_name
-    try:
-        model_info = litellm.get_model_info(model=model_name, custom_llm_provider=custom_llm_provider)
-    except Exception:
-        model_info = None
+    model_info: Final = _get_model_info_or_none(model_name, custom_llm_provider)
+    override_info: Final = (
+        _get_model_info_or_none(custom_pricing_model, custom_llm_provider) if custom_pricing_model is not None else None
+    )
 
     total_cost = 0.0
     for event in completed_events:
         usage = event.get("usage") or {}
-        total_cost += _transcription_usage_cost(usage, model_info)
+        total_cost += _transcription_usage_cost(usage, model_info, override_info)
     return total_cost
 
 
@@ -2623,23 +2629,60 @@ def _get_transcription_model_name_from_results(
     return None
 
 
-def _transcription_usage_cost(usage: dict, model_info: ModelInfo | None) -> float:
-    if model_info is None:
+def _get_model_info_or_none(model: str, custom_llm_provider: str) -> ModelInfo | None:
+    """``get_model_info`` for a key that may not be in the cost map."""
+    try:
+        return litellm.get_model_info(model=model, custom_llm_provider=custom_llm_provider)
+    except Exception:
+        return None
+
+
+def _transcription_rate(keys: tuple[str, ...], override: ModelInfo | None, base: ModelInfo | None) -> float:
+    """First rate set for any of ``keys``, resolving within one entry before the next.
+
+    The deployment override is consulted as a whole entry first, so an override that
+    prices only tokens applies its token rate to audio rather than reaching past itself
+    for the public audio rate. Rates the override leaves unset fall through to ``base``,
+    because replacing it outright would bill those at nothing.
+
+    Presence is tested with ``is not None`` rather than truthiness, so a deliberate zero
+    wins instead of falling through to a public rate.
+    """
+    for info in (override, base):
+        if info is None:
+            continue
+        for key in keys:
+            value = info.get(key)
+            if value is not None:
+                return float(value)
+    return 0.0
+
+
+def _transcription_usage_cost(
+    usage: dict,
+    model_info: ModelInfo | None,
+    override_info: ModelInfo | None = None,
+) -> float:
+    if model_info is None and override_info is None:
         return 0.0
+
     usage_type: Final = usage.get("type")
     if usage_type == "duration":
         seconds: Final = usage.get("seconds") or 0.0
-        per_second: Final = model_info.get("input_cost_per_second") or 0.0
-        return float(seconds) * float(per_second)
+        return float(seconds) * _transcription_rate(("input_cost_per_second",), override_info, model_info)
     if usage_type == "tokens":
         input_token_details: Final = usage.get("input_token_details") or {}
         audio_tokens: Final = input_token_details.get("audio_tokens") or 0
         text_tokens: Final = input_token_details.get("text_tokens") or 0
         output_tokens: Final = usage.get("output_tokens") or 0
-        audio_cost: Final = float(audio_tokens) * float(
-            model_info.get("input_cost_per_audio_token") or model_info.get("input_cost_per_token") or 0.0
+        audio_cost: Final = float(audio_tokens) * _transcription_rate(
+            ("input_cost_per_audio_token", "input_cost_per_token"), override_info, model_info
         )
-        text_cost: Final = float(text_tokens) * float(model_info.get("input_cost_per_token") or 0.0)
-        output_cost: Final = float(output_tokens) * float(model_info.get("output_cost_per_token") or 0.0)
+        text_cost: Final = float(text_tokens) * _transcription_rate(
+            ("input_cost_per_token",), override_info, model_info
+        )
+        output_cost: Final = float(output_tokens) * _transcription_rate(
+            ("output_cost_per_token",), override_info, model_info
+        )
         return audio_cost + text_cost + output_cost
     return 0.0

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -2637,25 +2637,37 @@ def _get_model_info_or_none(model: str, custom_llm_provider: str) -> ModelInfo |
         return None
 
 
+def _declared_transcription_rate(info: ModelInfo | None, keys: tuple[str, ...]) -> float | None:
+    """First of ``keys`` this entry actually prices, or ``None`` if it prices none of them.
+
+    Whether a rate was set is read off the raw ``litellm.model_cost`` entry rather than off
+    ``info``, because ``get_model_info`` defaults ``input_cost_per_token`` and
+    ``output_cost_per_token`` to 0 for entries that omit them. Those synthesized zeros are
+    indistinguishable from a deliberate zero, so reading presence off ``info`` bills an override
+    that prices only seconds at nothing instead of falling through to the public token rates.
+    """
+    if info is None:
+        return None
+    declared: Final = litellm.model_cost.get(info.get("key"))
+    if declared is None:
+        return None
+    return next(
+        (float(value) for key in keys if declared.get(key) is not None and (value := info.get(key)) is not None),
+        None,
+    )
+
+
 def _transcription_rate(keys: tuple[str, ...], override: ModelInfo | None, base: ModelInfo | None) -> float:
     """First rate set for any of ``keys``, resolving within one entry before the next.
 
     The deployment override is consulted as a whole entry first, so an override that
     prices only tokens applies its token rate to audio rather than reaching past itself
-    for the public audio rate. Rates the override leaves unset fall through to ``base``,
-    because replacing it outright would bill those at nothing.
-
-    Presence is tested with ``is not None`` rather than truthiness, so a deliberate zero
-    wins instead of falling through to a public rate.
+    for the public audio rate, and a rate it deliberately sets to zero wins. Rates the
+    override leaves unset fall through to ``base``, because replacing it outright would
+    bill those at nothing.
     """
-    for info in (override, base):
-        if info is None:
-            continue
-        for key in keys:
-            value = info.get(key)
-            if value is not None:
-                return float(value)
-    return 0.0
+    rates: Final = (_declared_transcription_rate(info, keys) for info in (override, base))
+    return next((rate for rate in rates if rate is not None), 0.0)
 
 
 def _transcription_usage_cost(

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -2476,7 +2476,16 @@ def _candidate_realtime_token_costs(
 
 
 def _cost_map_entry_declares_pricing(model_name: str, custom_llm_provider: str) -> bool:
+    """Whether the entry behind ``model_name`` sets any rate of its own, even a zero one.
+
+    The name is resolved the way ``get_model_info`` resolves it before the raw entry is read,
+    because a deployment-scoped name arrives here already carrying its provider prefix. Two raw
+    lookups cannot strip that prefix, so a zero-rated override read as declaring nothing, and a
+    session that should bill nothing fell through to the public rates instead.
+    """
+    resolved: Final = _get_model_info_or_none(model_name, custom_llm_provider)
     entries: Final = (
+        litellm.model_cost.get(resolved.get("key")) if resolved is not None else None,
         litellm.model_cost.get(model_name),
         litellm.model_cost.get(f"{custom_llm_provider}/{model_name}"),
     )

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -955,35 +955,119 @@ def test_realtime_transcription_partial_override_keeps_unset_rates(monkeypatch):
 @pytest.mark.parametrize(
     "label,override,expected_audio_rate,expected_per_second",
     [
-        # base is the public ASR entry: audio 6e-06, token 2.5e-06, per-second 0.017/60
         ("tokens only", {"input_cost_per_token": 0.0}, 0.0, 0.017 / 60),
         ("audio zeroed", {"input_cost_per_audio_token": 0.0}, 0.0, 0.017 / 60),
+        ("per second only", {"input_cost_per_second": 0.001}, 6e-06, 0.001),
         ("empty override", {}, 6e-06, 0.017 / 60),
         ("no override", None, 6e-06, 0.017 / 60),
     ],
 )
-def test_transcription_rate_precedence(label, override, expected_audio_rate, expected_per_second):
+def test_transcription_rate_precedence(monkeypatch, label, override, expected_audio_rate, expected_per_second):
     """Rates resolve within one entry before moving to the next, and zero is a real value.
 
     An override that prices only tokens must apply its own token rate to audio rather
-    than reaching past itself for the public audio rate, and a deliberate zero must win
-    instead of being treated as unset.
+    than reaching past itself for the public audio rate, a deliberate zero must win
+    instead of being treated as unset, and a rate the override never mentions must keep
+    the base entry's value.
     """
-    from litellm.cost_calculator import _transcription_rate
+    from litellm.cost_calculator import handle_realtime_transcription_cost_calculation
 
-    base = {
-        "input_cost_per_audio_token": 6e-06,
-        "input_cost_per_token": 2.5e-06,
-        "input_cost_per_second": 0.017 / 60,
-    }
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
 
-    audio_rate = _transcription_rate(("input_cost_per_audio_token", "input_cost_per_token"), override, base)
-    assert audio_rate == pytest.approx(expected_audio_rate, rel=1e-9), f"{label}: audio rate"
+    base_model = "asr-precedence-base"
+    deployment_id = "asr-precedence-deployment"
+    litellm.register_model(
+        model_cost={
+            base_model: {
+                "litellm_provider": "openai",
+                "mode": "audio_transcription",
+                "input_cost_per_audio_token": 6e-06,
+                "input_cost_per_token": 2.5e-06,
+                "input_cost_per_second": 0.017 / 60,
+            }
+        }
+    )
+    if override is not None:
+        litellm.register_model(
+            model_cost={deployment_id: {"litellm_provider": "openai", "mode": "audio_transcription", **override}}
+        )
 
-    per_second = _transcription_rate(("input_cost_per_second",), override, base)
-    assert per_second == pytest.approx(expected_per_second, rel=1e-9), (
+    def cost_for(usage: dict) -> float:
+        return handle_realtime_transcription_cost_calculation(
+            results=[
+                {"type": "transcription_session.created", "session": {"model": base_model}},
+                {"type": "conversation.item.input_audio_transcription.completed", "usage": usage},
+            ],
+            custom_llm_provider="openai",
+            litellm_model_name=base_model,
+            custom_pricing_model=deployment_id if override is not None else None,
+        )
+
+    audio_cost = cost_for({"type": "tokens", "input_token_details": {"audio_tokens": 100}})
+    assert audio_cost == pytest.approx(100 * expected_audio_rate, rel=1e-9), f"{label}: audio rate"
+
+    per_second_cost = cost_for({"type": "duration", "seconds": 120.0})
+    assert per_second_cost == pytest.approx(120.0 * expected_per_second, rel=1e-9), (
         f"{label}: an override must never blank a rate it does not set"
     )
+
+
+def test_realtime_transcription_per_second_override_keeps_public_token_rates(monkeypatch):
+    """A per-second override must not zero the token rates ``get_model_info`` synthesizes.
+
+    ``get_model_info`` defaults input_cost_per_token and output_cost_per_token to 0 for entries
+    that omit them, so a deployment priced only per second looked like it had declared token
+    rates of 0. Token-shaped transcription then billed nothing instead of falling through to the
+    public ASR rates, while the per-second rate the operator did set stayed in force.
+    """
+    from litellm.cost_calculator import handle_realtime_transcription_cost_calculation
+
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    asr_model = "gpt-4o-transcribe"
+    per_second_rate = 0.001
+    deployment_id = "deployment-hash-per-second-only"
+    litellm.register_model(
+        model_cost={
+            deployment_id: {
+                "litellm_provider": "openai",
+                "mode": "audio_transcription",
+                "input_cost_per_second": per_second_rate,
+            }
+        }
+    )
+
+    public = litellm.model_cost[asr_model]
+    session_event = {"type": "transcription_session.created", "session": {"model": asr_model}}
+
+    def cost_for(usage: dict) -> float:
+        return handle_realtime_transcription_cost_calculation(
+            results=[session_event, {"type": "conversation.item.input_audio_transcription.completed", "usage": usage}],
+            custom_llm_provider="openai",
+            litellm_model_name=asr_model,
+            custom_pricing_model=deployment_id,
+        )
+
+    token_cost = cost_for(
+        {
+            "type": "tokens",
+            "input_token_details": {"audio_tokens": 400, "text_tokens": 12},
+            "output_tokens": 30,
+        }
+    )
+    expected_token_cost = (
+        400 * public["input_cost_per_audio_token"]
+        + 12 * public["input_cost_per_token"]
+        + 30 * public["output_cost_per_token"]
+    )
+    assert expected_token_cost > 0, "the public ASR token rates must be non-zero for this test to mean anything"
+    assert token_cost == pytest.approx(expected_token_cost, rel=1e-9), (
+        "an override that prices only seconds must leave the public token rates in place"
+    )
+
+    assert cost_for({"type": "duration", "seconds": 120.0}) == pytest.approx(120.0 * per_second_rate, rel=1e-9)
 
 
 def test_realtime_transcription_no_completed_events_is_zero(monkeypatch):

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -4939,3 +4939,109 @@ def test_realtime_honours_deployment_custom_pricing(monkeypatch):
         custom_pricing_model=deployment_key,
     )
     assert zero_rated_cost == 0.0
+
+
+def test_realtime_honours_a_provider_prefixed_zero_rated_deployment(monkeypatch):
+    """Regression: the override arrived provider-prefixed and was read as pricing nothing.
+
+    `_select_model_name_for_cost_calc` hands back `<provider>/<model_id>`, so the name reaching
+    the pricing guard carries a prefix the raw cost-map lookups cannot strip. The rates resolved
+    correctly through `get_model_info`, then the guard rejected them as undeclared and the session
+    billed the public rates. A zero-rated deployment must stay at zero however its name arrives.
+    """
+    from litellm.types.utils import CompletionTokensDetailsWrapper
+
+    model = "gemini-live-2.5-flash-native-audio"
+    deployment_key = "deployment-id-for-a-prefixed-zero-rated-realtime-group"
+    paid = litellm.model_cost[model]
+    monkeypatch.setitem(
+        litellm.model_cost,
+        deployment_key,
+        {
+            **paid,
+            "input_cost_per_token": 0.0,
+            "output_cost_per_token": 0.0,
+            "input_cost_per_audio_token": 0.0,
+            "output_cost_per_audio_token": 0.0,
+        },
+    )
+
+    results: OpenAIRealtimeStreamList = [
+        {"type": "session.created", "session": {"model": model}},
+        {
+            "type": "response.done",
+            "response": {"usage": {"input_tokens": 219, "output_tokens": 81, "total_tokens": 300}},
+        },
+    ]
+    usage = Usage(
+        prompt_tokens=219,
+        completion_tokens=81,
+        total_tokens=300,
+        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=16, audio_tokens=203),
+        completion_tokens_details=CompletionTokensDetailsWrapper(text_tokens=23, audio_tokens=58),
+    )
+
+    paid_cost = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=usage,
+        custom_llm_provider="vertex_ai",
+        litellm_model_name=model,
+    )
+    assert paid_cost > 0
+
+    zero_rated_cost = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=usage,
+        custom_llm_provider="vertex_ai",
+        litellm_model_name=model,
+        custom_pricing_model=f"vertex_ai/{deployment_key}",
+    )
+    assert zero_rated_cost == 0.0
+
+
+def test_unpriced_deployment_entry_still_falls_through_to_the_session_model(monkeypatch):
+    """The guard's own purpose must survive: an entry that prices nothing is not an override.
+
+    Deployments are auto-registered under their model_id with no rates at all, and those must
+    keep billing at the session model's public rates rather than silently costing nothing.
+    """
+    from litellm.types.utils import CompletionTokensDetailsWrapper
+
+    model = "gemini-live-2.5-flash-native-audio"
+    deployment_key = "deployment-id-with-no-declared-rates"
+    monkeypatch.setitem(
+        litellm.model_cost,
+        deployment_key,
+        {key: value for key, value in litellm.model_cost[model].items() if "cost_per" not in key},
+    )
+
+    results: OpenAIRealtimeStreamList = [
+        {"type": "session.created", "session": {"model": model}},
+        {
+            "type": "response.done",
+            "response": {"usage": {"input_tokens": 219, "output_tokens": 81, "total_tokens": 300}},
+        },
+    ]
+    usage = Usage(
+        prompt_tokens=219,
+        completion_tokens=81,
+        total_tokens=300,
+        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=16, audio_tokens=203),
+        completion_tokens_details=CompletionTokensDetailsWrapper(text_tokens=23, audio_tokens=58),
+    )
+
+    with_unpriced_override = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=usage,
+        custom_llm_provider="vertex_ai",
+        litellm_model_name=model,
+        custom_pricing_model=f"vertex_ai/{deployment_key}",
+    )
+    without_override = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=usage,
+        custom_llm_provider="vertex_ai",
+        litellm_model_name=model,
+    )
+    assert with_unpriced_override == pytest.approx(without_override, rel=1e-9)
+    assert with_unpriced_override > 0

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -842,6 +842,150 @@ def test_realtime_transcription_duration_cost_resolves_model_from_litellm_name(
     assert abs(cost - 120.0 * (0.017 / 60)) < 1e-9
 
 
+def test_realtime_transcription_honors_deployment_pricing_override(monkeypatch):
+    """A deployment's pricing override must reach transcription events too.
+
+    Transcription is billed separately from response usage inside the same realtime
+    session, so a deployment registered at zero rates has to zero both. Resolving
+    transcription against the public ASR model instead billed a zero-rated
+    deployment for every .completed event.
+    """
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    deployment_id = "deployment-hash-zero-rated-asr"
+    litellm.register_model(
+        model_cost={
+            deployment_id: {
+                "litellm_provider": "openai",
+                "mode": "realtime",
+                "input_cost_per_second": 0.0,
+                "input_cost_per_token": 0.0,
+                "output_cost_per_token": 0.0,
+                "input_cost_per_audio_token": 0.0,
+            }
+        }
+    )
+
+    results: OpenAIRealtimeStreamList = [
+        {
+            "type": "session.created",
+            "session": {
+                "type": "transcription",
+                "audio": {"input": {"transcription": {"model": "gpt-realtime-whisper"}}},
+            },
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "usage": {"type": "duration", "seconds": 120.0},
+        },
+    ]
+
+    public_rate_cost = 120.0 * (0.017 / 60)
+    assert public_rate_cost > 0, "the public ASR rate must be non-zero for this test to mean anything"
+
+    without_override = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=Usage(),
+        custom_llm_provider="openai",
+        litellm_model_name="gpt-realtime-whisper",
+    )
+    assert abs(without_override - public_rate_cost) < 1e-9
+
+    with_override = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=Usage(),
+        custom_llm_provider="openai",
+        litellm_model_name="gpt-realtime-whisper",
+        custom_pricing_model=deployment_id,
+    )
+    assert with_override == 0.0, "the zero-rated deployment must not be billed for transcription"
+
+
+def test_realtime_transcription_partial_override_keeps_unset_rates(monkeypatch):
+    """An override must not blank the rates it does not set.
+
+    A deployment that prices tokens but omits input_cost_per_second would otherwise
+    bill duration-based transcription at nothing, because the cost helpers read
+    `.get(key) or 0.0`. Only the fields the operator actually set may win.
+    """
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    deployment_id = "deployment-hash-tokens-only"
+    litellm.register_model(
+        model_cost={
+            deployment_id: {
+                "litellm_provider": "openai",
+                "mode": "realtime",
+                "input_cost_per_token": 0.0,
+                "output_cost_per_token": 0.0,
+            }
+        }
+    )
+
+    results: OpenAIRealtimeStreamList = [
+        {
+            "type": "session.created",
+            "session": {
+                "type": "transcription",
+                "audio": {"input": {"transcription": {"model": "gpt-realtime-whisper"}}},
+            },
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "usage": {"type": "duration", "seconds": 120.0},
+        },
+    ]
+
+    cost = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=Usage(),
+        custom_llm_provider="openai",
+        litellm_model_name="gpt-realtime-whisper",
+        custom_pricing_model=deployment_id,
+    )
+
+    expected = 120.0 * (0.017 / 60)
+    assert cost == pytest.approx(expected, rel=1e-9), (
+        "duration must keep the ASR per-second rate the override left unset"
+    )
+
+
+@pytest.mark.parametrize(
+    "label,override,expected_audio_rate,expected_per_second",
+    [
+        # base is the public ASR entry: audio 6e-06, token 2.5e-06, per-second 0.017/60
+        ("tokens only", {"input_cost_per_token": 0.0}, 0.0, 0.017 / 60),
+        ("audio zeroed", {"input_cost_per_audio_token": 0.0}, 0.0, 0.017 / 60),
+        ("empty override", {}, 6e-06, 0.017 / 60),
+        ("no override", None, 6e-06, 0.017 / 60),
+    ],
+)
+def test_transcription_rate_precedence(label, override, expected_audio_rate, expected_per_second):
+    """Rates resolve within one entry before moving to the next, and zero is a real value.
+
+    An override that prices only tokens must apply its own token rate to audio rather
+    than reaching past itself for the public audio rate, and a deliberate zero must win
+    instead of being treated as unset.
+    """
+    from litellm.cost_calculator import _transcription_rate
+
+    base = {
+        "input_cost_per_audio_token": 6e-06,
+        "input_cost_per_token": 2.5e-06,
+        "input_cost_per_second": 0.017 / 60,
+    }
+
+    audio_rate = _transcription_rate(("input_cost_per_audio_token", "input_cost_per_token"), override, base)
+    assert audio_rate == pytest.approx(expected_audio_rate, rel=1e-9), f"{label}: audio rate"
+
+    per_second = _transcription_rate(("input_cost_per_second",), override, base)
+    assert per_second == pytest.approx(expected_per_second, rel=1e-9), (
+        f"{label}: an override must never blank a rate it does not set"
+    )
+
+
 def test_realtime_transcription_no_completed_events_is_zero(monkeypatch):
     """A realtime stream without transcription completed events adds no extra cost."""
     monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
@@ -4645,3 +4789,69 @@ def test_collect_and_combine_realtime_usage_stores_partitioned_text_tokens() -> 
     assert combined.completion_tokens_details.reasoning_tokens == 95
     assert combined.completion_tokens_details.text_tokens == 38
     assert combined.completion_tokens_details.audio_tokens == 0
+
+
+def test_realtime_honours_deployment_custom_pricing(monkeypatch):
+    """Regression: a deployment's pricing override never reached realtime costing.
+
+    `model_info` overrides are registered under the deployment's own model_id, and
+    only `_select_model_name_for_cost_calc` knows to look there. The realtime branch
+    discarded that result and priced by the model the session reported, so a config
+    that zeroes a realtime deployment was billed at the public rate anyway. Audio is
+    the bulk of a voice call, so the gap was most of the cost.
+    """
+    from litellm.types.utils import CompletionTokensDetailsWrapper
+
+    model = "gemini-3.1-flash-live-preview"
+    deployment_key = "deployment-id-for-a-zero-rated-realtime-group"
+    paid = litellm.model_cost[model]
+    monkeypatch.setitem(
+        litellm.model_cost,
+        deployment_key,
+        {
+            **paid,
+            "input_cost_per_token": 0.0,
+            "output_cost_per_token": 0.0,
+            "input_cost_per_audio_token": 0.0,
+            "output_cost_per_audio_token": 0.0,
+            "cache_read_input_token_cost": 0.0,
+        },
+    )
+
+    results: OpenAIRealtimeStreamList = [
+        {"type": "session.created", "session": {"model": model}},
+        {
+            "type": "response.done",
+            "response": {"usage": {"input_tokens": 10, "output_tokens": 200, "total_tokens": 210}},
+        },
+    ]
+    usage = Usage(
+        prompt_tokens=10,
+        completion_tokens=200,
+        total_tokens=210,
+        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=10, cached_tokens=0),
+        completion_tokens_details=CompletionTokensDetailsWrapper(text_tokens=20, audio_tokens=180),
+    )
+
+    paid_cost = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=usage,
+        custom_llm_provider="gemini",
+        litellm_model_name=model,
+    )
+    expected_paid = (
+        10 * paid["input_cost_per_token"]
+        + 20 * paid["output_cost_per_token"]
+        + 180 * paid["output_cost_per_audio_token"]
+    )
+    assert paid_cost == pytest.approx(expected_paid, rel=1e-9)
+    assert paid_cost > 0
+
+    zero_rated_cost = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=usage,
+        custom_llm_provider="gemini",
+        litellm_model_name=model,
+        custom_pricing_model=deployment_key,
+    )
+    assert zero_rated_cost == 0.0


### PR DESCRIPTION
## TLDR

Problem this solves:

- A realtime deployment's own pricing is ignored; the public rate bills
- So `model_info` overrides and `base_model` silently do nothing there

How it solves it:

- Pass the already-resolved cost model into the realtime branch
- Try it ahead of the model the session reported
- Cover transcription events in the same session, not just responses

## Relevant issues

Fixes #31087

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`completion_cost` resolves which model to price by through `_select_model_name_for_cost_calc`. That is what makes a deployment's `model_info` override work at all: the override is registered under the deployment's own `model_id`, and only that function knows to look there. `base_model` resolves the same way. Every other call type uses the result; the realtime branch discarded it and priced by the model the session reported, so a deployment configured with its own rates billed at the public rate anyway. This is the `base_model`/custom-pricing half of #31087.

**Before and after in one environment, only the fix differing.** A zero-rated deployment, configured the way an operator would:

```yaml
  - model_name: 'nto.gemini-live-2.5-flash-native-audio'
    model_info:
      mode: 'realtime'
      input_cost_per_token: 0.0
      output_cost_per_token: 0.0
      input_cost_per_audio_token: 0.0
      output_cost_per_audio_token: 0.0
      cache_read_input_token_cost: 0.0
    litellm_params:
      model: 'vertex_ai/gemini-live-2.5-flash-native-audio'
```

Real voice sessions through `/v1/realtime`, spend read back from `/spend/logs/v2`:

```
with the fix        16/61 tokens   $0.00000000
fix reverted        16/70 tokens   $0.00078800
```

Both runs used the same container, config and credentials; the second had only the two added lines removed from the mounted source. The zero-rated deployment bills the public rate without the fix.

**And on a live gateway**, which gives a cleaner control because two deployments of the *same* model landed on identical token counts. Commit `f0865c428b`:

```
  gemini-live-2.5-flash-native-audio         16/55 tokens   $0.00060800   BILLED
  nto.gemini-live-2.5-flash                  16/30 tokens   $0.00000000   ZERO-RATED
  nto.gemini-live-2.5-flash-native-audio     16/64 tokens   $0.00000000   ZERO-RATED
  gemini-live-2.5-flash                      16/30 tokens   $0.00031800   BILLED
```

`nto.gemini-live-2.5-flash` and `gemini-live-2.5-flash` are the same upstream model at the same 16/30 tokens. One is zero-rated and the other bills, which is the config being honoured rather than a pricing coincidence.

Worth noting why the gap was expensive rather than a rounding difference: on a voice session, output audio is the great majority of the cost, so "the override is ignored" meant close to the whole bill.

**The transcription half has no live run, and here is exactly why.** Review pointed out that transcription events resolved against the public ASR model, bypassing the override. That is real and now fixed, but it cannot be demonstrated on the deployment used above. Gemini Live does emit the event the cost path keys off, so the path is reached:

```
{
  "type": "conversation.item.input_audio_transcription.completed",
  "transcript": "Hello. What is the tallest waterfall in Ithaca, New York?",
  "item_id": "item_8b991e13",
  "content_index": 0
}
```

There is no `usage` object on it, so the path prices to $0.00000000 with or without an override; Gemini bills that audio through the session's input audio tokens instead (151 of them on this session). Feeding that verbatim event through the function both ways returns zero both times.

Being explicit about what that means for correctness: on Gemini Live the transcription amount is right today, because the audio is already priced through the session's input audio tokens and a separate charge would double-bill.

Demonstrating the override changing a transcription amount therefore needs a deployment whose `.completed` events carry `usage`, which is the realtime-whisper shape (`{"type": "duration", "seconds": N}`) this file already prices. The gateway used above serves batch `/v1/audio/transcriptions` models only. So that half rests on a regression test that bills the same 120-second duration event twice, once against the public entry at $0.034 and once against a zero-rated deployment at $0.00, and fails if the override is dropped or ordered last. The event shape itself is this file's pre-existing assumption rather than something I re-verified against a live OpenAI session, which is worth a reviewer's eye.

## Type

🐛 Bug Fix

## Changes

`handle_realtime_stream_cost_calculation` takes an optional `custom_pricing_model` and tries it ahead of the model the session reported. `completion_cost` passes the `selected_model` it already computed, when `custom_pricing` is set.

`handle_realtime_transcription_cost_calculation` takes the same argument, since transcription is billed separately from response usage inside one realtime session. Raised by review on this PR.

Precedence there is resolved per rate rather than per entry. Picking the override entry outright would turn every rate it leaves unset into zero, because the cost helpers read `.get(key) or 0.0`, so a deployment that prices only tokens would have billed duration-based transcription at nothing. That was a second review finding and it was a real regression in the first revision of this PR. Now each rate takes the override's value when the override sets one and the session's ASR rate otherwise, with a test for a token-only override that must keep the ASR per-second rate.

The override is simply the first entry in the candidate list `_first_priced_realtime_token_costs` already walks, so that helper and its zero-rate handling are untouched. Rebasing onto current staging turned out to help here rather than hurt: that helper accepts a candidate whose rates sum to zero as long as its cost-map entry declares pricing, which is exactly the condition a deliberately zero-rated deployment override satisfies. An earlier revision of this PR reinstated an inline loop in place of the helper, and this one no longer does.

With `custom_pricing` false the argument is `None` and the existing path is unchanged, so no non-realtime call type and no realtime call without an override behaves differently.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR



