### PR TITLE
fix(guardrails): record MCP tool guardrail evaluations and blocks in …

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -13,7 +13,7 @@ import json
 import os
 import re
 import time
-from collections.abc import AsyncIterator, Callable, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, TypedDict, cast
 from urllib.parse import ParseResult, urlparse
@@ -46,6 +46,9 @@ from litellm.constants import (
 )
 from litellm.exceptions import BlockedPiiEntityError, GuardrailRaisedException
 from litellm.experimental_mcp_client.client import MCPClient, MCPSigV4Auth
+from litellm.integrations.custom_guardrail import (
+    _sync_guardrail_info_to_logging_obj,  # pyright: ignore[reportPrivateUsage] - the same bridge @log_guardrail_information uses; reimplementing it here would fork the metadata-key logic
+)
 from litellm.litellm_core_utils.url_utils import SSRFError, async_safe_get
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
@@ -162,6 +165,7 @@ if TYPE_CHECKING:
     from mcp.types import CreateMessageRequestParams
 
     from litellm.caching.caching import InMemoryCache
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.types.mcp_server.mcp_toolset import MCPToolset
 
 try:
@@ -1231,6 +1235,35 @@ def _create_elicitation_callback():
         )
 
     return _elicitation_callback
+
+
+def _record_mcp_guardrail_evaluations(
+    synthetic_llm_data: dict[str, Any],  # mutable-ok: `_sync_guardrail_info_to_logging_obj` takes a concrete dict
+    litellm_logging_obj: "LiteLLMLoggingObj | None",
+) -> None:
+    """Bridge guardrail decision records off an MCP synthetic request onto the request's logger.
+
+    MCP guardrails run against a throwaway LLM-shaped dict from
+    ``ProxyLogging._convert_mcp_to_llm_format``, so ``@log_guardrail_information``
+    files ``standard_logging_guardrail_information`` in that dict's metadata bucket,
+    which ``get_standard_logging_object_payload`` never reads. Native (non-unified)
+    guardrails receive no ``logging_obj`` kwarg, so the decorator cannot bridge on
+    their behalf; this calls the same helper it would have.
+
+    Only the decision records move. The synthetic request's messages and tool
+    arguments stay behind: they can carry end-user data, and the monitor needs none
+    of it.
+    """
+    if litellm_logging_obj is None:
+        return
+
+    try:
+        _sync_guardrail_info_to_logging_obj(synthetic_llm_data, litellm_logging_obj)
+    except Exception as e:  # noqa: BLE001  # callers run this from a `finally` on the block path
+        # The breadth is the point. Narrowing to the knowable AttributeError/TypeError
+        # would let an unexpected type escape that ``finally`` and replace the guardrail's
+        # block with a bookkeeping error.
+        verbose_logger.warning("Failed to record MCP guardrail evaluation for logging: %s", e)
 
 
 class MCPServerManager:
@@ -4543,6 +4576,7 @@ class MCPServerManager:
         proxy_logging_obj: ProxyLogging | None,
         server: MCPServer,
         raw_headers: dict[str, str] | None = None,
+        litellm_logging_obj: "LiteLLMLoggingObj | None" = None,
     ) -> dict[str, Any]:
         """
         Run pre-call checks and guardrail hooks for an MCP tool call.
@@ -4551,6 +4585,10 @@ class MCPServerManager:
         dispatched through ``proxy_logging_obj``, depend on a logger being
         present. An absent logger must never be able to turn an authorization
         decision into a no-op.
+
+        ``litellm_logging_obj`` is the request's logger, and it is what lands a
+        ``pre_mcp_call`` evaluation (or a block) on the spend-log row the Guardrails
+        Monitor counts. It stays optional so callers that do no logging are unchanged.
 
         Returns a dict that may contain:
         - "arguments": hook-modified tool arguments (only if changed)
@@ -4610,8 +4648,13 @@ class MCPServerManager:
         # Create MCP request object for processing
         mcp_request_obj: Final = proxy_logging_obj._create_mcp_request_object_from_kwargs(pre_hook_kwargs)
 
-        # Convert to LLM format for existing guardrail compatibility
+        # Convert to LLM format for existing guardrail compatibility.
+        # Unified guardrails read the seeded logger off the request dict and pass it
+        # into ``apply_guardrail``, so ``@log_guardrail_information`` bridges their
+        # evaluations itself; the ``finally`` below covers native guardrails, which
+        # never receive it. Same seeding the pass-through routes do.
         synthetic_llm_data: Final = proxy_logging_obj._convert_mcp_to_llm_format(mcp_request_obj, pre_hook_kwargs)
+        synthetic_llm_data["litellm_logging_obj"] = litellm_logging_obj
 
         try:
             # Use standard pre_call_hook
@@ -4636,6 +4679,12 @@ class MCPServerManager:
             # Re-raise guardrail exceptions to properly fail the MCP call
             verbose_logger.error("Guardrail blocked MCP tool call pre call: %s", e)
             raise e
+        finally:
+            # ``finally`` rather than after the ``try``: a block raises straight out of
+            # here, and the failure spend-log row that "Total Blocked" counts is built
+            # from this logger further up the stack, so the record has to be attached
+            # before the exception leaves this frame.
+            _record_mcp_guardrail_evaluations(synthetic_llm_data, litellm_logging_obj)
 
         return hook_result
 
@@ -4647,8 +4696,14 @@ class MCPServerManager:
         user_api_key_auth: UserAPIKeyAuth | None,
         proxy_logging_obj: ProxyLogging,
         start_time: datetime.datetime,
+        litellm_logging_obj: "LiteLLMLoggingObj | None" = None,
     ):
-        """Create and return a during hook task for MCP tool calls."""
+        """Create and return a during hook task for MCP tool calls.
+
+        ``litellm_logging_obj`` is the request's logger; see ``pre_call_tool_check``.
+        The task is awaited before the tool call's success logging runs, so a
+        ``during_mcp_call`` evaluation recorded on it is serialized with that call.
+        """
         from litellm.types.llms.base import HiddenParams
         from litellm.types.mcp import MCPDuringCallRequestObject
 
@@ -4667,15 +4722,23 @@ class MCPServerManager:
             "user_api_key_auth": user_api_key_auth,
         }
 
+        # Seeded for the same reason as in ``pre_call_tool_check``.
         synthetic_llm_data: Final = proxy_logging_obj._convert_mcp_to_llm_format(request_obj, during_hook_kwargs)
+        synthetic_llm_data["litellm_logging_obj"] = litellm_logging_obj
 
-        return asyncio.create_task(
-            proxy_logging_obj.during_call_hook(
-                user_api_key_dict=user_api_key_auth,
-                data=synthetic_llm_data,
-                call_type=CallTypes.call_mcp_tool.value,
-            )
-        )
+        # Wrapped so the bridge runs inside the task: the caller only holds the task and
+        # gathers it later, so there is no other point that still sees a block here.
+        async def _run_during_call_hook() -> Mapping[str, Any] | None:
+            try:
+                return await proxy_logging_obj.during_call_hook(
+                    user_api_key_dict=user_api_key_auth,
+                    data=synthetic_llm_data,
+                    call_type=CallTypes.call_mcp_tool.value,
+                )
+            finally:
+                _record_mcp_guardrail_evaluations(synthetic_llm_data, litellm_logging_obj)
+
+        return asyncio.create_task(_run_during_call_hook())
 
     def _get_call_semaphore(self, mcp_server: MCPServer) -> asyncio.Semaphore | None:
         limit: Final = mcp_server.max_concurrent_requests
@@ -5204,6 +5267,7 @@ class MCPServerManager:
         oauth2_headers: dict[str, str] | None = None,
         raw_headers: dict[str, str] | None = None,
         host_progress_callback: Callable | None = None,
+        litellm_logging_obj: "LiteLLMLoggingObj | None" = None,
     ) -> CallToolResult:
         """
         Call a tool with the given name and arguments
