### PR TITLE
test(e2e/ui): assert the log drawer chevrons by their lucide classes

### DIFF
--- a/tests/e2e/ui/tests/logs/logs.spec.ts
+++ b/tests/e2e/ui/tests/logs/logs.spec.ts
@@ -129,17 +129,17 @@ test.describe("Logs page", () => {
     // box, so the wrapper reads as hidden while the clipped text node inside it does not.
     const header = sectionHeader(drawer, "Input");
     const body = header.locator("xpath=following-sibling::div[1]");
-    await expect(header.locator(".anticon-up")).toBeVisible();
+    await expect(header.locator(".lucide-chevron-up")).toBeVisible();
     await expect(body).toBeVisible();
 
     await header.click();
-    await expect(header.locator(".anticon-down")).toBeVisible({
+    await expect(header.locator(".lucide-chevron-down")).toBeVisible({
       timeout: 10_000,
     });
     await expect(body).toBeHidden({ timeout: 10_000 });
 
     await header.click();
-    await expect(header.locator(".anticon-up")).toBeVisible({
+    await expect(header.locator(".lucide-chevron-up")).toBeVisible({
       timeout: 10_000,
     });
     await expect(body).toBeVisible({ timeout: 10_000 });


### PR DESCRIPTION
## TLDR

Problem this solves:

- Logs collapse e2e test fails on every run
- It waits on antd icon classes the drawer no longer renders

How it solves it:

- Assert the lucide chevron classes the drawer renders today
- Three selector changes, no behavior or product code touched

## User Flow

This PR changes only an e2e test, so no end user's flow changes. The flow the test walks is unaffected in both directions:

Before: a proxy admin inspecting a request can already collapse and expand the Input card

1. They open https://litellm-domain/ui/?page=logs and click a request row
2. The details drawer opens showing "Request & Response"
3. They click the Input header and the input body collapses
4. They click it again and the body expands, showing the prompt

After: identical, step for step. The drawer, the header, the chevron and the collapse behavior are all unchanged

1. They open https://litellm-domain/ui/?page=logs and click a request row
2. The details drawer opens showing "Request & Response"
3. They click the Input header and the input body collapses
4. They click it again and the body expands, showing the prompt

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Run against a live proxy on localhost:4000 with the seeded e2e stack (`PROXY_PORT=4000 E2E_KEEP_ALIVE=1 ./tests/e2e/ui/run_e2e.sh`), the same environment CircleCI's `e2e_ui_testing` builds. Both sides ran with `CI=true`, so each failure burns all three attempts exactly as CI does.

### Before (ae8afec7c1)

1. `npx playwright test --config playwright.config.ts -g "the Input card collapses and expands"`
2. Output:

```
Error: expect(locator).toBeVisible() failed
Locator: getByRole('dialog').first().getByText('Input', { exact: true }).locator('../../..').locator('.anticon-up')
Expected: visible
Timeout: 10000ms
Error: element(s) not found

  130 |     const header = sectionHeader(drawer, "Input");
  131 |     const body = header.locator("xpath=following-sibling::div[1]");
> 132 |     await expect(header.locator(".anticon-up")).toBeVisible();
      |                                                 ^

  1 failed
    [chromium] > tests/logs/logs.spec.ts:112:7 > Logs page > the Input card collapses and expands
```

3. Byte-identical to CircleCI 88656 `e2e_ui_testing` at this same commit, where it is the only failure: `1 failed, 2 skipped, 98 passed`

### After (de2b220c36)

1. `npx playwright test --config playwright.config.ts -g "the Input card collapses and expands"`
2. Output:

```
Running 1 test using 1 worker
[1/1] [chromium] > tests/logs/logs.spec.ts:112:7 > Logs page > the Input card collapses and expands
  1 passed (12.7s)
```

3. Full suite on the same stack: `npx playwright test --config playwright.config.ts`

```
Running 101 tests using 1 worker
  1 failed
    [chromium] > tests/usage/usagePage.spec.ts:32:7 > Usage page > Top Virtual Keys lists a key that served traffic, toggles views, and opens key info
  2 skipped
  98 passed (5.8m)
```

4. That remaining failure is local only: the key it creates never reaches the Top Virtual Keys rollup on this machine. It passes in CircleCI 88656 at the merge base, where `logs.spec.ts` was the sole failure, and it fails here identically with and without this change

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

- Suite-wide grep confirms no other `.anticon` selector remains

## QA runbook

- tests/e2e/ui/tests/logs/logs.spec.ts:112 "the Input card collapses and expands" - the Input card in the log details drawer starts expanded with an up chevron, collapses to a down chevron on click, and expands again showing the prompt
  - [ ] Bring the stack up: `PROXY_PORT=4000 E2E_KEEP_ALIVE=1 ./tests/e2e/ui/run_e2e.sh`
  - [ ] Send a chat completion through the proxy so a row exists: `curl -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -d '{"model":"fake-openai-gpt-4","messages":[{"role":"user","content":"qa-collapse-probe"}]}'`
  - [ ] Open http://localhost:4000/ui/?page=logs and click the row for that request
  - [ ] Expect the drawer to show "Request & Response" and the Input header to carry an up chevron with the body visible
  - [ ] Click the Input header and expect the chevron to flip down and the body to collapse
  - [ ] Click it again and expect the up chevron back, the body visible, and `qa-collapse-probe` on screen
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
