### PR TITLE
feat(proxy): per-component response cost headers

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -941,6 +941,17 @@ class CostBreakdownHeaderValues(NamedTuple):
     tool_usage_cost: float | None = None
 
 
+def _uncached_input_cost(
+    input_cost: float | None,
+    cache_read_cost: float | None,
+    cache_creation_cost: float | None,
+) -> float | None:
+    """The stored input cost nests the cache costs inside it; headers advertise the additive split instead."""
+    if input_cost is None:
+        return None
+    return input_cost - (cache_read_cost or 0.0) - (cache_creation_cost or 0.0)
+
+
 def _get_cost_breakdown_from_logging_obj(
     litellm_logging_obj: LiteLLMLoggingObj | None,
 ) -> CostBreakdownHeaderValues:
@@ -957,7 +968,11 @@ def _get_cost_breakdown_from_logging_obj(
         discount_amount=cost_breakdown.get("discount_amount"),
         margin_total_amount=cost_breakdown.get("margin_total_amount"),
         margin_percent=cost_breakdown.get("margin_percent"),
-        input_cost=cost_breakdown.get("input_cost"),
+        input_cost=_uncached_input_cost(
+            input_cost=cost_breakdown.get("input_cost"),
+            cache_read_cost=cost_breakdown.get("cache_read_cost"),
+            cache_creation_cost=cost_breakdown.get("cache_creation_cost"),
+        ),
         output_cost=cost_breakdown.get("output_cost"),
         cache_read_cost=cost_breakdown.get("cache_read_cost"),
         cache_creation_cost=cost_breakdown.get("cache_creation_cost"),

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -930,26 +930,49 @@ def _override_openai_response_model(
 
 def _get_cost_breakdown_from_logging_obj(
     litellm_logging_obj: LiteLLMLoggingObj | None,
-) -> tuple[float | None, float | None, float | None, float | None]:
-    """
-    Extract discount and margin information from logging object's cost breakdown.
-
-    Returns:
-        Tuple of (original_cost, discount_amount, margin_total_amount, margin_percent)
-    """
+) -> tuple[
+    float | None,
+    float | None,
+    float | None,
+    float | None,
+    float | None,
+    float | None,
+    float | None,
+    float | None,
+    float | None,
+    float | None,
+]:
+    """Extract discount, margin, and per-component cost information from logging object's cost breakdown."""
     if not litellm_logging_obj or not hasattr(litellm_logging_obj, "cost_breakdown"):
-        return None, None, None, None
+        return None, None, None, None, None, None, None, None, None, None
 
     cost_breakdown: Final = litellm_logging_obj.cost_breakdown
     if not cost_breakdown:
-        return None, None, None, None
+        return None, None, None, None, None, None, None, None, None, None
 
     original_cost: Final = cost_breakdown.get("original_cost")
     discount_amount: Final = cost_breakdown.get("discount_amount")
     margin_total_amount: Final = cost_breakdown.get("margin_total_amount")
     margin_percent: Final = cost_breakdown.get("margin_percent")
+    input_cost: Final = cost_breakdown.get("input_cost")
+    output_cost: Final = cost_breakdown.get("output_cost")
+    cache_read_cost: Final = cost_breakdown.get("cache_read_cost")
+    cache_creation_cost: Final = cost_breakdown.get("cache_creation_cost")
+    reasoning_cost: Final = cost_breakdown.get("reasoning_cost")
+    tool_usage_cost: Final = cost_breakdown.get("tool_usage_cost")
 
-    return original_cost, discount_amount, margin_total_amount, margin_percent
+    return (
+        original_cost,
+        discount_amount,
+        margin_total_amount,
+        margin_percent,
+        input_cost,
+        output_cost,
+        cache_read_cost,
+        cache_creation_cost,
+        reasoning_cost,
+        tool_usage_cost,
+    )
 
 
 def _classifier_cost_from_request_data(request_data: Mapping[str, object] | None) -> float | None:
@@ -1075,12 +1098,18 @@ class ProxyBaseLLMRequestProcessing:
         exclude_values: Final = {"", None, "None"}
         hidden_params = hidden_params or {}
 
-        # Extract discount and margin info from cost_breakdown if available
+        # Extract discount, margin, and per-component cost info from cost_breakdown if available
         (
             original_cost,
             discount_amount,
             margin_total_amount,
             margin_percent,
+            input_cost,
+            output_cost,
+            cache_read_cost,
+            cache_creation_cost,
+            reasoning_cost,
+            tool_usage_cost,
         ) = _get_cost_breakdown_from_logging_obj(litellm_logging_obj=litellm_logging_obj)
 
         # Calculate updated spend for header (include current response_cost)
@@ -1116,6 +1145,14 @@ class ProxyBaseLLMRequestProcessing:
                 str(margin_total_amount) if margin_total_amount is not None else None
             ),
             "x-litellm-response-cost-margin-percent": (str(margin_percent) if margin_percent is not None else None),
