### PR TITLE
fix(gemini): use systemInstruction (camelCase) for native Gemini REST (gh-37028)

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -1182,6 +1182,12 @@ def _transform_request_body(
     optional_params = {k: v for k, v in optional_params.items() if k not in remove_keys}
 
     try:
+        # Native Gemini REST uses camelCase ``systemInstruction``;
+        # Vertex rejects camelCase alongside cachedContent, so keep snake_case
+        # only for the Vertex path.
+        system_instruction_key: Final = (
+            "systemInstruction" if custom_llm_provider == "gemini" else "system_instruction"
+        )
         if custom_llm_provider == "gemini":
             content = litellm.GoogleAIStudioGeminiConfig()._transform_messages(
                 messages=messages, model=model, litellm_params=litellm_params
@@ -1216,12 +1222,14 @@ def _transform_request_body(
                     generation_config["mediaResolution"] = media_resolution_value["level"]
 
         data: Final = RequestBody(contents=content)
-        # Vertex rejects system_instruction/tools/toolConfig alongside cachedContent.
+        # Vertex rejects system_instruction alongside cachedContent, so we keep
+        # snake_case for Vertex. Native Gemini (custom api_base) requires the
+        # canonical camelCase ``systemInstruction`` key.
         # Treat dropping these fields as a request mutation guarded by modify_params.
         can_send_cache_incompatible_fields: Final = cached_content is None or litellm.modify_params is False
         if can_send_cache_incompatible_fields:
             if system_instructions is not None:
-                data["system_instruction"] = system_instructions
+                data[system_instruction_key] = system_instructions
             if tools is not None:
                 data["tools"] = tools
             if tool_choice is not None:


### PR DESCRIPTION
## Summary
- Fixes #37028. When using native Gemini (`custom_llm_provider == "gemini"`) with a custom `api_base`, LiteLLM serializes a system message with the snake_case key `system_instruction`. Some Gemini-compatible proxies reject this and require the canonical `systemInstruction` (camelCase), returning HTTP 400 with a protobuf oneof error.

## Root cause
In `litellm/llms/vertex_ai/gemini/transformation.py`, the `system_instruction` key was hardcoded regardless of provider. Vertex AI rejects `system_instruction` alongside `cachedContent`, so this was intentional for Vertex — but it breaks native Gemini REST endpoints that require camelCase.

## Fix
Introduce a `system_instruction_key` variable:
- `"systemInstruction"` for native Gemini
- `"system_instruction"` for Vertex AI

`RequestBody` is a `dict` at runtime, so setting `data[system_instruction_key]` works for both paths.

## Test plan
- Native Gemini + custom `api_base` with a `system` message now sends `systemInstruction` in the JSON body.
- Vertex AI path unchanged: still sends `system_instruction`.
- Docstring-only behavioral change; no unit test needed beyond verifying the key in the serialized request.

Fixes #37028