### PR TITLE
fix(core): stop get_image_dimensions crashing on bare base64 and unfetchable URLs

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -213,12 +213,19 @@ def get_image_dimensions(
                     img_data = body
         except Exception:
             pass
-    if img_data is None:
-        # Not a URL or fetch failed — assume base64
-        _header, encoded = data.split(",", 1)
-        img_data = base64.b64decode(encoded)
+    if img_data is None and not data.startswith(("http://", "https://")):
+        # Not a URL — assume base64. Accept both data-URL form
+        # ('data:<mime>;base64,<payload>') and bare base64; on a decode
+        # error, leave img_data unset so the default dimensions are used.
+        encoded = data.partition(",")[2] if data.startswith("data:") else data
+        try:
+            img_data = base64.b64decode(encoded)
+        except ValueError:
+            verbose_logger.debug("Failed to decode base64 image data; using default dimensions")
 
-    img_type: Final = get_image_type(img_data)
+    # A URL that could not be fetched (or base64 that could not be decoded)
+    # leaves img_data unset — fall through to the default dimensions below.
+    img_type: Final = get_image_type(img_data) if img_data is not None else None
 
     if img_type == "png":
         w, h = struct.unpack(">LL", img_data[16:24])

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -186,6 +186,20 @@ def get_image_type(image_data: bytes) -> str | None:
     return None
 
 
+def _decode_base64_image(data: str) -> "bytes | None":
+    """Decode base64 image data, accepting both data-URL and bare base64 forms.
+
+    Returns None (and logs at debug) for input that does not decode, so callers
+    can fall back to default dimensions instead of failing the call.
+    """
+    encoded = data.partition(",")[2] if data.startswith("data:") else data
+    try:
+        return base64.b64decode(encoded)
+    except ValueError:
+        verbose_logger.debug("Failed to decode base64 image data; using default dimensions")
+        return None
+
+
 def get_image_dimensions(
     data: str,
 ) -> tuple[int, int]:
@@ -214,14 +228,9 @@ def get_image_dimensions(
         except Exception:
             pass
     if img_data is None and not data.startswith(("http://", "https://")):
-        # Not a URL — assume base64. Accept both data-URL form
-        # ('data:<mime>;base64,<payload>') and bare base64; on a decode
-        # error, leave img_data unset so the default dimensions are used.
-        encoded = data.partition(",")[2] if data.startswith("data:") else data
-        try:
-            img_data = base64.b64decode(encoded)
-        except ValueError:
-            verbose_logger.debug("Failed to decode base64 image data; using default dimensions")
+        # Not a URL or fetch failed — assume base64, keeping None on decode
+        # errors so the default dimensions are used below.
+        img_data = _decode_base64_image(data)
 
     # A URL that could not be fetched (or base64 that could not be decoded)
     # leaves img_data unset — fall through to the default dimensions below.

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -526,6 +526,53 @@ def test_img_url_token_counter(img_url, monkeypatch):
     assert height is not None
 
 
+def test_get_image_dimensions_bare_base64():
+    """
+    Bare base64 (no 'data:' URL prefix) is documented input for
+    get_image_dimensions and must not crash on the ','-split of a data URL.
+    """
+    import base64
+    import struct
+
+    from litellm.litellm_core_utils.token_counter import get_image_dimensions
+
+    # Minimal PNG header carrying 100x200 dimensions.
+    png = base64.b64encode(
+        b"\x89PNG\r\n\x1a\n" + b"\x00" * 8 + struct.pack(">LL", 100, 200) + b"\x00" * 16
+    )
+    assert get_image_dimensions(data=png.decode()) == (100, 200)
+
+
+def test_get_image_dimensions_unfetchable_url_returns_defaults(monkeypatch):
+    """A URL that cannot be fetched falls back to the default dimensions instead of raising."""
+
+    def _raise(client, url, **kwargs):
+        raise RuntimeError("connection failed")
+
+    monkeypatch.setattr(
+        "litellm.litellm_core_utils.token_counter.safe_get",
+        _raise,
+    )
+    from litellm.constants import DEFAULT_IMAGE_HEIGHT, DEFAULT_IMAGE_WIDTH
+    from litellm.litellm_core_utils.token_counter import get_image_dimensions
+
+    assert get_image_dimensions(data="https://invalid.invalid/x.png") == (
+        DEFAULT_IMAGE_WIDTH,
+        DEFAULT_IMAGE_HEIGHT,
+    )
+
+
+def test_get_image_dimensions_undecodable_data_returns_defaults():
+    """Data that is neither a fetchable URL nor decodable base64 uses the defaults."""
+    from litellm.constants import DEFAULT_IMAGE_HEIGHT, DEFAULT_IMAGE_WIDTH
+    from litellm.litellm_core_utils.token_counter import get_image_dimensions
+
+    assert get_image_dimensions(data="not-an-image!") == (
+        DEFAULT_IMAGE_WIDTH,
+        DEFAULT_IMAGE_HEIGHT,
+    )
+
+
 def test_token_encode_disallowed_special():
     encode(model="gpt-3.5-turbo", text="Hello, world! <|endoftext|>")
     token_counter(model="gpt-3.5-turbo", text="Hello, world! <|endoftext|>")


### PR DESCRIPTION
## Bug

`get_image_dimensions` documents `"The URL or base64 encoded string of the image."` as valid input, but two documented-or-implied inputs crash it:

```py
>>> get_image_dimensions(data="<bare base64 png>")        # docstring says this is supported
ValueError: not enough values to unpack (expected 2, got 1)   # data.split(",", 1)

>>> get_image_dimensions(data="https://host/x.png")       # host unreachable / times out
ValueError: not enough values to unpack (expected 2, got 1)   # falls into the base64 branch
```

The final fallback comment — *"return sensible default image dimensions if unable to get dimensions"* — was unreachable for these paths: the unconditional `_header, encoded = data.split(",", 1)` raised before the format detection, and a failed URL fetch dropped straight into that same branch.

This matters for `calculate_img_tokens(..., mode="high")`, which is exported public API: a temporarily-unreachable image URL or a bare-base64 payload turns token counting into an exception instead of an estimate.

## Fix

- The base64 branch accepts both data-URL form (`data:<mime>;base64,<payload>`) and bare base64; a decode error logs at debug and leaves the payload unset.
- An unfetchable URL no longer falls into the base64 branch at all.
- With no image data, format detection is skipped and `DEFAULT_IMAGE_WIDTH/DEFAULT_IMAGE_HEIGHT` is returned, as the fallback comment intended.

## Verification

Three new hermetic tests next to the existing mocked-fetch ones (no network): bare base64 parses real PNG dimensions (100×200); a mocked failed fetch returns the defaults; undecodable input returns the defaults. `tests/test_litellm/litellm_core_utils/test_token_counter.py`: 81 passed, 1 skipped (only the tokenizer-download tests deselected locally — those need network/model downloads and run in CI).
