### PR TITLE
Implement SSO email linking and fuzzy email matching

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2475,6 +2475,14 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         default=False,
         description="Public model hub for users to see what models they have access to, supported openai params, etc.",
     )
+    sso_email_linking_policy: Literal["strict", "create_new"] = Field(
+        default="strict",
+        description=(
+            "Policy for SSO/JWT email-based fuzzy user matching when the IdP subject doesn't match an existing "
+            "user_id/sso_user_id. 'strict' (default) refuses (403) any match against an already-bound or "
+            "proxy_admin row. 'create_new' silently provisions a new non-admin user instead of linking in that case."
+        ),
+    )
     pass_through_request_timeout: float | None = Field(
         default=None,
         description="Default upstream request timeout in seconds for native and custom pass-through endpoints that use pass_through_request. Defaults to 600 when unset.",
@@ -4521,6 +4529,14 @@ class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
     )
     user_id_jwt_field: str | None = None
     user_email_jwt_field: str | None = None
+    user_email_verified_jwt_field: str | None = Field(
+        default="email_verified",
+        description=(
+            "The field in the JWT token that stores whether the user's email is verified. Used to gate "
+            "email-based fuzzy user matching/linking. Defaults to the standard OIDC 'email_verified' claim; "
+            "set to None to never trust email-based linking for this issuer."
+        ),
+    )
     user_allowed_email_domain: str | None = None
     user_roles_jwt_field: str | None = None
     user_allowed_roles: list[str] | None = None

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -10,6 +10,7 @@ Run checks for:
 """
 
 import asyncio
+import enum
 import math
 import re
 import time
@@ -146,6 +147,8 @@ class _PrismaVectorStoreRow(Protocol):
 
 class _PrismaUserRow(Protocol):
     user_id: str
+    sso_user_id: str | None
+    user_role: str | None
     organization_memberships: Sequence[LiteLLM_OrganizationMembershipTable | None] | None
 
     def __iter__(self) -> Iterator[tuple[str, object]]: ...
@@ -1748,10 +1751,67 @@ def get_role_based_routes(
     )
 
 
+class SSOEmailLinkingPolicy(str, enum.Enum):
+    STRICT = "strict"
+    CREATE_NEW = "create_new"
+
+
+class _FuzzyEmailMatchDecision(str, enum.Enum):
+    LINK = "link"
+    REFUSE = "refuse"
+    IGNORE = "ignore"
+
+
+class EmailLinkingRefusedError(Exception):
+    """Raised when an SSO/JWT email-fuzzy-match hits a bound or admin row under the strict linking policy."""
+
+
+def _get_sso_email_linking_policy(general_settings: Mapping[str, object]) -> SSOEmailLinkingPolicy:
+    raw_policy: Final = general_settings.get("sso_email_linking_policy", SSOEmailLinkingPolicy.STRICT.value)
+    try:
+        return SSOEmailLinkingPolicy(raw_policy)
+    except ValueError:
+        return SSOEmailLinkingPolicy.STRICT
+
+
+def _decide_email_fuzzy_match(
+    matched_row: "_PrismaUserRow",
+    presented_sso_user_id: str | None,
+    email_verified: bool,
+    policy: SSOEmailLinkingPolicy,
+) -> _FuzzyEmailMatchDecision:
+    """
+    Pure decision for whether an email-matched row may be linked to a newly presented SSO/JWT subject.
+
+    - Unverified email: never link.
+    - proxy_admin rows, or rows already bound to a different subject: never link;
+      refused (403) under the strict policy when a subject was actually presented,
+      otherwise silently ignored (treated as no match).
+    - Unlinked/invited rows with a verified email: safe to link.
+    """
+    if not email_verified:
+        return _FuzzyEmailMatchDecision.IGNORE
+
+    is_admin: Final = matched_row.user_role == LitellmUserRoles.PROXY_ADMIN.value
+    is_bound_to_other: Final = (
+        presented_sso_user_id is not None
+        and matched_row.sso_user_id is not None
+        and matched_row.sso_user_id != presented_sso_user_id
+    )
+    if is_admin or is_bound_to_other:
+        if presented_sso_user_id is not None and policy is SSOEmailLinkingPolicy.STRICT:
+            return _FuzzyEmailMatchDecision.REFUSE
+        return _FuzzyEmailMatchDecision.IGNORE
+
+    return _FuzzyEmailMatchDecision.LINK
+
+
 async def _get_fuzzy_user_object(
     prisma_client: PrismaClient,
     sso_user_id: str | None = None,
     user_email: str | None = None,
+    email_verified: bool = False,
+    general_settings: Mapping[str, object] | None = None,
 ) -> "_PrismaUserRow | None":
     """
     Checks if sso user is in db.
