### PR TITLE
feat(proxy): gate the Global Control Plane worker registry on an enterprise license

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -38,6 +38,7 @@ from litellm.types.mcp import (
     MCPTransportType,
 )
 from litellm.types.mcp_server.mcp_server_manager import MCPInfo
+from litellm.types.proxy.control_plane_endpoints import WorkerRegistryEntry
 from litellm.types.router import RouterErrors, UpdateRouterConfig
 from litellm.types.secret_managers.main import KeyManagementSystem
 from litellm.types.utils import (
@@ -2332,6 +2333,15 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "borrowing the `cache_params` Redis and over the REDIS_* env fallback"
         ),
     )
+    control_plane_url: str | None = Field(
+        None,
+        description=(
+            "Global Control Plane: URL of the control plane whose admin UI manages this instance. "
+            "Enables /v3/login and /v3/login/exchange on this instance so that UI can authenticate "
+            "against it cross-origin, and restricts the SSO return_to origin to that URL. "
+            "No state is shared with the control plane"
+        ),
+    )
     allow_cli_sso_verification_uri_complete: bool | None = Field(
         None,
         description="opt-in to RFC 8628 verification_uri_complete for the CLI SSO device flow, pre-filling the user_code in the browser. Off by default; intended for same-host clients where the device that starts the flow and the browser run on the same machine",
@@ -2629,6 +2639,14 @@ class ConfigYAML(LiteLLMPydanticObjectBase):
         description="litellm Module settings. See __init__.py for all, example litellm.drop_params=True, litellm.set_verbose=True, litellm.api_base, litellm.cache",
     )
     general_settings: ConfigGeneralSettings | None = None
