### PR TITLE
feat(scripts): queue heavy gates behind a machine-wide slot lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: help test test-unit test-unit-llms test-unit-proxy-guardrails test-unit-proxy-core test-unit-proxy-misc \
 	test-unit-integrations test-unit-core-utils test-unit-other test-unit-root \
 	test-proxy-unit-a test-proxy-unit-b test-integration test-unit-helm \
-	info lint lint-dev lint-checks format \
+	info lint lint-inner lint-dev lint-checks format \
 	lint-basedpyright lint-e2e-basedpyright lint-basedpyright-budget-update lint-type-discipline lint-type-discipline-budget-update \
 	lint-ruff-budget lint-ruff-budget-update lint-budget-update lint-gate \
 	install-dev install-proxy-dev install-test-deps install-hooks \
@@ -239,8 +239,11 @@ check-import-safety: $(LINT_DEP_INSTALL)
 # does (merge-base with origin/litellm_internal_staging). Setup (env sync, Prisma client,
 # base fetch) runs once up front; the checks themselves are independent, so a sub-make
 # fans them out with -j and the fast ones finish under basedpyright's shadow.
-lint: lint-install lint-fetch-base
-	$(GATE_SLOT_LOCK) $(MAKE) -j $(LINT_JOBS) $(LINT_OUTPUT_SYNC) LINT_DEP_INSTALL= LINT_E2E_DEP_INSTALL= LINT_DEP_BASE= lint-checks
+lint:
+	@$(GATE_SLOT_LOCK) $(MAKE) lint-inner
+
+lint-inner: lint-install lint-fetch-base
+	$(MAKE) -j $(LINT_JOBS) $(LINT_OUTPUT_SYNC) LINT_DEP_INSTALL= LINT_E2E_DEP_INSTALL= LINT_DEP_BASE= lint-checks
 
 lint-checks: lint-format-check-changed lint-ruff lint-gate lint-type-discipline lint-basedpyright lint-e2e-basedpyright check-circular-imports check-import-safety
 

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@
 	lint-basedpyright lint-e2e-basedpyright lint-basedpyright-budget-update lint-type-discipline lint-type-discipline-budget-update \
 	lint-ruff-budget lint-ruff-budget-update lint-budget-update lint-gate \
 	install-dev install-proxy-dev install-test-deps install-hooks \
-	install-helm-unittest check-circular-imports check-import-safety check pre-commit \
-	lint-install lint-fetch-base bootstrap
+	install-helm-unittest check-circular-imports check-import-safety check check-inner pre-commit \
+	lint-install lint-fetch-base bootstrap bootstrap-inner
 
 # Default target
 help:
@@ -52,9 +52,16 @@ help:
 	@echo "  make test-proxy-unit-b  - Run proxy_unit_tests (p-z, ~28 files)"
 	@echo "  make test-integration   - Run integration tests"
 	@echo "  make test-unit-helm     - Run helm unit tests"
+	@echo ""
+	@echo "Heavy targets (check, bootstrap, lint) queue for LITELLM_GATE_SLOTS machine-wide"
+	@echo "slots (default 2; 0 disables) so parallel sessions don't thrash one machine."
 
 UV := uv
 UV_RUN := $(UV) run --no-sync
+
+# Machine-wide slot queue for the heavy targets below; python3 + stdlib only, so
+# it runs before any venv exists. See scripts/gate_slot_lock.py.
+GATE_SLOT_LOCK := python3 scripts/gate_slot_lock.py
 
 LINT_DEP_INSTALL ?= install-dev
 LINT_E2E_DEP_INSTALL ?= lint-install
@@ -74,6 +81,9 @@ install-dev:
 	$(UV) sync --inexact --frozen
 
 bootstrap:
+	@$(GATE_SLOT_LOCK) $(MAKE) bootstrap-inner
+
+bootstrap-inner:
 	$(UV) sync --inexact --frozen --extra proxy --group proxy-dev --group e2e-dev
 	$(UV_RUN) python scripts/prisma_generate_if_needed.py
 	cd ui/litellm-dashboard && ../../scripts/with_dashboard_node.sh npm install --no-audit --no-fund
@@ -230,7 +240,7 @@ check-import-safety: $(LINT_DEP_INSTALL)
 # base fetch) runs once up front; the checks themselves are independent, so a sub-make
 # fans them out with -j and the fast ones finish under basedpyright's shadow.
 lint: lint-install lint-fetch-base
