### PR TITLE
fix(exa_ai): keep highlights and summary in search results

### DIFF
--- a/litellm/llms/exa_ai/search/transformation.py
+++ b/litellm/llms/exa_ai/search/transformation.py
@@ -7,6 +7,7 @@ Exa AI API Reference: https://docs.exa.ai/reference/search
 from typing import Final, TypedDict
 
 import httpx
+from typing_extensions import ReadOnly
 
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.search.transformation import (
@@ -44,6 +45,42 @@ class ExaAISearchRequest(_ExaAISearchRequestRequired, total=False):
     context: bool | dict  # Optional - format results for LLMs
     moderation: bool  # Optional - enable content moderation, default false
     contents: dict  # Optional - content retrieval options
+
+
+class ExaAISearchResult(TypedDict, total=False):
+    """
+    A single entry of Exa AI's search response `results` array.
+    Based on: https://docs.exa.ai/reference/search
+    """
+
+    title: ReadOnly[str]
+    url: ReadOnly[str]
+    text: ReadOnly[str]
+    highlights: ReadOnly[list[str]]
+    summary: ReadOnly[str]
+    publishedDate: ReadOnly[str]
+
+
+_HIGHLIGHT_SEPARATOR: Final[str] = "\n\n"
+
+
+def _exa_snippet(result: ExaAISearchResult) -> str:
+    """
+    Exa returns each requested content mode in its own field, and omits `text`
+    entirely when only `highlights` or `summary` were asked for.
+    """
+    return (
+        result.get("text") or _HIGHLIGHT_SEPARATOR.join(result.get("highlights") or ()) or result.get("summary") or ""
+    )
+
+
+def _exa_content_fields(result: ExaAISearchResult) -> dict[str, list[str] | str]:
+    highlights: Final = result.get("highlights")
+    summary: Final = result.get("summary")
+    return {
+        **({"highlights": highlights} if highlights is not None else {}),
+        **({"summary": summary} if summary is not None else {}),
+    }
 
 
 class ExaAISearchConfig(BaseSearchConfig):
@@ -164,7 +201,8 @@ class ExaAISearchConfig(BaseSearchConfig):
         Exa AI → LiteLLM mappings:
         - results[].title → SearchResult.title
         - results[].url → SearchResult.url
-        - results[].text → SearchResult.snippet
+        - results[].text, else results[].highlights, else results[].summary → SearchResult.snippet
+        - results[].highlights, results[].summary → passed through when present
         - results[].publishedDate → SearchResult.date
         - No last_updated field in Exa AI response (set to None)
 
@@ -177,17 +215,17 @@ class ExaAISearchConfig(BaseSearchConfig):
         """
         response_json: Final = raw_response.json()
 
-        # Transform results to SearchResult objects
-        results: Final = []
-        for result in response_json.get("results", []):
-            search_result = SearchResult(
+        results: Final = [
+            SearchResult(
                 title=result.get("title", ""),
                 url=result.get("url", ""),
-                snippet=result.get("text", ""),  # Exa AI uses "text" for content
+                snippet=_exa_snippet(result),
                 date=result.get("publishedDate"),  # ISO 8601 datetime string
                 last_updated=None,  # Exa AI doesn't provide last_updated in response
+                **_exa_content_fields(result),
             )
-            results.append(search_result)
+            for result in response_json.get("results", [])
+        ]
 
         return SearchResponse(
             results=results,

--- a/tests/test_litellm/llms/exa_ai/search/test_transformation.py
+++ b/tests/test_litellm/llms/exa_ai/search/test_transformation.py
@@ -1,0 +1,118 @@
+"""
+Tests for Exa AI search response transformation.
+
+Regression coverage for https://github.com/BerriAI/litellm/issues/36905:
+Exa returns each requested content mode in its own response field and omits
+`text` entirely when only `highlights` or `summary` were requested, so reading
+only `text` silently dropped billed content and returned an empty snippet.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from litellm.llms.exa_ai.search.transformation import ExaAISearchConfig
+
+
+def _raw_response(payload: dict) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        content=json.dumps(payload).encode(),
+        request=httpx.Request("POST", "https://api.exa.ai/search"),
+    )
+
+
+@pytest.fixture
+def config() -> ExaAISearchConfig:
+    return ExaAISearchConfig()
+
+
+class TestExaAISnippetFallback:
+    def test_text_is_used_when_present(self, config):
+        response = config.transform_search_response(
+            raw_response=_raw_response(
+                {"results": [{"title": "t", "url": "https://example.com", "text": "full page text"}]}
+            ),
+            logging_obj=MagicMock(),
+        )
+
+        assert response.results[0].snippet == "full page text"
+
+    def test_highlights_fill_snippet_when_text_absent(self, config):
+        response = config.transform_search_response(
+            raw_response=_raw_response(
+                {
+                    "results": [
+                        {
+                            "title": "t",
+                            "url": "https://example.com",
+                            "highlights": ["first highlight", "second highlight"],
+                        }
+                    ]
+                }
+            ),
+            logging_obj=MagicMock(),
+        )
+
+        assert response.results[0].snippet == "first highlight\n\nsecond highlight"
+        assert response.results[0].highlights == ["first highlight", "second highlight"]
+
+    def test_summary_fills_snippet_when_text_and_highlights_absent(self, config):
+        response = config.transform_search_response(
+            raw_response=_raw_response(
+                {"results": [{"title": "t", "url": "https://example.com", "summary": "a short summary"}]}
+            ),
+            logging_obj=MagicMock(),
+        )
+
+        assert response.results[0].snippet == "a short summary"
+        assert response.results[0].summary == "a short summary"
+
+    def test_text_wins_over_highlights_and_summary(self, config):
+        response = config.transform_search_response(
+            raw_response=_raw_response(
+                {
+                    "results": [
+                        {
+                            "title": "t",
+                            "url": "https://example.com",
+                            "text": "full page text",
+                            "highlights": ["a highlight"],
+                            "summary": "a summary",
+                        }
+                    ]
+                }
+            ),
+            logging_obj=MagicMock(),
+        )
+
+        result = response.results[0]
+        assert result.snippet == "full page text"
+        assert result.highlights == ["a highlight"]
+        assert result.summary == "a summary"
+
+    def test_empty_highlights_list_falls_through_to_summary(self, config):
+        response = config.transform_search_response(
+            raw_response=_raw_response(
+                {"results": [{"title": "t", "url": "https://example.com", "highlights": [], "summary": "a summary"}]}
+            ),
+            logging_obj=MagicMock(),
+        )
+
+        assert response.results[0].snippet == "a summary"
+
+    def test_no_content_modes_yields_empty_snippet_and_no_extra_fields(self, config):
+        response = config.transform_search_response(
+            raw_response=_raw_response(
+                {"results": [{"title": "t", "url": "https://example.com", "publishedDate": "2026-08-14T00:00:00Z"}]}
+            ),
+            logging_obj=MagicMock(),
+        )
+
+        result = response.results[0]
+        assert result.snippet == ""
+        assert result.date == "2026-08-14T00:00:00Z"
+        assert not hasattr(result, "highlights")
+        assert not hasattr(result, "summary")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Exa highlights and summary searches returned empty snippets
- Exa still billed for the content it retrieved
- Transformer read only Exa's `text` field

