### PR TITLE
fix(logging): preserve uvicorn color_message args during secret redaction

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -96,8 +96,8 @@ class SecretRedactionFilter(logging.Filter):
         if isinstance(color_message, str) and original_args:
             try:
                 record.color_message = color_message % original_args
-            except Exception:
-                pass
+            except TypeError:
+                record.color_message = color_message
 
         try:
             record.msg = _redact_string(record.getMessage())

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -76,6 +76,24 @@ def redact_secrets(value: str) -> str:
     return _redact_string(value)
 
 
+def _substituted_color_message(record: logging.LogRecord) -> str | None:
+    """Render a record's ``color_message`` against its args, or None if absent.
+
+    uvicorn's colorized formatter re-renders `color_message` against
+    record.args at emit time (see uvicorn.logging.ColourizedFormatter) instead
+    of using the already-formatted record.msg, so it has to be substituted
+    before args are cleared or it is later formatted with no args and prints
+    the raw "%s://%s:%d" placeholders instead of the URL.
+    """
+    color_message: Final = record.__dict__.get("color_message")
+    if not isinstance(color_message, str) or not record.args:
+        return None
+    try:
+        return color_message % record.args
+    except TypeError:
+        return color_message
+
+
 class SecretRedactionFilter(logging.Filter):
     """Scrubs known secret/credential patterns from log records."""
 
@@ -85,19 +103,11 @@ class SecretRedactionFilter(logging.Filter):
         if not _ENABLE_SECRET_REDACTION:
             return True
 
-        original_args = record.args
-
-        # uvicorn's colorized formatter re-renders `color_message` against
-        # record.args at emit time (see uvicorn.logging.ColourizedFormatter),
-        # instead of using the already-formatted record.msg. Substitute it here
-        # too, before args are cleared below, or it's later formatted with no
-        # args and prints the raw "%s://%s:%d" placeholders instead of the URL.
-        color_message = record.__dict__.get("color_message")
-        if isinstance(color_message, str) and original_args:
-            try:
-                record.color_message = color_message % original_args
-            except TypeError:
-                record.color_message = color_message
+        # Runs before args are cleared, and before the extra-field loop below
+        # that redacts the substituted result.
+        substituted_color_message: Final = _substituted_color_message(record)
+        if substituted_color_message is not None:
+            record.color_message = substituted_color_message  # rebind-ok: a Filter scrubs records in place
 
         try:
             record.msg = _redact_string(record.getMessage())

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -85,6 +85,20 @@ class SecretRedactionFilter(logging.Filter):
         if not _ENABLE_SECRET_REDACTION:
             return True
 
+        original_args = record.args
+
+        # uvicorn's colorized formatter re-renders `color_message` against
+        # record.args at emit time (see uvicorn.logging.ColourizedFormatter),
+        # instead of using the already-formatted record.msg. Substitute it here
+        # too, before args are cleared below, or it's later formatted with no
+        # args and prints the raw "%s://%s:%d" placeholders instead of the URL.
+        color_message = record.__dict__.get("color_message")
+        if isinstance(color_message, str) and original_args:
+            try:
+                record.color_message = color_message % original_args
+            except Exception:
+                pass
+
         try:
             record.msg = _redact_string(record.getMessage())
             record.args = None

--- a/tests/test_litellm/test_secret_redaction.py
+++ b/tests/test_litellm/test_secret_redaction.py
@@ -147,6 +147,49 @@ def test_filter_redacts_extra_fields():
     assert record.region == "us-east-1"
 
 
+def test_filter_preserves_uvicorn_color_message_args():
+    """Regression test: uvicorn's startup banner logs a plain message plus a
+    colorized `extra={"color_message": ...}` copy of the same "%s://%s:%d" template,
+    both meant to be filled in from record.args. uvicorn's own ColourizedFormatter
+    re-substitutes color_message against record.args when writing to a TTY, instead
+    of using the already-formatted record.msg.
+
+    Before this fix, the filter cleared record.args after substituting only
+    record.msg, so color_message was rendered with args=None and the raw
+    "%s://%s:%d" placeholders were printed instead of the real host/port.
+    """
+    from uvicorn.logging import DefaultFormatter
+
+    addr_format = "%s://%s:%d"
+    plain_message = f"Uvicorn running on {addr_format} (Press CTRL+C to quit)"
+    color_message = f"Uvicorn running on {addr_format} (Press CTRL+C to quit)"
+
+    logger = logging.getLogger("uvicorn.error")
+    saved_handlers, saved_level = logger.handlers[:], logger.level
+    buf = StringIO()
+    handler = logging.StreamHandler(buf)
+    formatter = DefaultFormatter("%(levelprefix)s %(message)s")
+    formatter.use_colors = True
+    handler.setFormatter(formatter)
+    logger.handlers = [handler]
+    logger.setLevel(logging.INFO)
+    try:
+        logger.info(
+            plain_message,
+            "http",
+            "0.0.0.0",
+            4000,
+            extra={"color_message": color_message},
+        )
+        output = buf.getvalue()
+    finally:
+        logger.handlers = saved_handlers
+        logger.setLevel(saved_level)
+
+    assert "%s" not in output and "%d" not in output, f"unsubstituted placeholders leaked: {output!r}"
+    assert "http://0.0.0.0:4000" in output
+
+
 def test_disable_redaction_passes_secrets_through():
     """When LITELLM_DISABLE_REDACT_SECRETS=true, secrets pass through."""
     with patch("litellm._logging._ENABLE_SECRET_REDACTION", False):

