### PR TITLE
fix(responses): include output text annotations

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -808,7 +808,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         if role == "user" or role == "system" or role == "tool":
             return {"type": "input_text", "text": content}
         else:
-            return {"type": "output_text", "text": content}
+            return {"type": "output_text", "text": content, "annotations": []}
 
     def _convert_content_to_responses_format_image(
         self, content: "ChatCompletionImageObject", role: str
@@ -903,10 +903,12 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                                         converted[key] = file_data[key]
                             result.append(converted)
                             verbose_logger.debug("Chat provider:   file -> %s", converted)
+                        elif item_type == "output_text":
+                            result.append({"annotations": [], **item})
+                            verbose_logger.debug("Chat provider:   passthrough -> %s", item)
                         elif item_type in [
                             "input_text",
                             "input_image",
-                            "output_text",
                             "refusal",
                             "input_file",
                             "computer_screenshot",

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -810,6 +810,12 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         else:
             return {"type": "output_text", "text": content, "annotations": []}
 
+    @staticmethod
+    def _ensure_output_text_annotations(item: dict[str, object]) -> dict[str, object]:
+        if item.get("type") == "output_text":
+            return {"annotations": [], **item}
+        return item
+
     def _convert_content_to_responses_format_image(
         self, content: "ChatCompletionImageObject", role: str
     ) -> "ResponseInputImageParam":
@@ -903,19 +909,17 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                                         converted[key] = file_data[key]
                             result.append(converted)
                             verbose_logger.debug("Chat provider:   file -> %s", converted)
-                        elif item_type == "output_text":
-                            result.append({"annotations": [], **item})
-                            verbose_logger.debug("Chat provider:   passthrough -> %s", item)
                         elif item_type in [
                             "input_text",
                             "input_image",
+                            "output_text",
                             "refusal",
                             "input_file",
                             "computer_screenshot",
                             "summary_text",
                         ]:
                             # Already in responses API format
-                            result.append(item)
+                            result.append(self._ensure_output_text_annotations(item))
                             verbose_logger.debug("Chat provider:   passthrough -> %s", item)
                         else:
                             # Default to input_text for unknown types

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -30,6 +30,10 @@ from litellm.completion_extras.litellm_responses_transformation.transformation i
             [{"type": "output_text", "text": "ok", "annotations": []}],
         ),
         (
+            [{"type": "input_text", "text": "ok"}],
+            [{"type": "input_text", "text": "ok"}],
+        ),
+        (
             [{"type": "output_text", "text": "ok"}],
             [{"type": "output_text", "text": "ok", "annotations": []}],
         ),

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -18,6 +18,55 @@ from litellm.completion_extras.litellm_responses_transformation.transformation i
 )
 
 
+@pytest.mark.parametrize(
+    ("content", "expected_content"),
+    [
+        (
+            "ok",
+            [{"type": "output_text", "text": "ok", "annotations": []}],
+        ),
+        (
+            [{"type": "text", "text": "ok"}],
+            [{"type": "output_text", "text": "ok", "annotations": []}],
+        ),
+        (
+            [{"type": "output_text", "text": "ok"}],
+            [{"type": "output_text", "text": "ok", "annotations": []}],
+        ),
+        (
+            [
+                {
+                    "type": "output_text",
+                    "text": "ok",
+                    "annotations": [{"type": "url_citation", "url": "https://example.com"}],
+                }
+            ],
+            [
+                {
+                    "type": "output_text",
+                    "text": "ok",
+                    "annotations": [{"type": "url_citation", "url": "https://example.com"}],
+                }
+            ],
+        ),
+    ],
+)
+def test_assistant_output_text_includes_required_annotations(content, expected_content):
+    handler = LiteLLMResponsesTransformationHandler()
+
+    response, _ = handler.convert_chat_completion_messages_to_responses_api(
+        [{"role": "assistant", "content": content}]
+    )
+
+    assert response == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": expected_content,
+        }
+    ]
+
+
 def test_convert_chat_completion_messages_to_responses_api_image_input():
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         LiteLLMResponsesTransformationHandler,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bridged assistant history omits required `annotations`
- Strict Responses providers reject multi-turn chat requests

How it solves it:

- Add empty annotations to generated output text blocks
- Preserve annotations already present in list content

## User Flow

Before: a developer sends multi-turn chat history through the Responses bridge and receives a validation error

1. They send POST https://litellm-domain/v1/chat/completions with tools, reasoning effort, and assistant history
2. The provider returns 400 with `Required property 'annotations' is missing`

After: the same multi-turn chat request succeeds with spec-compliant assistant history

1. They send POST https://litellm-domain/v1/chat/completions with tools, reasoning effort, and assistant history
2. The provider accepts each `output_text` block because `annotations` is present

## Relevant issues

Fixes #37133

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live reproduction requires a compatible Azure AI Foundry endpoint, which is unavailable in the local environment

The reporter's 400 response and reproduction are documented in #37133

## Type

Bug Fix

Test

## Caveats (if any)

- Live provider verification requires a compatible Azure endpoint

### Final Attestation

- [x] The tests check required insertion and existing annotation preservation