+            "x-litellm-response-cost-input": (str(input_cost) if input_cost is not None else None),
+            "x-litellm-response-cost-output": (str(output_cost) if output_cost is not None else None),
+            "x-litellm-response-cost-cache-read": (str(cache_read_cost) if cache_read_cost is not None else None),
+            "x-litellm-response-cost-cache-creation": (
+                str(cache_creation_cost) if cache_creation_cost is not None else None
+            ),
+            "x-litellm-response-cost-reasoning": (str(reasoning_cost) if reasoning_cost is not None else None),
+            "x-litellm-response-cost-tool-usage": (str(tool_usage_cost) if tool_usage_cost is not None else None),
             "x-litellm-classifier-cost": (str(classifier_cost) if classifier_cost is not None else None),
             "x-litellm-key-tpm-limit": str(user_api_key_dict.tpm_limit),
             "x-litellm-key-rpm-limit": str(user_api_key_dict.rpm_limit),

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncGenerator, Callable, Mapping
 from datetime import datetime
 from functools import lru_cache
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Final, Literal, Protocol, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Protocol, overload
 
 import anyio
 import httpx
@@ -928,50 +928,41 @@ def _override_openai_response_model(
         )
 
 
+class CostBreakdownHeaderValues(NamedTuple):
+    original_cost: float | None = None
+    discount_amount: float | None = None
+    margin_total_amount: float | None = None
+    margin_percent: float | None = None
+    input_cost: float | None = None
+    output_cost: float | None = None
+    cache_read_cost: float | None = None
+    cache_creation_cost: float | None = None
+    reasoning_cost: float | None = None
+    tool_usage_cost: float | None = None
+
+
 def _get_cost_breakdown_from_logging_obj(
     litellm_logging_obj: LiteLLMLoggingObj | None,
-) -> tuple[
-    float | None,
-    float | None,
-    float | None,
-    float | None,
-    float | None,
-    float | None,
-    float | None,
-    float | None,
-    float | None,
-    float | None,
-]:
+) -> CostBreakdownHeaderValues:
     """Extract discount, margin, and per-component cost information from logging object's cost breakdown."""
     if not litellm_logging_obj or not hasattr(litellm_logging_obj, "cost_breakdown"):
-        return None, None, None, None, None, None, None, None, None, None
+        return CostBreakdownHeaderValues()
 
     cost_breakdown: Final = litellm_logging_obj.cost_breakdown
     if not cost_breakdown:
-        return None, None, None, None, None, None, None, None, None, None
+        return CostBreakdownHeaderValues()
 
