### PR TITLE
refactor(ui): declare DateRangePickerValue locally instead of importing it from tremor

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -140,9 +140,6 @@
     "local/filename-pascal-case": {
       "count": 1
     },
-    "no-restricted-imports": {
-      "count": 1
-    },
     "react-hooks/purity": {
       "count": 1
     },
@@ -299,11 +296,6 @@
   "src/app/(dashboard)/guardrails-monitor/_components/GuardrailDetail.tsx": {
     "no-nested-ternary": {
       "count": 3
-    }
-  },
-  "src/app/(dashboard)/guardrails-monitor/_components/GuardrailsMonitorView.tsx": {
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "src/app/(dashboard)/guardrails-monitor/_components/GuardrailsOverview.tsx": {
@@ -1484,9 +1476,6 @@
   "src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx": {
     "local/no-complex-jsx-arrow": {
       "count": 2
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "src/app/(dashboard)/usage/_components/components/UsageAIChatPanel.tsx": {
@@ -1505,9 +1494,6 @@
       "count": 1
     },
     "no-nested-ternary": {
-      "count": 1
-    },
-    "no-restricted-imports": {
       "count": 1
     },
     "react-hooks/purity": {
@@ -1736,32 +1722,9 @@
       "count": 1
     }
   },
-  "src/components/EntityUsageExport/ExportSummary.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/components/EntityUsageExport/UsageExportHeader.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/components/EntityUsageExport/types.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/components/EntityUsageExport/utils.test.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/components/EntityUsageExport/utils.ts": {
     "max-params": {
       "count": 3
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "src/components/GuardrailSettingsView.tsx": {
@@ -3220,9 +3183,6 @@
   },
   "src/components/user_agent_activity.tsx": {
     "local/filename-pascal-case": {
-      "count": 1
-    },
-    "no-restricted-imports": {
       "count": 1
     },
     "react-hooks/set-state-in-effect": {

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.tsx
@@ -1,4 +1,4 @@
-import { DateRangePickerValue } from "@tremor/react";
+import type { DateRangePickerValue } from "@/components/shared/date_picker_types";
 import React, { useEffect, useState } from "react";
 import NotificationsManager from "@/components/molecules/notifications_manager";
 import UsageDatePicker from "@/components/shared/usage_date_picker";

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/_components/GuardrailsMonitorView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/_components/GuardrailsMonitorView.tsx
@@ -1,4 +1,4 @@
-import type { DateRangePickerValue } from "@tremor/react";
+import type { DateRangePickerValue } from "@/components/shared/date_picker_types";
 import React, { useCallback, useMemo, useState } from "react";
 import { formatDate } from "@/components/networking";
 import AdvancedDatePicker from "@/components/shared/advanced_date_picker";

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
@@ -14,7 +14,7 @@ import { MoneyCell } from "@/components/shared/table_cells";
 import { Card as ShadcnCard, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { hasCapability, type Capability } from "@/utils/capabilities";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
-import type { DateRangePickerValue } from "@tremor/react";
+import type { DateRangePickerValue } from "@/components/shared/date_picker_types";
 import { ChevronDown, ChevronRight, ExternalLink, Info, Loader2 } from "lucide-react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Alert, AlertDescription } from "@/components/shared/Alert";

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
@@ -7,7 +7,7 @@
  */
 
 import { ChevronDown, ChevronRight, Download, ExternalLink, Info, Loader2, Sparkles, X } from "lucide-react";
-import type { DateRangePickerValue } from "@tremor/react";
+import type { DateRangePickerValue } from "@/components/shared/date_picker_types";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { BarChart } from "@/components/shared/charts";

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/ExportSummary.tsx
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/ExportSummary.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { DateRangePickerValue } from "@tremor/react";
+import type { DateRangePickerValue } from "@/components/shared/date_picker_types";
 
 interface ExportSummaryProps {
   dateRange: DateRangePickerValue;

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/UsageExportHeader.tsx
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/UsageExportHeader.tsx
@@ -1,4 +1,4 @@
-import type { DateRangePickerValue } from "@tremor/react";
+import type { DateRangePickerValue } from "@/components/shared/date_picker_types";
 import { Download } from "lucide-react";
 import React, { useState } from "react";
 import { Button } from "@/components/ui/button";

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/types.ts
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/types.ts
@@ -1,4 +1,4 @@
-import type { DateRangePickerValue } from "@tremor/react";
+import type { DateRangePickerValue } from "@/components/shared/date_picker_types";
 import type { Team } from "@/components/key_team_helpers/key_list";
 
 export type ExportFormat = "csv" | "json";

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/utils.test.ts
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/utils.test.ts
@@ -1,4 +1,4 @@
-import type { DateRangePickerValue } from "@tremor/react";
+import type { DateRangePickerValue } from "@/components/shared/date_picker_types";
 import Papa from "papaparse";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { EntitySpendData, ExportScope } from "./types";

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts
@@ -1,5 +1,5 @@
 import { formatNumberWithCommas } from "@/utils/dataUtils";
-import type { DateRangePickerValue } from "@tremor/react";
+import type { DateRangePickerValue } from "@/components/shared/date_picker_types";
 import Papa from "papaparse";
 import type { EntityBreakdown, EntitySpendData, EntityType, ExportMetadata, ExportScope } from "./types";
 

--- a/ui/litellm-dashboard/src/components/shared/advanced_date_picker.tsx
+++ b/ui/litellm-dashboard/src/components/shared/advanced_date_picker.tsx
@@ -1,5 +1,6 @@
 import { CalendarOutlined, ClockCircleOutlined } from "@ant-design/icons";
-import { Button, DateRangePickerValue, Text } from "@tremor/react";
+import { Button, Text } from "@tremor/react";
+import type { DateRangePickerValue } from "./date_picker_types";
 import moment from "moment";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 

--- a/ui/litellm-dashboard/src/components/shared/date_picker_types.ts
+++ b/ui/litellm-dashboard/src/components/shared/date_picker_types.ts
@@ -1,0 +1,5 @@
+export type DateRangePickerValue = {
+  from?: Date;
+  to?: Date;
+  selectValue?: string;
+};

--- a/ui/litellm-dashboard/src/components/shared/usage_date_picker.tsx
+++ b/ui/litellm-dashboard/src/components/shared/usage_date_picker.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useRef } from "react";
-import { DateRangePicker, DateRangePickerValue, Text } from "@tremor/react";
+import { DateRangePicker, Text } from "@tremor/react";
+import type { DateRangePickerValue } from "./date_picker_types";
 
 interface UsageDatePickerProps {
   value: DateRangePickerValue;

--- a/ui/litellm-dashboard/src/components/user_agent_activity.tsx
+++ b/ui/litellm-dashboard/src/components/user_agent_activity.tsx
@@ -17,7 +17,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { BarChart } from "@/components/shared/charts";
 import { userAgentSummaryCall, tagDauCall, tagWauCall, tagMauCall, tagDistinctCall } from "./networking";
 import PerUserUsage from "./per_user_usage";
-import type { DateRangePickerValue } from "@tremor/react";
+import type { DateRangePickerValue } from "@/components/shared/date_picker_types";
 import { ChartLoader } from "./shared/chart_loader";
 
 // New interfaces for the updated API response


### PR DESCRIPTION
## TLDR

Problem this solves:

- `DateRangePickerValue` still came from `@tremor/react`
- Twelve dashboard files carried a lint suppression for it
- Tremor is being phased out of the dashboard

How it solves it:

- Declares the same shape in `shared/date_picker_types.ts`
- Repoints all twelve files at that declaration
- Drops ten `no-restricted-imports` suppressions from the baseline

## User Flow

`DateRangePickerValue` is a type, not a component, so it exists only at compile time. Its declaration in `@tremor/react` is `{ from?: Date; to?: Date; selectValue?: string }`, and the local declaration is byte-for-byte that shape. Nothing reaches the browser differently, so the two lists below never diverge

Before: an admin filtering the dashboard by date range gets the picker they expect

1. They open http://localhost:4000/ui/usage and the page loads with a default range already applied
2. They click the date range control, choose "Last 7 days", and click Apply
3. The spend charts, the per-entity tables and the user agent activity panel all redraw for that window
4. They open http://localhost:4000/ui/caching and http://localhost:4000/ui/guardrails-monitor and change the range on each
5. Both pages refetch and redraw for the range they picked

After: identical, step for step

1. They open http://localhost:4000/ui/usage and the page loads with a default range already applied
2. They click the date range control, choose "Last 7 days", and click Apply
3. The spend charts, the per-entity tables and the user agent activity panel all redraw for that window
4. They open http://localhost:4000/ui/caching and http://localhost:4000/ui/guardrails-monitor and change the range on each
5. Both pages refetch and redraw for the range they picked

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Every date range control that this PR retypes lives on a page, so the proof is driving those pages by hand. Run the proxy on 4000 and the dashboard dev server on 3000, then walk the routes

1. Start the proxy, exporting `PROXY_BASE_URL` so the UI config does not override the dev server's base URL:

```bash
PROXY_BASE_URL=http://localhost:4000 python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

2. Start the dashboard dev server against that proxy:

```bash
cd ui/litellm-dashboard && npm run dev
```

3. Spend real money so the usage pages have something to draw, then confirm the calls landed:

```bash
for i in 1 2 3; do curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"say hi"}]}' | jq -r '.usage.total_tokens'; done
```

4. Open http://localhost:3000/usage, click the date range control, pick "Last 7 days", click Apply, and confirm the spend charts, the per-entity tables and the user agent activity panel all redraw for that window
5. On the same page click Export, confirm the modal shows the range you picked in its summary line, and download the CSV
6. Open http://localhost:3000/caching, change the range on that picker, and confirm the cache hit charts refetch
7. Open http://localhost:3000/guardrails-monitor, change the range, and confirm the guardrail table refetches
8. Open http://localhost:3000/old-usage and http://localhost:3000/cost-optimization, change the range on each, and confirm both still redraw: they consume the two date pickers whose prop type this PR moved, so they prove the swap reaches downstream callers too

## Type

🧹 Refactoring

## Caveats (if any)

- No new tests: the compiler is the only meaningful guard here
- `advanced_date_picker` and `usage_date_picker` keep their Tremor imports
- Migrating `DateRangePicker` itself needs react-day-picker, not yet approved

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