How it solves it:

- Snippet falls back from text to highlights to summary
- Raw highlights and summary pass through when present
- Six unit tests cover each content mode

## User Flow

Before: a developer searching through an Exa search tool asks for highlights instead of full page text, pays Exa for the retrieval, and gets nothing back to show

1. They send POST https://litellm-domain/v1/search/exa-search with `{"query":"net interest margin outlook","max_results":3,"contents":{"highlights":{"numSentences":3}}}`
2. HTTP 200 comes back with three well formed results carrying titles, urls and dates
3. Every result has `"snippet": ""`, and there is no highlights field anywhere in the response
4. Their Exa dashboard still shows the content retrieval as billed, so they paid for text they never received

After: the same request returns the highlights they paid for

1. They send the same POST https://litellm-domain/v1/search/exa-search with the same body
2. HTTP 200 comes back with the same three results
3. Each result's `snippet` now holds the highlight sentences, and a `highlights` array carries them individually
4. Sending `contents.summary` instead behaves the same way, with the summary text in `snippet` and a `summary` field alongside it

## Relevant issues

Fixes #36905

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I do not have an Exa API key, so I could not make the billed live call myself. What follows replays a real shaped Exa highlights response through the transformer at each commit, which is the exact code path the reproduction in #36905 hits. The live proxy steps are at the bottom and I will post that run if someone can lend a key

