### PR TITLE
fix(auth): return 403 for admin-only route denials

### DIFF
--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -226,17 +226,14 @@ class RouteChecks:
             route (str): The route being accessed
 
         Raises:
-            Exception: With user role and masked user_id information
+            HTTPException: 403, with user role and masked user_id information
         """
-        user_role = "unknown"
-        user_id = "unknown"
-        if user_obj is not None:
-            user_role = user_obj.user_role or "unknown"
-            user_id = user_obj.user_id or "unknown"
-
+        user_role: Final = (user_obj.user_role if user_obj is not None else None) or "unknown"
+        user_id: Final = (user_obj.user_id if user_obj is not None else None) or "unknown"
         masked_user_id: Final = RouteChecks._mask_user_id(user_id)
-        raise Exception(
-            f"Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route={route}. Your role={user_role}. Your user_id={masked_user_id}"
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route={route}. Your role={user_role}. Your user_id={masked_user_id}",
         )
 
     @staticmethod

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -62,6 +62,43 @@ def test_non_admin_config_update_route_rejected():
 
 
 @pytest.mark.parametrize(
+    "route",
+    ["/policies/list", "/prompts/list", "/in_product_nudges", "/config/update"],
+)
+def test_admin_only_route_denial_is_forbidden_and_carries_status(route):
+    """A valid non-admin key denied an admin-only route is an authorization
+    failure, so it must surface as 403 and carry the status code the metrics
+    layer reads, not an unlabelled 401.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/37108
+    """
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        user_email="test@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    valid_token = UserAPIKeyAuth(
+        user_id="test_user",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    with pytest.raises(HTTPException) as exc_info:
+        RouteChecks.non_proxy_admin_allowed_routes_check(
+            user_obj=user_obj,
+            _user_role=LitellmUserRoles.INTERNAL_USER.value,
+            route=route,
+            request=request,
+            valid_token=valid_token,
+            request_data={},
+        )
+
+    assert exc_info.value.status_code == 403
+    assert f"Route={route}" in str(exc_info.value.detail)
+
+
+@pytest.mark.parametrize(
     "role",
     [
         LitellmUserRoles.INTERNAL_USER.value,

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -1,7 +1,8 @@
 import os
 import sys
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from typing import Final
+from unittest.mock import AsyncMock, MagicMock, patch
 
 sys.path.insert(
     0, os.path.abspath("../../..")
@@ -3566,3 +3567,46 @@ def test_agent_registry_route_gate_open_to_non_admin_roles(user_role, method, ro
         valid_token=valid_token,
         request_data={},
     )
+
+
+@pytest.mark.parametrize("route", ["/policies/list", "/prompts/list"])
+def test_admin_only_denial_reaches_the_client_as_403(route):
+    """Drives a real request so the status the caller sees is asserted, not just the
+    status the check raises. A regression that swallowed it and re-raised 401 would
+    leave the direct-call tests above green.
+    """
+    from fastapi.testclient import TestClient
+
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy.proxy_server import app
+
+    key: Final = "sk-non-admin-1234"
+    valid_token: Final = UserAPIKeyAuth(
+        token=key, key_name=key, user_id="test_user", user_role=LitellmUserRoles.INTERNAL_USER.value
+    )
+    user_obj: Final = LiteLLM_UserTable(
+        user_id="test_user", user_email="test@example.com", user_role=LitellmUserRoles.INTERNAL_USER.value
+    )
+
+    class _StubIdentityStore:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def resolve(self, *args, **kwargs):
+            return MagicMock(source_key=valid_token)
+
+        @staticmethod
+        def key_from_principal(principal):
+            return valid_token
+
+    with (
+        patch.object(ps, "master_key", "sk-master-1234"),
+        patch.object(ps, "prisma_client", MagicMock()),
+        patch("litellm.proxy.auth.user_api_key_auth.IdentityStore", _StubIdentityStore),
+        patch("litellm.proxy.auth.user_api_key_auth.get_user_object", new=AsyncMock(return_value=user_obj)),
+    ):
+        response: Final = TestClient(app, raise_server_exceptions=False).get(
+            route, headers={"Authorization": f"Bearer {key}"}
+        )
+
+    assert response.status_code == 403, f"{route} returned {response.status_code}: {response.text[:200]}"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Admin-only route denials return 401 instead of 403
- Prometheus records them as `exception_status="None"`
- Those denials look identical to infrastructure failures

How it solves it:

- Raise `HTTPException` 403 instead of a bare `Exception`
- The status code then reaches both the client and the metric

## User Flow

Before: a developer holding a valid non-admin key is told their credentials are invalid, so they re-authenticate and nothing changes

1. An admin issues them a key with the `internal_user` role
2. They send `GET https://litellm-domain/policies/list` with that key
3. It comes back `401 Unauthorized`, and the message opens with "Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams"
4. Reading 401 as a credential problem, their client drops the key, signs in again, retries, and gets the same 401
5. Their operator opens the proxy metrics and finds the refusal recorded with `exception_class="Exception"` and `exception_status="None"` on `route="/policies/list"`, the same label pair an unreachable database produces, so it cannot be alerted on separately
6. A non-admin still cannot reach the route, and an admin still can

After: the same request is refused as forbidden, so the client keeps its key and the metric names the status

1. An admin issues them a key with the `internal_user` role
2. They send `GET https://litellm-domain/policies/list` with that key
3. It comes back `403 Forbidden` with the same explanation and no "Authentication Error" prefix
4. Their client keeps the key and stops re-authenticating, because 403 says the credential is fine and the permission is not
5. Their operator finds the refusal recorded with `exception_class="HTTPException"` and `exception_status="403"`, now distinguishable from an infrastructure failure
6. A non-admin still cannot reach the route, and an admin still can. Who may call what is unchanged, only how the refusal is reported

## Relevant issues

Fixes #37108

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, run once against a local proxy on `localhost:4000` backed by a scratch Postgres, with `callbacks: ["prometheus"]` enabled:

```bash
export MASTER=sk-1234
USERKEY=$(curl -s -X POST http://127.0.0.1:4000/user/new \
  -H "Authorization: Bearer $MASTER" -H "Content-Type: application/json" \
  -d '{"user_email":"nonadmin@example.com","user_role":"internal_user"}' \
  | python -c "import sys,json; print(json.load(sys.stdin)['key'])")
```

### Before (973329e9864154d429a7d739fb6a552fe03a9b3e)

1. Call two admin-only routes with the valid non-admin key

```bash
for r in /policies/list /prompts/list; do
  printf "GET %-16s -> " "$r"
  curl -s -o /tmp/b.json -w "%{http_code}" "http://127.0.0.1:4000$r" -H "Authorization: Bearer $USERKEY"
  echo "  $(head -c 120 /tmp/b.json)"
done
```

```
GET /policies/list   -> 401  {"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update
GET /prompts/list    -> 401  {"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update
```

2. Read the failure metric for those two routes

```bash
curl -sL http://127.0.0.1:4000/metrics -H "Authorization: Bearer $MASTER" \
  | grep -oE 'exception_class="[^"]*",exception_status="[^"]*"[^}]*route="/(policies|prompts)/list"'
```

```
exception_class="Exception",exception_status="None",...,route="/policies/list"
exception_class="Exception",exception_status="None",...,route="/prompts/list"
```

### After (2a0f2b6171)

1. Same two calls, same key

```bash
for r in /policies/list /prompts/list; do
  printf "GET %-16s -> " "$r"
  curl -s -o /tmp/b.json -w "%{http_code}" "http://127.0.0.1:4000$r" -H "Authorization: Bearer $USERKEY"
  echo "  $(head -c 120 /tmp/b.json)"
done
```

```
GET /policies/list   -> 403  {"error":{"message":"Only proxy admin can be used to generate, delete, update info for new keys/us
GET /prompts/list    -> 403  {"error":{"message":"Only proxy admin can be used to generate, delete, update info for new keys/us
```

2. Same metric read

```bash
curl -sL http://127.0.0.1:4000/metrics -H "Authorization: Bearer $MASTER" \
  | grep -oE 'exception_class="[^"]*",exception_status="[^"]*"[^}]*route="/(policies|prompts)/list"'
```

```
exception_class="HTTPException",exception_status="403",...,route="/policies/list"
exception_class="HTTPException",exception_status="403",...,route="/prompts/list"
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Clients treating 401 as "retry auth" see a status change
- Master-key-only routes still raise a bare `Exception`, left out of scope
- `/organization/list` and `/team/list` from the issue are already allowed for `internal_user`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

