### PR TITLE
fix(pricing): charge text output tokens for azure/gpt-image-1.5

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -7700,6 +7700,7 @@
         "input_cost_per_image_token": 8e-06,
         "litellm_provider": "azure",
         "mode": "image_generation",
+        "output_cost_per_token": 1e-05,
         "output_cost_per_image_token": 3.2e-05,
         "supported_endpoints": [
             "/v1/images/generations",
@@ -7713,6 +7714,7 @@
         "input_cost_per_image_token": 8e-06,
         "litellm_provider": "azure",
         "mode": "image_generation",
+        "output_cost_per_token": 1e-05,
         "output_cost_per_image_token": 3.2e-05,
         "supported_endpoints": [
             "/v1/images/generations",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -7700,6 +7700,7 @@
         "input_cost_per_image_token": 8e-06,
         "litellm_provider": "azure",
         "mode": "image_generation",
+        "output_cost_per_token": 1e-05,
         "output_cost_per_image_token": 3.2e-05,
         "supported_endpoints": [
             "/v1/images/generations",
@@ -7713,6 +7714,7 @@
         "input_cost_per_image_token": 8e-06,
         "litellm_provider": "azure",
         "mode": "image_generation",
+        "output_cost_per_token": 1e-05,
         "output_cost_per_image_token": 3.2e-05,
         "supported_endpoints": [
             "/v1/images/generations",

--- a/tests/test_litellm/test_gpt_image_cost_calculator.py
+++ b/tests/test_litellm/test_gpt_image_cost_calculator.py
@@ -348,6 +348,64 @@ class TestGPTImage15OutputImageTokens:
         )
 
 
+class TestAzureGPTImage15TextOutputTokens:
+    """
+    Test for GitHub issue #36637:
+    "azure/gpt-image-1.5" was missing ``output_cost_per_token``, so the text
+    portion of the output was billed at $0 while the identical OpenAI entry
+    ("gpt-image-1.5") charged $10/1M. Azure publishes a "gpt img 1.5 out txt"
+    meter at $10/1M, so both entries must price text output the same.
+    """
+
+    @pytest.mark.parametrize(
+        "model",
+        ["azure/gpt-image-1.5", "azure/gpt-image-1.5-2025-12-16"],
+    )
+    def test_azure_gpt_image_15_charges_text_output_tokens(self, model):
+        usage = Usage(
+            prompt_tokens=169,
+            completion_tokens=4599,
+            total_tokens=4768,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                text_tokens=169,
+                image_tokens=0,
+            ),
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                text_tokens=439,
+                image_tokens=4160,
+            ),
+        )
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(b64_json="test")],
+        )
+        image_response.usage = usage
+        image_response._hidden_params = {"custom_llm_provider": "azure"}
+
+        cost = litellm.completion_cost(
+            completion_response=image_response,
+            model=model,
+            call_type="image_generation",
+            custom_llm_provider="azure",
+        )
+
+        text_output_cost = 439 * 1e-05
+        expected_cost = 169 * 5e-06 + text_output_cost + 4160 * 3.2e-05
+
+        assert abs(cost - expected_cost) < 1e-6, (
+            f"Expected {expected_cost}, got {cost}. The {text_output_cost} of text "
+            f"output is likely being billed at $0 because {model} has no "
+            f"output_cost_per_token."
+        )
+
+    def test_azure_gpt_image_15_text_output_matches_openai_entry(self):
+        azure_info = litellm.get_model_info(model="azure/gpt-image-1.5", custom_llm_provider="azure")
+        openai_info = litellm.get_model_info(model="gpt-image-1.5", custom_llm_provider="openai")
+
+        assert azure_info["output_cost_per_token"] == openai_info["output_cost_per_token"]
+
+
 class TestCompletionCostIntegration:
     """Test the full completion_cost integration for gpt-image-1"""
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- azure/gpt-image-1.5 billed text output tokens at $0
- Same model on openai billed them at $10/1M
- Azure publishes a text output meter for 1.5

How it solves it:

- Add output_cost_per_token 1e-05 to both azure 1.5 entries
- Value taken from Azure's public retail pricing API
- Regression test pins azure and openai rates together

## User Flow

Before: a proxy admin routing image generation through an Azure gpt-image-1.5 deployment is undercharged on every request, so their spend dashboard understates real Azure spend

1. They send POST https://litellm-domain/v1/images/generations with `"model": "azure-gpt-image-1-5"` and a prompt
2. The image comes back with usage reporting both text and image output tokens
3. They open https://litellm-domain/ui/?page=logs and the request's spend covers the image output tokens only
4. The text output tokens are priced at $0, so the logged spend is lower than what Azure invoices them for

