### PR TITLE
fix(realtime): proxy OpenAI live WebSockets

### DIFF
--- a/gateway/routes/allowlist.py
+++ b/gateway/routes/allowlist.py
@@ -103,6 +103,7 @@ GATEWAY_PATH_PREFIXES: tuple[str, ...] = (
     "/toolset/",
     # Realtime / streaming
     "/v1/realtime",
+    "/v1/live",
     "/realtime",
     # Health & ops
     "/health",

--- a/litellm/llms/openai/realtime/handler.py
+++ b/litellm/llms/openai/realtime/handler.py
@@ -1,5 +1,5 @@
 """
-This file contains the calling OpenAI's `/v1/realtime` endpoint.
+This file contains the calling OpenAI's `/v1/realtime` and `/v1/live` endpoints.
 
 This requires websockets, and is currently only supported on LiteLLM Proxy.
 """
@@ -8,7 +8,7 @@ from typing import Any, Final, cast
 
 from litellm._logging import _redact_string, verbose_logger
 from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
-from litellm.types.realtime import RealtimeQueryParams
+from litellm.types.realtime import RealtimeAPIPath, RealtimeQueryParams
 
 from ....litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from ....litellm_core_utils.realtime_streaming import (
@@ -80,7 +80,12 @@ class OpenAIRealtime(OpenAIChatCompletion):
 
         return ssl_config
 
-    def _construct_url(self, api_base: str, query_params: RealtimeQueryParams) -> str:
+    def _construct_url(
+        self,
+        api_base: str,
+        query_params: RealtimeQueryParams,
+        realtime_api_path: RealtimeAPIPath = "/v1/realtime",
+    ) -> str:
         """
         Construct the backend websocket URL with all query parameters (including 'model').
         """
@@ -90,7 +95,7 @@ class OpenAIRealtime(OpenAIChatCompletion):
         api_base = api_base.replace("http://", "ws://")
         url = URL(api_base)
         # Set the correct path
-        url = url.copy_with(path="/v1/realtime")
+        url = url.copy_with(path=realtime_api_path)
         # Include all query parameters including 'model'
         if query_params:
             url = url.copy_with(params=query_params)
@@ -114,6 +119,7 @@ class OpenAIRealtime(OpenAIChatCompletion):
         client: Any | None = None,
         timeout: float | None = None,
         query_params: RealtimeQueryParams | None = None,
+        realtime_api_path: RealtimeAPIPath = "/v1/realtime",
         user_api_key_dict: Any | None = None,
         litellm_metadata: dict | None = None,
         **kwargs: Any,
@@ -129,7 +135,7 @@ class OpenAIRealtime(OpenAIChatCompletion):
         # Use all query params if provided, else fallback to just model
         if query_params is None:
             query_params = {"model": model}
-        url: Final = self._construct_url(api_base, query_params)
+        url: Final = self._construct_url(api_base, query_params, realtime_api_path)
 
         try:
             # Get provider-specific SSL configuration

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -393,9 +393,11 @@ class LiteLLMRoutes(enum.Enum):
         "/realtime",
         "/v1/realtime",
         "/openai/v1/realtime",
+        "/v1/live",
         "/realtime?{model}",
         "/v1/realtime?{model}",
         "/openai/v1/realtime?{model}",
+        "/v1/live?{model}",
         # realtime (GA WebRTC HTTP routes)
         "/realtime/client_secrets",
         "/v1/realtime/client_secrets",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -397,7 +397,6 @@ class LiteLLMRoutes(enum.Enum):
         "/realtime?{model}",
         "/v1/realtime?{model}",
         "/openai/v1/realtime?{model}",
-        "/v1/live?{model}",
         # realtime (GA WebRTC HTTP routes)
         "/realtime/client_secrets",
         "/v1/realtime/client_secrets",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -648,7 +648,7 @@ from litellm.types.proxy.management_endpoints.ui_sso import (
     DefaultTeamSSOParams,
     LiteLLM_UpperboundKeyGenerateParams,
 )
-from litellm.types.realtime import RealtimeQueryParams
+from litellm.types.realtime import RealtimeAPIPath, RealtimeQueryParams
 from litellm.types.router import (
     DeploymentTypedDict,
     RouterGeneralSettings,
@@ -10739,6 +10739,7 @@ def _realtime_query_params_template(model: str | None, intent: str | None) -> tu
 @app.websocket("/openai/v1/realtime")
 @app.websocket("/v1/realtime")
 @app.websocket("/realtime")
+@app.websocket("/v1/live")
 async def realtime_websocket_endpoint(
     websocket: WebSocket,
     model: str | None = fastapi.Query(None, description="The model to use for the websocket connection."),
@@ -10749,6 +10750,9 @@ async def realtime_websocket_endpoint(
     ),
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth_websocket),
 ):
+    realtime_api_path: Final[RealtimeAPIPath] = (
+        "/v1/live" if websocket.url.path.endswith("/v1/live") else "/v1/realtime"
+    )
     requested_protocols: Final = [
         p.strip() for p in (websocket.headers.get("sec-websocket-protocol") or "").split(",") if p.strip()
     ]
@@ -10783,6 +10787,7 @@ async def realtime_websocket_endpoint(
         "model": route_model,
         "websocket": websocket,
         "query_params": query_params,  # Only explicit params
+        "realtime_api_path": realtime_api_path,
     }
 
     # Pass guardrails into data so pre-call guardrail processing picks them up
@@ -10794,6 +10799,7 @@ async def realtime_websocket_endpoint(
 
     scope: Final = REALTIME_REQUEST_SCOPE_TEMPLATE.copy()
     scope["headers"] = headers_list
+    scope["path"] = realtime_api_path
 
     request: Final = Request(scope=scope)
 

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -11,6 +11,7 @@ from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.llms.xai.common_utils import XAIModelInfo
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.realtime import (
+    RealtimeAPIPath,
     RealtimeClientSecretRequest,
     RealtimeExpiresAfter,
     RealtimeQueryParams,
@@ -292,6 +293,7 @@ async def _arealtime(
     client: Any | None = None,
     timeout: float | None = None,
     query_params: RealtimeQueryParams | None = None,
+    realtime_api_path: RealtimeAPIPath = "/v1/realtime",
     **kwargs,
 ):
     """
@@ -316,6 +318,9 @@ async def _arealtime(
         api_base=api_base,
         api_key=api_key,
     )
+
+    if realtime_api_path == "/v1/live" and _custom_llm_provider != "openai":
+        raise ValueError("/v1/live is only supported by the OpenAI realtime provider")
 
     # If the client supplied `model` in the URL, ensure it uses the normalized
     # provider model (no proxy aliases). If they omitted it, preserve that shape
@@ -399,6 +404,7 @@ async def _arealtime(
             client=None,
             timeout=timeout,
             query_params=query_params,
+            realtime_api_path=realtime_api_path,
             user_api_key_dict=kwargs.get("user_api_key_dict"),
             litellm_metadata=_build_litellm_metadata(kwargs),
         )

--- a/litellm/types/realtime.py
+++ b/litellm/types/realtime.py
@@ -10,6 +10,7 @@ from .llms.openai import (
 )
 
 ALL_DELTA_TYPES = Literal["text", "audio"]
+RealtimeAPIPath = Literal["/v1/realtime", "/v1/live"]
 
 
 class RealtimeResponseTransformInput(TypedDict):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -879,6 +879,7 @@ API_ROUTE_TO_CALL_TYPES: Final[Mapping[str, Sequence[CallTypes]]] = {
     "/realtime": [CallTypes.arealtime],
     "/v1/realtime": [CallTypes.arealtime],
     "/openai/v1/realtime": [CallTypes.arealtime],
+    "/v1/live": [CallTypes.arealtime],
     # Provider-specific routes
     "/anthropic/v1/messages": [CallTypes.anthropic_messages],
     # Google GenAI routes

--- a/tests/test_litellm/llms/openai/realtime/test_openai_realtime_handler.py
+++ b/tests/test_litellm/llms/openai/realtime/test_openai_realtime_handler.py
@@ -48,6 +48,19 @@ def test_openai_realtime_handler_url_with_extra_params():
     assert "intent=chat" in url
 
 
+def test_openai_live_handler_url_construction():
+    from litellm.llms.openai.realtime.handler import OpenAIRealtime
+
+    handler = OpenAIRealtime()
+    url = handler._construct_url(
+        api_base="https://api.openai.com/v1",
+        query_params={"model": "gpt-live-1-boulder-alpha"},
+        realtime_api_path="/v1/live",
+    )
+
+    assert url == "wss://api.openai.com/v1/live?model=gpt-live-1-boulder-alpha"
+
+
 def test_openai_realtime_handler_model_parameter_inclusion():
     """
     Test that the model parameter is properly included in the WebSocket URL

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9128,7 +9128,7 @@ def test_realtime_websocket_route_aliases_registered():
     websocket_paths = {route.path for route in app.routes if isinstance(route, WebSocketRoute)}
     openai_routes = LiteLLMRoutes.openai_routes.value
 
-    for expected in ("/openai/v1/realtime", "/v1/realtime", "/realtime"):
+    for expected in ("/openai/v1/realtime", "/v1/realtime", "/realtime", "/v1/live"):
         assert expected in websocket_paths, (
             f"{expected!r} missing from registered WebSocket routes; the "
             f"realtime endpoint will 405 for clients hitting this path."

--- a/tests/test_litellm/realtime_api/test_main.py
+++ b/tests/test_litellm/realtime_api/test_main.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import sys
+from unittest.mock import AsyncMock, MagicMock
 
 sys.path.insert(0, os.path.abspath("../../.."))
 
@@ -103,3 +104,48 @@ def test_client_secret_forwards_nested_transcription_model_untouched(monkeypatch
     session = captured["request_data"]["session"]
     assert session["model"] == "gpt-4o-realtime-preview"
     assert session["input_audio_transcription"]["model"] == "whisper-1"
+
+
+@pytest.mark.asyncio
+async def test_live_path_uses_resolved_openai_credentials(monkeypatch):
+    mock_async_realtime = AsyncMock()
+    monkeypatch.setattr(
+        realtime_main,
+        "openai_realtime",
+        MagicMock(async_realtime=mock_async_realtime),
+    )
+
+    def fake_get_llm_provider(model, api_base=None, api_key=None):
+        return ("gpt-live-1-boulder-alpha", "openai", "provider-key", "https://api.openai.com/")
+
+    monkeypatch.setattr(realtime_main, "get_llm_provider", fake_get_llm_provider)
+
+    await realtime_main._arealtime.__wrapped__(
+        model="openai/gpt-live-1-boulder-alpha",
+        websocket=MagicMock(),
+        api_key="virtual-key",
+        realtime_api_path="/v1/live",
+        litellm_logging_obj=MagicMock(),
+    )
+
+    called_kwargs = mock_async_realtime.call_args.kwargs
+    assert called_kwargs["model"] == "gpt-live-1-boulder-alpha"
+    assert called_kwargs["api_key"] == "provider-key"
+    assert called_kwargs["realtime_api_path"] == "/v1/live"
+
+
+@pytest.mark.asyncio
+async def test_live_path_rejects_non_openai_provider(monkeypatch):
+    def fake_get_llm_provider(model, api_base=None, api_key=None):
+        return ("gpt-realtime", "azure", "provider-key", "https://example.openai.azure.com/")
+
+    monkeypatch.setattr(realtime_main, "get_llm_provider", fake_get_llm_provider)
+
+    with pytest.raises(ValueError, match="only supported by the OpenAI realtime provider"):
+        await realtime_main._arealtime.__wrapped__(
+            model="azure/gpt-realtime",
+            websocket=MagicMock(),
+            api_key="virtual-key",
+            realtime_api_path="/v1/live",
+            litellm_logging_obj=MagicMock(),
+        )

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -8814,7 +8814,7 @@ export interface paths {
          * WebSocket: realtime_websocket_endpoint
          * @description WebSocket connection endpoint
          */
-        get: operations["websocket_realtime_websocket_endpoint_get_3"];
+        get: operations["websocket_realtime_websocket_endpoint_get_4"];
         put?: never;
         post?: never;
         delete?: never;
@@ -11554,7 +11554,7 @@ export interface paths {
          * WebSocket: realtime_websocket_endpoint
          * @description WebSocket connection endpoint
          */
-        get: operations["websocket_realtime_websocket_endpoint_get"];
+        get: operations["websocket_realtime_websocket_endpoint_get_2"];
         put?: never;
         post?: never;
         delete?: never;
@@ -16977,6 +16977,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/live": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * WebSocket: realtime_websocket_endpoint
+         * @description WebSocket connection endpoint
+         */
+        get: operations["websocket_realtime_websocket_endpoint_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/mcp/access_groups": {
         parameters: {
             query?: never;
@@ -17848,7 +17868,7 @@ export interface paths {
          * WebSocket: realtime_websocket_endpoint
          * @description WebSocket connection endpoint
          */
-        get: operations["websocket_realtime_websocket_endpoint_get_2"];
+        get: operations["websocket_realtime_websocket_endpoint_get_3"];
         put?: never;
         post?: never;
         delete?: never;
@@ -47776,7 +47796,7 @@ export interface operations {
             };
         };
     };
-    websocket_realtime_websocket_endpoint_get_3: {
+    websocket_realtime_websocket_endpoint_get_4: {
         parameters: {
             query?: never;
             header?: never;
@@ -50553,7 +50573,7 @@ export interface operations {
             };
         };
     };
-    websocket_realtime_websocket_endpoint_get: {
+    websocket_realtime_websocket_endpoint_get_2: {
         parameters: {
             query?: never;
             header?: never;
@@ -57313,6 +57333,24 @@ export interface operations {
             };
         };
     };
+    websocket_realtime_websocket_endpoint_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description WebSocket Protocol Switched */
+            101: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     get_mcp_access_groups_v1_mcp_access_groups_get: {
         parameters: {
             query?: never;
@@ -58566,7 +58604,7 @@ export interface operations {
             };
         };
     };
-    websocket_realtime_websocket_endpoint_get_2: {
+    websocket_realtime_websocket_endpoint_get_3: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/live` WebSocket upgrades are rejected by LiteLLM Proxy
- Authenticated clients cannot establish OpenAI Live sessions

How it solves it:

- Registers `/v1/live` as an authenticated WebSocket route
- Preserves the Live path when connecting to OpenAI
- Rejects unsupported providers with a clear error

## User Flow

Before: a developer's OpenAI Live client is rejected before reaching the provider

1. They open `wss://litellm-domain/v1/live?model=<configured-openai-live-model>` with a LiteLLM virtual key
2. The proxy rejects the WebSocket upgrade with HTTP 403
3. No OpenAI Live session starts

After: the same client establishes an authenticated OpenAI Live session

1. They open `wss://litellm-domain/v1/live?model=<configured-openai-live-model>` with the same key
2. The proxy authenticates the request and upgrades the connection
3. Live events flow through the configured OpenAI deployment

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Current-tip live-provider QA requires an OpenAI credential and is not included

### After (421d25e)

1. Run the focused route, realtime, handler, and proxy test suites
2. Observe 339 tests passing, including `/v1/live` registration, provider validation, and upstream URL coverage

## Type

🐛 Bug Fix

## Caveats (if any)

- `/v1/live` supports OpenAI models only
- Full live-provider QA requires an OpenAI credential

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