-    original_cost: Final = cost_breakdown.get("original_cost")
-    discount_amount: Final = cost_breakdown.get("discount_amount")
-    margin_total_amount: Final = cost_breakdown.get("margin_total_amount")
-    margin_percent: Final = cost_breakdown.get("margin_percent")
-    input_cost: Final = cost_breakdown.get("input_cost")
-    output_cost: Final = cost_breakdown.get("output_cost")
-    cache_read_cost: Final = cost_breakdown.get("cache_read_cost")
-    cache_creation_cost: Final = cost_breakdown.get("cache_creation_cost")
-    reasoning_cost: Final = cost_breakdown.get("reasoning_cost")
-    tool_usage_cost: Final = cost_breakdown.get("tool_usage_cost")
-
-    return (
-        original_cost,
-        discount_amount,
-        margin_total_amount,
-        margin_percent,
-        input_cost,
-        output_cost,
-        cache_read_cost,
-        cache_creation_cost,
-        reasoning_cost,
-        tool_usage_cost,
+    return CostBreakdownHeaderValues(
+        original_cost=cost_breakdown.get("original_cost"),
+        discount_amount=cost_breakdown.get("discount_amount"),
+        margin_total_amount=cost_breakdown.get("margin_total_amount"),
+        margin_percent=cost_breakdown.get("margin_percent"),
+        input_cost=cost_breakdown.get("input_cost"),
+        output_cost=cost_breakdown.get("output_cost"),
+        cache_read_cost=cost_breakdown.get("cache_read_cost"),
+        cache_creation_cost=cost_breakdown.get("cache_creation_cost"),
+        reasoning_cost=cost_breakdown.get("reasoning_cost"),
+        tool_usage_cost=cost_breakdown.get("tool_usage_cost"),
     )
 
 
@@ -1098,19 +1089,7 @@ class ProxyBaseLLMRequestProcessing:
         exclude_values: Final = {"", None, "None"}
         hidden_params = hidden_params or {}
 
-        # Extract discount, margin, and per-component cost info from cost_breakdown if available
-        (
-            original_cost,
-            discount_amount,
-            margin_total_amount,
-            margin_percent,
-            input_cost,
-            output_cost,
-            cache_read_cost,
-            cache_creation_cost,
-            reasoning_cost,
-            tool_usage_cost,
-        ) = _get_cost_breakdown_from_logging_obj(litellm_logging_obj=litellm_logging_obj)
+        cost_breakdown: Final = _get_cost_breakdown_from_logging_obj(litellm_logging_obj=litellm_logging_obj)
 
         # Calculate updated spend for header (include current response_cost)
         current_spend: Final = user_api_key_dict.spend or 0.0
@@ -1139,20 +1118,36 @@ class ProxyBaseLLMRequestProcessing:
             "x-litellm-version": version,
             "x-litellm-model-region": model_region,
             "x-litellm-response-cost": str(response_cost),
-            "x-litellm-response-cost-original": (str(original_cost) if original_cost is not None else None),
-            "x-litellm-response-cost-discount-amount": (str(discount_amount) if discount_amount is not None else None),
+            "x-litellm-response-cost-original": (
+                str(cost_breakdown.original_cost) if cost_breakdown.original_cost is not None else None
+            ),
+            "x-litellm-response-cost-discount-amount": (
+                str(cost_breakdown.discount_amount) if cost_breakdown.discount_amount is not None else None
+            ),
             "x-litellm-response-cost-margin-amount": (
-                str(margin_total_amount) if margin_total_amount is not None else None
+                str(cost_breakdown.margin_total_amount) if cost_breakdown.margin_total_amount is not None else None
             ),
-            "x-litellm-response-cost-margin-percent": (str(margin_percent) if margin_percent is not None else None),
-            "x-litellm-response-cost-input": (str(input_cost) if input_cost is not None else None),
-            "x-litellm-response-cost-output": (str(output_cost) if output_cost is not None else None),
-            "x-litellm-response-cost-cache-read": (str(cache_read_cost) if cache_read_cost is not None else None),
+            "x-litellm-response-cost-margin-percent": (
+                str(cost_breakdown.margin_percent) if cost_breakdown.margin_percent is not None else None
+            ),
+            "x-litellm-response-cost-input": (
+                str(cost_breakdown.input_cost) if cost_breakdown.input_cost is not None else None
+            ),
+            "x-litellm-response-cost-output": (
+                str(cost_breakdown.output_cost) if cost_breakdown.output_cost is not None else None
+            ),
+            "x-litellm-response-cost-cache-read": (
+                str(cost_breakdown.cache_read_cost) if cost_breakdown.cache_read_cost is not None else None
+            ),
             "x-litellm-response-cost-cache-creation": (
-                str(cache_creation_cost) if cache_creation_cost is not None else None
+                str(cost_breakdown.cache_creation_cost) if cost_breakdown.cache_creation_cost is not None else None
             ),
-            "x-litellm-response-cost-reasoning": (str(reasoning_cost) if reasoning_cost is not None else None),
-            "x-litellm-response-cost-tool-usage": (str(tool_usage_cost) if tool_usage_cost is not None else None),
+            "x-litellm-response-cost-reasoning": (
+                str(cost_breakdown.reasoning_cost) if cost_breakdown.reasoning_cost is not None else None
+            ),
+            "x-litellm-response-cost-tool-usage": (
+                str(cost_breakdown.tool_usage_cost) if cost_breakdown.tool_usage_cost is not None else None
+            ),
             "x-litellm-classifier-cost": (str(classifier_cost) if classifier_cost is not None else None),
             "x-litellm-key-tpm-limit": str(user_api_key_dict.tpm_limit),
             "x-litellm-key-rpm-limit": str(user_api_key_dict.rpm_limit),

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -834,6 +834,174 @@ class TestProxyBaseLLMRequestProcessing:
         assert "x-litellm-response-cost-margin-amount" not in headers
         assert "x-litellm-response-cost-margin-percent" not in headers
 
+    def test_get_custom_headers_per_component_cost_breakdown(self):
+        """Test that per-component cost headers are included when component breakdown is available."""
+        from litellm.litellm_core_utils.litellm_logging import (
+            Logging as LiteLLMLoggingObj,
+        )
+
+        mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+        mock_user_api_key_dict.tpm_limit = None
+        mock_user_api_key_dict.rpm_limit = None
+        mock_user_api_key_dict.max_budget = None
+        mock_user_api_key_dict.spend = 0
+
+        logging_obj = LiteLLMLoggingObj(
+            model="gpt-5.4-nano",
+            messages=[{"role": "user", "content": "hello"}],
+            stream=False,
+            call_type="completion",
+            start_time=None,
+            litellm_call_id="test-call-id-components",
+            function_id="test-function",
+        )
+
+        input_cost: Final = 0.00002
+        output_cost: Final = 0.00004
+        cache_read_cost: Final = 0.000005
+        cache_creation_cost: Final = 0.00001
+        reasoning_cost: Final = 0.000015
+        tool_usage_cost: Final = 0.00003
+        total_cost: Final = (
+            input_cost + cache_read_cost + cache_creation_cost + output_cost + tool_usage_cost
+        )
+
+        logging_obj.set_cost_breakdown(
+            input_cost=input_cost,
+            output_cost=output_cost,
+            total_cost=total_cost,
+            cost_for_built_in_tools_cost_usd_dollar=tool_usage_cost,
+            cache_read_cost=cache_read_cost,
+            cache_creation_cost=cache_creation_cost,
+            reasoning_cost=reasoning_cost,
+        )
+
+        headers = ProxyBaseLLMRequestProcessing.get_custom_headers(
+            user_api_key_dict=mock_user_api_key_dict,
+            call_id="test-call-id-components",
+            response_cost=total_cost,
+            litellm_logging_obj=logging_obj,
+        )
+
+        assert "x-litellm-response-cost" in headers
+        assert float(headers["x-litellm-response-cost"]) == pytest.approx(total_cost)
+
+        assert "x-litellm-response-cost-input" in headers
+        assert float(headers["x-litellm-response-cost-input"]) == pytest.approx(input_cost)
+
+        assert "x-litellm-response-cost-output" in headers
+        assert float(headers["x-litellm-response-cost-output"]) == pytest.approx(output_cost)
+
+        assert "x-litellm-response-cost-cache-read" in headers
+        assert float(headers["x-litellm-response-cost-cache-read"]) == pytest.approx(cache_read_cost)
+
+        assert "x-litellm-response-cost-cache-creation" in headers
+        assert float(headers["x-litellm-response-cost-cache-creation"]) == pytest.approx(cache_creation_cost)
+
+        assert "x-litellm-response-cost-reasoning" in headers
+        assert float(headers["x-litellm-response-cost-reasoning"]) == pytest.approx(reasoning_cost)
+
+        assert "x-litellm-response-cost-tool-usage" in headers
+        assert float(headers["x-litellm-response-cost-tool-usage"]) == pytest.approx(tool_usage_cost)
+
+        component_sum: Final = (
+            float(headers["x-litellm-response-cost-input"])
+            + float(headers["x-litellm-response-cost-cache-read"])
+            + float(headers["x-litellm-response-cost-cache-creation"])
+            + float(headers["x-litellm-response-cost-output"])
+            + float(headers["x-litellm-response-cost-tool-usage"])
+        )
+        assert component_sum == pytest.approx(float(headers["x-litellm-response-cost"]))
+        assert float(headers["x-litellm-response-cost-reasoning"]) <= float(headers["x-litellm-response-cost-output"])
+
+    def test_get_custom_headers_without_cost_breakdown_omits_component_headers(self):
+        """Test that when litellm_logging_obj has no cost_breakdown, component headers are omitted."""
+        from litellm.litellm_core_utils.litellm_logging import (
+            Logging as LiteLLMLoggingObj,
+        )
+
+        mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+        mock_user_api_key_dict.tpm_limit = None
+        mock_user_api_key_dict.rpm_limit = None
+        mock_user_api_key_dict.max_budget = None
+        mock_user_api_key_dict.spend = 0
+
+        logging_obj = LiteLLMLoggingObj(
+            model="gpt-4",
+            messages=[],
+            stream=False,
+            call_type="completion",
+            start_time=None,
+            litellm_call_id="test-call-id-no-breakdown",
+            function_id="test-function",
+        )
+
+        headers = ProxyBaseLLMRequestProcessing.get_custom_headers(
+            user_api_key_dict=mock_user_api_key_dict,
+            response_cost=0.0001,
+            litellm_logging_obj=logging_obj,
+        )
+
+        assert "x-litellm-response-cost" in headers
+        assert "x-litellm-response-cost-input" not in headers
+        assert "x-litellm-response-cost-output" not in headers
+        assert "x-litellm-response-cost-cache-read" not in headers
+        assert "x-litellm-response-cost-cache-creation" not in headers
+        assert "x-litellm-response-cost-reasoning" not in headers
+        assert "x-litellm-response-cost-tool-usage" not in headers
+
+    def test_get_custom_headers_per_component_with_discount_and_margin(self):
+        """Test that component headers co-exist accurately with discount and margin headers."""
+        from litellm.litellm_core_utils.litellm_logging import (
+            Logging as LiteLLMLoggingObj,
+        )
+
+        mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+        mock_user_api_key_dict.tpm_limit = None
+        mock_user_api_key_dict.rpm_limit = None
+        mock_user_api_key_dict.max_budget = None
+        mock_user_api_key_dict.spend = 0
+
+        logging_obj = LiteLLMLoggingObj(
+            model="gpt-4",
+            messages=[],
+            stream=False,
+            call_type="completion",
+            start_time=None,
+            litellm_call_id="test-call-id-combined",
+            function_id="test-function",
+        )
+
+        logging_obj.set_cost_breakdown(
+            input_cost=0.00006,
+            output_cost=0.00004,
+            total_cost=0.000105,
+            cost_for_built_in_tools_cost_usd_dollar=0.0,
+            original_cost=0.0001,
+            discount_percent=0.05,
+            discount_amount=0.000005,
+            margin_percent=0.10,
+            margin_total_amount=0.00001,
+        )
+
+        headers = ProxyBaseLLMRequestProcessing.get_custom_headers(
+            user_api_key_dict=mock_user_api_key_dict,
+            response_cost=0.000105,
+            litellm_logging_obj=logging_obj,
+        )
+
+        assert float(headers["x-litellm-response-cost"]) == pytest.approx(0.000105)
+        assert float(headers["x-litellm-response-cost-original"]) == pytest.approx(0.0001)
+        assert float(headers["x-litellm-response-cost-discount-amount"]) == pytest.approx(0.000005)
+        assert float(headers["x-litellm-response-cost-margin-amount"]) == pytest.approx(0.00001)
+        assert float(headers["x-litellm-response-cost-margin-percent"]) == pytest.approx(0.10)
+        assert float(headers["x-litellm-response-cost-input"]) == pytest.approx(0.00006)
+        assert float(headers["x-litellm-response-cost-output"]) == pytest.approx(0.00004)
+        assert "x-litellm-response-cost-cache-read" not in headers
+        assert "x-litellm-response-cost-cache-creation" not in headers
+        assert "x-litellm-response-cost-reasoning" not in headers
+        assert float(headers["x-litellm-response-cost-tool-usage"]) == pytest.approx(0.0)
+
     @pytest.mark.parametrize("metadata_key", ["metadata", "litellm_metadata"])
     def test_get_custom_headers_classifier_cost_from_routing_decision(self, metadata_key):
         """The auto-router's LLM classifier cost must surface as its own header.

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -835,12 +835,13 @@ class TestProxyBaseLLMRequestProcessing:
         assert "x-litellm-response-cost-margin-percent" not in headers
 
     def test_get_custom_headers_per_component_cost_breakdown(self):
-        """Test per-component cost headers with production breakdown semantics.
+        """Test per-component cost headers against the stored production breakdown.
 
         cost_calculator stores full prompt cost (cache pricing included) as input_cost
-        and full completion cost (reasoning included) as output_cost, so the invariant
-        is input + output + tool_usage == total with cache components nested inside
-        input and reasoning nested inside output.
+        and full completion cost (reasoning included) as output_cost. The input header
+        subtracts the cache components so the emitted contract is additive:
+        input + cache_read + cache_creation + output + tool_usage == total, with
+        reasoning remaining a subset of output.
         """
         from litellm.litellm_core_utils.litellm_logging import (
             Logging as LiteLLMLoggingObj,
@@ -869,6 +870,7 @@ class TestProxyBaseLLMRequestProcessing:
         reasoning_cost: Final = 0.000015
         tool_usage_cost: Final = 0.00003
         total_cost: Final = input_cost + output_cost + tool_usage_cost
+        uncached_input_cost: Final = input_cost - cache_read_cost - cache_creation_cost
 
         logging_obj.set_cost_breakdown(
             input_cost=input_cost,
@@ -891,7 +893,7 @@ class TestProxyBaseLLMRequestProcessing:
         assert float(headers["x-litellm-response-cost"]) == pytest.approx(total_cost)
 
         assert "x-litellm-response-cost-input" in headers
-        assert float(headers["x-litellm-response-cost-input"]) == pytest.approx(input_cost)
+        assert float(headers["x-litellm-response-cost-input"]) == pytest.approx(uncached_input_cost)
 
         assert "x-litellm-response-cost-output" in headers
         assert float(headers["x-litellm-response-cost-output"]) == pytest.approx(output_cost)
@@ -910,14 +912,12 @@ class TestProxyBaseLLMRequestProcessing:
 
         component_sum: Final = (
             float(headers["x-litellm-response-cost-input"])
+            + float(headers["x-litellm-response-cost-cache-read"])
+            + float(headers["x-litellm-response-cost-cache-creation"])
             + float(headers["x-litellm-response-cost-output"])
             + float(headers["x-litellm-response-cost-tool-usage"])
         )
         assert component_sum == pytest.approx(float(headers["x-litellm-response-cost"]))
-        cache_sum: Final = float(headers["x-litellm-response-cost-cache-read"]) + float(
-            headers["x-litellm-response-cost-cache-creation"]
-        )
-        assert cache_sum <= float(headers["x-litellm-response-cost-input"])
         assert float(headers["x-litellm-response-cost-reasoning"]) <= float(headers["x-litellm-response-cost-output"])
 
     def test_get_custom_headers_without_cost_breakdown_omits_component_headers(self):
@@ -1152,6 +1152,31 @@ class TestProxyBaseLLMRequestProcessing:
         assert breakdown_no_discount.margin_percent is None
         assert breakdown_no_discount.input_cost == 0.00005
         assert breakdown_no_discount.output_cost == 0.00005
+
+        # Test that cache components stored nested inside input_cost are subtracted out
+        logging_obj_with_cache = LiteLLMLoggingObj(
+            model="claude-haiku-4-5",
+            messages=[{"role": "user", "content": "test"}],
+            stream=False,
+            call_type="completion",
+            start_time=None,
+            litellm_call_id="test-call-id-cache",
+            function_id="test-function-id-cache",
+        )
+        logging_obj_with_cache.set_cost_breakdown(
+            input_cost=0.00008,
+            output_cost=0.00002,
+            total_cost=0.0001,
+            cost_for_built_in_tools_cost_usd_dollar=0.0,
+            cache_read_cost=0.00003,
+            cache_creation_cost=0.00004,
+        )
+
+        breakdown_with_cache = _get_cost_breakdown_from_logging_obj(logging_obj_with_cache)
+        assert breakdown_with_cache.input_cost == pytest.approx(0.00001)
+        assert breakdown_with_cache.cache_read_cost == 0.00003
+        assert breakdown_with_cache.cache_creation_cost == 0.00004
+        assert breakdown_with_cache.output_cost == 0.00002
 
         # Test with None logging object
         breakdown_none = _get_cost_breakdown_from_logging_obj(None)

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1087,16 +1087,14 @@ class TestProxyBaseLLMRequestProcessing:
             discount_amount=0.000005,
         )
 
-        (
-            original_cost,
-            discount_amount,
-            margin_total_amount,
-            margin_percent,
-        ) = _get_cost_breakdown_from_logging_obj(logging_obj)
-        assert original_cost == 0.0001
-        assert discount_amount == 0.000005
-        assert margin_total_amount is None
-        assert margin_percent is None
+        breakdown = _get_cost_breakdown_from_logging_obj(logging_obj)
+        assert breakdown.original_cost == 0.0001
+        assert breakdown.discount_amount == 0.000005
+        assert breakdown.margin_total_amount is None
+        assert breakdown.margin_percent is None
+        assert breakdown.input_cost == 0.00005
+        assert breakdown.output_cost == 0.00005
+        assert breakdown.tool_usage_cost == 0.0
 
         # Test with margin info
         logging_obj_with_margin = LiteLLMLoggingObj(
@@ -1118,16 +1116,11 @@ class TestProxyBaseLLMRequestProcessing:
             margin_total_amount=0.00001,
         )
 
-        (
-            original_cost,
-            discount_amount,
-            margin_total_amount,
-            margin_percent,
-        ) = _get_cost_breakdown_from_logging_obj(logging_obj_with_margin)
-        assert original_cost == 0.0001
-        assert discount_amount is None
-        assert margin_total_amount == 0.00001
-        assert margin_percent == 0.10
+        breakdown_with_margin = _get_cost_breakdown_from_logging_obj(logging_obj_with_margin)
+        assert breakdown_with_margin.original_cost == 0.0001
+        assert breakdown_with_margin.discount_amount is None
+        assert breakdown_with_margin.margin_total_amount == 0.00001
+        assert breakdown_with_margin.margin_percent == 0.10
 
         # Test with no discount or margin info
         logging_obj_no_discount = LiteLLMLoggingObj(
@@ -1146,28 +1139,17 @@ class TestProxyBaseLLMRequestProcessing:
             cost_for_built_in_tools_cost_usd_dollar=0.0,
         )
 
-        (
-            original_cost,
-            discount_amount,
-            margin_total_amount,
-            margin_percent,
-        ) = _get_cost_breakdown_from_logging_obj(logging_obj_no_discount)
-        assert original_cost is None
-        assert discount_amount is None
-        assert margin_total_amount is None
-        assert margin_percent is None
+        breakdown_no_discount = _get_cost_breakdown_from_logging_obj(logging_obj_no_discount)
+        assert breakdown_no_discount.original_cost is None
+        assert breakdown_no_discount.discount_amount is None
+        assert breakdown_no_discount.margin_total_amount is None
+        assert breakdown_no_discount.margin_percent is None
+        assert breakdown_no_discount.input_cost == 0.00005
+        assert breakdown_no_discount.output_cost == 0.00005
 
         # Test with None logging object
-        (
-            original_cost,
-            discount_amount,
-            margin_total_amount,
-            margin_percent,
-        ) = _get_cost_breakdown_from_logging_obj(None)
-        assert original_cost is None
-        assert discount_amount is None
-        assert margin_total_amount is None
-        assert margin_percent is None
+        breakdown_none = _get_cost_breakdown_from_logging_obj(None)
+        assert all(value is None for value in breakdown_none)
 
     def test_get_custom_headers_key_spend_includes_response_cost(self):
         """

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -835,7 +835,13 @@ class TestProxyBaseLLMRequestProcessing:
         assert "x-litellm-response-cost-margin-percent" not in headers
 
     def test_get_custom_headers_per_component_cost_breakdown(self):
-        """Test that per-component cost headers are included when component breakdown is available."""
+        """Test per-component cost headers with production breakdown semantics.
+
+        cost_calculator stores full prompt cost (cache pricing included) as input_cost
+        and full completion cost (reasoning included) as output_cost, so the invariant
+        is input + output + tool_usage == total with cache components nested inside
+        input and reasoning nested inside output.
+        """
         from litellm.litellm_core_utils.litellm_logging import (
             Logging as LiteLLMLoggingObj,
         )
@@ -862,9 +868,7 @@ class TestProxyBaseLLMRequestProcessing:
         cache_creation_cost: Final = 0.00001
         reasoning_cost: Final = 0.000015
         tool_usage_cost: Final = 0.00003
-        total_cost: Final = (
-            input_cost + cache_read_cost + cache_creation_cost + output_cost + tool_usage_cost
-        )
+        total_cost: Final = input_cost + output_cost + tool_usage_cost
 
         logging_obj.set_cost_breakdown(
             input_cost=input_cost,
@@ -906,12 +910,14 @@ class TestProxyBaseLLMRequestProcessing:
 
         component_sum: Final = (
             float(headers["x-litellm-response-cost-input"])
-            + float(headers["x-litellm-response-cost-cache-read"])
-            + float(headers["x-litellm-response-cost-cache-creation"])
             + float(headers["x-litellm-response-cost-output"])
             + float(headers["x-litellm-response-cost-tool-usage"])
         )
         assert component_sum == pytest.approx(float(headers["x-litellm-response-cost"]))
+        cache_sum: Final = float(headers["x-litellm-response-cost-cache-read"]) + float(
+            headers["x-litellm-response-cost-cache-creation"]
+        )
+        assert cache_sum <= float(headers["x-litellm-response-cost-input"])
         assert float(headers["x-litellm-response-cost-reasoning"]) <= float(headers["x-litellm-response-cost-output"])
 
     def test_get_custom_headers_without_cost_breakdown_omits_component_headers(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Callers only see a total request cost, never its component split
- Attributing spend needs hand-copied pricing tables that drift per provider

How it solves it:

- Emits six `x-litellm-response-cost-*` component headers next to the total
- Input, cache read, cache creation, output, and tool usage sum exactly to the total; reasoning is a subset of output
- Reads the cost breakdown the proxy already computes per request
- Omits component headers cleanly when no breakdown was computed
- Existing cost, discount, and margin headers are unchanged

## User Flow

Before: a platform team fronting all LLM traffic through the LiteLLM proxy wants to show each internal app where its spend goes, but callers only ever see one total, so they rebuild the split by hand from their own pricing tables

1. An app sends POST https://litellm-domain/v1/chat/completions with a prompt-cached context on a reasoning model such as gpt-5.4-nano
2. The 200 response carries `x-litellm-response-cost: 7.4e-06` and the body's `usage` block carries token counts (`prompt_tokens`, `completion_tokens`, `cached_tokens`, `reasoning_tokens`)
3. To split the total they multiply those token counts by per-model rates copied into their own pricing table, which drifts: cache-write premiums, reasoning rates, and built-in tool charges differ per provider, and tool charges never appear in `usage` at all
4. When their hand-computed components fail to sum to the header total, they cannot tell which component is wrong

After: the same response states the split directly and it sums to the total

1. The app sends the same POST https://litellm-domain/v1/chat/completions with the same prompt-cached context
2. The 200 response carries the same `x-litellm-response-cost` total and now also `x-litellm-response-cost-input`, `-output`, `-cache-read`, `-cache-creation`, `-reasoning`, and `-tool-usage`
3. Input plus cache read plus cache creation plus output plus tool usage equals the total, reasoning being a subset of output, so the team attributes spend per component with no local pricing table

## Relevant issues

Closes #36875

## Linear ticket

Resolves LIT-5617

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live-proxy legs with real OpenAI and Anthropic spend, no mocks. Before leg at commit c9917cbf99 (this PR's merge base), after leg re-proven at commit 05beb7abb5 (this PR's behavioral tip). Each leg booted a bootstrapped worktree with `.venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port <port>` and hit all three unified endpoints: /v1/chat/completions and /v1/responses with gpt-5.4-nano, /v1/messages with claude-haiku-4-5 carrying a ~6k-token `cache_control: ephemeral` system block sent twice to exercise cache creation then cache read. An earlier eight-scenario after leg at 9079e4c47b surfaced that the input header still contained the cache costs nested inside it (Cursor Bugbot flagged the same double-count); 05beb7abb5 fixed that by subtracting the cache components from the input header, the same split the Admin UI's cost breakdown viewer shows, and the leg below re-proves the final contract

### Before leg (c9917cbf99, port 41387): component headers absent everywhere

```bash
curl -sD /tmp/h_a1.txt -o /tmp/b_a1.json -X POST http://localhost:41387/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d @body_a.json
grep -i '^x-litellm-response-cost' /tmp/h_a1.txt
```

A1 and A2 (identical, 200 OK, prompt_tokens=1177, completion_tokens=4, answer "391"):

```
x-litellm-response-cost: 0.00024040000000000002
x-litellm-response-cost-original: 0.00024040000000000002
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
```

B (/v1/responses, 200 OK, input_tokens=12, output_tokens=5):

```
x-litellm-response-cost: 8.65e-06
x-litellm-response-cost-original: 8.65e-06
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
```

C1 and C2 (/v1/messages; C1 cache_creation_input_tokens=6242, C2 cache_read_input_tokens=6242):

```
== c1 ==
x-litellm-response-cost: 0.0078345
x-litellm-response-cost-original: 0.0078345
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
== c2 ==
x-litellm-response-cost: 0.0006562
x-litellm-response-cost-original: 0.0006562
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
```

Across all five before-leg responses, zero occurrences of `-input`, `-output`, `-cache-read`, `-cache-creation`, `-reasoning`, or `-tool-usage`

### After leg (05beb7abb5, port 46746): six component headers present and additive

A1 (chat completions, gpt-5.4-nano, prompt_tokens=1417, completion_tokens=4, answer "391"; A2 byte-identical):

```bash
curl -sD /tmp/ha2_a1.txt -o /tmp/ba2_a1.json -X POST http://localhost:46746/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d @body_a.json
grep -i '^x-litellm-response-cost' /tmp/ha2_a1.txt
```

```
x-litellm-response-cost: 0.0002884
x-litellm-response-cost-original: 0.0002884
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
x-litellm-response-cost-input: 0.0002834
x-litellm-response-cost-output: 5e-06
x-litellm-response-cost-tool-usage: 0.0
```

B (/v1/responses, input_tokens=12, output_tokens=5):

```
x-litellm-response-cost: 8.65e-06
x-litellm-response-cost-input: 2.4e-06
x-litellm-response-cost-output: 6.25e-06
x-litellm-response-cost-tool-usage: 0.0
```

C1 (/v1/messages, cold cache, cache_creation_input_tokens=6242, input_tokens=12) then C2 (warm, cache_read_input_tokens=6242):

```
== c1 ==
x-litellm-response-cost: 0.0078345
x-litellm-response-cost-input: 1.1999999999999858e-05
x-litellm-response-cost-output: 2e-05
x-litellm-response-cost-cache-creation: 0.0078025
x-litellm-response-cost-tool-usage: 0.0
== c2 ==
x-litellm-response-cost: 0.0006562
x-litellm-response-cost-input: 1.1999999999999966e-05
x-litellm-response-cost-output: 2e-05
x-litellm-response-cost-cache-read: 0.0006242
x-litellm-response-cost-tool-usage: 0.0
```

C1n/C2n (same shape, fresh nonce guaranteeing a cold cache; cache_creation then cache_read of 6267 tokens) behaved identically: creation 0.00783375, read 0.0006267, input 1.2e-05 on both

Br (/v1/responses with `"reasoning": {"effort": "high"}`, input_tokens=25, output_tokens=175, reasoning_tokens=168):

```
x-litellm-response-cost: 0.00022375
x-litellm-response-cost-input: 4.9999999999999996e-06
x-litellm-response-cost-output: 0.00021875
x-litellm-response-cost-reasoning: 0.00021
x-litellm-response-cost-tool-usage: 0.0
```

### Sum invariant across all eight after-leg responses

Python check over the captured header files (rel_tol 1e-9, absent header = 0). Additive = input + cache-read + cache-creation + output + tool-usage; nested = input + output + tool-usage (the pre-fix contract)

| Scenario | Total | Additive holds | Nested holds | reasoning<=output |
| --- | --- | --- | --- | --- |
| A1 | 0.0002884 | True | True | True |
| A2 | 0.0002884 | True | True | True |
| B | 0.00000865 | True | True | True |
| C1 | 0.0078345 | True | False | True |
| C2 | 0.0006562 | True | False | True |
| C1n | 0.0078658 | True | False | True |
| C2n | 0.0006587 | True | False | True |
| Br | 0.0002238 | True | True | True |

On every cache scenario the input header is exactly the 12 uncached tokens x 1e-06 = 1.2e-05, cache creation = tokens x 1.25e-06, and cache read = tokens x 1e-07, matching Haiku 4.5 pricing to the digit (rel_tol 1e-9)

**Component semantics**: `_store_cost_breakdown_in_logging_obj` in cost_calculator.py records the full prompt cost (cache pricing already applied) as input_cost, so emitting it unchanged would double-count the cache once the cache headers exist. The header path therefore subtracts cache read and cache creation from input before emitting, the exact split the Admin UI's cost breakdown viewer already shows, delivering the additive contract issue #36875 asked for: input + cache-read + cache-creation + output + tool-usage = total, reasoning a subset of output. Spend-log storage is untouched

QA surprises:

- Stored input nests cache costs; headers now subtract them
- Nested formula now fails on cache scenarios, by design
- Input header carries float noise (1.19999...e-05), subtraction artifact
- No specified scenario produced reasoning tokens; added Br
- OpenAI auto-cache never hit on repeat prompts
- .env master key is double-quoted; strip quotes
- Harness reaped backgrounded proxies twice; detached Popen fixed it

## Type

🆕 New Feature

## Caveats (if any)

- Component headers appear on non-streaming responses only (headers leave before a stream's usage exists)
- Reasoning is a subset of output, so exclude it when summing components to the total
- Cache and reasoning headers appear only when those costs are nonzero
- The input header is the uncached input cost; spend logs keep storing the full prompt cost (cache included) as input_cost, so the header equals stored input minus the cache components

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
