### PR TITLE
fix(bedrock_mantle): stop sending max_tokens to gemma-4 models

### DIFF
--- a/litellm/llms/bedrock_mantle/chat/transformation.py
+++ b/litellm/llms/bedrock_mantle/chat/transformation.py
@@ -25,7 +25,7 @@ from litellm.types.llms.openai import AllMessageValues
 from litellm.types.router import GenericLiteLLMParams
 
 from ...openai_like.chat.transformation import OpenAILikeChatConfig
-from ..common_utils import mantle_base_segment
+from ..common_utils import mantle_base_segment, mantle_omits_max_tokens
 
 
 class BedrockMantleChatConfig(BedrockMantleAuthMixin, OpenAILikeChatConfig):
@@ -103,6 +103,8 @@ class BedrockMantleChatConfig(BedrockMantleAuthMixin, OpenAILikeChatConfig):
                     base_params.append("reasoning_effort")
         except Exception as e:
             verbose_logger.debug("BedrockMantleChatConfig: error checking reasoning support: %s", e)
+        if mantle_omits_max_tokens(model, litellm.model_cost):
+            return [param for param in base_params if param != "max_tokens"]
         return base_params
 
     def get_model_response_iterator(

--- a/litellm/llms/bedrock_mantle/common_utils.py
+++ b/litellm/llms/bedrock_mantle/common_utils.py
@@ -126,6 +126,21 @@ def mantle_supports_responses(model: str | None, model_cost: dict) -> bool:
     return entry.get("mode") == "responses"
 
 
+def mantle_omits_max_tokens(model: str | None, model_cost: dict) -> bool:
+    """Whether a Bedrock Mantle model rejects the OpenAI ``max_tokens`` param.
+
+    Data-driven from the model's price-map omit_max_tokens_param flag (overridable
+    via register_model / proxy model_info), matching mantle_base_segment. The
+    google gemma-4-* family carries that flag: Mantle answers max_tokens with
+    ``unsupported_parameter``, and its native-API name max_output_tokens is not a
+    substitute on this OpenAI-compatible route, so omitting it is the only thing
+    that succeeds. As above there is deliberately NO model-name match, so a new
+    model with the same quirk is a JSON change rather than a code change.
+    """
+    entry: Final = model_cost.get(f"bedrock_mantle/{model}", {})
+    return entry.get("omit_max_tokens_param") is True
+
+
 def mantle_base_segment(model: str | None, model_cost: dict) -> str:
     """Return the base path segment for a Bedrock Mantle model's OpenAI surface.
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -47068,6 +47068,7 @@
         "max_output_tokens": 256000,
         "max_tokens": 256000,
         "mode": "chat",
+        "omit_max_tokens_param": true,
         "use_openai_responses_path": true,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -47087,6 +47088,7 @@
         "max_output_tokens": 256000,
         "max_tokens": 256000,
         "mode": "chat",
+        "omit_max_tokens_param": true,
         "use_openai_responses_path": true,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -47106,6 +47108,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "omit_max_tokens_param": true,
         "use_openai_responses_path": true,
         "supported_endpoints": [
             "/v1/chat/completions",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -291,6 +291,7 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     ]
     supported_endpoints: list[str] | None
     use_openai_responses_path: bool | None
+    omit_max_tokens_param: bool | None
     tpm: int | None
     rpm: int | None
     provider_specific_entry: dict[str, float] | None

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -47068,6 +47068,7 @@
         "max_output_tokens": 256000,
         "max_tokens": 256000,
         "mode": "chat",
+        "omit_max_tokens_param": true,
         "use_openai_responses_path": true,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -47087,6 +47088,7 @@
         "max_output_tokens": 256000,
         "max_tokens": 256000,
         "mode": "chat",
+        "omit_max_tokens_param": true,
         "use_openai_responses_path": true,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -47106,6 +47108,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "omit_max_tokens_param": true,
         "use_openai_responses_path": true,
         "supported_endpoints": [
             "/v1/chat/completions",

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -50,14 +50,8 @@ class TestBedrockMantleProviderRegistration:
         assert len(litellm.bedrock_mantle_models) > 0
         assert "bedrock_mantle/openai.gpt-oss-120b" in litellm.bedrock_mantle_models
         assert "bedrock_mantle/openai.gpt-oss-20b" in litellm.bedrock_mantle_models
-        assert (
-            "bedrock_mantle/openai.gpt-oss-safeguard-120b"
-            in litellm.bedrock_mantle_models
-        )
-        assert (
-            "bedrock_mantle/openai.gpt-oss-safeguard-20b"
-            in litellm.bedrock_mantle_models
-        )
+        assert "bedrock_mantle/openai.gpt-oss-safeguard-120b" in litellm.bedrock_mantle_models
+        assert "bedrock_mantle/openai.gpt-oss-safeguard-20b" in litellm.bedrock_mantle_models
 
 
 class TestBedrockMantleConfig:
@@ -111,9 +105,7 @@ class TestBedrockMantleConfig:
             cfg._get_openai_compatible_provider_info(
                 None,
                 None,
-                litellm_params=GenericLiteLLMParams(
-                    aws_region_name="us-east-1.api.aws.attacker.example/"
-                ),
+                litellm_params=GenericLiteLLMParams(aws_region_name="us-east-1.api.aws.attacker.example/"),
             )
 
     def test_get_llm_provider_rejects_malicious_aws_region_name(self, monkeypatch):
@@ -126,14 +118,10 @@ class TestBedrockMantleConfig:
             litellm.get_llm_provider(
                 model="openai.gpt-5.5",
                 custom_llm_provider="bedrock_mantle",
-                litellm_params=GenericLiteLLMParams(
-                    aws_region_name="us-east-1.api.aws.attacker.example/"
-                ),
+                litellm_params=GenericLiteLLMParams(aws_region_name="us-east-1.api.aws.attacker.example/"),
             )
 
-    def test_get_llm_provider_uses_aws_region_name_for_responses(
-        self, monkeypatch, local_cost_map
-    ):
+    def test_get_llm_provider_uses_aws_region_name_for_responses(self, monkeypatch, local_cost_map):
         from litellm.types.router import GenericLiteLLMParams
 
         monkeypatch.delenv("BEDROCK_MANTLE_REGION", raising=False)
@@ -170,18 +158,14 @@ class TestBedrockMantleConfig:
         monkeypatch.setenv("BEDROCK_MANTLE_REGION", "us-east-2")
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         cfg = BedrockMantleChatConfig()
-        api_base, _ = cfg._get_openai_compatible_provider_info(
-            None, None, model="openai.gpt-oss-120b"
-        )
+        api_base, _ = cfg._get_openai_compatible_provider_info(None, None, model="openai.gpt-oss-120b")
         assert api_base == "https://bedrock-mantle.us-east-2.api.aws/v1"
 
     @pytest.mark.parametrize(
         "model_id",
         ["google.gemma-4-31b", "google.gemma-4-26b-a4b", "google.gemma-4-e2b"],
     )
-    def test_chat_base_for_gemma_4_uses_openai_v1(
-        self, monkeypatch, local_cost_map, model_id
-    ):
+    def test_chat_base_for_gemma_4_uses_openai_v1(self, monkeypatch, local_cost_map, model_id):
         # The chat-config bug the Gemma 4 cards exposed: gemma-4-* is served on the
         # /openai/v1 base, not the hardcoded /v1. Driven by the price-map
         # use_openai_responses_path flag (loaded by local_cost_map). Fails before
@@ -189,22 +173,16 @@ class TestBedrockMantleConfig:
         monkeypatch.setenv("BEDROCK_MANTLE_REGION", "us-east-2")
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         cfg = BedrockMantleChatConfig()
-        api_base, _ = cfg._get_openai_compatible_provider_info(
-            None, None, model=model_id
-        )
+        api_base, _ = cfg._get_openai_compatible_provider_info(None, None, model=model_id)
         assert api_base == "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
-    def test_chat_base_explicit_api_base_wins_over_derived(
-        self, monkeypatch, local_cost_map
-    ):
+    def test_chat_base_explicit_api_base_wins_over_derived(self, monkeypatch, local_cost_map):
         # An explicit api_base must not be overridden by the data-driven default,
         # even for a model whose default differs (gemma-4 -> openai/v1).
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         custom_base = "https://bedrock-mantle.us-west-2.api.aws/v1"
         cfg = BedrockMantleChatConfig()
-        api_base, _ = cfg._get_openai_compatible_provider_info(
-            custom_base, None, model="google.gemma-4-31b"
-        )
+        api_base, _ = cfg._get_openai_compatible_provider_info(custom_base, None, model="google.gemma-4-31b")
         assert api_base == custom_base
 
     def test_api_key_from_env(self, monkeypatch):
@@ -247,9 +225,7 @@ class TestBedrockMantleChatAuth:
         from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 
         signer = BaseAWSLLM()
-        signer.get_credentials = MagicMock(
-            side_effect=AssertionError("SigV4 must not run when a Bearer token exists")
-        )
+        signer.get_credentials = MagicMock(side_effect=AssertionError("SigV4 must not run when a Bearer token exists"))
         return signer
 
     def test_bearer_token_skips_sigv4(self, monkeypatch):
@@ -366,9 +342,7 @@ class TestBedrockMantleChatAuth:
 
         assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
 
-    def test_sigv4_scope_matches_api_base_when_aws_region_name_disagrees(
-        self, monkeypatch
-    ):
+    def test_sigv4_scope_matches_api_base_when_aws_region_name_disagrees(self, monkeypatch):
         # If a caller (e.g. proxy) passes a stale api_base in one region and an
         # aws_region_name in a different region, the SigV4 credential scope must
         # match the URL host or Bedrock rejects the request with 401. Without the
@@ -442,9 +416,7 @@ class TestBedrockMantleChatAuth:
         ):
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
-        monkeypatch.setenv(
-            "AWS_SECRET_ACCESS_KEY", "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0"
-        )
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0")
         monkeypatch.setenv("AWS_REGION", "us-east-2")
 
         requests = []
@@ -474,9 +446,7 @@ class TestBedrockMantleChatAuth:
                 request=httpx.Request("POST", url),
             )
 
-        with patch(
-            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post
-        ):
+        with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
             response = litellm.completion(
                 model="bedrock_mantle/openai.gpt-oss-120b",
                 messages=[{"role": "user", "content": "hello"}],
@@ -521,9 +491,7 @@ class TestBedrockMantleProjectHeader:
 
         def mock_post(self, url, data=None, headers=None, **kwargs):
             raw_body = data.decode("utf-8") if isinstance(data, bytes) else data
-            requests.append(
-                {"headers": headers or {}, "body": json.loads(raw_body or "{}")}
-            )
+            requests.append({"headers": headers or {}, "body": json.loads(raw_body or "{}")})
             return httpx.Response(
                 status_code=200,
                 json={
@@ -547,9 +515,7 @@ class TestBedrockMantleProjectHeader:
                 request=httpx.Request("POST", url),
             )
 
-        with patch(
-            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post
-        ):
+        with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
             response = litellm.completion(
                 model="bedrock_mantle/openai.gpt-oss-120b",
                 messages=[{"role": "user", "content": "hello"}],
@@ -565,16 +531,12 @@ class TestBedrockMantleProjectHeader:
 
 class TestBedrockMantleProviderResolution:
     def test_get_llm_provider_resolves_correctly(self):
-        model, provider, _, _ = litellm.get_llm_provider(
-            "bedrock_mantle/openai.gpt-oss-120b"
-        )
+        model, provider, _, _ = litellm.get_llm_provider("bedrock_mantle/openai.gpt-oss-120b")
         assert provider == "bedrock_mantle"
         assert model == "openai.gpt-oss-120b"
 
     def test_get_llm_provider_20b(self):
-        model, provider, _, _ = litellm.get_llm_provider(
-            "bedrock_mantle/openai.gpt-oss-20b"
-        )
+        model, provider, _, _ = litellm.get_llm_provider("bedrock_mantle/openai.gpt-oss-20b")
         assert provider == "bedrock_mantle"
         assert model == "openai.gpt-oss-20b"
 
@@ -620,9 +582,7 @@ class TestBedrockMantlePricing:
         monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "true")
         litellm.add_known_models()
         info_120b = litellm.get_model_info("bedrock_mantle/openai.gpt-oss-120b")
-        info_safeguard = litellm.get_model_info(
-            "bedrock_mantle/openai.gpt-oss-safeguard-120b"
-        )
+        info_safeguard = litellm.get_model_info("bedrock_mantle/openai.gpt-oss-safeguard-120b")
         assert info_safeguard["max_output_tokens"] > info_120b["max_output_tokens"]
 
     def test_reasoning_support(self, monkeypatch):
@@ -646,9 +606,7 @@ class TestBedrockMantlePricing:
         ("google.gemma-4-e2b", 4e-08, 8e-08, 128000),
     ],
 )
-def test_gemma_4_bedrock_mantle_model_metadata(
-    local_cost_map, model_id, input_cost, output_cost, max_tokens
-):
+def test_gemma_4_bedrock_mantle_model_metadata(local_cost_map, model_id, input_cost, output_cost, max_tokens):
     full_model_name = f"bedrock_mantle/{model_id}"
     info = litellm.get_model_info(full_model_name)
 
@@ -662,10 +620,7 @@ def test_gemma_4_bedrock_mantle_model_metadata(
     assert info["supports_tool_choice"] is True
     assert info["supports_vision"] is True
     assert (
-        litellm.supports_parallel_function_calling(
-            model=full_model_name, custom_llm_provider="bedrock_mantle"
-        )
-        is False
+        litellm.supports_parallel_function_calling(model=full_model_name, custom_llm_provider="bedrock_mantle") is False
     )
 
 
@@ -685,3 +640,72 @@ def test_gemma_4_models_register_under_bedrock_mantle(local_cost_map, model_id):
     resolved_model, provider, _, _ = litellm.get_llm_provider(full_model_name)
     assert provider == "bedrock_mantle"
     assert resolved_model == model_id
+
+
+class TestBedrockMantleMaxTokensOmission:
+    """
+    Regression coverage for https://github.com/BerriAI/litellm/issues/36970:
+    Mantle answers max_tokens with `unsupported_parameter` for the gemma-4-*
+    family, and the native-API name max_output_tokens is not a substitute on the
+    OpenAI-compatible route, so the param must not reach Bedrock. Driven by the
+    price-map omit_max_tokens_param flag, never by a model-name match.
+    """
+
+    @pytest.mark.parametrize(
+        "model_id",
+        ["google.gemma-4-31b", "google.gemma-4-26b-a4b", "google.gemma-4-e2b"],
+    )
+    def test_gemma_4_does_not_support_max_tokens(self, local_cost_map, model_id):
+        cfg = BedrockMantleChatConfig()
+
+        assert "max_tokens" not in cfg.get_supported_openai_params(model_id)
+
+    def test_non_gemma_model_still_supports_max_tokens(self, local_cost_map):
+        cfg = BedrockMantleChatConfig()
+
+        assert "max_tokens" in cfg.get_supported_openai_params("openai.gpt-oss-120b")
+
+    def test_max_tokens_dropped_for_gemma_4_when_drop_params(self, local_cost_map):
+        optional_params = litellm.utils.get_optional_params(
+            model="google.gemma-4-31b",
+            custom_llm_provider="bedrock_mantle",
+            max_tokens=50,
+            drop_params=True,
+        )
+
+        assert "max_tokens" not in optional_params
+
+    def test_max_tokens_raises_for_gemma_4_without_drop_params(self, local_cost_map):
+        with pytest.raises(litellm.UnsupportedParamsError) as exc_info:
+            litellm.utils.get_optional_params(
+                model="google.gemma-4-31b",
+                custom_llm_provider="bedrock_mantle",
+                max_tokens=50,
+                drop_params=False,
+            )
+
+        assert "max_tokens" in str(exc_info.value)
+
+    def test_max_tokens_forwarded_for_non_gemma_model(self, local_cost_map):
+        optional_params = litellm.utils.get_optional_params(
+            model="openai.gpt-oss-120b",
+            custom_llm_provider="bedrock_mantle",
+            max_tokens=50,
+            drop_params=False,
+        )
+
+        assert optional_params["max_tokens"] == 50
+
+    def test_flag_is_data_driven_not_name_matched(self, local_cost_map, monkeypatch):
+        from litellm.llms.bedrock_mantle.common_utils import mantle_omits_max_tokens
+
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "bedrock_mantle/vendor.some-future-model",
+            {"omit_max_tokens_param": True},
+        )
+        cfg = BedrockMantleChatConfig()
+
+        assert mantle_omits_max_tokens("vendor.some-future-model", litellm.model_cost) is True
+        assert "max_tokens" not in cfg.get_supported_openai_params("vendor.some-future-model")
+        assert mantle_omits_max_tokens("google.gemma-4-31b-not-a-real-model", litellm.model_cost) is False


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mantle rejects max_tokens for the gemma-4-* family
- litellm forwarded it anyway, causing an opaque APIConnectionError
- max_output_tokens is not a substitute on this route

How it solves it:

- Exclude max_tokens from supported params for those models
- drop_params now drops it, otherwise a clear litellm error
- Driven by a price-map flag, not a name match

## User Flow

Before: a developer calling a `bedrock_mantle/google.gemma-4-31b` deployment with any max_tokens value gets a connection-shaped error that names nothing they can act on

1. They send POST https://litellm-domain/v1/chat/completions with `{"model":"gemma-4","max_tokens":50,"messages":[...]}`
2. LiteLLM forwards max_tokens to Mantle unchanged
3. Mantle answers `unsupported_parameter: 'max_tokens' is not supported with this model`
4. That reaches them as `litellm.APIConnectionError`, which reads like a network or endpoint problem rather than a bad parameter
5. Renaming it to max_output_tokens, the name AWS's own native-API samples use, fails too with `unknown_parameter`, so there is no working value

After: the same request either succeeds or fails with something actionable

1. With `drop_params: true` they send the same POST and the request succeeds, with max_tokens omitted from what reaches Mantle
2. Without drop_params they send the same POST and get `litellm.UnsupportedParamsError: bedrock_mantle does not support parameters: ['max_tokens'], for model=google.gemma-4-31b`, naming both the parameter and the model
3. The message tells them to set drop_params to proceed, so the next step is obvious
4. Calling a non-gemma Mantle model such as openai.gpt-oss-120b with max_tokens is unchanged and still forwards the value

## Relevant issues

Fixes #36970

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I have no Bedrock Mantle access, so I could not make the billed live call. The reporter already confirmed both failing parameter names against a real `bedrock_mantle/google.gemma-4-31b` deployment in #36970. What follows runs the real parameter-resolution path, the one that decides what reaches Mantle, at each commit. Live proxy steps are at the bottom

Shared setup, saved as `mantle_demo.py` at the repo root

```python
import os
os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
import litellm
litellm.model_cost = litellm.get_model_cost_map(url="")
litellm.add_known_models()

for model in ("google.gemma-4-31b", "openai.gpt-oss-120b"):
    try:
        params = litellm.utils.get_optional_params(
            model=model, custom_llm_provider="bedrock_mantle",
            max_tokens=50, drop_params=False,
        )
        print(f"{model:22} drop_params=False -> {params}")
    except Exception as e:
        print(f"{model:22} drop_params=False -> {type(e).__name__}: {str(e).split(' To drop')[0]}")
```

### Before (973329e986)

1. `python mantle_demo.py`

```
google.gemma-4-31b     drop_params=False -> {'stream': False, 'max_tokens': 50}
openai.gpt-oss-120b    drop_params=False -> {'stream': False, 'max_tokens': 50}
```

2. max_tokens is forwarded for gemma, which is what Mantle rejects

### After (b60b195958)

1. `python mantle_demo.py`

```
google.gemma-4-31b     drop_params=False -> UnsupportedParamsError: litellm.UnsupportedParamsError: bedrock_mantle does not support parameters: ['max_tokens'], for model=google.gemma-4-31b.
openai.gpt-oss-120b    drop_params=False -> {'stream': False, 'max_tokens': 50}
```

2. gemma now fails fast and by name, and the non-gemma control is untouched

### End to end steps for a reviewer with Mantle access

1. Configure a `bedrock_mantle/google.gemma-4-31b` deployment and start the proxy on port 4000
2. `curl -sS -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $LITELLM_KEY" -H 'Content-Type: application/json' -d '{"model":"gemma-4","max_tokens":50,"messages":[{"role":"user","content":"say hi"}]}'`
3. On the base commit this returns the `unsupported_parameter` failure as an APIConnectionError, on this branch it returns UnsupportedParamsError naming max_tokens
4. Set `drop_params: true` on the deployment, repeat step 2, and confirm a normal completion comes back
5. Repeat step 2 against a non-gemma Mantle model and confirm max_tokens is still honoured

## Type

🐛 Bug Fix

## Caveats (if any)

- Behaviour is a clear error, not a silent drop, without drop_params
- Only max_tokens is gated, max_completion_tokens was not reported
- New price-map key applies to the three gemma-4 entries

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