@@ -5216,6 +5280,9 @@ class MCPServerManager:
             mcp_auth_header: MCP auth header (deprecated)
             mcp_server_auth_headers: Optional dict of server-specific auth headers {server_alias: auth_value}
             proxy_logging_obj: Optional ProxyLogging object for hook integration
+            litellm_logging_obj: Optional request logger the guardrail hooks record
+                their evaluations onto, so MCP guardrail activity reaches the
+                Guardrails Monitor. See ``pre_call_tool_check``
 
 
         Returns:
@@ -5246,6 +5313,7 @@ class MCPServerManager:
             proxy_logging_obj=proxy_logging_obj,
             server=mcp_server,
             raw_headers=raw_headers,
+            litellm_logging_obj=litellm_logging_obj,
         )
         if "arguments" in hook_result:
             arguments = hook_result["arguments"]
@@ -5260,6 +5328,7 @@ class MCPServerManager:
                 user_api_key_auth=user_api_key_auth,
                 proxy_logging_obj=proxy_logging_obj,
                 start_time=start_time,
+                litellm_logging_obj=litellm_logging_obj,
             )
             tasks.append(during_hook_task)
 

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2824,6 +2824,7 @@ if MCP_AVAILABLE:
                 proxy_logging_obj=proxy_logging_obj,
                 server=mcp_server,
                 raw_headers=raw_headers,
+                litellm_logging_obj=litellm_logging_obj,
             )
             # `pre_call_tool_check` may return guardrail-modified
             # arguments; honor them on the local path too.
@@ -2962,6 +2963,7 @@ if MCP_AVAILABLE:
                     proxy_logging_obj=proxy_logging_obj,
                     server=prefix_server,
                     raw_headers=raw_headers,
+                    litellm_logging_obj=litellm_logging_obj,
                 )
                 if "arguments" in hook_result:
                     arguments = hook_result["arguments"]  # pyright: ignore[reportAny]  # hook returns untyped args
@@ -3149,6 +3151,20 @@ if MCP_AVAILABLE:
             traceback_str: Final = traceback.format_exc(limit=MAXIMUM_TRACEBACK_LINES_TO_LOG)
             from litellm.proxy.proxy_server import proxy_logging_obj
 
+            # Ordering is load-bearing. ``_ProxyDBLogger.async_post_call_failure_hook``,
+            # reached below, writes the failure spend-log row from this logger's
+            # ``standard_logging_object``, which only exists once the failure handlers
+            # have run. Flush them first or the row lands with
+            # ``guardrail_information=None`` and a guardrail block is never counted.
+            #
+            # Not double-logged: both handlers gate on ``should_run_logging`` and then
+            # mark it, so the ``@client`` wrapper's own post-raise logging no-ops on this
+            # logger, same as ``_fire_mcp_tool_call_logging`` does for ``isError=True``.
+            if litellm_logging_obj is not None:
+                end_time: Final = datetime.now()  # noqa: DTZ005  # naive to match `start_time`, which it is subtracted from
+                litellm_logging_obj.failure_handler(e, traceback_str, start_time, end_time)
+                await litellm_logging_obj.async_failure_handler(e, traceback_str, start_time, end_time)
+
             if proxy_logging_obj and user_api_key_auth:
                 await proxy_logging_obj.post_call_failure_hook(
                     request_data=kwargs,
@@ -3326,6 +3342,7 @@ if MCP_AVAILABLE:
             raw_headers=raw_headers,
             proxy_logging_obj=proxy_logging_obj,
             host_progress_callback=host_progress_callback,
+            litellm_logging_obj=litellm_logging_obj,
         )
         verbose_logger.debug("CALL TOOL RESULT: %s", call_tool_result)
         return call_tool_result

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -798,6 +798,7 @@ class LiteLLM_Proxy_MCP_Handler:
                     oauth2_headers=oauth2_headers,
                     raw_headers=raw_headers,
                     proxy_logging_obj=proxy_logging_obj,
