### PR TITLE
fix(proxy): always emit the Anthropic /v1/models token limits, null when unknown

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -1227,16 +1227,13 @@ def process_anthropic_headers(headers: httpx.Headers | dict) -> dict:
 
 
 def _anthropic_model_entry(model: ModelInfoResponse, created_at: str) -> Mapping[str, object]:
-    token_limits: Final = (
-        ("max_input_tokens", model.get("max_input_tokens")),
-        ("max_tokens", model.get("max_output_tokens")),
-    )
     return {  # mutable-ok: JSON response body, serialized by the route and never mutated
         "type": "model",
         "id": model["id"],
         "display_name": model["id"],
         "created_at": created_at,
-        **{name: limit for name, limit in token_limits if limit is not None},  # mutable-ok: merged into the body above
+        "max_input_tokens": model.get("max_input_tokens"),
+        "max_tokens": model.get("max_output_tokens"),
     }
 
 
@@ -1246,7 +1243,8 @@ def create_anthropic_model_list_response(models: Sequence[ModelInfoResponse]) ->
     Clients that send an anthropic-version header parse the Anthropic Models API
     shape (type/display_name/created_at plus has_more/first_id/last_id) and filter
     the list themselves, so every model is returned here. The token limits carry
-    over from the OpenAI-shaped listing, named as the Messages API names them
+    over from the OpenAI-shaped listing, named as the Messages API names them, and
+    are always present because the vendor shape declares them nullable, not optional
     """
     created_at: Final = (
         datetime.fromtimestamp(DEFAULT_MODEL_CREATED_AT_TIME, tz=timezone.utc).isoformat().replace("+00:00", "Z")

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -2056,11 +2056,14 @@ def test_create_anthropic_model_list_response_shape():
         # ISO 8601 with a Z suffix, as the Anthropic Models API returns.
         assert entry["created_at"].endswith("Z")
         assert "+00:00" not in entry["created_at"]
-        assert "max_input_tokens" not in entry
-        assert "max_tokens" not in entry
+        assert entry["max_input_tokens"] is None
+        assert entry["max_tokens"] is None
 
 
 def test_create_anthropic_model_list_response_carries_token_limits():
+    """max_input_tokens and max_tokens are nullable in the Anthropic Models shape,
+    not optional, so both keys are emitted for every entry and carry null when the
+    limit is unknown."""
     from litellm.llms.anthropic.common_utils import (
         create_anthropic_model_list_response,
     )
@@ -2091,9 +2094,12 @@ def test_create_anthropic_model_list_response_carries_token_limits():
     assert opus["max_tokens"] == 64000
     assert "max_output_tokens" not in opus
     assert input_only["max_input_tokens"] == 8192
-    assert "max_tokens" not in input_only
-    assert "max_input_tokens" not in unknown
-    assert "max_tokens" not in unknown
+    assert input_only["max_tokens"] is None
+    assert unknown["max_input_tokens"] is None
+    assert unknown["max_tokens"] is None
+    for entry in response["data"]:
+        assert "max_input_tokens" in entry
+        assert "max_tokens" in entry
 
 
 def test_create_anthropic_model_list_response_empty():

--- a/tests/test_litellm/proxy/proxy_server/test_routes_models.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_models.py
@@ -15,6 +15,8 @@ import pytest
 
 import litellm
 from litellm.proxy import proxy_server
+from litellm.proxy import utils as proxy_utils
+from litellm.proxy.utils import create_model_info_response
 
 from .conftest import normalize  # type: ignore[import-not-found]
 
@@ -151,8 +153,38 @@ def test_anthropic_format_exposes_token_limits(
     assert claude["max_input_tokens"] == 200000
     assert claude["max_tokens"] == 64000
     assert "max_output_tokens" not in claude
-    assert "max_input_tokens" not in gpt_4
-    assert "max_tokens" not in gpt_4
+    assert gpt_4["max_input_tokens"] is None
+    assert gpt_4["max_tokens"] is None
+
+
+@pytest.mark.parametrize("path", ["/v1/models", "/models"])
+def test_anthropic_format_carries_router_configured_token_limits(client, auth_as, patched_models, monkeypatch, path):
+    """Pins the whole resolution chain, not just the formatter: a deployment's
+    configured limits beat the cost map, and the configured output budget is what
+    lands on the Anthropic ``max_tokens``. All eight limits differ, so an entry
+    built from another entry's lookup shows up as the wrong numbers."""
+
+    def _configured(model_name):
+        return (300000, 32000) if model_name == "gpt-4" else (500000, 4096)
+
+    def _cost_map_lookup(model_id):
+        max_input, max_output = (200000, 64000) if model_id == "gpt-4" else (100000, 8000)
+        return {"max_input_tokens": max_input, "max_output_tokens": max_output, "mode": "chat"}
+
+    patched_models.get_configured_token_limits = MagicMock(side_effect=_configured)
+
+    def _resolved(**kwargs):
+        return create_model_info_response(**kwargs, get_model_info=_cost_map_lookup)
+
+    monkeypatch.setattr(proxy_utils, "create_model_info_response", _resolved)
+
+    with auth_as():
+        response = client.get(path, headers={"anthropic-version": "2023-06-01"})
+
+    assert response.status_code == 200
+    gpt_4, claude = response.json()["data"]
+    assert (gpt_4["max_input_tokens"], gpt_4["max_tokens"]) == (300000, 32000)
+    assert (claude["max_input_tokens"], claude["max_tokens"]) == (500000, 4096)
 
 
 @pytest.mark.parametrize("path", ["/v1/models", "/models"])


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic `/v1/models` entries drop token limits it cannot resolve
- Vendor shape makes both fields nullable, not optional
- A strict client schema rejects entries missing those keys