After: the same request logs spend that accounts for text output too

1. They send the same POST https://litellm-domain/v1/images/generations with `"model": "azure-gpt-image-1-5"` and a prompt
2. The image comes back with the same usage breakdown
3. https://litellm-domain/ui/?page=logs now shows spend that includes the text output tokens at $10/1M
4. The logged spend lines up with the OpenAI-hosted version of the same model, and with Azure's own pricing

## Relevant issues

Addresses the gpt-image-1.5 half of #36637

The gpt-image-2 half of that issue, removing `output_cost_per_token` where Azure publishes no text output meter, is already covered by the open #32754, so this PR deliberately leaves it alone

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, the authoritative rate this PR encodes. Azure's public retail pricing API needs no auth, `Gl` is the Global deployment tier and prices are per 1M tokens

```bash
curl -s "https://prices.azure.com/api/retail/prices?\$filter=contains(productName,'Azure%20OpenAI')&\$top=1000" \
  | python -c "import sys,json; [print(i['meterName'],'=',i['retailPrice'],i['unitOfMeasure']) for i in json.load(sys.stdin)['Items'] if i['meterName'].startswith('gpt img 1.5')]" \
  | sort -u
```

```
gpt img 1.5 in cd img DZ 1M Tokens = 2.2 1M
gpt img 1.5 in cd txt DZ 1M Tokens = 1.375 1M
gpt img 1.5 in cd txt gl 1M Tokens = 1.25 1M
gpt img 1.5 in img DZ 1M Tokens = 8.8 1M
gpt img 1.5 in txt gl 1M Tokens = 5.0 1M
gpt img 1.5 out img DZ 1M Tokens = 35.2 1M
gpt img 1.5 out img gl 1M Tokens = 32.0 1M
gpt img 1.5 out txt gl 1M Tokens = 10.0 1M
```

`gpt img 1.5 out txt gl` is $10.00 per 1M, which is the `output_cost_per_token` of 1e-05 this PR adds. For contrast, gpt-image-2 has no `out txt` meter at all, which is why removing that key from gpt-image-2 in #32754 is correct and adding it here is correct

I do not have an Azure gpt-image-1.5 deployment, so I could not run the live proxy image generation myself. What follows is the rate the proxy resolves at each commit, which is the value the spend calculation multiplies by. The steps to confirm it end to end against a real deployment are at the bottom, and I will post that run if someone can lend a key

Same command at both commits

```bash
LITELLM_LOCAL_MODEL_COST_MAP=True python -c "
import litellm
litellm.model_cost = litellm.get_model_cost_map(url='')
for m, p in (('azure/gpt-image-1.5','azure'),('azure/gpt-image-1.5-2025-12-16','azure'),('gpt-image-1.5','openai')):
    print('%-32s output_cost_per_token=%s' % (m, litellm.get_model_info(model=m, custom_llm_provider=p).get('output_cost_per_token')))
"
```

### Before (973329e986)

1. The Azure entries resolve to a zero text output rate while the identical OpenAI entry resolves to $10/1M

```
azure/gpt-image-1.5              output_cost_per_token=0
azure/gpt-image-1.5-2025-12-16   output_cost_per_token=0
gpt-image-1.5                    output_cost_per_token=1e-05
```

### After (891317ba7e)

1. All three agree, and match the `gpt img 1.5 out txt gl` meter above

```
azure/gpt-image-1.5              output_cost_per_token=1e-05
azure/gpt-image-1.5-2025-12-16   output_cost_per_token=1e-05
gpt-image-1.5                    output_cost_per_token=1e-05
```

### End to end steps for a reviewer with an Azure deployment

1. Point a config at an Azure gpt-image-1.5 deployment named `azure-gpt-image-1-5` and start the proxy on port 4000
2. `curl -s -X POST http://localhost:4000/v1/images/generations -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d '{"model":"azure-gpt-image-1-5","prompt":"a red bicycle on a wet street at night","size":"1024x1024"}'`
3. Confirm the returned usage reports non-zero output text tokens
4. Open http://localhost:4000/ui/?page=logs and check the request's spend against `output text tokens * 1e-05 + output image tokens * 3.2e-05 + input text tokens * 5e-06`
5. On the base commit the first term is missing from the logged spend, on this branch it is included

## Type

🐛 Bug Fix

## Caveats (if any)

- Only the Global tier rate is added, matching the existing entries
- No azure/eu Data Zone entry for gpt-image-1.5 yet
- gpt-image-2 half of #36637 is left to #32754

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
