### PR TITLE
fix(bedrock): read batch usage by payload shape, not by provider name

### DIFF
--- a/basedpyright-code-budget.json
+++ b/basedpyright-code-budget.json
@@ -84,7 +84,7 @@
     "limit": 56
   },
   "reportPrivateUsage": {
-    "limit": 1824
+    "limit": 1823
   },
   "reportRedeclaration": {
     "limit": 8

--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -424,6 +424,38 @@ def _count_prompt_or_input_tokens(model: str, value: Any) -> int:
     return 0
 
 
+def _is_converse_usage_shape(usage_object: dict) -> bool:
+    """Converse-family models report camelCase token counts, not Anthropic's snake_case."""
+    return "inputTokens" in usage_object or "outputTokens" in usage_object
+
+
+def _get_converse_batch_usage(usage_object: dict) -> Usage:
+    """Read a Converse-shaped usage block with the same transform the live Converse path uses,
+    so a batch and an equivalent non-batch call agree on tokens."""
+    from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+    from litellm.types.llms.bedrock import ConverseTokenUsageBlock
+
+    input_tokens: Final = int(usage_object.get("inputTokens") or 0)
+    output_tokens: Final = int(usage_object.get("outputTokens") or 0)
+    cache_read: Final = int(
+        usage_object.get("cacheReadInputTokens") or usage_object.get("cacheReadInputTokenCount") or 0
+    )
+    cache_write: Final = int(
+        usage_object.get("cacheWriteInputTokens") or usage_object.get("cacheWriteInputTokenCount") or 0
+    )
+    return AmazonConverseConfig().transform_usage(
+        ConverseTokenUsageBlock(
+            inputTokens=input_tokens,
+            outputTokens=output_tokens,
+            totalTokens=int(usage_object.get("totalTokens") or input_tokens + output_tokens),
+            cacheReadInputTokenCount=cache_read,
+            cacheReadInputTokens=cache_read,
+            cacheWriteInputTokenCount=cache_write,
+            cacheWriteInputTokens=cache_write,
+        )
+    )
+
+
 def _get_batch_job_usage_from_response_body(response_body: dict, custom_llm_provider: str = "openai") -> Usage:
     """
     Get the tokens of a batch job from the response body
@@ -431,10 +463,21 @@ def _get_batch_job_usage_from_response_body(response_body: dict, custom_llm_prov
     if custom_llm_provider in ("anthropic", "bedrock"):
         from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
-        return AnthropicConfig().calculate_usage(
-            usage_object=response_body.get("usage", None) or {},
+        usage_object: Final = response_body.get("usage", None) or {}
+        if custom_llm_provider == "bedrock" and _is_converse_usage_shape(usage_object):
+            return _get_converse_batch_usage(usage_object)
+        anthropic_usage: Final = AnthropicConfig().calculate_usage(
+            usage_object=usage_object,
             reasoning_content=None,
         )
+        if usage_object and anthropic_usage.total_tokens == 0:
+            verbose_logger.warning(
+                "batch output line reported usage this parser does not understand, so it will be billed at $0. "
+                "provider=%s usage_keys=%s",
+                custom_llm_provider,
+                sorted(usage_object.keys()),
+            )
+        return anthropic_usage
     from litellm.responses.utils import ResponseAPILoggingUtils
 
     _usage_dict: Final = response_body.get("usage", None) or {}

--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -424,48 +424,17 @@ def _count_prompt_or_input_tokens(model: str, value: Any) -> int:
     return 0
 
 
-def _is_converse_usage_shape(usage_object: dict) -> bool:
-    """Converse-family models report camelCase token counts, not Anthropic's snake_case."""
-    return "inputTokens" in usage_object or "outputTokens" in usage_object
-
-
-def _get_converse_batch_usage(usage_object: dict) -> Usage:
-    """Read a Converse-shaped usage block with the same transform the live Converse path uses,
-    so a batch and an equivalent non-batch call agree on tokens."""
-    from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
-    from litellm.types.llms.bedrock import ConverseTokenUsageBlock
-
-    input_tokens: Final = int(usage_object.get("inputTokens") or 0)
-    output_tokens: Final = int(usage_object.get("outputTokens") or 0)
-    cache_read: Final = int(
-        usage_object.get("cacheReadInputTokens") or usage_object.get("cacheReadInputTokenCount") or 0
-    )
-    cache_write: Final = int(
-        usage_object.get("cacheWriteInputTokens") or usage_object.get("cacheWriteInputTokenCount") or 0
-    )
-    return AmazonConverseConfig().transform_usage(
-        ConverseTokenUsageBlock(
-            inputTokens=input_tokens,
-            outputTokens=output_tokens,
-            totalTokens=int(usage_object.get("totalTokens") or input_tokens + output_tokens),
-            cacheReadInputTokenCount=cache_read,
-            cacheReadInputTokens=cache_read,
-            cacheWriteInputTokenCount=cache_write,
-            cacheWriteInputTokens=cache_write,
-        )
-    )
-
-
 def _get_batch_job_usage_from_response_body(response_body: dict, custom_llm_provider: str = "openai") -> Usage:
     """
     Get the tokens of a batch job from the response body
     """
     if custom_llm_provider in ("anthropic", "bedrock"):
         from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+        from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
 
         usage_object: Final = response_body.get("usage", None) or {}
-        if custom_llm_provider == "bedrock" and _is_converse_usage_shape(usage_object):
-            return _get_converse_batch_usage(usage_object)
+        if custom_llm_provider == "bedrock" and AmazonConverseConfig.is_converse_usage_shape(usage_object):
+            return AmazonConverseConfig().usage_from_batch_output(usage_object)
         anthropic_usage: Final = AnthropicConfig().calculate_usage(
             usage_object=usage_object,
             reasoning_content=None,

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1770,7 +1770,7 @@ class AmazonConverseConfig(BaseConfig):
                 thinking_blocks_list.append(_redacted_block)
         return thinking_blocks_list
 
-    def _transform_usage(
+    def transform_usage(
         self,
         usage: ConverseTokenUsageBlock,
         reasoning_content: str | None = None,
@@ -2191,7 +2191,7 @@ class AmazonConverseConfig(BaseConfig):
             chat_completion_message["tool_calls"] = filtered_tools
 
         ## CALCULATING USAGE - bedrock returns usage in the headers
-        usage: Final = self._transform_usage(
+        usage: Final = self.transform_usage(
             completion_response["usage"],
             reasoning_content=chat_completion_message.get("reasoning_content"),
         )

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -6,6 +6,7 @@ import copy
 import json
 import time
 import types
+from collections.abc import Mapping
 from typing import Final, Literal, cast, overload
 
 import httpx
@@ -1769,6 +1770,42 @@ class AmazonConverseConfig(BaseConfig):
                 )
                 thinking_blocks_list.append(_redacted_block)
         return thinking_blocks_list
+
+    @staticmethod
+    def is_converse_usage_shape(usage_object: Mapping[str, object]) -> bool:
+        """Converse-family models report camelCase token counts, not Anthropic's snake_case."""
+        return "inputTokens" in usage_object or "outputTokens" in usage_object
+
+    @staticmethod
+    def _usage_count(usage_object: Mapping[str, object], *keys: str) -> int:
+        for key in keys:
+            value = usage_object.get(key)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return int(value)
+        return 0
+
+    def usage_from_batch_output(self, usage_object: Mapping[str, object]) -> Usage:
+        """Read a Converse-shaped usage block out of a batch output line.
+
+        Batch output omits fields the live API always sends, so the block is
+        completed before going through the same transform, keeping a batch and an
+        equivalent non-batch call in agreement on tokens.
+        """
+        input_tokens: Final = self._usage_count(usage_object, "inputTokens")
+        output_tokens: Final = self._usage_count(usage_object, "outputTokens")
+        cache_read: Final = self._usage_count(usage_object, "cacheReadInputTokens", "cacheReadInputTokenCount")
+        cache_write: Final = self._usage_count(usage_object, "cacheWriteInputTokens", "cacheWriteInputTokenCount")
+        return self.transform_usage(
+            ConverseTokenUsageBlock(
+                inputTokens=input_tokens,
+                outputTokens=output_tokens,
+                totalTokens=self._usage_count(usage_object, "totalTokens") or input_tokens + output_tokens,
+                cacheReadInputTokenCount=cache_read,
+                cacheReadInputTokens=cache_read,
+                cacheWriteInputTokenCount=cache_write,
+                cacheWriteInputTokens=cache_write,
+            )
+        )
 
     def transform_usage(
         self,

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -559,7 +559,7 @@ class AWSEventStreamDecoder:
             elif "stopReason" in chunk_data:
                 finish_reason = map_finish_reason(chunk_data.get("stopReason", "stop"))
             elif "usage" in chunk_data:
-                usage = converse_config._transform_usage(chunk_data.get("usage", {}))
+                usage = converse_config.transform_usage(chunk_data.get("usage", {}))
 
             model_response_provider_specific_fields: Final = {}
             if "trace" in chunk_data:

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -1303,12 +1303,7 @@ async def test_output_file_content_bedrock_reads_with_deployment_aws_credentials
 
 
 # =========================================================================== #
-# Bedrock batch usage is parsed by the shape of the payload, not the provider
-#
-# Regression: every bedrock batch line went through the Anthropic usage parser,
-# which reads snake_case input_tokens/output_tokens. A Converse-family model
-# (Nova and friends) reports camelCase inputTokens/outputTokens, so usage read
-# 0/0/0 and the batch billed $0 despite real token consumption.
+# _get_batch_job_usage_from_response_body: bedrock usage shapes
 # =========================================================================== #
 
 

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -15,6 +15,7 @@ deterministic stand-ins so the arithmetic under test is the only variable.
 """
 
 import json
+import logging
 import os
 import sys
 from types import MappingProxyType
@@ -1299,3 +1300,60 @@ async def test_output_file_content_bedrock_reads_with_deployment_aws_credentials
     assert captured["aws_region_name"] == "us-west-2"
     assert captured["_litellm_internal_model_credentials"] is snapshot
     assert "model" not in captured
+
+
+# =========================================================================== #
+# Bedrock batch usage is parsed by the shape of the payload, not the provider
+#
+# Regression: every bedrock batch line went through the Anthropic usage parser,
+# which reads snake_case input_tokens/output_tokens. A Converse-family model
+# (Nova and friends) reports camelCase inputTokens/outputTokens, so usage read
+# 0/0/0 and the batch billed $0 despite real token consumption.
+# =========================================================================== #
+
+
+def test_bedrock_converse_shaped_batch_usage_is_parsed():
+    body = {"model": "us.amazon.nova-lite-v1:0", "usage": {"inputTokens": 2202, "outputTokens": 540, "totalTokens": 2742}}
+    usage = bu._get_batch_job_usage_from_response_body(body, custom_llm_provider="bedrock")
+    assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (2202, 540, 2742)
+
+
+def test_bedrock_converse_batch_usage_totals_default_when_absent():
+    body = {"model": "us.amazon.nova-lite-v1:0", "usage": {"inputTokens": 10, "outputTokens": 4}}
+    usage = bu._get_batch_job_usage_from_response_body(body, custom_llm_provider="bedrock")
+    assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (10, 4, 14)
+
+
+def test_bedrock_converse_batch_usage_includes_cache_tokens():
+    body = {
+        "model": "us.amazon.nova-lite-v1:0",
+        "usage": {
+            "inputTokens": 100,
+            "outputTokens": 20,
+            "totalTokens": 120,
+            "cacheReadInputTokens": 800,
+            "cacheWriteInputTokens": 200,
+        },
+    }
+    usage = bu._get_batch_job_usage_from_response_body(body, custom_llm_provider="bedrock")
+    assert usage.prompt_tokens == 1100
+    assert usage.completion_tokens == 20
+    assert usage.prompt_tokens_details.cached_tokens == 800
+    assert usage.prompt_tokens_details.cache_creation_tokens == 200
+
+
+def test_bedrock_anthropic_shaped_batch_usage_still_parsed():
+    """Anthropic-shaped bedrock output (what an Anthropic model's batch emits) must not regress."""
+    body = {"model": "claude-sonnet-4-6", "usage": {"input_tokens": 18, "output_tokens": 10}}
+    usage = bu._get_batch_job_usage_from_response_body(body, custom_llm_provider="bedrock")
+    assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (18, 10, 28)
+
+
+def test_unparsable_bedrock_batch_usage_warns(caplog):
+    """An unrecognized usage shape must be visible, not a silent $0."""
+    body = {"model": "amazon.titan-text-lite-v1", "usage": {"inputTextTokenCount": 42}}
+    with caplog.at_level(logging.WARNING):
+        usage = bu._get_batch_job_usage_from_response_body(body, custom_llm_provider="bedrock")
+    assert usage.total_tokens == 0
+    assert "does not understand" in caplog.text
+    assert "inputTextTokenCount" in caplog.text

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -6003,3 +6003,43 @@ def test_adaptive_thinking_dropped_when_max_tokens_too_small_converse():
     )
 
     assert "thinking" not in optional_params
+
+
+def test_is_converse_usage_shape_distinguishes_camel_case_from_anthropic():
+    config = AmazonConverseConfig()
+    assert config.is_converse_usage_shape({"inputTokens": 1, "outputTokens": 2}) is True
+    assert config.is_converse_usage_shape({"outputTokens": 2}) is True
+    assert config.is_converse_usage_shape({"input_tokens": 1, "output_tokens": 2}) is False
+    assert config.is_converse_usage_shape({}) is False
+
+
+def test_usage_from_batch_output_completes_an_incomplete_block():
+    """Batch output omits totalTokens and the cache counts the live API always sends."""
+    usage = AmazonConverseConfig().usage_from_batch_output({"inputTokens": 2202, "outputTokens": 540})
+    assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (2202, 540, 2742)
+
+
+def test_usage_from_batch_output_inflates_input_by_cache_counts():
+    usage = AmazonConverseConfig().usage_from_batch_output(
+        {
+            "inputTokens": 100,
+            "outputTokens": 20,
+            "totalTokens": 120,
+            "cacheReadInputTokens": 800,
+            "cacheWriteInputTokens": 200,
+        }
+    )
+    assert usage.prompt_tokens == 1100
+    assert usage.prompt_tokens_details.cached_tokens == 800
+    assert usage.prompt_tokens_details.cache_creation_tokens == 200
+
+
+def test_streaming_usage_chunk_is_transformed():
+    """The streaming decoder's usage event feeds the same public transform."""
+    from litellm.llms.bedrock.chat.invoke_handler import AWSEventStreamDecoder
+
+    decoder = AWSEventStreamDecoder(model="us.amazon.nova-lite-v1:0")
+    chunk = decoder.converse_chunk_parser({"usage": {"inputTokens": 11, "outputTokens": 4, "totalTokens": 15}})
+    assert chunk.usage.prompt_tokens == 11
+    assert chunk.usage.completion_tokens == 4
+    assert chunk.usage.total_tokens == 15

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -30,7 +30,7 @@ def test_transform_usage():
         }
     )
     config = AmazonConverseConfig()
-    openai_usage = config._transform_usage(usage)
+    openai_usage = config.transform_usage(usage)
     assert (
         openai_usage.prompt_tokens
         == usage["inputTokens"]
@@ -62,7 +62,7 @@ def test_transform_usage_with_reasoning_content():
     )
     config = AmazonConverseConfig()
     reasoning_text = "Let me think about this step by step."
-    openai_usage = config._transform_usage(usage, reasoning_content=reasoning_text)
+    openai_usage = config.transform_usage(usage, reasoning_content=reasoning_text)
     assert openai_usage.completion_tokens_details is not None
     assert openai_usage.completion_tokens_details.reasoning_tokens > 0
     assert openai_usage.completion_tokens_details.text_tokens == (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every Bedrock batch line uses the Anthropic usage parser
- Converse models report camelCase counts it cannot read
- Nova batches report zero tokens and bill $0
- An unreadable usage shape fails silently

How it solves it:

- Pick the usage parser by the payload's shape
- Warn when no parser understands a shape

## User Flow

Before: a team running Nova batch jobs sees every completed batch logged with zero tokens and $0.00 spend, so the work appears free and never reaches chargeback

1. They upload a JSONL file with POST https://litellm-domain/v1/files (`purpose: batch`, `target_model_names: amazon.nova-lite`) and get back a gateway file id
2. They send POST https://litellm-domain/v1/batches with that `input_file_id` and get back a batch id with `status: validating`
3. They poll GET https://litellm-domain/v1/batches/{batch_id} until it returns `status: completed`
4. They download the batch's output with GET https://litellm-domain/v1/files/{output_file_id}/content and count real token usage in it, line by line
5. They open https://litellm-domain/ui/?page=logs and find that same batch recorded as 0 prompt tokens, 0 completion tokens, and $0.00 spend

After: the same batch reports the tokens its own output file shows, and bills accordingly

1. They upload the same JSONL file with POST https://litellm-domain/v1/files and get back a gateway file id
2. They send the same POST https://litellm-domain/v1/batches and get back a batch id with `status: validating`
3. They poll GET https://litellm-domain/v1/batches/{batch_id} until it returns `status: completed`
4. They download the same output with GET https://litellm-domain/v1/files/{output_file_id}/content and count the same real token usage
5. https://litellm-domain/ui/?page=logs now shows that batch with those same token counts and non-zero spend

## Relevant issues

## Linear ticket

Resolves LIT-5668

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Two live Bedrock managed batch runs against real AWS in us-west-2, one per checkpoint, each on its own proxy booted from a fresh Postgres with the batch cost job polling every 30s. Model `bedrock/us.amazon.nova-lite-v1:0` (Converse family), the same 110-record JSONL both times, real $$$

Each leg is the exact end-user flow:

```bash
curl -s http://localhost:$PORT/v1/files -H "Authorization: Bearer $KEY" \
  -F purpose=batch -F target_model_names=nova-batch -F file=@batch_input.jsonl
curl -s http://localhost:$PORT/v1/batches -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"input_file_id": "<file id>", "endpoint": "/v1/chat/completions", "completion_window": "24h"}'
curl -s http://localhost:$PORT/v1/batches/<batch id> -H "Authorization: Bearer $KEY"   # poll until completed
curl -s http://localhost:$PORT/v1/files/<output file id>/content -H "Authorization: Bearer $KEY" -H "custom-llm-provider: bedrock"
```

Before, at merge base 973329e986: the batch completes and Bedrock's own output file reports real usage on every one of the 110 lines, for example `"usage":{"inputTokens":8,"outputTokens":11,"totalTokens":19}`, summing to 990 input, 1597 output, and 2587 total tokens, yet the tracked spend row reads zero across the board

```
    call_type    |          model           | prompt_tokens | completion_tokens | total_tokens | spend
-----------------+--------------------------+---------------+-------------------+--------------+-------
 aretrieve_batch | us.amazon.nova-lite-v1:0 |             0 |                 0 |            0 |     0
```

After, at PR tip 5fe7793a14: same flow, same model, same input file. The output file sums to 990 input, 1577 output, and 2567 total tokens, and the spend row now matches it token for token, priced at the 50% batch rate on nova-lite's on-demand cost

```
    call_type    |          model           | prompt_tokens | completion_tokens | total_tokens |   spend
-----------------+--------------------------+---------------+-------------------+--------------+------------
 aretrieve_batch | us.amazon.nova-lite-v1:0 |           990 |              1577 |         2567 | 0.00021894
```

The after leg logged zero "billed at $0" warnings, confirming the Converse shape is now parsed rather than warned about. Anthropic-shaped Bedrock batches were additionally verified unaffected across 23 real batches on a deployed gateway, where token counts reconciled exactly against the providers' own output files

## Type

🐛 Bug Fix

## Changes

Bedrock batch usage was parsed by provider name rather than by the shape of the payload, and the single parser chosen reads Anthropic's snake_case token counts. Any Converse-family model, Nova being the common one, reports camelCase counts instead, so usage aggregated to 0/0/0 and the batch priced at $0 despite real consumption

Usage is now selected by the shape it actually has. A Converse-shaped block goes through the same transform the live Converse path uses, so a batch and an equivalent non-batch call agree on tokens, including cache reads and cache writes. Anthropic-shaped output keeps its existing parser, and the OpenAI-shaped path for other providers is untouched

Reusing the live transform means also exposing it: this makes the Converse usage transform public, since batch parsing is a second legitimate caller from outside that module. That additionally removes the private-member access `invoke_handler` was already making on it, which is why the basedpyright budget ratchets down by one here

A payload neither parser understands, such as an InvokeModel-native shape from Titan, Cohere, or Llama, still reads zero. That is left as is rather than guessed at, but it no longer does so quietly: it warns with the usage keys it saw, so the next unhandled shape shows up in logs instead of as a silently free batch

## Caveats

- Titan, Cohere, and Llama shapes still read zero, now logged
- Fixing tokens alone is not enough; pricing needs the deployment's model

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
