### PR TITLE
fix(proxy): reserve budget for per-second priced audio transcription

### DIFF
--- a/litellm/proxy/dev_config.yaml
+++ b/litellm/proxy/dev_config.yaml
@@ -33,6 +33,12 @@ model_list:
       model: anthropic/claude-sonnet-5
       api_key: os.environ/ANTHROPIC_API_KEY
 
+  # ---------- Audio transcription ----------
+  - model_name: whisper-1
+    litellm_params:
+      model: openai/whisper-1
+      api_key: os.environ/OPENAI_API_KEY
+
   # ---------- Embeddings (for complexity router semantic keyword matching) ----------
   - model_name: voyage-4-large
     litellm_params:

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -8,10 +8,12 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Final, NoReturn, cast
 
 from fastapi import HTTPException, status
+from starlette.datastructures import UploadFile
 
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching import DualCache
+from litellm.litellm_core_utils.audio_utils.utils import calculate_request_duration
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import select_tier_for_input, tier_rate
 from litellm.proxy._types import (
@@ -982,8 +984,17 @@ def _input_cost_for_cost_info(
     request_body: dict,
     route: str,
     model: str,
-    model_info: dict[str, Any],
+    model_info: Mapping[str, Any],
 ) -> float | None:
+    # The provider bills the full duration on accepting the upload, so a
+    # cancelled transcription has no unbilled share to refund.
+    audio_cost: Final = _estimate_audio_transcription_cost(
+        request_body=request_body,
+        model_info=model_info,
+    )
+    if audio_cost is not None:
+        return audio_cost
+
     input_tokens: Final = _estimate_input_tokens(
         request_body=request_body,
         route=route,
@@ -1026,7 +1037,7 @@ def _max_cost_for_cost_info(
     request_body: dict,
     route: str,
     model: str,
-    model_info: dict[str, Any],
+    model_info: Mapping[str, Any],
 ) -> float | None:
     image_cost: Final = _estimate_image_generation_cost(
         request_body=request_body,
@@ -1034,6 +1045,13 @@ def _max_cost_for_cost_info(
     )
     if image_cost is not None:
         return image_cost
+
+    audio_cost: Final = _estimate_audio_transcription_cost(
+        request_body=request_body,
+        model_info=model_info,
+    )
+    if audio_cost is not None:
+        return audio_cost
 
     input_tokens: Final = _estimate_input_tokens(
         request_body=request_body,
@@ -1085,7 +1103,7 @@ def _max_cost_for_cost_info(
 
 def _estimate_image_generation_cost(
     request_body: dict,
-    model_info: dict[str, Any],
+    model_info: Mapping[str, Any],
 ) -> float | None:
     """
     Reserve `n × per-image cost` for image-generation requests so concurrent
@@ -1121,6 +1139,58 @@ def _estimate_image_generation_cost(
     return cost_per_image * max(n, 1)
 
 
+# Bytes-per-second floor for bounding an upload's duration when it cannot be
+# decoded. 500 sits below the lowest rate measured for speech at 8-32 kbps.
+MIN_AUDIO_BYTES_PER_SECOND: Final = 500.0
+
+
+def _estimate_audio_transcription_cost(
+    request_body: dict,
+    model_info: Mapping[str, Any],
+) -> float | None:
+    """Cost of transcribing the request's audio: its duration times the model's
+    per-second rate. ``None`` for anything not priced that way."""
+    if model_info.get("mode") != "audio_transcription":
+        return None
+
+    cost_per_second: Final = _audio_cost_per_second(model_info)
+    if cost_per_second is None or cost_per_second <= 0:
+        return None
+
+    seconds: Final = _estimate_audio_duration_seconds(request_body=request_body)
+    if seconds is None:
+        return None
+
+    return cost_per_second * seconds
+
+
+def _audio_cost_per_second(model_info: Mapping[str, Any]) -> float | None:
+    """The model's per-second billing rate, chosen the way ``cost_per_second``
+    chooses it."""
+    output_cost_per_second: Final = _to_float(model_info.get("output_cost_per_second"))
+    if output_cost_per_second is not None:
+        return output_cost_per_second
+    return _to_float(model_info.get("input_cost_per_second"))
+
+
+def _estimate_audio_duration_seconds(request_body: dict) -> float | None:
+    """Seconds of audio in the request, read from the file when it can be decoded
+    and bounded from its byte count when it cannot. ``None`` when the request
+    carries no readable upload."""
+    upload: Final = request_body.get("file")
+    if not isinstance(upload, UploadFile):
+        return None
+
+    exact_duration: Final = calculate_request_duration(upload.file)
+    if exact_duration is not None and exact_duration > 0:
+        return exact_duration
+
+    size_in_bytes: Final = _to_float(upload.size)
+    if size_in_bytes is None or size_in_bytes <= 0:
+        return None
+    return size_in_bytes / MIN_AUDIO_BYTES_PER_SECOND
+
+
 def _get_model_cost_info(
     model: str,
     llm_router: Router | None,
@@ -1135,67 +1205,66 @@ def _get_model_cost_info(
 def _get_model_cost_infos(
     model: str,
     llm_router: Router | None,
-) -> list[dict[str, Any]]:
+) -> tuple[Mapping[str, Any], ...]:
     """Cost-info candidates to estimate a request against for one model group.
 
     Reservation runs before routing, so the deployment that will serve the request
     is unknown. Rather than guess, we estimate the cost against every eligible
-    pricing shape in the group (the group's flat rates plus each deployment's
-    tiered table) and let the caller reserve the maximum, so a cheaper sibling
-    deployment can never leave the request under-reserved.
+    pricing shape in the group (the group's flat rates, each deployment's own cost
+    info, and each deployment's tiered table) and let the caller reserve the
+    maximum, so a cheaper sibling deployment can never leave the request
+    under-reserved.
     """
     try:
         base: Final = _get_model_cost_info(model=model, llm_router=llm_router)
         if base is None:
-            return []
-        tiered_tables: Final = _get_deployment_tiered_pricing_tables(model=model, llm_router=llm_router)
+            return ()
+        deployment_infos: Final = _get_deployment_cost_infos(model=model, llm_router=llm_router)
     except Exception:
         verbose_proxy_logger.debug(
             "Unable to load model cost info for budget reservation",
             exc_info=True,
         )
-        return []
-    if not tiered_tables:
-        return [base]
-    return [base, *({**base, "tiered_pricing": table} for table in tiered_tables)]
+        return ()
+    return (
+        base,
+        *deployment_infos,
+        *(
+            {**base, "tiered_pricing": tiered_pricing}
+            for info in deployment_infos
+            if isinstance(tiered_pricing := info.get("tiered_pricing"), list) and tiered_pricing
+        ),
+    )
 
 
-def _deployment_tiered_pricing_table(
+def _get_deployment_cost_infos(
+    model: str,
+    llm_router: Router | None,
+) -> tuple[Mapping[str, Any], ...]:
+    if llm_router is None:
+        return ()
+    deployments: Final = llm_router.get_model_list(model_name=model) or ()
+    return tuple(
+        info for deployment in deployments if (info := _deployment_cost_info(deployment, llm_router)) is not None
+    )
+
+
+def _deployment_cost_info(
     deployment: dict[str, Any],
     llm_router: Router,
-) -> list[dict] | None:
+) -> Mapping[str, Any] | None:
     model_id: Final = deployment.get("model_info", {}).get("id")
     backend_model: Final = deployment.get("litellm_params", {}).get("model")
     if not isinstance(model_id, str) or not isinstance(backend_model, str):
         return None
-    deployment_model_info: Final = llm_router.get_deployment_model_info(model_id=model_id, model_name=backend_model)
-    if deployment_model_info is None:
-        return None
-    tiered_pricing: Final = deployment_model_info.get("tiered_pricing")
-    if isinstance(tiered_pricing, list) and tiered_pricing:
-        return tiered_pricing
-    return None
-
-
-def _get_deployment_tiered_pricing_tables(
-    model: str,
-    llm_router: Router | None,
-) -> list[list[dict]]:
-    if llm_router is None:
-        return []
-    deployments: Final = llm_router.get_model_list(model_name=model) or []
-    return [
-        table
-        for deployment in deployments
-        if (table := _deployment_tiered_pricing_table(deployment, llm_router)) is not None
-    ]
+    return llm_router.get_deployment_model_info(model_id=model_id, model_name=backend_model)
 
 
 def _estimate_input_tokens(
     request_body: dict,
     route: str,
     model: str,
-    model_info: dict[str, Any],
+    model_info: Mapping[str, Any],
 ) -> int | None:
     try:
         if "messages" in request_body:
@@ -1232,7 +1301,7 @@ DEFAULT_MAX_OUTPUT_TOKENS_FALLBACK: Final = 16384
 def _estimate_output_tokens(
     request_body: dict,
     route: str,
-    model_info: dict[str, Any],
+    model_info: Mapping[str, Any],
 ) -> int | None:
     if _is_input_only_route(route=route):
         return 0

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Final, NoReturn, cast
@@ -184,10 +185,12 @@ async def reserve_budget_for_request(
         return None
 
     current_spend_by_counter_key: Final[dict[str, float]] = {}
+    audio_duration: Final = _audio_duration_reader(request_body)
     reservation_cost = estimate_request_max_cost(
         request_body=request_body,
         route=route,
         llm_router=llm_router,
+        audio_duration=audio_duration,
     )
     # estimate_request_max_cost still returns None when the model is unknown
     # to the cost map (no token-priced cost fields, e.g. image/audio routes).
@@ -246,7 +249,9 @@ async def reserve_budget_for_request(
     if not applied_entries:
         return None
 
-    input_cost: Final = estimate_request_input_cost(request_body=request_body, route=route, llm_router=llm_router)
+    input_cost: Final = estimate_request_input_cost(
+        request_body=request_body, route=route, llm_router=llm_router, audio_duration=audio_duration
+    )
     return {
         "reserved_cost": reservation_cost,
         "entries": applied_entries,
@@ -908,20 +913,21 @@ def estimate_request_max_cost(
     request_body: dict,
     route: str,
     llm_router: Router | None,
+    audio_duration: Callable[[], float | None] | None = None,
 ) -> float | None:
     model: Final = get_model_from_request(request_body, route, llm_router=llm_router)
     if model is None:
         return None
 
     models: Final = [model] if isinstance(model, str) else model
-    audio_seconds: Final = _estimate_audio_duration_seconds(request_body=request_body)
+    read_duration: Final = audio_duration or _audio_duration_reader(request_body)
     estimates = [
         _estimate_request_max_cost_for_model(
             request_body=request_body,
             route=route,
             model=model_name,
             llm_router=llm_router,
-            audio_seconds=audio_seconds,
+            audio_duration=read_duration,
         )
         for model_name in models
     ]
@@ -935,6 +941,7 @@ def estimate_request_input_cost(
     request_body: dict,
     route: str,
     llm_router: Router | None,
+    audio_duration: Callable[[], float | None] | None = None,
 ) -> float | None:
     """Cost of the request's input tokens alone.
 
@@ -948,14 +955,14 @@ def estimate_request_input_cost(
         return None
 
     models: Final = [model] if isinstance(model, str) else model
-    audio_seconds: Final = _estimate_audio_duration_seconds(request_body=request_body)
+    read_duration: Final = audio_duration or _audio_duration_reader(request_body)
     estimates = [
         _estimate_request_input_cost_for_model(
             request_body=request_body,
             route=route,
             model=model_name,
             llm_router=llm_router,
-            audio_seconds=audio_seconds,
+            audio_duration=read_duration,
         )
         for model_name in models
     ]
@@ -970,7 +977,7 @@ def _estimate_request_input_cost_for_model(
     route: str,
     model: str,
     llm_router: Router | None,
-    audio_seconds: float | None,
+    audio_duration: Callable[[], float | None],
 ) -> float | None:
     estimates: Final = [
         _input_cost_for_cost_info(
@@ -978,7 +985,7 @@ def _estimate_request_input_cost_for_model(
             route=route,
             model=model,
             model_info=model_info,
-            audio_seconds=audio_seconds,
+            audio_duration=audio_duration,
         )
         for model_info in _get_model_cost_infos(model=model, llm_router=llm_router)
     ]
@@ -991,12 +998,12 @@ def _input_cost_for_cost_info(
     route: str,
     model: str,
     model_info: Mapping[str, Any],
-    audio_seconds: float | None,
+    audio_duration: Callable[[], float | None],
 ) -> float | None:
     # The provider bills the full duration on accepting the upload, so a
     # cancelled transcription has no unbilled share to refund.
     audio_cost: Final = _estimate_audio_transcription_cost(
-        audio_seconds=audio_seconds,
+        audio_duration=audio_duration,
         model_info=model_info,
     )
     if audio_cost is not None:
@@ -1026,7 +1033,7 @@ def _estimate_request_max_cost_for_model(
     route: str,
     model: str,
     llm_router: Router | None,
-    audio_seconds: float | None,
+    audio_duration: Callable[[], float | None],
 ) -> float | None:
     estimates: Final = [
         _max_cost_for_cost_info(
@@ -1034,7 +1041,7 @@ def _estimate_request_max_cost_for_model(
             route=route,
             model=model,
             model_info=model_info,
-            audio_seconds=audio_seconds,
+            audio_duration=audio_duration,
         )
         for model_info in _get_model_cost_infos(model=model, llm_router=llm_router)
     ]
@@ -1047,7 +1054,7 @@ def _max_cost_for_cost_info(
     route: str,
     model: str,
     model_info: Mapping[str, Any],
-    audio_seconds: float | None,
+    audio_duration: Callable[[], float | None],
 ) -> float | None:
     image_cost: Final = _estimate_image_generation_cost(
         request_body=request_body,
@@ -1057,7 +1064,7 @@ def _max_cost_for_cost_info(
         return image_cost
 
     audio_cost: Final = _estimate_audio_transcription_cost(
-        audio_seconds=audio_seconds,
+        audio_duration=audio_duration,
         model_info=model_info,
     )
     if audio_cost is not None:
@@ -1159,16 +1166,20 @@ MAX_AUDIO_DECODE_BYTES: Final = 25 * 1024 * 1024
 
 
 def _estimate_audio_transcription_cost(
-    audio_seconds: float | None,
+    audio_duration: Callable[[], float | None],
     model_info: Mapping[str, Any],
 ) -> float | None:
     """Cost of transcribing the request's audio: its duration times the model's
     per-second rate. ``None`` for anything not priced that way."""
-    if audio_seconds is None or model_info.get("mode") != "audio_transcription":
+    if model_info.get("mode") != "audio_transcription":
         return None
 
     cost_per_second: Final = _audio_cost_per_second(model_info)
     if cost_per_second is None or cost_per_second <= 0:
+        return None
+
+    audio_seconds: Final = audio_duration()
+    if audio_seconds is None:
         return None
 
     return cost_per_second * audio_seconds
@@ -1181,6 +1192,14 @@ def _audio_cost_per_second(model_info: Mapping[str, Any]) -> float | None:
     if output_cost_per_second is not None and output_cost_per_second > 0:
         return output_cost_per_second
     return _to_float(model_info.get("input_cost_per_second"))
+
+
+def _audio_duration_reader(request_body: dict) -> Callable[[], float | None]:
+    """Defers the duration read until a per-second-priced candidate needs it, and
+    performs it at most once. Any route can carry a multipart file, and reading
+    one pulls it into memory, so nothing is read on the strength of the body
+    alone."""
+    return functools.lru_cache(maxsize=1)(lambda: _estimate_audio_duration_seconds(request_body=request_body))
 
 
 def _estimate_audio_duration_seconds(request_body: dict) -> float | None:

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -914,12 +914,14 @@ def estimate_request_max_cost(
         return None
 
     models: Final = [model] if isinstance(model, str) else model
+    audio_seconds: Final = _estimate_audio_duration_seconds(request_body=request_body)
     estimates = [
         _estimate_request_max_cost_for_model(
             request_body=request_body,
             route=route,
             model=model_name,
             llm_router=llm_router,
+            audio_seconds=audio_seconds,
         )
         for model_name in models
     ]
@@ -946,12 +948,14 @@ def estimate_request_input_cost(
         return None
 
     models: Final = [model] if isinstance(model, str) else model
+    audio_seconds: Final = _estimate_audio_duration_seconds(request_body=request_body)
     estimates = [
         _estimate_request_input_cost_for_model(
             request_body=request_body,
             route=route,
             model=model_name,
             llm_router=llm_router,
+            audio_seconds=audio_seconds,
         )
         for model_name in models
     ]
@@ -966,6 +970,7 @@ def _estimate_request_input_cost_for_model(
     route: str,
     model: str,
     llm_router: Router | None,
+    audio_seconds: float | None,
 ) -> float | None:
     estimates: Final = [
         _input_cost_for_cost_info(
@@ -973,6 +978,7 @@ def _estimate_request_input_cost_for_model(
             route=route,
             model=model,
             model_info=model_info,
+            audio_seconds=audio_seconds,
         )
         for model_info in _get_model_cost_infos(model=model, llm_router=llm_router)
     ]
@@ -985,11 +991,12 @@ def _input_cost_for_cost_info(
     route: str,
     model: str,
     model_info: Mapping[str, Any],
+    audio_seconds: float | None,
 ) -> float | None:
     # The provider bills the full duration on accepting the upload, so a
     # cancelled transcription has no unbilled share to refund.
     audio_cost: Final = _estimate_audio_transcription_cost(
-        request_body=request_body,
+        audio_seconds=audio_seconds,
         model_info=model_info,
     )
     if audio_cost is not None:
@@ -1019,6 +1026,7 @@ def _estimate_request_max_cost_for_model(
     route: str,
     model: str,
     llm_router: Router | None,
+    audio_seconds: float | None,
 ) -> float | None:
     estimates: Final = [
         _max_cost_for_cost_info(
@@ -1026,6 +1034,7 @@ def _estimate_request_max_cost_for_model(
             route=route,
             model=model,
             model_info=model_info,
+            audio_seconds=audio_seconds,
         )
         for model_info in _get_model_cost_infos(model=model, llm_router=llm_router)
     ]
@@ -1038,6 +1047,7 @@ def _max_cost_for_cost_info(
     route: str,
     model: str,
     model_info: Mapping[str, Any],
+    audio_seconds: float | None,
 ) -> float | None:
     image_cost: Final = _estimate_image_generation_cost(
         request_body=request_body,
@@ -1047,7 +1057,7 @@ def _max_cost_for_cost_info(
         return image_cost
 
     audio_cost: Final = _estimate_audio_transcription_cost(
-        request_body=request_body,
+        audio_seconds=audio_seconds,
         model_info=model_info,
     )
     if audio_cost is not None:
@@ -1143,32 +1153,32 @@ def _estimate_image_generation_cost(
 # decoded. 500 sits below the lowest rate measured for speech at 8-32 kbps.
 MIN_AUDIO_BYTES_PER_SECOND: Final = 500.0
 
+# Cap on what a duration read will pull into memory during auth. Above it the
+# byte-count ceiling is used instead of decoding.
+MAX_AUDIO_DECODE_BYTES: Final = 25 * 1024 * 1024
+
 
 def _estimate_audio_transcription_cost(
-    request_body: dict,
+    audio_seconds: float | None,
     model_info: Mapping[str, Any],
 ) -> float | None:
     """Cost of transcribing the request's audio: its duration times the model's
     per-second rate. ``None`` for anything not priced that way."""
-    if model_info.get("mode") != "audio_transcription":
+    if audio_seconds is None or model_info.get("mode") != "audio_transcription":
         return None
 
     cost_per_second: Final = _audio_cost_per_second(model_info)
     if cost_per_second is None or cost_per_second <= 0:
         return None
 
-    seconds: Final = _estimate_audio_duration_seconds(request_body=request_body)
-    if seconds is None:
-        return None
-
-    return cost_per_second * seconds
+    return cost_per_second * audio_seconds
 
 
 def _audio_cost_per_second(model_info: Mapping[str, Any]) -> float | None:
     """The model's per-second billing rate, chosen the way ``cost_per_second``
     chooses it."""
     output_cost_per_second: Final = _to_float(model_info.get("output_cost_per_second"))
-    if output_cost_per_second is not None:
+    if output_cost_per_second is not None and output_cost_per_second > 0:
         return output_cost_per_second
     return _to_float(model_info.get("input_cost_per_second"))
 
@@ -1180,12 +1190,15 @@ def _estimate_audio_duration_seconds(request_body: dict) -> float | None:
     upload: Final = request_body.get("file")
     if not isinstance(upload, UploadFile):
         return None
+    size_in_bytes: Final = _to_float(upload.size)
+
+    if size_in_bytes is not None and size_in_bytes > MAX_AUDIO_DECODE_BYTES:
+        return size_in_bytes / MIN_AUDIO_BYTES_PER_SECOND
 
     exact_duration: Final = calculate_request_duration(upload.file)
     if exact_duration is not None and exact_duration > 0:
         return exact_duration
 
-    size_in_bytes: Final = _to_float(upload.size)
     if size_in_bytes is None or size_in_bytes <= 0:
         return None
     return size_in_bytes / MIN_AUDIO_BYTES_PER_SECOND

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -6,11 +6,14 @@ in the litellm hot path: token counting, model info lookup, provider
 resolution, and cost calculation.
 """
 
+import io
 import threading
+import wave
 
 import pytest
 
 import litellm
+from litellm.litellm_core_utils.audio_utils.utils import calculate_request_duration
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 from litellm.litellm_core_utils.thread_pool_executor import executor
 from litellm.litellm_core_utils.token_counter import token_counter
@@ -208,6 +211,45 @@ def test_get_model_cost_key_exact_match():
 def test_get_model_cost_key_case_insensitive():
     """Benchmark model cost key lookup with case-insensitive fallback."""
     litellm.utils._get_model_cost_key("GPT-4o")
+
+
+# ---------------------------------------------------------------------------
+# Audio duration extraction (budget reservation, auth path)
+# ---------------------------------------------------------------------------
+
+
+def _benchmark_wav(duration_seconds: float, sample_rate: int = 16000) -> bytes:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00" * int(sample_rate * duration_seconds))
+    return buffer.getvalue()
+
+
+SHORT_WAV = _benchmark_wav(5.0)
+LONG_WAV = _benchmark_wav(600.0)
+UNREADABLE_UPLOAD = b"\x00\x00\x00\x20ftypM4A " + b"\x11" * (2 * 1024 * 1024)
+
+
+@pytest.mark.benchmark
+def test_audio_duration_short_wav():
+    """Duration read for a 5s WAV, the common transcription upload."""
+    calculate_request_duration(io.BytesIO(SHORT_WAV))
+
+
+@pytest.mark.benchmark
+def test_audio_duration_long_wav():
+    """Duration read for 10 minutes of WAV, ~19 MB, near the provider size cap."""
+    calculate_request_duration(io.BytesIO(LONG_WAV))
+
+
+@pytest.mark.benchmark
+def test_audio_duration_unreadable_container():
+    """Measures the failure path taken by any upload libsndfile declines to
+    decode, before the byte-count ceiling picks it up."""
+    calculate_request_duration(io.BytesIO(UNREADABLE_UPLOAD))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -7,6 +7,7 @@ resolution, and cost calculation.
 """
 
 import io
+import tempfile
 import threading
 import wave
 
@@ -214,7 +215,7 @@ def test_get_model_cost_key_case_insensitive():
 
 
 # ---------------------------------------------------------------------------
-# Audio duration extraction (budget reservation, auth path)
+# Audio duration extraction
 # ---------------------------------------------------------------------------
 
 
@@ -228,28 +229,37 @@ def _benchmark_wav(duration_seconds: float, sample_rate: int = 16000) -> bytes:
     return buffer.getvalue()
 
 
-SHORT_WAV = _benchmark_wav(5.0)
-LONG_WAV = _benchmark_wav(600.0)
-UNREADABLE_UPLOAD = b"\x00\x00\x00\x20ftypM4A " + b"\x11" * (2 * 1024 * 1024)
+def _spooled_upload(content: bytes) -> tempfile.SpooledTemporaryFile:
+    """A starlette-shaped upload. A BytesIO over an existing bytes object shares
+    its buffer, so reading it costs nothing and would understate the real work."""
+    handle = tempfile.SpooledTemporaryFile(max_size=1024 * 1024)
+    handle.write(content)
+    handle.seek(0)
+    return handle
+
+
+SHORT_UPLOAD = _spooled_upload(_benchmark_wav(5.0))
+LONG_UPLOAD = _spooled_upload(_benchmark_wav(600.0))
+UNREADABLE_UPLOAD = _spooled_upload(b"\x00\x00\x00\x20ftypM4A " + b"\x11" * (2 * 1024 * 1024))
 
 
 @pytest.mark.benchmark
 def test_audio_duration_short_wav():
     """Duration read for a 5s WAV, the common transcription upload."""
-    calculate_request_duration(io.BytesIO(SHORT_WAV))
+    calculate_request_duration(SHORT_UPLOAD)
 
 
 @pytest.mark.benchmark
 def test_audio_duration_long_wav():
     """Duration read for 10 minutes of WAV, ~19 MB, near the provider size cap."""
-    calculate_request_duration(io.BytesIO(LONG_WAV))
+    calculate_request_duration(LONG_UPLOAD)
 
 
 @pytest.mark.benchmark
 def test_audio_duration_unreadable_container():
     """Measures the failure path taken by any upload libsndfile declines to
     decode, before the byte-count ceiling picks it up."""
-    calculate_request_duration(io.BytesIO(UNREADABLE_UPLOAD))
+    calculate_request_duration(UNREADABLE_UPLOAD)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -2663,6 +2663,68 @@ def test_should_price_transcription_from_input_rate_when_output_rate_absent():
     assert estimated == pytest.approx(10.0 * 0.0002)
 
 
+def test_should_price_transcription_from_input_rate_when_output_rate_is_zero():
+    """43 of the 55 per-second transcription models (deepgram, assemblyai, azure
+    speech) declare output_cost_per_second: 0.0 alongside a positive input rate.
+    cost_per_second bills them on the input rate, so treating 0.0 as the answer
+    would leave the majority of transcription models unreserved."""
+    estimated = _estimate_transcription(
+        _transcription_body(_upload(_wav_bytes(10.0))),
+        cost_info={
+            "mode": "audio_transcription",
+            "input_cost_per_second": 0.00020833,
+            "output_cost_per_second": 0.0,
+        },
+    )
+
+    assert estimated == pytest.approx(10.0 * 0.00020833)
+
+
+def test_should_not_decode_an_upload_above_the_memory_cap():
+    """Decoding reads the whole upload into memory, and it runs during auth. An
+    upload past the cap must be sized from its byte count rather than read in."""
+    from litellm.proxy.spend_tracking.budget_reservation import MAX_AUDIO_DECODE_BYTES
+
+    oversized = _upload(b"\x00" * (MAX_AUDIO_DECODE_BYTES + 1), filename="huge.wav")
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.calculate_request_duration"
+    ) as decode:
+        estimated = _estimate_transcription(_transcription_body(oversized))
+
+    decode.assert_not_called()
+    assert estimated == pytest.approx((MAX_AUDIO_DECODE_BYTES + 1) / 500.0 * 0.0001)
+
+
+def test_should_decode_the_upload_once_regardless_of_pricing_candidate_count():
+    """The duration is read once per request, not once per pricing candidate. A
+    routed group yields several candidates, and decoding per candidate would read
+    the whole file into memory that many times."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "whisper-1",
+                "litellm_params": {"model": "openai/whisper-1", "api_key": "sk-test"},
+            },
+            {
+                "model_name": "whisper-1",
+                "litellm_params": {"model": "azure/whisper-1", "api_key": "sk-test", "api_base": "https://e.test"},
+            },
+        ]
+    )
+
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.calculate_request_duration",
+        return_value=20.0,
+    ) as decode:
+        estimate_request_max_cost(
+            request_body=_transcription_body(_upload(_wav_bytes(20.0))),
+            route="/v1/audio/transcriptions",
+            llm_router=router,
+        )
+
+    assert decode.call_count == 1
+
+
 def test_should_fall_back_to_byte_ceiling_when_duration_is_unreadable():
     """An upload whose audio cannot be decoded must still reserve, bounded by its
     byte count, rather than fall back to no reservation at all. Uses .m4a as a

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -2695,6 +2695,26 @@ def test_should_not_decode_an_upload_above_the_memory_cap():
     assert estimated == pytest.approx((MAX_AUDIO_DECODE_BYTES + 1) / 500.0 * 0.0001)
 
 
+def test_should_not_read_the_upload_for_a_non_transcription_model():
+    """Body parsing is content-type driven, so any LLM route can carry a multipart
+    file. Reading one pulls it into memory, so a chat model must never trigger the
+    read no matter what the body contains."""
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.calculate_request_duration"
+    ) as decode:
+        estimate_request_max_cost(
+            request_body={
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "hi"}],
+                "file": _upload(_wav_bytes(600.0)),
+            },
+            route="/v1/chat/completions",
+            llm_router=None,
+        )
+
+    decode.assert_not_called()
+
+
 def test_should_decode_the_upload_once_regardless_of_pricing_candidate_count():
     """The duration is read once per request, not once per pricing candidate. A
     routed group yields several candidates, and decoding per candidate would read

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1080,8 +1080,8 @@ def test_reservation_uses_most_expensive_deployment_in_group():
             return_value={"max_output_tokens": 200000},
         ),
         patch(
-            "litellm.proxy.spend_tracking.budget_reservation._get_deployment_tiered_pricing_tables",
-            return_value=[cheap, expensive],
+            "litellm.proxy.spend_tracking.budget_reservation._get_deployment_cost_infos",
+            return_value=[{"tiered_pricing": cheap}, {"tiered_pricing": expensive}],
         ),
         patch(
             "litellm.proxy.spend_tracking.budget_reservation._estimate_input_tokens",
@@ -2583,3 +2583,290 @@ async def test_streaming_slow_path_processes_and_yields_chunk(spend_counter_stat
 
     assert received == [{"content": "hi"}]
     streaming_logging_obj.async_post_call_streaming_hook.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Audio transcription
+# ---------------------------------------------------------------------------
+
+WHISPER_COST_INFO = {
+    "mode": "audio_transcription",
+    "input_cost_per_second": 0.0001,
+    "output_cost_per_second": 0.0001,
+}
+
+
+def _wav_bytes(duration_seconds: float, sample_rate: int = 16000) -> bytes:
+    """A real, decodable mono PCM WAV, so the exact-duration path actually runs."""
+    import io
+    import wave
+
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00" * int(sample_rate * duration_seconds))
+    return buffer.getvalue()
+
+
+def _upload(content: bytes, filename: str = "speech.wav"):
+    import io
+
+    from fastapi import UploadFile
+
+    return UploadFile(file=io.BytesIO(content), filename=filename, size=len(content))
+
+
+def _transcription_body(upload) -> dict:
+    return {"model": "whisper-1", "file": upload}
+
+
+def _estimate_transcription(request_body: dict, cost_info: dict | None = None) -> float | None:
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation._get_model_cost_info",
+        return_value=WHISPER_COST_INFO if cost_info is None else cost_info,
+    ):
+        return estimate_request_max_cost(
+            request_body=request_body,
+            route="/v1/audio/transcriptions",
+            llm_router=None,
+        )
+
+
+def test_should_reserve_transcription_cost_from_exact_audio_duration():
+    """Regression: the estimator returned None for whisper-1, so
+    reserve_budget_for_request never reserved and a key could overspend without
+    limit. The estimate must be the audio's duration times the per-second rate."""
+    estimated = _estimate_transcription(_transcription_body(_upload(_wav_bytes(12.0))))
+
+    assert estimated == pytest.approx(12.0 * 0.0001)
+
+
+def test_transcription_reservation_does_not_sum_input_and_output_per_second_rates():
+    """cost_per_second() prefers output_cost_per_second and never adds
+    input_cost_per_second to it. whisper-1 sets both to 0.0001, so summing them
+    would reserve exactly double what the request is billed."""
+    estimated = _estimate_transcription(_transcription_body(_upload(_wav_bytes(10.0))))
+
+    assert estimated == pytest.approx(10.0 * 0.0001)
+    assert estimated != pytest.approx(10.0 * 0.0002)
+
+
+def test_should_price_transcription_from_input_rate_when_output_rate_absent():
+    """Providers like azure/gpt-realtime-whisper declare only input_cost_per_second."""
+    estimated = _estimate_transcription(
+        _transcription_body(_upload(_wav_bytes(10.0))),
+        cost_info={"mode": "audio_transcription", "input_cost_per_second": 0.0002},
+    )
+
+    assert estimated == pytest.approx(10.0 * 0.0002)
+
+
+def test_should_fall_back_to_byte_ceiling_when_duration_is_unreadable():
+    """An upload whose audio cannot be decoded must still reserve, bounded by its
+    byte count, rather than fall back to no reservation at all. Uses .m4a as a
+    concrete example of a container the installed libsndfile declines."""
+    from litellm.proxy.spend_tracking.budget_reservation import MIN_AUDIO_BYTES_PER_SECOND
+
+    opaque = b"\x00\x00\x00\x20ftypM4A " + b"\x11" * 40000
+    estimated = _estimate_transcription(_transcription_body(_upload(opaque, filename="memo.m4a")))
+
+    assert estimated == pytest.approx(len(opaque) / MIN_AUDIO_BYTES_PER_SECOND * 0.0001)
+
+
+def test_should_prefer_exact_duration_over_the_byte_ceiling():
+    """The ceiling is a fallback, not the primary path: a readable file must be
+    priced on its real duration, which is far cheaper than the ceiling implies."""
+    from litellm.proxy.spend_tracking.budget_reservation import MIN_AUDIO_BYTES_PER_SECOND
+
+    content = _wav_bytes(4.0)
+    estimated = _estimate_transcription(_transcription_body(_upload(content)))
+
+    ceiling_estimate = len(content) / MIN_AUDIO_BYTES_PER_SECOND * 0.0001
+    assert estimated == pytest.approx(4.0 * 0.0001)
+    assert estimated < ceiling_estimate
+
+
+def test_estimating_duration_leaves_the_upload_readable_by_the_endpoint():
+    """Estimation runs during auth, before audio_transcriptions() reads the same
+    UploadFile. Consuming the stream here would send an empty file to the provider."""
+    content = _wav_bytes(3.0)
+    upload = _upload(content)
+
+    assert _estimate_transcription(_transcription_body(upload)) == pytest.approx(3.0 * 0.0001)
+    assert upload.file.read() == content
+
+
+def test_should_skip_reservation_when_audio_file_is_absent():
+    assert _estimate_transcription({"model": "whisper-1"}) is None
+
+
+def test_should_skip_reservation_when_audio_file_has_no_size_or_duration():
+    """Must be None, never 0.0: a zero estimate skips the reservation just as None
+    does, but silently, and reads downstream as 'this request is free'."""
+    import io
+
+    from fastapi import UploadFile
+
+    sizeless = UploadFile(file=io.BytesIO(b""), filename="empty.m4a", size=0)
+
+    assert _estimate_transcription(_transcription_body(sizeless)) is None
+
+
+def test_token_priced_transcription_model_still_uses_the_token_path():
+    """The 11 token-priced transcription models (e.g. gpt-4o-transcribe) carry no
+    per-second rate. They must keep estimating through the token path untouched."""
+    token_priced = {
+        "mode": "audio_transcription",
+        "input_cost_per_token": 2.5e-06,
+        "output_cost_per_token": 1e-05,
+        "max_input_tokens": 16000,
+        "max_output_tokens": 2000,
+    }
+    estimated = _estimate_transcription(
+        _transcription_body(_upload(_wav_bytes(30.0))),
+        cost_info=token_priced,
+    )
+
+    assert estimated == pytest.approx((16000 * 2.5e-06) + (2000 * 1e-05))
+
+
+def test_per_second_pricing_survives_the_router_model_group_path():
+    """ModelGroupInfo is a pydantic model that drops undeclared fields, and it does
+    not declare the per-second rates. Going through a real Router (as every proxy
+    does) would otherwise strip them and leave the fix inert in production, while
+    tests that patch _get_model_cost_info would still pass."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "whisper-1",
+                "litellm_params": {"model": "openai/whisper-1", "api_key": "sk-test"},
+            }
+        ]
+    )
+
+    estimated = estimate_request_max_cost(
+        request_body=_transcription_body(_upload(_wav_bytes(20.0))),
+        route="/v1/audio/transcriptions",
+        llm_router=router,
+    )
+
+    assert estimated == pytest.approx(20.0 * 0.0001)
+
+
+@pytest.mark.asyncio
+async def test_should_reject_concurrent_transcription_against_depleted_budget(
+    spend_counter_state,
+):
+    """The reported bug: a key at its budget kept admitting whisper requests while
+    chat requests on the same key correctly returned 429. With the reservation in
+    place, a second concurrent transcription against a budget the first already
+    pinned must raise BudgetExceededError."""
+    _, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token = UserAPIKeyAuth(token="key-audio-deplete", spend=0.0, max_budget=0.001)
+    await key_cache.async_set_cache(key="key-audio-deplete", value=valid_token)
+
+    async def reserve():
+        with patch(
+            "litellm.proxy.spend_tracking.budget_reservation._get_model_cost_info",
+            return_value=WHISPER_COST_INFO,
+        ):
+            return await reserve_budget_for_request(
+                request_body=_transcription_body(_upload(_wav_bytes(10.0))),
+                route="/v1/audio/transcriptions",
+                llm_router=None,
+                valid_token=valid_token,
+                team_object=None,
+                user_object=None,
+                prisma_client=None,
+                user_api_key_cache=key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+
+    first = await reserve()
+    assert first is not None
+    assert first["reserved_cost"] == pytest.approx(0.001)
+
+    with pytest.raises(litellm.BudgetExceededError):
+        await reserve()
+
+    await release_budget_reservation(first)
+
+
+@pytest.mark.asyncio
+async def test_should_release_over_reserved_transcription_cost_on_reconcile(
+    spend_counter_state,
+):
+    """The byte ceiling deliberately over-reserves for unreadable containers. That is
+    only safe because reconciliation gives the surplus back; if it did not, an
+    over-estimate would permanently inflate recorded spend."""
+    from litellm.proxy.spend_tracking.budget_reservation import reconcile_budget_reservation
+
+    counter_cache, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token = UserAPIKeyAuth(token="key-audio-reconcile", spend=0.0, max_budget=10.0)
+    await key_cache.async_set_cache(key="key-audio-reconcile", value=valid_token)
+
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation._get_model_cost_info",
+        return_value=WHISPER_COST_INFO,
+    ):
+        reservation = await reserve_budget_for_request(
+            request_body=_transcription_body(_upload(b"\x00" * 50000, filename="memo.m4a")),
+            route="/v1/audio/transcriptions",
+            llm_router=None,
+            valid_token=valid_token,
+            team_object=None,
+            user_object=None,
+            prisma_client=None,
+            user_api_key_cache=key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
+    assert reservation is not None
+    assert reservation["reserved_cost"] == pytest.approx(50000 / 500.0 * 0.0001)
+
+    await reconcile_budget_reservation(budget_reservation=reservation, actual_cost=0.004)
+
+    assert await counter_cache.async_get_cache(key="spend:key:key-audio-reconcile") == pytest.approx(0.004)
+
+
+def test_reasoning_rate_reaches_the_estimator_through_the_router():
+    """ModelGroupInfo drops output_cost_per_reasoning_token along with the
+    per-second rates, so on a routed proxy _max_cost_for_cost_info could never
+    apply the higher reasoning rate its own comment says it reserves at. Pinning
+    this because it is the one non-audio estimate the deployment-cost-info
+    candidates deliberately move."""
+    reasoning_model = {
+        "mode": "chat",
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 2e-07,
+        "output_cost_per_reasoning_token": 5e-07,
+        "max_input_tokens": 1000,
+        "max_output_tokens": 100,
+    }
+    request_body = {"model": "reasoner", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 100}
+
+    with (
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._get_model_cost_info",
+            return_value={k: v for k, v in reasoning_model.items() if k != "output_cost_per_reasoning_token"},
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._get_deployment_cost_infos",
+            return_value=[reasoning_model],
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._estimate_input_tokens",
+            return_value=10,
+        ),
+    ):
+        estimated = estimate_request_max_cost(
+            request_body=request_body,
+            route="/chat/completions",
+            llm_router=None,
+        )
+
+    assert estimated == pytest.approx((10 * 2e-07) + (100 * 5e-07))


### PR DESCRIPTION
## TLDR

Problem this solves:

- Per-second priced audio models never reserved budget
- Concurrent transcriptions all passed after the budget ran out
- Chat requests returned 429, audio on the same key did not
- Per-second pricing never reached the estimator on routed proxies

How it solves it:

- Price a transcription from how long the audio is
- Use the same rate the provider actually bills at
- Read the real duration, else bound it by file size
- Estimator now also reads each deployment's own pricing

## User Flow

Before: a team caps a virtual key at $5 for transcription and is billed past the cap anyway

1. They create a key with `"max_budget": 5` and `"models": ["whisper-1"]`
2. They send several POST https://litellm-domain/v1/audio/transcriptions at once, each with an audio file
3. Every one returns 200 with a transcript, including the ones sent after the cap was reached
4. They open https://litellm-domain/ui/?page=logs and watch spend pass $5 and keep climbing toward $7
5. The same key sending POST https://litellm-domain/v1/chat/completions gets 429 saying the budget is exceeded, so only audio slips through

After: the cap holds for audio exactly as it does for chat

1. They create a key with `"max_budget": 5` and `"models": ["whisper-1"]`
2. They send several POST https://litellm-domain/v1/audio/transcriptions at once, each with an audio file
3. Requests that fit the remaining budget return 200 with a transcript, and the rest return 429 naming the key and its budget
4. https://litellm-domain/ui/?page=logs shows spend settling at or below $5
5. The same key sending POST https://litellm-domain/v1/chat/completions gets the same 429, so both routes now behave identically

## Relevant issues

Relates to #35524, which reports that budget reservation is skipped whenever a request's cost cannot be estimated, names audio among the affected route types, and asks for an explicit policy covering all of them. For audio this PR takes a narrower path. These models already carry a per-second price in the model cost map, and only the audio's duration was missing, so this measures the duration and prices the request instead of declaring it unpriceable. The broader policy question stays open for other unpriceable request shapes, so this does not close the issue

#35584 comes at the same problem from the other end, warning by default and returning 503 under `fail_closed_budget_enforcement` when no estimate is available. The two fit together, since this PR shrinks the set of requests that reach that branch at all

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Test Setup

Every run below hit a local proxy on `localhost:4000` calling the real OpenAI API

The first two runs each generate a fresh virtual key, capped at `$0.00015` and allowed to call `whisper-1` and `gpt-5.4-mini`. The audio is the repository's own `litellm/litellm_core_utils/audio_utils/audio_health_check.wav`, 0.66 seconds long, which costs `$0.000066` on `whisper-1`. Two calls fit the cap with `$0.000018` left over

Each of those runs fires five transcriptions at once, then one chat request on the same key. The two runs after them use their own key and budget, stated where they appear

### Before the Fix

Branch: `litellm_internal_staging`
Commit: `1a183efaa1`

All five audio requests were accepted and spend settled at 220% of the cap. The chat request that followed correctly returned 429, so the same key held its budget on chat but not on audio

```text
--- 5 concurrent POST /v1/audio/transcriptions ---
  req1  HTTP 200  transcript: <text>
  req2  HTTP 200  transcript: <text>
  req3  HTTP 200  transcript: <text>
  req4  HTTP 200  transcript: <text>
  req5  HTTP 200  transcript: <text>

--- POST /v1/chat/completions on the SAME key ---
  chat  HTTP 429  Budget has been exceeded! Key=key (<redacted>) Current cost: 0.00033000001311302184, Max budget: 0.00015

--- settled spend for this key ---
  {"spend":0.0003300000131130218,"max_budget":0.00015}
```

### After the Fix

Branch: `litellm_audio_budget_reservation`
Commit: `667abbe494`

The audio cost is now estimated and reserved before dispatch. Two of the five concurrent requests were rejected with 429

```text
--- 5 concurrent POST /v1/audio/transcriptions ---
  req1  HTTP 200  transcript: <text>
  req2  HTTP 200  transcript: <text>
  req3  HTTP 200  transcript: <text>
  req4  HTTP 429  Budget has been exceeded! Key=<redacted> Current cost: 0.000216, Max budget: 0.00015
  req5  HTTP 429  Budget has been exceeded! Key=<redacted> Current cost: 0.000216, Max budget: 0.00015

--- POST /v1/chat/completions on the SAME key ---
  chat  HTTP 429  Budget has been exceeded! Key=key (<redacted>) Current cost: 0.0001980000078678131, Max budget: 0.00015

--- settled spend for this key ---
  {"spend":0.0001980000078678131,"max_budget":0.00015}
```

Which of the five are refused varies between runs because they race. The audio rejections name the key by hash because they come from the new pre-dispatch reservation, which reports the counter including its own reservation. The chat rejection names it by alias because it comes from the pre-existing read-time check, reading the reconciled spend of the three that ran

#### Byte-Count Fallback

When the audio cannot be decoded, the reservation falls back to the upload's byte count. This run used the same audio re-encoded to `.m4a`, which the audio library cannot decode, so the duration is bounded from the file size instead

The file is 7219 bytes. At 500 bytes per second that bounds it at 14.4 seconds, so each request reserves `$0.001444` against a `$0.002` key budget. Five were fired at once, as above

```text
--- 5 concurrent POST /v1/audio/transcriptions ---
  req1  HTTP 200  transcript: <text>
  req2  HTTP 429  Budget has been exceeded! Key=<redacted> Current cost: 0.0034438000000000003, Max budget: 0.002
  req3  HTTP 200  transcript: <text>
  req4  HTTP 429  Budget has been exceeded! Key=<redacted> Current cost: 0.0034438000000000003, Max budget: 0.002
  req5  HTTP 429  Budget has been exceeded! Key=<redacted> Current cost: 0.0034438000000000003, Max budget: 0.002

--- settled spend for this key ---
  {"spend":0.0001379999995231628,"max_budget":0.002}
```

Before the fix an undecodable upload produced no estimate at all, so nothing was reserved and this 429 could not happen

The reservation is held only while the request is in flight. The first to arrive reserved the full `$0.001444` and the next was shrunk to the `$0.000556` of headroom left, which put the counter at the `$0.002` cap and is why the other three were refused. Reconciliation then replaced both reservations with what the transcriptions actually cost, `$0.000138` in total

#### Oversized Uploads

Reading an upload's duration pulls it into memory, and that happens during authentication, before the route applies `max_file_size_mb`. Above 25 MB the duration is bounded from the byte count instead, so a large upload is never materialized there

Two concurrent 26,214,446-byte uploads against a `$0.01` key:

```text
--- 2 concurrent POST /v1/audio/transcriptions ---
  req1  HTTP 429  Budget has been exceeded! Key=<redacted> Current cost: 5.2528892, Max budget: 0.01
  req2  HTTP 413  litellm.APIError: APIError: OpenAIException - 413: Maximum content size limit (26214400) exceeded (26214907 bytes read). Received Model Group=whisper-1
```

`5.2528892` is the `$0.01` counter plus `26214446 / 500 x $0.0001`, the byte ceiling. Had the file been decoded it would have measured 819.2 seconds and reserved `$0.08192`, so the number itself shows the decode was skipped. The 413 on `req2` is OpenAI's own 25 MB limit, reached because a fresh key has full headroom and the existing policy shrinks an oversized reservation to fit rather than refusing it

#### Known Limitation

The after-fix run settled at `$0.000198`, or 132% of the `$0.00015` cap. The existing `_apply_over_budget_reservation_policy` is what allows this. When a request does not fit the remaining budget it shrinks the reservation to whatever headroom is left and admits the request anyway, so the third transcription was let through against `$0.000018` of headroom and went on to cost the full `$0.000066`. This PR does not change that policy

Chat reaches that same policy and still stays under budget. Five concurrent `gpt-5.4-mini` requests on a fresh key with the same `$0.00015` cap:

```text
--- 5 concurrent POST /v1/chat/completions ---
  req1  HTTP 200  succeeded
  req2  HTTP 200  succeeded
  req3  HTTP 429  Budget has been exceeded! Key=<redacted> Current cost: 0.00022875, Max budget: 0.00015
  req4  HTTP 429  Budget has been exceeded! Key=<redacted> Current cost: 0.00022875, Max budget: 0.00015
  req5  HTTP 429  Budget has been exceeded! Key=<redacted> Current cost: 0.00022875, Max budget: 0.00015

--- settled spend for this key ---
  {"spend":0.000057,"max_budget":0.00015}
```

Two were admitted and three refused, the same shape as audio. Chat still settles low because its reservation is a ceiling rather than a measurement: it reserves the caller's full `max_tokens`, `$0.00007875` per request here, while the two that ran cost `$0.000057` between them. Audio has no such slack, since the duration it reserves is the duration it gets billed for

### Reproduction Commands

The proxy config used for these runs, saved as `config.yaml`:

```yaml
model_list:
  - model_name: whisper-1
    litellm_params:
      model: openai/whisper-1
      api_key: os.environ/OPENAI_API_KEY
  - model_name: gpt-5.4-mini
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234
```

```bash
docker compose up -d db
export DATABASE_URL="postgresql://llmproxy:dbpassword9090@localhost:5432/litellm"
python litellm/proxy/proxy_cli.py --config config.yaml --use_v2_migration_resolver

KEY=$(curl -s -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"max_budget": 0.00015, "models": ["whisper-1","gpt-5.4-mini"]}' | jq -r .key)

for i in 1 2 3 4 5; do
  curl -s -o /dev/null -w "req$i -> %{http_code}\n" \
    -X POST http://localhost:4000/v1/audio/transcriptions \
    -H "Authorization: Bearer $KEY" -F model=whisper-1 \
    -F file=@litellm/litellm_core_utils/audio_utils/audio_health_check.wav &
done; wait

curl -s -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"say hi"}],"max_tokens":16}'

sleep 22
curl -s "http://localhost:4000/key/info?key=$KEY" -H "Authorization: Bearer sk-1234" \
  | jq -c '{spend:.info.spend,max_budget:.info.max_budget}'
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Undecodable uploads reserve on a measured size ceiling, then reconcile
- Uploads above 25 MB reserve on size, never decoded during auth
- Cancelling mid-transcription keeps the charge, the provider already billed
- Image generation now reserves on routed proxies, previously zero
- Five dashscope models now reserve at their reasoning rate

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
