### PR TITLE
feat(proxy): weekly/monthly cost savings report emails

### DIFF
--- a/litellm/integrations/email_alerting.py
+++ b/litellm/integrations/email_alerting.py
@@ -3,11 +3,17 @@ Functions for sending Email Alerts
 """
 
 import os
-from typing import Final
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Final
 
 from litellm._logging import verbose_logger, verbose_proxy_logger
 from litellm.proxy._types import WebhookEvent
 from litellm.repositories.team_repository import TeamRepository
+
+if TYPE_CHECKING:
+    from reportlab.platypus import Image as ReportlabImage
+
+    from litellm.proxy.spend_tracking.cost_savings_report import CostSavingsReport
 
 # we use this for the email header, please send a test email if you change this. verify it looks good on email
 LITELLM_LOGO_URL: Final = "https://litellm-listing.s3.amazonaws.com/litellm_logo.png"
@@ -129,3 +135,198 @@ async def send_team_budget_alert(webhook_event: WebhookEvent) -> bool:
     )
 
     return False
+
+
+def build_cost_savings_report_email(report: "CostSavingsReport") -> tuple[str, str]:
+    """
+    Returns (subject, html) for a cost-savings report email. Pure function, no I/O.
+    """
+    email_logo_url = os.getenv("SMTP_SENDER_LOGO", os.getenv("EMAIL_LOGO_URL", None)) or LITELLM_LOGO_URL
+    email_support_contact = os.getenv("EMAIL_SUPPORT_CONTACT", None) or LITELLM_SUPPORT_CONTACT
+
+    date_range: Final = f"{report.start_date.strftime('%b %d, %Y')} - {report.end_date.strftime('%b %d, %Y')}"
+    subject: Final = f"LiteLLM Cost Savings Report ({date_range})"
+
+    html: Final = f"""
+    <img src="{email_logo_url}" alt="LiteLLM Logo" width="150" height="50" /> <br/><br/><br/>
+
+    Cost Savings Report for <b>{date_range}</b> <br/> <br/>
+
+    Total spend: <b>${round(report.total_spend, 4)}</b> <br/> <br/>
+
+    <ul>
+        <li>Auto Router savings: <b>${round(report.autorouter_savings_spend, 4)}</b></li>
+        <li>Prompt Compression savings: <b>${round(report.compression_savings_spend, 4)}</b></li>
+        <li>Prompt Caching savings: <b>${round(report.prompt_caching_savings_spend, 4)}</b></li>
+    </ul>
+
+    Total savings: <b>${round(report.total_savings, 4)}</b> <br/> <br/>
+
+    If you have any questions, please send an email to {email_support_contact} <br/> <br/>
+
+    Best, <br/>
+    The LiteLLM team <br/>
+    """
+
+    return subject, html
+
+
+LITELLM_LOGO_PATH: Final = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "proxy", "_experimental", "out", "assets", "logos", "litellm.jpg")
+)
+CUSTOM_LOGO_FETCH_TIMEOUT_SECONDS: Final = 5.0
+_LOGO_MAX_WIDTH_INCHES: Final = 2.0
+_LOGO_MAX_HEIGHT_INCHES: Final = 0.6
+
+
+def _custom_logo_url() -> str | None:
+    return os.getenv("SMTP_SENDER_LOGO", os.getenv("EMAIL_LOGO_URL", None))
+
+
+async def _fetch_custom_logo_bytes() -> bytes | None:
+    """
+    Fetches the proxy admin's custom logo (same SMTP_SENDER_LOGO / EMAIL_LOGO_URL env
+    vars the HTML email already uses), for embedding in the cost savings report PDF.
+    Returns None when no custom logo is configured, or on any fetch failure, so the
+    caller falls back to the bundled LiteLLM logo.
+    """
+    custom_logo_url: Final = _custom_logo_url()
+    if not custom_logo_url or not custom_logo_url.startswith(("http://", "https://")):
+        return None
+
+    from litellm.llms.custom_httpx.http_handler import (
+        get_async_httpx_client,
+        httpxSpecialProvider,
+    )
+
+    try:
+        client: Final = get_async_httpx_client(llm_provider=httpxSpecialProvider.EmailReporting)
+        response: Final = await client.get(custom_logo_url, timeout=CUSTOM_LOGO_FETCH_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        return response.content
+    except Exception as e:  # noqa: BLE001  # a broken custom logo must fall back, not break the report
+        verbose_proxy_logger.warning("Email Alerting: failed to fetch custom logo %s: %s", custom_logo_url, e)
+        return None
+
+
+def _sized_logo_image(image_bytes: bytes) -> "ReportlabImage":
+    """
+    Loads an ``Image`` flowable scaled to fit within the report header's logo box,
+    preserving the source image's aspect ratio (custom logos can be any shape).
+    """
+    from io import BytesIO
+
+    from PIL import Image as PILImage
+    from reportlab.lib.units import inch
+    from reportlab.platypus import Image
+
+    with PILImage.open(BytesIO(image_bytes)) as pil_image:
+        intrinsic_width, intrinsic_height = pil_image.size
+
+    scale: Final = min(
+        (_LOGO_MAX_WIDTH_INCHES * inch) / intrinsic_width,
+        (_LOGO_MAX_HEIGHT_INCHES * inch) / intrinsic_height,
+    )
+    return Image(
+        BytesIO(image_bytes),
+        width=intrinsic_width * scale,
+        height=intrinsic_height * scale,
+        hAlign="LEFT",
+    )
+
+
+def build_cost_savings_report_pdf(report: "CostSavingsReport", logo_bytes: bytes | None = None) -> bytes:
+    """
+    Renders the cost-savings report as a one-page, left-aligned PDF, for attachment
+    to the email. Pass ``logo_bytes`` for a proxy admin's custom logo; falls back to
+    the bundled LiteLLM logo asset (no network I/O) when not given.
+    """
+    from io import BytesIO
+
+    from reportlab.lib import colors
+    from reportlab.lib.enums import TA_LEFT
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+    from reportlab.lib.units import inch
+    from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+    date_range: Final = f"{report.start_date.strftime('%b %d, %Y')} - {report.end_date.strftime('%b %d, %Y')}"
+
+    with open(LITELLM_LOGO_PATH, "rb") as f:
+        fallback_logo_bytes: Final = f.read()
+    logo: Final = _sized_logo_image(logo_bytes or fallback_logo_bytes)
+
+    base_styles: Final = getSampleStyleSheet()
+    title_style: Final = ParagraphStyle("LeftTitle", parent=base_styles["Title"], alignment=TA_LEFT)
+    date_style: Final = ParagraphStyle(
+        "LeftDate", parent=base_styles["Normal"], alignment=TA_LEFT, textColor=colors.grey
+    )
+
+    rows: Final = (
+        ("Metric", "Amount"),
+        ("Total spend", f"${report.total_spend:,.4f}"),
+        ("Auto Router savings", f"${report.autorouter_savings_spend:,.4f}"),
+        ("Prompt Compression savings", f"${report.compression_savings_spend:,.4f}"),
+        ("Prompt Caching savings", f"${report.prompt_caching_savings_spend:,.4f}"),
+        ("Total savings", f"${report.total_savings:,.4f}"),
+    )
+    table: Final = Table(rows, colWidths=(3 * inch, 2 * inch), hAlign="LEFT")
+    table.setStyle(
+        TableStyle(
+            (
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#1a1a2e")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTNAME", (0, -1), (-1, -1), "Helvetica-Bold"),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("ROWBACKGROUNDS", (0, 1), (-1, -2), (colors.white, colors.HexColor("#f5f5f5"))),
+            )
+        )
+    )
+
+    buffer: Final = BytesIO()
+    doc: Final = SimpleDocTemplate(buffer, pagesize=letter, title="LiteLLM Cost Savings Report")
+    # reportlab's SimpleDocTemplate.build() mutates (pops from) the flowables list it
+    # is given, so a tuple isn't accepted here.
+    flowables: Final = [  # mutable-ok: reportlab's build() deletes items from this list in place
+        logo,
+        Spacer(1, 0.25 * inch),
+        Paragraph("LiteLLM Cost Savings Report", title_style),
+        Paragraph(date_range, date_style),
+        Spacer(1, 0.3 * inch),
+        table,
+    ]
+    doc.build(flowables)
+    return buffer.getvalue()
+
+
+async def send_cost_savings_report_email(recipient_emails: Sequence[str], report: "CostSavingsReport") -> bool:
+    """
+    Send the periodic cost-savings report email to the configured recipients,
+    with a PDF copy of the report attached.
+    Returns True if sent, False if not.
+    """
+    from litellm.proxy.utils import EmailAttachment, send_email
+
+    if not recipient_emails:
+        verbose_proxy_logger.warning("Email Alerting: No recipients configured for cost savings report")
+        return False
+
+    subject, html = build_cost_savings_report_email(report)
+    custom_logo_bytes: Final = await _fetch_custom_logo_bytes()
+    pdf_bytes: Final = build_cost_savings_report_pdf(report, logo_bytes=custom_logo_bytes)
+
+    await send_email(
+        receiver_email=",".join(recipient_emails),
+        subject=subject,
+        html=html,
+        attachments=(
+            EmailAttachment(
+                filename=f"litellm_cost_savings_report_{report.start_date}_{report.end_date}.pdf",
+                content=pdf_bytes,
+                mime_type="application/pdf",
+            ),
+        ),
+    )
+
+    return True

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8467,6 +8467,13 @@ class ProxyStartupEvent:
             prisma_client=prisma_client,
         )
 
+        await cls._initialize_cost_savings_report_jobs(
+            scheduler=scheduler,
+            general_settings=general_settings,
+            proxy_logging_obj=proxy_logging_obj,
+            prisma_client=prisma_client,
+        )
+
         await cls._initialize_spend_tracking_background_jobs(scheduler=scheduler)
 
         ### SPEND LOG CLEANUP ###
@@ -8810,6 +8817,62 @@ class ProxyStartupEvent:
                     replace_existing=True,
                 )
                 await proxy_logging_obj.slack_alerting_instance.send_fallback_stats_from_prometheus()
+
+    @classmethod
+    async def _initialize_cost_savings_report_jobs(
+        cls,
+        scheduler: AsyncIOScheduler,
+        general_settings: Mapping[str, object],
+        proxy_logging_obj: ProxyLogging,
+        prisma_client: PrismaClient,
+    ) -> None:
+        """Initialize scheduled weekly/monthly cost savings report emails."""
+        if prisma_client is None:
+            return
+
+        recipient_emails: Final = general_settings.get("cost_savings_report_recipients")
+        if not recipient_emails:
+            return
+
+        from litellm.proxy.spend_tracking.cost_savings_report import (
+            send_monthly_cost_savings_report,
+            send_weekly_cost_savings_report,
+        )
+
+        print("Alerting: Initializing Weekly/Monthly Cost Savings Reports")  # noqa: T201
+        cost_savings_report_frequency: Final[str] = general_settings.get("cost_savings_report_frequency", "7d") or "7d"
+
+        days: Final = int(cost_savings_report_frequency[:-1])
+        if cost_savings_report_frequency[-1].lower() != "d":
+            raise ValueError("cost_savings_report_frequency must be specified in days, e.g., '1d', '7d'")
+
+        weekly_delay: Final = timedelta(seconds=10 + random.randint(0, 300))
+        weekly_now: Final = datetime.now()  # noqa: DTZ005  # naive local time, matches spend report job
+        weekly_next_run_time: Final = weekly_now + weekly_delay
+        scheduler.add_job(
+            send_weekly_cost_savings_report,
+            "interval",
+            days=days,
+            next_run_time=weekly_next_run_time,
+            args=[
+                prisma_client,
+                proxy_logging_obj.internal_usage_cache.dual_cache,
+                recipient_emails,
+                cost_savings_report_frequency,
+            ],
+            id="weekly_cost_savings_report_job",
+            replace_existing=True,
+            misfire_grace_time=APSCHEDULER_MISFIRE_GRACE_TIME,
+        )
+
+        scheduler.add_job(
+            send_monthly_cost_savings_report,
+            "cron",
+            day=1,
+            args=[prisma_client, proxy_logging_obj.internal_usage_cache.dual_cache, recipient_emails],
+            id="monthly_cost_savings_report_job",
+            replace_existing=True,
+        )
 
     @classmethod
     async def _setup_prisma_client(

--- a/litellm/proxy/spend_tracking/cost_savings_report.py
+++ b/litellm/proxy/spend_tracking/cost_savings_report.py
@@ -1,0 +1,166 @@
+"""
+Scheduled weekly/monthly cost-savings report emails.
+
+Reuses the daily savings rollups (autorouter/compression/prompt-caching, see
+``litellm/proxy/spend_tracking/savings.py``) already aggregated for the Cost
+Optimization dashboard, and reports them to a configured recipient list on a
+cadence, instead of only surfacing them in the UI.
+"""
+
+import datetime
+from calendar import monthrange
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Final
+
+from litellm._logging import verbose_proxy_logger
+from litellm.caching.caching import DualCache
+from litellm.litellm_core_utils.duration_parser import duration_in_seconds
+from litellm.proxy.utils import PrismaClient
+
+
+@dataclass(frozen=True, slots=True)
+class CostSavingsReport:
+    start_date: datetime.date
+    end_date: datetime.date
+    total_spend: float
+    autorouter_savings_spend: float
+    compression_savings_spend: float
+    prompt_caching_savings_spend: float
+
+    @property
+    def total_savings(self) -> float:
+        return self.autorouter_savings_spend + self.compression_savings_spend + self.prompt_caching_savings_spend
+
+
+async def get_cost_savings_report_for_time_range(
+    prisma_client: PrismaClient,
+    start_date: datetime.date,
+    end_date: datetime.date,
+) -> CostSavingsReport | None:
+    """
+    Returns the proxy-wide cost-savings report for ``[start_date, end_date]``, or
+    ``None`` when there is nothing to report (no spend, no savings).
+    """
+    from litellm.proxy.management_endpoints.common_daily_activity import (
+        get_daily_activity_aggregated,
+    )
+
+    resp: Final = await get_daily_activity_aggregated(
+        prisma_client=prisma_client,
+        table_name="litellm_dailyuserspend",
+        entity_id_field="user_id",
+        entity_id=None,
+        entity_metadata_field=None,
+        start_date=start_date.strftime("%Y-%m-%d"),
+        end_date=end_date.strftime("%Y-%m-%d"),
+        model=None,
+        api_key=None,
+    )
+
+    total_spend: Final = resp.metadata.total_spend or 0.0
+    autorouter_savings_spend: Final = resp.metadata.total_autorouter_savings_spend or 0.0
+    compression_savings_spend: Final = resp.metadata.total_compression_savings_spend or 0.0
+    prompt_caching_savings_spend: Final = resp.metadata.total_prompt_caching_savings_spend or 0.0
+
+    nothing_to_report: Final = (
+        total_spend == 0.0
+        and autorouter_savings_spend == 0.0
+        and compression_savings_spend == 0.0
+        and prompt_caching_savings_spend == 0.0
+    )
+    if nothing_to_report:
+        return None
+
+    return CostSavingsReport(
+        start_date=start_date,
+        end_date=end_date,
+        total_spend=total_spend,
+        autorouter_savings_spend=autorouter_savings_spend,
+        compression_savings_spend=compression_savings_spend,
+        prompt_caching_savings_spend=prompt_caching_savings_spend,
+    )
+
+
+async def send_weekly_cost_savings_report(
+    prisma_client: PrismaClient,
+    internal_usage_cache: DualCache,
+    recipient_emails: Sequence[str],
+    time_range: str = "7d",
+) -> None:
+    """
+    Args:
+        time_range: A string specifying the time range for the report, e.g., "1d", "7d", "30d"
+    """
+    from litellm.integrations.email_alerting import send_cost_savings_report_email
+
+    try:
+        days: Final = int(time_range[:-1])
+        if time_range[-1].lower() != "d":
+            raise ValueError("Time range must be specified in days, e.g., '7d'")
+
+        end_date: Final = datetime.datetime.now().date()  # noqa: DTZ005  # naive local time, matches spend report job
+        start_date: Final = end_date - datetime.timedelta(days=days)
+
+        event_cache_key: Final = (
+            f"weekly_cost_savings_report_sent_{start_date.strftime('%Y-%m-%d')}_{end_date.strftime('%Y-%m-%d')}"
+        )
+        if await internal_usage_cache.async_get_cache(key=event_cache_key):
+            return
+
+        report: Final = await get_cost_savings_report_for_time_range(
+            prisma_client=prisma_client,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        if report is None:
+            return
+
+        await send_cost_savings_report_email(recipient_emails=list(recipient_emails), report=report)
+
+        await internal_usage_cache.async_set_cache(
+            key=event_cache_key,
+            value="SENT",
+            ttl=duration_in_seconds(time_range),
+        )
+    except ValueError as ve:
+        verbose_proxy_logger.error("Invalid time range format: %s", ve)
+    except Exception as e:  # noqa: BLE001  # scheduled job must never crash the scheduler loop
+        verbose_proxy_logger.error("Error sending weekly cost savings report: %s", e)
+
+
+async def send_monthly_cost_savings_report(
+    prisma_client: PrismaClient,
+    internal_usage_cache: DualCache,
+    recipient_emails: Sequence[str],
+) -> None:
+    from litellm.integrations.email_alerting import send_cost_savings_report_email
+
+    try:
+        end_date: Final = datetime.datetime.now().date()  # noqa: DTZ005  # naive local time, matches spend report job
+        start_date: Final = end_date.replace(day=1)
+
+        event_cache_key: Final = (
+            f"monthly_cost_savings_report_sent_{start_date.strftime('%Y-%m-%d')}_{end_date.strftime('%Y-%m-%d')}"
+        )
+        if await internal_usage_cache.async_get_cache(key=event_cache_key):
+            return
+
+        report: Final = await get_cost_savings_report_for_time_range(
+            prisma_client=prisma_client,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        if report is None:
+            return
+
+        await send_cost_savings_report_email(recipient_emails=list(recipient_emails), report=report)
+
+        _, days_in_month = monthrange(end_date.year, end_date.month)
+        await internal_usage_cache.async_set_cache(
+            key=event_cache_key,
+            value="SENT",
+            ttl=duration_in_seconds(f"{days_in_month}d"),
+        )
+    except Exception as e:  # noqa: BLE001  # scheduled job must never crash the scheduler loop
+        verbose_proxy_logger.error("Error sending monthly cost savings report: %s", e)

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -13,6 +13,7 @@ import traceback
 from collections.abc import AsyncGenerator, Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
+from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal, Optional, Union, cast, overload
@@ -5302,11 +5303,19 @@ def _create_smtp_connection(smtp_host: str, smtp_port: int) -> smtplib.SMTP:
     return smtplib.SMTP(host=smtp_host, port=smtp_port)
 
 
+@dataclass(frozen=True, slots=True)
+class EmailAttachment:
+    filename: str
+    content: bytes
+    mime_type: str = "application/octet-stream"
+
+
 async def send_email(
     receiver_email: str | None = None,
     subject: str | None = None,
     html: str | None = None,
-):
+    attachments: Sequence[EmailAttachment] = (),
+) -> None:
     """
     smtp_host,
     smtp_port,
