### PR TITLE
fix(proxy): reserve the larger declared output budget for TPM limits

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -462,6 +462,23 @@ def _call_id_from_callback_kwargs(kwargs: object) -> str | None:
     return call_id if isinstance(call_id, str) else None
 
 
+def _declared_output_budget(value: object) -> int | None:
+    """Coerce a declared output budget to tokens, or None when it names no budget.
+
+    Accepts every shape the pre-existing ``int(...)`` coercion did, floats and numeric
+    strings included, because a budget this cannot read is a budget this cannot reserve
+    against, which is the bypass the caller-declared limits are checked for.
+    """
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(float(value))
+        except ValueError:
+            return None
+    return None
+
+
 class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
     def __init__(
         self,
@@ -604,7 +621,18 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
 
         estimated_input_tokens: Final = max(1, total_chars // DEFAULT_CHARS_PER_TOKEN) if total_chars > 0 else 0
 
-        explicit_max_tokens: Final = data.get("max_tokens") or data.get("max_completion_tokens")
+        # Both spellings can arrive together, e.g. a deployment-level max_tokens default under a
+        # client-supplied max_completion_tokens. Reserving against the larger keeps the estimate an
+        # upper bound on what the provider can emit, whichever one it ends up honouring.
+        declared_output_budgets: Final = tuple(
+            budget
+            for budget in (
+                _declared_output_budget(data.get("max_tokens")),
+                _declared_output_budget(data.get("max_completion_tokens")),
+            )
+            if budget is not None
+        )
+        explicit_max_tokens: Final = max(declared_output_budgets) if declared_output_budgets else None
 
         match (explicit_max_tokens, input_text):
             case (mt, _) if mt is not None:

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -5593,3 +5593,82 @@ def test_internal_call_origin_success_ops_are_skipped():
 
     assert charged
     assert skipped == []
+
+
+def _conflicting_budget_bodies() -> Dict[str, Dict[str, object]]:
+    """The same request, three ways of declaring the output budget."""
+    base = {"model": "gpt-5-chat", "messages": [{"role": "user", "content": "hi"}]}
+    return {
+        "both": {**base, "max_tokens": 1, "max_completion_tokens": 10000},
+        "only_large": {**base, "max_completion_tokens": 10000},
+        "only_small": {**base, "max_tokens": 1},
+    }
+
+
+def test_conflicting_token_limits_reserve_the_larger_declared_budget():
+    """Both spellings together must reserve the larger budget, not whichever is read first.
+
+    A request declaring max_tokens=1 alongside max_completion_tokens=10000 previously
+    reserved one output token while the provider stayed free to emit ten thousand.
+    """
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(DualCache())
+    )
+    bodies = _conflicting_budget_bodies()
+
+    reserved = {
+        label: handler._estimate_tokens_for_request(data=body)
+        for label, body in bodies.items()
+    }
+
+    assert reserved["both"] == reserved["only_large"]
+    assert reserved["both"] > reserved["only_small"]
+
+
+@pytest.mark.parametrize("declared", [10000, 10000.0, "10000"])
+def test_non_integer_output_budgets_still_reserve_their_declared_size(declared):
+    """A budget litellm cannot read is a budget it cannot reserve against.
+
+    A float or numeric-string max_tokens is explicit enough to suppress the capped
+    output floor, so dropping it from the estimate under-reserves and reopens the
+    same TPM bypass that reading both spellings was meant to close.
+    """
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(DualCache())
+    )
+    base = {"model": "gpt-5-chat", "messages": [{"role": "user", "content": "hi"}]}
+
+    reserved = handler._estimate_tokens_for_request(data={**base, "max_tokens": declared})
+    reserved_int = handler._estimate_tokens_for_request(data={**base, "max_tokens": 10000})
+
+    assert reserved == reserved_int
+
+
+@pytest.mark.asyncio
+async def test_conflicting_token_limits_cannot_bypass_tpm_reservation():
+    """The pre-call hook must refuse a request whose larger declared budget exceeds the TPM limit."""
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache)
+    )
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=hash_token("sk-conflicting-budgets"), tpm_limit=100, models=[]
+    )
+    bodies = _conflicting_budget_bodies()
+
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data=dict(bodies["only_small"]),
+        call_type="",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=local_cache,
+            data=dict(bodies["both"]),
+            call_type="",
+        )
+
+    assert exc_info.value.status_code == 429


### PR DESCRIPTION
## TLDR

Problem this solves:

- A request declaring both token-limit fields reserved the wrong one
- `max_tokens=1` plus `max_completion_tokens=10000` reserved 2 tokens
- The provider then emitted up to 10,000 against that reservation

How it solves it:

- Reserve against the larger declared budget, not the first one read
- Over-reserving is the safe direction; reconciliation refunds the difference

## User Flow

Before: a caller holding a key capped at 100 TPM gets a full-size generation admitted by declaring a tiny `max_tokens` alongside a large `max_completion_tokens`

