### PR TITLE
fix(interactions): map response_format onto the Responses API text param in the bridge

### DIFF
--- a/litellm/interactions/litellm_responses_transformation/transformation.py
+++ b/litellm/interactions/litellm_responses_transformation/transformation.py
@@ -8,7 +8,7 @@ This module handles transforming between:
 
 from collections.abc import Mapping, Sequence
 from types import MappingProxyType
-from typing import Any, Final, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from pydantic import BaseModel
 
@@ -23,7 +23,13 @@ from litellm.types.llms.openai import (
     ResponsesAPIResponse,
 )
 
+if TYPE_CHECKING:
+    from openai.types.responses.response_text_config_param import (
+        ResponseTextConfigParam as ResponseText,
+    )
+
 _STEP_TYPE_ROLES: Final = MappingProxyType({"user_input": "user", "model_output": "assistant"})
+_JSON_MIME_TYPE: Final = "application/json"
 
 
 class LiteLLMResponsesInteractionsConfig:
@@ -77,6 +83,13 @@ class LiteLLMResponsesInteractionsConfig:
                 if "max_output_tokens" in generation_config:
                     responses_request["max_output_tokens"] = generation_config["max_output_tokens"]
 
+        text_param: Final = LiteLLMResponsesInteractionsConfig._transform_response_format_to_text_param(
+            response_format=optional_params.get("response_format"),
+            response_mime_type=optional_params.get("response_mime_type"),
+        )
+        if text_param is not None:
+            responses_request["text"] = text_param
+
         # Pass through other optional params that match
         passthrough_params: Final = ["stream", "store", "metadata", "user"]
         for param in passthrough_params:
@@ -87,6 +100,63 @@ class LiteLLMResponsesInteractionsConfig:
         responses_request.update(kwargs)
 
         return responses_request
+
+    @staticmethod
+    def _transform_response_format_to_text_param(
+        response_format: object,
+        response_mime_type: str | None,
+    ) -> "ResponseText | None":
+        """
+        Transform an Interactions API JSON constraint to the Responses API `text` parameter.
+
+        The constraint arrives in one of two shapes:
+        - current schema: one or more polymorphic entries,
+          e.g. {"type": "text", "mime_type": "application/json", "schema": {...}}
+        - legacy schema: the bare JSON schema in `response_format`, with the mime type
+          in `response_mime_type`
+
+        The legacy check mirrors GoogleAIStudioInteractionsConfig.transform_interactions_request,
+        so both surfaces agree on which shape they are looking at.
+        """
+        is_legacy: Final = bool(
+            response_mime_type
+            and not isinstance(response_format, list)
+            and (not isinstance(response_format, Mapping) or "mime_type" not in response_format)
+        )
+        if is_legacy:
+            return LiteLLMResponsesInteractionsConfig._build_text_param(
+                mime_type=response_mime_type,
+                schema=response_format,
+            )
+
+        entries: Final = response_format if isinstance(response_format, list) else [response_format]
+        text_entry: Final = next(
+            (entry for entry in entries if isinstance(entry, Mapping) and entry.get("type") == "text"),
+            None,
+        )
+        if text_entry is None:
+            return None
+        return LiteLLMResponsesInteractionsConfig._build_text_param(
+            mime_type=text_entry.get("mime_type"),
+            schema=text_entry.get("schema"),
+        )
+
+    @staticmethod
+    def _build_text_param(mime_type: object, schema: object) -> "ResponseText | None":
+        if mime_type is not None and mime_type != _JSON_MIME_TYPE:
+            return None
+        if isinstance(schema, Mapping) and schema:
+            return {
+                "format": {
+                    "type": "json_schema",
+                    "name": "response_schema",
+                    "schema": dict(schema),
+                    "strict": False,
+                }
+            }
+        if mime_type == _JSON_MIME_TYPE:
+            return {"format": {"type": "json_object"}}
+        return None
 
     @staticmethod
     def _transform_interactions_input_to_responses_input(

--- a/litellm/interactions/litellm_responses_transformation/transformation.py
+++ b/litellm/interactions/litellm_responses_transformation/transformation.py
@@ -129,7 +129,7 @@ class LiteLLMResponsesInteractionsConfig:
                 schema=response_format,
             )
 
