### PR TITLE
fix: forward metadata into speech() litellm_params_dict so Gemini TTS spend is tracked

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7945,7 +7945,7 @@ def speech(
 
     if max_retries is None:
         max_retries = litellm.num_retries or openai.DEFAULT_MAX_RETRIES
-    litellm_params_dict: Final = get_litellm_params(**kwargs)
+    litellm_params_dict: Final = get_litellm_params(metadata=metadata, **kwargs)
 
     # Get provider-specific text-to-speech config and map parameters
     text_to_speech_provider_config = ProviderConfigManager.get_provider_text_to_speech_config(

--- a/tests/test_litellm/llms/gemini/test_gemini_tts.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_tts.py
@@ -420,5 +420,44 @@ class TestGeminiTTSSpeechConfigInRequestBody:
         assert "AUDIO" in generation_config["responseModalities"]
 
 
+class TestSpeechToCompletionBridgeMetadata:
+    """Regression for #37015: metadata must be forwarded into the inner completion call."""
+
+    def test_metadata_forwarded_to_bridge(self):
+        from unittest.mock import MagicMock, patch
+
+        from litellm.endpoints.speech.speech_to_completion_bridge.transformation import (
+            SpeechToCompletionBridgeTransformationHandler,
+        )
+        from litellm.litellm_core_utils.get_litellm_params import get_litellm_params
+
+        metadata = {"user_api_key": "test_key_hash", "user_api_key_user_id": "user123"}
+        litellm_params_dict = get_litellm_params(metadata=metadata)
+
+        assert litellm_params_dict["metadata"] == metadata, (
+            "metadata must be present in litellm_params_dict; without this the inner "
+            "completion call overwrites it with None and spend tracking is lost"
+        )
+
+        handler = SpeechToCompletionBridgeTransformationHandler()
+        logging_obj = MagicMock()
+
+        request_kwargs = handler.transform_request(
+            model="gemini-2.5-flash-preview-tts",
+            input="hello",
+            voice="Kore",
+            optional_params={},
+            litellm_params=litellm_params_dict,
+            headers={},
+            litellm_logging_obj=logging_obj,
+            custom_llm_provider="gemini",
+        )
+
+        assert request_kwargs["metadata"] == metadata, (
+            "metadata must survive transform_request so the inner completion call "
+            "does not overwrite the logging object's metadata with None"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini TTS (and any TTS provider using the speech-to-completion bridge) is never spend-tracked on the proxy
- Virtual key spend stays 0 and no spend-log row is written for these calls

How it solves it:

- `speech()` takes `metadata` as an explicit named argument, so it never ends up in `**kwargs`
- `get_litellm_params(**kwargs)` therefore produced a dict with `metadata: None`, which the bridge spread into the inner `completion()` call, overwriting the logging object's key/user/team context
- Pass `metadata=metadata` explicitly to `get_litellm_params` so the inner call carries the real metadata

## User Flow

Before: a developer using `gemini/gemini-2.5-flash-preview-tts` through the proxy sees no spend logged and key budgets never trip

1. They send POST https://litellm-domain/v1/audio/speech with `{"model": "gemini/gemini-2.5-flash-preview-tts", "input": "hello", "voice": "Kore"}` using a virtual key and receive 200 with `audio/wav` bytes
2. They send POST https://litellm-domain/v1/audio/speech with `{"model": "openai/tts-1", "input": "hello", "voice": "alloy"}` using the same key and receive 200 with `audio/mpeg` bytes
3. GET https://litellm-domain/spend/logs lists only the OpenAI request; the Gemini request is absent
4. GET https://litellm-domain/key/info shows `"spend": 0.00027` (only the OpenAI call), so a budget on the key never trips regardless of Gemini TTS volume

After: both calls are logged and billed to the key

1. They send the same POST for `gemini/gemini-2.5-flash-preview-tts` and receive 200 with audio
2. They send the same POST for `openai/tts-1` and receive 200 with audio
3. GET https://litellm-domain/spend/logs lists both requests, the Gemini one with `call_type: aspeech` and non-zero spend
4. GET https://litellm-domain/key/info shows the combined spend from both calls, and a max budget on the key applies to Gemini TTS too

## Relevant issues

Fixes #37015

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Type

🐛 Bug Fix

## Screenshots / Proof of Fix

Run the proxy with a Gemini API key and a virtual key, then:

```bash
# Before fix: Gemini call logs metadata as None, no spend row appears
curl -s -X POST http://localhost:4000/v1/audio/speech \
  -H "Authorization: Bearer <virtual-key>" \
  -H "Content-Type: application/json" \
  -d '{"model":"gemini/gemini-2.5-flash-preview-tts","input":"spend tracking check","voice":"Kore"}' \
  --output /tmp/out.wav

# After fix: spend row appears with call_type aspeech and non-zero spend
curl -s http://localhost:4000/spend/logs -H "Authorization: Bearer sk-1234" | jq '.[] | select(.model | test("gemini"))'
```

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR