### PR TITLE
fix(anthropic): honor chat completions routing opt-ins

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -40,15 +40,20 @@ from .utils import AnthropicMessagesRequestUtils, mock_response
 # Providers that are routed directly to the OpenAI Responses API instead of
 # going through chat/completions.
 _RESPONSES_API_PROVIDERS: Final = frozenset({"openai"})
+_OPENAI_CHAT_COMPLETIONS_MODEL_PREFIX: Final = "openai/chat_completions/"
 
 
-def _should_route_to_responses_api(custom_llm_provider: str | None) -> bool:
+def _should_route_to_responses_api(
+    custom_llm_provider: str | None,
+    *,
+    use_chat_completions_api: bool,
+) -> bool:
     """Return True when the provider should use the Responses API path.
 
-    Set ``litellm.use_chat_completions_url_for_anthropic_messages = True`` to
-    opt out and route OpenAI/Azure requests through chat/completions instead.
+    OpenAI models can opt out through the global setting, deployment flag, or
+    ``openai/chat_completions/`` model prefix.
     """
-    if litellm.use_chat_completions_url_for_anthropic_messages:
+    if litellm.use_chat_completions_url_for_anthropic_messages or use_chat_completions_api:
         return False
     return custom_llm_provider in _RESPONSES_API_PROVIDERS
 
@@ -442,16 +447,25 @@ def anthropic_messages_handler(
         api_base=api_base,
         custom_llm_provider=custom_llm_provider,
     )
+    model_uses_chat_completions_prefix: Final = model.startswith(_OPENAI_CHAT_COMPLETIONS_MODEL_PREFIX)
+    provider_model: Final = (
+        f"openai/{model.removeprefix(_OPENAI_CHAT_COMPLETIONS_MODEL_PREFIX)}"
+        if model_uses_chat_completions_prefix
+        else model
+    )
     (
         model,
         custom_llm_provider,
-        dynamic_api_key,
-        dynamic_api_base,
+        _dynamic_api_key,
+        _dynamic_api_base,
     ) = litellm.get_llm_provider(
-        model=model,
+        model=provider_model,
         custom_llm_provider=custom_llm_provider,
         api_base=litellm_params.api_base,
         api_key=litellm_params.api_key,
+    )
+    force_chat_completions: Final = (
+        litellm_params.use_chat_completions_api is True or model_uses_chat_completions_prefix
     )
 
     # Store agentic loop params in logging object for agentic hooks
@@ -491,6 +505,7 @@ def anthropic_messages_handler(
         )
 
         if LiteLLM_Proxy_MCP_Handler._should_use_litellm_mcp_gateway(tools=tools):