@@ -5343,6 +5352,12 @@ async def send_email(
 
     # Attach the body to the email
     email_message.attach(MIMEText(html, "html"))
+
+    for attachment in attachments:
+        _, _, mime_subtype = attachment.mime_type.partition("/")
+        part = MIMEApplication(attachment.content, _subtype=mime_subtype or "octet-stream")
+        part.add_header("Content-Disposition", "attachment", filename=attachment.filename)
+        email_message.attach(part)
 
     try:
         using_ssl: Final = _should_use_smtp_ssl(smtp_port=smtp_port)

--- a/litellm/types/llms/custom_http.py
+++ b/litellm/types/llms/custom_http.py
@@ -31,6 +31,7 @@ class httpxSpecialProvider(str, Enum):
     UI = "ui"
     Sandbox = "sandbox"
     ModelCostMap = "model_cost_map"
+    EmailReporting = "email_reporting"
 
 
 VerifyTypes = str | bool | ssl.SSLContext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ proxy-runtime = [
     "azure-ai-contentsafety>=1.0.0,<2.0",
     "azure-storage-file-datalake>=12.20.0,<13.0",
     "pypdf>=6.12.0,<7.0",
+    "reportlab>=4.2.0,<5.0",
     "llm-sandbox>=0.3.39,<1.0",
     "detect-secrets>=1.5.0,<2.0",
 ]

--- a/tests/test_litellm/integrations/test_email_alerting.py
+++ b/tests/test_litellm/integrations/test_email_alerting.py
@@ -1,0 +1,174 @@
+import datetime
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pypdf import PdfReader
+
+from litellm.integrations.email_alerting import (
+    _fetch_custom_logo_bytes,
+    build_cost_savings_report_email,
+    build_cost_savings_report_pdf,
+    send_cost_savings_report_email,
+)
+from litellm.proxy.spend_tracking.cost_savings_report import CostSavingsReport
+from litellm.proxy.utils import EmailAttachment
+
+
+def _tiny_png_bytes(color: tuple[int, int, int]) -> bytes:
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (40, 10), color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _report(**overrides) -> CostSavingsReport:
+    defaults = dict(
+        start_date=datetime.date(2026, 1, 1),
+        end_date=datetime.date(2026, 1, 8),
+        total_spend=100.0,
+        autorouter_savings_spend=10.5,
+        compression_savings_spend=2.25,
+        prompt_caching_savings_spend=1.25,
+    )
+    defaults.update(overrides)
+    return CostSavingsReport(**defaults)
+
+
+def test_build_cost_savings_report_email_contains_each_savings_driver_and_total():
+    subject, html = build_cost_savings_report_email(_report())
+
+    assert "Jan 01, 2026" in subject and "Jan 08, 2026" in subject
+    assert "$100.0" in html
+    assert "$10.5" in html
+    assert "$2.25" in html
+    assert "$1.25" in html
+    assert "$14.0" in html  # total_savings = 10.5 + 2.25 + 1.25
+
+
+def test_build_cost_savings_report_email_reflects_savings_changes():
+    _, html_before = build_cost_savings_report_email(_report(autorouter_savings_spend=10.5))
+    _, html_after = build_cost_savings_report_email(_report(autorouter_savings_spend=20.5))
+
+    assert html_before != html_after
+    assert "$20.5" in html_after
+    assert "$10.5" not in html_after
+
+
+def _pdf_text(pdf_bytes: bytes) -> str:
+    reader = PdfReader(BytesIO(pdf_bytes))
+    return "\n".join(page.extract_text() for page in reader.pages)
+
+
+def test_build_cost_savings_report_pdf_contains_each_savings_driver_and_total():
+    pdf_bytes = build_cost_savings_report_pdf(_report())
+
+    assert pdf_bytes.startswith(b"%PDF-")
+    text = _pdf_text(pdf_bytes)
+    assert "100.0000" in text
+    assert "10.5000" in text
+    assert "2.2500" in text
+    assert "1.2500" in text
+    assert "14.0000" in text  # total_savings = 10.5 + 2.25 + 1.25
+
+
+def test_build_cost_savings_report_pdf_reflects_savings_changes():
+    text_before = _pdf_text(build_cost_savings_report_pdf(_report(autorouter_savings_spend=10.5)))
+    text_after = _pdf_text(build_cost_savings_report_pdf(_report(autorouter_savings_spend=20.5)))
+
+    assert "20.5000" in text_after
+    assert "20.5000" not in text_before
+
+
+def test_build_cost_savings_report_pdf_embeds_custom_logo_when_given():
+    default_pdf = build_cost_savings_report_pdf(_report())
+    custom_logo_pdf = build_cost_savings_report_pdf(_report(), logo_bytes=_tiny_png_bytes((255, 0, 0)))
+
+    assert custom_logo_pdf.startswith(b"%PDF-")
+    assert custom_logo_pdf != default_pdf
+
+
+def test_build_cost_savings_report_pdf_preserves_custom_logo_aspect_ratio():
+    # a very wide, short logo should not be squeezed into a square box
+    wide_logo_pdf = build_cost_savings_report_pdf(_report(), logo_bytes=_tiny_png_bytes((0, 255, 0)))
+    assert wide_logo_pdf.startswith(b"%PDF-")
+
+
+@pytest.mark.asyncio
+async def test_fetch_custom_logo_bytes_returns_none_when_unset(monkeypatch):
+    monkeypatch.delenv("SMTP_SENDER_LOGO", raising=False)
+    monkeypatch.delenv("EMAIL_LOGO_URL", raising=False)
+
+    assert await _fetch_custom_logo_bytes() is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_custom_logo_bytes_returns_content_on_success(monkeypatch):
+    monkeypatch.setenv("EMAIL_LOGO_URL", "https://example.com/logo.png")
+    logo_bytes = _tiny_png_bytes((0, 0, 255))
+
+    mock_response = MagicMock()
+    mock_response.content = logo_bytes
+    mock_response.raise_for_status = MagicMock()
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.get_async_httpx_client",
+        return_value=mock_client,
+    ):
+        result = await _fetch_custom_logo_bytes()
+
+    assert result == logo_bytes
+    mock_client.get.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_custom_logo_bytes_falls_back_to_none_on_failure(monkeypatch):
+    monkeypatch.setenv("EMAIL_LOGO_URL", "https://example.com/logo.png")
+
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(side_effect=RuntimeError("network down"))
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.get_async_httpx_client",
+        return_value=mock_client,
+    ):
+        result = await _fetch_custom_logo_bytes()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_send_cost_savings_report_email_sends_built_content_to_recipients():
+    report = _report()
+    expected_subject, expected_html = build_cost_savings_report_email(report)
+
+    with patch("litellm.proxy.utils.send_email", new=AsyncMock()) as mock_send_email:
+        sent = await send_cost_savings_report_email(
+            recipient_emails=["a@example.com", "b@example.com"],
+            report=report,
+        )
+
+    assert sent is True
+    mock_send_email.assert_awaited_once()
+    _, kwargs = mock_send_email.await_args
+    assert kwargs["receiver_email"] == "a@example.com,b@example.com"
+    assert kwargs["subject"] == expected_subject
+    assert kwargs["html"] == expected_html
+    assert len(kwargs["attachments"]) == 1
+    attachment: EmailAttachment = kwargs["attachments"][0]
+    assert attachment.filename == f"litellm_cost_savings_report_{report.start_date}_{report.end_date}.pdf"
+    assert attachment.mime_type == "application/pdf"
+    assert attachment.content.startswith(b"%PDF-")
+    assert "14.0000" in _pdf_text(attachment.content)  # total_savings
+
+
+@pytest.mark.asyncio
+async def test_send_cost_savings_report_email_noop_when_no_recipients():
+    with patch("litellm.proxy.utils.send_email", new=AsyncMock()) as mock_send_email:
+        sent = await send_cost_savings_report_email(recipient_emails=[], report=_report())
+
+    assert sent is False
+    mock_send_email.assert_not_awaited()

