### PR TITLE
fix(bedrock): register managed-batch litellm_params so they stop leaking to the provider (internal copy of #36633)

### DIFF
--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -266,16 +266,7 @@ class CredentialLiteLLMParams(BaseModel):
     s3_region_name: str | None = None
     s3_encryption_key_id: str | None = None
     aws_batch_role_arn: str | None = None
-    # Same reason as ``azure_ad_token`` above: this model is a whitelist, so a
-    # managed-batch field it does not declare is silently dropped by
-    # ``get_deployment_credentials_with_provider`` before the batch and files
-    # transformations that read it ever run. ``s3_bucket_name`` /
-    # ``s3_region_name`` / ``aws_batch_role_arn`` were added for #25104; these two
-    # are the remainder of the same deployment config.
     s3_output_bucket_name: str | None = None
-    # A list of {"key": str, "value": str}; the batch transformation validates the
-    # shape itself via _validate_bedrock_tags, so this stays a plain list to keep
-    # that error message rather than failing earlier with a Pydantic one.
     bedrock_tags: list | None = None
     ## IBM WATSONX ##
     watsonx_region_name: str | None = None

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -266,6 +266,17 @@ class CredentialLiteLLMParams(BaseModel):
     s3_region_name: str | None = None
     s3_encryption_key_id: str | None = None
     aws_batch_role_arn: str | None = None
+    # Same reason as ``azure_ad_token`` above: this model is a whitelist, so a
+    # managed-batch field it does not declare is silently dropped by
+    # ``get_deployment_credentials_with_provider`` before the batch and files
+    # transformations that read it ever run. ``s3_bucket_name`` /
+    # ``s3_region_name`` / ``aws_batch_role_arn`` were added for #25104; these two
+    # are the remainder of the same deployment config.
+    s3_output_bucket_name: str | None = None
+    # A list of {"key": str, "value": str}; the batch transformation validates the
+    # shape itself via _validate_bedrock_tags, so this stays a plain list to keep
+    # that error message rather than failing earlier with a Pydantic one.
+    bedrock_tags: list | None = None
     ## IBM WATSONX ##
     watsonx_region_name: str | None = None
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3402,18 +3402,17 @@ TRUSTED_CALLBACK_VARS_FIELD: Final = "litellm_trusted_callback_vars"
 # files transformations. Listed for the same reason as the fields above: these sit on
 # a deployment that also serves chat, so leaking them into extra_body makes Bedrock
 # reject every non-batch request to that deployment.
-bedrock_batch_litellm_params: Final = [
+bedrock_batch_litellm_params: Final = (
     "aws_batch_role_arn",
     "s3_bucket_name",
     "s3_region_name",
     "s3_output_bucket_name",
     "bedrock_tags",
-]
+)
 
 all_litellm_params = (
     agentic_loop_internal_litellm_params
-    + [TRUSTED_CALLBACK_VARS_FIELD]
-    + bedrock_batch_litellm_params
+    + [TRUSTED_CALLBACK_VARS_FIELD, *bedrock_batch_litellm_params]
     + [
         "metadata",
         "litellm_metadata",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3398,9 +3398,22 @@ agentic_loop_internal_litellm_params: Final = [
 # the provider.
 TRUSTED_CALLBACK_VARS_FIELD: Final = "litellm_trusted_callback_vars"
 
+# Bedrock managed-batch deployment config, read from litellm_params by the batch and
+# files transformations. Listed for the same reason as the fields above: these sit on
+# a deployment that also serves chat, so leaking them into extra_body makes Bedrock
+# reject every non-batch request to that deployment.
+bedrock_batch_litellm_params: Final = [
+    "aws_batch_role_arn",
+    "s3_bucket_name",
+    "s3_region_name",
+    "s3_output_bucket_name",
+    "bedrock_tags",
+]
+
 all_litellm_params = (
     agentic_loop_internal_litellm_params
     + [TRUSTED_CALLBACK_VARS_FIELD]
+    + bedrock_batch_litellm_params
     + [
         "metadata",
         "litellm_metadata",

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -29,7 +29,8 @@ from litellm.types.utils import (
     StreamingChoices,
     Usage,
 )
-from litellm.types.utils import all_litellm_params
+from litellm.types.utils import all_litellm_params, bedrock_batch_litellm_params
+from litellm.types.router import GenericLiteLLMParams
 from litellm.utils import (
     ProviderConfigManager,
     TextCompletionStreamWrapper,
@@ -4752,3 +4753,36 @@ def test_websearch_interception_control_fields_never_reach_the_provider():
         f"{sorted(set(non_default) - {'a_real_provider_specific_param'})}"
     )
     assert set(WEBSEARCH_INTERNAL_CONTROL_FIELDS) <= set(all_litellm_params)
+
+
+def test_bedrock_batch_params_never_reach_the_provider():
+    """A Bedrock managed-batch deployment carries aws_batch_role_arn / s3_* /
+    bedrock_tags in its litellm_params, and the same deployment also serves chat.
+    Anything the param builder does not recognize is swept into extra_body, so
+    Bedrock rejects the whole call: `aws_batch_role_arn: Extra inputs are not
+    permitted` (Anthropic models) or `extraneous key [aws_batch_role_arn] is not
+    permitted` (Nova/Llama/Titan), turning every non-batch request to that
+    deployment into a 400.
+
+    The batch path is unaffected by registering them, because GenericLiteLLMParams
+    is extra="allow" and preserves them into litellm_params for the batch and files
+    transformations that read them.
+    """
+    kwargs = {
+        "a_real_provider_specific_param": 1,
+        **{field: "configured-value" for field in bedrock_batch_litellm_params},
+    }
+
+    non_default = get_non_default_completion_params(dict(kwargs))
+
+    assert non_default == {"a_real_provider_specific_param": 1}, (
+        "bedrock batch params leaked into the provider params: "
+        f"{sorted(set(non_default) - {'a_real_provider_specific_param'})}"
+    )
+    assert set(bedrock_batch_litellm_params) <= set(all_litellm_params)
+
+    batch_params = dict(GenericLiteLLMParams(**kwargs))
+    assert all(batch_params.get(field) == "configured-value" for field in bedrock_batch_litellm_params), (
+        "registering these must not strip them from the batch path: "
+        f"{sorted(f for f in bedrock_batch_litellm_params if batch_params.get(f) != 'configured-value')}"
+    )

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -30,7 +30,7 @@ from litellm.types.utils import (
     Usage,
 )
 from litellm.types.utils import all_litellm_params, bedrock_batch_litellm_params
-from litellm.types.router import GenericLiteLLMParams
+from litellm.types.router import CredentialLiteLLMParams, GenericLiteLLMParams
 from litellm.utils import (
     ProviderConfigManager,
     TextCompletionStreamWrapper,
@@ -4768,10 +4768,13 @@ def test_bedrock_batch_params_never_reach_the_provider():
     is extra="allow" and preserves them into litellm_params for the batch and files
     transformations that read them.
     """
-    kwargs = {
-        "a_real_provider_specific_param": 1,
-        **{field: "configured-value" for field in bedrock_batch_litellm_params},
+    # bedrock_tags is a list of {"key", "value"} dicts; the rest are plain strings, so
+    # give each field a value of its real shape rather than one string for all of them.
+    configured = {
+        field: ([{"key": "team", "value": "configured-value"}] if field == "bedrock_tags" else "configured-value")
+        for field in bedrock_batch_litellm_params
     }
+    kwargs = {"a_real_provider_specific_param": 1, **configured}
 
     non_default = get_non_default_completion_params(dict(kwargs))
 
@@ -4782,7 +4785,21 @@ def test_bedrock_batch_params_never_reach_the_provider():
     assert set(bedrock_batch_litellm_params) <= set(all_litellm_params)
 
     batch_params = dict(GenericLiteLLMParams(**kwargs))
-    assert all(batch_params.get(field) == "configured-value" for field in bedrock_batch_litellm_params), (
+    assert all(batch_params.get(field) == configured[field] for field in bedrock_batch_litellm_params), (
         "registering these must not strip them from the batch path: "
-        f"{sorted(f for f in bedrock_batch_litellm_params if batch_params.get(f) != 'configured-value')}"
+        f"{sorted(f for f in bedrock_batch_litellm_params if batch_params.get(f) != configured[f])}"
+    )
+
+    # GenericLiteLLMParams is extra="allow", so the assertion above would hold even for a
+    # field nothing declares. The proxy's files/batch/passthrough callers do not see that
+    # dict: get_deployment_credentials_with_provider round-trips the deployment through
+    # CredentialLiteLLMParams, which is a whitelist, so an undeclared field is dropped
+    # before the batch transformation reads it. Reproduce that round-trip here so the
+    # preservation claim covers the path the proxy actually takes.
+    normalized = CredentialLiteLLMParams.model_validate(
+        GenericLiteLLMParams(**kwargs).model_dump(exclude_none=True)
+    ).model_dump(exclude_none=True)
+    assert all(normalized.get(field) == configured[field] for field in bedrock_batch_litellm_params), (
+        "credential normalization dropped batch params before the transformation: "
+        f"{sorted(f for f in bedrock_batch_litellm_params if normalized.get(f) != configured[f])}"
     )

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4768,8 +4768,6 @@ def test_bedrock_batch_params_never_reach_the_provider():
     is extra="allow" and preserves them into litellm_params for the batch and files
     transformations that read them.
     """
-    # bedrock_tags is a list of {"key", "value"} dicts; the rest are plain strings, so
-    # give each field a value of its real shape rather than one string for all of them.
     configured = {
         field: ([{"key": "team", "value": "configured-value"}] if field == "bedrock_tags" else "configured-value")
         for field in bedrock_batch_litellm_params
@@ -4790,12 +4788,6 @@ def test_bedrock_batch_params_never_reach_the_provider():
         f"{sorted(f for f in bedrock_batch_litellm_params if batch_params.get(f) != configured[f])}"
     )
 
-    # GenericLiteLLMParams is extra="allow", so the assertion above would hold even for a
-    # field nothing declares. The proxy's files/batch/passthrough callers do not see that
-    # dict: get_deployment_credentials_with_provider round-trips the deployment through
-    # CredentialLiteLLMParams, which is a whitelist, so an undeclared field is dropped
-    # before the batch transformation reads it. Reproduce that round-trip here so the
-    # preservation claim covers the path the proxy actually takes.
     normalized = CredentialLiteLLMParams.model_validate(
         GenericLiteLLMParams(**kwargs).model_dump(exclude_none=True)
     ).model_dump(exclude_none=True)

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -27010,6 +27010,8 @@ export interface components {
             aws_web_identity_token?: string | null;
             /** Azure Ad Token */
             azure_ad_token?: string | null;
+            /** Bedrock Tags */
+            bedrock_tags?: unknown[] | null;
             /** Budget Duration */
             budget_duration?: string | null;
             /** Cache Creation Input Audio Token Cost */
@@ -27235,6 +27237,8 @@ export interface components {
             s3_bucket_name?: string | null;
             /** S3 Encryption Key Id */
             s3_encryption_key_id?: string | null;
+            /** S3 Output Bucket Name */
+            s3_output_bucket_name?: string | null;
             /** S3 Region Name */
             s3_region_name?: string | null;
             /** Search Context Cost Per Query */
@@ -35919,6 +35923,8 @@ export interface components {
             aws_web_identity_token?: string | null;
             /** Azure Ad Token */
             azure_ad_token?: string | null;
+            /** Bedrock Tags */
+            bedrock_tags?: unknown[] | null;
             /** Budget Duration */
             budget_duration?: string | null;
             /** Cache Creation Input Audio Token Cost */
@@ -36144,6 +36150,8 @@ export interface components {
             s3_bucket_name?: string | null;
             /** S3 Encryption Key Id */
             s3_encryption_key_id?: string | null;
+            /** S3 Output Bucket Name */
+            s3_output_bucket_name?: string | null;
             /** S3 Region Name */
             s3_region_name?: string | null;
             /** Search Context Cost Per Query */


### PR DESCRIPTION
Internal copy of https://github.com/BerriAI/litellm/pull/36633 into `litellm_internal_staging`. The original lives on an org-owned fork that rejects maintainer pushes, so its lint fix could not land there. This branch carries the three original commits verbatim (author preserved) plus one commit that turns the new batch-params list into a tuple so the LIT002 gate passes

Original head: `cu-aaii/litellm:litellm_bedrock_batch_params_leak` @ `89d259cf87`
Original PR: https://github.com/BerriAI/litellm/pull/36633

## TLDR

Problem this solves:

- Bedrock batch settings break chat on the same deployment
- Provider rejects the request as an unexpected field
- Batch could only run on a batch-only deployment

How it solves it:

- Register the five batch fields as litellm params
- Same list the agentic-loop and callback fields use
- List is a tuple so the lint gate stays green

## User Flow

Before: a developer whose app calls a Bedrock model gets a provider error on every chat request, as soon as the proxy admin configures that model for batch

1. The proxy admin adds the batch settings (role ARN, bucket, region) to an existing Bedrock deployment so the same model can also run batch jobs
2. The developer sends POST https://litellm-domain/v1/chat/completions with `{"model": "claude-haiku-4-5", "messages": [...]}`
3. The response is HTTP 400. On Anthropic models it reads `aws_batch_role_arn: Extra inputs are not permitted`; on Nova, Llama and Titan it reads `extraneous key [aws_batch_role_arn] is not permitted`
4. Every chat and embedding request to that model fails the same way, so the model is usable for batch only and the admin has to stand up a second, batch-only deployment of the same model

After: the same request succeeds, so one deployment serves both chat and batch

1. The proxy admin adds the same batch settings to the same Bedrock deployment
2. The developer sends the same POST https://litellm-domain/v1/chat/completions
3. The response is HTTP 200 with the assistant's reply and real token usage
4. Batch jobs against that model keep working, so no duplicate deployment is needed

## Relevant issues

Supersedes #36633

## Linear ticket

Resolves LIT-5598

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Re-run on this branch. Live local proxies, real Bedrock calls in us-east-1, real spend, no mocks, no DB. The `claude-haiku-4-5` deployment under test carries all five managed-batch fields (`aws_batch_role_arn`, `s3_bucket_name`, `s3_region_name`, `s3_output_bucket_name`, `bedrock_tags`); a second `titan-embed` deployment (`amazon.titan-embed-text-v2:0`) carries the original three. Both legs boot the same config and differ only in the commit the proxy runs from

Before, at the merge base 5a50fe0b46 (port 44322): every non-batch request to the deployment fails

```
$ curl -sS -w "\nHTTP %{http_code}\n" http://localhost:44322/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Reply with exactly: chat-ok"}],"max_tokens":16}'
HTTP 400
{"message": "litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: aws_batch_role_arn: Extra inputs are not permitted\"}. Received Model Group=claude-haiku-4-5\nAvailable Model Group Fallbacks=None", "type": null, "param": null, "code": "400"}

$ curl -sS -w "\nHTTP %{http_code}\n" http://localhost:44322/v1/messages ... -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Reply with exactly: messages-ok"}],"max_tokens":16}'
HTTP 200
content: messages-ok | usage: 14 in / 6 out

$ curl -sS -w "\nHTTP %{http_code}\n" http://localhost:44322/v1/responses ... -d '{"model":"claude-haiku-4-5","input":"Reply with exactly: responses-ok","max_output_tokens":16}'
HTTP 400
{"message": "litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: aws_batch_role_arn: Extra inputs are not permitted\"}. Received Model Group=claude-haiku-4-5\nAvailable Model Group Fallbacks=None", "type": null, "param": null, "code": "400"}

$ curl -sS -w "\nHTTP %{http_code}\n" http://localhost:44322/v1/embeddings ... -d '{"model":"titan-embed","input":"embed-ok"}'
HTTP 400
{"message": "litellm.BadRequestError: BedrockException - {\"message\":\"Malformed input request: 3 schema violations found, please reformat your input and try again.\"}. Received Model Group=titan-embed\nAvailable Model Group Fallbacks=None", "type": null, "param": null, "code": "400"}
```

After, at e46ff74bc0 (port 39674): the same requests succeed on the same deployment

```
$ curl -sS -w "\nHTTP %{http_code}\n" http://localhost:39674/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Reply with exactly: chat-ok"}],"max_tokens":16}'
HTTP 200
content: chat-ok | usage total_tokens: 20

$ curl -sS -w "\nHTTP %{http_code}\n" http://localhost:39674/v1/messages ... -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Reply with exactly: messages-ok"}],"max_tokens":16}'
HTTP 200
content: messages-ok | usage: 14 in / 6 out

$ curl -sS -w "\nHTTP %{http_code}\n" http://localhost:39674/v1/responses ... -d '{"model":"claude-haiku-4-5","input":"Reply with exactly: responses-ok","max_output_tokens":16}'
HTTP 200
output: responses-ok | usage total_tokens: 20

$ curl -sS -w "\nHTTP %{http_code}\n" http://localhost:39674/v1/embeddings ... -d '{"model":"titan-embed","input":"embed-ok"}'
HTTP 200
embedding dims: 1024 | usage total_tokens: 3
```

The only commit since, 71d951bfc0, deletes comments in the credential model and the test and cannot change behavior, so the proof above stands for the current head. The original PR's run at 02b0ee7608 / 3312f0beea showed the same before/after on the same four routes

QA observations:

- /v1/messages never leaked; 200 on both legs
- Titan reports the leak as three schema violations
- Live batch execution itself is exercised in #36634

## Type

🐛 Bug Fix

## Caveats (if any)

- `bedrock_tags` and `s3_output_bucket_name` registered but untested live
- Only the five documented Bedrock batch fields are covered

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 71d951bfc0e9bbeb552009e9c1a9756a62100a71. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->