### PR TITLE
fix: treat blank litellm_params as unset when resolving credentials

### DIFF
--- a/litellm/litellm_core_utils/credential_accessor.py
+++ b/litellm/litellm_core_utils/credential_accessor.py
@@ -19,6 +19,17 @@ class CredentialAccessor:
         return {}
 
     @staticmethod
+    def is_unset(value: object) -> bool:
+        """A credential fills in what the deployment left unset, and "" is unset just like None.
+
+        The dashboard's model edit form stores blank inputs as "" in litellm_params; counting
+        those as configured shadowed the credential's api_base and silently routed requests
+        at the provider default.
+        """
+
+        return value is None or (isinstance(value, str) and not value.strip())
+
+    @staticmethod
     def upsert_credentials(credentials: list[CredentialItem]):
         """Add a credential to the list of credentials."""
 

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -18,9 +18,6 @@ from litellm.utils import get_valid_models
 _CREDENTIAL_LITELLM_PARAM_FIELDS = set(CredentialLiteLLMParams.model_fields)
 
 
-_CREDENTIAL_LITELLM_PARAM_FIELDS = set(CredentialLiteLLMParams.model_fields)
-
-
 def _check_wildcard_routing(model: str) -> bool:
     """
     Returns True if a model is a provider wildcard.
@@ -256,7 +253,7 @@ def _hydrate_litellm_credential_name(
 
     litellm_params = litellm_params.model_copy()
     for key, value in credential_values.items():
-        if key in _CREDENTIAL_LITELLM_PARAM_FIELDS and getattr(litellm_params, key, None) is None:
+        if key in _CREDENTIAL_LITELLM_PARAM_FIELDS and CredentialAccessor.is_unset(getattr(litellm_params, key, None)):
             setattr(litellm_params, key, value)
     litellm_params.litellm_credential_name = None
     return litellm_params

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -624,7 +624,7 @@ def load_credentials_from_list(kwargs: dict):
     if credential_name and litellm.credential_list:
         credential_accessor: Final[Mapping[str, object]] = CredentialAccessor.get_credential_values(credential_name)
         for key, value in credential_accessor.items():
-            if key not in kwargs:
+            if CredentialAccessor.is_unset(kwargs.get(key)):
                 kwargs[key] = value
 
 

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -432,6 +432,59 @@ def test_wildcard_credential_hydration_preserves_deployment_params(
     }
 
 
+def test_wildcard_credential_hydration_fills_blank_deployment_params(monkeypatch):
+    """A blank api_base on the deployment must not shadow the credential's endpoint.
+
+    The dashboard's model edit form writes blank inputs into litellm_params verbatim, so a
+    stored "" counted as configured and the credential's api_base was never applied.
+    """
+    import litellm
+    from litellm.proxy.auth import model_checks
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    from litellm.types.router import LiteLLM_Params
+    from litellm.types.utils import CredentialItem
+
+    monkeypatch.setattr(
+        litellm,
+        "credential_list",
+        [
+            CredentialItem(
+                credential_name="openai-credential",
+                credential_info={"provider": "openai"},
+                credential_values={
+                    "api_key": "stored-openai-key",
+                    "api_base": "https://relay.test/v1",
+                },
+            )
+        ],
+    )
+
+    captured_params = {}
+
+    def fake_get_provider_models(provider, litellm_params=None):
+        captured_params["api_base"] = litellm_params.api_base
+        captured_params["api_key"] = litellm_params.api_key
+        return ["gpt-4o"]
+
+    monkeypatch.setattr(model_checks, "get_provider_models", fake_get_provider_models)
+
+    result = get_known_models_from_wildcard(
+        wildcard_model="openai/*",
+        litellm_params=LiteLLM_Params(
+            model="openai/*",
+            custom_llm_provider="openai",
+            api_base="",
+            litellm_credential_name="openai-credential",
+        ),
+    )
+
+    assert result == ["openai/gpt-4o"]
+    assert captured_params == {
+        "api_base": "https://relay.test/v1",
+        "api_key": "stored-openai-key",
+    }
+
+
 def test_wildcard_custom_prefix_does_not_stack_provider_prefix(monkeypatch):
     """Regression test for #30358.
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -22,6 +22,7 @@ from litellm._logging import (
 from litellm.proxy.utils import is_valid_api_key
 from litellm.types.utils import (
     CallTypes,
+    CredentialItem,
     Delta,
     LlmProviders,
     ModelResponseStream,
@@ -43,6 +44,7 @@ from litellm.utils import (
     get_prompt_cache_min_tokens,
     is_cached_message,
     is_prompt_caching_valid_prompt,
+    load_credentials_from_list,
 )
 
 # Adds the parent directory to the system path
@@ -4841,3 +4843,45 @@ def test_completion_does_not_leak_rust_flag_into_provider_request_body():
     create_kwargs = mock_client.chat.completions.with_raw_response.create.call_args.kwargs
     assert "rust" not in create_kwargs
     assert "rust" not in (create_kwargs.get("extra_body") or {})
+
+
+def _relay_credential():
+    return CredentialItem(
+        credential_name="relay",
+        credential_info={"provider": "openai"},
+        credential_values={
+            "api_base": "https://relay.test/v1",
+            "api_key": "sk-from-credential",
+        },
+    )
+
+
+@pytest.mark.parametrize("unset_value", ["", "   ", None])
+def test_load_credentials_from_list_fills_unset_deployment_params(unset_value):
+    """A blank api_base on the deployment must not shadow the credential's endpoint.
+
+    The dashboard's model edit form writes blank inputs into litellm_params verbatim, so a
+    stored "" counted as configured. The credential's api_base was then never applied and the
+    empty value fell through to the provider default, which silently misrouted every request.
+    """
+    litellm.credential_list = [_relay_credential()]
+    kwargs = {"litellm_credential_name": "relay", "api_base": unset_value}
+
+    load_credentials_from_list(kwargs)
+
+    assert kwargs["api_base"] == "https://relay.test/v1"
+    assert kwargs["api_key"] == "sk-from-credential"
+
+
+def test_load_credentials_from_list_keeps_configured_deployment_params():
+    """A credential only fills in what the deployment left unset; a real value still wins."""
+    litellm.credential_list = [_relay_credential()]
+    kwargs = {
+        "litellm_credential_name": "relay",
+        "api_base": "https://deployment.test/v1",
+    }
+
+    load_credentials_from_list(kwargs)
+
+    assert kwargs["api_base"] == "https://deployment.test/v1"
+    assert kwargs["api_key"] == "sk-from-credential"


### PR DESCRIPTION
## TLDR

Problem this solves:

- A blank API base on a model silently overrode its credential
- Requests went to the provider default, not the credential's endpoint
- Rotating the credential's key had no visible effect

How it solves it:

- Credentials now fill in blank values, not only missing ones
- An explicitly configured value still takes precedence

## User Flow

Before: an admin rotates a stored credential and one model stays broken, while a fresh copy of that same model works

1. They open https://litellm-domain/ui/?page=models, open a model that draws its key from a stored credential, and save it with the API base box left empty
2. They open that credential and set the new key and endpoint on it
3. They send POST https://litellm-domain/v1/chat/completions naming that model
4. The call never reaches the credential's endpoint. It hangs until the client gives up, or comes back 401 quoting a completely different provider
5. They add the same model again as a new entry against the same credential, and that copy returns 200, so the credential itself is fine

After: the rotation takes effect on the model they already had

1. They open https://litellm-domain/ui/?page=models, open a model that draws its key from a stored credential, and save it with the API base box left empty
2. They open that credential and set the new key and endpoint on it
3. They send POST https://litellm-domain/v1/chat/completions naming that model
4. The call returns 200 from the endpoint stored on the credential, with real token usage
5. They add the same model again as a new entry against the same credential, and that copy returns 200

## Relevant issues

Fixes #37152

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Validation status for 2f1c690cea (current tip): 411 focused credential, model-check and utils tests pass locally, and `uv lock --check` passes. The dashboard API types were regenerated, which clears the API Types Sync failure; codecov/patch passed on the previous tip and is re-running here. The diff is now limited to this fix: no dependency file, no scan exemption and no upstream test is touched.

`test_join_binds_the_membership_to_the_requested_team` is left exactly as it is on main, and it is timing sensitive on its own. It caches its org rows with the 5 second TTL that `DEFAULT_IN_MEMORY_TTL` gives org entries (`litellm/constants.py`), then spends seconds in real Postgres round-trips, so on a loaded runner the entry expires and the getter falls through to the dead-DB sentinel (`TypeError: object MagicMock can't be used in 'await' expression`). Measured locally against `postgres:16` with the same `prisma generate` + `prisma db push` steps CI uses: 3 passed in 6.53s, with 3.0s in that test's call phase. So it is green on an idle machine and may flake under load; the one line fix (`InMemoryCache(clock=...)` already exists on the class) belongs in its own PR, and I am happy to open that.

One check is red and it is red repository-wide, not on this PR: **osv-scan**. `osv-scanner.toml` ignores `GHSA-h7x2-h6g9-p789` / `PYSEC-2026-3865` (mlflow, High 7.1) only until 2026-09-14, that date has now passed, and `uv.lock` on main still pins mlflow 3.15.0. Unrelated branches fail the same job for the same advisory in the same hour, for example `feat/xai-supergrok-oauth-failover`, `feat/thinking-param-translation`, `cursor/xai-grok-imagine-image-video-7688` and `litellm_bulk_new_user` at 2026-09-14T02:20Z, and the scheduled scan on main hits it as well.

This revision deliberately drops the two files that were used to work around it (raising mlflow to `>=3.16.0` in `pyproject.toml` plus the matching `uv.lock` update). `.github/workflows/guard-fork-dependencies.yml` rejects any fork PR that modifies `uv.lock`, and `test-linting` and `test-mcp` run `uv lock --check`, so `pyproject.toml` cannot move without the lockfile either. Clearing osv-scan therefore needs a lockfile bump from a branch in the canonical repository; the advisory covers 3.13.0 to 3.15.2, so mlflow 3.16.0 is outside it. As a side benefit of dropping those files, this PR no longer touches any scan exemption.

The live API results below are historical, captured at the labeled commits. They have not been rerun for this revision because DEEPSEEK_API_KEY is unavailable in the current environment, and the full `make check` suite was not rerun locally after the revert.

Shared setup, `/tmp/blank_api_base_repro.yaml`. `edited-model` carries the blank API base a dashboard save leaves behind; `newly-added-model` is the same deployment without it:

```yaml
credential_list:
  - credential_name: openai-compat-cred
    credential_info:
      provider: openai
    credential_values:
      api_base: https://api.deepseek.com/v1
      api_key: os.environ/DEEPSEEK_API_KEY

model_list:
  - model_name: edited-model
    litellm_params:
      model: openai/deepseek-chat
      api_base: ""
      litellm_credential_name: openai-compat-cred

  - model_name: newly-added-model
    litellm_params:
      model: openai/deepseek-chat
      litellm_credential_name: openai-compat-cred

general_settings:
  master_key: sk-1234
```

Both sides run the same proxy command, against the real DeepSeek API:

```bash
uv run --frozen python litellm/proxy/proxy_cli.py --config /tmp/blank_api_base_repro.yaml --port 4000
```

The provider key is redacted below where the upstream echoed it back.

### Before (bc6e7df05b)

#### Model saved with a blank API base

1. Command:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"edited-model","messages":[{"role":"user","content":"reply with the single word: ok"}],"max_tokens":8}' \
  -w "\nHTTP %{http_code}\n"
```

2. Output. The DeepSeek key was sent to OpenAI, so the request never reached the endpoint on the credential:

```
{"error":{"message":"litellm.AuthenticationError: AuthenticationError: OpenAIException - Incorrect API key provided: sk-REDACTED. You can find your API key at https://platform.openai.com/account/api-keys.. Received Model Group=edited-model\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
HTTP 401
```

#### Model created without an API base

1. Command:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"newly-added-model","messages":[{"role":"user","content":"reply with the single word: ok"}],"max_tokens":8}' \
  -w "\nHTTP %{http_code}\n"
```

2. Output:

```
{"id":"4aac7f1d-0051-4e24-87b8-484cb335fac9","created":1786954807,"model":"newly-added-model","object":"chat.completion","system_fingerprint":"a26a7955944dc5c60445bff77fac9c8e","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant","provider_specific_fields":{"refusal":null}},"provider_specific_fields":{}}],"usage":{"completion_tokens":1,"prompt_tokens":11,"total_tokens":12,"prompt_tokens_details":{"cached_tokens":0},"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":11}}
HTTP 200
```

### After (6f8e3114e1)

#### Model saved with a blank API base

1. Command:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"edited-model","messages":[{"role":"user","content":"reply with the single word: ok"}],"max_tokens":8}' \
  -w "\nHTTP %{http_code}\n"
```

2. Output. The request now lands on the credential's endpoint and DeepSeek answers:

```
{"id":"9c5520c3-48af-4e60-ade9-cef0216eea2c","created":1786954836,"model":"edited-model","object":"chat.completion","system_fingerprint":"a26a7955944dc5c60445bff77fac9c8e","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant","provider_specific_fields":{"refusal":null}},"provider_specific_fields":{}}],"usage":{"completion_tokens":1,"prompt_tokens":11,"total_tokens":12,"prompt_tokens_details":{"cached_tokens":0},"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":11}}
HTTP 200
```

#### Model created without an API base

1. Command:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"newly-added-model","messages":[{"role":"user","content":"reply with the single word: ok"}],"max_tokens":8}' \
  -w "\nHTTP %{http_code}\n"
```

2. Output, unchanged:

```
{"id":"1a482ec2-b574-42b4-849f-1c79ba94e249","created":1786954837,"model":"newly-added-model","object":"chat.completion","system_fingerprint":"a26a7955944dc5c60445bff77fac9c8e","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant","provider_specific_fields":{"refusal":null}},"provider_specific_fields":{}}],"usage":{"completion_tokens":1,"prompt_tokens":11,"total_tokens":12,"prompt_tokens_details":{"cached_tokens":0},"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":11}}
HTTP 200
```

## Type

🐛 Bug Fix

## Caveats (if any)

- A blank API base without a credential still hits the provider default
- The dashboard still saves blank text inputs verbatim

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR






