### PR TITLE
fix(batches): price a retrieved batch from its deployment's model and rates

### DIFF
--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -48,6 +48,7 @@ async def _handle_completed_batch(
     custom_llm_provider: Literal["openai", "azure", "vertex_ai", "hosted_vllm", "anthropic"],
     model_name: str | None = None,
     litellm_params: dict | None = None,
+    model_info: ModelInfo | None = None,
 ) -> tuple[float, Usage, list[str]]:
     """Fetch a completed batch's output file and aggregate its cost, usage, and
     models in a single pass over the JSONL lines, so the parsed file content is
@@ -58,6 +59,9 @@ async def _handle_completed_batch(
         custom_llm_provider: The LLM provider
         model_name: Optional model name
         litellm_params: Optional litellm parameters containing credentials (api_key, api_base, etc.)
+        model_info: Optional deployment-level model info with custom pricing,
+            threaded through so a deployment's configured rates win over the
+            global cost map.
     """
     file_content = await _fetch_batch_output_file_content(batch, custom_llm_provider, litellm_params=litellm_params)
 
@@ -75,6 +79,7 @@ async def _handle_completed_batch(
         entries=_iter_batch_input_entries(file_content),
         custom_llm_provider=custom_llm_provider,
         model_name=model_name,
+        model_info=model_info,
     )
 
 

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -2160,7 +2160,7 @@ def batch_cost_calculator(
     output_cost_per_token: Final = model_info.get("output_cost_per_token")
     total_prompt_cost = 0.0
     total_completion_cost = 0.0
-    if input_cost_per_token_batches:
+    if input_cost_per_token_batches is not None:
         total_prompt_cost = usage.prompt_tokens * input_cost_per_token_batches
     elif input_cost_per_token:
         details: Final = parse_prompt_tokens_details(usage)
@@ -2180,7 +2180,7 @@ def batch_cost_calculator(
 
         cache_creation_cost: Final = model_info.get("cache_creation_input_token_cost") or input_cost_per_token
         total_prompt_cost += cache_creation_tokens * cache_creation_cost / 2
-    if output_cost_per_token_batches:
+    if output_cost_per_token_batches is not None:
         total_completion_cost = usage.completion_tokens * output_cost_per_token_batches
     elif output_cost_per_token:
         total_completion_cost = (

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -107,6 +107,7 @@ from litellm.types.utils import (
     LiteLLMBatch,
     LiteLLMLoggingBaseClass,
     LiteLLMRealtimeStreamLoggingObject,
+    ModelInfo,
     ModelResponse,
     ModelResponseStream,
     RawRequestTypedDict,
@@ -577,6 +578,20 @@ class Logging(LiteLLMLoggingBaseClass):
             if model_id is not None:
                 return model_id
         return None
+
+    def get_router_deployment_model_info(self) -> ModelInfo | None:
+        """Pricing the router registered under this deployment's model_info.id.
+
+        Returns None when the deployment declares no pricing of its own, so the
+        caller falls back to the global cost map.
+        """
+        model_id: Final = self.get_router_model_id()
+        if model_id is None:
+            return None
+        try:
+            return litellm.get_model_info(model=model_id)
+        except Exception:  # noqa: BLE001  # get_model_info raises for any id with no registered pricing
+            return None
 
     def update_environment_variables(
         self,
@@ -2592,7 +2607,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 ) = await _handle_completed_batch(
                     batch=result,
                     custom_llm_provider=self.custom_llm_provider,
+                    model_name=self.model,
                     litellm_params=self.litellm_params,
+                    model_info=self.get_router_deployment_model_info(),
                 )
 
                 result._hidden_params["response_cost"] = response_cost

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -583,14 +583,26 @@ class Logging(LiteLLMLoggingBaseClass):
         """Pricing the router registered under this deployment's model_info.id.
 
         Returns None when the deployment declares no pricing of its own, so the
-        caller falls back to the global cost map.
+        caller falls back to the global cost map. The raw registration is what
+        decides that: the router registers an entry for every deployment, and
+        get_model_info fills absent costs with 0, so asking it directly cannot
+        tell "configured as free" apart from "no pricing configured".
         """
+        pricing_keys: Final = (
+            "input_cost_per_token",
+            "output_cost_per_token",
+            "input_cost_per_token_batches",
+            "output_cost_per_token_batches",
+        )
         model_id: Final = self.get_router_model_id()
         if model_id is None:
             return None
+        registered: Final = litellm.model_cost.get(model_id)
+        if not isinstance(registered, dict) or not any(registered.get(key) is not None for key in pricing_keys):
+            return None
         try:
             return litellm.get_model_info(model=model_id)
-        except Exception:  # noqa: BLE001  # get_model_info raises for any id with no registered pricing
+        except Exception:  # noqa: BLE001  # get_model_info raises for ids it cannot resolve a provider for
             return None
 
     def update_environment_variables(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -610,8 +610,11 @@ class Logging(LiteLLMLoggingBaseClass):
         decides that: the router registers an entry for every deployment, and
         get_model_info fills absent costs with 0, so asking it directly cannot
         tell "configured as free" apart from "no pricing configured". A deployment
-        may declare only one side of its pricing, so a rate it leaves unset keeps
-        the model's published value instead of billing as zero.
+        may declare only one side of its pricing, so the side it leaves out keeps
+        the model's published rates instead of billing as zero. Ownership is per
+        token direction: declaring either rate for a direction takes that whole
+        direction, so a published batch rate can never displace a standard rate
+        the deployment configured itself.
         """
         model_id: Final = self.get_router_model_id()
         if model_id is None:
@@ -628,13 +631,19 @@ class Logging(LiteLLMLoggingBaseClass):
         published: Final = self._published_model_info()
         if published is None:
             return merged
-        if registered.get("input_cost_per_token") is None:
+        declares_input: Final = (
+            registered.get("input_cost_per_token") is not None
+            or registered.get("input_cost_per_token_batches") is not None
+        )
+        declares_output: Final = (
+            registered.get("output_cost_per_token") is not None
+            or registered.get("output_cost_per_token_batches") is not None
+        )
+        if not declares_input:
             merged["input_cost_per_token"] = published.get("input_cost_per_token")
-        if registered.get("output_cost_per_token") is None:
-            merged["output_cost_per_token"] = published.get("output_cost_per_token")
-        if registered.get("input_cost_per_token_batches") is None:
             merged["input_cost_per_token_batches"] = published.get("input_cost_per_token_batches")
-        if registered.get("output_cost_per_token_batches") is None:
+        if not declares_output:
+            merged["output_cost_per_token"] = published.get("output_cost_per_token")
             merged["output_cost_per_token_batches"] = published.get("output_cost_per_token_batches")
         return merged
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -582,13 +582,17 @@ class Logging(LiteLLMLoggingBaseClass):
     def get_deployment_model_for_cost(self) -> str | None:
         """The provider-qualified model to price against.
 
-        self.model can be the router's model_group alias, which no cost map
-        resolves, so the deployment's own litellm_params model wins when present.
+        On a batch retrieve both self.model and litellm_params["model"] can be
+        unset, and self.model can otherwise carry the router's model_group alias,
+        which no cost map resolves. model_call_details holds the deployment's own
+        provider-qualified model, so it is preferred.
         """
-        deployment_model: Final = self.litellm_params.get("model") if hasattr(self, "litellm_params") else None
-        if isinstance(deployment_model, str) and deployment_model:
-            return deployment_model
-        return self.model
+        candidates: Final = (
+            (self.model_call_details or {}).get("model") if hasattr(self, "model_call_details") else None,
+            self.litellm_params.get("model") if hasattr(self, "litellm_params") else None,
+            self.model,
+        )
+        return next((candidate for candidate in candidates if isinstance(candidate, str) and candidate), None)
 
     def get_router_deployment_model_info(self) -> ModelInfo | None:
         """Pricing the router registered under this deployment's model_info.id.

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -579,6 +579,17 @@ class Logging(LiteLLMLoggingBaseClass):
                 return model_id
         return None
 
+    def get_deployment_model_for_cost(self) -> str | None:
+        """The provider-qualified model to price against.
+
+        self.model can be the router's model_group alias, which no cost map
+        resolves, so the deployment's own litellm_params model wins when present.
+        """
+        deployment_model: Final = self.litellm_params.get("model") if hasattr(self, "litellm_params") else None
+        if isinstance(deployment_model, str) and deployment_model:
+            return deployment_model
+        return self.model
+
     def get_router_deployment_model_info(self) -> ModelInfo | None:
         """Pricing the router registered under this deployment's model_info.id.
 
@@ -2619,7 +2630,7 @@ class Logging(LiteLLMLoggingBaseClass):
                 ) = await _handle_completed_batch(
                     batch=result,
                     custom_llm_provider=self.custom_llm_provider,
-                    model_name=self.model,
+                    model_name=self.get_deployment_model_for_cost(),
                     litellm_params=self.litellm_params,
                     model_info=self.get_router_deployment_model_info(),
                 )

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -307,6 +307,14 @@ def _get_cached_prometheus_logger():
     return _PrometheusLogger
 
 
+_DEPLOYMENT_PRICING_KEYS: Final = (
+    "input_cost_per_token",
+    "output_cost_per_token",
+    "input_cost_per_token_batches",
+    "output_cost_per_token_batches",
+)
+
+
 class Logging(LiteLLMLoggingBaseClass):
     global \
         supabaseClient, \
@@ -601,23 +609,43 @@ class Logging(LiteLLMLoggingBaseClass):
         caller falls back to the global cost map. The raw registration is what
         decides that: the router registers an entry for every deployment, and
         get_model_info fills absent costs with 0, so asking it directly cannot
-        tell "configured as free" apart from "no pricing configured".
+        tell "configured as free" apart from "no pricing configured". A deployment
+        may declare only one side of its pricing, so a rate it leaves unset keeps
+        the model's published value instead of billing as zero.
         """
-        pricing_keys: Final = (
-            "input_cost_per_token",
-            "output_cost_per_token",
-            "input_cost_per_token_batches",
-            "output_cost_per_token_batches",
-        )
         model_id: Final = self.get_router_model_id()
         if model_id is None:
             return None
         registered: Final = litellm.model_cost.get(model_id)
-        if not isinstance(registered, dict) or not any(registered.get(key) is not None for key in pricing_keys):
+        if not isinstance(registered, dict) or not any(
+            registered.get(key) is not None for key in _DEPLOYMENT_PRICING_KEYS
+        ):
             return None
         try:
-            return litellm.get_model_info(model=model_id)
+            merged: Final = litellm.get_model_info(model=model_id)
         except Exception:  # noqa: BLE001  # get_model_info raises for ids it cannot resolve a provider for
+            return None
+        published: Final = self._published_model_info()
+        if published is None:
+            return merged
+        if registered.get("input_cost_per_token") is None:
+            merged["input_cost_per_token"] = published.get("input_cost_per_token")
+        if registered.get("output_cost_per_token") is None:
+            merged["output_cost_per_token"] = published.get("output_cost_per_token")
+        if registered.get("input_cost_per_token_batches") is None:
+            merged["input_cost_per_token_batches"] = published.get("input_cost_per_token_batches")
+        if registered.get("output_cost_per_token_batches") is None:
+            merged["output_cost_per_token_batches"] = published.get("output_cost_per_token_batches")
+        return merged
+
+    def _published_model_info(self) -> ModelInfo | None:
+        """The cost map's own entry for this deployment's model, when it resolves."""
+        deployment_model: Final = self.get_deployment_model_for_cost()
+        if deployment_model is None:
+            return None
+        try:
+            return litellm.get_model_info(model=deployment_model)
+        except Exception:  # noqa: BLE001  # no published entry to layer the declared rates over
             return None
 
     def update_environment_variables(

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -1303,17 +1303,10 @@ async def test_output_file_content_bedrock_reads_with_deployment_aws_credentials
 
 # =========================================================================== #
 # _handle_completed_batch threads the deployment's model identity + pricing
-#
-# Regression: the retrieve path called _handle_completed_batch with neither
-# model_name nor model_info. For bedrock that left cost_model falling back to
-# the provider's own response model ("claude-sonnet-4-6"), which does not
-# resolve under custom_llm_provider="bedrock", so cost silently became $0 while
-# usage stayed correct. Dropping model_info separately discarded a deployment's
-# configured rates, billing a zero-cost deployment at the public rate.
 # =========================================================================== #
 
 
-def _bedrock_row(model, input_tokens, output_tokens):
+def _bedrock_row(model: str, input_tokens: int, output_tokens: int) -> dict[str, object]:
     return {
         "modelInput": {"messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]},
         "modelOutput": {
@@ -1335,11 +1328,11 @@ def _bedrock_row(model, input_tokens, output_tokens):
 
 
 @pytest.mark.asyncio
-async def test_handle_completed_bedrock_batch_prices_from_deployment_model(monkeypatch):
+async def test_handle_completed_bedrock_batch_prices_from_deployment_model(monkeypatch) -> None:
     """A bedrock batch must price from the deployment model, not the response model."""
     rows = [_bedrock_row("claude-sonnet-4-6", 18, 10)] * 100
 
-    async def fake_fetch(batch, custom_llm_provider, litellm_params=None):
+    async def fake_fetch(batch: object, custom_llm_provider: str, litellm_params: dict | None = None) -> bytes:
         return _vertex_jsonl(rows)
 
     monkeypatch.setattr(bu, "_fetch_batch_output_file_content", fake_fetch)
@@ -1365,11 +1358,11 @@ async def test_handle_completed_bedrock_batch_prices_from_deployment_model(monke
 
 
 @pytest.mark.asyncio
-async def test_handle_completed_batch_honors_deployment_pricing(monkeypatch):
+async def test_handle_completed_batch_honors_deployment_pricing(monkeypatch) -> None:
     """A deployment's configured rates must win over the global cost map."""
     rows = [_success_row(model="gemini-2.5-flash", usage=_usage(60, 75))]
 
-    async def fake_fetch(batch, custom_llm_provider, litellm_params=None):
+    async def fake_fetch(batch: object, custom_llm_provider: str, litellm_params: dict | None = None) -> bytes:
         return _vertex_jsonl(rows)
 
     monkeypatch.setattr(bu, "_fetch_batch_output_file_content", fake_fetch)

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -1299,3 +1299,98 @@ async def test_output_file_content_bedrock_reads_with_deployment_aws_credentials
     assert captured["aws_region_name"] == "us-west-2"
     assert captured["_litellm_internal_model_credentials"] is snapshot
     assert "model" not in captured
+
+
+# =========================================================================== #
+# _handle_completed_batch threads the deployment's model identity + pricing
+#
+# Regression: the retrieve path called _handle_completed_batch with neither
+# model_name nor model_info. For bedrock that left cost_model falling back to
+# the provider's own response model ("claude-sonnet-4-6"), which does not
+# resolve under custom_llm_provider="bedrock", so cost silently became $0 while
+# usage stayed correct. Dropping model_info separately discarded a deployment's
+# configured rates, billing a zero-cost deployment at the public rate.
+# =========================================================================== #
+
+
+def _bedrock_row(model, input_tokens, output_tokens):
+    return {
+        "modelInput": {"messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]},
+        "modelOutput": {
+            "model": model,
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "ok"}],
+            "stop_reason": "end_turn",
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+        },
+        "recordId": "r",
+    }
+
+
+@pytest.mark.asyncio
+async def test_handle_completed_bedrock_batch_prices_from_deployment_model(monkeypatch):
+    """A bedrock batch must price from the deployment model, not the response model."""
+    rows = [_bedrock_row("claude-sonnet-4-6", 18, 10)] * 100
+
+    async def fake_fetch(batch, custom_llm_provider, litellm_params=None):
+        return _vertex_jsonl(rows)
+
+    monkeypatch.setattr(bu, "_fetch_batch_output_file_content", fake_fetch)
+
+    cost, usage, _ = await bu._handle_completed_batch(
+        _batch("of"),
+        custom_llm_provider="bedrock",
+        model_name="bedrock/global.anthropic.claude-sonnet-4-6",
+    )
+
+    assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (1800, 1000, 2800)
+    # 3e-06 / 1.5e-05 on-demand, halved for batch.
+    assert cost == pytest.approx(1800 * 3e-06 / 2 + 1000 * 1.5e-05 / 2)
+
+    # The response model alone cannot price a bedrock batch: this is the $0 bug.
+    zero_cost, zero_usage, _ = await bu._handle_completed_batch(
+        _batch("of"),
+        custom_llm_provider="bedrock",
+        model_name=None,
+    )
+    assert zero_cost == 0.0
+    assert zero_usage.total_tokens == 2800
+
+
+@pytest.mark.asyncio
+async def test_handle_completed_batch_honors_deployment_pricing(monkeypatch):
+    """A deployment's configured rates must win over the global cost map."""
+    rows = [_success_row(model="gemini-2.5-flash", usage=_usage(60, 75))]
+
+    async def fake_fetch(batch, custom_llm_provider, litellm_params=None):
+        return _vertex_jsonl(rows)
+
+    monkeypatch.setattr(bu, "_fetch_batch_output_file_content", fake_fetch)
+
+    free_cost, _, _ = await bu._handle_completed_batch(
+        _batch("of"),
+        custom_llm_provider="vertex_ai",
+        model_name="vertex_ai/gemini-2.5-flash",
+        model_info={
+            "input_cost_per_token": 0.0,
+            "output_cost_per_token": 0.0,
+            "input_cost_per_token_batches": 0.0,
+            "output_cost_per_token_batches": 0.0,
+        },
+    )
+    assert free_cost == 0.0
+
+    billed_cost, _, _ = await bu._handle_completed_batch(
+        _batch("of"),
+        custom_llm_provider="vertex_ai",
+        model_name="vertex_ai/gemini-2.5-flash",
+        model_info=None,
+    )
+    assert billed_cost > 0.0

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -437,6 +437,19 @@ class TestGetRouterDeploymentModelInfo:
         finally:
             litellm.model_cost.pop(deployment_id, None)
 
+    def test_returns_none_when_the_deployment_id_resolves_no_provider(self, logging_obj) -> None:
+        """A registration whose id get_model_info cannot resolve yields no pricing."""
+        deployment_id = "deploy-unresolvable-provider-1"
+        litellm.model_cost[deployment_id] = {"id": deployment_id, "input_cost_per_token": 4e-06}
+        logging_obj.litellm_params = {"litellm_metadata": {"model_info": {"id": deployment_id}}}
+        logging_obj.model_call_details["model"] = None
+        logging_obj.model = None
+        try:
+            with patch.object(litellm, "get_model_info", side_effect=Exception("unresolvable")):
+                assert logging_obj.get_router_deployment_model_info() is None
+        finally:
+            litellm.model_cost.pop(deployment_id, None)
+
     def test_falls_back_to_declared_rates_when_the_model_has_no_published_entry(self, logging_obj) -> None:
         """With no published entry to layer under, the declared rates still apply."""
         deployment_id = "deploy-unpublished-model-1"

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -437,6 +437,28 @@ class TestGetRouterDeploymentModelInfo:
         finally:
             litellm.model_cost.pop(deployment_id, None)
 
+    def test_keeps_declared_rates_when_no_model_is_resolvable(self, logging_obj) -> None:
+        """With no model to look a published entry up by, the declared rates stand alone."""
+        deployment_id = "deploy-no-model-at-all-1"
+        litellm.model_cost[deployment_id] = {
+            "id": deployment_id,
+            "input_cost_per_token": 9e-06,
+            "output_cost_per_token": 2e-05,
+            "litellm_provider": "bedrock",
+            "mode": "chat",
+        }
+        logging_obj.litellm_params = {"litellm_metadata": {"model_info": {"id": deployment_id}}}
+        logging_obj.model_call_details["model"] = None
+        logging_obj.model = None
+        try:
+            assert logging_obj.get_deployment_model_for_cost() is None
+            info = logging_obj.get_router_deployment_model_info()
+            assert info is not None
+            assert info["input_cost_per_token"] == 9e-06
+            assert info["output_cost_per_token"] == 2e-05
+        finally:
+            litellm.model_cost.pop(deployment_id, None)
+
     def test_returns_none_when_the_deployment_id_resolves_no_provider(self, logging_obj) -> None:
         """A registration whose id get_model_info cannot resolve yields no pricing."""
         deployment_id = "deploy-unresolvable-provider-1"

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import sys
 import asyncio
@@ -338,6 +339,102 @@ class TestGetRouterModelId:
         )
         # litellm_params exists but is empty by default
         assert obj.get_router_model_id() is None
+
+
+class TestGetRouterDeploymentModelInfo:
+    """Pricing a deployment registered under its own model_info.id."""
+
+    def test_returns_registered_deployment_pricing(self, logging_obj):
+        deployment_id = "deploy-zero-cost-1"
+        litellm.model_cost[deployment_id] = {
+            "input_cost_per_token": 0.0,
+            "output_cost_per_token": 0.0,
+            "input_cost_per_token_batches": 0.0,
+            "output_cost_per_token_batches": 0.0,
+            "litellm_provider": "vertex_ai",
+            "mode": "chat",
+        }
+        logging_obj.litellm_params = {"litellm_metadata": {"model_info": {"id": deployment_id}}}
+        try:
+            info = logging_obj.get_router_deployment_model_info()
+            assert info is not None
+            assert info["input_cost_per_token"] == 0.0
+            assert info["output_cost_per_token_batches"] == 0.0
+        finally:
+            litellm.model_cost.pop(deployment_id, None)
+
+    def test_returns_none_for_unregistered_deployment(self, logging_obj):
+        logging_obj.litellm_params = {"litellm_metadata": {"model_info": {"id": "deploy-never-registered"}}}
+        assert logging_obj.get_router_deployment_model_info() is None
+
+    def test_returns_none_without_a_deployment_id(self, logging_obj):
+        logging_obj.litellm_params = {"api_base": ""}
+        assert logging_obj.get_router_deployment_model_info() is None
+
+
+class TestRetrieveBatchCostPassesModelIdentity:
+    """Regression: retrieving a batch priced it with no model identity at all.
+
+    _handle_completed_batch was called without model_name or model_info, so a
+    bedrock batch fell back to the provider's own response model (unresolvable
+    under custom_llm_provider="bedrock") and silently cost $0, and a deployment's
+    configured rates were ignored entirely.
+    """
+
+    @pytest.mark.asyncio
+    async def test_forwards_deployment_model_and_pricing(self, monkeypatch):
+        from litellm.litellm_core_utils import litellm_logging as logging_module
+        from litellm.types.utils import LiteLLMBatch, Usage
+
+        deployment_id = "deploy-batch-pricing-1"
+        litellm.model_cost[deployment_id] = {
+            "input_cost_per_token": 0.0,
+            "output_cost_per_token": 0.0,
+            "litellm_provider": "bedrock",
+            "mode": "chat",
+        }
+
+        captured: dict = {}
+
+        async def fake_handle_completed_batch(**kwargs):
+            captured.update(kwargs)
+            return 1.25, Usage(prompt_tokens=1800, completion_tokens=1000, total_tokens=2800), ["m"]
+
+        monkeypatch.setattr(logging_module, "_handle_completed_batch", fake_handle_completed_batch)
+
+        obj = LitellmLogging(
+            model="bedrock/global.anthropic.claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "Hey"}],
+            stream=False,
+            call_type="aretrieve_batch",
+            start_time=time.time(),
+            litellm_call_id="batch-call-1",
+            function_id="f",
+        )
+        obj.custom_llm_provider = "bedrock"
+        obj.litellm_params = {"litellm_metadata": {"model_info": {"id": deployment_id}}}
+
+        batch = LiteLLMBatch(
+            id="batch_abc",
+            completion_window="24h",
+            created_at=1,
+            endpoint="/v1/chat/completions",
+            input_file_id="file-in",
+            object="batch",
+            status="completed",
+            output_file_id="file-out",
+        )
+
+        try:
+            with contextlib.suppress(Exception):
+                await obj._async_success_handler_body(result=batch, start_time=None, end_time=None)
+        finally:
+            litellm.model_cost.pop(deployment_id, None)
+
+        assert captured, "_handle_completed_batch was never called"
+        assert captured["model_name"] == "bedrock/global.anthropic.claude-sonnet-4-6"
+        assert captured["model_info"] is not None
+        assert captured["model_info"]["input_cost_per_token"] == 0.0
 
 
 class TestAnthropicPassthroughCustomPricing:

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -367,6 +367,24 @@ class TestGetRouterDeploymentModelInfo:
         logging_obj.litellm_params = {"litellm_metadata": {"model_info": {"id": "deploy-never-registered"}}}
         assert logging_obj.get_router_deployment_model_info() is None
 
+    def test_returns_none_when_deployment_registered_without_pricing(self, logging_obj):
+        """The router registers an entry for EVERY deployment, priced or not.
+
+        get_model_info fills absent costs with 0, so consulting it directly would
+        hand back free pricing for an ordinary deployment and bill its batches $0.
+        """
+        deployment_id = "deploy-no-pricing-1"
+        litellm.register_model(
+            model_cost={deployment_id: {"id": deployment_id, "access_groups": ["x"]}},
+            persist_across_reloads=False,
+        )
+        logging_obj.litellm_params = {"litellm_metadata": {"model_info": {"id": deployment_id}}}
+        try:
+            assert litellm.get_model_info(model=deployment_id)["input_cost_per_token"] == 0
+            assert logging_obj.get_router_deployment_model_info() is None
+        finally:
+            litellm.model_cost.pop(deployment_id, None)
+
     def test_returns_none_without_a_deployment_id(self, logging_obj):
         logging_obj.litellm_params = {"api_base": ""}
         assert logging_obj.get_router_deployment_model_info() is None

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -344,7 +344,7 @@ class TestGetRouterModelId:
 class TestGetRouterDeploymentModelInfo:
     """Pricing a deployment registered under its own model_info.id."""
 
-    def test_returns_registered_deployment_pricing(self, logging_obj):
+    def test_returns_registered_deployment_pricing(self, logging_obj) -> None:
         deployment_id = "deploy-zero-cost-1"
         litellm.model_cost[deployment_id] = {
             "input_cost_per_token": 0.0,
@@ -363,11 +363,11 @@ class TestGetRouterDeploymentModelInfo:
         finally:
             litellm.model_cost.pop(deployment_id, None)
 
-    def test_returns_none_for_unregistered_deployment(self, logging_obj):
+    def test_returns_none_for_unregistered_deployment(self, logging_obj) -> None:
         logging_obj.litellm_params = {"litellm_metadata": {"model_info": {"id": "deploy-never-registered"}}}
         assert logging_obj.get_router_deployment_model_info() is None
 
-    def test_returns_none_when_deployment_registered_without_pricing(self, logging_obj):
+    def test_returns_none_when_deployment_registered_without_pricing(self, logging_obj) -> None:
         """The router registers an entry for EVERY deployment, priced or not.
 
         get_model_info fills absent costs with 0, so consulting it directly would
@@ -385,9 +385,73 @@ class TestGetRouterDeploymentModelInfo:
         finally:
             litellm.model_cost.pop(deployment_id, None)
 
-    def test_returns_none_without_a_deployment_id(self, logging_obj):
+    def test_returns_none_without_a_deployment_id(self, logging_obj) -> None:
         logging_obj.litellm_params = {"api_base": ""}
         assert logging_obj.get_router_deployment_model_info() is None
+
+    @pytest.mark.parametrize(
+        "declared,expected_input,expected_output",
+        [
+            ({"input_cost_per_token": 1e-06}, 1e-06, 1.5e-05),
+            ({"output_cost_per_token": 5e-06}, 3e-06, 5e-06),
+            ({"input_cost_per_token": 0.0, "output_cost_per_token": 0.0}, 0.0, 0.0),
+        ],
+        ids=["input-only", "output-only", "both-zero"],
+    )
+    def test_one_sided_override_keeps_the_published_rate_for_the_other_side(
+        self,
+        declared: dict[str, float],
+        expected_input: float,
+        expected_output: float,
+    ) -> None:
+        """A deployment may configure one direction only.
+
+        Substituting its pricing wholesale billed the direction it left unset at
+        zero, because get_model_info fills an absent cost with 0 and that
+        suppressed the global fallback.
+        """
+        from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+        model = "bedrock/global.anthropic.claude-sonnet-4-6"
+        published = litellm.get_model_info(model=model)
+        assert (published["input_cost_per_token"], published["output_cost_per_token"]) == (3e-06, 1.5e-05)
+
+        deployment_id = f"deploy-one-sided-{'-'.join(sorted(declared))}"
+        litellm.model_cost[deployment_id] = {"id": deployment_id, **declared}
+        obj = LiteLLMLoggingObj(
+            model=model,
+            messages=[],
+            stream=False,
+            call_type="aretrieve_batch",
+            start_time=time.time(),
+            litellm_call_id="one-sided",
+            function_id="f",
+        )
+        obj.litellm_params = {"litellm_metadata": {"model_info": {"id": deployment_id}}, "model": model}
+        obj.model_call_details["model"] = model
+        try:
+            info = obj.get_router_deployment_model_info()
+            assert info is not None
+            assert info["input_cost_per_token"] == expected_input
+            assert info["output_cost_per_token"] == expected_output
+        finally:
+            litellm.model_cost.pop(deployment_id, None)
+
+    def test_falls_back_to_declared_rates_when_the_model_has_no_published_entry(self, logging_obj) -> None:
+        """With no published entry to layer under, the declared rates still apply."""
+        deployment_id = "deploy-unpublished-model-1"
+        litellm.model_cost[deployment_id] = {"id": deployment_id, "input_cost_per_token": 7e-06}
+        logging_obj.litellm_params = {
+            "litellm_metadata": {"model_info": {"id": deployment_id}},
+            "model": "not-a-real-provider/not-a-real-model-xyz",
+        }
+        logging_obj.model_call_details["model"] = "not-a-real-provider/not-a-real-model-xyz"
+        try:
+            info = logging_obj.get_router_deployment_model_info()
+            assert info is not None
+            assert info["input_cost_per_token"] == 7e-06
+        finally:
+            litellm.model_cost.pop(deployment_id, None)
 
 
 class TestRetrieveBatchCostPassesModelIdentity:
@@ -400,7 +464,7 @@ class TestRetrieveBatchCostPassesModelIdentity:
     """
 
     @pytest.mark.asyncio
-    async def test_forwards_deployment_model_and_pricing(self, monkeypatch):
+    async def test_forwards_deployment_model_and_pricing(self, monkeypatch) -> None:
         from litellm.litellm_core_utils import litellm_logging as logging_module
         from litellm.types.utils import LiteLLMBatch, Usage
 
@@ -412,9 +476,9 @@ class TestRetrieveBatchCostPassesModelIdentity:
             "mode": "chat",
         }
 
-        captured: dict = {}
+        captured: dict[str, object] = {}
 
-        async def fake_handle_completed_batch(**kwargs):
+        async def fake_handle_completed_batch(**kwargs: object) -> tuple[float, Usage, list[str]]:
             captured.update(kwargs)
             return 1.25, Usage(prompt_tokens=1800, completion_tokens=1000, total_tokens=2800), ["m"]
 

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -437,6 +437,47 @@ class TestGetRouterDeploymentModelInfo:
         finally:
             litellm.model_cost.pop(deployment_id, None)
 
+    def test_a_published_batch_rate_never_displaces_a_declared_standard_rate(self) -> None:
+        """Ownership is per token direction, not per field.
+
+        Filling the batch field from the published entry let that rate win, so a
+        deployment configuring only its standard rate had batches billed at the
+        published batch price instead of half the rate it configured.
+        """
+        from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+        model = "ft:gpt-3.5-turbo"
+        published = litellm.get_model_info(model=model)
+        assert published["input_cost_per_token_batches"] is not None
+
+        deployment_id = "deploy-standard-input-only-1"
+        litellm.model_cost[deployment_id] = {
+            "id": deployment_id,
+            "input_cost_per_token": 1e-06,
+            "litellm_provider": "openai",
+            "mode": "chat",
+        }
+        obj = LiteLLMLoggingObj(
+            model=model,
+            messages=[],
+            stream=False,
+            call_type="aretrieve_batch",
+            start_time=time.time(),
+            litellm_call_id="direction-ownership",
+            function_id="f",
+        )
+        obj.litellm_params = {"litellm_metadata": {"model_info": {"id": deployment_id}}, "model": model}
+        obj.model_call_details["model"] = model
+        try:
+            info = obj.get_router_deployment_model_info()
+            assert info is not None
+            assert info["input_cost_per_token"] == 1e-06
+            assert info["input_cost_per_token_batches"] is None
+            assert info["output_cost_per_token"] == published["output_cost_per_token"]
+            assert info["output_cost_per_token_batches"] == published["output_cost_per_token_batches"]
+        finally:
+            litellm.model_cost.pop(deployment_id, None)
+
     def test_keeps_declared_rates_when_no_model_is_resolvable(self, logging_obj) -> None:
         """With no model to look a published entry up by, the declared rates stand alone."""
         deployment_id = "deploy-no-model-at-all-1"

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3595,6 +3595,43 @@ def test_batch_cost_calculator_cache_creation_falls_back_to_input_rate():
     assert prompt_cost == pytest.approx((1000 * 3e-6 + 8000 * 3e-7 + 2000 * 3e-6) / 2)
 
 
+@pytest.mark.parametrize(
+    "batch_rate,expected_prompt,expected_completion",
+    [
+        (0.0, 0.0, 0.0),
+        (1e-6, 1000 * 1e-6, 500 * 1e-6),
+        (None, 1000 * 3e-6 / 2, 500 * 15e-6 / 2),
+    ],
+    ids=["explicit-zero", "explicit-nonzero", "unset"],
+)
+def test_batch_cost_calculator_honors_an_explicitly_zero_batch_rate(
+    batch_rate: float | None,
+    expected_prompt: float,
+    expected_completion: float,
+) -> None:
+    """A batch rate configured as 0.0 means free, not unset.
+
+    Gating the batch fields on truthiness read an explicit 0.0 as absent and
+    charged half the standard rate for that token direction instead.
+    """
+    from litellm.cost_calculator import batch_cost_calculator
+
+    model_info: dict[str, float] = {"input_cost_per_token": 3e-6, "output_cost_per_token": 15e-6}
+    if batch_rate is not None:
+        model_info["input_cost_per_token_batches"] = batch_rate
+        model_info["output_cost_per_token_batches"] = batch_rate
+
+    prompt_cost, completion_cost_value = batch_cost_calculator(
+        usage=Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500),
+        model="claude-sonnet-4-5-20250929",
+        custom_llm_provider="anthropic",
+        model_info=model_info,  # type: ignore[arg-type]
+    )
+
+    assert prompt_cost == pytest.approx(expected_prompt)
+    assert completion_cost_value == pytest.approx(expected_completion)
+
+
 def test_combine_usage_objects_sums_mirrored_cache_write_fields_once():
     """
     cache_write_tokens and cache_creation_tokens mirror each other on


### PR DESCRIPTION
## TLDR

Problem this solves:

- Retrieving a batch prices it with no model identity
- Bedrock batches silently cost $0 with correct tokens
- A deployment's own configured rates are ignored
- A zero-cost deployment gets billed the public rate

How it solves it:

- Price against the deployment's own provider-qualified model
- Honor rates the deployment actually declares

## User Flow

Before: a team running Bedrock batch jobs sees every completed batch land in their spend logs with real token counts but $0.00 spend, so chargeback under-reports

1. They upload a JSONL file with POST https://litellm-domain/v1/files (`purpose: batch`, `target_model_names: claude-sonnet-4-6`) and get back a gateway file id
2. They send POST https://litellm-domain/v1/batches with that `input_file_id` and get back a batch id with `status: validating`
3. They poll GET https://litellm-domain/v1/batches/{batch_id} until it returns `status: completed`
4. They open https://litellm-domain/ui/?page=logs and find the batch's entry showing 1800 prompt and 1000 completion tokens against $0.00 spend
5. A team whose gateway administrator configured a zero-cost deployment sees the opposite: their batch is billed at the model's public rate even though their deployment is configured to cost nothing

After: the same batch reports the spend those tokens actually cost, and a zero-cost deployment stays at zero

1. They upload the same JSONL file with POST https://litellm-domain/v1/files and get back a gateway file id
2. They send the same POST https://litellm-domain/v1/batches and get back a batch id with `status: validating`
3. They poll GET https://litellm-domain/v1/batches/{batch_id} until it returns `status: completed`
4. https://litellm-domain/ui/?page=logs now shows the same 1800 and 1000 tokens against $0.0102, matching the model's published batch rate
5. The zero-cost deployment's batch shows $0.00, because the rate configured on that deployment is the one applied

## Relevant issues

Follows #36876 and #37050, which made a batch cost row reach the spend logs at all. With rows now landing, their amounts became auditable, which is how this surfaced

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup. A proxy runs against real Bedrock and Vertex with 23 batch-enabled deployments: five Bedrock Anthropic models, nine standard Vertex models, and nine Vertex deployments configured to cost nothing. Batch polling is off so the retrieve path is the only accountant, which is the path this PR changes. `LITELLM_LOCAL_MODEL_COST_MAP=True`, matching how these deployments run. One real batch per deployment was submitted and left to complete, then every batch was retrieved over HTTP and the resulting spend rows read back from the database. The same 23 batches are used on both sides, with the rows cleared and each batch's stored state rewound between runs so both runs price the same provider output

### Before (973329e986)

#### Bedrock Anthropic

1. `GET /v1/batches/{id}` for each of the five, then read the rows

```
claude-opus-4-5     spend=0   total_tokens=2800
claude-opus-4-6     spend=0   total_tokens=2800
claude-sonnet-4-5   spend=0   total_tokens=2800
claude-sonnet-4-6   spend=0   total_tokens=2800
```

2. Usage is correct and spend is zero, so nothing in usage reporting reveals it

#### Standard Vertex

1. Same retrieve for the nine standard deployments

```
gemini-2.5-flash        0.00010025    133
gemini-2.5-pro          0.0004025     133
gemini-3.1-pro-preview  0.000516      136
gemini-3.7-flash        0.0001575     132
```

2. These are already correct, and must stay correct

#### Zero-cost deployments

1. Same retrieve for the nine deployments configured with zero rates

```
zero-cost gemini-2.5-flash       0.00010025    133
zero-cost gemini-2.5-pro         0.0003975     132
zero-cost gemini-3.1-pro-preview 0.000522      137
zero-cost gemini-3.7-flash       0.00016125    134
```

2. Every one is billed at the public rate, ignoring the rates configured on the deployment

### After (d86c0bdcbd)

#### Bedrock Anthropic

1. `GET /v1/batches/{id}` for each of the five, then read the rows

```
claude-haiku-4-5    spend=0.0034    total_tokens=2800
claude-opus-4-5     spend=0.017     total_tokens=2800
claude-opus-4-6     spend=0.017     total_tokens=2800
claude-sonnet-4-5   spend=0.0102    total_tokens=2800
claude-sonnet-4-6   spend=0.0102    total_tokens=2800
```

2. Each equals that model's published rate applied to 1800 prompt and 1000 completion tokens and halved for batch: Haiku 4.5 at $1/$5 per million gives $0.0034, Sonnet at $3/$15 gives $0.0102, Opus at $5/$25 gives $0.017

#### Standard Vertex

1. Same retrieve for the nine standard deployments

```
gemini-2.5-flash        0.00010025    133
gemini-2.5-pro          0.0004025     133
gemini-3.1-pro-preview  0.000516      136
gemini-3.7-flash        0.0001575     132
```

2. Byte-for-byte identical to Before, so standard pricing is untouched

#### Zero-cost deployments

1. Same retrieve for the nine zero-rate deployments

```
zero-cost gemini-2.5-flash       0   133
zero-cost gemini-2.5-pro         0   132
zero-cost gemini-3.1-pro-preview 0   137
zero-cost gemini-3.7-flash       0   134
```

2. All nine now cost nothing while still reporting real token counts, so the configured rates are the ones applied

Across all 23 batches every row carries token counts that reconcile against the provider's own output file, 23 of 23 price as expected, and no batch produced more than one row

## Type

🐛 Bug Fix

## Changes

Retrieving a completed batch computed its cost with no model identity: the call that aggregates a batch's output passed neither the deployment's model nor its pricing

For Bedrock that mattered because the cost model then fell back to the provider's own response model, a bare name like `claude-opus-4-5-20251101`, which does not resolve under a bedrock provider prefix. The lookup missed, and a missed lookup returns zero rather than raising, so cost became $0 while usage stayed correct

Dropping the deployment's model info mattered independently: rates configured on a deployment are registered by the router under that deployment's id, and never consulting them meant a deployment configured to cost nothing was billed from the global map instead. Standard deployments were unaffected, since their configured rates and the global map agree, which is why this only showed up on Bedrock and on zero-rate deployments

Both are fixed at the one call site, by passing the deployment's model and the pricing registered for it. Two details are worth calling out because the obvious implementations of each are wrong:

The model comes from `model_call_details`. On this path `self.model` and `litellm_params["model"]` are both None, and `self.model` can otherwise hold the router's `model_group` alias, which no cost map resolves; a live retrieve confirmed `model_call_details` is the only one of the three carrying the provider-qualified deployment model

Deployment pricing is decided from the raw registration rather than `get_model_info`. The router registers an entry for every deployment whether or not it declares pricing, and `get_model_info` fills absent costs with 0, so asking it cannot tell "configured as free" apart from "no pricing configured" and would have priced every ordinary deployment's batches at $0. `get_router_deployment_model_info` therefore returns pricing only when the deployment actually declares one of the batch cost fields, leaving the global map as the default

One behavior change worth naming: with a model name now reaching this path, a proxy that sets `disable_vertex_batch_output_transformation` will take the Vertex-specific accounting branch on retrieve, which it previously could not reach. That branch exists for exactly that flag, so this makes the flag work on the retrieve path rather than changing what it means

## Caveats

- Bedrock InvokeModel usage shapes beyond Anthropic's remain unparsed
- Those bill $0 for a separate reason, fixed in #37078

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
