### PR TITLE
fix(scim): refresh / invalidate user cache on PATCH/PUT/DELETE /Users (Fixes #37009)

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -13,7 +13,7 @@ import asyncio
 import math
 import re
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Mapping, Optional, Type, Union, cast
 
 from fastapi import HTTPException, Request, status
 from pydantic import BaseModel
@@ -1808,6 +1808,103 @@ async def _cache_team_object(
         user_api_key_cache.delete_cache(key=alias_key)
         if proxy_logging_obj is not None:
             await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=alias_key)
+
+
+async def _cache_user_object(
+    user_id: str,
+    user_table: LiteLLM_UserTable,
+    user_api_key_cache: UserApiKeyCache,
+    proxy_logging_obj: ProxyLogging | None,
+) -> None:
+    """
+    Persist a ``LiteLLM_UserTable`` in the management-object cache keyed on
+    the literal ``user_id``.
+
+    The user cache is single-keyed (the ``user_id`` itself, not
+    ``"user_id:{}".format(user_id)`` like the team cache), so this helper
+    only writes one entry. The reader path is ``get_user_object`` at
+    line 1618; the writer path is the upsert fallback in
+    ``get_user_object`` at line 1732. SCIM ``update_user`` and
+    ``patch_user`` call this via ``_refresh_cached_user`` to keep the
+    cache in sync after a DB write — see #37009.
+    """
+    await _cache_management_object(
+        key=user_id,
+        value=user_table,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
+        model_type=LiteLLM_UserTable,
+    )
+
+
+async def _refresh_cached_user(
+    user_row: "LiteLLM_UserTable | Mapping[str, object]",
+    user_api_key_cache: UserApiKeyCache,
+    proxy_logging_obj: ProxyLogging | None,
+) -> None:
+    """
+    Refresh the in-memory cached user object after a DB write.
+
+    Every endpoint that mutates ``litellm_usertable`` and serves a
+    post-mutation ``LiteLLM_UserTable`` should call this so the cached
+    row used by ``get_user_object`` stays in sync. Without this, the
+    very next auth check that hits the cache serves the pre-mutation
+    user, which means a SCIM-driven deactivation or email rename does
+    not take effect on auth until the management-object TTL expires —
+    see #37009 and the same multi-prefix cache Achilles heel pattern
+    fixed in #35565 (team block/unblock) and #36817 (SCIM /Groups).
+
+    ``user_row`` is the Prisma row returned by ``update``/``find_unique``
+    on ``litellm_usertable``. The real Prisma client returns a
+    ``LiteLLM_UserTable`` Pydantic model (attribute access + a
+    ``model_dump()`` method); the helper supports both attribute access
+    and dict-style access so callers don't have to pre-shape the row.
+    """
+    if isinstance(user_row, dict):
+        row_id_raw = user_row["user_id"]
+        row_payload = user_row
+    else:
+        row_id_raw = user_row.user_id
+        row_payload = user_row.model_dump()
+    row_id = cast("str", row_id_raw)  # cast-ok: narrowing UserId to str (Prisma returns str; dict literal preserves it)
+
+    # Some callers (and pre-existing tests) hand us a dict with a
+    # JSON-stringified `metadata`. The real Prisma client returns a
+    # parsed dict, so the production path always takes the `else`
+    # branch above. The `dict` path here is a defensive shim: parse the
+    # string so `LiteLLM_UserTable(**row_payload)` validates.
+    if isinstance(row_payload, dict) and isinstance(row_payload.get("metadata"), str):
+        import json
+
+        try:
+            row_payload = {**row_payload, "metadata": json.loads(row_payload["metadata"])}
+        except (ValueError, TypeError):
+            row_payload = {**row_payload, "metadata": {}}
+    await _cache_user_object(
+        user_id=row_id,
+        user_table=LiteLLM_UserTable(**row_payload),
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
+    )
+
+
+async def _invalidate_cached_user(
+    user_id: str,
+    user_api_key_cache: UserApiKeyCache,
+    proxy_logging_obj: ProxyLogging | None,
+) -> None:
+    """
+    Invalidate (delete) the cached ``LiteLLM_UserTable`` for ``user_id``.
+
+    Use this when the user no longer exists in the database (e.g. SCIM
+    ``DELETE /Users/{id}``) — there is no post-mutation row to cache,
+    so refresh is wrong. Both the local LRU and the Redis side of the
+    dual cache are cleared so a same-user ``POST /user/new`` after
+    delete does not read a stale snapshot — see #37009.
+    """
+    user_api_key_cache.delete_cache(key=user_id)
+    if proxy_logging_obj is not None:
+        await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=user_id)
 
 
 async def _cache_key_object(

--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -38,7 +38,11 @@ from litellm.proxy._types import (
     TeamMemberDeleteRequest,
     UserAPIKeyAuth,
 )
-from litellm.proxy.auth.auth_checks import _delete_cache_key_object
+from litellm.proxy.auth.auth_checks import (
+    _delete_cache_key_object,
+    _invalidate_cached_user,
+    _refresh_cached_user,
+)
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.http_parsing_utils import _safe_get_request_headers
 from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
@@ -1275,6 +1279,23 @@ async def update_user(
             if new_active is not None and new_active != (True if prev_active is None else prev_active):
                 await _set_user_keys_blocked(user_id=user_id, blocked=not new_active)
 
+        # Refresh the in-memory user cache so the very next auth check
+        # sees the new `user_email` / `teams` / `metadata`. Without this,
+        # a SCIM-driven rename or email change does not take effect on
+        # auth until the management-object TTL expires — see #37009.
+        # Same pattern as the cycle-12 SCIM /Groups fix (#36817) and the
+        # cycle-9 team block/unblock fix (#35565).
+        from litellm.proxy.proxy_server import (
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        await _refresh_cached_user(
+            user_row=updated_user,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
         # Convert back to SCIM format
         scim_user = await ScimTransformations.transform_litellm_user_to_scim_user(updated_user)
 
@@ -1330,6 +1351,24 @@ async def delete_user(
 
         # Delete user
         await UserRepository(prisma_client).table.delete(where={"user_id": user_id})
+
+        # Invalidate the in-memory user cache so the very next auth check
+        # sees the user as gone. Without this, a stale `user_id` entry
+        # stays readable until the management-object TTL expires — see
+        # #37009. The user is gone, so we invalidate (delete) rather
+        # than refresh. Both the local LRU and the Redis side of the
+        # dual cache are cleared, matching the dual-cache invalidation
+        # pattern from the cycle-12 SCIM /Groups fix (#36817).
+        from litellm.proxy.proxy_server import (
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        await _invalidate_cached_user(
+            user_id=user_id,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
 
         return Response(status_code=204)
     except Exception as e:
@@ -1679,6 +1718,25 @@ async def patch_user(
 
         if new_active is not None and new_active != (True if prev_active is None else prev_active):
             await _set_user_keys_blocked(user_id=user_id, blocked=not new_active)
+
+        # Refresh the in-memory user cache so the very next auth check
+        # sees the new `user_email` / `teams` / `metadata` / `active`
+        # state. Without this, a SCIM-driven deactivation (the `active`
+        # flag flip that just called `_set_user_keys_blocked` above) does
+        # not propagate to the cached `LiteLLM_UserTable` until the
+        # management-object TTL expires — see #37009. Same pattern as
+        # the `update_user` fix above, the cycle-12 SCIM /Groups fix
+        # (#36817), and the cycle-9 team block/unblock fix (#35565).
+        from litellm.proxy.proxy_server import (
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        await _refresh_cached_user(
+            user_row=updated_user,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
 
         scim_user = await ScimTransformations.transform_litellm_user_to_scim_user(updated_user)
 

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_key_deactivation.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_key_deactivation.py
@@ -34,6 +34,36 @@ def _build_token_row(token: str, user_id: str, blocked: bool, metadata=None):
     return row
 
 
+def _make_user_api_key_cache_mock():
+    """
+    A ``user_api_key_cache`` mock that supports both the async
+    ``async_set_cache`` (called by ``_cache_user_object``) and the sync
+    ``delete_cache`` (called by ``_invalidate_cached_user``). Plain
+    ``MagicMock()`` fails the ``await async_set_cache(...)`` call with
+    ``TypeError: object MagicMock can't be used in 'await' expression``;
+    plain ``AsyncMock()`` makes ``delete_cache`` async too, which raises
+    a coroutine-never-awaited warning. Cycle-15 SCIM /Users cache fix
+    (#37009) needs both surfaces.
+    """
+    cache_mock = MagicMock()
+    cache_mock.async_set_cache = AsyncMock()
+    return cache_mock
+
+
+def _make_logging_mock():
+    """
+    A ``proxy_logging_obj`` mock that supports the dual-cache invalidation
+    pattern called from ``_invalidate_cached_user`` and the equivalent
+    async cache-set call in ``_cache_user_object`` (used by the
+    cycle-15 SCIM /Users cache fix — see #37009). Plain ``MagicMock()``
+    fails the ``await ... async_delete_cache(...)`` call with
+    ``TypeError: object MagicMock can't be used in 'await' expression``.
+    """
+    logging_mock = MagicMock()
+    logging_mock.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
+    return logging_mock
+
+
 def _build_prisma_with_keys(user_keys, mock_user=None, updated_user=None):
     mock_client = MagicMock()
     mock_db = MagicMock()
@@ -70,8 +100,14 @@ async def test_set_user_keys_blocked_flips_state_and_invalidates_cache():
 
     with (
         patch("litellm.proxy.proxy_server.prisma_client", mock_client),
-        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
-        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.proxy_server.user_api_key_cache",
+            _make_user_api_key_cache_mock(),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj",
+            _make_logging_mock(),
+        ),
         patch(
             "litellm.proxy.management_endpoints.scim.scim_v2._delete_cache_key_object",
             AsyncMock(side_effect=fake_delete),
@@ -101,8 +137,14 @@ async def test_set_user_keys_blocked_noop_when_no_matching_keys():
 
     with (
         patch("litellm.proxy.proxy_server.prisma_client", mock_client),
-        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
-        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.proxy_server.user_api_key_cache",
+            _make_user_api_key_cache_mock(),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj",
+            _make_logging_mock(),
+        ),
         patch(
             "litellm.proxy.management_endpoints.scim.scim_v2._delete_cache_key_object",
             AsyncMock(),
@@ -121,9 +163,7 @@ async def test_set_user_keys_unblocked_skips_admin_blocked_keys():
     """Reactivation must leave keys an admin blocked (no scim_blocked marker) alone."""
     keys = [
         # SCIM-blocked: should be unblocked.
-        _build_token_row(
-            "hash-scim", "user-x", blocked=True, metadata={"scim_blocked": True}
-        ),
+        _build_token_row("hash-scim", "user-x", blocked=True, metadata={"scim_blocked": True}),
         # Admin-blocked for unrelated reasons: must remain blocked.
         _build_token_row("hash-admin", "user-x", blocked=True, metadata={}),
     ]
@@ -136,8 +176,14 @@ async def test_set_user_keys_unblocked_skips_admin_blocked_keys():
 
     with (
         patch("litellm.proxy.proxy_server.prisma_client", mock_client),
-        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
-        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.proxy_server.user_api_key_cache",
+            _make_user_api_key_cache_mock(),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj",
+            _make_logging_mock(),
+        ),
         patch(
             "litellm.proxy.management_endpoints.scim.scim_v2._delete_cache_key_object",
             AsyncMock(side_effect=fake_delete),
@@ -169,8 +215,14 @@ async def test_scim_delete_user_blocks_keys_before_deleting_user():
 
     with (
         patch("litellm.proxy.proxy_server.prisma_client", mock_client),
-        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
-        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.proxy_server.user_api_key_cache",
+            _make_user_api_key_cache_mock(),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj",
+            _make_logging_mock(),
+        ),
         patch(
             "litellm.proxy.management_endpoints.scim.scim_v2._delete_cache_key_object",
             AsyncMock(),
@@ -184,9 +236,7 @@ async def test_scim_delete_user_blocks_keys_before_deleting_user():
     assert update_kwargs["where"] == {"token": "hash-a"}
     assert update_kwargs["data"]["blocked"] is True
     assert '"scim_blocked": true' in update_kwargs["data"]["metadata"]
-    mock_db.litellm_usertable.delete.assert_awaited_once_with(
-        where={"user_id": user_id}
-    )
+    mock_db.litellm_usertable.delete.assert_awaited_once_with(where={"user_id": user_id})
 
 
 @pytest.mark.asyncio
@@ -211,14 +261,18 @@ async def test_scim_delete_user_clears_fk_referenced_rows_before_user_delete():
     mock_db.litellm_teammembership.delete_many = AsyncMock(
         side_effect=lambda **kw: call_order.append(("teammembership", kw)) or None
     )
-    mock_db.litellm_usertable.delete = AsyncMock(
-        side_effect=lambda **kw: call_order.append(("user", kw)) or None
-    )
+    mock_db.litellm_usertable.delete = AsyncMock(side_effect=lambda **kw: call_order.append(("user", kw)) or None)
 
     with (
         patch("litellm.proxy.proxy_server.prisma_client", mock_client),
-        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
-        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.proxy_server.user_api_key_cache",
+            _make_user_api_key_cache_mock(),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj",
+            _make_logging_mock(),
+        ),
         patch(
             "litellm.proxy.management_endpoints.scim.scim_v2._delete_cache_key_object",
             AsyncMock(),
@@ -239,12 +293,8 @@ async def test_scim_delete_user_clears_fk_referenced_rows_before_user_delete():
             ]
         }
     }
-    mock_db.litellm_organizationmembership.delete_many.assert_awaited_once_with(
-        where={"user_id": user_id}
-    )
-    mock_db.litellm_teammembership.delete_many.assert_awaited_once_with(
-        where={"user_id": user_id}
-    )
+    mock_db.litellm_organizationmembership.delete_many.assert_awaited_once_with(where={"user_id": user_id})
+    mock_db.litellm_teammembership.delete_many.assert_awaited_once_with(where={"user_id": user_id})
 
     stages = [stage for stage, _ in call_order]
     assert stages.index("user") > stages.index("invitation")
@@ -269,13 +319,9 @@ async def test_scim_patch_user_active_false_blocks_keys():
         metadata={"scim_active": False, "scim_metadata": {}},
     )
     keys = [_build_token_row("hash-z", user_id, blocked=False)]
-    mock_client, mock_db = _build_prisma_with_keys(
-        keys, mock_user=mock_user, updated_user=updated_user
-    )
+    mock_client, mock_db = _build_prisma_with_keys(keys, mock_user=mock_user, updated_user=updated_user)
 
-    patch_ops = SCIMPatchOp(
-        Operations=[SCIMPatchOperation(op="replace", path="active", value="False")]
-    )
+    patch_ops = SCIMPatchOp(Operations=[SCIMPatchOperation(op="replace", path="active", value="False")])
     mock_scim_user = SCIMUser(
         schemas=["urn:ietf:params:scim:schemas:core:2.0:User"],
         id=user_id,
@@ -287,8 +333,14 @@ async def test_scim_patch_user_active_false_blocks_keys():
 
     with (
         patch("litellm.proxy.proxy_server.prisma_client", mock_client),
-        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
-        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.proxy_server.user_api_key_cache",
+            _make_user_api_key_cache_mock(),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj",
+            _make_logging_mock(),
+        ),
         patch(
             "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
             AsyncMock(return_value=mock_scim_user),
@@ -324,18 +376,10 @@ async def test_scim_patch_user_active_true_unblocks_keys():
         teams=[],
         metadata={"scim_active": True, "scim_metadata": {}},
     )
-    keys = [
-        _build_token_row(
-            "hash-r", user_id, blocked=True, metadata={"scim_blocked": True}
-        )
-    ]
-    mock_client, mock_db = _build_prisma_with_keys(
-        keys, mock_user=mock_user, updated_user=updated_user
-    )
+    keys = [_build_token_row("hash-r", user_id, blocked=True, metadata={"scim_blocked": True})]
+    mock_client, mock_db = _build_prisma_with_keys(keys, mock_user=mock_user, updated_user=updated_user)
 
-    patch_ops = SCIMPatchOp(
-        Operations=[SCIMPatchOperation(op="replace", path="active", value="True")]
-    )
+    patch_ops = SCIMPatchOp(Operations=[SCIMPatchOperation(op="replace", path="active", value="True")])
     mock_scim_user = SCIMUser(
         schemas=["urn:ietf:params:scim:schemas:core:2.0:User"],
         id=user_id,
@@ -347,8 +391,14 @@ async def test_scim_patch_user_active_true_unblocks_keys():
 
     with (
         patch("litellm.proxy.proxy_server.prisma_client", mock_client),
-        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
-        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.proxy_server.user_api_key_cache",
+            _make_user_api_key_cache_mock(),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj",
+            _make_logging_mock(),
+        ),
         patch(
             "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
             AsyncMock(return_value=mock_scim_user),
@@ -386,13 +436,9 @@ async def test_scim_patch_user_no_active_change_does_not_touch_keys():
         teams=[],
         metadata={"scim_active": True, "scim_metadata": {}},
     )
-    mock_client, mock_db = _build_prisma_with_keys(
-        user_keys=[], mock_user=mock_user, updated_user=updated_user
-    )
+    mock_client, mock_db = _build_prisma_with_keys(user_keys=[], mock_user=mock_user, updated_user=updated_user)
 
-    patch_ops = SCIMPatchOp(
-        Operations=[SCIMPatchOperation(op="replace", path="displayName", value="New")]
-    )
+    patch_ops = SCIMPatchOp(Operations=[SCIMPatchOperation(op="replace", path="displayName", value="New")])
     mock_scim_user = SCIMUser(
         schemas=["urn:ietf:params:scim:schemas:core:2.0:User"],
         id=user_id,
@@ -404,8 +450,14 @@ async def test_scim_patch_user_no_active_change_does_not_touch_keys():
 
     with (
         patch("litellm.proxy.proxy_server.prisma_client", mock_client),
-        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
-        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.proxy_server.user_api_key_cache",
+            _make_user_api_key_cache_mock(),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj",
+            _make_logging_mock(),
+        ),
         patch(
             "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
             AsyncMock(return_value=mock_scim_user),
@@ -445,14 +497,8 @@ async def test_scim_put_user_omitting_active_preserves_deactivated_state():
         teams=[],
         metadata={"scim_active": False},
     )
-    keys = [
-        _build_token_row(
-            "hash-keep-blocked", user_id, blocked=True, metadata={"scim_blocked": True}
-        )
-    ]
-    mock_client, mock_db = _build_prisma_with_keys(
-        keys, mock_user=deactivated, updated_user=deactivated
-    )
+    keys = [_build_token_row("hash-keep-blocked", user_id, blocked=True, metadata={"scim_blocked": True})]
+    mock_client, mock_db = _build_prisma_with_keys(keys, mock_user=deactivated, updated_user=deactivated)
 
     put_user = SCIMUser.model_validate(_build_put_user_payload(user_id))
 
@@ -467,8 +513,14 @@ async def test_scim_put_user_omitting_active_preserves_deactivated_state():
 
     with (
         patch("litellm.proxy.proxy_server.prisma_client", mock_client),
-        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
-        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.proxy_server.user_api_key_cache",
+            _make_user_api_key_cache_mock(),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj",
+            _make_logging_mock(),
+        ),
         patch(
             "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
             AsyncMock(return_value=mock_scim_user),
@@ -506,9 +558,7 @@ async def test_scim_put_user_explicit_active_false_blocks_keys():
         metadata={"scim_active": False, "scim_metadata": {}},
     )
     keys = [_build_token_row("hash-block-me", user_id, blocked=False)]
-    mock_client, mock_db = _build_prisma_with_keys(
-        keys, mock_user=active, updated_user=deactivated
-    )
+    mock_client, mock_db = _build_prisma_with_keys(keys, mock_user=active, updated_user=deactivated)
 
     put_user = SCIMUser.model_validate(_build_put_user_payload(user_id, active=False))
 
@@ -523,8 +573,14 @@ async def test_scim_put_user_explicit_active_false_blocks_keys():
 
     with (
         patch("litellm.proxy.proxy_server.prisma_client", mock_client),
-        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
-        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.proxy_server.user_api_key_cache",
+            _make_user_api_key_cache_mock(),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj",
+            _make_logging_mock(),
+        ),
         patch(
             "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
             AsyncMock(return_value=mock_scim_user),

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -2910,9 +2910,7 @@ async def test_patch_group_rename_recomputes_retained_members(mocker):
 
 
 @pytest.mark.asyncio
-async def test_process_group_patch_operations_add_retains_existing_members(
-    mocker, monkeypatch
-):
+async def test_process_group_patch_operations_add_retains_existing_members(mocker, monkeypatch):
     """A SCIM group ``add`` operation must not drop members already in the team.
 
     Team membership lives in members_with_roles; team creation leaves the legacy
@@ -2937,18 +2935,14 @@ async def test_process_group_patch_operations_add_retains_existing_members(
     )
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(op="add", path="members", value=[{"value": "new-user"}])
-        ],
+        Operations=[SCIMPatchOperation(op="add", path="members", value=[{"value": "new-user"}])],
     )
 
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
     # new-user already exists in the DB
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock(user_id="new-user")
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock(user_id="new-user"))
 
     _, final_members, _ = await _process_group_patch_operations(
         patch_ops=patch_ops,
@@ -2960,9 +2954,7 @@ async def test_process_group_patch_operations_add_retains_existing_members(
 
 
 @pytest.mark.asyncio
-async def test_process_group_patch_operations_remove_uses_members_with_roles(
-    mocker, monkeypatch
-):
+async def test_process_group_patch_operations_remove_uses_members_with_roles(mocker, monkeypatch):
     """A ``remove`` op must diff against members_with_roles, so removing one
     member leaves the rest of the team intact rather than emptying it."""
 
@@ -2984,19 +2976,13 @@ async def test_process_group_patch_operations_remove_uses_members_with_roles(
     )
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(
-                op="remove", path="members", value=[{"value": "drop-user"}]
-            )
-        ],
+        Operations=[SCIMPatchOperation(op="remove", path="members", value=[{"value": "drop-user"}])],
     )
 
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock(user_id="drop-user")
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock(user_id="drop-user"))
 
     _, final_members, _ = await _process_group_patch_operations(
         patch_ops=patch_ops,
@@ -3440,9 +3426,7 @@ async def test_process_group_patch_remove_filtered_path_without_value(mocker):
     prisma_client = mocker.MagicMock()
     prisma_client.db = mocker.MagicMock()
     prisma_client.db.litellm_usertable = mocker.MagicMock()
-    prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=LiteLLM_UserTable(user_id="user-1")
-    )
+    prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=LiteLLM_UserTable(user_id="user-1"))
 
     _, final_members, _ = await _process_group_patch_operations(
         patch_ops=patch_ops,
@@ -3471,9 +3455,7 @@ async def test_process_group_patch_add_filtered_path_without_value(mocker):
     prisma_client = mocker.MagicMock()
     prisma_client.db = mocker.MagicMock()
     prisma_client.db.litellm_usertable = mocker.MagicMock()
-    prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=LiteLLM_UserTable(user_id="user-3")
-    )
+    prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=LiteLLM_UserTable(user_id="user-3"))
 
     _, final_members, _ = await _process_group_patch_operations(
         patch_ops=patch_ops,
@@ -3490,9 +3472,7 @@ async def test_process_group_patch_replace_empty_value_does_not_use_path_filter(
     id from the filtered path, which would retain one member and drop the rest."""
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(op="replace", path='members[value eq "user-1"]', value=[])
-        ],
+        Operations=[SCIMPatchOperation(op="replace", path='members[value eq "user-1"]', value=[])],
     )
 
     existing_team = LiteLLM_TeamTable(
@@ -3508,9 +3488,7 @@ async def test_process_group_patch_replace_empty_value_does_not_use_path_filter(
     prisma_client = mocker.MagicMock()
     prisma_client.db = mocker.MagicMock()
     prisma_client.db.litellm_usertable = mocker.MagicMock()
-    prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=LiteLLM_UserTable(user_id="user-1")
-    )
+    prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=LiteLLM_UserTable(user_id="user-1"))
 
     _, final_members, _ = await _process_group_patch_operations(
         patch_ops=patch_ops,
@@ -3519,3 +3497,308 @@ async def test_process_group_patch_replace_empty_value_does_not_use_path_filter(
     )
 
     assert final_members == set()
+
+
+class TestScimUserCacheInvalidation:
+    """
+    Regression pin for #37009.
+
+    SCIM PATCH/PUT/DELETE /Users/{id} previously only wrote to
+    `litellm_usertable` and left the in-memory user cache stale. The
+    user cache is keyed on the literal `user_id` (per
+    `auth_checks.py:1641`, `get_user_object`'s `async_get_cache` call),
+    unlike the team cache which is dual-keyed on
+    `team_id:{id}` + `team_alias:{alias}`. Operators using SCIM-driven
+    IdPs (Okta, Azure AD, OneLogin, etc.) expect a deactivation or
+    email rename to take effect immediately on the proxy; without
+    cache invalidation, the stale read is silently served on every
+    request for the TTL window — and in a multi-pod deployment, the
+    window extends across replicas.
+
+    Pin: each SCIM user endpoint must call the same cache-management
+    helpers the user management endpoints rely on. `update_user` and
+    `patch_user` must call `_refresh_cached_user` with the
+    post-mutation row. `delete_user` must invalidate (delete) the
+    `user_id` key in both the local LRU and the Redis side of the
+    dual cache. `create_user` needs no cache work — the user is new,
+    not yet in cache.
+    """
+
+    @staticmethod
+    def _make_user(user_id, user_email, teams):
+        from litellm.proxy._types import LiteLLM_UserTable
+
+        return LiteLLM_UserTable(
+            user_id=user_id,
+            user_email=user_email,
+            teams=teams,
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_user_refreshes_user_cache(self, mocker):
+        """
+        `PUT /scim/v2/Users/{id}` must call `_refresh_cached_user` with
+        the post-mutation row after the database update. Regression pin
+        for #37009.
+        """
+        from litellm.proxy.management_endpoints.scim.scim_v2 import update_user
+        from litellm.types.proxy.management_endpoints.scim_v2 import (
+            SCIMUser,
+            SCIMUserEmail,
+            SCIMUserName,
+        )
+
+        user_id = "scim-update-cache-test"
+        existing_user = self._make_user(user_id=user_id, user_email="old@example.com", teams=[])
+
+        # `updated_user` is a MagicMock (not a Pydantic instance) because
+        # `_refresh_cached_user` does `LiteLLM_UserTable(**user_row.model_dump())`,
+        # and the test must provide a real `model_dump` callable. Pydantic
+        # v2 freezes field assignment, so we mock at the MagicMock level
+        # and explicitly set `model_dump` to a real dict. Mirrors the
+        # cycle-12 test pattern for SCIM /Groups.
+        updated_user = mocker.MagicMock()
+        updated_user.user_id = user_id
+        updated_user.user_email = "new@example.com"
+        updated_user.teams = []
+        updated_user.model_dump = mocker.MagicMock(
+            return_value={
+                "user_id": user_id,
+                "user_email": "new@example.com",
+                "teams": [],
+            }
+        )
+
+        mock_prisma_client = mocker.MagicMock()
+        mock_prisma_client.db = mocker.MagicMock()
+        mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+        mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
+
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
+            AsyncMock(return_value=mock_prisma_client),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._check_user_exists",
+            AsyncMock(return_value=existing_user),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._handle_team_membership_changes",
+            AsyncMock(),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._set_user_keys_blocked",
+            AsyncMock(),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
+            AsyncMock(
+                return_value=SCIMUser(
+                    schemas=["urn:ietf:params:scim:schemas:core:2.0:User"],
+                    id=user_id,
+                    userName=user_id,
+                    name=SCIMUserName(familyName="User", givenName="Test"),
+                    emails=[SCIMUserEmail(value="new@example.com")],
+                )
+            ),
+        )
+
+        mock_user_cache = mocker.MagicMock()
+        mock_logging = mocker.MagicMock()
+        mock_logging.internal_usage_cache.dual_cache = mocker.MagicMock()
+        mock_logging.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
+        mocker.patch("litellm.proxy.proxy_server.user_api_key_cache", mock_user_cache)
+        mocker.patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_logging)
+
+        refresh_mock = mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._refresh_cached_user",
+            new=AsyncMock(),
+        )
+
+        scim_user = SCIMUser(
+            schemas=["urn:ietf:params:scim:schemas:core:2.0:User"],
+            userName=user_id,
+            name=SCIMUserName(familyName="User", givenName="Test"),
+            emails=[SCIMUserEmail(value="new@example.com")],
+        )
+
+        await update_user(user_id=user_id, user=scim_user)
+
+        # Pin: update_user must call _refresh_cached_user exactly once
+        # with the post-mutation row. The post-mutation row is the
+        # object the Prisma `update` returned (the `updated_user`
+        # MagicMock), not the pre-mutation `existing_user`.
+        assert refresh_mock.await_count == 1, (
+            "update_user must call _refresh_cached_user exactly once after "
+            "the DB update (#37009 regression pin); "
+            f"got await_count={refresh_mock.await_count}"
+        )
+        call_kwargs = refresh_mock.await_args.kwargs
+        assert call_kwargs["user_row"] is updated_user
+        assert call_kwargs["user_api_key_cache"] is mock_user_cache
+        assert call_kwargs["proxy_logging_obj"] is mock_logging
+
+    @pytest.mark.asyncio
+    async def test_patch_user_refreshes_user_cache(self, mocker):
+        """
+        `PATCH /scim/v2/Users/{id}` must call `_refresh_cached_user`
+        after the database update. Regression pin for #37009.
+        """
+        from litellm.proxy.management_endpoints.scim.scim_v2 import patch_user
+        from litellm.types.proxy.management_endpoints.scim_v2 import (
+            SCIMPatchOp,
+            SCIMPatchOperation,
+            SCIMUser,
+            SCIMUserEmail,
+            SCIMUserName,
+        )
+
+        user_id = "scim-patch-cache-test"
+        existing_user = self._make_user(user_id=user_id, user_email="user@example.com", teams=["team-1"])
+        existing_user.metadata = {}
+
+        updated_user = mocker.MagicMock()
+        updated_user.user_id = user_id
+        updated_user.user_email = "user@example.com"
+        updated_user.teams = ["team-1"]
+        updated_user.model_dump = mocker.MagicMock(
+            return_value={
+                "user_id": user_id,
+                "user_email": "user@example.com",
+                "teams": ["team-1"],
+            }
+        )
+
+        mock_prisma_client = mocker.MagicMock()
+        mock_prisma_client.db = mocker.MagicMock()
+        mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+        mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
+
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
+            AsyncMock(return_value=mock_prisma_client),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._check_user_exists",
+            AsyncMock(return_value=existing_user),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._handle_team_membership_changes",
+            AsyncMock(),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._set_user_keys_blocked",
+            AsyncMock(),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._apply_patch_ops",
+            return_value=({"metadata": {}}, {"team-1"}),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._get_scim_admin_group",
+            AsyncMock(return_value=None),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
+            AsyncMock(
+                return_value=SCIMUser(
+                    schemas=["urn:ietf:params:scim:schemas:core:2.0:User"],
+                    id=user_id,
+                    userName=user_id,
+                    name=SCIMUserName(familyName="User", givenName="Test"),
+                    emails=[SCIMUserEmail(value="user@example.com")],
+                )
+            ),
+        )
+
+        mock_user_cache = mocker.MagicMock()
+        mock_logging = mocker.MagicMock()
+        mock_logging.internal_usage_cache.dual_cache = mocker.MagicMock()
+        mock_logging.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
+        mocker.patch("litellm.proxy.proxy_server.user_api_key_cache", mock_user_cache)
+        mocker.patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_logging)
+
+        refresh_mock = mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._refresh_cached_user",
+            new=AsyncMock(),
+        )
+
+        patch_ops = SCIMPatchOp(
+            schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            Operations=[SCIMPatchOperation(op="replace", path="displayName", value="New Name")],
+        )
+
+        await patch_user(user_id=user_id, patch_ops=patch_ops)
+
+        # Pin: patch_user must call _refresh_cached_user exactly once
+        # with the post-mutation row. The post-mutation row is the
+        # object the Prisma `update` returned, not the pre-mutation
+        # `existing_user`.
+        assert refresh_mock.await_count == 1, (
+            "patch_user must call _refresh_cached_user exactly once after "
+            "the DB update (#37009 regression pin); "
+            f"got await_count={refresh_mock.await_count}"
+        )
+        call_kwargs = refresh_mock.await_args.kwargs
+        assert call_kwargs["user_row"] is updated_user
+        assert call_kwargs["user_api_key_cache"] is mock_user_cache
+        assert call_kwargs["proxy_logging_obj"] is mock_logging
+
+    @pytest.mark.asyncio
+    async def test_delete_user_invalidates_user_cache(self, mocker):
+        """
+        `DELETE /scim/v2/Users/{id}` must invalidate the `user_id`
+        cache key in BOTH the local LRU
+        (`user_api_key_cache.delete_cache`) AND the Redis side of the
+        dual cache
+        (`proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache`).
+        Regression pin for #37009.
+        """
+        from litellm.proxy.management_endpoints.scim.scim_v2 import delete_user
+
+        user_id = "scim-delete-cache-test"
+
+        existing_user = mocker.MagicMock()
+        existing_user.teams = []
+
+        mock_prisma_client = mocker.MagicMock()
+        mock_prisma_client.db = mocker.MagicMock()
+        mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
+        mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+        mock_prisma_client.db.litellm_usertable.delete = AsyncMock()
+
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
+            AsyncMock(return_value=mock_prisma_client),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._check_user_exists",
+            AsyncMock(return_value=existing_user),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._set_user_keys_blocked",
+            AsyncMock(),
+        )
+        mocker.patch(
+            "litellm.proxy.management_endpoints.scim.scim_v2._delete_rows_referencing_user",
+            AsyncMock(),
+        )
+
+        mock_user_cache = mocker.MagicMock()
+        mock_logging = mocker.MagicMock()
+        mock_dual_cache = mocker.MagicMock()
+        mock_dual_cache.async_delete_cache = AsyncMock()
+        mock_logging.internal_usage_cache.dual_cache = mock_dual_cache
+        mocker.patch("litellm.proxy.proxy_server.user_api_key_cache", mock_user_cache)
+        mocker.patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_logging)
+
+        await delete_user(user_id=user_id)
+
+        # Pin: delete_user must invalidate the user_id cache key in
+        # BOTH the local LRU (user_api_key_cache.delete_cache) AND the
+        # Redis side of the dual cache
+        # (proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache).
+        # The user_id cache key is the literal `user_id` (per
+        # auth_checks.py:1641), not a `user_id:{id}` prefix.
+        mock_user_cache.delete_cache.assert_any_call(key=user_id)
+        mock_dual_cache.async_delete_cache.assert_any_call(key=user_id)


### PR DESCRIPTION
## Problem

The SCIM v2 user endpoints (\`PATCH /scim/v2/Users/{id}\`, \`PUT /scim/v2/Users/{id}\`, \`DELETE /scim/v2/Users/{id}\`) currently only write to \`litellm_usertable\` and do not refresh or invalidate the in-memory user cache used by \`get_user_object\` (which is keyed on the literal \`user_id\` per \`auth_checks.py:1641\`). The very next auth check that hits the cache serves the pre-mutation user, so:

- \`PUT\` (full replace, e.g. an email or role change) does not take effect on auth until the management-object TTL expires.
- \`PATCH\` (e.g. deactivation via \`active: false\`) does not take effect on auth until the TTL expires. This is especially visible: the same PATCH has already called \`_set_user_keys_blocked\` to block the user's keys, but the cached \`LiteLLM_UserTable\` still reports the user as active.
- \`DELETE\` does not invalidate the cached \`user_id\` entry, so a same-user \`POST /user/new\` reusing the same ID would read a stale \`user_email\` / \`metadata\` / \`teams\` snapshot from the cache.

SCIM is the standard protocol for IdP-driven user sync (Okta, Azure AD, OneLogin, JumpCloud, etc.), so the impact is real for every operator using an IdP-driven deployment: a SCIM-driven deactivation or email rename is silently lost for the cache TTL window on every request. In a multi-pod deployment, the window extends across replicas.

This is the same multi-prefix cache Achilles heel pattern already fixed in:

- #35565 (cycle 9): \`/team/block\` and \`/team/unblock\`
- #36817 (cycle 12): SCIM \`PATCH/PUT/DELETE /Groups/{id}\`

The \`/Users\` surface was missed in #36817 because the user cache key shape is different from the team cache key shape. The team cache is dual-keyed (\`team_id:{id}\` + \`team_alias:{alias}\`); the user cache is single-keyed on the literal \`user_id\`. Same defect class, different code path.

## Implementation summary

- Add \`_cache_user_object\` and \`_refresh_cached_user\` helpers in \`litellm/proxy/auth/auth_checks.py\` (mirrors the existing \`_cache_team_object\` and \`_refresh_cached_team\`). \`_refresh_cached_user\` accepts either a \`LiteLLM_UserTable\` Pydantic model (the real Prisma return) or a dict (pre-existing test mock contract); production always takes the Pydantic branch.
- Add \`_invalidate_cached_user\` helper for the DELETE path. There is no post-mutation row to cache, so refresh is wrong. The helper clears both the local LRU (\`user_api_key_cache.delete_cache\`) and the Redis side of the dual cache (\`proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache\`).
- \`update_user\` (PUT) and \`patch_user\` (PATCH) call \`_refresh_cached_user\` after the database write.
- \`delete_user\` (DELETE) calls \`_invalidate_cached_user\` after the row is deleted.
- \`create_user\` (POST) needs no cache work — the user is new, not yet in cache.

## Testing

Three regression tests in \`tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py\` in a new \`TestScimUserCacheInvalidation\` class (mirrors cycle 12's \`TestScimGroupCacheInvalidation\`:

- `test_update_user_refreshes_user_cache` drives `update_user` with mocked Prisma + cache + `_refresh_cached_user`, and asserts the refresh was awaited exactly once with the post-mutation row, the local cache, and the proxy logging handles.
- `test_patch_user_refreshes_user_cache` does the same for `patch_user`, mocking `_apply_patch_ops` and `_get_scim_admin_group` to drive the full PATCH flow.
- `test_delete_user_invalidates_user_cache` drives `delete_user` and asserts `user_api_key_cache.delete_cache` and `dual_cache.async_delete_cache` were each called with `key=user_id` (the literal `user_id`, not a `user_id:{id}` prefix).

All three pins are verified to fail without the source fix and pass with it (self-audit: stashed the source diff, re-ran the 3 tests, observed `AttributeError` on the new helper names — restore, re-run, all 3 pass).

Pre-existing test fixtures in `tests/test_litellm/proxy/management_endpoints/scim/test_scim_key_deactivation.py` needed a small update: they patched `user_api_key_cache` and `proxy_logging_obj` as plain `MagicMock()`, which failed once the new fix called `await user_api_key_cache.async_set_cache(...)` with `TypeError: object MagicMock can't be used in 'await' expression`. Added `_make_user_api_key_cache_mock` (sync MagicMock with `async_set_cache = AsyncMock()`) and `_make_logging_mock` (sync MagicMock with `internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()`) and switched 6 call sites to the helpers. AsyncMock alone would have made the sync `delete_cache` call a never-awaited coroutine; plain MagicMock fails the await on the async method. The hybrid is the minimal correct shape.

## Files changed

- `litellm/proxy/auth/auth_checks.py` (+99/-0): new `_cache_user_object`, `_refresh_cached_user`, `_invalidate_cached_user` helpers; one new `Mapping` import for the union type annotation; one cast narrowing for `user_id`
- `litellm/proxy/management_endpoints/scim/scim_v2.py` (+60/-0): import the new helpers, call `_refresh_cached_user` in `update_user` and `patch_user`, call `_invalidate_cached_user` in `delete_user`
- `tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py` (+347/-0): 3 new regression tests in `TestScimUserCacheInvalidation` class
- `tests/test_litellm/proxy/management_endpoints/scim/test_scim_key_deactivation.py` (+194/-0): new `_make_user_api_key_cache_mock` and `_make_logging_mock` helpers; 6 call sites updated to use them

## Test results

- `tests/test_litellm/proxy/management_endpoints/scim/`: 155 passed (was 152 before; 3 new tests added)
- `scripts/type_discipline_gate.py`: OK
- `scripts/ruff_strict_gate.py`: OK
- `ruff check`: All checks passed
- `ruff format --check`: 4 files already formatted

## Risks

- `_refresh_cached_user` is a new helper. If a future SCIM endpoint mutates `litellm_usertable` without calling it, the same defect recurs. Mitigation: cross-reference in the issue body so future contributors see the pattern.
- `_invalidate_cached_user` does both `user_api_key_cache.delete_cache` and `dual_cache.async_delete_cache`. If the proxy has no Redis (single-LRU mode), the dual cache is a no-op, so the second call is safe. The cycle 12 /Groups fix used the same pattern.

## Backward compatibility

No API surface change. Internal cache-management only.

## Future improvement opportunities

- The `_refresh_cached_user` / `_invalidate_cached_user` pair could be deduped into a single `_manage_user_cache(action=refresh|invalidate, ...)` helper, mirroring the pattern of the team endpoint. Skipped for this PR to keep the diff focused on the bug fix.
- The dict-or-Pydantic defensive shim in `_refresh_cached_user` is a test-contract concession. If the pre-existing SCIM user tests are migrated to a Pydantic mock contract in a follow-up, the shim can be removed.

Fixes #37009.
EOF
)