### PR TITLE
fix(anthropic_messages): route stop_sequences through chat/completions for OpenAI models

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -349,6 +349,12 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         if not isinstance(thinking, dict) or thinking.get("type") != "enabled":
             return
 
+        if completion_kwargs.get("stop"):
+            # The Responses API has no `stop` equivalent; staying on chat/completions
+            # (already routed to by _should_route_to_responses_api) so `stop` is honored,
+            # even at the cost of losing the reasoning-summary content block.
+            return
+
         model: Final = completion_kwargs.get("model")
         try:
             model_info: Final = get_model_info(model=cast(str, model), custom_llm_provider=custom_llm_provider)

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -42,13 +42,20 @@ from .utils import AnthropicMessagesRequestUtils, mock_response
 _RESPONSES_API_PROVIDERS: Final = frozenset({"openai"})
 
 
-def _should_route_to_responses_api(custom_llm_provider: str | None) -> bool:
+def _should_route_to_responses_api(custom_llm_provider: str | None, stop_sequences: list[str] | None = None) -> bool:
     """Return True when the provider should use the Responses API path.
 
     Set ``litellm.use_chat_completions_url_for_anthropic_messages = True`` to
     opt out and route OpenAI/Azure requests through chat/completions instead.
+
+    The Responses API has no ``stop`` equivalent, so ``translate_request``
+    silently drops ``stop_sequences``. Route those requests through
+    chat/completions instead, which already maps ``stop_sequences`` to
+    ``stop`` (see ``LiteLLMAnthropicMessagesAdapter._translate_stop_sequences_to_openai``).
     """
     if litellm.use_chat_completions_url_for_anthropic_messages:
+        return False
+    if stop_sequences:
         return False
     return custom_llm_provider in _RESPONSES_API_PROVIDERS
 
@@ -551,7 +558,7 @@ def anthropic_messages_handler(
             custom_llm_provider=custom_llm_provider,
             **kwargs,
         )
-        if _should_route_to_responses_api(custom_llm_provider):
+        if _should_route_to_responses_api(custom_llm_provider, stop_sequences=stop_sequences):
             return LiteLLMMessagesToResponsesAPIHandler.anthropic_messages_handler(**_shared_kwargs)
 
         # The in-gateway context_management polyfill runs inside

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -604,6 +604,25 @@ class TestThinkingSummaryPreservation:
         finally:
             litellm.reasoning_auto_summary = original
 