@@ -1760,7 +1820,9 @@ async def _get_fuzzy_user_object(
 
     - Check if sso_user_id is user_id in db
     - Check if sso_user_id is sso_user_id in db
-    - Check if user_email is user_email in db
+    - Check if user_email is user_email in db, and only link it to the presented
+      subject if the email is verified and the row isn't an admin or already bound
+      to a different subject (see `_decide_email_fuzzy_match`)
     - If not, create new user with user_email and sso_user_id and user_id = sso_user_id
     """
 
@@ -1779,13 +1841,30 @@ async def _get_fuzzy_user_object(
             include={"organization_memberships": True},
         )
 
-        if response is not None and sso_user_id is not None:  # update sso_user_id
-            asyncio.create_task(  # background task to update user with sso id
-                _user_table(UserRepository(prisma_client)).update(
+        if response is not None:
+            if general_settings is None:
+                from litellm.proxy.proxy_server import general_settings as _proxy_general_settings
+
+                general_settings = _proxy_general_settings
+
+            decision: Final = _decide_email_fuzzy_match(
+                matched_row=response,
+                presented_sso_user_id=sso_user_id,
+                email_verified=email_verified,
+                policy=_get_sso_email_linking_policy(general_settings),
+            )
+            if decision is _FuzzyEmailMatchDecision.REFUSE:
+                raise EmailLinkingRefusedError(
+                    f"Refusing to link user_email={user_email!r} to sso_user_id={sso_user_id!r}: "
+                    "matched row is a proxy_admin or already bound to a different subject."
+                )
+            if decision is _FuzzyEmailMatchDecision.IGNORE:
+                return None
+            if sso_user_id is not None:  # update sso_user_id
+                await _user_table(UserRepository(prisma_client)).update(
                     where={"user_id": response.user_id},
                     data={"sso_user_id": sso_user_id},
                 )
-            )
 
     return response
 
@@ -1829,6 +1908,7 @@ async def get_user_object(
     sso_user_id: str | None = None,
     user_email: str | None = None,
     check_db_only: bool | None = None,
+    email_verified: bool = False,
 ) -> LiteLLM_UserTable | None:
     """
     - Check if user id in proxy User Table
@@ -1873,6 +1953,7 @@ async def get_user_object(
                     prisma_client=prisma_client,
                     sso_user_id=sso_user_id,
                     user_email=user_email,
+                    email_verified=email_verified,
                 )
 
         else:
@@ -1959,6 +2040,8 @@ async def get_user_object(
         )
 
         return _response
+    except EmailLinkingRefusedError:
+        raise
     except Exception as e:  # if user not in db
         _log_budget_lookup_failure("user", e)
         raise ValueError(

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -55,6 +55,7 @@ from litellm.proxy.utils import PrismaClient, ProxyLogging
 from litellm.repositories.user_repository import UserRepository
 
 from .auth_checks import (
+    EmailLinkingRefusedError,
     _allowed_routes_check,
     allowed_routes_check,
     get_actual_routes,
@@ -531,6 +532,27 @@ class JWTHandler:
         except KeyError:
             user_email = default_value
         return user_email
+
+    def get_email_verified(self, token: dict, default_value: bool) -> bool:
+        """
+        Returns whether the token's email claim is verified.
+
+        Set via 'user_email_verified_jwt_field' in the config (defaults to the
+        standard OIDC 'email_verified' claim). Gates email-based fuzzy user
+        matching/linking - see `auth_checks._decide_email_fuzzy_match`.
+        """
+        try:
+            if self.litellm_jwtauth.user_email_verified_jwt_field is not None:
+                email_verified = get_nested_value(
+                    data=token,
+                    key_path=self.litellm_jwtauth.user_email_verified_jwt_field,
+                    default=default_value,
+                )
+            else:
+                email_verified = default_value
+        except KeyError:
+            email_verified = default_value
+        return bool(email_verified)
 
     def get_object_id(self, token: dict, default_value: str | None) -> str | None:
         try:
@@ -1417,14 +1439,15 @@ class JWTAuthManager:
     async def get_user_info(
         jwt_handler: JWTHandler,
         jwt_valid_token: dict,
-    ) -> tuple[str | None, str | None, bool | None]:
-        """Get user email and validation status"""
+    ) -> tuple[str | None, str | None, bool | None, bool]:
+        """Get user email, validation status, and email-verified status"""
         user_email: Final = jwt_handler.get_user_email(token=jwt_valid_token, default_value=None)
         valid_user_email = None
         if jwt_handler.is_enforced_email_domain():
             valid_user_email = False if user_email is None else jwt_handler.is_allowed_domain(user_email=user_email)
         user_id: Final = jwt_handler.get_user_id(token=jwt_valid_token, default_value=user_email)
-        return user_id, user_email, valid_user_email
+        email_verified: Final = jwt_handler.get_email_verified(token=jwt_valid_token, default_value=False)
+        return user_id, user_email, valid_user_email, email_verified
 
     @staticmethod
     def _canonical_user_id_from_db(
@@ -1456,6 +1479,7 @@ class JWTAuthManager:
         proxy_logging_obj: ProxyLogging,
         route: str,
         org_alias: str | None = None,
+        email_verified: bool = False,
     ) -> tuple[
         LiteLLM_UserTable | None,
         LiteLLM_OrganizationTable | None,
@@ -1508,20 +1532,29 @@ class JWTAuthManager:
 
         user_object: LiteLLM_UserTable | None = None
         if user_id:
-            user_object = (
-                await get_user_object(
-                    user_id=user_id,
-                    prisma_client=prisma_client,
-                    user_api_key_cache=user_api_key_cache,
-                    user_id_upsert=jwt_handler.is_upsert_user_id(valid_user_email=valid_user_email),
-                    parent_otel_span=parent_otel_span,
-                    proxy_logging_obj=proxy_logging_obj,
-                    user_email=user_email,
-                    sso_user_id=user_id,
+            try:
+                user_object = (
+                    await get_user_object(
+                        user_id=user_id,
+                        prisma_client=prisma_client,
+                        user_api_key_cache=user_api_key_cache,
+                        user_id_upsert=jwt_handler.is_upsert_user_id(valid_user_email=valid_user_email),
+                        parent_otel_span=parent_otel_span,
+                        proxy_logging_obj=proxy_logging_obj,
+                        user_email=user_email,
+                        sso_user_id=user_id,
+                        email_verified=email_verified,
+                    )
+                    if user_id
+                    else None
                 )
-                if user_id
-                else None
-            )
+            except EmailLinkingRefusedError as e:
+                raise ProxyException(
+                    message=f"JWT subject does not match the existing user for this email. {e}",
+                    type=ProxyErrorTypes.auth_error,
+                    param="user_email",
+                    code=403,
+                ) from e
 
         end_user_object: LiteLLM_EndUserTable | None = None
         if end_user_id:
@@ -2059,7 +2092,9 @@ class JWTAuthManager:
         object_id = jwt_handler.get_object_id(token=jwt_valid_token, default_value=None)
 
         # Get basic user info
-        user_id, user_email, valid_user_email = await JWTAuthManager.get_user_info(jwt_handler, jwt_valid_token)
+        user_id, user_email, valid_user_email, email_verified = await JWTAuthManager.get_user_info(
+            jwt_handler, jwt_valid_token
+        )
 
         # Get IDs
         org_id: Final = jwt_handler.get_org_id(token=jwt_valid_token, default_value=None)
@@ -2216,6 +2251,7 @@ class JWTAuthManager:
             proxy_logging_obj=proxy_logging_obj,
             route=route,
             org_alias=org_alias,
+            email_verified=email_verified,
         )
 
         # Derive org_id from org_object if resolved by alias

--- a/litellm/proxy/management_endpoints/types.py
+++ b/litellm/proxy/management_endpoints/types.py
@@ -57,3 +57,4 @@ class CustomOpenID(OpenID):
     team_ids: list[str]
     user_role: LitellmUserRoles | None = None
     extra_fields: dict[str, Any] | None = None
+    email_verified: bool = False

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -86,7 +86,11 @@ from litellm.proxy._types import (
     TeamMemberAddRequest,
     UserAPIKeyAuth,
 )
-from litellm.proxy.auth.auth_checks import ExperimentalUIJWTToken, get_user_object
+from litellm.proxy.auth.auth_checks import (
+    EmailLinkingRefusedError,
+    ExperimentalUIJWTToken,
+    get_user_object,
+)
 from litellm.proxy.auth.auth_utils import (
     _get_request_ip_address,
     _has_user_setup_sso,
@@ -1174,6 +1178,10 @@ def generic_response_convertor(
 
     generic_user_role_attribute_name: Final = os.getenv("GENERIC_USER_ROLE_ATTRIBUTE", "role")
 
+    generic_user_email_verified_attribute_name: Final = os.getenv(
+        "GENERIC_USER_EMAIL_VERIFIED_ATTRIBUTE", "email_verified"
+    )
+
     generic_user_extra_attributes: Final = os.getenv("GENERIC_USER_EXTRA_ATTRIBUTES", None)
 
     verbose_proxy_logger.debug(
@@ -1272,6 +1280,7 @@ def generic_response_convertor(
         team_ids=all_teams,
         user_role=user_role,
         extra_fields=extra_fields,
+        email_verified=bool(get_nested_value(response, generic_user_email_verified_attribute_name, default=False)),
     )
 
 
@@ -1725,12 +1734,30 @@ def get_disabled_non_admin_personal_key_creation():
     return bool("proxy_admin" in allowed_user_roles)
 
 
+def _email_verified_from_sso_result(result: "CustomOpenID | OpenID | dict") -> bool:
+    """
+    Whether the IdP-asserted email on `result` is verified, for gating
+    email-based fuzzy user linking (see `auth_checks._decide_email_fuzzy_match`).
+
+    `CustomOpenID` (Microsoft, Generic/OIDC) carries an explicit `email_verified`
+    flag set at parse time. A bare `fastapi_sso.OpenID` is only ever produced by
+    the Google branch, whose SSO handler already rejects unverified emails
+    before returning a result, so that case is implicitly verified.
+    """
+    if isinstance(result, CustomOpenID):
+        return result.email_verified
+    if isinstance(result, dict):
+        return bool(result.get("email_verified", False))
+    return True
+
+
 async def get_existing_user_info_from_db(
     user_id: str | None,
     user_email: str | None,
     prisma_client: PrismaClient,
     user_api_key_cache: UserApiKeyCache,
     proxy_logging_obj: ProxyLogging,
+    email_verified: bool = False,
 ) -> LiteLLM_UserTable | None:
     try:
         user_info = await get_user_object(
@@ -1742,7 +1769,10 @@ async def get_existing_user_info_from_db(
             parent_otel_span=None,
             proxy_logging_obj=proxy_logging_obj,
             sso_user_id=user_id,
+            email_verified=email_verified,
         )
+    except EmailLinkingRefusedError:
+        raise
     except Exception as e:
         verbose_proxy_logger.debug("Error getting user object: %s", e)
         user_info = None
@@ -1775,6 +1805,7 @@ async def get_user_info_from_db(
         user_email = normalize_email(
             getattr(result, "email", None) if not isinstance(result, dict) else result.get("email", None)
         )
+        email_verified: Final = _email_verified_from_sso_result(result)
 
         user_info: LiteLLM_UserTable | NewUserResponse | None = None
 
@@ -1785,6 +1816,7 @@ async def get_user_info_from_db(
                 prisma_client=prisma_client,
                 user_api_key_cache=user_api_key_cache,
                 proxy_logging_obj=proxy_logging_obj,
+                email_verified=email_verified,
             )
             if user_info is not None:
                 break
@@ -1808,6 +1840,8 @@ async def get_user_info_from_db(
         )
 
         return user_info
+    except EmailLinkingRefusedError:
+        raise
     except Exception as e:
         verbose_proxy_logger.exception("[Non-Blocking] Error trying to add sso user to db: %s", e)
 
@@ -2259,15 +2293,21 @@ async def _complete_cli_sso_callback_session(
 
     user_id: Final = parsed_openid_result.get("user_id")
     user_email: Final = parsed_openid_result.get("user_email")
-    user_info: Final = await get_user_info_from_db(
-        result=result,
-        prisma_client=prisma_client,
-        user_api_key_cache=user_api_key_cache,
-        proxy_logging_obj=proxy_logging_obj,
-        user_email=user_email,
-        user_defined_values=user_defined_values,
-        alternate_user_id=user_id,
-    )
+    try:
+        user_info: Final = await get_user_info_from_db(
+            result=result,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+            user_email=user_email,
+            user_defined_values=user_defined_values,
+            alternate_user_id=user_id,
+        )
+    except EmailLinkingRefusedError as e:
+        raise HTTPException(
+            status_code=403,
+            detail=f"SSO subject does not match the existing user for this email. {e}",
+        ) from e
     if user_info is None:
         raise HTTPException(status_code=500, detail="Failed to retrieve user information from SSO")
     if not user_info.user_id:
@@ -3505,15 +3545,21 @@ class SSOAuthenticationHandler:
             received_response=received_response,
         )
 
-        user_info = await get_user_info_from_db(
-            result=result,
-            prisma_client=prisma_client,
-            user_api_key_cache=user_api_key_cache,
-            proxy_logging_obj=proxy_logging_obj,
-            user_email=user_email,
-            user_defined_values=user_defined_values,
-            alternate_user_id=user_id,
-        )
+        try:
+            user_info = await get_user_info_from_db(
+                result=result,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+                user_email=user_email,
+                user_defined_values=user_defined_values,
+                alternate_user_id=user_id,
+            )
+        except EmailLinkingRefusedError as e:
+            raise HTTPException(
+                status_code=403,
+                detail=f"SSO subject does not match the existing user for this email. {e}",
+            ) from e
 
         # Sync user role from JWT claims via jwt_litellm_role_map (if configured).
         # This ensures SSO users get the same role mapping as API/JWT users.
@@ -4277,6 +4323,10 @@ class MicrosoftSSOHandler:
             last_name=response.get(MICROSOFT_USER_LAST_NAME_ATTRIBUTE),
             team_ids=team_ids,
             user_role=user_role,
+            # `mail` comes from the tenant-managed Graph API directory, not a
+            # self-asserted end-user claim, so it's trustworthy for email-based
+            # fuzzy user linking.
+            email_verified=True,
         )
         verbose_proxy_logger.debug("Microsoft SSO OpenID Response: %s", openid_response)
         return openid_response

--- a/tests/proxy_unit_tests/test_auth_checks.py
+++ b/tests/proxy_unit_tests/test_auth_checks.py
@@ -836,7 +836,10 @@ async def test_can_user_call_model_with_no_default_models():
 
 @pytest.mark.asyncio
 async def test_get_fuzzy_user_object():
-    from litellm.proxy.auth.auth_checks import _get_fuzzy_user_object
+    from litellm.proxy.auth.auth_checks import (
+        EmailLinkingRefusedError,
+        _get_fuzzy_user_object,
+    )
     from litellm.proxy.utils import PrismaClient
     from unittest.mock import AsyncMock, MagicMock
 
@@ -845,46 +848,71 @@ async def test_get_fuzzy_user_object():
     mock_prisma.db = MagicMock()
     mock_prisma.db.litellm_usertable = MagicMock()
 
-    # Mock user data
-    test_user = LiteLLM_UserTable(
+    # A row already bound to a different SSO subject than the one presented below.
+    bound_user = LiteLLM_UserTable(
         user_id="test_123",
         sso_user_id="sso_123",
         user_email="test@example.com",
         organization_memberships=[],
         max_budget=None,
     )
+    # An invited/unlinked row: email set by an admin, never logged in via SSO yet.
+    unlinked_user = LiteLLM_UserTable(
+        user_id="test_456",
+        sso_user_id=None,
+        user_email="unlinked@example.com",
+        organization_memberships=[],
+        max_budget=None,
+    )
 
     # Test 1: Find user by SSO ID
-    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=test_user)
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=bound_user)
     result = await _get_fuzzy_user_object(
         prisma_client=mock_prisma, sso_user_id="sso_123", user_email="test@example.com"
     )
-    assert result == test_user
+    assert result == bound_user
     mock_prisma.db.litellm_usertable.find_unique.assert_called_with(
         where={"sso_user_id": "sso_123"}, include={"organization_memberships": True}
     )
 
-    # Test 2: SSO ID not found, find by email
+    # Test 2: SSO ID not found, email matches an unlinked/invited row with a verified
+    # email -> safe to link. The rebind is awaited directly (no more fire-and-forget).
     mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-    mock_prisma.db.litellm_usertable.find_first = AsyncMock(return_value=test_user)
+    mock_prisma.db.litellm_usertable.find_first = AsyncMock(return_value=unlinked_user)
     mock_prisma.db.litellm_usertable.update = AsyncMock()
 
     result = await _get_fuzzy_user_object(
         prisma_client=mock_prisma,
         sso_user_id="new_sso_456",
-        user_email="test@example.com",
+        user_email="unlinked@example.com",
+        email_verified=True,
+        general_settings={},
     )
-    assert result == test_user
+    assert result == unlinked_user
     mock_prisma.db.litellm_usertable.find_first.assert_called_with(
-        where={"user_email": {"equals": "test@example.com", "mode": "insensitive"}},
+        where={"user_email": {"equals": "unlinked@example.com", "mode": "insensitive"}},
         include={"organization_memberships": True},
     )
-
-    # Test 3: Verify background SSO update task when user found by email
-    await asyncio.sleep(0.1)  # Allow time for background task
     mock_prisma.db.litellm_usertable.update.assert_called_with(
-        where={"user_id": "test_123"}, data={"sso_user_id": "new_sso_456"}
+        where={"user_id": "test_456"}, data={"sso_user_id": "new_sso_456"}
     )
+
+    # Test 3: SSO ID not found, email matches a row already bound to a DIFFERENT
+    # subject -> refused under the default strict policy, never rebound. This is
+    # the regression test for the account-rebinding vulnerability.
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma.db.litellm_usertable.find_first = AsyncMock(return_value=bound_user)
+    mock_prisma.db.litellm_usertable.update = AsyncMock()
+
+    with pytest.raises(EmailLinkingRefusedError):
+        await _get_fuzzy_user_object(
+            prisma_client=mock_prisma,
+            sso_user_id="new_sso_456",
+            user_email="test@example.com",
+            email_verified=True,
+            general_settings={},
+        )
+    mock_prisma.db.litellm_usertable.update.assert_not_called()
 
     # Test 4: User not found by either method
     mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
@@ -897,26 +925,217 @@ async def test_get_fuzzy_user_object():
     )
     assert result is None
 
-    # Test 5: Only email provided (no SSO ID)
-    mock_prisma.db.litellm_usertable.find_first = AsyncMock(return_value=test_user)
+    # Test 5: Only email provided (no SSO ID) -> read-only match, no rebind write
+    # is possible regardless of policy, but the email must still be verified.
+    mock_prisma.db.litellm_usertable.find_first = AsyncMock(return_value=bound_user)
     result = await _get_fuzzy_user_object(
-        prisma_client=mock_prisma, user_email="test@example.com"
+        prisma_client=mock_prisma, user_email="test@example.com", email_verified=True
     )
-    assert result == test_user
+    assert result == bound_user
     mock_prisma.db.litellm_usertable.find_first.assert_called_with(
         where={"user_email": {"equals": "test@example.com", "mode": "insensitive"}},
         include={"organization_memberships": True},
     )
 
     # Test 6: Only SSO ID provided (no email)
-    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=test_user)
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=bound_user)
     result = await _get_fuzzy_user_object(
         prisma_client=mock_prisma, sso_user_id="sso_123"
     )
-    assert result == test_user
+    assert result == bound_user
     mock_prisma.db.litellm_usertable.find_unique.assert_called_with(
         where={"sso_user_id": "sso_123"}, include={"organization_memberships": True}
     )
+
+
+@pytest.mark.asyncio
+async def test_get_fuzzy_user_object_email_not_verified():
+    """Unverified email must never be used to link an account, regardless of policy."""
+    from litellm.proxy.auth.auth_checks import _get_fuzzy_user_object
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_usertable = MagicMock()
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma.db.litellm_usertable.find_first = AsyncMock(
+        return_value=LiteLLM_UserTable(
+            user_id="test_456",
+            sso_user_id=None,
+            user_email="unlinked@example.com",
+            organization_memberships=[],
+            max_budget=None,
+        )
+    )
+    mock_prisma.db.litellm_usertable.update = AsyncMock()
+
+    result = await _get_fuzzy_user_object(
+        prisma_client=mock_prisma,
+        sso_user_id="new_sso_456",
+        user_email="unlinked@example.com",
+        email_verified=False,
+        general_settings={},
+    )
+    assert result is None
+    mock_prisma.db.litellm_usertable.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_fuzzy_user_object_admin_row_never_linked():
+    """A proxy_admin row must never be linked/inherited via email match, under either policy."""
+    from litellm.proxy.auth.auth_checks import EmailLinkingRefusedError, _get_fuzzy_user_object
+    from litellm.proxy._types import LitellmUserRoles
+    from unittest.mock import AsyncMock, MagicMock
+
+    admin_user = LiteLLM_UserTable(
+        user_id="admin_123",
+        sso_user_id=None,
+        user_email="admin@example.com",
+        user_role=LitellmUserRoles.PROXY_ADMIN.value,
+        organization_memberships=[],
+        max_budget=None,
+    )
+
+    def _make_mock_prisma() -> MagicMock:
+        mock_prisma = MagicMock()
+        mock_prisma.db = MagicMock()
+        mock_prisma.db.litellm_usertable = MagicMock()
+        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+        mock_prisma.db.litellm_usertable.find_first = AsyncMock(return_value=admin_user)
+        mock_prisma.db.litellm_usertable.update = AsyncMock()
+        return mock_prisma
+
+    # strict policy -> refused (403 upstream)
+    strict_prisma = _make_mock_prisma()
+    with pytest.raises(EmailLinkingRefusedError):
+        await _get_fuzzy_user_object(
+            prisma_client=strict_prisma,
+            sso_user_id="attacker_sub",
+            user_email="admin@example.com",
+            email_verified=True,
+            general_settings={"sso_email_linking_policy": "strict"},
+        )
+    strict_prisma.db.litellm_usertable.update.assert_not_called()
+
+    # create_new policy -> silently ignored, never linked/rebound
+    create_new_prisma = _make_mock_prisma()
+    result = await _get_fuzzy_user_object(
+        prisma_client=create_new_prisma,
+        sso_user_id="attacker_sub",
+        user_email="admin@example.com",
+        email_verified=True,
+        general_settings={"sso_email_linking_policy": "create_new"},
+    )
+    assert result is None
+    create_new_prisma.db.litellm_usertable.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_fuzzy_user_object_create_new_policy_on_conflict():
+    """create_new policy on a bound-to-other-subject row: ignore, don't link, don't refuse."""
+    from litellm.proxy.auth.auth_checks import _get_fuzzy_user_object
+    from unittest.mock import AsyncMock, MagicMock
+
+    bound_user = LiteLLM_UserTable(
+        user_id="test_123",
+        sso_user_id="sso_123",
+        user_email="test@example.com",
+        organization_memberships=[],
+        max_budget=None,
+    )
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_usertable = MagicMock()
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma.db.litellm_usertable.find_first = AsyncMock(return_value=bound_user)
+    mock_prisma.db.litellm_usertable.update = AsyncMock()
+
+    result = await _get_fuzzy_user_object(
+        prisma_client=mock_prisma,
+        sso_user_id="new_sso_456",
+        user_email="test@example.com",
+        email_verified=True,
+        general_settings={"sso_email_linking_policy": "create_new"},
+    )
+    assert result is None
+    mock_prisma.db.litellm_usertable.update.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "matched_row_kwargs, presented_sso_user_id, email_verified, policy, expected",
+    [
+        # (a) mismatched subject on a bound row -> refuse under strict
+        (
+            {"sso_user_id": "sso_123"},
+            "new_sso_456",
+            True,
+            "strict",
+            "refuse",
+        ),
+        # (b) unverified email -> ignore, regardless of anything else
+        (
+            {"sso_user_id": None},
+            "new_sso_456",
+            False,
+            "strict",
+            "ignore",
+        ),
+        # (c) admin row -> never link, strict refuses
+        (
+            {"sso_user_id": None, "user_role": "proxy_admin"},
+            "new_sso_456",
+            True,
+            "strict",
+            "refuse",
+        ),
+        # (c) admin row -> never link, create_new silently ignores
+        (
+            {"sso_user_id": None, "user_role": "proxy_admin"},
+            "new_sso_456",
+            True,
+            "create_new",
+            "ignore",
+        ),
+        # (d) unlinked/invited row with verified email -> link
+        (
+            {"sso_user_id": None},
+            "new_sso_456",
+            True,
+            "strict",
+            "link",
+        ),
+        # (e) create_new policy on a conflict -> ignore, never link/refuse
+        (
+            {"sso_user_id": "sso_123"},
+            "new_sso_456",
+            True,
+            "create_new",
+            "ignore",
+        ),
+    ],
+)
+def test_decide_email_fuzzy_match(
+    matched_row_kwargs, presented_sso_user_id, email_verified, policy, expected
+):
+    from litellm.proxy.auth.auth_checks import (
+        SSOEmailLinkingPolicy,
+        _decide_email_fuzzy_match,
+    )
+
+    matched_row = LiteLLM_UserTable(
+        user_id="test_123",
+        user_email="test@example.com",
+        organization_memberships=[],
+        max_budget=None,
+        **matched_row_kwargs,
+    )
+    decision = _decide_email_fuzzy_match(
+        matched_row=matched_row,
+        presented_sso_user_id=presented_sso_user_id,
+        email_verified=email_verified,
+        policy=SSOEmailLinkingPolicy(policy),
+    )
+    assert decision.value == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -3013,6 +3013,7 @@ async def test_get_fuzzy_user_object_case_insensitive_email():
         prisma_client=mock_prisma,
         sso_user_id=None,
         user_email="test@example.com",  # Lowercase search
+        email_verified=True,
     )
 
     # Verify user was found despite case difference

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -301,7 +301,7 @@ async def test_auth_builder_proxy_admin_user_role():
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=("test_user_1", "test@example.com", True),
+            return_value=("test_user_1", "test@example.com", True, True),
         ) as mock_get_user_info,
         patch.object(jwt_handler, "get_org_id", return_value=None) as mock_get_org_id,
         patch.object(
@@ -396,7 +396,7 @@ async def test_auth_builder_non_proxy_admin_user_role():
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=("test_user_1", "test@example.com", True),
+            return_value=("test_user_1", "test@example.com", True, True),
         ) as mock_get_user_info,
         patch.object(jwt_handler, "get_org_id", return_value=None) as mock_get_org_id,
         patch.object(
@@ -494,7 +494,7 @@ async def test_auth_builder_result_includes_user_email(row_email, expected_email
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=("test_user_1", "claim@example.com", True),
+            return_value=("test_user_1", "claim@example.com", True, True),
         ),
         patch.object(jwt_handler, "get_org_id", return_value=None),
         patch.object(jwt_handler, "get_end_user_id", return_value=None),
@@ -1372,7 +1372,7 @@ async def test_auth_builder_returns_team_membership_object():
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=(_user_id, "test@example.com", True),
+            return_value=(_user_id, "test@example.com", True, True),
         ) as mock_get_user_info,
         patch.object(jwt_handler, "get_org_id", return_value=None) as mock_get_org_id,
         patch.object(
@@ -1517,7 +1517,7 @@ async def test_auth_builder_with_oidc_userinfo_enabled():
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=("test_user_1", "test@example.com", True),
+            return_value=("test_user_1", "test@example.com", True, True),
         ) as mock_get_user_info,
         patch.object(jwt_handler, "get_org_id", return_value=None) as mock_get_org_id,
         patch.object(
@@ -1641,7 +1641,7 @@ async def test_auth_builder_with_oidc_userinfo_disabled():
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=("test_user_1", None, None),
+            return_value=("test_user_1", None, None, True),
         ) as mock_get_user_info,
         patch.object(jwt_handler, "get_org_id", return_value=None) as mock_get_org_id,
         patch.object(
@@ -1761,7 +1761,7 @@ async def test_auth_builder_oidc_enabled_falls_back_to_jwt_auth_for_jwt_tokens()
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=("test_user_1", None, None),
+            return_value=("test_user_1", None, None, True),
         ),
         patch.object(jwt_handler, "get_org_id", return_value=None),
         patch.object(jwt_handler, "get_end_user_id", return_value=None),