+            mcp_kwargs: Final = {**kwargs, "use_chat_completions_api": True} if force_chat_completions else kwargs
             return anthropic_messages_with_mcp(
                 max_tokens=max_tokens,
                 messages=messages,
@@ -510,7 +525,7 @@ def anthropic_messages_handler(
                 api_base=api_base,
                 client=client,
                 custom_llm_provider=custom_llm_provider,
-                **kwargs,
+                **mcp_kwargs,
             )
 
     anthropic_messages_provider_config: BaseAnthropicMessagesConfig | None = None
@@ -551,7 +566,10 @@ def anthropic_messages_handler(
             custom_llm_provider=custom_llm_provider,
             **kwargs,
         )
-        if _should_route_to_responses_api(custom_llm_provider):
+        if _should_route_to_responses_api(
+            custom_llm_provider,
+            use_chat_completions_api=force_chat_completions,
+        ):
             return LiteLLMMessagesToResponsesAPIHandler.anthropic_messages_handler(**_shared_kwargs)
 
         # The in-gateway context_management polyfill runs inside

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -101,6 +101,98 @@ async def test_openai_model_does_not_forward_stream_options_to_responses_api():
     assert "stream_options" not in request_body
 
 
+def _chat_completion_response(text: str, output_tokens: int) -> ModelResponse:
+    return ModelResponse(
+        id="chatcmpl-test",
+        model="custom-model",
+        choices=[
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": "stop",
+            }
+        ],
+        usage={
+            "prompt_tokens": 8,
+            "completion_tokens": output_tokens,
+            "total_tokens": 8 + output_tokens,
+        },
+    )
+
+
+def test_use_chat_completions_api_routes_directly_and_preserves_content():
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages_handler,
+    )
+
+    completion_response = _chat_completion_response("EXPLICIT CHAT OK", 4)
+
+    with (
+        patch("litellm.completion", return_value=completion_response) as mock_completion,
+        patch("litellm.responses") as mock_responses,
+    ):
+        result = anthropic_messages_handler(
+            max_tokens=16,
+            messages=[{"role": "user", "content": "Reply with exactly: EXPLICIT CHAT OK"}],
+            model="openai/gpt-5.5",
+            api_base="https://openai-compatible.example/v1",
+            api_key="test-api-key",
+            use_chat_completions_api=True,
+        )
+
+    mock_completion.assert_called_once()
+    mock_responses.assert_not_called()
+    assert result["content"] == [{"type": "text", "text": "EXPLICIT CHAT OK"}]
+    assert result["usage"]["output_tokens"] == 4
+
+
+def test_openai_chat_completions_model_prefix_is_not_forwarded_upstream():
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages_handler,
+    )
+
+    completion_response = _chat_completion_response("PREFIX OK", 2)
+
+    with patch("litellm.completion", return_value=completion_response) as mock_completion:
+        result = anthropic_messages_handler(
+            max_tokens=16,
+            messages=[{"role": "user", "content": "Reply with exactly: PREFIX OK"}],
+            model="openai/chat_completions/custom-model",
+            api_base="https://openai-compatible.example/v1",
+            api_key="test-api-key",
+        )
+
+    assert mock_completion.call_args.kwargs["model"] == "custom-model"
+    assert result["content"] == [{"type": "text", "text": "PREFIX OK"}]
+
+
+def test_chat_completions_prefix_survives_mcp_redispatch():
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages_handler,
+    )
+
+    with (
+        patch(
+            "litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._should_use_litellm_mcp_gateway",
+            return_value=True,
+        ),
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler.anthropic_messages_with_mcp",
+            new_callable=MagicMock,
+        ) as mock_mcp,
+    ):
+        anthropic_messages_handler(
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            model="openai/chat_completions/custom-model",
+            tools=[{"type": "mcp", "server_label": "test", "server_url": "litellm_proxy"}],
+            api_key="test-api-key",
+        )
+
+    assert mock_mcp.call_args.kwargs["model"] == "custom-model"
+    assert mock_mcp.call_args.kwargs["use_chat_completions_api"] is True
+
+
 def test_anthropic_experimental_pass_through_messages_handler_dynamic_api_key_and_api_base_and_custom_values():
     """
     Test that api key, api base, and extra kwargs are forwarded to litellm.completion for Azure models.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic Messages ignores Chat Completions routing opt-ins
- Generated text can become a successful empty response

How it solves it:

- Routes explicit opt-ins directly through Chat Completions
- Strips the model routing prefix before upstream requests

## User Flow

Before: a developer using a Chat Completions-only OpenAI-compatible base gets a blank Anthropic response

1. The proxy admin configures `use_chat_completions_api: true` with a custom `api_base`
2. The developer sends POST https://litellm-domain/v1/messages with that model
3. The proxy returns HTTP 200 with `content: []` despite nonzero output tokens

After: the same request returns the generated text as Anthropic content

1. The proxy admin keeps `use_chat_completions_api: true` with the same custom `api_base`
2. The developer sends the same POST https://litellm-domain/v1/messages with that model
3. The proxy returns HTTP 200 with a populated text content block

## Relevant issues

Fixes #37088

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Live provider proof was not captured because the reported upstream requires provider-specific credentials unavailable in this environment

## Type

Bug Fix

## Caveats (if any)

- Custom-base fallback remains explicit rather than capability-detected

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