How it solves it:

- Always emit `max_input_tokens` and `max_tokens`
- Send `null` when LiteLLM knows no limit

## User Flow

Before: a Claude Code user pointed at a LiteLLM gateway gets a model list where some entries silently lack the two token-limit fields, so a client that validates the vendor schema rejects those entries instead of showing them

1. They set the gateway base URL and enable gateway model discovery
2. Their client sends `GET https://litellm-domain/v1/models` with `anthropic-version: 2023-06-01`
3. Models whose limits the gateway knows come back with `max_input_tokens` and `max_tokens`
4. Models whose limits it does not know come back with neither key present at all
5. A client that expects those keys to always exist, holding `null` when unknown, treats step 4's entries as malformed and drops them from the picker

After: every entry carries both keys, with `null` standing in for an unknown limit, so the whole list validates

1. They set the gateway base URL and enable gateway model discovery
2. Their client sends `GET https://litellm-domain/v1/models` with `anthropic-version: 2023-06-01`
3. Models whose limits the gateway knows come back with `max_input_tokens` and `max_tokens`
4. Models whose limits it does not know now come back with `"max_input_tokens": null` and `"max_tokens": null`
5. Every entry validates, so the picker lists every model the key can reach

## Relevant issues

Follow-up to #35455

## Linear ticket

Resolves LIT-5550

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This changes an entry that the merged code deliberately shapes the other way, so the note belongs up front. #35455 emits the two limits only when it can resolve them, and its tests pin that omission. This PR changes that to always-present-possibly-null and inverts those assertions on purpose, for two reasons. Anthropic's docs type them `number or null` under `ModelInfo` while marking genuinely optional things "optional" elsewhere on the same page, and the live vendor endpoint returns both keys on every entry it serves.

The vendor call, run against the real API:

```
$ curl -s "https://api.anthropic.com/v1/models?limit=100" -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01"
{"data":[{"type":"model","id":"claude-opus-5","display_name":"Claude Opus 5","created_at":"2026-07-24T00:00:00Z","max_input_tokens":1000000,"max_tokens":128000,"capabilities":{...}}, ... ],"has_more":false,"first_id":"claude-opus-5","last_id":"claude-sonnet-4-5-20250929"}
```