1. An admin issues a key with `{"tpm_limit": 100}` via POST https://litellm-domain/key/generate
2. The caller sends POST https://litellm-domain/v1/chat/completions with `{"max_tokens": 1, "max_completion_tokens": 10000}`
3. The gateway admits the request, having set aside 2 tokens of the 100 the key is allowed
4. The same caller sending only `{"max_completion_tokens": 10000}` is refused with HTTP 429, so the cap is enforced only against callers who declare their budget once

After: the same request is refused, and declaring the budget twice buys nothing

1. An admin issues a key with `{"tpm_limit": 100}` via POST https://litellm-domain/key/generate
2. The caller sends POST https://litellm-domain/v1/chat/completions with `{"max_tokens": 1, "max_completion_tokens": 10000}`
3. The gateway sets aside 10,001 tokens, sees that it exceeds the 100 the key is allowed, and returns HTTP 429 naming `Limit type: tokens`
4. The same caller sending only `{"max_completion_tokens": 10000}` is refused identically, so both spellings now cost the same

## Relevant issues

Found while reviewing #36857, which makes `azure/gpt-5-chat` translate `max_tokens` into `max_completion_tokens` and so joins the families where the legacy field is dropped before the provider sees it. The under-reservation predates that change and already applied to `azure/gpt-5`, `azure/o3-mini`, `openai/gpt-5` and `openai/o3-mini`, which is why the fix belongs here in the limiter rather than in any one provider's param mapping

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy on 127.0.0.1:45559 backed by its own Postgres on 127.0.0.1:55490, with one Azure deployment pointed at a local HTTP server on 127.0.0.1:45560 that records the request body. The rate limiter is the real one, the key is a real virtual key carrying `tpm_limit: 100`, and each leg uses a fresh key so no leg inherits another's window. `--detailed_debug` is on so the limiter prints the figure it reserved

Every leg runs the same three requests: the conflicting one, then two controls that declare the budget once

Before, at 40a418440c121202f57f93c64b67209971de317c (this branch's base):

```
$ curl -s http://127.0.0.1:45559/health/liveliness
"I'm alive!"

$ curl -s -X POST http://127.0.0.1:45559/key/generate -H 'Authorization: Bearer sk-lit5549b' \
    -H 'Content-Type: application/json' -d '{"tpm_limit": 100, "models": ["gpt-5-chat"]}'
-> sk-1rMFzjtEFB1jZnkixMuZDg

CASE A, both fields
$ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:45559/v1/chat/completions \
    -H "Authorization: Bearer $KEY_A" -H 'Content-Type: application/json' \
    -d '{"model":"gpt-5-chat","messages":[{"role":"user","content":"hi"}],"max_tokens":1,"max_completion_tokens":10000}'
HTTP 400
TPM reservation estimate: input=1, max_tokens=1 (explicit=True), total=2

CONTROL B, only max_completion_tokens=10000, fresh key
HTTP 429  Rate limit exceeded ... Limit type: tokens. Current limit: 100
TPM reservation estimate: input=1, max_tokens=10000 (explicit=True), total=10001

CONTROL C, only max_tokens=1, fresh key
HTTP 400
TPM reservation estimate: input=1, max_tokens=1 (explicit=True), total=2
```

After, at 10af55201e1a79b7baa6ea8a40816973284f8514 (this PR):

```
$ curl -s http://127.0.0.1:45559/health/liveliness
"I'm alive!"

CASE A, both fields
$ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:45559/v1/chat/completions \
    -H "Authorization: Bearer $KEY_A" -H 'Content-Type: application/json' \
    -d '{"model":"gpt-5-chat","messages":[{"role":"user","content":"hi"}],"max_tokens":1,"max_completion_tokens":10000}'
{"error":{"message":"Rate limit exceeded for api_key: 6ea9af16... Limit type: tokens. Current limit: 100, Remaining: 100. ...","type":"throttling_error","code":"429"}}
HTTP 429
TPM reservation estimate: input=1, max_tokens=10000 (explicit=True), total=10001

CONTROL B, only max_completion_tokens=10000, fresh key
HTTP 429  Rate limit exceeded ... Limit type: tokens. Current limit: 100
TPM reservation estimate: input=1, max_tokens=10000 (explicit=True), total=10001

CONTROL C, only max_tokens=1, fresh key
HTTP 400
TPM reservation estimate: input=1, max_tokens=1 (explicit=True), total=2
```

The reserved figure for the identical request moves from 2 to 10001, and case A moves from admitted to refused while both controls stay exactly where they were. Control B is the load-bearing one: it shows the harness can produce a 429 at this limit before the fix, so case A being admitted was the conflicting pair winning rather than the cap being unreachable. The HTTP 400 on case A before, and on control C in both runs, is the separate Azure defect in #36857, which this branch does not carry; it is what a request looks like when the limiter lets it through to the provider

## Type

🐛 Bug Fix

## Caveats (if any)

- Over-reservation is deliberate; reconciliation refunds the unused difference
- `max` is right even when `max_tokens` is the larger declared value
- Line 2597 already reads both fields, so 607 was the lone offender

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 10af55201e1a79b7baa6ea8a40816973284f8514. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->