+                    litellm_logging_obj=litellm_logging_obj,
                 )
 
                 if proxy_logging_obj:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_block_recording.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_block_recording.py
@@ -1,0 +1,126 @@
+"""Tests for guardrail-block recording in
+``litellm.proxy._experimental.mcp_server.server.call_mcp_tool``.
+
+A pre-call MCP guardrail block *raises* into ``call_mcp_tool``'s
+``except Exception``. The failure spend-log row that the Guardrails Monitor's
+"Total Blocked" counts is written by ``_ProxyDBLogger.async_post_call_failure_hook``
+(reached via ``proxy_logging_obj.post_call_failure_hook``), which reads
+``standard_logging_object`` off the request's logging obj -- and that only exists
+once ``failure_handler`` / ``async_failure_handler`` have run. So the failure
+handlers must run *before* ``post_call_failure_hook``, otherwise the row persists
+with ``guardrail_information=None`` and the block is never counted. These tests
+pin that ordering.
+
+``call_mcp_tool`` is wrapped by ``@client`` (``litellm.utils.client``), which uses
+``functools.wraps`` and therefore exposes the raw undecorated coroutine as
+``__wrapped__``. The tests drive ``__wrapped__`` directly so the except-block
+ordering is observed in isolation, without the wrapper's own post-raise logging
+firing. Note that this means they do not exercise the wrapper's dedup path; that
+dedup rests on ``should_run_logging("sync_failure")`` / ``("async_failure")``,
+which has its own coverage in the logging tests.
+
+``proxy_logging_obj`` is imported lazily inside the except block via
+``from litellm.proxy.proxy_server import proxy_logging_obj``; the real
+``proxy_server`` module is heavy, so a fake module is injected into ``sys.modules``
+to satisfy that lazy import without loading it.
+"""
+
+import contextlib
+import sys
+import types
+from unittest import mock
+
+import pytest
+from fastapi import HTTPException
+
+from litellm.proxy._experimental.mcp_server import server
+
+
+class _RecordingLoggingObj:
+    """Stands in for ``LiteLLMLoggingObj``, recording the failure flush the fix
+    makes so the test can assert it happens before ``post_call_failure_hook``."""
+
+    def __init__(self, order: list) -> None:
+        self._order = order
+        self.failure_calls = 0
+        self.async_failure_calls = 0
+
+    def failure_handler(self, *_args, **_kwargs) -> None:
+        self.failure_calls += 1
+        self._order.append("failure_handler")
+
+    async def async_failure_handler(self, *_args, **_kwargs) -> None:
+        self.async_failure_calls += 1
+        self._order.append("async_failure_handler")
+
+
+async def _call_block(logging_obj, order: list, *, user_api_key_auth=mock.sentinel.auth):
+    """Drive ``call_mcp_tool`` into its except path via ``arguments=None``, which
+    raises ``HTTPException(400)`` before any server-manager call, and return once it
+    re-raises."""
+
+    async def _record_post_call_failure_hook(**_kwargs) -> None:
+        order.append("post_call_failure_hook")
+
+    proxy_logging_obj = mock.MagicMock()
+    proxy_logging_obj.post_call_failure_hook.side_effect = _record_post_call_failure_hook
+
+    fake_proxy_server = types.ModuleType("litellm.proxy.proxy_server")
+    fake_proxy_server.proxy_logging_obj = proxy_logging_obj  # pyright: ignore[reportAttributeAccessIssue]
+
+    with mock.patch.dict(sys.modules, {"litellm.proxy.proxy_server": fake_proxy_server}):
+        with contextlib.suppress(HTTPException):
+            await server.call_mcp_tool.__wrapped__(
+                name="t",
+                arguments=None,
+                user_api_key_auth=user_api_key_auth,
+                litellm_logging_obj=logging_obj,
+            )
+
+
+@pytest.mark.asyncio
+async def test_block_flushes_failure_before_post_call_failure_hook():
+    order: list = []
+    await _call_block(_RecordingLoggingObj(order), order)
+
+    assert order == ["failure_handler", "async_failure_handler", "post_call_failure_hook"], order
+
+
+@pytest.mark.asyncio
+async def test_block_flushes_each_handler_exactly_once():
+    """Each handler runs once, so the block yields exactly one counted row rather
+    than double-counting on the shared logging obj."""
+    order: list = []
+    obj = _RecordingLoggingObj(order)
+    await _call_block(obj, order)
+
+    assert (obj.failure_calls, obj.async_failure_calls) == (1, 1)
+
+
+@pytest.mark.asyncio
+async def test_block_flushes_failure_for_anonymous_calls():
+    """With no ``user_api_key_auth`` the failure handlers still run, so OTel and the
+    other failure sinks see the block.
+
+    ``post_call_failure_hook`` stays gated on auth, matching the pre-existing
+    contract: SpendLogs rows are attributable billing/audit records and the
+    downstream DB logger dereferences authenticated key, budget, and route data.
+    Counting anonymous MCP blocks needs a counter that does not live in SpendLogs,
+    which is a separate design change, not part of this fix.
+    """
+    order: list = []
+    obj = _RecordingLoggingObj(order)
+    await _call_block(obj, order, user_api_key_auth=None)
+
+    assert order == ["failure_handler", "async_failure_handler"], order
+
+
+@pytest.mark.asyncio
+async def test_absent_logging_obj_still_calls_hook_and_skips_flush():
+    """Without a logging obj the flush is skipped (no crash) but
+    ``post_call_failure_hook`` still fires. Byte-equivalent to stock behavior for
+    that branch; its value is as a mutation-killer for the ``is not None`` guard."""
+    order: list = []
+    await _call_block(None, order)
+
+    assert order == ["post_call_failure_hook"], order

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_guardrail_usage_monitor.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_guardrail_usage_monitor.py
@@ -1,0 +1,301 @@
+"""Tests for MCP guardrail evaluations reaching the Guardrails Monitor.
+
+MCP tool calls run their guardrails against a throwaway LLM-shaped dict built by
+``ProxyLogging._convert_mcp_to_llm_format``, not against the dict the tool call is
+logged from. ``@log_guardrail_information`` therefore appends
+``standard_logging_guardrail_information`` to that throwaway dict's metadata
+bucket, where ``get_standard_logging_object_payload`` never sees it, so the
+Guardrails Monitor reported zero evaluations and zero blocks for MCP traffic.
+
+``pre_call_tool_check`` and ``_create_during_hook_task`` now take the request's
+``litellm_logging_obj`` and bridge those records onto it. These tests pin both the
+seeding (which unified guardrails consume off ``data["litellm_logging_obj"]``) and
+the bridge (which native guardrails depend on), including on the block path.
+"""
+
+import asyncio
+import datetime
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from litellm.exceptions import GuardrailRaisedException
+from litellm.proxy._experimental.mcp_server import mcp_server_manager as MOD
+
+
+class _FakeLoggingObj:
+    """Minimal stand-in for ``LiteLLMLoggingObj``.
+
+    ``_sync_guardrail_info_to_logging_obj`` reads exactly these two attributes,
+    and the spend-log payload is built from ``litellm_params["metadata"]``, so a
+    real ``Logging`` instance would add setup cost without adding coverage.
+    """
+
+    def __init__(self) -> None:
+        self.litellm_params: dict[str, Any] = {"metadata": {}}
+        self.model_call_details: dict[str, Any] = {"litellm_params": self.litellm_params}
+
+    @property
+    def recorded_guardrails(self) -> list:
+        return self.litellm_params["metadata"].get("standard_logging_guardrail_information", [])
+
+
+def _bare_manager() -> MOD.MCPServerManager:
+    """An ``MCPServerManager`` without running ``__init__``.
+
+    The authorization/validation helpers on the path are stubbed out so the test
+    reaches the guardrail hooks; they have their own coverage elsewhere.
+    """
+    mgr = MOD.MCPServerManager.__new__(MOD.MCPServerManager)
+    mgr.check_allowed_or_banned_tools = lambda name, server: True
+    mgr.validate_allowed_params = lambda tool_name, arguments, server: None
+
+    async def _ok(*_args, **_kwargs) -> None:
+        return None
+
+    mgr.check_tool_permission_for_key_team = _ok
+    return mgr
+
+
+def _fake_proxy_logging(capture: dict, *, guardrail_effect=None):
+    """A ``proxy_logging_obj`` double whose hooks capture the data they receive.
+
+    ``guardrail_effect`` stands in for a guardrail: it is handed the synthetic
+    request dict so it can append a guardrail record (and optionally raise, the
+    way a blocking guardrail does).
+    """
+    plo = mock.MagicMock()
+    plo._create_mcp_request_object_from_kwargs.return_value = mock.MagicMock()
+    # Mirror the real conversion's metadata bucket so a test can prove it survives.
+    plo._convert_mcp_to_llm_format.side_effect = lambda *_a, **_k: {
+        "metadata": {"headers": {"x-forwarded-for": "1.2.3.4"}}
+    }
+
+    async def _hook(*, user_api_key_dict, data, call_type) -> None:
+        del user_api_key_dict  # captured shape is what matters, not the auth double
+        capture["data"] = data
+        capture["call_type"] = call_type
+        if guardrail_effect is not None:
+            guardrail_effect(data)
+
+    plo.pre_call_hook.side_effect = _hook
+    plo.during_call_hook.side_effect = _hook
+    return plo
+
+
+def _record_guardrail(status: str = "success"):
+    """Write a guardrail record the way ``@log_guardrail_information`` does."""
+
+    def _effect(data: dict) -> None:
+        data.setdefault("metadata", {}).setdefault("standard_logging_guardrail_information", []).append(
+            {"guardrail_name": "test-guardrail", "guardrail_status": status}
+        )
+
+    return _effect
+
+
+def _blocking_guardrail():
+    record = _record_guardrail(status="guardrail_intervened")
+
+    def _effect(data: dict) -> None:
+        record(data)
+        raise GuardrailRaisedException(guardrail_name="test-guardrail", message="blocked")
+
+    return _effect
+
+
+async def _run_pre_call(mgr, plo, logging_obj) -> dict:
+    return await mgr.pre_call_tool_check(
+        name="t",
+        arguments={},
+        server_name="s",
+        user_api_key_auth=None,
+        proxy_logging_obj=plo,
+        server=mock.MagicMock(),
+        raw_headers={},
+        litellm_logging_obj=logging_obj,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pre_call_seeds_request_logging_obj_for_unified_guardrails():
+    """Unified guardrails read ``data["litellm_logging_obj"]`` and pass it into
+    ``apply_guardrail``, whose ``@log_guardrail_information`` wrapper bridges the
+    evaluation onto that logger itself. Drop the seed and that path records
+    nothing."""
+    capture: dict = {}
+    logging_obj = _FakeLoggingObj()
+    await _run_pre_call(_bare_manager(), _fake_proxy_logging(capture), logging_obj)
+
+    assert capture["data"]["litellm_logging_obj"] is logging_obj
+
+
+@pytest.mark.asyncio
+async def test_pre_call_keeps_synthetic_request_headers_metadata():
+    """The seed must not clobber the metadata bucket ``_convert_mcp_to_llm_format``
+    builds: guardrails such as ``MCPJWTSigner`` read ``metadata["headers"]`` off
+    it."""
+    capture: dict = {}
+    await _run_pre_call(_bare_manager(), _fake_proxy_logging(capture), _FakeLoggingObj())
+
+    assert capture["data"]["metadata"]["headers"] == {"x-forwarded-for": "1.2.3.4"}
+
+
+@pytest.mark.asyncio
+async def test_pre_call_bridges_allowed_evaluation_onto_request_logger():
+    """An allowed ``pre_mcp_call`` evaluation must land on the request logger, which
+    is what the monitor's "Total Evaluations" counts."""
+    capture: dict = {}
+    logging_obj = _FakeLoggingObj()
+    plo = _fake_proxy_logging(capture, guardrail_effect=_record_guardrail())
+
+    await _run_pre_call(_bare_manager(), plo, logging_obj)
+
+    assert logging_obj.recorded_guardrails == [{"guardrail_name": "test-guardrail", "guardrail_status": "success"}]
+
+
+@pytest.mark.asyncio
+async def test_pre_call_bridges_blocked_evaluation_before_reraising():
+    """A block raises straight out of ``pre_call_tool_check``, and the failure
+    spend-log row that "Total Blocked" counts is built from this logger further up
+    the stack. So the record has to be attached before the exception leaves the
+    frame -- hence the bridge lives in a ``finally``."""
+    capture: dict = {}
+    logging_obj = _FakeLoggingObj()
+    plo = _fake_proxy_logging(capture, guardrail_effect=_blocking_guardrail())
+
+    with pytest.raises(GuardrailRaisedException):
+        await _run_pre_call(_bare_manager(), plo, logging_obj)
+
+    assert logging_obj.recorded_guardrails == [
+        {"guardrail_name": "test-guardrail", "guardrail_status": "guardrail_intervened"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pre_call_without_logging_obj_is_unchanged():
+    """Callers that thread no logger are unaffected: the seed is an explicit
+    ``None`` (which every consumer reads via ``.get``) and nothing is bridged.
+    Guards against the bridge assuming a logger exists."""
+    capture: dict = {}
+    plo = _fake_proxy_logging(capture, guardrail_effect=_record_guardrail())
+    mgr = _bare_manager()
+
+    result = await mgr.pre_call_tool_check(
+        name="t",
+        arguments={},
+        server_name="s",
+        user_api_key_auth=None,
+        proxy_logging_obj=plo,
+        server=mock.MagicMock(),
+        raw_headers={},
+    )
+
+    assert result == {}
+    assert capture["data"]["litellm_logging_obj"] is None
+
+
+@pytest.mark.asyncio
+async def test_during_hook_seeds_and_bridges_onto_request_logger():
+    """``during_mcp_call`` evaluations need the same treatment. The task is awaited
+    before the tool call's success logging runs, so the record is serialized with
+    that call."""
+    capture: dict = {}
+    logging_obj = _FakeLoggingObj()
+    plo = _fake_proxy_logging(capture, guardrail_effect=_record_guardrail())
+
+    await _bare_manager()._create_during_hook_task(
+        name="t",
+        arguments={},
+        server_name_from_prefix="s",
+        user_api_key_auth=None,
+        proxy_logging_obj=plo,
+        start_time=datetime.datetime(2026, 7, 14),
+        litellm_logging_obj=logging_obj,
+    )
+
+    assert capture["data"]["litellm_logging_obj"] is logging_obj
+    assert logging_obj.recorded_guardrails == [{"guardrail_name": "test-guardrail", "guardrail_status": "success"}]
+
+
+@pytest.mark.asyncio
+async def test_during_hook_bridges_even_when_hook_raises():
+    """A during-call guardrail block must still be recorded before the task's
+    exception propagates to the ``asyncio.gather`` in ``call_tool``."""
+    capture: dict = {}
+    logging_obj = _FakeLoggingObj()
+    plo = _fake_proxy_logging(capture, guardrail_effect=_blocking_guardrail())
+
+    task = _bare_manager()._create_during_hook_task(
+        name="t",
+        arguments={},
+        server_name_from_prefix="s",
+        user_api_key_auth=None,
+        proxy_logging_obj=plo,
+        start_time=datetime.datetime(2026, 7, 14),
+        litellm_logging_obj=logging_obj,
+    )
+    with pytest.raises(GuardrailRaisedException):
+        await task
+
+    assert logging_obj.recorded_guardrails == [
+        {"guardrail_name": "test-guardrail", "guardrail_status": "guardrail_intervened"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bridge_failure_does_not_mask_a_guardrail_block():
+    """Recording is best-effort bookkeeping. If the bridge itself raises, the guardrail's
+    block must still be what the caller sees, not a bookkeeping error.
+
+    The bridge is forced to fail by making the logger's ``model_call_details`` raise, and
+    the swallow is asserted (not just the surviving exception type) so the test cannot go
+    vacuous if a refactor stops the bridge from touching that attribute.
+    """
+    capture: dict = {}
+    plo = _fake_proxy_logging(capture, guardrail_effect=_blocking_guardrail())
+
+    broken_logging_obj = mock.MagicMock()
+    type(broken_logging_obj).model_call_details = mock.PropertyMock(side_effect=RuntimeError("boom"))
+
+    with mock.patch.object(MOD.verbose_logger, "warning") as warn:
+        with pytest.raises(GuardrailRaisedException):
+            await _run_pre_call(_bare_manager(), plo, broken_logging_obj)
+
+    assert warn.call_count == 1, "the bridge did not actually fail, so this test proves nothing"
+    assert "boom" in str(warn.call_args)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_threads_logging_obj_into_both_hooks():
+    """``call_tool`` is the single entry point every MCP dispatch route funnels
+    through, so it must hand the logger to both guardrail hook sites."""
+    mgr = _bare_manager()
+    logging_obj = _FakeLoggingObj()
+    seen: dict = {}
+
+    async def _fake_pre_call_tool_check(**kwargs):
+        seen["pre_call"] = kwargs.get("litellm_logging_obj")
+        return {}
+
+    def _fake_during_hook_task(**kwargs):
+        seen["during_call"] = kwargs.get("litellm_logging_obj")
+        return asyncio.get_running_loop().create_future()
+
+    mgr.pre_call_tool_check = _fake_pre_call_tool_check
+    mgr._create_during_hook_task = _fake_during_hook_task
+    mgr._resolve_mcp_server_for_tool_call = lambda server_name, name: mock.MagicMock(spec_path=None)
+    mgr._resolve_oauth2_headers_for_tool_call = mock.AsyncMock(return_value=None)
+    mgr._call_regular_mcp_tool = mock.AsyncMock(return_value=mock.MagicMock())
+
+    with mock.patch.object(MOD, "_resolve_byok_mcp_auth_header", mock.AsyncMock(return_value=None)):
+        await mgr.call_tool(
+            server_name="s",
+            name="t",
+            arguments={},
+            proxy_logging_obj=mock.MagicMock(),
+            litellm_logging_obj=logging_obj,
+        )
+
+    assert seen == {"pre_call": logging_obj, "during_call": logging_obj}

--- a/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
+++ b/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
@@ -451,6 +451,42 @@ async def test_execute_tool_calls_passes_litellm_call_id_and_trace_id_to_functio
 
 
 @pytest.mark.asyncio
+async def test_execute_tool_calls_threads_logging_obj_into_call_tool(monkeypatch):
+    """The Responses-API MCP path must hand the request's litellm_logging_obj to
+    global_mcp_server_manager.call_tool, otherwise pre_call_tool_check /
+    _create_during_hook_task get None and no guardrail evaluation is bridged onto
+    the request logger, so MCP tool calls made through the Responses API report zero
+    guardrail evaluations in the monitor. Drop the litellm_logging_obj kwarg on the
+    call_tool invocation and this fails."""
+    _setup_proxy_logging(monkeypatch)
+    call_tool_mock = _setup_mcp_call_environment(monkeypatch)
+
+    sentinel_logging_obj = MagicMock()
+    sentinel_logging_obj.async_post_mcp_tool_call_hook = AsyncMock()
+    sentinel_logging_obj.async_success_handler = AsyncMock()
+
+    handler_module = importlib.import_module("litellm.responses.mcp.litellm_proxy_mcp_handler")
+    monkeypatch.setattr(
+        handler_module,
+        "function_setup",
+        lambda *_args, **_kwargs: (sentinel_logging_obj, None),
+    )
+
+    tool_name = "deepwiki-read_wiki_structure"
+    tool_calls = [{"id": "call-1", "function": {"name": tool_name, "arguments": "{}"}}]
+
+    await LiteLLM_Proxy_MCP_Handler._execute_tool_calls(
+        tool_server_map={tool_name: "deepwiki"},
+        tool_calls=tool_calls,
+        user_api_key_auth=None,
+    )
+
+    assert call_tool_mock.await_count == 1
+    assert call_tool_mock.await_args is not None
+    assert call_tool_mock.await_args.kwargs["litellm_logging_obj"] is sentinel_logging_obj
+
+
+@pytest.mark.asyncio
 async def test_get_mcp_tools_from_manager_enables_list_tools_logging(monkeypatch):
     """
     Regression test for 872e5b98...:


### PR DESCRIPTION
> Base branch: `litellm_internal_staging`

## TLDR

Problem this solves:

- Guardrails Monitor reports 0 evaluations for all MCP tool traffic
- It also reports 0 blocks, so MCP guardrails look inert
- Admins cannot tell a firing MCP guardrail from a broken one

How it solves it:

- Threads the request's logger into the MCP guardrail hooks
- Bridges guardrail decision records onto that logger
- Flushes failure logging before the spend-log row is written
- Covers every MCP tool entry point, Responses API included

## User Flow

Before: a proxy admin who put a guardrail on MCP tool calls sees the Guardrails Monitor stay empty, so the guardrail looks dead even while it is refusing calls

1. They configure a guardrail on their MCP tool traffic and restart the proxy
2. They call an MCP tool through `POST http://localhost:4000/mcp` and it succeeds
3. They call it again with input the guardrail refuses, and the tool call comes back as an error naming the guardrail, so the guardrail is provably running
4. They open http://localhost:4000/ui/?page=guardrails and the monitor shows Total Evaluations 0 and Total Blocked 0
5. They open http://localhost:4000/ui/?page=logs, click into either MCP tool call, and the row carries no guardrail detail at all
6. Having no way to tell a working MCP guardrail from a misconfigured one, they cannot report on or alert off MCP guardrail activity

After: the same steps, and the monitor now counts both the allowed evaluation and the refusal

1. They configure a guardrail on their MCP tool traffic and restart the proxy
2. They call an MCP tool through `POST http://localhost:4000/mcp` and it succeeds
3. They call it again with input the guardrail refuses, and the tool call comes back as an error naming the guardrail
4. They open http://localhost:4000/ui/?page=guardrails and the monitor shows Total Evaluations 2 and Total Blocked 1
5. They open http://localhost:4000/ui/?page=logs, click into either MCP tool call, and the row shows which guardrail ran and whether it allowed or blocked
6. They can now report on and alert off MCP guardrail activity the same way they already do for chat completions

## Relevant issues

Reimplements #34249 (Eugene Yao) on current `litellm_internal_staging`, written from scratch against today's staging rather than rebased, since the MCP tool-call path moved underneath it

It also lands the review feedback #34249 collected. This one is based on `litellm_internal_staging` instead of `main`. It reuses the `function_setup` call the Responses API MCP path already makes rather than adding a second one. It drops the metadata aliasing, so the synthetic guardrail request's metadata bucket is left as `_convert_mcp_to_llm_format` built it and nothing else reads through an alias. And it threads the Responses API entry point, which the original left on the old behavior, so `/v1/responses` MCP tool calls are counted too

## Linear ticket

Resolves LIT-5677

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

End to end against a real proxy on `localhost:4000` backed by a real Postgres, driven by real MCP tool calls over streamable HTTP, with the counts read back from the same endpoint the Admin UI Guardrails Monitor page calls. No mocks anywhere in this section

Before commit: `2bc9bb4a9d308fd8791e8af67d2e5bd92f6d5947` (this PR's parent)
After commit: `c3576be27bb052e0fb49bd15863398a2b9547605`

The branch has since been squashed to the current tip `9858d021eef07fefb955d7dc9d4c8e1595afb495`. Everything between the measured commit and that tip is comment and docstring wording, two rule-named `# noqa` suppressions, one return annotation, hoisting an import from function-local to module level, and one strengthened assertion in a test. Nothing that changes what the run above measured. All four legs were then re-run at that tip against the same parent commit on Python 3.12, this time through the plain `litellm --config` CLI path with no uvicorn workaround, and produced the identical table: before 0 and 0 with null `guardrail_information` in both configs, after 1 evaluated with 0 blocked for the allowing guardrail and 1 evaluated with 1 blocked for the blocking one, with `guardrail_information` present on the matching spend-log rows and `LiteLLM_DailyGuardrailMetrics` populated

Setup is a synthetic MCP server exposing one tool, `synthetic_echo`, plus two probe guardrails registered on `mode: "pre_mcp_call"`, one that always allows and one that always blocks. Both subclass `CustomGuardrail` and carry `@log_guardrail_information`, so the real decorator path is exercised. The one configured model points at `http://127.0.0.1:9/unused` with a placeholder key, so no provider is ever contacted, and every tool argument is synthetic

What the monitor actually reads: `GET /guardrails/usage/overview` in `litellm/proxy/guardrails/usage_endpoints.py`, which sums `LiteLLM_DailyGuardrailMetrics`. Those rows are aggregated by `process_spend_logs_guardrail_usage` out of `LiteLLM_SpendLogs.metadata->'guardrail_information'`. There is no dedicated guardrail column, so that one JSON key is the thing this PR makes appear

| Tree | Guardrail | Tool call result | SpendLogs `status` | `metadata->'guardrail_information'` | `totalRequests` | `totalBlocked` |
|---|---|---|---|---|---|---|
| Before | allow | `echo:synthetic-probe-003`, `isError:false` | `success` | **null** | **0** | **0** |
| Before | block | `Error: Guardrail violation ... synthetic-block`, `isError:true` | `failure` | **null** | **0** | **0** |
| After | allow | `echo:synthetic-probe-001`, `isError:false` | `success` | present, `guardrail_status: "success"` | **1** | **0** |
| After | block | `Error: Guardrail violation ... synthetic-block`, `isError:true` | `failure` | present, `guardrail_status: "guardrail_intervened"` | **1** | **1** |

`LiteLLM_DailyGuardrailMetrics` held zero rows on the before tree in both cases. On the after tree:

```
 guardrail_id     |    date    | requests_evaluated | passed_count | blocked_count
------------------+------------+--------------------+--------------+---------------
 synthetic-allow  | 2026-08-14 |                  1 |            1 |             0
 synthetic-block  | 2026-08-14 |                  1 |            0 |             1
```

The blocked call's spend-log row on the after tree, read straight out of Postgres:

```
 status  |                         gi
---------+-----------------------------------------------------
 failure | [                                                  +
         |     {                                              +
         |         "duration": 0.000014,                      +
         |         "end_time": 1786737260.155436,             +
         |         "start_time": 1786737260.155423,           +
         |         "guardrail_mode": "pre_call",              +
         |         "guardrail_name": "synthetic-block",       +
         |         "guardrail_status": "guardrail_intervened",+
         |         "guardrail_provider": null,                +
         |         "guardrail_response": "REDACTED_BY_LITELM",+
         |         "masked_entity_count": null                +
         |     }                                              +
         | ]
 success | null
(2 rows)
```

One thing worth stating precisely, because it bounds the claim: the before tree already wrote a `status="failure"` spend-log row for the blocked call. What changes here is that the row carries the guardrail decision record at all, and therefore that the monitor counts it. This PR does not create that failure row

Scope of what the run above measures: `pre_mcp_call`, on the streamable HTTP `/mcp` route, for an authenticated key. The `during_mcp_call` hook and the Responses API entry point are covered by the unit tests rather than by this run, and blocks on anonymous calls are the known gap described under Caveats

Reproducing it, with the proxy pointed at either tree by swapping `$TREE`, and the three tables truncated between runs so counts start at zero:

```bash
export PATH="/path/to/venv/bin:$PATH"          # the prisma CLI must be on PATH
export DATABASE_URL='postgresql://postgres@127.0.0.1:55432/litellm'
export TREE=/path/to/this/branch                # or the parent commit's tree

docker run -d --name mcpproof-pg -p 55432:5432 \
  -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_DB=litellm postgres:16
prisma migrate deploy --schema="$TREE/litellm-proxy-extras/litellm_proxy_extras/schema.prisma"

python stub_mcp_server.py &                     # FastMCP, stateless_http, exposes synthetic_echo
cd "$TREE"
CONFIG_FILE_PATH=config_block.yaml python -m uvicorn litellm.proxy.proxy_server:app \
  --host 127.0.0.1 --port 4000 --loop asyncio &
until curl -sf localhost:4000/health/readiness >/dev/null; do sleep 1; done

MCP=(-H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json'
     -H 'Accept: application/json, text/event-stream' -H 'x-mcp-servers: synthetic_stub')
curl -s http://localhost:4000/mcp/ "${MCP[@]}" -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}'
curl -s http://localhost:4000/mcp/ "${MCP[@]}" -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"synthetic_stub-synthetic_echo","arguments":{"text":"synthetic-probe-001"}}}'

sleep 20                                        # spend-log flush plus daily-metrics aggregation
curl -s "http://localhost:4000/guardrails/usage/overview?start_date=$(date +%F)&end_date=$(date +%F)" \
  -H 'Authorization: Bearer sk-1234' | python -m json.tool
docker exec -i mcpproof-pg psql -U postgres -d litellm -c \
  'SELECT status, metadata->>'"'"'guardrail_information'"'"' FROM "LiteLLM_SpendLogs";'
docker exec -i mcpproof-pg psql -U postgres -d litellm -c \
  'SELECT * FROM "LiteLLM_DailyGuardrailMetrics";'
```

Expected on the before tree: `totalRequests` 0, `totalBlocked` 0, `guardrail_information` null, `LiteLLM_DailyGuardrailMetrics` empty. On this branch: 1 and 1 for the blocking config, 1 and 0 for the allowing one. The equivalent in the UI is `http://localhost:4000/ui/?page=guardrails` going from an empty monitor to a populated one

Two deviations from the standard local-proxy recipe, disclosed rather than papered over. First, `proxy_cli.py` hard-codes `uvloop` off Windows and uvloop does not import on Python 3.14 (`ImportError: cannot import name 'BaseDefaultEventLoopPolicy' from 'asyncio.events'`), so the identical ASGI app was launched through `uvicorn --loop asyncio` instead of `litellm --config ...`. Same `proxy_server:app`, same config loading, same routers, only the event loop and the CLI wrapper differ, and on Python 3.12 or older the normal command should work unchanged. Second, migrations had to be applied by hand with `prisma migrate deploy` because the proxy did not run them on startup. Both proxies also logged an unrelated `AttributeError: 'Batch' object has no attribute 'litellm_dailygatewayrequests'` from `gateway_request_tracking.py`, identically on both trees, which touches gateway request counts rather than guardrails and cannot bias the comparison

## Type

🐛 Bug Fix

## Caveats (if any)

- Blocks on anonymous MCP calls are still not counted
- That needs a counter outside SpendLogs, which is attributable
- Only guardrail decision records are bridged onto the logger
- Messages and tool arguments are deliberately not copied

Anonymous MCP calls, spelled out because Greptile filed it as P1 twice on #34249 and it was declined there: a guardrail block on an unauthenticated MCP call still does not reach the monitor. The failure handlers now run for those calls, so OTel and the other failure sinks see the block, but `post_call_failure_hook` stays gated on an authenticated key. That gate is deliberate and predates this PR. The spend-log writer downstream of it dereferences authenticated key and budget data, and a SpendLogs row is an attributable billing and audit record, so an anonymous row has nothing to attribute. Counting anonymous blocks needs a counter that does not live in SpendLogs, which is a separate design change rather than something to bolt onto this fix. `test_block_flushes_failure_for_anonymous_calls` pins the current behavior so the gap is visible rather than silent

On what gets recorded: only guardrail decision metadata moves onto the request logger, meaning the guardrail name, the event, the outcome and the timing. The synthetic guardrail request that MCP builds also holds the tool arguments and the LLM-shaped message list, and those are deliberately left behind. Nothing the monitor renders needs them, and copying them would push end-user payload into spend logs

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9858d021eef07fefb955d7dc9d4c8e1595afb495. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->