### PR TITLE
fix(vertex_ai): convert messages to contents in gemini count_tokens

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -1164,21 +1164,29 @@ class VertexAITokenCounter(BaseTokenCounter):
                     original_response=result,
                 )
         else:
-            # Use standard Vertex AI (Gemini) token counter
             from litellm.llms.vertex_ai.count_tokens.handler import VertexAITokenCounter
+            from litellm.llms.vertex_ai.gemini.transformation import (
+                _gemini_convert_messages_with_history,
+            )
+
+            resolved_contents: Final = (
+                contents
+                if contents is not None
+                else _gemini_convert_messages_with_history(messages=messages or [])
+            )
 
             count_tokens_params: Final = {
                 "model": model_to_use,
-                "contents": contents,
+                "contents": resolved_contents,
             }
             count_tokens_params_request.update(count_tokens_params)
             result = await VertexAITokenCounter().acount_tokens(
                 **count_tokens_params_request,
             )
 
-            if result is not None:
+            if result is not None and "totalTokens" in result:
                 return TokenCountResponse(
-                    total_tokens=result.get("totalTokens", 0),
+                    total_tokens=result["totalTokens"],
                     request_model=request_model,
                     model_used=model_to_use,
                     tokenizer_type=result.get("tokenizer_used", ""),

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -1170,9 +1170,7 @@ class VertexAITokenCounter(BaseTokenCounter):
             )
 
             resolved_contents: Final = (
-                contents
-                if contents is not None
-                else _gemini_convert_messages_with_history(messages=messages or [])
+                contents if contents is not None else _gemini_convert_messages_with_history(messages=messages or [])
             )
 
             count_tokens_params: Final = {

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -1166,7 +1166,7 @@ class VertexAITokenCounter(BaseTokenCounter):
         else:
             from litellm.llms.vertex_ai.count_tokens.handler import VertexAITokenCounter
             from litellm.llms.vertex_ai.gemini.transformation import (
-                _gemini_convert_messages_with_history,
+                _gemini_convert_messages_with_history,  # pyright: ignore[reportPrivateUsage]  # shared helper already used by gemini/chat, context_caching, and vertex_and_google_ai_studio_gemini
             )
 
             resolved_contents: Final = (

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -1170,7 +1170,11 @@ class VertexAITokenCounter(BaseTokenCounter):
             )
 
             resolved_contents: Final = (
-                contents if contents is not None else _gemini_convert_messages_with_history(messages=messages or [])
+                contents
+                if contents is not None
+                else _gemini_convert_messages_with_history(
+                    messages=messages or []  # mutable-ok: fallback for None messages; helper signature requires list
+                )
             )
 
             count_tokens_params: Final = {

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -1276,6 +1276,85 @@ async def test_vertex_ai_token_counter_routes_gemini_models():
 
 
 @pytest.mark.asyncio
+async def test_vertex_ai_token_counter_converts_messages_to_contents_for_gemini():
+    """
+    Regression test for #36921: acount_tokens passed contents=None to the
+    Gemini countTokens endpoint when called with messages=, causing a
+    silent zero token count. Verify messages are converted to Gemini
+    contents format when contents is None.
+    """
+    from unittest.mock import patch
+
+    from litellm.llms.vertex_ai.common_utils import VertexAITokenCounter
+
+    token_counter = VertexAITokenCounter()
+
+    with patch(
+        "litellm.llms.vertex_ai.count_tokens.handler.VertexAITokenCounter.acount_tokens"
+    ) as mock_acount_tokens:
+        mock_acount_tokens.return_value = {
+            "totalTokens": 42,
+            "tokenizer_used": "gemini",
+        }
+
+        await token_counter.count_tokens(
+            model_to_use="gemini-2.5-flash",
+            messages=[{"role": "user", "content": "Hello, how are you?"}],
+            contents=None,
+            deployment={
+                "litellm_params": {
+                    "vertex_project": "test-project",
+                    "vertex_location": "us-central1",
+                }
+            },
+            request_model="vertex_ai/gemini-2.5-flash",
+        )
+
+        mock_acount_tokens.assert_called_once()
+        call_kwargs = mock_acount_tokens.call_args.kwargs
+        passed_contents = call_kwargs["contents"]
+        assert passed_contents is not None
+        assert isinstance(passed_contents, list)
+        assert len(passed_contents) >= 1
+        assert "parts" in passed_contents[0]
+
+
+@pytest.mark.asyncio
+async def test_vertex_ai_token_counter_returns_none_when_api_omits_total_tokens():
+    """
+    Regression test for #36921: Vertex returns HTTP 200 with no totalTokens
+    when contents is null. The old code read totalTokens with a default of 0
+    and returned a silent zero. Verify we now return None so the caller falls
+    back to local token counting.
+    """
+    from unittest.mock import patch
+
+    from litellm.llms.vertex_ai.common_utils import VertexAITokenCounter
+
+    token_counter = VertexAITokenCounter()
+
+    with patch(
+        "litellm.llms.vertex_ai.count_tokens.handler.VertexAITokenCounter.acount_tokens"
+    ) as mock_acount_tokens:
+        mock_acount_tokens.return_value = {"tokenizer_used": "gemini"}
+
+        result = await token_counter.count_tokens(
+            model_to_use="gemini-2.5-flash",
+            messages=[{"role": "user", "content": "Hello"}],
+            contents=None,
+            deployment={
+                "litellm_params": {
+                    "vertex_project": "test-project",
+                    "vertex_location": "us-central1",
+                }
+            },
+            request_model="vertex_ai/gemini-2.5-flash",
+        )
+
+        assert result is None
+
+
+@pytest.mark.asyncio
 async def test_vertex_ai_partner_model_detection():
     """
     Test that VertexAIPartnerModels.is_vertex_partner_model correctly identifies


### PR DESCRIPTION
## TLDR

Problem this solves:

- `acount_tokens` returns `total_tokens=0` for vertex gemini models
- the gemini branch sent `{"contents": null}` to countTokens
- vertex answers 200 with no `totalTokens`, read as zero

How it solves it:

- converts `messages` to gemini `contents` before counting
- a response without `totalTokens` now fails, so local counting takes over
- the gemini count-tokens client is injected, so tests use a fake

## User Flow

Before: a developer guarding against context-window overflow gets a zero token count for every vertex gemini model, so the guard never trips and the overflow only shows up as a provider 400

1. They send POST https://litellm-domain/utils/token_counter?call_endpoint=true with `{"model": "vertex-gemini-25-flash", "messages": [{"role": "user", "content": "Hello, tell me a one-sentence fun fact about octopuses."}]}`
2. The response is `{"total_tokens": 0, "model_used": "gemini-2.5-flash", "original_response": {}, "error": false}`
3. Their guard compares 0 against the context window, passes, and sends the real request
4. POST https://litellm-domain/v1/chat/completions comes back 400 once the prompt is actually too long

After: the same call returns the real vertex count, so the guard sees the same number the completion will be billed on

1. They send the identical POST https://litellm-domain/utils/token_counter?call_endpoint=true
2. The response is `{"total_tokens": 15, "model_used": "gemini-2.5-flash", "original_response": {"totalTokens": 15, "totalBillableCharacters": 47, "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 15}]}}`
3. POST https://litellm-domain/v1/chat/completions with the same messages reports `usage.prompt_tokens: 15`, matching what they were told up front
4. If vertex ever answers without a token count, they get the local estimate instead of a zero

## Relevant issues

Fixes #36921

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4000 against real vertex ai, same config and same curl for both runs. Before was captured at base `litellm_internal_staging` @ `ed02a121dd` (only `litellm/llms/vertex_ai/common_utils.py` swapped back), after at this branch's head plus the test-only DI commit, `039e8995a6`

Ground truth from a real completion:

```
$ curl -s http://localhost:4000/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"vertex-gemini-25-flash","messages":[{"role":"user","content":"Hello, tell me a one-sentence fun fact about octopuses."}]}'
"usage":{"completion_tokens":698,"prompt_tokens":15,"total_tokens":713}
```

Before:

```
$ curl -s -X POST 'http://localhost:4000/utils/token_counter?call_endpoint=true' \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"vertex-gemini-25-flash","messages":[{"role":"user","content":"Hello, tell me a one-sentence fun fact about octopuses."}]}'
{"total_tokens":0,"request_model":"vertex-gemini-25-flash","model_used":"gemini-2.5-flash","tokenizer_type":"","original_response":{},"error":false,"error_message":null,"status_code":null}
```

After, identical command:

```
{"total_tokens":15,"request_model":"vertex-gemini-25-flash","model_used":"gemini-2.5-flash","tokenizer_type":"","original_response":{"totalTokens":15,"totalBillableCharacters":47,"promptTokensDetails":[{"modality":"TEXT","tokenCount":15}]},"error":false,"error_message":null,"status_code":null}
```

Multi-turn, to show the whole history is converted and not just the last message:

```
$ M='[{"role":"user","content":"What is the capital of France?"},{"role":"assistant","content":"Paris is the capital of France."},{"role":"user","content":"And what is the population of that city, roughly?"}]'
$ curl -s -X POST 'http://localhost:4000/utils/token_counter?call_endpoint=true' \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d "{\"model\":\"vertex-gemini-25-flash\",\"messages\":$M}"
{"total_tokens":25,"model_used":"gemini-2.5-flash","original_response":{"totalTokens":25,"totalBillableCharacters":92,"promptTokensDetails":[{"modality":"TEXT","tokenCount":25}]},"error":false}
$ curl -s http://localhost:4000/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d "{\"model\":\"vertex-gemini-25-flash\",\"messages\":$M}"
"usage":{"completion_tokens":371,"prompt_tokens":25,"total_tokens":396}
```

`vertex_ai/gemini-3.7-flash` on `global` behaves the same, 15 from the counter against `prompt_tokens: 15`, and the local path (no `call_endpoint`) still answers `{"total_tokens":22,"tokenizer_type":"openai_tokenizer"}` unchanged

## Type

Bug Fix

## Caveats (if any)

- `tokenizer_type` comes back `""`, vertex sends no `tokenizer_used`
- the no-`totalTokens` fallback is covered by unit tests only
- vertex rejects token counting for claude, so the partner branch is unproven live
- this path needs `google-genai`, which lives only in the `proxy-runtime` extra
- `system` and `tools` are still dropped on the gemini count_tokens path
- the local fallback has no gemini tokenizer, so it stays approximate


Link to Devin session: https://app.devin.ai/sessions/26f9a0440c3d4ccb8f2541310c368098