### PR TITLE
feat(deepseek): allow disabling thinking

### DIFF
--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -49,18 +49,20 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         thinking_value = optional_params.pop("thinking", None)
         reasoning_effort = optional_params.pop("reasoning_effort", None)
 
-        # Handle thinking parameter - only accept {"type": "enabled"}
+        # Handle thinking parameter - DeepSeek accepts explicit enabled/disabled mode.
         if thinking_value is not None:
-            if (
-                isinstance(thinking_value, dict)
-                and thinking_value.get("type") == "enabled"
+            if isinstance(thinking_value, dict) and thinking_value.get("type") in (
+                "enabled",
+                "disabled",
             ):
-                # DeepSeek only accepts {"type": "enabled"}, ignore budget_tokens
-                optional_params["thinking"] = {"type": "enabled"}
+                # DeepSeek does not support budget_tokens; pass only the mode.
+                optional_params["thinking"] = {"type": thinking_value["type"]}
 
-        # Handle reasoning_effort - map to thinking enabled
-        elif reasoning_effort is not None and reasoning_effort != "none":
-            optional_params["thinking"] = {"type": "enabled"}
+        # Handle reasoning_effort - map none to explicit disabled thinking.
+        elif reasoning_effort is not None:
+            optional_params["thinking"] = {
+                "type": "disabled" if reasoning_effort == "none" else "enabled"
+            }
 
         return optional_params
 

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -647,7 +647,7 @@ ANTHROPIC_API_ONLY_HEADERS = {  # fails if calling anthropic on vertex ai / bedr
 
 
 class AnthropicThinkingParam(TypedDict, total=False):
-    type: Literal["enabled", "adaptive"]
+    type: Literal["enabled", "disabled", "adaptive"]
     budget_tokens: int
 
 

--- a/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -4,7 +4,6 @@ Unit tests for DeepSeek chat transformation.
 Tests the thinking and reasoning_effort parameter handling for DeepSeek models.
 """
 
-import pytest
 from litellm.llms.deepseek.chat.transformation import DeepSeekChatConfig
 
 
@@ -34,6 +33,17 @@ class TestDeepSeekThinkingParams:
         )
 
         assert result["thinking"] == {"type": "enabled"}
+
+    def test_map_thinking_disabled(self):
+        """Test that explicit disabled thinking is passed to DeepSeek."""
+        result = self.config.map_openai_params(
+            non_default_params={"thinking": {"type": "disabled"}},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result["thinking"] == {"type": "disabled"}
 
     def test_map_thinking_with_budget_tokens_strips_budget(self):
         """Test that budget_tokens is stripped from thinking param (DeepSeek doesn't support it)."""
@@ -93,8 +103,8 @@ class TestDeepSeekThinkingParams:
 
         assert result["thinking"] == {"type": "enabled"}
 
-    def test_map_reasoning_effort_none_does_not_enable_thinking(self):
-        """Test that reasoning_effort='none' does not enable thinking."""
+    def test_map_reasoning_effort_none_disables_thinking(self):
+        """Test that reasoning_effort='none' explicitly disables thinking."""
         non_default_params = {"reasoning_effort": "none"}
         optional_params = {}
 
@@ -105,7 +115,7 @@ class TestDeepSeekThinkingParams:
             drop_params=False,
         )
 
-        assert "thinking" not in result
+        assert result["thinking"] == {"type": "disabled"}
 
     def test_map_reasoning_effort_null_does_not_enable_thinking(self):
         """Test that reasoning_effort=None does not enable thinking."""
@@ -138,6 +148,33 @@ class TestDeepSeekThinkingParams:
 
         # thinking should be set, reasoning_effort should not override
         assert result["thinking"] == {"type": "enabled"}
+
+    def test_thinking_disabled_takes_precedence_over_reasoning_effort(self):
+        result = self.config.map_openai_params(
+            non_default_params={
+                "thinking": {"type": "disabled"},
+                "reasoning_effort": "high",
+            },
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result["thinking"] == {"type": "disabled"}
+
+    def test_map_thinking_preserves_unrelated_optional_params(self):
+        result = self.config.map_openai_params(
+            non_default_params={
+                "thinking": {"type": "disabled", "budget_tokens": 2048},
+                "temperature": 0.2,
+            },
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result["thinking"] == {"type": "disabled"}
+        assert result["temperature"] == 0.2
 
     def test_invalid_thinking_type_ignored(self):
         """Test that invalid thinking type values are ignored."""


### PR DESCRIPTION
## What does this PR do?

Allows DeepSeek callers to explicitly disable thinking while preserving the existing enabled behavior.

Supported inputs:

- `thinking={"type":"disabled"}`
- `reasoning_effort="none"`

The transformation strips unsupported `budget_tokens` for DeepSeek and gives an explicit `thinking` value precedence over `reasoning_effort`.

## Tests

- `uv run pytest tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py -q`
- `uv run ruff check litellm/types/llms/anthropic.py litellm/llms/deepseek/chat/transformation.py tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py`