--- a/tests/test_litellm/proxy/spend_tracking/test_cost_savings_report.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_cost_savings_report.py
@@ -1,0 +1,84 @@
+import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from litellm.proxy.spend_tracking.cost_savings_report import (
+    CostSavingsReport,
+    get_cost_savings_report_for_time_range,
+)
+from litellm.types.proxy.management_endpoints.common_daily_activity import (
+    DailySpendMetadata,
+    SpendAnalyticsPaginatedResponse,
+)
+
+
+def _aggregated_response(
+    total_spend: float,
+    autorouter_savings_spend: float,
+    compression_savings_spend: float,
+    prompt_caching_savings_spend: float,
+) -> SpendAnalyticsPaginatedResponse:
+    return SpendAnalyticsPaginatedResponse(
+        results=[],
+        metadata=DailySpendMetadata(
+            total_spend=total_spend,
+            total_compression_savings_spend=compression_savings_spend,
+            total_prompt_caching_savings_spend=prompt_caching_savings_spend,
+            total_autorouter_savings_spend=autorouter_savings_spend,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_cost_savings_report_maps_aggregated_totals_onto_report():
+    mock_response = _aggregated_response(
+        total_spend=100.0,
+        autorouter_savings_spend=10.5,
+        compression_savings_spend=2.25,
+        prompt_caching_savings_spend=1.25,
+    )
+    start_date = datetime.date(2026, 1, 1)
+    end_date = datetime.date(2026, 1, 8)
+
+    with patch(
+        "litellm.proxy.management_endpoints.common_daily_activity.get_daily_activity_aggregated",
+        new=AsyncMock(return_value=mock_response),
+    ):
+        report = await get_cost_savings_report_for_time_range(
+            prisma_client=AsyncMock(),
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    assert report == CostSavingsReport(
+        start_date=start_date,
+        end_date=end_date,
+        total_spend=100.0,
+        autorouter_savings_spend=10.5,
+        compression_savings_spend=2.25,
+        prompt_caching_savings_spend=1.25,
+    )
+    assert report.total_savings == pytest.approx(14.0)
+
+
+@pytest.mark.asyncio
+async def test_get_cost_savings_report_returns_none_when_nothing_to_report():
+    mock_response = _aggregated_response(
+        total_spend=0.0,
+        autorouter_savings_spend=0.0,
+        compression_savings_spend=0.0,
+        prompt_caching_savings_spend=0.0,
+    )
+
+    with patch(
+        "litellm.proxy.management_endpoints.common_daily_activity.get_daily_activity_aggregated",
+        new=AsyncMock(return_value=mock_response),
+    ):
+        report = await get_cost_savings_report_for_time_range(
+            prisma_client=AsyncMock(),
+            start_date=datetime.date(2026, 1, 1),
+            end_date=datetime.date(2026, 1, 8),
+        )
+
+    assert report is None

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -757,6 +757,47 @@ async def test_initialize_scheduled_jobs_credentials(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_cost_savings_report_jobs_not_scheduled_without_recipients():
+    from litellm.proxy.proxy_server import ProxyStartupEvent
+    from litellm.proxy.utils import ProxyLogging
+
+    mock_scheduler = MagicMock()
+    mock_proxy_logging = MagicMock(spec=ProxyLogging)
+
+    await ProxyStartupEvent._initialize_cost_savings_report_jobs(
+        scheduler=mock_scheduler,
+        general_settings={},
+        proxy_logging_obj=mock_proxy_logging,
+        prisma_client=MagicMock(),
+    )
+
+    mock_scheduler.add_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cost_savings_report_jobs_scheduled_with_recipients():
+    from litellm.proxy.proxy_server import ProxyStartupEvent
+    from litellm.proxy.utils import ProxyLogging
+
+    mock_scheduler = MagicMock()
+    mock_proxy_logging = MagicMock(spec=ProxyLogging)
+    mock_proxy_logging.internal_usage_cache = MagicMock()
+
+    await ProxyStartupEvent._initialize_cost_savings_report_jobs(
+        scheduler=mock_scheduler,
+        general_settings={"cost_savings_report_recipients": ["admin@example.com"]},
+        proxy_logging_obj=mock_proxy_logging,
+        prisma_client=MagicMock(),
+    )
+
+    scheduled_job_ids = [call.kwargs["id"] for call in mock_scheduler.add_job.mock_calls]
+    assert scheduled_job_ids == [
+        "weekly_cost_savings_report_job",
+        "monthly_cost_savings_report_job",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_periodic_reload_job_scheduled_without_store_model_in_db(monkeypatch):
     """
     Regression (LIT-4882): reload schedules configured from the Admin UI live in the DB and

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -951,6 +951,69 @@ class TestSendEmailStartTls:
         assert context.check_hostname is True
 
 
+class TestSendEmailAttachments:
+    @pytest.mark.asyncio
+    async def test_attachment_is_included_with_filename_and_content(self, monkeypatch):
+        from litellm.proxy.utils import EmailAttachment, send_email
+
+        monkeypatch.setenv("SMTP_HOST", "mail.example.com")
+        monkeypatch.setenv("SMTP_PORT", "587")
+        monkeypatch.setenv("SMTP_SENDER_EMAIL", "sender@example.com")
+        monkeypatch.delenv("SMTP_TLS", raising=False)
+        monkeypatch.delenv("SMTP_USE_SSL", raising=False)
+
+        mock_server = MagicMock(spec=smtplib.SMTP)
+        with patch("litellm.proxy.utils._create_smtp_connection") as mock_create_connection:
+            mock_create_connection.return_value.__enter__.return_value = mock_server
+            await send_email(
+                receiver_email="receiver@example.com",
+                subject="test",
+                html="<p>test</p>",
+                attachments=[
+                    EmailAttachment(
+                        filename="report.pdf",
+                        content=b"%PDF-1.4 fake pdf bytes",
+                        mime_type="application/pdf",
+                    )
+                ],
+            )
+
+        _, kwargs = mock_server.send_message.call_args
+        sent_message = kwargs["msg"]
+        pdf_parts = [
+            part for part in sent_message.walk() if part.get_content_type() == "application/pdf"
+        ]
+        assert len(pdf_parts) == 1
+        assert pdf_parts[0].get_filename() == "report.pdf"
+        assert pdf_parts[0].get_payload(decode=True) == b"%PDF-1.4 fake pdf bytes"
+
+    @pytest.mark.asyncio
+    async def test_no_attachment_part_when_none_given(self, monkeypatch):
+        from litellm.proxy.utils import send_email
+
+        monkeypatch.setenv("SMTP_HOST", "mail.example.com")
+        monkeypatch.setenv("SMTP_PORT", "587")
+        monkeypatch.setenv("SMTP_SENDER_EMAIL", "sender@example.com")
+        monkeypatch.delenv("SMTP_TLS", raising=False)
+        monkeypatch.delenv("SMTP_USE_SSL", raising=False)
+
+        mock_server = MagicMock(spec=smtplib.SMTP)
+        with patch("litellm.proxy.utils._create_smtp_connection") as mock_create_connection:
+            mock_create_connection.return_value.__enter__.return_value = mock_server
+            await send_email(
+                receiver_email="receiver@example.com",
+                subject="test",
+                html="<p>test</p>",
+            )
+
+        _, kwargs = mock_server.send_message.call_args
+        sent_message = kwargs["msg"]
+        assert [part.get_content_type() for part in sent_message.walk()] == [
+            "multipart/mixed",
+            "text/html",
+        ]
+
+
 class _RecordingMCPGuardrail(CustomGuardrail):
     """Unified guardrail that masks every text it is handed."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-04T19:23:00.022310687Z"
+exclude-newer = "2026-08-13T19:41:46.381216Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4295,6 +4295,7 @@ proxy-runtime = [
     { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
     { name = "pypdf" },
+    { name = "reportlab" },
     { name = "sentry-sdk" },
 ]
 saml = [
@@ -4475,6 +4476,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'cli'", specifier = ">=6.0.3,<7.0" },
     { name = "pyyaml", marker = "extra == 'proxy'", specifier = ">=6.0.3,<7.0" },
     { name = "redisvl", marker = "extra == 'extra-proxy'", specifier = ">=0.4.1,<1.0" },
+    { name = "reportlab", marker = "extra == 'proxy-runtime'", specifier = ">=4.2.0,<5.0" },
     { name = "requests", marker = "extra == 'cli'", specifier = ">=2.32.0,<3.0" },
     { name = "resend", marker = "extra == 'extra-proxy'", specifier = ">=2.23.0,<3.0" },
     { name = "restrictedpython", marker = "extra == 'proxy'", specifier = ">=8.1,<9.0" },
@@ -8092,6 +8094,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
     { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
     { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
+name = "reportlab"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/3f/b3861b7e40c9d66f4a04e018958d681d16b948bfd1963c962d43a8c23f66/reportlab-4.5.1.tar.gz", hash = "sha256:9fdf68f4de9171ec66acb4a5feed8f8ca2af43479e707a6fbb0daa75d88e5494", size = 3939748, upload-time = "2026-05-12T10:14:13.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/45/ea7fad10122440de6e845568d106bffdc456ca0e8a1d8ae10b46016087e4/reportlab-4.5.1-py3-none-any.whl", hash = "sha256:06fce8cb56c83307cfa4909cdf4e6a2ddbb44e5d6ef4d2edca896d7e9769f091", size = 1957812, upload-time = "2026-05-12T10:14:10.622Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Auto router users only see estimated savings on the cost optimization tab, with no periodic export
- No way to get a recurring summary of auto-router, compression, and caching savings

How it solves it:

- Adds scheduled weekly/monthly emails summarizing all cost-optimization savings drivers
- Attaches a formatted PDF report alongside the HTML summary

## User Flow

Before: a proxy admin using the auto router has to remember to open the Admin UI to see savings

1. They open https://litellm-domain/ui/?page=cost-optimization and check the Auto Router tab
2. They see an "estimated savings" tile, but get no periodic export or historical snapshot
3. There is no way to share these numbers with their team without manually copying them out

After: the same admin gets a recurring email with the numbers and a PDF they can forward

1. The proxy admin sets `general_settings.cost_savings_report_recipients: ["admin@example.com"]` in their config and restarts the proxy
2. On the configured cadence (`cost_savings_report_frequency`, default `7d`, plus a monthly report on the 1st), the proxy computes real spend and savings from the daily spend rollups for the window
3. The recipient receives an email with an HTML summary (total spend, auto-router/compression/caching savings, total savings) and a PDF attachment with the same numbers, left-aligned under the LiteLLM logo (or the proxy's own custom logo, if `SMTP_SENDER_LOGO`/`EMAIL_LOGO_URL` is set)
4. If there is nothing to report (zero spend and zero savings in the window), no email is sent

## Relevant issues

Resolves #37076

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix
<img width="603" height="665" alt="Screenshot 2026-08-16 at 3 51 17 PM" src="https://github.com/user-attachments/assets/b5117706-523a-4e84-bcb1-0b97570307fd" />

Commit: `be9a608912`

Ran against a real Neon Postgres proxy DB and real Gmail SMTP relay (no mocks), computing the report from actual `LiteLLM_DailyUserSpend` rollups and sending a real email with a live SMTP connection:

```python
import asyncio, datetime
from litellm.proxy.utils import PrismaClient, ProxyLogging
from litellm.proxy.spend_tracking.cost_savings_report import get_cost_savings_report_for_time_range
from litellm.integrations.email_alerting import send_cost_savings_report_email

async def main():
    proxy_logging_obj = ProxyLogging(user_api_key_cache=None)
    prisma_client = PrismaClient(database_url=os.environ["DATABASE_URL"], proxy_logging_obj=proxy_logging_obj)
    await prisma_client.connect()
    end_date = datetime.date.today()
    start_date = end_date - datetime.timedelta(days=30)
    report = await get_cost_savings_report_for_time_range(prisma_client, start_date, end_date)
    print("REPORT FROM DB:", report)
    sent = await send_cost_savings_report_email(recipient_emails=["mubashir@berri.ai"], report=report)
    print("EMAIL SENT:", sent)

asyncio.run(main())
```

Output:

```
REPORT FROM DB: CostSavingsReport(start_date=datetime.date(2026, 7, 17), end_date=datetime.date(2026, 8, 16), total_spend=1.0954538700000003, autorouter_savings_spend=0.0, compression_savings_spend=0.0, prompt_caching_savings_spend=0.010348109999999999)
EMAIL SENT: True
```

Confirmed the email arrived with the correct numbers in both the HTML body and the PDF attachment (logo, title, date range, and the per-driver savings table, all left-aligned).

Also confirmed the scheduler wires up correctly at proxy startup: with `cost_savings_report_recipients` set in `general_settings`, the log shows `Alerting: Initializing Weekly/Monthly Cost Savings Reports` and the two APScheduler jobs (`weekly_cost_savings_report_job`, `monthly_cost_savings_report_job`) register; with the key unset, no job is scheduled.

## Type

🆕 New Feature

## Changes

- `litellm/proxy/spend_tracking/cost_savings_report.py` (new): `CostSavingsReport` dataclass plus `get_cost_savings_report_for_time_range`, `send_weekly_cost_savings_report`, `send_monthly_cost_savings_report`, reusing the existing `get_daily_activity_aggregated` daily-rollup aggregation
- `litellm/integrations/email_alerting.py`: `build_cost_savings_report_email` (HTML), `build_cost_savings_report_pdf` (reportlab, left-aligned, embeds a custom or bundled LiteLLM logo), `_fetch_custom_logo_bytes`, `send_cost_savings_report_email`
- `litellm/proxy/utils.py`: `send_email` gains an optional `attachments: Sequence[EmailAttachment]` parameter
- `litellm/proxy/proxy_server.py`: `ProxyStartupEvent._initialize_cost_savings_report_jobs` schedules the weekly/monthly jobs, gated on `general_settings.cost_savings_report_recipients`
- `litellm/types/llms/custom_http.py`: new `httpxSpecialProvider.EmailReporting` for the custom-logo fetch
- `pyproject.toml`/`uv.lock`: adds `reportlab` to the `proxy-runtime` extra
- Tests: `tests/test_litellm/proxy/spend_tracking/test_cost_savings_report.py`, `tests/test_litellm/integrations/test_email_alerting.py`, plus additions to `tests/test_litellm/proxy/test_proxy_utils.py` and `tests/test_litellm/proxy/test_proxy_server.py`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR