### PR TITLE
docs(github): proof-of-fix section shows only the latest run as Before/After with nested cases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -66,7 +66,7 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
 <!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
      The proof must be completely e2e with no mocks, using actual LLM calls costing real $$$ if applicable. `pytest` commands are not enough
      Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones. The run must be up to date. As soon as a new commit is made and it makes this PR description's after sha stale (it's no longer tip of PR), you must re-run the QA
-     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly
+     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides, and numbered steps (command, observed output) under every case, never loose prose; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly
 
 ### Before (<hash>)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -65,11 +65,35 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
 
 <!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
      The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
-     For bug fixes: show reproduction before the fix and passing behavior after
-     Include the commit hash each proof was captured at, for both the before and the after runs
-     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
-     For new features: show the feature working end-to-end
-     For UI changes: include before/after screenshots -->
+     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones
+     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly
+
+### Before (<hash>)
+
+#### <case 1>
+
+1. ...
+2. ...
+
+#### <case 2>
+
+1. ...
+
+### After (<hash>)
+
+#### <case 1>
+
+1. ...
+2. ...
+
+#### <case 2>
+
+1. ...
+
+     For bug fixes: Before shows the reproduction, After shows the same steps passing
+     For new features: Before shows the capability missing, After shows it working end-to-end
+     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), make each endpoint its own case, not just one
+     For UI changes: before/after screenshots under the same headings -->
 
 ## Type
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -64,8 +64,8 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
 ## Screenshots / Proof of Fix
 
 <!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
-     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
-     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones
+     The proof must be completely e2e with no mocks, using actual LLM calls costing real $$$ if applicable. `pytest` commands are not enough
+     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones. The run must be up to date. As soon as a new commit is made and it makes this PR description's after sha stale (it's no longer tip of PR), you must re-run the QA
      Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly
 
 ### Before (<hash>)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Proof-of-fix sections accumulate every historical QA run
- Reviewers dig through superseded runs to find the current one
- No prescribed layout, so every PR structures proof differently

How it solves it:

- Template now prescribes latest-run-only Before (hash) / After (hash) headings
- Multiple cases nest as lower-level headings, same names both sides

## User Flow

Before: a maintainer reviewing a long-lived PR has to dig through stacked QA runs to find the one that matches the tip

1. A contributor opens https://github.com/BerriAI/litellm/compare and the PR description box loads the template, whose proof comment asks for commit hashes but says nothing about superseded runs
2. They capture proof, push more commits, and append a fresh run under a new bold label each time, keeping the old ones
3. The reviewer opens the PR, scrolls a Screenshots / Proof of Fix section holding several dated runs at different hashes, and has to work out which one reflects the current tip
4. PR #36943's pre-cleanup revision (see its edit history) shows the result: two run blocks at four different hashes with prose stitching them together

After: the same section holds exactly one run, split into Before and After at named hashes, so the reviewer reads it top to bottom once

1. A contributor opens https://github.com/BerriAI/litellm/compare and the PR description box loads the template, whose proof comment now shows the exact skeleton: `### Before (<hash>)` and `### After (<hash>)`, one `####` heading per case, shared setup above Before
2. They capture proof at the merge base and the tip, and on every behavioral push they replace the section with the fresh run instead of appending
3. The reviewer opens the PR and reads one Before block and one After block with matching case headings, compares them case by case, and is done
4. PR #36943's current body shows the result of the same content restructured that way

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Template-only change, so the proof is the format applied to a real PR body

### Before (`13d94ec546`)

1. PR #36943's original description (first entry in its edit history) stacks two QA runs: one at merge base `423b791ee0` / head `732e23a4f9` and an older author run at `8843766` / `ce66cbc`, interleaved as bold labels and prose
2. Nothing in the template said which run is current or how to structure cases

### After (`269038876b`)

1. https://github.com/BerriAI/litellm/pull/36943 now carries the same evidence as one `### Before` / `### After` pair with four matching `####` case headings each, shared setup above, and a one-line capture note for the odd-hash cache case
2. A fresh PR opened against this branch renders the skeleton inside the Screenshots comment for the author to fill in

## Type

📖 Documentation

## Caveats (if any)

- No CI gate enforces the format; it is guidance for authors
- Older PR bodies are not migrated, only #36943 was restructured

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
