### PR TITLE
Add tiyuvta as an OpenAI-compatible provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -175,6 +175,12 @@
     "base_class": "openai_gpt",
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/messages"]
   },
+  "tiyuvta": {
+    "base_url": "https://api.tiyuvta.ai/v1",
+    "api_key_env": "TIYUVTA_API_KEY",
+    "api_base_env": "TIYUVTA_API_BASE",
+    "supported_endpoints": ["/v1/chat/completions", "/v1/completions"]
+  },
   "pinstripes": {
     "base_url": "https://pinstripes.io/v1",
     "api_key_env": "PINSTRIPES_API_KEY",


### PR DESCRIPTION
Adds `tiyuvta` to `litellm/llms/openai_like/providers.json`, following that directory's README.

```json
"tiyuvta": {
  "base_url": "https://api.tiyuvta.ai/v1",
  "api_key_env": "TIYUVTA_API_KEY",
  "api_base_env": "TIYUVTA_API_BASE",
  "supported_endpoints": ["/v1/chat/completions", "/v1/completions"]
}
```

**What it is.** A prepaid OpenAI-compatible inference endpoint I run, serving Qwen3.8-27B at its full 262,144-token context on [memra](https://github.com/avifenesh/memra), an open-source Rust + CUDA engine. Docs: <https://inference.tiyuvta.ai/docs>. `GET https://api.tiyuvta.ai/v1/models` is public and answers 200.

**No `param_mappings`.** Most entries here map `max_completion_tokens` → `max_tokens`. This endpoint already accepts `max_completion_tokens` as an alias for `max_tokens` server-side, with a test covering it, so the mapping would be a no-op and is left out rather than added for symmetry.

**`supported_endpoints` lists only what is actually served**: chat completions and completions. No `/v1/responses`, `/v1/messages` or `/v1/embeddings` — declaring those would make `JSONProviderRegistry.supports_responses_api()` answer yes for an endpoint that has none.

Streaming, tool calls, `response_format` (`json_object` and `json_schema`), and separated reasoning output all work through the standard Chat Completions shape.

JSON validated: parses, 27 providers, no duplicate keys.