### PR TITLE
feat(ui): link user detail team names to team pages

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.test.tsx
@@ -42,8 +42,16 @@ const MOCK_USER_DATA_NO_TEAMS = {
   teams: [],
 };
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/users",
+  useSearchParams: () => new URLSearchParams(window.location.search),
+}));
+
+// entityLinks -> migratedPages imports serverRootPath from the same module, so the mock must export it too.
 vi.mock("@/components/networking", () => {
   return {
+    serverRootPath: "/",
     userGetInfoV2: (...args: any[]) => mockUserGetInfoV2(...args),
     userDeleteCall: vi.fn(),
     userUpdateUserCall: (...args: unknown[]) => mockUserUpdateUserCall(...args),
@@ -142,6 +150,21 @@ describe("UserInfoView", () => {
     await waitFor(() => {
       expect(screen.getByText("Alpha Team")).toBeInTheDocument();
       expect(screen.getByText("Beta Team")).toBeInTheDocument();
+    });
+  });
+
+  it("should link each team name to its team page", async () => {
+    render(<UserInfoView {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Alpha Team" })).toHaveAttribute(
+        "href",
+        expect.stringContaining("/teams?team=team-1"),
+      );
+      expect(screen.getByRole("link", { name: "Beta Team" })).toHaveAttribute(
+        "href",
+        expect.stringContaining("/teams?team=team-2"),
+      );
     });
   });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.tsx
@@ -34,6 +34,8 @@ import {
 } from "@/components/networking";
 import { Button as AntdButton, Modal, Select as AntdSelect, Form, Tooltip } from "antd";
 import { rolesWithWriteAccess } from "@/utils/roles";
+import { teamDetailHref } from "@/utils/entityLinks";
+import { BadgeLink } from "@/components/shared/BadgeLink";
 import { UserEditView } from "../user_edit_view";
 import OnboardingModal, { InvitationLink } from "@/components/onboarding_link";
 import { formatNumberWithCommas, copyToClipboard as utilCopyToClipboard } from "@/utils/dataUtils";
@@ -484,7 +486,11 @@ export default function UserInfoView({
                         <TableBody>
                           {teamDetails.slice(0, isTeamsExpanded ? teamDetails.length : 20).map((team) => (
                             <TableRow key={team.team_id}>
-                              <TableCell>{team.team_alias || team.team_id}</TableCell>
+                              <TableCell>
+                                <BadgeLink href={teamDetailHref(team.team_id)}>
+                                  {team.team_alias || team.team_id}
+                                </BadgeLink>
+                              </TableCell>
                               {isProxyAdmin && (
                                 <TableCell className="text-right">
                                   <Button


### PR DESCRIPTION
## TLDR

Problem this solves:

- Team names on the user detail page are plain text
- Walking from a user to one of their teams needs a manual search

How it solves it:

- Team names become badge links to the team's detail page
- Same entity-link pattern already used on the organization page

## User Flow

Before: an admin inspecting a user cannot jump to that user's team

1. They open http://localhost:4000/ui/?page=users and click a user to reach the user detail view
2. The Teams card lists team names like "dd-qa-team" as plain text with nothing to click
3. To inspect that team they go back to the Teams page and search for it by name

After: the same team names are clickable and land on the team page

1. They open http://localhost:4000/ui/?page=users and click a user to reach the user detail view
2. The Teams card shows each team as a clickable badge
3. Clicking it opens that team's detail page directly, and cmd-click opens it in a new tab

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Before/after screenshots of the user detail Teams card to be added below

Unit coverage: user_info_view.test.tsx now asserts each team name renders as a link whose href targets that team's detail page

## Type

🆕 New Feature

## Caveats (if any)

- Uses the shared BadgeLink + entityLinks helpers, so href shape matches the org page's team links

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
