### PR TITLE
feat(ui): add Lite mixed-provider auto-router preset

### DIFF
--- a/ui/litellm-dashboard/src/autorouter_presets.json
+++ b/ui/litellm-dashboard/src/autorouter_presets.json
@@ -31,8 +31,7 @@
         "timeout_ms": 3000,
         "classification_rubric": "agentic"
       },
-      "classifier_context_window_size": 3,
-      "classifier_context_per_turn_chars": 200,
+      "classifier_context_window_size": 0,
       "escalation_keywords": ["LITELLM ESCALATE"],
       "session_affinity": false,
       "deployment_affinity": true

--- a/ui/litellm-dashboard/src/autorouter_presets.json
+++ b/ui/litellm-dashboard/src/autorouter_presets.json
@@ -15,6 +15,29 @@
       "deployment_affinity": true
     }
   },
+  "lite": {
+    "label": "Lite",
+    "description": "Cost-optimized routing across providers: DeepSeek V4 Flash for simple queries, Muse Spark 1.2 for medium, Kimi K3 for complex, Claude Opus 5 for reasoning-heavy requests. An LLM classifier with the agentic rubric assigns tiers.",
+    "complexity_router_config": {
+      "tiers": {
+        "SIMPLE": ["deepseek-v4-flash"],
+        "MEDIUM": ["muse-spark-1.2"],
+        "COMPLEX": ["kimi-k3"],
+        "REASONING": ["claude-opus-5"]
+      },
+      "classifier_type": "llm",
+      "classifier_llm_config": {
+        "model": "deepseek-v4-flash",
+        "timeout_ms": 3000,
+        "classification_rubric": "agentic"
+      },
+      "classifier_context_window_size": 3,
+      "classifier_context_per_turn_chars": 200,
+      "escalation_keywords": ["LITELLM ESCALATE"],
+      "session_affinity": false,
+      "deployment_affinity": true
+    }
+  },
   "openai_family": {
     "label": "OpenAI Family",
     "description": "Routes across the GPT model family: gpt-5.4-nano for simple queries, gpt-5.4-mini for medium, gpt-5.4 for complex, o3 for reasoning-heavy requests.",

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -353,7 +353,7 @@ describe("AddAutoRouterTab", () => {
       (option) => option.querySelector(".font-medium")?.textContent,
     );
 
-    expect(labels).toEqual(["Anthropic Family", "OpenAI Family", "Custom Configuration"]);
+    expect(labels).toEqual(["Anthropic Family", "Lite", "OpenAI Family", "Custom Configuration"]);
   });
 
   describe("routing test", () => {
@@ -673,7 +673,7 @@ describe("AddAutoRouterTab", () => {
       const labels = Array.from(document.querySelectorAll<HTMLElement>(".ant-select-item-option")).map(
         (option) => option.querySelector(".font-medium")?.textContent,
       );
-      expect(labels).toEqual(["Anthropic Family", "OpenAI Family", "Custom Configuration"]);
+      expect(labels).toEqual(["Anthropic Family", "Lite", "OpenAI Family", "Custom Configuration"]);
     });
 
     it.each([

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -60,8 +60,8 @@ describe("autorouter_presets", () => {
       timeout_ms: 3000,
       classification_rubric: "agentic",
     });
-    expect(config.classifier_context_window_size).toBe(3);
-    expect(config.classifier_context_per_turn_chars).toBe(200);
+    expect(config.classifier_context_window_size).toBe(0);
+    expect(config.classifier_context_per_turn_chars).toBeUndefined();
     expect(getRequiredModelsInPreset(lite)).toEqual(
       new Set(["deepseek-v4-flash", "muse-spark-1.2", "kimi-k3", "claude-opus-5"]),
     );

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -18,9 +18,9 @@ import { DEFAULT_ESCALATION_KEYWORDS } from "@/components/add_model/EscalationKe
 const groupsOnly = (models: Iterable<string>) => buildModelAvailability(models, []);
 
 describe("autorouter_presets", () => {
-  it("loads exactly the two model-family presets", () => {
+  it("loads exactly the bundled presets", () => {
     const presets = getAllPresets();
-    expect(presets.map((p) => p.label).sort()).toEqual(["Anthropic Family", "OpenAI Family"]);
+    expect(presets.map((p) => p.label).sort()).toEqual(["Anthropic Family", "Lite", "OpenAI Family"]);
     // Every preset carries all four fields the UI relies on; a JSON typo dropping one fails here.
     for (const p of presets) {
       expect(p).toMatchObject({ key: expect.any(String), label: expect.any(String), description: expect.any(String) });
@@ -33,14 +33,38 @@ describe("autorouter_presets", () => {
     expect(getPresetByKey("does_not_exist")).toBeUndefined();
   });
 
-  it("keeps every preset a plain heuristic complexity router (no adaptive/quality settings)", () => {
+  it("keeps every preset free of adaptive/quality settings", () => {
     for (const { complexity_router_config: config } of getAllPresets()) {
-      expect(config.classifier_type).toBe("heuristic");
       expect(config.adaptive).toBeUndefined();
       expect(config.adaptive_weights).toBeUndefined();
       expect(config.adaptive_eligible).toBeUndefined();
       expect(config.tier_distance_penalty).toBeUndefined();
     }
+  });
+
+  it("keeps the model-family presets on the heuristic classifier", () => {
+    for (const key of ["anthropic_family", "openai_family"]) {
+      expect(getPresetByKey(key)!.complexity_router_config.classifier_type).toBe("heuristic");
+    }
+  });
+
+  // The lite preset ships the LLM classifier with the bundled agentic rubric rather than an inline
+  // system_prompt, so rubric tuning in the backend reaches it without a JSON edit. Its classifier
+  // model doubles as the SIMPLE tier model, so availability gating stays at exactly four models.
+  it("pins the lite preset's LLM classifier config and required models", () => {
+    const lite = getPresetByKey("lite")!;
+    const config = lite.complexity_router_config;
+    expect(config.classifier_type).toBe("llm");
+    expect(config.classifier_llm_config).toEqual({
+      model: "deepseek-v4-flash",
+      timeout_ms: 3000,
+      classification_rubric: "agentic",
+    });
+    expect(config.classifier_context_window_size).toBe(3);
+    expect(config.classifier_context_per_turn_chars).toBe(200);
+    expect(getRequiredModelsInPreset(lite)).toEqual(
+      new Set(["deepseek-v4-flash", "muse-spark-1.2", "kimi-k3", "claude-opus-5"]),
+    );
   });
 
   it("collects every tier model as a required model", () => {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Both bundled auto-router presets are single-provider and heuristic-only
- No preset shows off the LLM classifier or cost arbitrage across providers

How it solves it:

- Adds a "Lite" preset: cheap models per tier, Opus 5 for reasoning
- Uses the LLM classifier with the bundled agentic rubric

## User Flow

Before: an admin wanting mixed-provider cost routing has to hand-build the whole tier config

1. They open http://localhost:4000/ui/?page=models, pick the Add Auto Router tab, and open the template dropdown
2. They see only Anthropic Family, OpenAI Family, and Custom Configuration
3. To route cheap models per tier they pick Custom Configuration and fill in all four tiers, the classifier type, the classifier model, and its timeout by hand

After: the same admin applies one template and submits

1. They open http://localhost:4000/ui/?page=models, pick the Add Auto Router tab, and open the template dropdown
2. A "Lite" option is listed. It is enabled when deepseek-v4-flash, muse-spark-1.2, kimi-k3, and claude-opus-5 are registered, and shows "Missing: ..." naming the absent models otherwise
3. Clicking it prefills the four tiers, the LLM classifier on deepseek-v4-flash with a 3s timeout and the agentic rubric, and no conversation context sent to the classifier (window size 0)
4. They name the router and submit; the created auto-router routes simple traffic to DeepSeek V4 Flash and reasoning traffic to Claude Opus 5

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

UI-only change, so this is the click path to capture (screenshots to follow):

### Before (ae8afec7c1)

1. Run the proxy and UI dev server, open http://localhost:3000/ui/?page=models, Add Auto Router tab
2. Open the template dropdown: only Anthropic Family, OpenAI Family, Custom Configuration

### After (2b4107572b)

1. Register deepseek-v4-flash, muse-spark-1.2, kimi-k3, and claude-opus-5 as models (any provider spelling works, deployment matching resolves them)
2. Open the same dropdown: "Lite" is listed and enabled; with one model missing it shows "Missing: <model>" and is disabled
3. Click Lite: tiers prefill with the four models, classifier shows LLM with deepseek-v4-flash, 3000 ms timeout, agentic rubric
4. Submit and send one simple and one reasoning-heavy request to the new router, then check http://localhost:4000/ui/?page=logs to see them land on deepseek-v4-flash and claude-opus-5 respectively

## Type

🆕 New Feature

## Caveats (if any)

- Preset stays disabled until all four tier models plus classifier are registered

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