-	$(MAKE) -j $(LINT_JOBS) $(LINT_OUTPUT_SYNC) LINT_DEP_INSTALL= LINT_E2E_DEP_INSTALL= LINT_DEP_BASE= lint-checks
+	$(GATE_SLOT_LOCK) $(MAKE) -j $(LINT_JOBS) $(LINT_OUTPUT_SYNC) LINT_DEP_INSTALL= LINT_E2E_DEP_INSTALL= LINT_DEP_BASE= lint-checks
 
 lint-checks: lint-format-check-changed lint-ruff lint-gate lint-type-discipline lint-basedpyright lint-e2e-basedpyright check-circular-imports check-import-safety
 
@@ -244,7 +254,10 @@ lint-dev: lint-format-changed check-circular-imports check-import-safety
 # test-linting.yml (Python), test-litellm-ui-build.yml's frontend-lint (dashboard), and
 # check-ui-api-types.yml (API-type drift), skipping any whose files aren't in scope.
 # Not auto-installed as a git hook so it never slows an unrelated human commit.
-check: bootstrap
+check:
+	@$(GATE_SLOT_LOCK) $(MAKE) check-inner
+
+check-inner: bootstrap
 	./scripts/pre_commit_lint.sh
 
 pre-commit:

--- a/scripts/gate_slot_lock.py
+++ b/scripts/gate_slot_lock.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Machine-wide slot lock for this repo's heavy entrypoints.
+
+`make check`, `make bootstrap`, `make lint`, and the standalone budget gates
+(scripts/ruff_strict_gate.py, scripts/type_discipline_gate.py,
+scripts/type_check_gate.py) each hold one of N machine-wide slots while they
+run, so however many sessions and worktrees share one machine, at most N of
+them execute a basedpyright/pytest/prettier storm at a time instead of all
+thrashing it at once. Slots are fcntl.flock files (macOS ships no flock(1)
+binary, hence python3 + stdlib only, runnable before any venv exists) under a
+per-user cache directory shared by every worktree and session:
+~/.cache/litellm/gate-slots by default, $LITELLM_GATE_SLOT_DIR to override.
+A holder's lock dies with its process, so a crash leaves nothing to clean up.
+
+$LITELLM_GATE_SLOTS sets the slot count (default 2); 0 disables locking.
+Waiting is a blocking flock on a turnstile file plus a slow poll of the slots,
+so contenders queue roughly first-come-first-served without busy-spinning.
+A process that acquired (or deliberately skipped) a slot exports
+LITELLM_GATE_SLOT_HELD, and nested acquisitions under that marker are no-ops,
+so `make check` invoking the gates internally can never deadlock against
+itself. Any filesystem error fails open and the command runs unlocked: the
+lock is a courtesy to the machine, never a gate that may break a build (CI
+runs one job per machine, so there it only ever takes the instant path).
+
+CLI: python3 scripts/gate_slot_lock.py <command> [args...]
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import IO, TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HELD_MARKER_ENV: Final = "LITELLM_GATE_SLOT_HELD"
+SLOT_COUNT_ENV: Final = "LITELLM_GATE_SLOTS"
+SLOT_DIR_ENV: Final = "LITELLM_GATE_SLOT_DIR"
+DEFAULT_SLOT_COUNT: Final = 2
+POLL_SECONDS: Final = 2.0
+
+
+def _slot_dir() -> Path:
+    override: Final = os.environ.get(SLOT_DIR_ENV)
+    return Path(override) if override else Path.home() / ".cache" / "litellm" / "gate-slots"
+
+
+def _slot_count() -> int:
+    raw: Final = os.environ.get(SLOT_COUNT_ENV)
+    if not raw:
+        return DEFAULT_SLOT_COUNT
+    try:
+        return int(raw)
+    except ValueError:
+        print(
+            f"gate_slot_lock: ignoring non-integer {SLOT_COUNT_ENV}={raw!r}; "
+            f"using {DEFAULT_SLOT_COUNT} slots",
+            file=sys.stderr,
+        )
+        return DEFAULT_SLOT_COUNT
+
+
+def _try_slot(directory: Path, index: int) -> IO[bytes] | None:
+    handle: Final = (directory / f"slot-{index}.lock").open("wb")
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        handle.close()
+        return None
+    except OSError:
+        handle.close()
+        raise
+    return handle
+
+
+def _wait_for_slot(directory: Path, count: int) -> IO[bytes]:
+    print(
+        f"gate_slot_lock: all {count} machine-wide slots are busy; queueing "
+        f"(set {SLOT_COUNT_ENV}=0 to disable)",
+        file=sys.stderr,
+        flush=True,
+    )
+    with (directory / "turnstile.lock").open("wb") as turnstile:
+        fcntl.flock(turnstile, fcntl.LOCK_EX)
+        while True:
+            for index in range(count):
+                held = _try_slot(directory, index)
+                if held is not None:
+                    return held
+            time.sleep(POLL_SECONDS)
+
+
+def _locked_handle(count: int) -> IO[bytes]:
+    directory: Final = _slot_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    for index in range(count):
+        immediate = _try_slot(directory, index)
+        if immediate is not None:
+            return immediate
+    return _wait_for_slot(directory, count)
+
+
+def acquire_slot() -> IO[bytes] | None:
+    """Hold a machine-wide slot for the life of the returned handle.
+
+    The caller must keep the handle referenced until the process exits;
+    dropping it closes the file and releases the slot. Returns None without
+    locking when this process already runs under a held slot, when locking is
+    disabled, or when the filesystem refuses to cooperate."""
+    if os.environ.get(HELD_MARKER_ENV):
+        return None
+    count: Final = _slot_count()
+    if count <= 0:
+        os.environ[HELD_MARKER_ENV] = "1"
+        return None
+    try:
+        handle: Final = _locked_handle(count)
+    except (OSError, RuntimeError) as error:
+        print(f"gate_slot_lock: locking unavailable ({error}); running unlocked", file=sys.stderr)
+        os.environ[HELD_MARKER_ENV] = "1"
+        return None
+    os.environ[HELD_MARKER_ENV] = "1"
+    return handle
+
+
+@contextlib.contextmanager
+def held_slot() -> Iterator[None]:
+    """Run the with-block while holding a machine-wide slot (or its no-op forms)."""
+    prior_marker: Final = os.environ.get(HELD_MARKER_ENV)
+    handle: Final = acquire_slot()
+    try:
+        yield
+    finally:
+        if handle is not None:
+            handle.close()
+        if not prior_marker:
+            os.environ.pop(HELD_MARKER_ENV, None)
+
+
+def _wait_ignoring_interrupts(process: subprocess.Popen[bytes]) -> int:
+    while True:
+        try:
+            return process.wait()
+        except KeyboardInterrupt:
+            continue
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: gate_slot_lock.py <command> [args...]", file=sys.stderr)
+        return 2
+    try:
+        held: Final = acquire_slot()
+    except KeyboardInterrupt:
+        return 130
+    try:
+        code: Final = _wait_ignoring_interrupts(subprocess.Popen(sys.argv[1:]))
+    except FileNotFoundError as error:
+        print(f"gate_slot_lock: {error}", file=sys.stderr)
+        return 127
+    if held is not None:
+        held.close()
+    return code if code >= 0 else 128 - code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pre_commit_lint.sh
+++ b/scripts/pre_commit_lint.sh
@@ -24,6 +24,16 @@
 
 set -eu
 