Shared setup, saved as `exa_demo.py` at the repo root. The payload mirrors what Exa returns for `contents.highlights`, with no `text` field, which is the whole point of the bug

```python
import json
import httpx
from unittest.mock import MagicMock
from litellm.llms.exa_ai.search.transformation import ExaAISearchConfig

payload = {
    "results": [
        {
            "title": "Lion Finance Group Q2 results",
            "url": "https://example.com/q2",
            "publishedDate": "2026-08-01T00:00:00Z",
            "highlights": [
                "Net interest margin is expected to compress modestly through 2026.",
                "Management guided to a 3.9% to 4.1% NIM range for the full year.",
            ],
            "highlightScores": [0.41, 0.38],
        }
    ]
}
resp = httpx.Response(200, content=json.dumps(payload).encode(),
                      request=httpx.Request("POST", "https://api.exa.ai/search"))
out = ExaAISearchConfig().transform_search_response(raw_response=resp, logging_obj=MagicMock())
print(json.dumps(out.model_dump(), indent=2))
```

### Before (973329e986)

1. `python exa_demo.py`

```json
{
  "results": [
    {
      "title": "Lion Finance Group Q2 results",
      "url": "https://example.com/q2",
      "snippet": "",
      "date": "2026-08-01T00:00:00Z",
      "last_updated": null
    }
  ],
  "object": "search"
}
```

2. The snippet is empty and the highlights are gone, matching the report

### After (e9a9750a5a)

1. `python exa_demo.py`

```json
{
  "results": [
    {
      "title": "Lion Finance Group Q2 results",
      "url": "https://example.com/q2",
      "snippet": "Net interest margin is expected to compress modestly through 2026.\n\nManagement guided to a 3.9% to 4.1% NIM range for the full year.",
      "date": "2026-08-01T00:00:00Z",
      "last_updated": null,
      "highlights": [
        "Net interest margin is expected to compress modestly through 2026.",
        "Management guided to a 3.9% to 4.1% NIM range for the full year."
      ]
    }
  ],
  "object": "search"
}
```

2. The snippet carries the highlights and the raw array is preserved

### End to end steps for a reviewer with an Exa key

1. Configure a search tool with `search_provider: exa_ai` and `api_key: os.environ/EXA_API_KEY`, then start the proxy on port 4000
2. `curl -sS -X POST http://localhost:4000/v1/search/exa-search -H "Authorization: Bearer $LITELLM_KEY" -H 'Content-Type: application/json' -d '{"query":"net interest margin outlook","max_results":3,"contents":{"highlights":{"query":"net interest margin outlook","numSentences":3}}}'`
3. On the base commit every result has an empty snippet, on this branch each snippet holds the highlight sentences
4. Repeat with `"contents":{"summary":{"query":"What is the outlook for net interest margin?"}}` and confirm the summary lands in the snippet
5. Repeat with `"contents":{"text":{"maxCharacters":800}}` and confirm the existing text behaviour is unchanged

## Type

🐛 Bug Fix

## Caveats (if any)

- Only the Exa adapter is touched, Tavily has the same pattern
- highlightScores is passed to Exa but still not surfaced
- Default `contents` injection still retrieves full page text

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
