### PR TITLE
fix(streaming): preserve usage in OpenAI SDK chunks

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1451,11 +1451,7 @@ class CustomStreamWrapper:
                     setattr(
                         model_response,
                         "usage",
-                        litellm.Usage(
-                            prompt_tokens=response_obj["usage"].get("prompt_tokens", None) or None,
-                            completion_tokens=response_obj["usage"].get("completion_tokens", None) or None,
-                            total_tokens=response_obj["usage"].get("total_tokens", None) or None,
-                        ),
+                        litellm.Usage(**response_obj["usage"]),
                     )
                 elif isinstance(response_obj["usage"], Usage):
                     setattr(

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1571,9 +1571,7 @@ class CustomStreamWrapper:
 
             if hasattr(chunk, "usage") and chunk.usage is not None:
                 model_response.usage = (
-                    litellm.Usage(**chunk.usage.model_dump())
-                    if isinstance(chunk.usage, BaseModel)
-                    else chunk.usage
+                    litellm.Usage(**chunk.usage.model_dump()) if isinstance(chunk.usage, BaseModel) else chunk.usage
                 )
 
             ## RETURN ARG

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1570,7 +1570,11 @@ class CustomStreamWrapper:
                 self.tool_call = True
 
             if hasattr(chunk, "usage") and chunk.usage is not None:
-                model_response.usage = chunk.usage
+                model_response.usage = (
+                    litellm.Usage(**chunk.usage.model_dump())
+                    if isinstance(chunk.usage, BaseModel)
+                    else chunk.usage
+                )
 
             ## RETURN ARG
             result: Final = self.return_processed_chunk_logic(

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -661,6 +661,48 @@ def test_usage_only_openai_chunk_preserves_usage_details(
     assert response.usage.completion_tokens_details.reasoning_tokens == 0
 
 
+def test_openai_sdk_usage_is_preserved_in_stream_assembly():
+    from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
+
+    stream = CustomStreamWrapper(
+        completion_stream=None,
+        model="z-ai/glm-5.2",
+        logging_obj=SimpleNamespace(
+            model_call_details={"litellm_params": {}},
+            messages=[{"role": "user", "content": "Reply with exactly: ok"}],
+            stream_options={"include_usage": True},
+        ),
+        custom_llm_provider="openai",
+    )
+    chunk = ChatCompletionChunk.model_validate(
+        {
+            "id": "gen-test",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "z-ai/glm-5.2",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "length"}],
+            "usage": {
+                "prompt_tokens": 17,
+                "completion_tokens": 4,
+                "total_tokens": 21,
+                "prompt_tokens_details": {"cached_tokens": 15},
+                "completion_tokens_details": {"reasoning_tokens": 4},
+            },
+        }
+    )
+
+    assembled = litellm.stream_chunk_builder(
+        chunks=[stream.chunk_creator(chunk)], messages=stream.messages
+    )
+
+    assert assembled is not None
+    assert assembled.usage.prompt_tokens == 17
+    assert assembled.usage.completion_tokens == 4
+    assert assembled.usage.total_tokens == 21
+    assert assembled.usage.prompt_tokens_details.cached_tokens == 15
+    assert assembled.usage.completion_tokens_details.reasoning_tokens == 4
+
+
 def test_finish_reason_chunk_preserves_non_openai_attributes(
     initialized_custom_stream_wrapper: CustomStreamWrapper,
 ):

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -616,6 +617,48 @@ def test_streaming_handler_with_stop_chunk(
         **args, model_response=ModelResponseStream()
     )
     assert returned_chunk is None
+
+
+def test_usage_only_openai_chunk_preserves_usage_details(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    initialized_custom_stream_wrapper.custom_llm_provider = "openai"
+    initialized_custom_stream_wrapper.stream_options = {"include_usage": True}
+    chunk = SimpleNamespace(
+        id="chatcmpl-test",
+        model="glm-4.7",
+        choices=[],
+        usage={
+            "completion_tokens": 28,
+            "prompt_tokens": 3721,
+            "total_tokens": 3749,
+            "completion_tokens_details": {
+                "accepted_prediction_tokens": None,
+                "audio_tokens": 0,
+                "reasoning_tokens": 0,
+                "rejected_prediction_tokens": None,
+                "image_tokens": 0,
+            },
+            "prompt_tokens_details": {
+                "audio_tokens": 0,
+                "cache_write_tokens": 0,
+                "cached_tokens": 3237,
+                "video_tokens": 0,
+            },
+            "cost": 0.0003777566,
+            "is_byok": False,
+            "cost_details": {
+                "upstream_inference_cost": 0.0003777566,
+                "upstream_inference_prompt_cost": 0.0003494206,
+                "upstream_inference_completions_cost": 0.000028336,
+            },
+        },
+    )
+
+    response = initialized_custom_stream_wrapper.chunk_creator(chunk)
+
+    assert response.usage.prompt_tokens_details.cached_tokens == 3237
+    assert response.usage.completion_tokens_details.reasoning_tokens == 0
 
 
 def test_finish_reason_chunk_preserves_non_openai_attributes(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Usage-only and final SDK chunks follow distinct paths
- Final SDK chunks overwrite provider usage during assembly

How it solves it:

- Retain usage-only chunk normalization
- Normalize final SDK usage before stream assembly

## User Flow

Before: a developer streams an OpenRouter completion and records incorrect usage

1. They send `POST https://proxy.example/v1/chat/completions` with `"model": "openai/z-ai/glm-5.2"`, `"stream": true`, and `"stream_options": {"include_usage": true}`
2. The provider completes successfully, but the assembled stream reports estimated prompt tokens and zero completion tokens
3. Their usage tracker records `12` total tokens and no cached-token count instead of the provider totals

After: the same developer records the provider-reported usage from that stream

1. They send the same `POST https://proxy.example/v1/chat/completions` request
2. The provider completes successfully and the assembled stream retains its usage fields
3. Their usage tracker records `17` prompt, `4` completion, `21` total, cached-token, and reasoning-token details

## Relevant issues


## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: export `OPENROUTER_API_KEY` and, if required, `HTTP_PROXY` and `HTTPS_PROXY`. At each commit, run:

```sh
PYTHONPATH=litellm uv run python - <<'PY'
import os
import litellm

messages = [{"role": "user", "content": "Reply with exactly: ok"}]
response = litellm.completion(
    model="openai/z-ai/glm-5.2",
    api_base="https://openrouter.ai/api/v1",
    api_key=os.environ["OPENROUTER_API_KEY"],
    messages=messages,
    max_tokens=4,
    stream=True,
    stream_options={"include_usage": True},
)
assembled = litellm.stream_chunk_builder(chunks=list(response), messages=messages)
print({
    "prompt_tokens": assembled.usage.prompt_tokens,
    "completion_tokens": assembled.usage.completion_tokens,
    "total_tokens": assembled.usage.total_tokens,
    "cached_tokens": getattr(assembled.usage.prompt_tokens_details, "cached_tokens", None),
    "reasoning_tokens": getattr(assembled.usage.completion_tokens_details, "reasoning_tokens", None),
})
PY
```

### Before (901b08f524)

1. Run the shared stream request from this commit with `stream_options={"include_usage": True}`
2. Observed output: `{'prompt_tokens': 12, 'completion_tokens': 0, 'total_tokens': 12, 'cached_tokens': None, 'reasoning_tokens': 4}`

### After (678e89fc2e)

1. Run the identical shared stream request from this commit with `stream_options={"include_usage": True}`
2. Observed output: `{'prompt_tokens': 17, 'completion_tokens': 4, 'total_tokens': 21, 'cached_tokens': 14, 'reasoning_tokens': 4}`

## Type

🐛 Bug Fix

## Caveats (if any)

- Cached-token totals vary with provider cache state

### Final Attestation

- [x] The tests cover usage-only chunks and OpenAI SDK final chunks