--- a/tests/test_litellm/test_secret_redaction.py
+++ b/tests/test_litellm/test_secret_redaction.py
@@ -190,6 +190,28 @@ def test_filter_preserves_uvicorn_color_message_args():
     assert "http://0.0.0.0:4000" in output
 
 
+def test_filter_redacts_secrets_substituted_into_color_message():
+    """The color_message substitution runs before the extra-field redaction
+    loop, so a secret arriving through record.args lands in color_message and
+    must still be scrubbed. Substituting after that loop would ship the secret
+    to any colorized handler."""
+    record = logging.LogRecord(
+        name="uvicorn.error",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="connecting with %s",
+        args=(SECRET,),
+        exc_info=None,
+    )
+    record.color_message = "connecting with %s"
+
+    _secret_filter.filter(record)
+
+    assert SECRET not in record.color_message
+    assert "REDACTED" in record.color_message
+
+
 def test_disable_redaction_passes_secrets_through():
     """When LITELLM_DISABLE_REDACT_SECRETS=true, secrets pass through."""
     with patch("litellm._logging._ENABLE_SECRET_REDACTION", False):


### PR DESCRIPTION
## TLDR

fixes #37121

Problem this solves:

- Proxy startup can print literal `%s://%s:%d` instead of the real URL
- Only shows in a real TTY (colors on), so it's easy to miss in CI/Docker

How it solves it:

- Preserve record.args long enough to also substitute uvicorn's color_message
- Redaction filter now fixes up color_message before clearing args

## User Flow

Before: an admin starting the proxy in an interactive terminal can't tell what port it's listening on

1. They run `litellm --config config.yaml --port 4000` directly in a terminal (no piping)
2. The startup banner prints `INFO:     Uvicorn running on %s://%s:%d (Press CTRL+C to quit)`
3. They have to already know the port from their own `--port` flag; the log line is useless

After: the same startup banner shows the real address

1. They run the same command in the same terminal
2. The startup banner prints `INFO:     Uvicorn running on http://0.0.0.0:4000 (Press CTRL+C to quit)`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

before:
<img width="603" height="117" alt="Screenshot 2026-08-16 at 5 53 40 PM" src="https://github.com/user-attachments/assets/cb5ba62c-d5d7-4551-83aa-472cd3390004" />

after:
<img width="603" height="117" alt="Screenshot 2026-08-16 at 5 48 16 PM" src="https://github.com/user-attachments/assets/c971e676-09e5-4556-9dac-b5dd5761b1fb" />



Reproduced by running the real proxy (`python -m litellm.proxy.proxy_cli --config litellm/proxy/dev_config.yaml`) under a real TTY, at the merge base before this fix:

```
INFO:     Started server process [%d]
INFO:     Uvicorn running on %s://%s:%d (Press CTRL+C to quit)
```

With this fix applied, the same startup path prints:

```
INFO:     Uvicorn running on http://0.0.0.0:4000 (Press CTRL+C to quit)
```

Two regression tests in `tests/test_litellm/test_secret_redaction.py` cover this. `test_filter_preserves_uvicorn_color_message_args` drives uvicorn's actual `DefaultFormatter` in color mode and fails without the fix, reproducing this exact output. `test_filter_redacts_secrets_substituted_into_color_message` pins the ordering that keeps the substitution safe: it runs before args are cleared, which puts it ahead of the extra-field redaction loop, so a secret arriving through `record.args` is still scrubbed out of `color_message`.

## Type

🐛 Bug Fix

## Caveats (if any)

- Only reproduces when stderr is a real TTY (colors on); piping through `tee` or running without a TTY (e.g. most Docker/CI setups) masks it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret-redaction ordering on log records (including third-party uvicorn logs). The change is small and tested, but a mistake here could either leak credentials in colorized logs or leave placeholders unfilled.
> 
> **Overview**
> Fixes proxy startup banners that printed raw `%s://%s:%d` on a TTY instead of the real listen URL.
> 
> `SecretRedactionFilter` now interpolates uvicorn’s `color_message` extra against `record.args` *before* clearing args, then the existing extra-field redaction loop still scrubs any secrets that landed in that string. Regression tests cover both the colorized uvicorn formatter path and secret substitution into `color_message`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89a175be71305c32d16bd1f5bb4c9f081ab4bf14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->