@@ -3086,7 +3086,7 @@ async def test_auth_builder_single_team_db_fallback_when_jwt_has_no_team(
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=(user_id, "u@example.com", True),
+            return_value=(user_id, "u@example.com", True, True),
         ),
         patch.object(jwt_handler, "get_org_id", return_value=None),
         patch.object(jwt_handler, "get_end_user_id", return_value=None),
@@ -3204,7 +3204,7 @@ async def test_auth_builder_single_team_fallback_membership_error_skips_no_raise
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=(user_id, "u@example.com", True),
+            return_value=(user_id, "u@example.com", True, True),
         ),
         patch.object(jwt_handler, "get_org_id", return_value=None),
         patch.object(jwt_handler, "get_end_user_id", return_value=None),
@@ -4044,6 +4044,46 @@ async def test_get_objects_team_membership_uses_rebound_user_id():
 
 
 @pytest.mark.asyncio
+async def test_get_objects_refuses_email_linking_mismatch():
+    """
+    A JWT subject that only matches an existing user via the email-fuzzy-match
+    fallback (e.g. because it collides with a proxy_admin row's email) must not
+    silently resolve to a user_object/is_proxy_admin - get_objects should
+    surface the refusal as a 403, not let it leak through.
+    """
+    from litellm.caching.caching import DualCache
+    from litellm.proxy.auth.auth_checks import EmailLinkingRefusedError
+
+    async def fake_get_user_object(*args, **kwargs):
+        raise EmailLinkingRefusedError("matched row is a proxy_admin or bound to a different subject")
+
+    jwt_handler = JWTHandler()
+    jwt_handler.litellm_jwtauth = LiteLLM_JWTAuth(user_id_jwt_field="email")
+
+    with patch(
+        "litellm.proxy.auth.handle_jwt.get_user_object",
+        side_effect=fake_get_user_object,
+    ):
+        with pytest.raises(ProxyException) as exc_info:
+            await JWTAuthManager.get_objects(
+                user_id="attacker@example.com",
+                user_email="attacker@example.com",
+                org_id=None,
+                end_user_id=None,
+                team_id=None,
+                valid_user_email=None,
+                jwt_handler=jwt_handler,
+                prisma_client=MagicMock(),
+                user_api_key_cache=DualCache(),
+                parent_otel_span=None,
+                proxy_logging_obj=MagicMock(),
+                route="/chat/completions",
+            )
+
+    assert exc_info.value.code == str(403)
+
+
+@pytest.mark.asyncio
 async def test_multi_issuer_jwt_validates_selected_issuer_and_maps_claims(
     monkeypatch,
 ):