HTTP 200, and all 10 entries carry both keys. Being honest about what that does and does not settle: it proves the keys are always PRESENT in vendor output, and it cannot show the unknown case because every Anthropic model has known limits. The docs are what say an unknown value is `null` rather than an absent key.

Live proxy, before at `e1f3d6e158` from a clean checkout of that commit, after at `5c9abf1ad5`. Both run the same config: one model the cost map knows, one carrying configured limits in `model_info`, and one with no known limits.

```
$ curl -s http://127.0.0.1:45501/health/liveliness -H "Authorization: Bearer sk-lit5550b"
"I'm alive!"
```

Before, OpenAI envelope:

```
$ curl -s http://127.0.0.1:45501/v1/models -H "Authorization: Bearer sk-lit5550b"
{"data":[{"id":"claude-sonnet-4-5","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":200000,"max_output_tokens":64000},{"id":"configured-limits-model","object":"model","created":1677610602,"owned_by":"openai","max_input_tokens":300000,"max_output_tokens":32000},{"id":"unknown-limits-model","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}
```

Before, Anthropic envelope, note `unknown-limits-model` has neither key:

```
$ curl -s http://127.0.0.1:45501/v1/models -H "Authorization: Bearer sk-lit5550b" -H "anthropic-version: 2023-06-01"
{"data":[{"type":"model","id":"claude-sonnet-4-5","display_name":"claude-sonnet-4-5","created_at":"2023-02-28T18:56:42Z","max_input_tokens":200000,"max_tokens":64000},{"type":"model","id":"configured-limits-model","display_name":"configured-limits-model","created_at":"2023-02-28T18:56:42Z","max_input_tokens":300000,"max_tokens":32000},{"type":"model","id":"unknown-limits-model","display_name":"unknown-limits-model","created_at":"2023-02-28T18:56:42Z"}],"has_more":false,"first_id":"claude-sonnet-4-5","last_id":"unknown-limits-model"}
```

After, OpenAI envelope, byte for byte what it was before:

```
$ curl -s http://127.0.0.1:45502/v1/models -H "Authorization: Bearer sk-lit5550b"
{"data":[{"id":"claude-sonnet-4-5","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":200000,"max_output_tokens":64000},{"id":"configured-limits-model","object":"model","created":1677610602,"owned_by":"openai","max_input_tokens":300000,"max_output_tokens":32000},{"id":"unknown-limits-model","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}
```

After, Anthropic envelope, `unknown-limits-model` now carries both keys as null:

```
$ curl -s http://127.0.0.1:45502/v1/models -H "Authorization: Bearer sk-lit5550b" -H "anthropic-version: 2023-06-01"
{"data":[{"type":"model","id":"claude-sonnet-4-5","display_name":"claude-sonnet-4-5","created_at":"2023-02-28T18:56:42Z","max_input_tokens":200000,"max_tokens":64000},{"type":"model","id":"configured-limits-model","display_name":"configured-limits-model","created_at":"2023-02-28T18:56:42Z","max_input_tokens":300000,"max_tokens":32000},{"type":"model","id":"unknown-limits-model","display_name":"unknown-limits-model","created_at":"2023-02-28T18:56:42Z","max_input_tokens":null,"max_tokens":null}],"has_more":false,"first_id":"claude-sonnet-4-5","last_id":"unknown-limits-model"}
```

`configured-limits-model` also shows the resolution order holding end to end: 300000 and 32000 come from the deployment's `model_info`, beating the cost map, and the configured output budget lands on `max_tokens` rather than on `max_input_tokens`

## Type

🐛 Bug Fix

## Caveats (if any)

- `capabilities` still omitted, nine sub-objects of separate work
- `display_name` still falls back to the model id
- `created_at` still the epoch placeholder the vendor spec permits

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