+# Queue for one of the machine-wide heavy-work slots (see scripts/gate_slot_lock.py)
+# before anything else, so N parallel `make check` runs across worktrees execute two
+# at a time instead of thrashing the machine. The wrapper exports
+# LITELLM_GATE_SLOT_HELD, so this re-exec happens exactly once and everything this
+# script spawns (make lint, the budget gates) skips its own acquisition.
+if [ -z "${LITELLM_GATE_SLOT_HELD:-}" ]; then
+    script_dir=$(python3 -c 'import os, sys; print(os.path.dirname(os.path.realpath(sys.argv[1])))' "$0")
+    exec python3 "$script_dir/gate_slot_lock.py" "$0" "$@"
+fi
+
 if [ -z "${PRE_COMMIT_LINT_INNER:-}" ]; then
     log_file=$(git rev-parse --path-format=absolute --git-path pre_commit_lint.log)
     if : > "$log_file" 2>/dev/null; then

--- a/scripts/ruff_strict_gate.py
+++ b/scripts/ruff_strict_gate.py
@@ -215,7 +215,10 @@ def main() -> None:
     parser.add_argument("--base", default=DEFAULT_BASE)
     parser.add_argument("--update", action="store_true")
     args = parser.parse_args()
-    cmd_update(args.base) if args.update else cmd_check(args.base)
+    from gate_slot_lock import held_slot
+
+    with held_slot():
+        cmd_update(args.base) if args.update else cmd_check(args.base)
 
 
 if __name__ == "__main__":

--- a/scripts/type_check_gate.py
+++ b/scripts/type_check_gate.py
@@ -670,16 +670,19 @@ def main() -> None:
     parser.add_argument("--update", action="store_true")
     parser.add_argument("--emit-counts-dir", type=Path)
     args = parser.parse_args()