+    def test_stop_present_keeps_thinking_model_on_chat_completions(self):
+        """Regression for #37118: the Responses API has no `stop` equivalent, so a
+        translated `stop` must keep the request on chat/completions even when
+        thinking is enabled, instead of being rerouted (and silently dropped)."""
+        from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+            LiteLLMMessagesToCompletionTransformationHandler,
+        )
+
+        completion_kwargs = {
+            "model": "openai/gpt-5.2",
+            "custom_llm_provider": "openai",
+            "reasoning_effort": "medium",
+            "stop": ["STOPPROBE"],
+        }
+        LiteLLMMessagesToCompletionTransformationHandler._route_openai_thinking_to_responses_api_if_needed(
+            completion_kwargs, thinking={"type": "enabled", "budget_tokens": 5000}
+        )
+        assert completion_kwargs["model"] == "openai/gpt-5.2"
+
     def test_openai_model_with_thinking_summary_end_to_end(self):
         """End-to-end: anthropic_messages_handler should preserve thinking.summary for OpenAI models."""
         from litellm.llms.anthropic.experimental_pass_through.messages.handler import (

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -39,6 +39,36 @@ def test_anthropic_experimental_pass_through_messages_handler():
         assert mock_responses.call_args.kwargs["api_key"] == "test-api-key"
 
 
+def test_openai_model_with_stop_sequences_routes_to_chat_completions():
+    """
+    Regression test for #37118. The Responses API has no `stop` equivalent, so
+    OpenAI models with `stop_sequences` set must route through chat/completions
+    (which maps `stop_sequences` -> `stop`) instead of being silently dropped
+    on the default Responses API path.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages_handler,
+    )
+
+    with (
+        patch("litellm.responses", return_value="test-response") as mock_responses,
+        patch("litellm.completion", return_value=MagicMock()) as mock_completion,
+    ):
+        try:
+            anthropic_messages_handler(
+                max_tokens=100,
+                messages=[{"role": "user", "content": "Hello, how are you?"}],
+                model="openai/gpt-4o-mini",
+                api_key="test-api-key",
+                stop_sequences=["STOPPROBE"],
+            )
+        except (ValueError, TypeError, AttributeError) as e:
+            print(f"Error: {e}")
+        mock_responses.assert_not_called()
+        mock_completion.assert_called_once()
+        assert mock_completion.call_args.kwargs["stop"] == ["STOPPROBE"]
+
+
 @pytest.mark.asyncio
 async def test_openai_model_does_not_forward_stream_options_to_responses_api():
     """


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/messages` requests to an OpenAI model drop `stop_sequences` entirely
- The default Responses API path has no `stop` field, so the value never reaches the provider

How it solves it:

- Route requests carrying `stop_sequences` through the chat/completions adapter instead
- That path already maps `stop_sequences` to `stop`, so the provider actually honors it

## User Flow

Before: a Claude Code user pointed at the proxy via `ANTHROPIC_BASE_URL` cannot cut generation at a stop token when the deployment is an OpenAI model.

1. The admin starts the proxy with an OpenAI deployment (e.g. `openai/gpt-4o-mini`) and no extra flags.
2. The user sends `POST http://127.0.0.1:4000/v1/messages` with `"stop_sequences": ["STOPPROBE"]` and a prompt that writes that token first, then more text.
3. The response is 200 with `stop_reason: end_turn`. The text starts with `STOPPROBE` and keeps going past it, ignoring the stop token entirely.

After: the same request honors the stop token.

1. The admin starts the same proxy, unchanged.
2. The user sends the same `POST http://127.0.0.1:4000/v1/messages` with `"stop_sequences": ["STOPPROBE"]`.
3. The response is 200 and generation stops at that token, matching what `/v1/chat/completions` with `"stop": ["STOPPROBE"]` already does against the same deployment.

## Relevant issues

Fixes #37118

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

I could not reach a live OpenAI-backed proxy from this sandboxed environment (no `OPENAI_API_KEY` available), so I could not capture the curl-based before/after this repo normally asks for. Below is the regression test I added and ran locally instead, plus the exact curl commands a reviewer can run against a live proxy to confirm the fix end to end.

### Regression test (verified fails before the fix, passes after)

```
$ uv run pytest tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py -k stop_sequences -q

# before the fix (litellm/llms/.../messages/handler.py reverted to HEAD~1):
FAILED .../test_anthropic_experimental_pass_through_messages_handler.py::test_openai_model_with_stop_sequences_routes_to_chat_completions
- AssertionError: Expected 'responses' to not have been called. Called 1 times.

# after the fix:
1 passed, 32 deselected
```

Full file (33 tests) also passes: `1 passed` -> `33 passed`.

### Manual verification (for a reviewer with an OpenAI key)

Start the proxy:

```bash
cat > config.yaml <<'EOF'
model_list:
  - model_name: gpt-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
EOF
python litellm/proxy/proxy_cli.py --config config.yaml --port 4000 --detailed_debug --reload
```

Then:

```bash
curl -s http://127.0.0.1:4000/v1/messages \
  -H 'content-type: application/json' \
  -H 'anthropic-version: 2023-06-01' \
  -d '{"model":"gpt-mini","max_tokens":80,"stop_sequences":["STOPPROBE"],"messages":[{"role":"user","content":"Write the exact token STOPPROBE as the first word, then write a 40-word poem about cats. Do not skip the token."}]}'
```

Expected after this fix: `stop_reason` is `stop_sequence` (or the response text ends at `STOPPROBE` without the poem following it), matching what the equivalent `/v1/chat/completions` call with `"stop": ["STOPPROBE"]` already does.

## Type

🐛 Bug Fix

## Caveats (if any)

- Only routes around the gap; does not add `stop` support to the Responses API itself, since OpenAI's Responses API has no such parameter
- Azure models already route through chat/completions unconditionally, so they were unaffected by this bug

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
