### PR TITLE
fix(ui): rename models table Status column to Source

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
@@ -192,7 +192,7 @@ describe("AllModelsTab", () => {
       expect(lastModelsInfoCall().sortOrder).toBe(firstDirection);
     });
 
-    it("maps the hidden Status column to the server field status", () => {
+    it("maps the hidden Source column to the server field status", () => {
       expect(toServerSortField(STATUS_COLUMN_ID)).toBe("status");
     });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTable.test.tsx
@@ -79,7 +79,7 @@ const row = (modelId: string): HTMLElement => {
 };
 
 describe("AllModelsTable", () => {
-  it("renders the nine design columns and hides Status behind the Columns menu", async () => {
+  it("renders the nine design columns and hides Source behind the Columns menu", async () => {
     const user = userEvent.setup();
     render(<AllModelsTable {...baseProps} />);
 
@@ -97,12 +97,15 @@ describe("AllModelsTable", () => {
       expect(screen.getByRole("columnheader", { name: new RegExp(header, "i") })).toBeInTheDocument();
     }
 
+    expect(screen.queryByRole("columnheader", { name: /^source$/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("columnheader", { name: /^status$/i })).not.toBeInTheDocument();
     expect(screen.queryByText("DB Model")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /columns/i }));
-    await user.click(await screen.findByRole("menuitemcheckbox", { name: /status/i }));
+    expect(screen.queryByRole("menuitemcheckbox", { name: /status/i })).not.toBeInTheDocument();
+    await user.click(await screen.findByRole("menuitemcheckbox", { name: /^source$/i }));
 
+    expect(await screen.findByRole("columnheader", { name: /^source$/i })).toBeInTheDocument();
     expect(await screen.findByText("DB Model")).toBeInTheDocument();
   });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/ModelsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/ModelsTableColumns.tsx
@@ -453,8 +453,8 @@ export const getModelsTableColumns = ({
   {
     id: STATUS_COLUMN_ID,
     accessorFn: (row) => row.model_info.db_model,
-    meta: { title: "Status", skeleton: "badge" },
-    header: ({ column }) => <DataTableSortHeader column={column} title="Status" />,
+    meta: { title: "Source", skeleton: "badge" },
+    header: ({ column }) => <DataTableSortHeader column={column} title="Source" />,
     enableSorting: true,
     size: 140,
     minSize: 100,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Models table column "Status" actually shows model provenance, not health
- "Status" reads like liveness and confuses admins

How it solves it:

- Renames the column header and column-picker label to "Source"
- Badge values ("DB Model" / "Config Model") and sorting stay the same

## User Flow

Before: an admin scanning the models table misreads the Status column as health

1. They open http://localhost:4000/ui/?page=models and enable the "Status" column from the column picker
2. The column shows "DB Model" or "Config Model" badges, which is where the model is defined, not a health state
3. They look for up/down health info in it and find none

After: the same column is named for what it shows

1. They open http://localhost:4000/ui/?page=models and enable the "Source" column from the column picker
2. The column shows the same "DB Model" or "Config Model" badges under a name that says provenance
3. Health checks remain on the separate Health Status tab, so the two are no longer conflated

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Before/after screenshots of the models table column picker and header to be added below

## Type

🧹 Refactoring

## Caveats (if any)

- Display-only rename; column id and server sort field are unchanged

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
