### PR TITLE
fix(streaming): trust provider usage cost selectively

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -53,6 +53,7 @@ FUNCTION_CALL_ATTRIBUTE: Final = "function_call"
 _SYNC_ITER_EXHAUSTED: Final = object()
 
 _GCHUNK_FIELDS: Final[frozenset] = frozenset(GChunk.__annotations__)
+_TRUSTED_USAGE_COST_PROVIDERS: Final[frozenset[str]] = frozenset({LlmProviders.OPENROUTER.value})
 
 
 def _next_sync_or_exhausted(it: Any) -> object:
@@ -1792,12 +1793,14 @@ class CustomStreamWrapper:
     @staticmethod
     def _propagate_usage_cost_to_hidden_params(
         response: "ModelResponse",
+        custom_llm_provider: str | None,
     ) -> None:
         """
-        If the assembled response carries a provider-reported cost on
-        usage.cost, copy it into _hidden_params so litellm's cost
-        calculator uses it instead of a token-based estimate.
+        Copy a trusted provider's USD usage.cost into the cost override header.
         """
+        if custom_llm_provider not in _TRUSTED_USAGE_COST_PROVIDERS:
+            return
+
         _usage: Final[Usage | None] = getattr(response, "usage", None)
         if _usage is not None and hasattr(_usage, "cost") and _usage.cost is not None:
             if "additional_headers" not in response._hidden_params:
@@ -1911,7 +1914,10 @@ class CustomStreamWrapper:
 
                 response = self.model_response_creator()
                 if complete_streaming_response is not None:
-                    self._propagate_usage_cost_to_hidden_params(complete_streaming_response)
+                    self._propagate_usage_cost_to_hidden_params(
+                        complete_streaming_response,
+                        self.custom_llm_provider,
+                    )
 
                     setattr(
                         response,
@@ -2161,7 +2167,10 @@ class CustomStreamWrapper:
 
             response: Final = self.model_response_creator()
             if complete_streaming_response is not None:
-                self._propagate_usage_cost_to_hidden_params(complete_streaming_response)
+                self._propagate_usage_cost_to_hidden_params(
+                    complete_streaming_response,
+                    self.custom_llm_provider,
+                )
 
                 setattr(
                     response,

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -26,6 +26,7 @@ from litellm.litellm_core_utils.streaming_handler import (
 from litellm.types.utils import (
     CompletionTokensDetailsWrapper,
     Delta,
+    ModelResponse,
     ModelResponseStream,
     PromptTokensDetailsWrapper,
     StandardLoggingPayload,
@@ -1657,7 +1658,9 @@ def test_openrouter_streaming_cost_propagates_to_hidden_params():
     assert complete_response.usage.cost == 0.00025
 
     # Use the real propagation method from CustomStreamWrapper
-    CustomStreamWrapper._propagate_usage_cost_to_hidden_params(complete_response)
+    CustomStreamWrapper._propagate_usage_cost_to_hidden_params(
+        complete_response, "openrouter"
+    )
 
     assert "additional_headers" in complete_response._hidden_params
     assert (
@@ -1674,6 +1677,50 @@ def test_openrouter_streaming_cost_propagates_to_hidden_params():
         complete_response._hidden_params
     )
     assert provider_cost == 0.00025
+
+
+def test_openai_compatible_streaming_cost_is_not_trusted_as_usd():
+    model = "openai/test-provider-cost-unit"
+    litellm.register_model(
+        {
+            model: {
+                "input_cost_per_token": 1e-6,
+                "output_cost_per_token": 2e-6,
+                "litellm_provider": "openai",
+                "mode": "chat",
+            }
+        }
+    )
+    complete_response = ModelResponse(
+        id="chatcmpl-openai-compatible",
+        model=model,
+        choices=[],
+        usage=Usage(
+            completion_tokens=5,
+            prompt_tokens=10,
+            total_tokens=15,
+            cost=3_144_000,
+        ),
+    )
+
+    CustomStreamWrapper._propagate_usage_cost_to_hidden_params(
+        complete_response, "openai"
+    )
+
+    assert "llm_provider-x-litellm-response-cost" not in complete_response._hidden_params.get(
+        "additional_headers", {}
+    )
+
+    from litellm.cost_calculator import response_cost_calculator
+
+    response_cost = response_cost_calculator(
+        response_object=complete_response,
+        model=model,
+        custom_llm_provider="openai",
+        call_type="completion",
+        optional_params={},
+    )
+    assert response_cost == pytest.approx(2e-5)
 
 
 def test_handle_special_delta_attributes(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Generic gateways can report cost in non-USD units
- That value can override configured pricing and exhaust budgets

How it solves it:

- Trust streaming usage cost only for known USD providers
- Keep OpenRouter behavior and test generic gateway fallback

## User Flow

Before: a proxy admin's configured pricing is replaced by an upstream value in another unit

1. The admin configures token prices for an OpenAI-compatible deployment
2. A developer sends POST https://litellm-domain/v1/chat/completions with `"stream": true`
3. The upstream's final usage chunk contains `"cost": 3144000` in its internal unit
4. https://litellm-domain/ui/?page=logs records $3,144,000 and the configured budget is exhausted

After: the same request is costed from the admin's configured token prices

1. The admin configures the same token prices for the deployment
2. A developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true`
3. The upstream's final usage chunk contains the same `"cost": 3144000` value
4. https://litellm-domain/ui/?page=logs records the configured token cost and the budget remains accurate

## Relevant issues

Fixes #35829

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Live proof requires access to the affected third-party upstream. The focused regression uses its reported `3144000` value and verifies the configured $0.00002 token cost wins

## Type

Bug Fix

## Caveats (if any)

- Provider-reported streaming cost remains trusted for OpenRouter

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