+    worker_registry: list[WorkerRegistryEntry] | None = Field(
+        None,
+        description=(
+            "Global Control Plane: the independent proxy instances this instance's admin UI manages. "
+            "Setting it makes this a control plane, which serves the UI and does not route LLM requests. "
+            "Enterprise-only"
+        ),
+    )
     router_settings: UpdateRouterConfig | None = Field(
         None,
         description="litellm router object settings. See router.py __init__ for all, example router.num_retries=5, router.timeout=5, router.max_retries=5, router.retry_after=5",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5427,9 +5427,11 @@ class ProxyConfig:
             # Load vector stores from config
             litellm.vector_store_registry.load_vector_stores_from_config(vector_store_registry_config)
 
-        ## WORKER REGISTRY (Control Plane)
+        ## WORKER REGISTRY (Global Control Plane)
         worker_registry_config: Final = config.get("worker_registry", None)
         if worker_registry_config:
+            if premium_user is not True:
+                raise ValueError("Trying to use `worker_registry`" + CommonProxyErrors.not_premium_user.value)
             self.worker_registry = [WorkerRegistryEntry(**e) for e in worker_registry_config]
         else:
             self.worker_registry = []

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import litellm
+from litellm.proxy._types import CommonProxyErrors
 from litellm.proxy.proxy_server import (
     ProxyConfig,
     _is_remote_module_url,
@@ -1209,13 +1210,61 @@ async def test_ProxyConfig__init_non_llm_configs_empty_config():
 
 
 @pytest.mark.asyncio
-async def test_ProxyConfig__init_non_llm_configs_invalid_worker_registry_raises():
+async def test_ProxyConfig__init_non_llm_configs_premium_invalid_worker_registry_raises(monkeypatch):
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
     pc = ProxyConfig()
     with pytest.raises(Exception):
         await pc._init_non_llm_configs(
             config={"worker_registry": [{"totally": "invalid"}]},
             config_file_path=None,
         )
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__init_non_llm_configs_worker_registry_requires_premium(monkeypatch):
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", False)
+    pc = ProxyConfig()
+    with pytest.raises(ValueError) as exc_info:
+        await pc._init_non_llm_configs(
+            config={
+                "worker_registry": [
+                    {"worker_id": "worker-a", "name": "Worker A", "url": "http://localhost:4001"}
+                ]
+            },
+            config_file_path=None,
+        )
+    message = str(exc_info.value)
+    assert "worker_registry" in message
+    assert CommonProxyErrors.not_premium_user.value in message
+    assert pc.worker_registry == []
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__init_non_llm_configs_worker_registry_loads_for_premium(monkeypatch):
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+    pc = ProxyConfig()
+    await pc._init_non_llm_configs(
+        config={
+            "worker_registry": [
+                {"worker_id": "worker-a", "name": "Worker A", "url": "http://localhost:4001"},
+                {"worker_id": "worker-b", "name": "Worker B", "url": "https://worker-b.example.com"},
+            ]
+        },
+        config_file_path=None,
+    )
+    assert [(w.worker_id, w.name, w.url) for w in pc.worker_registry] == [
+        ("worker-a", "Worker A", "http://localhost:4001"),
+        ("worker-b", "Worker B", "https://worker-b.example.com"),
+    ]
+
+
+@pytest.mark.parametrize("premium", [True, False])
+@pytest.mark.asyncio
+async def test_ProxyConfig__init_non_llm_configs_no_worker_registry_is_never_gated(monkeypatch, premium):
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", premium)
+    pc = ProxyConfig()
+    await pc._init_non_llm_configs(config={}, config_file_path=None)
+    assert pc.worker_registry == []
 
 
 # ---------------------------------------------------------------------------

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23611,6 +23611,11 @@ export interface components {
              * @description proxy level default model for all chat completion calls
              */
             completion_model?: string | null;
+            /**
+             * Control Plane Url
+             * @description Global Control Plane: URL of the control plane whose admin UI manages this instance. Enables /v3/login and /v3/login/exchange on this instance so that UI can authenticate against it cross-origin, and restricts the SSO return_to origin to that URL. No state is shared with the control plane
+             */
+            control_plane_url?: string | null;
             /** @description standalone Redis for cross-pod coordination (tpm/rpm rate limits, spend tracking, pod lock manager, shared health checks), configured independently of the response-cache backend; takes precedence over borrowing the `cache_params` Redis and over the REDIS_* env fallback */
             coordination_redis?: components["schemas"]["CoordinationRedisParams"] | null;
             /**
@@ -23964,6 +23969,11 @@ export interface components {
             model_list?: components["schemas"]["ModelParams"][] | null;
             /** @description litellm router object settings. See router.py __init__ for all, example router.num_retries=5, router.timeout=5, router.max_retries=5, router.retry_after=5 */
             router_settings?: components["schemas"]["UpdateRouterConfig"] | null;
+            /**
+             * Worker Registry
+             * @description Global Control Plane: the independent proxy instances this instance's admin UI manages. Setting it makes this a control plane, which serves the UI and does not route LLM requests. Enterprise-only
+             */
+            worker_registry?: components["schemas"]["WorkerRegistryEntry"][] | null;
         };
         /** ConfigurableClientsideParamsCustomAuth */
         "ConfigurableClientsideParamsCustomAuth-Input": {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Global Control Plane is sold as Enterprise but had no license check
- Any OSS install could run one for free
- Its two config keys were undeclared, so they were undiscoverable

How it solves it:

- Check the license when the worker registry is loaded
- Fail startup loudly instead of dropping the registry silently
- Declare both keys so they reach the generated config schema

## User Flow

Before: an admin with no Enterprise license stands up a control plane and it just works, so the Enterprise requirement is unenforced

1. They write a config with a `worker_registry` listing two proxies, and no `LITELLM_LICENSE` in the environment
2. They start the proxy on port 4633, and it boots normally with no warning
3. They open `http://localhost:4633/.well-known/litellm-ui-config` and get `"is_control_plane": true` with both workers listed
4. They open the admin UI and get the worker selector on the login page, managing both proxies from one place, without a license

After: the same admin is told at startup that this needs a license, and a licensed admin is unaffected

1. They write the same config with the same `worker_registry`, still with no `LITELLM_LICENSE`
2. They start the proxy, and it refuses to boot: `Trying to use worker_registry` followed by `You must be a LiteLLM Enterprise user to use this feature`, then `Application startup failed. Exiting.`
3. They set a valid `LITELLM_LICENSE` and start again, and the proxy boots normally
4. `http://localhost:4633/.well-known/litellm-ui-config` returns `"is_control_plane": true` with both workers, byte for byte what it returned before this change

## Relevant issues

## Linear ticket

Resolves LIT-5633

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Three legs against a live proxy on port 4633, same config file throughout, differing only in code revision and whether a license is present.

Config used in all three legs:

```yaml
model_list: []

general_settings:
  master_key: sk-5633

worker_registry:
  - worker_id: "worker-a"
    name: "Worker A"
    url: "http://localhost:4634"
  - worker_id: "worker-b"
    name: "Worker B"
    url: "http://localhost:4635"
```

### Before, unlicensed, at `40a418440c` (base)

The control plane comes up and serves the full worker registry with no license present, which is the gap this PR closes.

```bash
LITELLM_LICENSE="" python litellm/proxy/proxy_cli.py --config cp_config_5633.yaml --port 4633
curl -s http://localhost:4633/.well-known/litellm-ui-config
```

```json
{"server_root_path":"","proxy_base_url":null,"auto_redirect_to_sso":false,"admin_ui_disabled":false,"sso_configured":false,"hide_default_credentials_hint":false,"is_control_plane":true,"workers":[{"worker_id":"worker-a","name":"Worker A","url":"http://localhost:4634"},{"worker_id":"worker-b","name":"Worker B","url":"http://localhost:4635"}]}
```

### After, unlicensed, at `f622c85c9c`

Same command, same config. Startup now refuses.

```bash
LITELLM_LICENSE="" python litellm/proxy/proxy_cli.py --config cp_config_5633.yaml --port 4633
```

```
    raise ValueError("Trying to use `worker_registry`" + CommonProxyErrors.not_premium_user.value)
ValueError: Trying to use `worker_registry`You must be a LiteLLM Enterprise user to use this feature. If you have a license please set `LITELLM_LICENSE` in your env. Get a 7 day trial key here: https://www.litellm.ai/enterprise#trial.
ERROR:    Application startup failed. Exiting.
```

### After, licensed, at `f622c85c9c`

Same command with a real `LITELLM_LICENSE` set. The proxy boots and the response is identical to the before leg, so licensed deployments see no change.

```bash
curl -s http://localhost:4633/.well-known/litellm-ui-config
```

```json
{"server_root_path":"","proxy_base_url":null,"auto_redirect_to_sso":false,"admin_ui_disabled":false,"sso_configured":false,"hide_default_credentials_hint":false,"is_control_plane":true,"workers":[{"worker_id":"worker-a","name":"Worker A","url":"http://localhost:4634"},{"worker_id":"worker-b","name":"Worker B","url":"http://localhost:4635"}]}
```

### Mutation check on the new tests

Each mutant applied on its own and reverted from a scratchpad copy, so the runs are independent.

```
mutant 1, gate deleted entirely
  -> 1 failed, 11 passed  (worker_registry_requires_premium)

mutant 2, `premium_user is not True` flipped to `premium_user is True`
  -> 2 failed, 10 passed  (requires_premium and loads_for_premium)

restored
  -> 12 passed
```

## Review notes

Greptile raised two findings on `f622c85c`, one accepted and one declined.

**Accepted: a test comment violating the repo comment policy.** Removed. The test is renamed to `..._premium_invalid_worker_registry_raises`, so the name carries what the comment was explaining and nothing is lost. The mutation check was re-run after the rename, since a rename is exactly the kind of change that can silently turn an assertion vacuous, and the mutant still dies.

**Declined: adding a user-controlled transition flag to soften the startup failure.** This is a licensing gate, so a flag that lets an unlicensed proxy load `worker_registry` anyway would remove the entitlement it exists to enforce. There is also no precedent for one: `litellm/proxy/` has 35 call sites using `CommonProxyErrors.not_premium_user`, and a grep for any bypass or transition mechanism across them returns nothing. Every one raises unconditionally, including the `enforced_params` gate 200 lines above this change in the same function. Adding a flag here would make this the only gate of 36 with an escape hatch.

The breaking change is real and is called out under Caveats. The right mitigation is a release note naming `worker_registry`, not a bypass.

## Type

🆕 New Feature

## Caveats (if any)

- Breaking for unlicensed installs already running a worker registry
- Needs a release note naming `worker_registry`
- Companion docs PR BerriAI/litellm-docs#899 renames this feature and drops its beta label
- Worker selector flow still has no e2e coverage

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


