### PR TITLE
fix(ptu): stop a PTU deployment billing for grounded search

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -366,13 +366,22 @@ _EMPTY_MODEL_INFO: Final[Mapping[str, object]] = _NO_PRICING_OVERRIDE
 # (an embedding's output_vector_size, the regional uplift multipliers), and zeroing one of
 # those would destroy the deployment's configuration rather than stop a charge.
 _CUSTOM_PRICING_FIELDS: Final = frozenset(f for f in CustomPricingLiteLLMParams.model_fields if "cost" in f)
+# search_context_cost_per_query holds its rates in a table keyed by context size, and an absent
+# table means the provider's own default rate rather than free (litellm/llms/gemini/cost_calculator
+# falls back to $0.035), so it is zeroed in place rather than emptied like tiered_pricing.
+_PTU_ZEROED_TABLE_FIELDS: Final = frozenset({"search_context_cost_per_query"})
+_SEARCH_CONTEXT_SIZES: Final = ("search_context_size_low", "search_context_size_medium", "search_context_size_high")
 
 
 def _is_nonzero_price(value: object) -> bool:
+    if isinstance(value, dict):  # an all-zero table is how a rate is expressed as free
+        return any(_is_nonzero_price(rate) for rate in value.values())
     return isinstance(value, (int, float)) and not isinstance(value, bool) and value != 0
 
 
 def _is_zero_price(value: object) -> bool:
+    if isinstance(value, dict):
+        return bool(value) and not _is_nonzero_price(value)
     if isinstance(value, (list, tuple)):
         return not value
     return isinstance(value, (int, float)) and not isinstance(value, bool) and value == 0
@@ -411,7 +420,7 @@ def _ptu_zeroed_pricing(
     model_info: Mapping[str, object],
     litellm_params: Mapping[str, object],
     supplied: Mapping[str, object],
-) -> Mapping[str, float | tuple[()]]:
+) -> Mapping[str, float | tuple[()] | Mapping[str, float]]:
     """The pricing a PTU deployment must carry, empty unless one is being stored.
 
     Reserved capacity is already billed by the flat cost the rollup writes, so charging the
@@ -439,7 +448,14 @@ def _ptu_zeroed_pricing(
     )
     if not stored:
         return _PTU_ZEROED_PRICING
-    return MappingProxyType({**_PTU_ZEROED_PRICING, **dict.fromkeys(stored, 0.0)})
+    tables: Final = stored & _PTU_ZEROED_TABLE_FIELDS
+    return MappingProxyType(
+        {
+            **_PTU_ZEROED_PRICING,
+            **dict.fromkeys(stored - tables, 0.0),
+            **dict.fromkeys(tables, dict.fromkeys(_SEARCH_CONTEXT_SIZES, 0.0)),
+        }
+    )
 
 
 def _ptu_pricing_delta(
@@ -448,7 +464,7 @@ def _ptu_pricing_delta(
     model_info: Mapping[str, object],
     litellm_params: Mapping[str, object],
     patch: updateDeployment,
-) -> tuple[Mapping[str, float | tuple[()]], frozenset[str]]:
+) -> tuple[Mapping[str, float | tuple[()] | Mapping[str, float]], frozenset[str]]:
     """The pricing a patch must write into both blobs, and the pricing it must drop from them.
 
     A patch that takes the deployment off PTU takes the zeroed pricing with it, since the zeros

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -368,15 +368,20 @@ _EMPTY_MODEL_INFO: Final[Mapping[str, object]] = _NO_PRICING_OVERRIDE
 _CUSTOM_PRICING_FIELDS: Final = frozenset(f for f in CustomPricingLiteLLMParams.model_fields if "cost" in f)
 # search_context_cost_per_query holds its rates in a table keyed by context size, and an absent
 # table means the provider's own default rate rather than free (litellm/llms/gemini/cost_calculator
-# falls back to $0.035), so it is zeroed in place rather than emptied like tiered_pricing.
+# falls back to $0.035), so it is zeroed in place rather than emptied like tiered_pricing, and
+# written on every PTU deployment rather than only where a table is already stored.
 _PTU_ZEROED_TABLE_FIELDS: Final = frozenset({"search_context_cost_per_query"})
 _SEARCH_CONTEXT_SIZES: Final = ("search_context_size_low", "search_context_size_medium", "search_context_size_high")
 
 
+def _is_nonzero_rate(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and value != 0
+
+
 def _is_nonzero_price(value: object) -> bool:
     if isinstance(value, dict):  # an all-zero table is how a rate is expressed as free
-        return any(_is_nonzero_price(rate) for rate in value.values())
-    return isinstance(value, (int, float)) and not isinstance(value, bool) and value != 0
+        return any(_is_nonzero_rate(rate) for rate in value.values())
+    return _is_nonzero_rate(value)
 
 
 def _is_zero_price(value: object) -> bool:
@@ -446,14 +451,11 @@ def _ptu_zeroed_pricing(
         for field in _CUSTOM_PRICING_FIELDS
         if _is_nonzero_price(model_info.get(field)) or _is_nonzero_price(litellm_params.get(field))
     )
-    if not stored:
-        return _PTU_ZEROED_PRICING
-    tables: Final = stored & _PTU_ZEROED_TABLE_FIELDS
     return MappingProxyType(
         {
             **_PTU_ZEROED_PRICING,
-            **dict.fromkeys(stored - tables, 0.0),
-            **dict.fromkeys(tables, dict.fromkeys(_SEARCH_CONTEXT_SIZES, 0.0)),
+            **dict.fromkeys(_PTU_ZEROED_TABLE_FIELDS, dict.fromkeys(_SEARCH_CONTEXT_SIZES, 0.0)),
+            **dict.fromkeys(stored - _PTU_ZEROED_TABLE_FIELDS, 0.0),
         }
     )
 

--- a/tests/test_litellm/proxy/management_endpoints/test_ptu_model_settings.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ptu_model_settings.py
@@ -21,6 +21,7 @@ from litellm.llms.gemini.cost_calculator import cost_per_web_search_request
 from litellm.proxy.management_endpoints.model_management_endpoints import (
     _PTU_ZEROED_PRICING_FIELDS,
     _SEARCH_CONTEXT_SIZES,
+    _is_nonzero_price,
     _merged_ptu_model_info,
     _update_team_model_in_db,
     _ptu_priced_deployment,
@@ -770,6 +771,7 @@ class TestPtuDeploymentsAreNotBilledPerToken:
         assert self._zeroed(model_info=self.PTU) == {
             **dict.fromkeys(_PTU_ZEROED_PRICING_FIELDS, 0.0),
             "tiered_pricing": (),
+            "search_context_cost_per_query": dict.fromkeys(_SEARCH_CONTEXT_SIZES, 0.0),
         }
 
     def test_nothing_is_zeroed_while_the_feature_is_disabled(self, monkeypatch):
@@ -1033,7 +1035,11 @@ class TestPtuDeploymentsAreNotBilledPerToken:
             )
         )
         registered = Router._deployment_model_cost_payload(priced)
-        charged = {k: v for k, v in registered.items() if "cost" in k and k != "cost_per_ptu_per_hour" and v}
+        charged = {
+            k: v
+            for k, v in registered.items()
+            if "cost" in k and k != "cost_per_ptu_per_hour" and _is_nonzero_price(v)
+        }
         assert charged == {}
 
     def test_the_cost_map_tiers_contribute_no_price_to_a_priced_ptu_deployment(self):

--- a/tests/test_litellm/proxy/management_endpoints/test_ptu_model_settings.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ptu_model_settings.py
@@ -17,8 +17,10 @@ from litellm.proxy._types import (
 )
 from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 from litellm.proxy.auth.auth_checks import _is_model_cost_zero
+from litellm.llms.gemini.cost_calculator import cost_per_web_search_request
 from litellm.proxy.management_endpoints.model_management_endpoints import (
     _PTU_ZEROED_PRICING_FIELDS,
+    _SEARCH_CONTEXT_SIZES,
     _merged_ptu_model_info,
     _update_team_model_in_db,
     _ptu_priced_deployment,
@@ -29,6 +31,7 @@ from litellm.proxy.management_endpoints.model_management_endpoints import (
     update_db_model,
 )
 from litellm.proxy.spend_tracking.ptu_feature_flag import PTU_COST_ATTRIBUTION_ENV_VAR
+from litellm.types.utils import PromptTokensDetailsWrapper
 from litellm.router import Router
 from litellm.types.router import (
     SPECIAL_MODEL_INFO_PARAMS,
@@ -789,6 +792,39 @@ class TestPtuDeploymentsAreNotBilledPerToken:
         assert exc.value.status_code == 400
         assert "tiered_pricing" in str(exc.value.detail)
 
+    def test_a_search_context_price_the_caller_supplies_is_refused(self):
+        """The rates sit in a table keyed by context size, so a guard that only reads numbers
+        lets a per-request charge onto a deployment its reserved capacity already pays for."""
+        with pytest.raises(HTTPException) as exc:
+            self._zeroed(model_info=self.PTU, supplied={"search_context_cost_per_query": {"search_context_size_medium": 0.05}})
+        assert exc.value.status_code == 400
+        assert "search_context_cost_per_query" in str(exc.value.detail)
+
+    def test_search_context_already_on_the_row_is_zeroed_in_place(self):
+        """An absent table means the provider's own default rate rather than free, so emptying or
+        dropping this one would start a charge instead of stopping it."""
+        stored = {"search_context_cost_per_query": {"search_context_size_medium": 0.05}}
+        override = self._zeroed(model_info=self.PTU, litellm_params=stored)
+        assert override["search_context_cost_per_query"] == dict.fromkeys(_SEARCH_CONTEXT_SIZES, 0.0)
+        assert cost_per_web_search_request(usage=self._grounded_usage(), model_info={**stored, **override}) == 0
+        assert cost_per_web_search_request(usage=self._grounded_usage(), model_info={}) > 0
+
+    def test_an_all_zero_search_context_table_is_not_a_price(self):
+        """An all-zero table is how an operator expresses free, so refusing it would block the save
+        and replacing it would restore the provider default."""
+        free = dict.fromkeys(_SEARCH_CONTEXT_SIZES, 0.0)
+        assert self._zeroed(model_info=self.PTU, supplied={"search_context_cost_per_query": free})
+        assert cost_per_web_search_request(usage=self._grounded_usage(), model_info={"search_context_cost_per_query": free}) == 0
+
+    @staticmethod
+    def _grounded_usage():
+        return Usage(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+            prompt_tokens_details=PromptTokensDetailsWrapper(web_search_requests=1),
+        )
+
     def test_tiered_pricing_already_on_the_row_is_emptied_not_zeroed(self):
         """tiered_pricing is a table of ranges, so the zero the other fields store would not even
         validate. Dropping it instead would fall back to the cost map's tiers, whose rates outrank
@@ -937,6 +973,43 @@ class TestPtuDeploymentsAreNotBilledPerToken:
             ),
         )
         assert "input_cost_per_second" not in json.loads(off["litellm_params"])
+
+    def test_removing_ptu_config_releases_a_zeroed_search_context_table(self):
+        """The all-zero table exists only to stop the double charge, so a deployment taken off PTU
+        has to give it up or it keeps serving grounded requests for free forever."""
+        on = update_db_model(
+            db_model=Deployment(
+                model_name="grounded",
+                litellm_params=LiteLLM_Params(
+                    model="gemini/gemini-2.5-pro",
+                    search_context_cost_per_query={"search_context_size_medium": 0.05},
+                ),
+                model_info=ModelInfo(id="dep-ground", team_id="t"),
+            ),
+            updated_patch=updateDeployment(
+                model_info=ModelInfo(
+                    id="dep-ground",
+                    team_id="t",
+                    ptu_effective_from=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc),
+                    **self.PTU,
+                )
+            ),
+        )
+        assert json.loads(on["litellm_params"])["search_context_cost_per_query"] == dict.fromkeys(
+            _SEARCH_CONTEXT_SIZES, 0.0
+        )
+
+        off = update_db_model(
+            db_model=Deployment(
+                model_name="grounded",
+                litellm_params=LiteLLM_Params(**json.loads(on["litellm_params"])),
+                model_info=ModelInfo(**json.loads(on["model_info"])),
+            ),
+            updated_patch=updateDeployment(
+                model_info=ModelInfo(id="dep-ground", ptu_count=None, cost_per_ptu_per_hour=None)
+            ),
+        )
+        assert "search_context_cost_per_query" not in json.loads(off["litellm_params"])
 
     @pytest.mark.parametrize(
         "backend", ["azure/gpt-4o", "anthropic/claude-sonnet-4-5", "bedrock/anthropic.claude-sonnet-4-20250514-v1:0"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- PTU deployments still billed per grounded search request
- The guard only recognised a price held as a number
- Reserved capacity was charged twice for the same traffic

How it solves it:

- A rate table counts as a price when any rate is non-zero
- The table is zeroed in place, not dropped
- An all-zero table stays untouched, since that means free

## User Flow

Before: a team whose PTU deployment answers grounded questions is charged per search on top of the capacity it already reserved

1. An admin sends POST https://litellm-domain/model/new for a Gemini deployment with `ptu_count`, `cost_per_ptu_per_hour`, and `search_context_cost_per_query` set to `{"search_context_size_medium": 0.05}`
2. The proxy answers 200 and the deployment goes live
3. Someone on that team sends POST https://litellm-domain/v1/chat/completions asking a question that needs a web search, and gets a normal answer back
4. https://litellm-domain/ui/?page=logs shows that request at $0.05, even though the team already pays hourly for the reserved capacity serving it

After: the same deployment records no per-search charge, and the admin is told up front that the rate cannot be set

1. The admin sends the same POST https://litellm-domain/model/new
2. The proxy answers 400 saying a PTU deployment bills by reserved capacity, so `search_context_cost_per_query` cannot be charged on top of it, and names sending 0 or no value as the way forward
3. The admin resends without that rate and gets 200
4. The same grounded question over POST https://litellm-domain/v1/chat/completions returns the same answer
5. https://litellm-domain/ui/?page=logs shows that request at $0

An admin who deliberately wants grounding free can still send an all-zero table, and it is stored exactly as sent

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

## Screenshots / Proof of Fix

Two proxies from two worktrees, real Gemini traffic, real Postgres, one database each. Before ran at `487da4d1e4` (staging tip), after at `1b81c05acf`. Each proxy prints the tree it loaded and whether the fix is present, so the two legs cannot be confused.

```
$ head -2 base.log
tree : /Users/yucheng/litellm-wt/ptufield_base/litellm/__init__.py
fix  : False
$ head -2 head.log
tree : /Users/yucheng/litellm-wt/ptufield/litellm/__init__.py
fix  : True
```

Creating a PTU deployment that also charges per search, against both:

```
$ curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:$PORT/model/new \
    -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
    -d '{"model_name":"ptu-charging-search",
         "litellm_params":{"model":"gemini/gemini-2.5-pro","api_key":"os.environ/GEMINI_API_KEY",
                           "search_context_cost_per_query":{"search_context_size_medium":0.05}},
         "model_info":{"team_id":"'$TEAM'","ptu_count":10,"cost_per_ptu_per_hour":2.0,
                       "ptu_effective_from":"2026-01-01T00:00:00Z"}}'

487da4d1e4 (before)  200
1b81c05acf (after)   400
```

The 400 body:

```
A PTU deployment bills by reserved capacity, so search_context_cost_per_query cannot be charged
on top of it. Send 0 or no value, or remove ptu_count and cost_per_ptu_per_hour to bill per token.
```

A real grounded completion through each proxy, on a PTU deployment, with the same question:

```
$ curl -s -X POST http://127.0.0.1:$PORT/v1/chat/completions \
    -H "Authorization: Bearer $TEAM_KEY" -H 'Content-Type: application/json' \
    -d '{"model":"'$MODEL'","messages":[{"role":"user","content":"Who won the 2026 FIFA World Cup? Search the web."}],
         "tools":[{"googleSearch":{}}],"max_tokens":300}' | jq .usage.prompt_tokens_details

{ "text_tokens": 17, "tool_use_tokens": 113, "web_search_requests": 1 }
```

Both legs really did search. The recorded spend:

```
$ psql -c 'select model_group, total_tokens, spend from "LiteLLM_SpendLogs" where total_tokens > 0'

487da4d1e4 (before)  ptu-charging-search   tokens=556  spend=0.05
1b81c05acf (after)   ptu-free-search       tokens=510  spend=0
```

An all-zero table is still accepted after the fix, and is stored exactly as sent rather than being replaced:

```
$ curl ... -d '{... "search_context_cost_per_query":{"search_context_size_low":0,
                                                     "search_context_size_medium":0,
                                                     "search_context_size_high":0} ...}'
1b81c05acf (after)   200
stored: {'search_context_size_low': 0, 'search_context_size_high': 0, 'search_context_size_medium': 0}
```

Behavior changes worth calling out. `POST /model/new` and `PATCH /model/{model_id}/update` now answer 400 for a PTU deployment carrying a non-zero `search_context_cost_per_query`, where they used to accept it. Sweeping every first-party producer of that field across `litellm/`, `ui/litellm-dashboard/`, `litellm/proxy/client/` and `tests/e2e/` turns up no caller that sends it, so no shipped flow changes. A deployment without PTU config is untouched, and a PTU deployment taken back off PTU gives up the all-zero table so it returns to its provider's normal rate.

## Type

🐛 Bug Fix

## Caveats (if any)

- A PTU deployment with no table still bills the provider default
- xAI ignores an all-zero table, so its default survives this fix
- Legacy POST /model/update still applies no PTU guard at all

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/37043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1b81c05acf8e0a0a744e0d768ef71f3f8819627c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->