### PR TITLE
fix(bedrock): split Converse 1h vs 5m cache writes by cacheDetails TTL

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -57,6 +57,7 @@ from litellm.types.llms.openai import (
     OpenAIMessageContentListBlock,
 )
 from litellm.types.utils import (
+    CacheCreationTokenDetails,
     ChatCompletionMessageToolCall,
     CompletionTokensDetailsWrapper,
     Function,
@@ -1770,6 +1771,23 @@ class AmazonConverseConfig(BaseConfig):
                 thinking_blocks_list.append(_redacted_block)
         return thinking_blocks_list
 
+    @staticmethod
+    def _transform_cache_details(
+        cache_details: list[ConverseCacheDetailBlock] | None,
+    ) -> CacheCreationTokenDetails | None:
+        if not cache_details:
+            return None
+        ephemeral_5m_input_tokens: Final = sum(
+            detail["inputTokens"] for detail in cache_details if detail.get("ttl") == "5m"
+        )
+        ephemeral_1h_input_tokens: Final = sum(
+            detail["inputTokens"] for detail in cache_details if detail.get("ttl") == "1h"
+        )
+        return CacheCreationTokenDetails(
+            ephemeral_5m_input_tokens=ephemeral_5m_input_tokens,
+            ephemeral_1h_input_tokens=ephemeral_1h_input_tokens,
+        )
+
     def _transform_usage(
         self,
         usage: ConverseTokenUsageBlock,
@@ -1789,9 +1807,12 @@ class AmazonConverseConfig(BaseConfig):
             cache_creation_input_tokens = usage["cacheWriteInputTokens"]
             input_tokens += cache_creation_input_tokens
 
+        cache_creation_token_details: Final = self._transform_cache_details(usage.get("cacheDetails"))
+
         prompt_tokens_details: Final = PromptTokensDetailsWrapper(
             cached_tokens=cache_read_input_tokens,
             cache_creation_tokens=cache_creation_input_tokens,
+            cache_creation_token_details=cache_creation_token_details,
             text_tokens=raw_input_tokens,
         )
         reasoning_tokens = token_counter(text=reasoning_content, count_response_tokens=True) if reasoning_content else 0

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -2,7 +2,7 @@ import json
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final, Literal
 
-from typing_extensions import Required, TypedDict, override
+from typing_extensions import ReadOnly, Required, TypedDict, override
 
 from .openai import ChatCompletionToolCallChunk
 
@@ -217,8 +217,8 @@ class ConverseResponseOutputBlock(TypedDict):
 
 
 class ConverseCacheDetailBlock(TypedDict):
-    inputTokens: int
-    ttl: Literal["5m", "1h"]
+    inputTokens: ReadOnly[int]
+    ttl: ReadOnly[Literal["5m", "1h"]]
 
 
 class ConverseTokenUsageBlock(TypedDict):
@@ -229,7 +229,7 @@ class ConverseTokenUsageBlock(TypedDict):
     cacheReadInputTokens: int
     cacheWriteInputTokenCount: int
     cacheWriteInputTokens: int
-    cacheDetails: list[ConverseCacheDetailBlock]
+    cacheDetails: ReadOnly[list[ConverseCacheDetailBlock]]
 
 
 class ServiceTierBlock(TypedDict):

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -216,6 +216,11 @@ class ConverseResponseOutputBlock(TypedDict):
     message: MessageBlock | None
 
 
+class ConverseCacheDetailBlock(TypedDict):
+    inputTokens: int
+    ttl: Literal["5m", "1h"]
+
+
 class ConverseTokenUsageBlock(TypedDict):
     inputTokens: int
     outputTokens: int
@@ -224,6 +229,7 @@ class ConverseTokenUsageBlock(TypedDict):
     cacheReadInputTokens: int
     cacheWriteInputTokenCount: int
     cacheWriteInputTokens: int
+    cacheDetails: list[ConverseCacheDetailBlock]
 
 
 class ServiceTierBlock(TypedDict):

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -6003,3 +6003,41 @@ def test_adaptive_thinking_dropped_when_max_tokens_too_small_converse():
     )
 
     assert "thinking" not in optional_params
+
+
+def test_transform_usage_splits_cache_writes_by_ttl():
+    config = AmazonConverseConfig()
+    usage: ConverseTokenUsageBlock = {
+        "inputTokens": 100,
+        "outputTokens": 50,
+        "totalTokens": 150,
+        "cacheReadInputTokens": 0,
+        "cacheWriteInputTokens": 4000,
+        "cacheDetails": [
+            {"inputTokens": 3000, "ttl": "1h"},
+            {"inputTokens": 1000, "ttl": "5m"},
+        ],
+    }
+
+    result = config._transform_usage(usage)
+
+    details = result.prompt_tokens_details.cache_creation_token_details
+    assert details is not None
+    assert details.ephemeral_1h_input_tokens == 3000
+    assert details.ephemeral_5m_input_tokens == 1000
+    assert result.cache_creation_input_tokens == 4000
+
+
+def test_transform_usage_without_cache_details_leaves_ttl_split_unset():
+    config = AmazonConverseConfig()
+    usage: ConverseTokenUsageBlock = {
+        "inputTokens": 100,
+        "outputTokens": 50,
+        "totalTokens": 150,
+        "cacheWriteInputTokens": 4000,
+    }
+
+    result = config._transform_usage(usage)
+
+    assert getattr(result.prompt_tokens_details, "cache_creation_token_details", None) is None
+    assert result.cache_creation_input_tokens == 4000


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Converse 1-hour cache writes get billed at the 5-minute rate
- 1h cache writes undercounted by roughly 31 to 37 percent

How it solves it:

- parse the per-TTL `cacheDetails` array Bedrock returns on `TokenUsage`
- populate `cache_creation_token_details` so the cost calc applies the 1h rate to 1h writes

## User Flow

Before: a developer running Claude with a 1-hour prompt cache TTL on the Bedrock Converse path sees cache-write spend that is too low

1. They send a request with a 1h cache checkpoint and get a response whose usage reports, say, 3000 cache-write tokens at 1h TTL and 1000 at 5m
2. The proxy bills all 4000 tokens at the 5-minute cache-write rate
3. Their logged spend for that request is about 31 percent under the real AWS charge

After: the same request bills each TTL bucket at its own rate

1. They send the same request with the same 1h and 5m cache-write split
2. The proxy bills the 3000 1h tokens at the 1h rate and the 1000 5m tokens at the 5m rate
3. Their logged spend matches what AWS actually charges

## Relevant issues

Fixes #36760

## Linear ticket

## Type

🐛 Bug Fix

## Changes

`AmazonConverseConfig._transform_usage` only read the aggregate `cacheWriteInputTokens` field, so `cache_creation_token_details` stayed unset and `calculate_cache_writing_cost` billed the whole cache-write count at the 5-minute rate. Bedrock's Converse `TokenUsage` actually returns a `cacheDetails` array with a per-TTL breakdown (`inputTokens` plus `ttl` of `5m` or `1h`, sorted 1h first), which `ConverseTokenUsageBlock` did not declare, so it was dropped before it reached the transform. This declares `cacheDetails` on the usage block, adds a `ConverseCacheDetailBlock` type, and sums the per-TTL buckets into `CacheCreationTokenDetails(ephemeral_5m_input_tokens, ephemeral_1h_input_tokens)`, the same shape the Anthropic direct provider and Vertex already produce. When `cacheDetails` is absent the split stays `None` and behavior is unchanged.

## Screenshots / Proof of Fix

Verified against the real `model_cost` map at commit 860fa15ee3 (Bedrock `anthropic.claude-haiku-4-5`: 5m cache-write 1.25e-6, 1h 2e-6), running a Converse usage with a 3000 token 1h write and a 1000 token 5m write through `_transform_usage` then `completion_cost`:

```
cache-write cost NEW (split): 0.00725000   OLD (all 5m): 0.00500000   -> 31.0% undercount fixed
total completion_cost: 0.00760000
```

Regression tests in `tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py`: `test_transform_usage_splits_cache_writes_by_ttl` (asserts the 1h/5m split) and `test_transform_usage_without_cache_details_leaves_ttl_split_unset` (guards the no-regression path). Both pass; they fail if the parse is removed.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