@@ -4762,7 +4802,7 @@ async def test_auth_builder_db_team_fallback_when_jwt_has_no_team(
                 JWTAuthManager,
                 "get_user_info",
                 new_callable=AsyncMock,
-                return_value=(user_id, "u@example.com", True),
+                return_value=(user_id, "u@example.com", True, True),
             ),
             patch.object(jwt_handler, "get_org_id", return_value=None),
             patch.object(jwt_handler, "get_end_user_id", return_value=None),
@@ -5054,7 +5094,7 @@ async def _run_auth_builder_with_header_team(
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=(user_object.user_id, "u@example.com", True),
+            return_value=(user_object.user_id, "u@example.com", True, True),
         ),
         patch.object(jwt_handler, "get_org_id", return_value=None),
         patch.object(jwt_handler, "get_end_user_id", return_value=None),
@@ -5318,7 +5358,7 @@ async def test_auth_builder_db_fallback_does_not_validate_rbac_team_against_db_m
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=(user_id, "u@example.com", True),
+            return_value=(user_id, "u@example.com", True, True),
         ),
         patch.object(jwt_handler, "get_org_id", return_value=None),
         patch.object(jwt_handler, "get_end_user_id", return_value=None),
@@ -5473,7 +5513,7 @@ async def test_auth_builder_db_fallback_runs_when_only_team_id_default_set():
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=(user_id, "u@example.com", True),
+            return_value=(user_id, "u@example.com", True, True),
         ),
         patch.object(jwt_handler, "get_org_id", return_value=None),
         patch.object(jwt_handler, "get_end_user_id", return_value=None),
