### PR TITLE
fix(ui): keep the cost tracking removal confirmation open until it settles

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/_components/cost_tracking_settings.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/_components/cost_tracking_settings.test.tsx
@@ -199,12 +199,8 @@ describe("CostTrackingSettings", () => {
 
     it("should hold the confirmation open while the removal is still in flight", async () => {
       mockDiscountConfig.mockReturnValue({ openai: 0.05 });
-      let settleRemoval: () => void = () => {};
-      mockRemoveDiscount.mockReturnValue(
-        new Promise<void>((resolve) => {
-          settleRemoval = resolve;
-        }),
-      );
+      const { promise, resolve: settleRemoval } = Promise.withResolvers<void>();
+      mockRemoveDiscount.mockReturnValue(promise);
 
       const user = await expandAndRemove("Provider Discounts", "Remove discount for openai");
       await user.click(await screen.findByRole("button", { name: "Remove" }));

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/_components/cost_tracking_settings.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/_components/cost_tracking_settings.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../../../../../tests/test-utils";
 import CostTrackingSettings from "./cost_tracking_settings";
@@ -195,6 +195,32 @@ describe("CostTrackingSettings", () => {
 
       expect(mockRemoveDiscount).not.toHaveBeenCalled();
       expect(screen.queryByRole("button", { name: "Remove" })).not.toBeInTheDocument();
+    });
+
+    it("should hold the confirmation open while the removal is still in flight", async () => {
+      mockDiscountConfig.mockReturnValue({ openai: 0.05 });
+      let settleRemoval: () => void = () => {};
+      mockRemoveDiscount.mockReturnValue(
+        new Promise<void>((resolve) => {
+          settleRemoval = resolve;
+        }),
+      );
+
+      const user = await expandAndRemove("Provider Discounts", "Remove discount for openai");
+      await user.click(await screen.findByRole("button", { name: "Remove" }));
+
+      const removing = await screen.findByRole("button", { name: "Removing…" });
+      expect(removing).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+
+      await act(async () => {
+        settleRemoval();
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+      });
+      expect(mockRemoveDiscount).toHaveBeenCalledWith("openai");
     });
 
     it("should remove the margin once removal is confirmed", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/_components/cost_tracking_settings.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/_components/cost_tracking_settings.tsx
@@ -3,7 +3,6 @@ import { ChevronDown } from "lucide-react";
 import { Modal, Form } from "antd";
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -66,6 +65,7 @@ const CostTrackingSettings: React.FC<CostTrackingSettingsProps> = ({ userID, use
   const [fixedAmountValue, setFixedAmountValue] = useState<string>("");
   const [models, setModels] = useState<string[]>([]);
   const [pendingRemoval, setPendingRemoval] = useState<PendingRemoval | null>(null);
+  const [isRemoving, setIsRemoving] = useState(false);
   const [form] = Form.useForm();
   const [marginForm] = Form.useForm();
 
@@ -131,14 +131,19 @@ const CostTrackingSettings: React.FC<CostTrackingSettingsProps> = ({ userID, use
     setPendingRemoval({ kind: "discount", provider, displayName: providerDisplayName });
   };
 
-  const handleConfirmRemoval = () => {
+  const handleConfirmRemoval = async () => {
     if (!pendingRemoval) return;
-    if (pendingRemoval.kind === "discount") {
-      removeProvider(pendingRemoval.provider);
-    } else {
-      removeMargin(pendingRemoval.provider);
+    setIsRemoving(true);
+    try {
+      if (pendingRemoval.kind === "discount") {
+        await removeProvider(pendingRemoval.provider);
+      } else {
+        await removeMargin(pendingRemoval.provider);
+      }
+    } finally {
+      setIsRemoving(false);
+      setPendingRemoval(null);
     }
-    setPendingRemoval(null);
   };
 
   const handleAddMargin = async () => {
@@ -311,7 +316,7 @@ const CostTrackingSettings: React.FC<CostTrackingSettingsProps> = ({ userID, use
       </div>
 
       {pendingRemoval && (
-        <AlertDialog open onOpenChange={(open) => !open && setPendingRemoval(null)}>
+        <AlertDialog open onOpenChange={(open) => !open && !isRemoving && setPendingRemoval(null)}>
           <AlertDialogContent>
             <AlertDialogHeader>
               <AlertDialogTitle>{REMOVAL_COPY[pendingRemoval.kind].title}</AlertDialogTitle>
@@ -321,10 +326,10 @@ const CostTrackingSettings: React.FC<CostTrackingSettingsProps> = ({ userID, use
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction variant="destructive" onClick={handleConfirmRemoval}>
-                Remove
-              </AlertDialogAction>
+              <AlertDialogCancel disabled={isRemoving}>Cancel</AlertDialogCancel>
+              <Button variant="destructive" onClick={handleConfirmRemoval} disabled={isRemoving}>
+                {isRemoving ? "Removing…" : "Remove"}
+              </Button>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>


### PR DESCRIPTION
## TLDR

Problem this solves:

- Removal confirmation closed instantly, before the request finished
- Admin got no feedback that the removal was running
- Nothing stopped them firing a second, duplicate removal

How it solves it:

- Confirm button no longer auto-closes the dialog on click
- Dialog stays open and relabels the button to "Removing…"
- Cancel and Remove both disabled until the request settles

## User Flow

Before: an admin removing a provider discount sees the confirmation vanish the instant they click Remove, with nothing on screen saying the removal is running

1. They sign in and open http://localhost:4000/ui/?page=cost-tracking, then expand "Provider Discounts"
2. They click "Remove discount for openai" and a confirmation asks "Are you sure you want to remove the discount for openai?"
3. They click "Remove" and the confirmation disappears immediately, while the save round-trip is still in flight
4. The openai row is still listed, with no pending or disabled state anywhere on the page, so nothing tells them the removal was accepted
5. Reading that as a failed click, they click "Remove discount for openai" again and confirm a second time, firing a duplicate removal

After: the confirmation stays up and visibly busy until the removal actually finishes

1. They sign in and open http://localhost:4000/ui/?page=cost-tracking, then expand "Provider Discounts"
2. They click "Remove discount for openai" and a confirmation asks "Are you sure you want to remove the discount for openai?"
3. They click "Remove" and the confirmation stays on screen, with the button now reading "Removing…"
4. Both "Removing…" and "Cancel" are greyed out for the duration, and clicking outside does not dismiss the confirmation, so a duplicate removal cannot be fired
5. Once the round-trip settles, the confirmation closes on its own and the openai row is gone from Provider Discounts

The same flow applies to the Fee/Price Margin section and its "Remove margin for openai" action

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Against a proxy running on http://localhost:4000 with a database attached, signed in as a proxy admin:

1. Seed a provider discount so the Provider Discounts section has a row to remove:

```bash
curl -sS -X PATCH http://localhost:4000/config/cost_discount_config \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"openai": 0.05}'
```

2. Confirm the proxy stored it, expecting `openai` under `values`:

```bash
curl -sS http://localhost:4000/config/cost_discount_config \
  -H "Authorization: Bearer sk-1234"
```

3. Open http://localhost:4000/ui/?page=cost-tracking and expand the "Provider Discounts" accordion; the openai row should be listed with its 5% discount
4. Open the browser devtools Network tab and throttle to "Slow 4G" so the save round-trip is long enough to watch; without throttling the request finishes in milliseconds on localhost and the busy state flashes by
5. Click "Remove discount for openai", then click "Remove" in the confirmation, and screenshot the dialog while the PATCH is still pending; it should stay open with the button reading "Removing…" and both that button and "Cancel" greyed out
6. Try clicking "Cancel" and clicking outside the dialog during that window; neither should dismiss it
7. Let the request finish and screenshot again; the dialog should close on its own and the openai row should be gone
8. Confirm the proxy agrees, expecting `values` with no `openai` key:

```bash
curl -sS http://localhost:4000/config/cost_discount_config \
  -H "Authorization: Bearer sk-1234"
```

9. Repeat steps 3 through 8 against the "Fee/Price Margin" section and its "Remove margin for openai" action, seeding and reading that section with `/config/cost_margin_config` instead:

```bash
curl -sS -X PATCH http://localhost:4000/config/cost_margin_config \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"openai": {"percentage": 0.1}}'
```

For the before capture, run the same steps at `c9917cbf99` (the `litellm_internal_staging` commit this branch merges); at step 5 the dialog disappears the moment "Remove" is clicked, so there is nothing to screenshot but the row still sitting there mid-request

## Type

🐛 Bug Fix

## Caveats (if any)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
