### PR TITLE
fix(xai): stop rejecting `instructions` on the Responses API (unblocks web search + system prompt)

### DIFF
--- a/litellm/llms/xai/responses/transformation.py
+++ b/litellm/llms/xai/responses/transformation.py
@@ -46,7 +46,6 @@ class XAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
 
     Inherits from OpenAIResponsesAPIConfig since XAI's Responses API is largely
     compatible with OpenAI's, with a few differences:
-    - Does not support the 'instructions' parameter
     - Requires code_interpreter tools to have 'container' field removed
     - Recommends store=false when sending images
 
@@ -56,20 +55,6 @@ class XAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
     @property
     def custom_llm_provider(self) -> LlmProviders:
         return LlmProviders.XAI
-
-    def get_supported_openai_params(self, model: str) -> list:
-        """
-        Get supported parameters for XAI Responses API.
-
-        XAI supports most OpenAI Responses API params except 'instructions'.
-        """
-        supported_params: Final = super().get_supported_openai_params(model)
-
-        # Remove 'instructions' as it's not supported by XAI
-        if "instructions" in supported_params:
-            supported_params.remove("instructions")
-
-        return supported_params
 
     def _transform_web_search_tool(self, tool: Mapping[str, object]) -> Mapping[str, object]:
         """
@@ -160,18 +145,12 @@ class XAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         Map parameters for XAI Responses API.
 
         Handles XAI-specific transformations:
-        1. Drops 'instructions' parameter (not supported)
-        2. Transforms code_interpreter tools to remove 'container' field
-        3. Transforms web_search tools to XAI format (removes search_context_size, adds filters)
-        4. Transforms x_search tools to XAI format
-        5. Sets store=false when images are detected (recommended by XAI)
+        1. Transforms code_interpreter tools to remove 'container' field
+        2. Transforms web_search tools to XAI format (removes search_context_size, adds filters)
+        3. Transforms x_search tools to XAI format
+        4. Sets store=false when images are detected (recommended by XAI)
         """
         params: Final = dict(response_api_optional_params)
-
-        # Drop instructions parameter (not supported by XAI)
-        if "instructions" in params:
-            verbose_logger.debug("XAI Responses API does not support 'instructions' parameter. Dropping it.")
-            params.pop("instructions")
 
         if "metadata" in params:
             verbose_logger.debug("XAI Responses API does not support 'metadata' parameter. Dropping it.")

--- a/tests/test_litellm/llms/xai/responses/test_xai_responses_transformation.py
+++ b/tests/test_litellm/llms/xai/responses/test_xai_responses_transformation.py
@@ -7,12 +7,14 @@ transformations for the Responses API.
 Source: litellm/llms/xai/responses/transformation.py
 """
 
+from typing import Final
 from unittest.mock import MagicMock, Mock
 
 import httpx
 import pytest
 
 import litellm
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from litellm.llms.xai.cost_calculator import cost_per_token
 from litellm.llms.xai.responses.transformation import XAIResponsesAPIConfig
 from litellm.responses.utils import ResponseAPILoggingUtils
@@ -53,23 +55,26 @@ class TestXAIResponsesAPITransformation:
         assert result["tools"][0]["type"] == "code_interpreter"
         assert "container" not in result["tools"][0], "Container field should be removed"
 
-    def test_instructions_parameter_dropped(self):
-        """Test that instructions parameter is dropped for XAI"""
+    def test_instructions_parameter_preserved(self):
+        """XAI accepts `instructions`, so it must survive param mapping.
+
+        Dropping it silently discards the caller's system prompt.
+        """
         config = XAIResponsesAPIConfig()
 
         params = ResponsesAPIOptionalRequestParams(instructions="You are a helpful assistant.", temperature=0.7)
 
         result = config.map_openai_params(response_api_optional_params=params, model="grok-4-fast", drop_params=False)
 
-        assert "instructions" not in result, "Instructions should be dropped"
+        assert result.get("instructions") == "You are a helpful assistant.", "Instructions should be preserved"
         assert result.get("temperature") == 0.7, "Other params should be preserved"
 
-    def test_supported_params_excludes_instructions(self):
-        """Test that get_supported_openai_params excludes instructions"""
+    def test_supported_params_includes_instructions(self):
+        """Test that get_supported_openai_params includes instructions"""
         config = XAIResponsesAPIConfig()
         supported = config.get_supported_openai_params("grok-4-fast")
 
-        assert "instructions" not in supported, "instructions should not be supported"
+        assert "instructions" in supported, "instructions should be supported"
         assert "tools" in supported, "tools should be supported"
         assert "temperature" in supported, "temperature should be supported"
         assert "model" in supported, "model should be supported"
@@ -492,3 +497,74 @@ class TestXAIResponsesReportedCost:
         )
 
         assert usage.cost is None
+
+
+class TestXAICompletionBridgeSystemPrompt:
+    """`web_search_options` bridges xAI completions to the Responses API.
+
+    The bridge hoists a system message into `instructions`, so excluding
+    `instructions` from XAI's supported params made every web-search request
+    carrying a system prompt fail — and made `drop_params=True` silently
+    discard the system prompt instead.
+    """
+
+    MESSAGES = [
+        {"role": "system", "content": "Answer briefly."},
+        {"role": "user", "content": "Newest litellm version on PyPI?"},
+    ]
+
+    @staticmethod
+    def _mock_response() -> MagicMock:
+        mock_resp: Final = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.text = "raw"
+        mock_resp.json.return_value = {
+            "id": "resp_1",
+            "object": "response",
+            "created_at": 1754900000,
+            "model": "grok-4.3",
+            "status": "completed",
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": 1.0,
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "1.97.0", "annotations": []}],
+                }
+            ],
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 0},
+            },
+        }
+        return mock_resp
+
+    def test_system_prompt_survives_web_search_bridge(self):
+        """A system message + web_search_options must reach XAI as `instructions`."""
+        client: Final = HTTPHandler()
+        client.post = MagicMock(return_value=self._mock_response())
+
+        litellm.completion(
+            model="xai/grok-4.3",
+            messages=self.MESSAGES,
+            web_search_options={"search_context_size": "medium"},
+            api_key="fake-key",
+            client=client,
+        )
+
+        client.post.assert_called_once()
+        request_body: Final = client.post.call_args.kwargs["json"]
+
+        assert request_body["instructions"] == "Answer briefly.", "System prompt must not be dropped"
+        assert [tool["type"] for tool in request_body["tools"]] == ["web_search"]
+        # The system message is carried by `instructions`, not duplicated into input.
+        assert [item["role"] for item in request_body["input"]] == ["user"]

--- a/tests/test_litellm/llms/xai/xai_responses/test_transformation.py
+++ b/tests/test_litellm/llms/xai/xai_responses/test_transformation.py
@@ -53,8 +53,11 @@ class TestXAIResponsesAPITransformation:
             "container" not in result["tools"][0]
         ), "Container field should be removed"
 
-    def test_instructions_parameter_dropped(self):
-        """Test that instructions parameter is dropped for XAI"""
+    def test_instructions_parameter_preserved(self):
+        """XAI accepts `instructions`, so it must survive param mapping.
+
+        Dropping it silently discards the caller's system prompt.
+        """
         config = XAIResponsesAPIConfig()
 
         params = ResponsesAPIOptionalRequestParams(
@@ -65,15 +68,17 @@ class TestXAIResponsesAPITransformation:
             response_api_optional_params=params, model="grok-4-fast", drop_params=False
         )
 
-        assert "instructions" not in result, "Instructions should be dropped"
+        assert (
+            result.get("instructions") == "You are a helpful assistant."
+        ), "Instructions should be preserved"
         assert result.get("temperature") == 0.7, "Other params should be preserved"
 
-    def test_supported_params_excludes_instructions(self):
-        """Test that get_supported_openai_params excludes instructions"""
+    def test_supported_params_includes_instructions(self):
+        """Test that get_supported_openai_params includes instructions"""
         config = XAIResponsesAPIConfig()
         supported = config.get_supported_openai_params("grok-4-fast")
 
-        assert "instructions" not in supported, "instructions should not be supported"
+        assert "instructions" in supported, "instructions should be supported"
         assert "tools" in supported, "tools should be supported"
         assert "temperature" in supported, "temperature should be supported"
         assert "model" in supported, "model should be supported"


### PR DESCRIPTION
## TLDR

Problem this solves:

- xAI web search + a system prompt fails: `UnsupportedParamsError` on `instructions`
- The premise is wrong — xAI does support `instructions`
- `drop_params=True` "fixes" it by silently discarding the system prompt

How it solves it:

- Stop removing `instructions` from xAI's supported Responses params
- Drop the matching unreachable `params.pop("instructions")`
- Invert two stale assertions, add a regression test on the bridge path

## User Flow

Before: a developer whose app asks Grok questions needing current web results cannot use a system prompt at all — the request is rejected before it leaves their process.

1. They call `litellm.completion(model="xai/grok-4.3", ...)` with a `system` message ("You must answer with the bare version number and nothing else."), a `user` question, and `web_search_options={"search_context_size": "medium"}`
2. Nothing reaches xAI. They get `litellm.UnsupportedParamsError: LlmProviders.XAI does not support parameters: {'instructions': 'You must answer with the bare version number and nothing else.'}`
3. They follow the error's own advice and set `drop_params=True`. The call returns 200 with a correct, web-sourced answer — but their system prompt was thrown away, so instead of `1.100.0` they get four paragraphs with three citations and `pip install` instructions. Nothing in the response says the instructions were dropped
4. They delete the system message to get the call working, losing output-format control on every web-search request

After: the same request succeeds with the system prompt honored.

1. They call `litellm.completion(model="xai/grok-4.3", ...)` with the same `system` message, `user` question, and `web_search_options`
2. The request reaches xAI, which runs the web search and applies the system prompt
3. They get back `1.100.0` — current, search-sourced, formatted exactly as asked
4. Setting `drop_params=True` changes nothing; the system prompt is preserved either way

## Relevant issues

Fixes #37127

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live xAI, no mocks. Shared setup for every case below:

```python
import litellm, os

SYSTEM = "You must answer with the bare version number and nothing else."
MSGS = [
    {"role": "system", "content": SYSTEM},
    {"role": "user", "content": "What is the newest litellm version on PyPI?"},
]

litellm.completion(
    model="xai/grok-4.3",
    messages=MSGS,
    web_search_options={"search_context_size": "medium"},
    api_key=os.environ["GROK_API_KEY"],
    max_tokens=4000,
    # drop_params=True   # case 2 only
)
```

The question is chosen so the answer is only reachable via live search, and the system prompt is chosen so it is visible in the output whether it survived.

### Before (168a0055a)

#### Case 1: default

1. Run the snippet above.
2. Observed:

```
UnsupportedParamsError: litellm.UnsupportedParamsError: LlmProviders.XAI does not
support parameters: {'instructions': 'You must answer with the bare version number
and nothing else.'}, for model=grok-4.3. To drop these, set `litellm.drop_params=True`
```

#### Case 2: `drop_params=True`

1. Run the same snippet with `drop_params=True`.
2. Observed — the call succeeds and the system prompt is silently gone. Four paragraphs, three citations and install instructions, where the system prompt asked for a bare version number:

```
content: '**1.101.0rc1 (released September 6, 2026) is the newest version on PyPI, followed
closely by the stable release 1.100.0 (also September 6, 2026).**[[1]]...[[2]]...

The main
PyPI project page for litellm currently highlights **1.100.0** as the primary/latest stable
version.[[3]] ... You can install the latest (including pre-releases) with: ...'
obeyed system prompt (bare version only): False
usage: 13195 in / 826 out
```

### After (26f601f96)

#### Case 1: default

1. Run the snippet above.
2. Observed:

```
content: '1.100.0'
obeyed system prompt (bare version only): True
usage: 7367 in / 261 out
```

#### Case 2: `drop_params=True`

1. Run the same snippet with `drop_params=True`.
2. Observed — identical, no longer sensitive to `drop_params`:

```
content: '1.100.0'
obeyed system prompt (bare version only): True
usage: 7394 in / 309 out
```

The multi-thousand input-token counts are the injected live search results, so search is genuinely running in every passing case.

### Evidence that xAI accepts `instructions`

Three direct `POST https://api.x.ai/v1/responses` calls, no litellm in the path:

```
=== 1. instructions only ===
  HTTP 200
  output_text: BANANA          <- instructions were "Always answer with exactly the word BANANA."
  echoed instructions: 'Always answer with exactly the word BANANA.'

=== 2. instructions + web_search tool ===
  HTTP 200
  output_text: **1.97.0**
  echoed instructions: 'Answer in exactly one short sentence.'

=== 3. system role in input + web_search ===
  HTTP 200
  output_text: **1.97.0**
```

xAI accepts `instructions`, honors it, and echoes it back — including alongside a server-side `web_search` tool. It is also listed in [their API reference](https://docs.x.ai/docs/api-reference#create-new-response).

### Unit tests

`tests/test_litellm/llms/xai/` and `tests/test_litellm/test_xai_responses_auto_routing.py`: 362 passed. The one failure, `test_write_auth_file_creates_private_file`, is a POSIX file-mode assertion that fails on Windows on the merge base too and is untouched by this PR.

Type discipline: the only `litellm/` file this PR changes drops LIT001 from 8 to 7 and leaves every other rule flat, so no rule can rise against the base.

## Type

🐛 Bug Fix

## Caveats (if any)

- Two near-duplicate xAI Responses test files exist; both updated
- Did not touch the shared bridge's system→`instructions` hoist — unnecessary once xAI accepts it
- Regression test injects a mocked `client=` rather than patching `HTTPHandler.post`
- Rebased onto current staging; kept upstream's retyped `_transform_web_search_tool` signature
