### PR TITLE
fix(ollama): forward completion api_base to model-info lookup

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1015,7 +1015,11 @@ def responses_api_bridge_check(
     try:
         model_info = cast(
             dict,
-            _get_model_info_helper(model=model, custom_llm_provider=custom_llm_provider),
+            _get_model_info_helper(
+                model=model,
+                custom_llm_provider=custom_llm_provider,
+                api_base=api_base,
+            ),
         )
         if model_info.get("mode") is None and model.startswith("responses/"):
             model = model.replace("responses/", "")

--- a/tests/test_litellm/llms/ollama/test_ollama_model_info.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_model_info.py
@@ -231,6 +231,36 @@ class TestOllamaModelInfo:
 class TestOllamaGetModelInfo:
     """Tests for OllamaConfig.get_model_info() api_base threading and graceful fallback."""
 
+    def test_responses_api_bridge_check_uses_provided_api_base_for_ollama(
+        self, monkeypatch
+    ):
+        """Bridge lookup must hit the completion api_base, not localhost:11434.
+
+        Regression for https://github.com/BerriAI/litellm/issues/37041
+        """
+        from litellm.main import responses_api_bridge_check
+
+        captured_urls = []
+
+        def mock_post(url, json, headers=None):
+            captured_urls.append(url)
+            return DummyResponse({"template": "", "model_info": {}}, status_code=200)
+
+        monkeypatch.setattr("litellm.module_level_client.post", mock_post)
+        monkeypatch.delenv("OLLAMA_API_BASE", raising=False)
+
+        responses_api_bridge_check(
+            model="unknown-custom-model",
+            custom_llm_provider="ollama",
+            api_base="http://my-remote-server:30000",
+        )
+
+        assert captured_urls
+        assert all(
+            url.startswith("http://my-remote-server:30000") for url in captured_urls
+        )
+        assert not any("localhost:11434" in url for url in captured_urls)
+
     def test_get_model_info_uses_provided_api_base(self, monkeypatch):
         """When api_base is passed, get_model_info should use it instead of env var or default."""
         from litellm.llms.ollama.completion.transformation import OllamaConfig

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -743,6 +743,30 @@ def test_responses_api_bridge_check_strips_responses_prefix():
         assert model_info["mode"] == "responses"
 
 
+def test_responses_api_bridge_check_forwards_api_base_to_model_info_helper():
+    """completion() api_base must reach Ollama /api/show, not localhost:11434.
+
+    Regression for https://github.com/BerriAI/litellm/issues/37041
+    """
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"mode": "chat"}
+        api_base = "http://my-host:30000"
+
+        responses_api_bridge_check(
+            model="my-custom-model",
+            custom_llm_provider="ollama",
+            api_base=api_base,
+        )
+
+        mock_get_model_info.assert_called_once_with(
+            model="my-custom-model",
+            custom_llm_provider="ollama",
+            api_base=api_base,
+        )
+
+
 def test_responses_api_bridge_check_gpt_5_4_pro():
     """Test that gpt-5.4-pro routes through responses API bridge, not chat completions.
 


### PR DESCRIPTION
## TLDR

Problem this solves:

* Remote Ollama completions wait on unnecessary localhost timeouts.
* Model-info lookup ignores the supplied `api_base`.

How it solves it:

* Forwards `api_base` to the model-info lookup.
* `/api/show` now uses the configured Ollama host.

## User Flow

Before: a developer using remote Ollama sees an unnecessary delay before completion.

1. They send `POST http://litellm-host:4000/v1/chat/completions` using an Ollama model configured on a remote host.
2. The request waits while model information is requested from `localhost:11434`.
3. Generation uses the correct remote host and returns successfully, but only after the delay.

After: the same completion uses the configured Ollama host without the localhost delay.

1. They send the same `POST http://litellm-host:4000/v1/chat/completions` request.
2. Model information is requested from the configured remote Ollama host.
3. Generation completes without waiting on `localhost:11434`.

## Relevant issues

Fixes #37041

## Linear ticket

## Pre-Submission checklist

* [x] I have added meaningful tests
* [ ] My PR passes all CI/CD checks
* [x] My PR's scope is as isolated as possible
* [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Live end-to-end proof has not yet been captured against a remote Ollama server. Regression tests verify that the supplied `api_base` reaches the model-info lookup and that `/api/show` does not use `localhost:11434`.

## Type

Bug Fix

## Caveats (if any)

* Live verification requires an Ollama server on a non-default host.

### Final Attestation

* [x] The tests cover the affected forwarding behavior and regression case.
