### PR TITLE
fix(ui): default user metadata to empty JSON object on create

### DIFF
--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -189,7 +189,7 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
         labelCol={{ span: 8 }}
         wrapperCol={{ span: 16 }}
         labelAlign="left"
-        initialValues={{ user_role: "internal_user_viewer", send_invite_email: true }}
+        initialValues={{ user_role: "internal_user_viewer", send_invite_email: true, metadata: "{}" }}
       >
         <Alert
           message="Email invitations"
@@ -282,7 +282,7 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
           labelCol={{ span: 8 }}
           wrapperCol={{ span: 16 }}
           labelAlign="left"
-          initialValues={{ user_role: "internal_user_viewer", send_invite_email: true }}
+          initialValues={{ user_role: "internal_user_viewer", send_invite_email: true, metadata: "{}" }}
         >
           <Form.Item label="User Email" name="user_email">
             <Input />


### PR DESCRIPTION
## Summary

Creating a new user through the LiteLLM Admin UI fails with the following error when the **Metadata** field is left empty:

```json
{"detail":[{"type":"dict_type","loc":["body","metadata"],"msg":"Input should be a valid dictionary","input":""}]}
```

### Root cause

The "Create User" / "Invite User" form (`CreateUserButton.tsx`) renders the metadata `Input.TextArea` with no default value, so submitting with an untouched field sends `metadata: ""` (an empty string). `POST /user/new` expects a dict, so it rejects the empty string with the `dict_type` error above. Typing `{}` manually works, which matches the reported behavior.

### Change

Default the metadata field to `"{}"` via `initialValues` in both the embedded and standalone create-user forms, so an untouched field submits a valid empty dict instead of `""`. This is the two-line diff below — no other files change.

---

This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini.
