### PR TITLE
fix: add supports_mid_conversation_system to bare first-party Claude cost-map keys

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12106,6 +12106,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -12493,6 +12494,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -12528,6 +12530,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -12566,6 +12569,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -47684,6 +47688,7 @@
         },
         "source": "https://docs.claude.com/en/docs/about-claude/models/overview",
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12106,6 +12106,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -12493,6 +12494,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -12528,6 +12530,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -12566,6 +12569,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -47684,6 +47688,7 @@
         },
         "source": "https://docs.claude.com/en/docs/about-claude/models/overview",
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -960,3 +960,40 @@ def test_gate_passthrough_skipped_when_only_chat_completions_supported(monkeypat
     assert result == "translated"
     assert translation_calls["count"] == 1
     assert "config" not in captured
+
+
+def test_first_party_claude_4_8_plus_cost_map_entries_carry_mid_conversation_system_flag():
+    """Regional and provider-prefixed Claude 4.8+/5 entries carry
+    ``supports_mid_conversation_system``, but the bare first-party keys
+    (``claude-opus-4-8``) that a plain ``custom_llm_provider="anthropic"``
+    lookup resolves were missed, so that lookup reports the capability as
+    unset. Every mapped first-party entry the fallback rule matches must
+    carry the flag."""
+    import json
+    import os
+    import re
+
+    import litellm
+
+    cost_map_path = os.path.join(
+        os.path.dirname(litellm.__file__), "model_prices_and_context_window_backup.json"
+    )
+    with open(cost_map_path) as f:
+        cost_map = json.load(f)
+    rules = cost_map["fallback_generalizations"]["rules"]
+    rule_pattern = next(
+        (r["pattern"] for r in rules if r["name"] == "claude-mid-conversation-system"),
+        None,
+    )
+    assert rule_pattern is not None, "claude-mid-conversation-system rule not found in fallback_generalizations"
+    pattern = re.compile(rule_pattern, re.IGNORECASE)
+    missing = [
+        key
+        for key, info in cost_map.items()
+        if isinstance(info, dict)
+        and info.get("litellm_provider") == "anthropic"
+        and "claude" in key
+        and pattern.search(key)
+        and info.get("supports_mid_conversation_system") is not True
+    ]
+    assert missing == []


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bare first-party keys (`claude-opus-4-8`, the 5 family) lack `supports_mid_conversation_system`
- Regional and provider-prefixed variants of the same models carry it
- A plain `custom_llm_provider="anthropic"` lookup reports the capability as unset

How it solves it:

- Adds the flag to the 5 bare first-party entries in both cost-map files
- Adds a sweep test so future first-party entries cannot miss it

## User Flow

Before: a developer checking whether their model keeps mid-conversation system messages gets a wrong answer for first-party keys

1. They call `litellm.get_model_info(model="claude-opus-4-8", custom_llm_provider="anthropic")`
2. `supports_mid_conversation_system` comes back `None`, so their code treats a model that supports the feature as unsupported
3. On a proxy serving `anthropic/claude-opus-4-8`, `GET /model/info` shows the same `null` under `model_info`
4. The same call with `model="vertex_ai/claude-opus-4-8"` returns `True`, so the same model reports different capabilities per route

After: the same lookup answers consistently on every route

1. They call `litellm.get_model_info(model="claude-opus-4-8", custom_llm_provider="anthropic")`
2. `supports_mid_conversation_system` comes back `True`, matching the regional and provider-prefixed entries
3. `GET /model/info` on the same proxy shows `true` for every `anthropic/<bare key>` deployment

## Relevant issues

Surfaced by the reporter in #36559 (follow-up to #36968); this PR is the cost-map data fix only

## Linear ticket

Part of LIT-5872 (https://linear.app/litellm-ai/issue/LIT-5872/hoisting-mid-conversation-system-reminders-on-pre-48-claude)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a capability-metadata fix. The flag is only read on the bedrock, vertex_ai, and azure_ai partner routes, whose entries already carry it, so no request bytes change for any model and a paid LLM call cannot demonstrate it. The user-visible surfaces are the SDK lookup and the proxy's `/model/info`, so both legs below drive those against a real proxy booted from each commit, with no mocks

Both legs use the same config: five deployments whose `litellm_params.model` is `anthropic/<bare key>`, `LITELLM_LOCAL_MODEL_COST_MAP=True`, master key `sk-1234`

### Before, at 2bc9bb4a9d308fd8791e8af67d2e5bd92f6d5947 (merge base)

SDK lookup:

```
$ for m in claude-opus-4-8 claude-sonnet-5 claude-opus-5 claude-fable-5 claude-mythos-5; do LITELLM_LOCAL_MODEL_COST_MAP=True .venv/bin/python -c "import litellm; print('$m', litellm.get_model_info(model='$m', custom_llm_provider='anthropic').get('supports_mid_conversation_system'))"; done
claude-opus-4-8 None
claude-sonnet-5 None
claude-opus-5 None
claude-fable-5 None
claude-mythos-5 None
```

Proxy on port 44191 (confirmed free with `lsof -nP -iTCP:44191 -sTCP:LISTEN` before boot):

```
$ curl -s http://localhost:44191/model/info -H "Authorization: Bearer sk-1234" | jq -c '.data[] | {model_name, supports_mid_conversation_system: .model_info.supports_mid_conversation_system}'
{"model_name":"claude-opus-4-8","supports_mid_conversation_system":null}
{"model_name":"claude-sonnet-5","supports_mid_conversation_system":null}
{"model_name":"claude-opus-5","supports_mid_conversation_system":null}
{"model_name":"claude-fable-5","supports_mid_conversation_system":null}
{"model_name":"claude-mythos-5","supports_mid_conversation_system":null}
```

`GET /v1/model/info` with the same filter returned the same five `null` rows

### After, at 4cd1c81a2dcd905112a7bc388afb5ed1412b8aa7 (PR head)

SDK lookup:

```
$ for m in claude-opus-4-8 claude-sonnet-5 claude-opus-5 claude-fable-5 claude-mythos-5; do LITELLM_LOCAL_MODEL_COST_MAP=True .venv/bin/python -c "import litellm; print('$m', litellm.get_model_info(model='$m', custom_llm_provider='anthropic').get('supports_mid_conversation_system'))"; done
claude-opus-4-8 True
claude-sonnet-5 True
claude-opus-5 True
claude-fable-5 True
claude-mythos-5 True
```

Proxy on port 43817 (confirmed free the same way):

```
$ curl -s http://localhost:43817/model/info -H "Authorization: Bearer sk-1234" | jq -c '.data[] | {model_name, supports_mid_conversation_system: .model_info.supports_mid_conversation_system}'
{"model_name":"claude-opus-4-8","supports_mid_conversation_system":true}
{"model_name":"claude-sonnet-5","supports_mid_conversation_system":true}
{"model_name":"claude-opus-5","supports_mid_conversation_system":true}
{"model_name":"claude-fable-5","supports_mid_conversation_system":true}
{"model_name":"claude-mythos-5","supports_mid_conversation_system":true}
```

`GET /v1/model/info` with the same filter returned the same five `true` rows

Both proxies also listed 58 unrelated deployments loaded from the dev database (the worktree `.env` sets `DATABASE_URL`); those rows are omitted above and are identical between legs

The new sweep test fails at the merge base (`assert missing == []` reports all five keys) and passes at the head

## Type

🐛 Bug Fix

## Caveats (if any)

- Data plus one sweep test only; no behavior code touched
- Minor: the sweep test lives next to the flag's consumer tests in `test_anthropic_experimental_pass_through_messages_handler.py` rather than beside the existing shipped-backup sweep in `tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py`; left as is since moving it buys nothing for a data fix
- Minor: the test re-imports `json`, `os`, and `litellm` inside the function although the file already imports them at the top; harmless

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 4cd1c81a2dcd905112a7bc388afb5ed1412b8aa7 passes /live-pr-risk