-    ensure_typecheck_env()
-    head = count_basedpyright(run_basedpyright())
-    if args.emit_counts_dir is not None:
-        cmd_emit_counts(
-            head, args.emit_counts_dir, _run(["git", "rev-parse", "HEAD"]).strip()
-        )
-    elif args.update:
-        cmd_update(head, args.base)
-    else:
-        cmd_check(head, args.base)
+    from gate_slot_lock import held_slot
+
+    with held_slot():
+        ensure_typecheck_env()
+        head = count_basedpyright(run_basedpyright())
+        if args.emit_counts_dir is not None:
+            cmd_emit_counts(
+                head, args.emit_counts_dir, _run(["git", "rev-parse", "HEAD"]).strip()
+            )
+        elif args.update:
+            cmd_update(head, args.base)
+        else:
+            cmd_check(head, args.base)
 
 
 if __name__ == "__main__":

--- a/scripts/type_discipline_gate.py
+++ b/scripts/type_discipline_gate.py
@@ -267,7 +267,10 @@ def main() -> None:
     parser.add_argument("--base", default=DEFAULT_BASE)
     parser.add_argument("--update", action="store_true")
     args = parser.parse_args()
-    cmd_update(args.base) if args.update else cmd_check(args.base)
+    from gate_slot_lock import held_slot
+
+    with held_slot():
+        cmd_update(args.base) if args.update else cmd_check(args.base)
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/test_gate_slot_lock.py
+++ b/tests/test_litellm/test_gate_slot_lock.py
@@ -1,0 +1,311 @@
+import fcntl
+import importlib.util
+import os
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Sequence
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER = ROOT / "scripts" / "gate_slot_lock.py"
+
+_spec = importlib.util.spec_from_file_location("gate_slot_lock", HELPER)
+assert _spec is not None and _spec.loader is not None
+gate_slot_lock = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate_slot_lock)
+
+START_THEN_WAIT_FOR = (
+    "import pathlib, sys, time\n"
+    "pathlib.Path(sys.argv[1]).touch()\n"
+    "deadline = time.monotonic() + 20\n"
+    "while not pathlib.Path(sys.argv[2]).exists():\n"
+    "    if time.monotonic() > deadline:\n"
+    "        sys.exit(3)\n"
+    "    time.sleep(0.05)\n"
+)
+
+TOUCH_TARGET = "import pathlib, sys\npathlib.Path(sys.argv[1]).touch()\n"
+
+RECORD_INTERVAL = (
+    "import sys, time\n"
+    "with open(sys.argv[1], 'a') as events:\n"
+    "    events.write(f'start {time.monotonic()}\\n')\n"
+    "    events.flush()\n"
+    "    time.sleep(0.6)\n"
+    "    events.write(f'end {time.monotonic()}\\n')\n"
+    "    events.flush()\n"
+)
+
+
+def _env(lock_dir: Path, slots: str) -> dict[str, str]:
+    return {
+        "PATH": os.environ["PATH"],
+        "HOME": str(lock_dir.parent),
+        "LITELLM_GATE_SLOT_DIR": str(lock_dir),
+        "LITELLM_GATE_SLOTS": slots,
+    }
+
+
+def _wrapped(payload: Sequence[str]) -> list[str]:
+    return [sys.executable, str(HELPER), sys.executable, "-c", *payload]
+
+
+def _wait_until(predicate: Callable[[], bool], timeout_seconds: float) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
+
+
+def _terminate_group(process: subprocess.Popen[bytes]) -> None:
+    with suppress(ProcessLookupError, PermissionError):
+        os.killpg(process.pid, signal.SIGKILL)
+
+
+def _reap(process: subprocess.Popen[bytes]) -> None:
+    with suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=10)
+    if process.poll() is None:
+        process.kill()
+        process.wait(timeout=10)
+
+
+def test_six_contenders_never_exceed_two_slots_and_all_complete(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "locks"
+    events_file = tmp_path / "events.log"
+    env = _env(lock_dir, "2")
+    procs = [
+        subprocess.Popen(
+            _wrapped([RECORD_INTERVAL, str(events_file)]),
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        for _ in range(6)
+    ]
+    try:
+        assert [proc.wait(timeout=60) for proc in procs] == [0] * 6
+    finally:
+        for proc in procs:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=10)
+    events = sorted(
+        (float(stamp), 1 if kind == "start" else -1)
+        for kind, stamp in (line.split() for line in events_file.read_text().splitlines())
+    )
+    assert len(events) == 12
+    concurrency_peaks = []
+    running = 0
+    for _, delta in events:
+        running += delta
+        concurrency_peaks.append(running)
+    assert max(concurrency_peaks) <= 2
+
+
+def test_two_slots_admit_two_holders_at_once(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "locks"
+    first_started = tmp_path / "first.started"
+    second_started = tmp_path / "second.started"
+    env = _env(lock_dir, "2")
+    first = subprocess.Popen(
+        _wrapped([START_THEN_WAIT_FOR, str(first_started), str(second_started)]), env=env
+    )
+    second = subprocess.Popen(
+        _wrapped([START_THEN_WAIT_FOR, str(second_started), str(first_started)]), env=env
+    )
+    assert first.wait(timeout=30) == 0
+    assert second.wait(timeout=30) == 0
+
+
+def test_contender_beyond_capacity_queues_until_the_slot_frees(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "locks"
+    holder_started = tmp_path / "holder.started"
+    release = tmp_path / "release"
+    done = tmp_path / "done"
+    env = _env(lock_dir, "1")
+    holder = subprocess.Popen(
+        _wrapped([START_THEN_WAIT_FOR, str(holder_started), str(release)]), env=env
+    )
+    try:
+        assert _wait_until(holder_started.exists, 10)
+        contender = subprocess.Popen(
+            _wrapped([TOUCH_TARGET, str(done)]),
+            env=env,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            time.sleep(1.5)
+            assert not done.exists()
+            release.touch()
+            assert holder.wait(timeout=10) == 0
+            assert contender.wait(timeout=30) == 0
+            assert done.exists()
+            assert contender.stderr is not None
+            assert b"queueing" in contender.stderr.read()
+        finally:
+            release.touch()
+            _reap(contender)
+    finally:
+        release.touch()
+        _reap(holder)
+
+
+def test_nested_wrapping_reenters_instead_of_deadlocking(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "locks"
+    nested = [
+        sys.executable,
+        str(HELPER),
+        sys.executable,
+        str(HELPER),
+        sys.executable,
+        "-c",
+        "print('nested ok')",
+    ]
+    proc = subprocess.Popen(
+        nested,
+        env=_env(lock_dir, "1"),
+        stdout=subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        stdout, _ = proc.communicate(timeout=20)
+    except subprocess.TimeoutExpired:
+        _terminate_group(proc)
+        pytest.fail("nested gate_slot_lock invocations deadlocked")
+    assert proc.returncode == 0
+    assert b"nested ok" in stdout
+
+
+def test_wrapped_command_exit_code_is_propagated(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [sys.executable, str(HELPER), sys.executable, "-c", "raise SystemExit(7)"],
+        env=_env(tmp_path / "locks", "2"),
+    )
+    assert proc.returncode == 7
+
+
+def test_missing_command_exits_127_and_no_command_exits_2(tmp_path: Path) -> None:
+    env = _env(tmp_path / "locks", "2")
+    missing = subprocess.run(
+        [sys.executable, str(HELPER), str(tmp_path / "no-such-binary")],
+        env=env,
+        capture_output=True,
+    )
+    assert missing.returncode == 127
+    bare = subprocess.run([sys.executable, str(HELPER)], env=env, capture_output=True)
+    assert bare.returncode == 2
+
+
+def test_wrapped_command_killed_by_signal_maps_to_128_plus_signal(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        _wrapped(["import os, signal\nos.kill(os.getpid(), signal.SIGTERM)\n"]),
+        env=_env(tmp_path / "locks", "2"),
+    )
+    assert proc.returncode == 128 + signal.SIGTERM
+
+
+def test_unusable_lock_dir_fails_open_and_still_runs_the_command(tmp_path: Path) -> None:
+    blocker = tmp_path / "blocker"
+    blocker.write_text("")
+    done = tmp_path / "done"
+    proc = subprocess.run(
+        _wrapped([TOUCH_TARGET, str(done)]),
+        env=_env(blocker / "locks", "2"),
+        capture_output=True,
+    )
+    assert proc.returncode == 0
+    assert done.exists()
+    assert b"running unlocked" in proc.stderr
+
+
+def test_zero_slots_disables_locking_entirely(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "locks"
+    done = tmp_path / "done"
+    proc = subprocess.run(
+        _wrapped([TOUCH_TARGET, str(done)]),
+        env=_env(lock_dir, "0"),
+    )
+    assert proc.returncode == 0
+    assert done.exists()
+    assert not lock_dir.exists()
+
+
+def test_non_integer_slot_count_warns_and_falls_back_to_default(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [sys.executable, str(HELPER), sys.executable, "-c", "print('ran')"],
+        env=_env(tmp_path / "locks", "lots"),
+        capture_output=True,
+    )
+    assert proc.returncode == 0
+    assert b"ran" in proc.stdout
+    assert b"LITELLM_GATE_SLOTS" in proc.stderr
+
+
+def test_killed_holder_releases_its_slot_for_the_next_contender(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "locks"
+    holder_started = tmp_path / "holder.started"
+    never = tmp_path / "never"
+    env = _env(lock_dir, "1")
+    holder = subprocess.Popen(
+        _wrapped([START_THEN_WAIT_FOR, str(holder_started), str(never)]),
+        env=env,
+        start_new_session=True,
+    )
+    try:
+        assert _wait_until(holder_started.exists, 10)
+    finally:
+        _terminate_group(holder)
+    holder.wait(timeout=10)
+    after = subprocess.run(
+        [sys.executable, str(HELPER), sys.executable, "-c", "print('freed')"],
+        env=env,
+        capture_output=True,
+        timeout=20,
+    )
+    assert after.returncode == 0
+    assert b"freed" in after.stdout
+
+
+def test_acquire_slot_holds_marks_and_releases_in_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lock_dir = tmp_path / "locks"
+    monkeypatch.setenv("LITELLM_GATE_SLOT_HELD", "")
+    monkeypatch.setenv("LITELLM_GATE_SLOT_DIR", str(lock_dir))
+    monkeypatch.setenv("LITELLM_GATE_SLOTS", "1")
+    handle = gate_slot_lock.acquire_slot()
+    assert handle is not None
+    assert os.environ["LITELLM_GATE_SLOT_HELD"] == "1"
+    assert gate_slot_lock.acquire_slot() is None
+    with (lock_dir / "slot-0.lock").open("wb") as probe:
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        handle.close()
+        fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(probe, fcntl.LOCK_UN)
+
+
+def test_held_slot_context_manager_releases_on_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lock_dir = tmp_path / "locks"
+    monkeypatch.setenv("LITELLM_GATE_SLOT_HELD", "")
+    monkeypatch.setenv("LITELLM_GATE_SLOT_DIR", str(lock_dir))
+    monkeypatch.setenv("LITELLM_GATE_SLOTS", "1")
+    with gate_slot_lock.held_slot():
+        assert os.environ["LITELLM_GATE_SLOT_HELD"] == "1"
+        with (lock_dir / "slot-0.lock").open("wb") as probe:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    assert not os.environ.get("LITELLM_GATE_SLOT_HELD")
+    with (lock_dir / "slot-0.lock").open("wb") as probe:
+        fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(probe, fcntl.LOCK_UN)

--- a/tests/test_litellm/test_gate_slot_lock.py
+++ b/tests/test_litellm/test_gate_slot_lock.py
@@ -115,12 +115,8 @@ def test_two_slots_admit_two_holders_at_once(tmp_path: Path) -> None:
     first_started = tmp_path / "first.started"
     second_started = tmp_path / "second.started"
     env = _env(lock_dir, "2")
-    first = subprocess.Popen(
-        _wrapped([START_THEN_WAIT_FOR, str(first_started), str(second_started)]), env=env
-    )
-    second = subprocess.Popen(
-        _wrapped([START_THEN_WAIT_FOR, str(second_started), str(first_started)]), env=env
-    )
+    first = subprocess.Popen(_wrapped([START_THEN_WAIT_FOR, str(first_started), str(second_started)]), env=env)
+    second = subprocess.Popen(_wrapped([START_THEN_WAIT_FOR, str(second_started), str(first_started)]), env=env)
     assert first.wait(timeout=30) == 0
     assert second.wait(timeout=30) == 0
 
@@ -131,9 +127,7 @@ def test_contender_beyond_capacity_queues_until_the_slot_frees(tmp_path: Path) -
     release = tmp_path / "release"
     done = tmp_path / "done"
     env = _env(lock_dir, "1")
-    holder = subprocess.Popen(
-        _wrapped([START_THEN_WAIT_FOR, str(holder_started), str(release)]), env=env
-    )
+    holder = subprocess.Popen(_wrapped([START_THEN_WAIT_FOR, str(holder_started), str(release)]), env=env)
     try:
         assert _wait_until(holder_started.exists, 10)
         contender = subprocess.Popen(
@@ -274,9 +268,7 @@ def test_killed_holder_releases_its_slot_for_the_next_contender(tmp_path: Path) 
     assert b"freed" in after.stdout
 
 
-def test_acquire_slot_holds_marks_and_releases_in_process(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_acquire_slot_holds_marks_and_releases_in_process(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     lock_dir = tmp_path / "locks"
     monkeypatch.setenv("LITELLM_GATE_SLOT_HELD", "")
     monkeypatch.setenv("LITELLM_GATE_SLOT_DIR", str(lock_dir))
@@ -293,9 +285,7 @@ def test_acquire_slot_holds_marks_and_releases_in_process(
         fcntl.flock(probe, fcntl.LOCK_UN)
 
 
-def test_held_slot_context_manager_releases_on_exit(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_held_slot_context_manager_releases_on_exit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     lock_dir = tmp_path / "locks"
     monkeypatch.setenv("LITELLM_GATE_SLOT_HELD", "")
     monkeypatch.setenv("LITELLM_GATE_SLOT_DIR", str(lock_dir))
@@ -309,3 +299,35 @@ def test_held_slot_context_manager_releases_on_exit(
     with (lock_dir / "slot-0.lock").open("wb") as probe:
         fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
         fcntl.flock(probe, fcntl.LOCK_UN)
+
+
+def _make_rule(target: str) -> tuple[list[str], list[str]]:
+    database = subprocess.run(
+        ["make", "--dry-run", "--print-data-base", "info"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    lines = database.splitlines()
+    for index, line in enumerate(lines):
+        if line != f"{target}:" and not line.startswith(f"{target}: "):
+            continue
+        recipe: list[str] = []
+        for follower in lines[index + 1 :]:
+            if follower.startswith("#"):
+                continue
+            if not follower.startswith("\t"):
+                break
+            recipe.append(follower.strip())
+        return line.split(":", 1)[1].split(), recipe
+    raise AssertionError(f"target {target} not found in make database")
+
+
+def test_direct_make_lint_takes_a_slot_before_any_setup() -> None:
+    lint_prerequisites, lint_recipe = _make_rule("lint")
+    assert lint_prerequisites == []
+    assert any("$(GATE_SLOT_LOCK)" in line for line in lint_recipe)
+    inner_prerequisites, _ = _make_rule("lint-inner")
+    assert "lint-install" in inner_prerequisites
+    assert "lint-fetch-base" in inner_prerequisites

--- a/tests/test_litellm/test_pre_commit_lint.py
+++ b/tests/test_litellm/test_pre_commit_lint.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import signal
 import subprocess
 import time
@@ -418,6 +419,46 @@ def test_staged_files_matching_no_check_print_an_explicit_noop_note_and_nonempty
     log = (repo / ".git" / "pre_commit_lint.log").read_text()
     assert "check: summary" in log
     assert "skipped: Python lint (make lint) (no litellm/ Python files in scope)" in log
+
+
+def test_run_queues_through_the_machine_wide_gate_slot_lock(tmp_path: Path) -> None:
+    repo, bin_dir = _sandbox(tmp_path)
+    lock_dir = tmp_path / "gate-locks"
+    proc = _run(repo, bin_dir, {"LITELLM_GATE_SLOT_DIR": str(lock_dir)})
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert (lock_dir / "slot-0.lock").exists()
+
+
+def test_run_under_a_held_slot_skips_reacquiring_the_gate_lock(tmp_path: Path) -> None:
+    repo, bin_dir = _sandbox(tmp_path)
+    lock_dir = tmp_path / "gate-locks"
+    proc = _run(
+        repo,
+        bin_dir,
+        {"LITELLM_GATE_SLOT_DIR": str(lock_dir), "LITELLM_GATE_SLOT_HELD": "1"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert not lock_dir.exists()
+
+
+def test_hook_symlink_install_still_resolves_the_slot_lock_helper(tmp_path: Path) -> None:
+    repo, bin_dir = _sandbox(tmp_path)
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy(SCRIPT, scripts_dir / "pre_commit_lint.sh")
+    shutil.copy(SCRIPT.parent / "gate_slot_lock.py", scripts_dir / "gate_slot_lock.py")
+    (repo / ".git" / "hooks" / "pre-commit").symlink_to(Path("../../scripts/pre_commit_lint.sh"))
+    lock_dir = tmp_path / "gate-locks"
+    proc = subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "hooked"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=_env(repo, bin_dir, {"LITELLM_GATE_SLOT_DIR": str(lock_dir)}),
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert (lock_dir / "slot-0.lock").exists()
 
 
 def test_failing_run_ends_with_a_fail_verdict(tmp_path: Path) -> None:


### PR DESCRIPTION
## TLDR

Problem this solves:

- N parallel `make check` runs across worktrees thrash one machine
- Every run slows down and long commands start timing out flaky

How it solves it:

- New `scripts/gate_slot_lock.py`: machine-wide fcntl slot lock, 2 slots
- `make check`/`bootstrap`/`lint` and the budget gates queue through it
- `make lint` takes its slot first, so even its dependency setup queues
- Nested invocations reenter via an env marker, so no deadlocks
- `LITELLM_GATE_SLOTS` overrides the count; `0` disables; errors fail open

## User Flow

Before: a developer running several agent sessions has three worktrees run `make check` at once, and the machine becomes unusable

1. Three sessions each run `make check` in their own litellm worktree at the same time
2. Three basedpyright/prettier/pytest storms execute simultaneously, CPU and RAM peg, and every run crawls
3. Unrelated commands on the machine slow down or time out while all three grind on

After: the same three runs queue two at a time and all pass

1. Three sessions each run `make check` in their own litellm worktree at the same time
2. Two runs proceed immediately; the third prints `gate_slot_lock: all 2 machine-wide slots are busy; queueing (set LITELLM_GATE_SLOTS=0 to disable)` and waits
3. As soon as one of the first two finishes, the queued run starts on its own and ends in `check: PASS` like the others
4. A developer who wants the old behavior sets `LITELLM_GATE_SLOTS=0` (or another slot count) and the lock steps aside

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before, at the merge base 870a8cf764: three parallel `make check` runs across three bootstrapped worktrees all execute at once, nothing queues or throttles them

```
$ for i in 1 2 3; do bash -c "echo \"run $i launched \$(date +%T)\"; make -C $W/qa36988-b$i check > /tmp/qa36988_before_$i.log 2>&1; echo \"run $i exit=\$? finished \$(date +%T)\"" & done; wait
run 1 launched 21:18:25
run 2 launched 21:18:25
run 3 launched 21:18:25
run 3 exit=0 finished 21:18:27
run 1 exit=0 finished 21:18:27
run 2 exit=0 finished 21:18:27

$ grep -c queueing /tmp/qa36988_before_*.log
/tmp/qa36988_before_1.log:0
/tmp/qa36988_before_2.log:0
/tmp/qa36988_before_3.log:0

$ for i in 1 2 3; do echo "log $i: $(grep -o 'check: PASS' /tmp/qa36988_before_$i.log)"; done
log 1: check: PASS
log 2: check: PASS
log 3: check: PASS
```

After, at this PR's tip 17f5c909f0: the same three runs queue two at a time, the third prints the queueing notice, and all three pass

```
$ for i in 1 2 3; do bash -c "echo \"run $i launched \$(date +%T)\"; make -C $W/qa36988-a$i check > /tmp/qa36988_after_$i.log 2>&1; echo \"run $i exit=\$? finished \$(date +%T)\"" & done; wait
run 1 launched 21:19:12
run 2 launched 21:19:12
run 3 launched 21:19:12
run 1 exit=0 finished 21:19:14
run 2 exit=0 finished 21:19:14
run 3 exit=0 finished 21:19:16

$ grep -l queueing /tmp/qa36988_after_*.log
/tmp/qa36988_after_3.log
$ grep -h queueing /tmp/qa36988_after_3.log
gate_slot_lock: all 2 machine-wide slots are busy; queueing (set LITELLM_GATE_SLOTS=0 to disable)

$ grep -H "check: PASS" /tmp/qa36988_after_*.log
/tmp/qa36988_after_1.log:check: PASS
/tmp/qa36988_after_2.log:check: PASS
/tmp/qa36988_after_3.log:check: PASS
```

Direct `make lint` at 17f5c909f0 joins the queue before doing any setup: with both slots held by long-running checks, its first output is the queueing notice, and `uv sync`/`git fetch` only run once a slot frees (at the parent commit the setup deps ran before the queue was joined); the run then passes

```
$ head -3 /tmp/qa36988_lint.log
gate_slot_lock: all 2 machine-wide slots are busy; queueing (set LITELLM_GATE_SLOTS=0 to disable)
uv sync --inexact --frozen --group proxy-dev --group e2e-dev
Audited 198 packages in 21ms

lint exit=0 finished 21:30:27
```

The header-documented hook flow still works at the tip. Linked worktrees resolve `.git/hooks` to the shared main checkout, so this demo pins the same script via `core.hooksPath`; a fresh-clone `ln -s` install goes through the identical entrypoint and is pinned by a regression test

```
$ git -c core.hooksPath=.qa-hooks commit -m "chore: demo commit through the hook"
check: logging full output to .../worktrees/qa36988-a1/pre_commit_lint.log
check: summary
    skipped: Python lint (make lint) (no litellm/ Python files in scope)
    ...
check: PASS
[detached HEAD 5ec947e0b1] chore: demo commit through the hook
 1 file changed, 1 insertion(+)
```

Notes from the QA run:

- Clean-tree checks short-circuit to "nothing to check" (pre-existing, unchanged)
- `make lint` always runs full checks; only `make check` scopes (unchanged)

## Type

🚄 Infrastructure

## Caveats (if any)

- `make -jN check` sub-make may warn "jobserver unavailable"; inner targets are serial anyway
- Queueing is roughly FIFO; a fresh arrival can occasionally beat a waiter to a freed slot
- CI takes the instant-acquire path (one job per machine) and any lock error fails open

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
