### PR TITLE
fix(passthrough): stop forwarding client Accept-Encoding upstream

### DIFF
--- a/litellm/passthrough/utils.py
+++ b/litellm/passthrough/utils.py
@@ -18,6 +18,7 @@ _PASS_THROUGH_PROTECTED_HEADERS: Final[frozenset] = frozenset(
         "x-goog-api-key",
         "host",
         "content-length",
+        "accept-encoding",
     }
 )
 

--- a/litellm/passthrough/utils.py
+++ b/litellm/passthrough/utils.py
@@ -69,6 +69,9 @@ class BasePassthroughUtils:
             # Header We Should NOT forward
             request_headers.pop("content-length", None)
             request_headers.pop("host", None)
+            # accept-encoding must stay client-negotiated: forwarding e.g. "br" when
+            # the brotli package is absent relays undecodable bytes to the caller
+            request_headers.pop("accept-encoding", None)
 
             custom_header_names: Final = {header_name.lower() for header_name in headers}
             for header_name in list(request_headers.keys()):

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
@@ -580,6 +580,7 @@ def test_forward_headers_never_forwards_client_accept_encoding():
 
     request_headers = {
         "accept-encoding": "gzip, deflate, br, zstd",
+        "x-pass-accept-encoding": "br",
         "x-request-id": "req-123",
     }
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
@@ -568,6 +568,31 @@ def test_forward_headers_custom_wins_case_insensitive_over_request_authorization
     assert result["x-request-id"] == "req-123"
 
 