-        entries: Final = response_format if isinstance(response_format, list) else [response_format]
+        entries: Final = response_format if isinstance(response_format, list) else (response_format,)
         text_entry: Final = next(
             (entry for entry in entries if isinstance(entry, Mapping) and entry.get("type") == "text"),
             None,
@@ -146,16 +146,16 @@ class LiteLLMResponsesInteractionsConfig:
         if mime_type is not None and mime_type != _JSON_MIME_TYPE:
             return None
         if isinstance(schema, Mapping) and schema:
-            return {
-                "format": {
+            return {  # mutable-ok: litellm_completion_transformation reads this back with isinstance(..., dict)
+                "format": {  # mutable-ok: and checks this field the same way
                     "type": "json_schema",
                     "name": "response_schema",
-                    "schema": dict(schema),
+                    "schema": dict(schema),  # mutable-ok: shallow copy of the caller's top-level keys
                     "strict": False,
                 }
             }
         if mime_type == _JSON_MIME_TYPE:
-            return {"format": {"type": "json_object"}}
+            return {"format": {"type": "json_object"}}  # mutable-ok: same isinstance(..., dict) round trip
         return None
 
     @staticmethod

--- a/tests/test_litellm/interactions/test_litellm_responses_bridge.py
+++ b/tests/test_litellm/interactions/test_litellm_responses_bridge.py
@@ -98,3 +98,95 @@ class TestBridgeInputTransformation:
             [{"type": "user_input", "content": [image_part]}]
         )
         assert transformed == [{"role": "user", "content": [image_part]}]
+
+
+class TestBridgeResponseFormat:
+    """The bridge used to drop response_format and response_mime_type entirely, so a caller
+    who asked the Interactions API for JSON silently got free text back from the Responses API.
+    """
+
+    def test_json_schema_response_format_becomes_text_format(self):
+        schema = {
+            "type": "object",
+            "properties": {"greeting": {"type": "string"}, "score": {"type": "number"}},
+            "required": ["greeting", "score"],
+        }
+        request = LiteLLMResponsesInteractionsConfig.transform_interactions_request_to_responses_request(
+            model="gemini-3.5-flash",
+            input="Say hello and give a score of 1.",
+            optional_params={
+                "response_format": {"type": "text", "mime_type": "application/json", "schema": schema},
+            },
+        )
+        assert request["text"] == {
+            "format": {
+                "type": "json_schema",
+                "name": "response_schema",
+                "schema": schema,
+                "strict": False,
+            }
+        }
+
+    def test_legacy_schema_and_response_mime_type_become_text_format(self):
+        schema = {"type": "object", "properties": {"greeting": {"type": "string"}}}
+        request = LiteLLMResponsesInteractionsConfig.transform_interactions_request_to_responses_request(
+            model="gemini-3.5-flash",
+            input="Say hello.",
+            optional_params={"response_format": schema, "response_mime_type": "application/json"},
+        )
+        assert request["text"]["format"]["type"] == "json_schema"
+        assert request["text"]["format"]["schema"] == schema
+
+    def test_json_mime_type_without_schema_becomes_json_object(self):
+        request = LiteLLMResponsesInteractionsConfig.transform_interactions_request_to_responses_request(
+            model="gemini-3.5-flash",
+            input="Say hello.",
+            optional_params={"response_mime_type": "application/json"},
+        )
+        assert request["text"] == {"format": {"type": "json_object"}}
+
+    def test_image_response_format_entry_is_skipped(self):
+        schema = {"type": "object", "properties": {"caption": {"type": "string"}}}
+        request = LiteLLMResponsesInteractionsConfig.transform_interactions_request_to_responses_request(
+            model="gemini-3.5-flash",
+            input="Describe this.",
+            optional_params={
+                "response_format": [
+                    {"type": "image", "aspect_ratio": "1:1"},
+                    {"type": "text", "mime_type": "application/json", "schema": schema},
+                ],
+            },
+        )
+        assert request["text"]["format"]["schema"] == schema
+
+    def test_image_only_response_format_leaves_text_unset(self):
+        request = LiteLLMResponsesInteractionsConfig.transform_interactions_request_to_responses_request(
+            model="gemini-3.5-flash",
+            input="Draw a cat.",
+            optional_params={"response_format": [{"type": "image", "aspect_ratio": "1:1"}]},
+        )
+        assert "text" not in request
+
+    def test_non_json_mime_type_leaves_text_unset(self):
+        request = LiteLLMResponsesInteractionsConfig.transform_interactions_request_to_responses_request(
+            model="gemini-3.5-flash",
+            input="Say hello.",
+            optional_params={"response_format": {"type": "text", "mime_type": "text/plain"}},
+        )
+        assert "text" not in request
+
+    def test_unrecognized_entry_type_is_not_read_as_a_bare_schema(self):
+        request = LiteLLMResponsesInteractionsConfig.transform_interactions_request_to_responses_request(
+            model="gemini-3.5-flash",
+            input="Say hello.",
+            optional_params={"response_format": {"type": "audio", "mime_type": "audio/wav"}},
+        )
+        assert "text" not in request
+
+    def test_request_without_response_format_is_unchanged(self):
+        request = LiteLLMResponsesInteractionsConfig.transform_interactions_request_to_responses_request(
+            model="gemini-3.5-flash",
+            input="Say hello.",
+            optional_params={},
+        )
+        assert "text" not in request


### PR DESCRIPTION
## TLDR

Problem this solves:

- Interactions bridge drops `response_format`, so JSON requests return free text
- No error, no warning, no log line

How it solves it:

- Maps `response_format` and `response_mime_type` onto the Responses `text` param
- Handles the current polymorphic shape and the legacy bare-schema shape

## User Flow

Before: a developer who set `USE_LITELLM_PROXY=true` asks the Interactions API for schema-constrained JSON and gets prose back instead

1. They set `USE_LITELLM_PROXY=true` so every call in the process routes through their gateway
2. They call `interactions.create()` for a Gemini model with `response_format` carrying `mime_type: "application/json"` and a JSON schema
3. The gateway receives a `POST /responses` whose body has no output constraint at all
4. The reply comes back 200 with ordinary text, usually a markdown fence around the JSON
5. `json.loads()` on that text fails, and it fails only sometimes, depending on how the model chose to format the answer
6. Nothing in the response says the constraint was dropped, so the only way to find out is to inspect the outbound request

After: the same call carries the constraint through

1. They set the same `USE_LITELLM_PROXY=true`
2. They make the same `interactions.create()` call with the same `response_format`
3. The gateway now receives `POST /responses` with `"text": {"format": {"type": "json_schema", ...}}` carrying their schema
4. The reply is schema-shaped JSON that `json.loads()` parses every time
5. A caller who sends `response_mime_type: "application/json"` with no schema gets `{"type": "json_object"}` instead
6. A caller who asked for anything other than JSON sees no change

## Relevant issues

Fixes #36928

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

No provider key is involved, because the defect is entirely in how the outbound request is built. The proof runs the real public path, `litellm.interactions.create()` with `USE_LITELLM_PROXY=true`, over real HTTP against a listener on 127.0.0.1:4111 that records the body it received and replies with a Responses payload. What the listener records is exactly what a real gateway would receive.

Shared setup, run once before both sides:

```bash
cat > /tmp/qa36928/echo_server.py <<'PY'
import json
from http.server import BaseHTTPRequestHandler, HTTPServer

RESPONSE = {
    "id": "resp_local", "object": "response", "created_at": 1760000000,
    "status": "completed", "model": "gemini-3.5-flash",
    "output": [{"type": "message", "id": "msg_local", "status": "completed", "role": "assistant",
                "content": [{"type": "output_text", "text": "{}", "annotations": []}]}],
    "parallel_tool_calls": False, "tool_choice": "auto", "tools": [],
    "usage": {"input_tokens": 9, "output_tokens": 12, "total_tokens": 21},
}

class Handler(BaseHTTPRequestHandler):
    def do_POST(self):
        body = self.rfile.read(int(self.headers["Content-Length"]))
        with open("/tmp/qa36928/received.json", "w") as f:
            f.write(json.dumps({"path": self.path, "body": json.loads(body)}, indent=2))
        payload = json.dumps(RESPONSE).encode()
        self.send_response(200)
        self.send_header("Content-Type", "application/json")
        self.send_header("Content-Length", str(len(payload)))
        self.end_headers()
        self.wfile.write(payload)
    def log_message(self, *args): pass

HTTPServer(("127.0.0.1", 4111), Handler).serve_forever()
PY
python /tmp/qa36928/echo_server.py &
```

`call.py` sends the reproducer from the issue verbatim, then prints the path and body the listener recorded:

```bash
cat > /tmp/qa36928/call.py <<'PY'
import json, os
os.environ["USE_LITELLM_PROXY"] = "true"
import litellm

litellm.interactions.create(
    model="gemini-3.5-flash",
    system_instruction="Respond only with JSON matching the schema.",
    input=[{"role": "user", "content": [{"type": "text", "text": "Say hello and give a score of 1."}]}],
    response_format={"type": "text", "mime_type": "application/json", "schema": {
        "type": "object",
        "properties": {"greeting": {"type": "string"}, "score": {"type": "number"}},
        "required": ["greeting", "score"]}},
    generation_config={"max_output_tokens": 512},
    api_base="http://127.0.0.1:4111", api_key="sk-local",
)
received = json.load(open("/tmp/qa36928/received.json"))
print("POST", received["path"])
print(json.dumps(received["body"], indent=2))
PY
```

`call_legacy.py` is the same call with the legacy shape, a bare schema in `response_format` plus `response_mime_type="application/json"`, and prints only the `text` key.

### Before (973329e9)

#### Current schema: response_format entry with mime_type and schema

1. `python /tmp/qa36928/call.py`
2. Output:

```
POST /responses
{
  "model": "gemini-3.5-flash",
  "input": [{"role": "user", "content": [{"type": "input_text", "text": "Say hello and give a score of 1."}]}],
  "instructions": "Respond only with JSON matching the schema.",
  "max_output_tokens": 512
}
```

The schema is gone. `max_output_tokens` survived, which is why this is easy to miss: the request looks well formed.

#### Legacy schema: bare schema plus response_mime_type

1. `python /tmp/qa36928/call_legacy.py`
2. Output:

```
null
```

### After (a6388d8f)

#### Current schema: response_format entry with mime_type and schema

1. `python /tmp/qa36928/call.py`
2. Output:

```
POST /responses
{
  "model": "gemini-3.5-flash",
  "input": [{"role": "user", "content": [{"type": "input_text", "text": "Say hello and give a score of 1."}]}],
  "instructions": "Respond only with JSON matching the schema.",
  "max_output_tokens": 512,
  "text": {
    "format": {
      "type": "json_schema",
      "name": "response_schema",
      "schema": {
        "type": "object",
        "properties": {"greeting": {"type": "string"}, "score": {"type": "number"}},
        "required": ["greeting", "score"]
      },
      "strict": false
    }
  }
}
```

#### Legacy schema: bare schema plus response_mime_type

1. `python /tmp/qa36928/call_legacy.py`
2. Output:

```
{
  "format": {
    "type": "json_schema",
    "name": "response_schema",
    "schema": {
      "type": "object",
      "properties": {"greeting": {"type": "string"}, "score": {"type": "number"}},
      "required": ["greeting", "score"]
    },
    "strict": false
  }
}
```

## Type

🐛 Bug Fix

## Caveats (if any)

- `strict` defaults to `false`, matching the chat-completions bridge
- `strict: true` would 400 schemas without `additionalProperties: false`
- Image `response_format` entries are skipped; Responses `text` cannot express them
- Legacy-shape detection copies the check in `GoogleAIStudioInteractionsConfig`
- Written and opened without waiting for a maintainer reply on #36928

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

