### PR TITLE
fix(ui): stop the models tab strip from scrolling vertically

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.tsx
@@ -175,16 +175,18 @@ export default function ModelsAndEndpointsPage() {
         ) : (
           <Tabs value={activeKey} onValueChange={setActiveKey}>
             <div className="flex min-w-0 flex-nowrap items-center gap-3 border-b">
-              <TabsList variant="line" className="min-w-0 flex-1 justify-start overflow-x-auto">
-                {visibleSlugs.map((slug) => {
-                  const key = slug || BASE_TAB_KEY;
-                  return (
-                    <TabsTrigger key={key} value={key} className="flex-none">
-                      {tabLabel(slug)}
-                    </TabsTrigger>
-                  );
-                })}
-              </TabsList>
+              <div className="-mb-1.5 min-w-0 flex-1 overflow-x-auto pb-1.5">
+                <TabsList variant="line" className="w-max justify-start">
+                  {visibleSlugs.map((slug) => {
+                    const key = slug || BASE_TAB_KEY;
+                    return (
+                      <TabsTrigger key={key} value={key} className="flex-none">
+                        {tabLabel(slug)}
+                      </TabsTrigger>
+                    );
+                  })}
+                </TabsList>
+              </div>
               <div className="flex shrink-0 items-center gap-2 pb-1">
                 {lastRefreshed && (
                   <span className="text-xs text-muted-foreground">Last Refreshed: {lastRefreshed}</span>


### PR DESCRIPTION
## TLDR

Problem this solves:

- The Models + Endpoints tab strip scrolls vertically
- Vertical scrolling there is meaningless, only horizontal is
- A stray wheel nudge shifts the tabs out of alignment

How it solves it:

- Moves the horizontal scroller off the tab list onto a wrapper
- Gives that wrapper room for the active-tab underline
- Cancels the extra room with a matching negative margin

## User Flow

Before: an admin browsing model deployments can scroll the tab strip up and down, which nothing on the page calls for

1. They open https://litellm-domain/ui/?page=models
2. The tab row runs off the right edge, so they scroll it sideways to reach Model Group Alias
3. Hovering the tab row and scrolling down, or letting a trackpad add a little vertical drift, shifts the whole strip up by a pixel
4. The tab labels and the active-tab underline sit a pixel off the line under them until the row is scrolled back

After: the same tab row scrolls sideways only, and vertical scrolling over it moves the page like everywhere else

1. They open https://litellm-domain/ui/?page=models
2. The tab row runs off the right edge, so they scroll it sideways to reach Model Group Alias
3. Hovering the tab row and scrolling down scrolls the page, and the strip itself does not budge vertically
4. The tab labels and the active-tab underline stay on the line under them

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Measured on the Models + Endpoints tab strip at a 1280x800 viewport, before at `40a418440c` (this branch's base) and after at `5219658b8f`, reading the scroll box the tabs live in:

| | before | after |
|---|---|---|
| vertical scroll range | 1px | 0px |
| horizontal scroll range | 365px | 368px |
| tab row position and height | top 272, 37px | top 272, 37px |

Screenshots to follow.

## Type

🐛 Bug Fix

## Caveats (if any)

- No unit test: layout geometry is unassertable in jsdom
- A Playwright spec under tests/e2e/ui could cover it