@@ -5557,7 +5597,7 @@ async def test_auth_builder_alias_only_token_resolves_alias_not_db_fallback():
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=(user_id, "u@example.com", True),
+            return_value=(user_id, "u@example.com", True, True),
         ),
         patch.object(jwt_handler, "get_org_id", return_value=None),
         patch.object(jwt_handler, "get_end_user_id", return_value=None),
@@ -5741,7 +5781,7 @@ async def test_auth_builder_db_fallback_enforces_passthrough_route_access():
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=(user_id, "u@example.com", True),
+            return_value=(user_id, "u@example.com", True, True),
         ),
         patch.object(jwt_handler, "get_org_id", return_value=None),
         patch.object(jwt_handler, "get_end_user_id", return_value=None),
@@ -5882,7 +5922,7 @@ async def test_auth_builder_provisional_header_team_is_not_upserted():
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=(user_id, "u@example.com", True),
+            return_value=(user_id, "u@example.com", True, True),
         ),
         patch.object(jwt_handler, "get_org_id", return_value=None),
         patch.object(jwt_handler, "get_end_user_id", return_value=None),
@@ -5959,7 +5999,7 @@ async def test_auth_builder_header_cannot_override_rbac_team_under_db_fallback()
             JWTAuthManager,
             "get_user_info",
             new_callable=AsyncMock,
