### PR TITLE
fix(caching): guard Redis disconnect when cluster mode has no shared pool

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -1353,7 +1353,9 @@ class RedisCache(BaseCache):
         self.redis_client.flushall()
 
     async def disconnect(self):
-        await self.async_redis_conn_pool.disconnect(inuse_connections=True)
+        # None in cluster mode: a RedisCluster owns per-node pools, so no shared pool is built
+        if self.async_redis_conn_pool is not None:
+            await self.async_redis_conn_pool.disconnect(inuse_connections=True)
         try:
             self.redis_client.close()
         except Exception as e:

--- a/litellm/caching/redis_cluster_cache.py
+++ b/litellm/caching/redis_cluster_cache.py
@@ -56,6 +56,17 @@ class RedisClusterCache(RedisCache):
         async_redis_cluster_client: Final = self.init_async_client()
         return await async_redis_cluster_client.mget_nonatomic(keys=keys)
 
+    async def disconnect(self):
+        """
+        Overrides `disconnect` in redis_cache.py
+
+        The cluster client owns its per-node pools, so closing it is the only way to release them
+        """
+        if self.redis_async_redis_cluster_client is not None:
+            await self.redis_async_redis_cluster_client.aclose()
+            self.redis_async_redis_cluster_client = None
+        await super().disconnect()
+
     async def test_connection(self) -> dict:
         """
         Test the Redis Cluster connection.

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -608,3 +608,34 @@ async def test_only_connectivity_failures_open_the_breaker(error, opens_breaker)
             await _run_under_circuit_breaker(breaker, "op", failing_call)
 
     assert breaker.is_open() is opens_breaker
+
+
+@pytest.mark.asyncio
+async def test_disconnect_skips_absent_connection_pool(redis_no_ping):
+    """
+    `get_redis_connection_pool` returns None in cluster mode, so disconnect must guard it.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/37137
+    """
+    with patch("litellm._redis.get_redis_connection_pool", return_value=None):
+        cache = RedisCache(host="localhost", port=6379, password="hello")
+
+    assert cache.async_redis_conn_pool is None
+
+    await cache.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_closes_connection_pool_when_present(redis_no_ping):
+    """A non-cluster cache still tears its shared pool down."""
+    mock_pool = MagicMock()
+    mock_pool.disconnect = AsyncMock()
+
+    with patch("litellm._redis.get_redis_connection_pool", return_value=mock_pool):
+        cache = RedisCache(host="localhost", port=6379, password="hello")
+
+    assert cache.async_redis_conn_pool is mock_pool
+
+    await cache.disconnect()
+
+    mock_pool.disconnect.assert_awaited_once_with(inuse_connections=True)

--- a/tests/test_litellm/caching/test_redis_cluster_cache.py
+++ b/tests/test_litellm/caching/test_redis_cluster_cache.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -179,3 +179,53 @@ def test_router_create_redis_cache_cluster_detection(
     with patch.object(RedisCache, "__init__", _mock_redis_cache_init):
         redis_cache = Router._create_redis_cache(cache_config)
         assert isinstance(redis_cache, expected_cache_type)
+
+
+@pytest.mark.asyncio
+@patch("litellm._redis.init_redis_cluster")
+async def test_redis_cluster_disconnect_without_connection_pool(mock_init_redis_cluster):
+    """
+    Cluster mode has no shared connection pool, so disconnect must not dereference it.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/37137
+    """
+    mock_init_redis_cluster.return_value = MagicMock()
+
+    cache = RedisClusterCache(
+        startup_nodes=[{"host": "localhost", "port": 6379}],
+        password="hello",
+    )
+
+    assert cache.async_redis_conn_pool is None
+
+    await cache.disconnect()
+
+
+@pytest.mark.asyncio
+@patch("litellm._redis.init_redis_cluster")
+async def test_redis_cluster_disconnect_closes_cluster_client(mock_init_redis_cluster):
+    """
+    The cluster client owns its per-node pools, so disconnect has to close it explicitly.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/37137
+    """
+    from redis.asyncio import RedisCluster
+
+    mock_init_redis_cluster.return_value = MagicMock()
+
+    cache = RedisClusterCache(
+        startup_nodes=[{"host": "localhost", "port": 6379}],
+        password="hello",
+    )
+
+    mock_cluster_client = MagicMock(spec=RedisCluster)
+    mock_cluster_client.aclose = AsyncMock()
+    with patch("litellm._redis.get_redis_async_client", return_value=mock_cluster_client):
+        cache.init_async_client()
+
+    assert cache.redis_async_redis_cluster_client is mock_cluster_client
+
+    await cache.disconnect()
+
+    mock_cluster_client.aclose.assert_awaited_once()
+    assert cache.redis_async_redis_cluster_client is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every proxy shutdown crashes when Redis cluster mode is on
- Billing flush and other teardown steps are skipped
- Cluster client and its per-node pools are never released

How it solves it:

- Skip the shared pool teardown when there is no shared pool
- Close the cluster client explicitly, then delegate to the base class

## User Flow

Before: an admin running Redis in cluster mode loses part of every shutdown

1. They start the proxy with Redis caching pointed at a cluster-mode endpoint, for example ElastiCache Serverless, which is always cluster mode
2. They send SIGTERM to restart or deploy
3. Shutdown ends with `AttributeError: 'NoneType' object has no attribute 'disconnect'`, and uvicorn reports `Application shutdown failed. Exiting.`
4. Everything ordered after the cache teardown never runs, so up to one export interval of billable request counts is dropped on that restart, every restart

After: the same restart completes and nothing after the cache teardown is skipped

1. They start the proxy with the same cluster-mode Redis configuration
2. They send SIGTERM to restart or deploy
3. Shutdown completes without raising
4. The billing flush runs, so no export interval is lost across the restart

## Relevant issues

Fixes #37137

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, a real cluster-mode Redis with all slots served by one node, no mocks:

```
docker run -d --name litellm-redis-cluster -p 7000:7000 redis:7 redis-server --port 7000 \
  --cluster-enabled yes --cluster-config-file nodes.conf --cluster-node-timeout 5000 \
  --cluster-announce-ip 127.0.0.1 --appendonly no
docker exec litellm-redis-cluster redis-cli -p 7000 cluster addslotsrange 0 16383
docker exec litellm-redis-cluster redis-cli -p 7000 cluster info | head -2
# cluster_state:ok
# cluster_slots_assigned:16384
```

`repro.py`, which caches through the real cluster and then shuts the cache down:

```python
import asyncio
from litellm.caching.redis_cluster_cache import RedisClusterCache

async def main() -> None:
    cache = RedisClusterCache(startup_nodes=[{"host": "127.0.0.1", "port": 7000}])
    await cache.async_set_cache("proof:37137", "value-from-litellm")
    print("cached value:", await cache.async_get_cache("proof:37137"))
    print("async_redis_conn_pool is:", cache.async_redis_conn_pool)
    await cache.disconnect()
    print("shutdown completed cleanly")

asyncio.run(main())
```

### Before (973329e986)

1. `python repro.py`
2. Output, the cache round trip succeeds and the teardown then raises:

```
cached value: value-from-litellm
async_redis_conn_pool is: None
Traceback (most recent call last):
  File "repro.py", line 11, in main
    await cache.disconnect()
  File "litellm/caching/redis_cache.py", line 1356, in disconnect
    await self.async_redis_conn_pool.disconnect(inuse_connections=True)
AttributeError: 'NoneType' object has no attribute 'disconnect'
```

### After (3b3103ff33)

1. `python repro.py`
2. Output, the same round trip succeeds and the teardown now completes:

```
cached value: value-from-litellm
async_redis_conn_pool is: None
shutdown completed cleanly
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Captured at the cache layer, not a full SIGTERM proxy run
- Cache teardown in shutdown stays unguarded against other failures
- Happy to add that try/except here if you want it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