+def test_forward_headers_never_forwards_client_accept_encoding():
+    """
+    The client's Accept-Encoding must not reach the upstream provider: the proxy's
+    HTTP client decodes the upstream body and advertises only encodings it can
+    decode. Forwarding e.g. "br" on an install without the brotli package makes
+    the proxy relay raw compressed bytes with the content-encoding header stripped
+    (garbled JSON for /v1/models and count_tokens through the Anthropic passthrough).
+    """
+    from litellm.passthrough.utils import BasePassthroughUtils
+
+    request_headers = {
+        "accept-encoding": "gzip, deflate, br, zstd",
+        "x-request-id": "req-123",
+    }
+
+    result = BasePassthroughUtils.forward_headers_from_request(
+        request_headers=request_headers,
+        headers={},
+        forward_headers=True,
+    )
+
+    assert "accept-encoding" not in result
+    assert result["x-request-id"] == "req-123"
+
+
 @pytest.mark.asyncio
 async def test_vertex_passthrough_custom_model_name_replaced_in_url():
     """


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic now brotli-compresses non-streaming JSON when clients advertise `br`
- Passthrough forwards the client's `Accept-Encoding` verbatim upstream
- Shipped Docker images have no brotli package, so nothing decodes it
- Proxy then relays raw brotli bytes with the `content-encoding` header stripped
- Claude Code gets garbled `/v1/models` and `count_tokens` bodies through the passthrough
- Streaming kept working only because Anthropic gzips SSE

How it solves it:

- Never forward the client's `Accept-Encoding` on passthrough routes
- The proxy's HTTP client then advertises only encodings it can decode
- `x-pass-accept-encoding` is also refused via the existing protected-header list, so the force-forward mechanism cannot reintroduce it

## User Flow

Before: a developer points Claude Code at the LiteLLM Anthropic passthrough on a stock Docker deploy, chat works, but /context shows zero tokens for every category

1. They run `ANTHROPIC_BASE_URL=https://litellm-domain/anthropic ANTHROPIC_AUTH_TOKEN=sk-... claude` and chat normally; streamed replies from POST https://litellm-domain/anthropic/v1/messages?beta=true look fine
2. They run `/context` inside Claude Code, which fires POST https://litellm-domain/anthropic/v1/messages/count_tokens?beta=true per category; each returns 200 with a body of raw compressed bytes instead of JSON
3. The /context panel renders nonsense: "122 tools · 0 tokens", "3 agents · 0 tokens", and 72.6k tokens lumped into Messages in a nearly empty session
4. A plain `curl https://litellm-domain/anthropic/v1/models -H 'accept-encoding: gzip, deflate, br, zstd'` also prints binary garbage instead of the model list

After: the same setup returns readable JSON everywhere, and /context shows the real breakdown

1. They run `ANTHROPIC_BASE_URL=https://litellm-domain/anthropic ANTHROPIC_AUTH_TOKEN=sk-... claude` and chat normally; streamed replies look fine as before
2. They run `/context`; every POST https://litellm-domain/anthropic/v1/messages/count_tokens?beta=true returns readable JSON like `{"input_tokens":10}`
3. The /context panel shows the true per-category numbers (system prompt 6.5k, system tools 35.5k, MCP tools 23.8k, messages 4.9k)
4. The same `curl https://litellm-domain/anthropic/v1/models` prints the normal JSON model list

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

All runs use a proxy venv without the brotli package, matching the shipped Docker images, and hit the real Anthropic API

Before, at 3840970613 (staging tip without this fix):

```
$ curl -s "http://127.0.0.1:38644/anthropic/v1/models?limit=2" \
    -H 'x-litellm-api-key: sk-1234' -H 'anthropic-version: 2023-06-01' \
    -H 'accept-encoding: gzip, deflate, br, zstd' | head -c 64 | xxd
00000000: a068 0000 5055 5555 fd9f ae0e 7256 0350  .h..PUUU....rV.P
00000010: 5308 f708 d76b c03d 0e11 a708 0850 1057  S....k.=.....P.W
00000020: 1573 1770 dd40 5534 c21c 1c74 000e c682  .s.p.@U4...t....

$ curl -s -X POST "http://127.0.0.1:38644/anthropic/v1/messages/count_tokens" \
    -H 'x-litellm-api-key: sk-1234' -H 'anthropic-version: 2023-06-01' \
    -H 'content-type: application/json' -H 'accept-encoding: gzip, deflate, br, zstd' \
    -d '{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"Hello, world"}]}' | xxd
00000000: 2001 107b 2269 6e70 7574 5f74 6f6b 656e   ..{"input_token
00000010: 7322 3a31 307d 03                        s":10}.
```

Claude Code 2.1.233 pointed at that proxy (`ANTHROPIC_BASE_URL=http://127.0.0.1:38644/anthropic`), after one tiny exchange, `/context` shows:

```
74.6k/200k tokens (37%)
Messages: 72.6k tokens (36.3%)
122 tools · 0 tokens
3 agents · 0 tokens
1 file · 0 tokens
```

After, at 90493a217f (same brotli-less venv, same commands):

```
$ curl -s "http://127.0.0.1:42817/anthropic/v1/models?limit=2" ... (same headers)
{"data":[{"type":"model","id":"claude-opus-5","display_name":"Claude Opus 5",...

$ curl -s -X POST "http://127.0.0.1:42817/anthropic/v1/messages/count_tokens" ... (same headers/body)
{"input_tokens":10}

$ curl -s -X POST "http://127.0.0.1:42817/anthropic/v1/messages/count_tokens" \
    ... (same headers/body, plus -H 'x-pass-accept-encoding: br')
{"input_tokens":10}
```

Same Claude Code session shape against the fixed proxy (captured at d0be6eee8a; the follow-up commit 90493a217f only hardens the `x-pass-accept-encoding` path shown above), `/context` now shows the real breakdown:

```
74.6k/200k tokens (37%)
System prompt: 6.5k tokens (3.2%)
System tools: 35.5k tokens (17.8%)
MCP tools: 23.8k tokens (11.9%)
Custom agents: 207 tokens (0.1%)
Memory files: 1.6k tokens (0.8%)
Skills: 2k tokens (1.0%)
Messages: 4.9k tokens (2.5%)
```

Streamed chat itself (POST /anthropic/v1/messages?beta=true) worked in both runs because Anthropic gzips SSE, which the proxy always decodes

## Type

🐛 Bug Fix

## Caveats (if any)

- Upstream hop now negotiates gzip instead of brotli, marginally larger transfers

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