-            return_value=(user_id, "u@example.com", True),
+            return_value=(user_id, "u@example.com", True, True),
         ),
         patch.object(jwt_handler, "get_org_id", return_value=None),
         patch.object(jwt_handler, "get_end_user_id", return_value=None),
@@ -6041,7 +6081,7 @@ async def test_auth_builder_header_team_enforces_team_allowed_routes_under_db_fa
                 JWTAuthManager,
                 "get_user_info",
                 new_callable=AsyncMock,
-                return_value=(user_id, "u@example.com", True),
+                return_value=(user_id, "u@example.com", True, True),
             ),
             patch.object(jwt_handler, "get_org_id", return_value=None),
             patch.object(jwt_handler, "get_end_user_id", return_value=None),

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -1410,6 +1410,105 @@ async def test_get_user_info_from_db_user_exists_updates_user():
         assert user_info == updated_user
 
 
+def test_email_verified_from_sso_result():
+    """
+    `_email_verified_from_sso_result` gates email-based fuzzy user linking.
+
+    - Google returns a bare fastapi_sso OpenID (no email_verified field) because
+      its library already rejects unverified emails before returning a result,
+      so that case is implicitly verified.
+    - Microsoft/Generic build a CustomOpenID carrying an explicit flag.
+    """
+    from fastapi_sso.sso.base import OpenID
+
+    from litellm.proxy.management_endpoints.ui_sso import (
+        _email_verified_from_sso_result,
+    )
+
+    google_result = OpenID(id="g-1", email="user@example.com", provider="google")
+    assert _email_verified_from_sso_result(google_result) is True
+
+    verified_custom = CustomOpenID(
+        id="m-1", email="user@example.com", provider="microsoft", team_ids=[], email_verified=True
+    )
+    assert _email_verified_from_sso_result(verified_custom) is True
+
+    unverified_custom = CustomOpenID(
+        id="o-1", email="user@example.com", provider="generic", team_ids=[], email_verified=False
+    )
+    assert _email_verified_from_sso_result(unverified_custom) is False
+
+    assert _email_verified_from_sso_result({"email_verified": True}) is True
+    assert _email_verified_from_sso_result({}) is False
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_from_db_refuses_admin_email_match():
+    """
+    An IdP asserting a new subject/email that matches an existing proxy_admin
+    row (and no direct user_id/sso_user_id match) must not silently resolve to
+    that admin row - the refusal must propagate out of get_user_info_from_db,
+    not be swallowed as "user not found" (which would fall through to creating
+    a brand new user and hide the conflict).
+    """
+    from litellm.proxy.auth.auth_checks import EmailLinkingRefusedError
+    from litellm.proxy.management_endpoints.ui_sso import get_user_info_from_db
+
+    sso_result = CustomOpenID(
+        id="attacker-sub",
+        email="admin@example.com",
+        provider="generic",
+        team_ids=[],
+        email_verified=True,
+    )
+    args = {
+        "result": sso_result,
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": MagicMock(),
+        "proxy_logging_obj": MagicMock(),
+        "user_email": "admin@example.com",
+        "user_defined_values": None,
+    }
+
+    with patch(
+        "litellm.proxy.management_endpoints.ui_sso.get_user_object",
+        side_effect=EmailLinkingRefusedError("matched row is a proxy_admin"),
+    ):
+        with pytest.raises(EmailLinkingRefusedError):
+            await get_user_info_from_db(**args)
+
+
+@pytest.mark.asyncio
+async def test_get_existing_user_info_from_db_links_unverified_invited_row():
+    """
+    Sanity check for the legitimate invited-user flow: an unlinked row found via
+    email with a verified email is passed straight through to get_user_object
+    with email_verified=True, so the real linking decision (see
+    auth_checks._decide_email_fuzzy_match) can allow it.
+    """
+    from litellm.proxy.management_endpoints.ui_sso import get_existing_user_info_from_db
+
+    invited_user = LiteLLM_UserTable(
+        user_id="invited-1", sso_user_id=None, user_email="invited@example.com"
+    )
+
+    with patch(
+        "litellm.proxy.management_endpoints.ui_sso.get_user_object",
+        return_value=invited_user,
+    ) as mock_get_user_object:
+        result = await get_existing_user_info_from_db(
+            user_id="new-sub-123",
+            user_email="invited@example.com",
+            prisma_client=MagicMock(),
+            user_api_key_cache=MagicMock(),
+            proxy_logging_obj=MagicMock(),
+            email_verified=True,
+        )
+
+    assert result == invited_user
+    assert mock_get_user_object.call_args.kwargs["email_verified"] is True
+
+
 @pytest.mark.asyncio
 async def test_check_and_update_if_proxy_admin_id():
     """


### PR DESCRIPTION
## TLDR

Problem this solves:

* Unverified emails could trigger unsafe SSO/JWT account linking.
* Existing SSO identities could be silently rebound by email.
* Proxy admins could have their identity and privileges taken over.

How it solves it:

* Require verified emails before allowing fuzzy account linking.
* Block linking to proxy admins and differently-bound SSO identities.
* Add strict and create-new policies for unsafe matches.
* Read email verification status from SSO and JWT claims.
* Add regression tests for admin and unverified-email cases.

## User Flow

Before: a second identity-provider subject can take over an existing proxy admin through email matching

1. An administrator already has a LiteLLM account bound to SSO subject `admin-subject`.
2. A different identity-provider subject authenticates at `GET https://litellm-domain/sso/callback` with the administrator's email.
3. LiteLLM finds the administrator account by case-insensitive email matching and rebinds its SSO identity.
4. The new subject is redirected into `https://litellm-domain/ui/` with the stored `proxy_admin` role.
5. The new subject can call `POST https://litellm-domain/key/generate` and other administrator routes.
6. The original administrator can no longer sign in using `admin-subject`.
7. The second subject can access management data and operations belonging to the original administrator.

After: an email match cannot silently take over a privileged or already-bound account

1. An administrator already has a LiteLLM account bound to SSO subject `admin-subject`.
2. A different identity-provider subject authenticates at `GET https://litellm-domain/sso/callback` with the administrator's email.
3. LiteLLM checks whether the email is verified and whether the account is already privileged or bound to another subject.
4. `GET https://litellm-domain/sso/callback` returns `403` under the default strict policy, or creates a separate non-admin user under `create_new`.
5. The new subject cannot call `POST https://litellm-domain/key/generate` using the administrator's account.
6. The original administrator remains able to sign in using `admin-subject`.
7. The second subject cannot access or modify the original administrator's management objects.

## Relevant issues

Fixes #36942

## Linear ticket

## Pre-Submission checklist

* [x] I have added meaningful tests
* [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
* [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
* [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [[Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Before (`46ffc2ab7d4b29889b54f9ccefd78f995a0e53ff`)

#### Existing proxy admin can be rebound through email

1. Configure SSO/JWT authentication with an existing `proxy_admin` user.
2. Authenticate with a different SSO subject using the same administrator email.
3. The email match returns the existing administrator account and replaces its SSO subject.
4. The new subject receives the existing `proxy_admin` privileges.

### After (`508be1d81fc8dca5c502b401d96bec8d429d428e`)

#### Existing proxy admin cannot be rebound through email

1. Configure SSO/JWT authentication with an existing `proxy_admin` user.
2. Authenticate with a different SSO subject using the same verified administrator email.
3. The email match detects the existing privileged or differently-bound account.
4. The default strict policy refuses the link instead of rebinding the account.

## Type

🐛 Bug Fix

## Caveats (if any)

* Email linking requires the identity provider to provide verification status.
* Strict linking is the default policy for backwards-safe behavior.
* `create_new` provisions a separate non-admin user for blocked matches.

## Final Attestation

* [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR