### PR TITLE
feat(realtime): add realtime_audio guardrail hook with per-frame holdback

### DIFF
--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -127,7 +127,7 @@ class RealTimeStreaming:
         # Optional per-provider GA event normalizer (e.g. XAIRealtimeNormalizer).
         self._event_normalizer = event_normalizer
         # Monotonic per-speaker frame counters for the realtime_audio hook.
-        self._audio_frame_seq: dict[str, int] = {"user": 0, "model": 0}
+        self._audio_frame_seq: dict[str, int] = {"user": 0, "model": 0}  # mutable-ok: per-speaker frame counter
         # Audio formats as declared by the client's session config, when it declares them.
         self._client_audio_format: str | None = None
         self._model_audio_format: str | None = None
@@ -152,7 +152,7 @@ class RealTimeStreaming:
     _SESSION_CONFIG_CLIENT_TYPES = frozenset(["session.update", "session.create"])
     # Realtime defaults when the session declares no explicit format: client mics
     # commonly send 16 kHz while model output is 24 kHz.
-    _DEFAULT_AUDIO_SAMPLE_RATE_HZ: ClassVar[dict[str, int]] = {"user": 16000, "model": 24000}
+    _DEFAULT_AUDIO_SAMPLE_RATE_HZ: ClassVar[Mapping[str, int]] = {"user": 16000, "model": 24000}
     _AUDIO_FORMAT_MAP: dict[str, dict[str, str | int]] = {
         "pcm16": {"type": "audio/pcm", "rate": 24000},
         "g711_ulaw": {"type": "audio/G711-ulaw", "rate": 8000},
@@ -576,12 +576,12 @@ class RealTimeStreaming:
         """
         if not self._has_realtime_audio_guardrails():
             return False
-        event_obj: dict | None = event if isinstance(event, dict) else self._parse_backend_event(event_str)  # type: ignore[assignment]
+        event_obj: Final = event if isinstance(event, dict) else self._parse_backend_event(event_str)
         if not isinstance(event_obj, dict):
             return False
         if event_obj.get("type") not in self._AUDIO_DELTA_EVENT_TYPES:
             return False
-        delta = event_obj.get("delta")
+        delta: Final = event_obj.get("delta")
         if not isinstance(delta, str) or not delta:
             return False
         return await self.run_realtime_audio_guardrails(delta, speaker="model")
@@ -769,14 +769,13 @@ class RealTimeStreaming:
         seq: Final = self._audio_frame_seq.get(speaker, 0)
         self._audio_frame_seq[speaker] = seq + 1
 
-        if sample_rate_hz is None:
-            sample_rate_hz = self._audio_sample_rate_hz(speaker)
+        resolved_rate: Final = sample_rate_hz if sample_rate_hz is not None else self._audio_sample_rate_hz(speaker)
 
-        frame: GuardrailAudioFrame = {
+        frame: Final[GuardrailAudioFrame] = {
             "speaker": speaker,
             "audio": audio_b64,
             "encoding": encoding,
-            "sample_rate_hz": sample_rate_hz,
+            "sample_rate_hz": resolved_rate,
             "sequence": seq,
         }
         _already_run: Final[set] = set()
@@ -817,14 +816,14 @@ class RealTimeStreaming:
         """
         declared: Final = self._client_audio_format if speaker == "user" else self._model_audio_format
         if declared is not None:
-            rate = self._AUDIO_FORMAT_MAP.get(declared, {}).get("rate")
+            rate: Final = self._AUDIO_FORMAT_MAP.get(declared, {}).get("rate")
             if isinstance(rate, int):
                 return rate
         return self._DEFAULT_AUDIO_SAMPLE_RATE_HZ[speaker]
 
-    def _remember_declared_audio_formats(self, msg_obj: dict) -> None:
+    def _remember_declared_audio_formats(self, msg_obj: Mapping[str, object]) -> None:
         """Record audio formats from a client ``session.update``/``session.create``."""
-        session = msg_obj.get("session")
+        session: Final = msg_obj.get("session")
         if not isinstance(session, dict):
             return
         for key, attr in (
@@ -1474,7 +1473,7 @@ class RealTimeStreaming:
                         and not guardrail_turn_detection_injected
                         and self._has_audio_transcription_guardrails()
                     ):
-                        session = msg_obj.get("session")
+                        session: Final = msg_obj.get("session")
                         if isinstance(session, dict):
                             td_overridden = False
                             flat_td = session.get("turn_detection")
@@ -1524,7 +1523,7 @@ class RealTimeStreaming:
                             message = json.dumps(msg_obj)
 
                     if msg_type == "session.update" and self._event_normalizer:
-                        session = msg_obj.get("session")
+                        session: Final = msg_obj.get("session")
                         if isinstance(session, dict):
                             msg_obj["session"] = self._event_normalizer.patch_outgoing_session(session)
                             message = json.dumps(msg_obj)

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Final, Protocol, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal, Protocol, cast
 
 import litellm
 from litellm._logging import verbose_logger
@@ -126,6 +126,11 @@ class RealTimeStreaming:
         self._is_transcription_session: bool = force_transcription_model is not None
         # Optional per-provider GA event normalizer (e.g. XAIRealtimeNormalizer).
         self._event_normalizer = event_normalizer
+        # Monotonic per-speaker frame counters for the realtime_audio hook.
+        self._audio_frame_seq: dict[str, int] = {"user": 0, "model": 0}
+        # Audio formats as declared by the client's session config, when it declares them.
+        self._client_audio_format: str | None = None
+        self._model_audio_format: str | None = None
 
     # Per-connection caps for pre-setup audio frames (message count + total bytes).
     _MAX_BUFFERED_MESSAGES: int = 200
@@ -141,6 +146,13 @@ class RealTimeStreaming:
         ]
     )
     _CLIENT_AUDIO_BUFFER_COMMIT_TYPES = frozenset(["input_audio_buffer.commit", "input_audio_buffer.end"])
+    # Both beta and GA spellings of the model audio delta.
+    _AUDIO_DELTA_EVENT_TYPES = frozenset(["response.audio.delta", "response.output_audio.delta"])
+    # Client messages that may declare the session's audio formats.
+    _SESSION_CONFIG_CLIENT_TYPES = frozenset(["session.update", "session.create"])
+    # Realtime defaults when the session declares no explicit format: client mics
+    # commonly send 16 kHz while model output is 24 kHz.
+    _DEFAULT_AUDIO_SAMPLE_RATE_HZ: ClassVar[dict[str, int]] = {"user": 16000, "model": 24000}
     _AUDIO_FORMAT_MAP: dict[str, dict[str, str | int]] = {
         "pcm16": {"type": "audio/pcm", "rate": 24000},
         "g711_ulaw": {"type": "audio/G711-ulaw", "rate": 8000},
@@ -555,6 +567,25 @@ class RealTimeStreaming:
                 return False
         return True
 
+    async def _should_withhold_model_audio(self, event: object, event_str: str) -> bool:
+        """Screen a model audio delta before it reaches the client.
+
+        Returns True when the frame must not be forwarded. This is the holdback
+        point: the frame is dropped and the session stays open, so a guardrail
+        can suppress a fragment of speech without hanging up the call.
+        """
+        if not self._has_realtime_audio_guardrails():
+            return False
+        event_obj: dict | None = event if isinstance(event, dict) else self._parse_backend_event(event_str)  # type: ignore[assignment]
+        if not isinstance(event_obj, dict):
+            return False
+        if event_obj.get("type") not in self._AUDIO_DELTA_EVENT_TYPES:
+            return False
+        delta = event_obj.get("delta")
+        if not isinstance(delta, str) or not delta:
+            return False
+        return await self.run_realtime_audio_guardrails(delta, speaker="model")
+
     def _should_drop_event_from_client(self, event: object) -> bool:
         """Return True for provider-specific events that must not reach GA clients."""
         if self._event_normalizer is not None:
@@ -572,6 +603,8 @@ class RealTimeStreaming:
 
     async def _send_event_to_client(self, event: object, event_str: str) -> bool:
         if self._should_drop_event_from_client(event):
+            return False
+        if await self._should_withhold_model_audio(event, event_str):
             return False
         if isinstance(event, dict):
             event = self._normalize_event_for_ga_client(event)
@@ -697,6 +730,110 @@ class RealTimeStreaming:
                 GuardrailEventHooks.post_call,
             ]
         )
+
+    def _has_realtime_audio_guardrails(self) -> bool:
+        """Return True when a guardrail opted into the raw-audio hook.
+
+        Kept separate from ``_has_realtime_guardrails`` so that sessions with
+        only text guardrails pay nothing for this path: no parse of audio
+        events, no await before forwarding, no added latency.
+        """
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        return self._has_realtime_guardrails_for_event_hooks([GuardrailEventHooks.realtime_audio])
+
+    async def run_realtime_audio_guardrails(
+        self,
+        audio_b64: str,
+        speaker: Literal["user", "model"],
+        encoding: str = "pcm16",
+        sample_rate_hz: int | None = None,
+    ) -> bool:
+        """Run registered guardrails on a single realtime audio frame.
+
+        Returns True when the frame must be withheld (not forwarded), False when clean.
+
+        ``run_realtime_guardrails`` sees only the provider's own transcription.
+        This hands the guardrail the audio itself, so a guardrail can apply its
+        own speech models rather than inheriting the provider's transcription
+        quality, timing and vocabulary.
+
+        A withheld frame is dropped and the session stays open — the audio
+        analogue of ``stream_holdback_chars``, rather than the all-or-nothing
+        ``end_session_after_n_fails``.
+        """
+        from litellm.integrations.custom_guardrail import CustomGuardrail
+        from litellm.types.guardrails import GuardrailEventHooks
+        from litellm.types.utils import GuardrailAudioFrame
+
+        seq: Final = self._audio_frame_seq.get(speaker, 0)
+        self._audio_frame_seq[speaker] = seq + 1
+
+        if sample_rate_hz is None:
+            sample_rate_hz = self._audio_sample_rate_hz(speaker)
+
+        frame: GuardrailAudioFrame = {
+            "speaker": speaker,
+            "audio": audio_b64,
+            "encoding": encoding,
+            "sample_rate_hz": sample_rate_hz,
+            "sequence": seq,
+        }
+        _already_run: Final[set] = set()
+
+        for callback in litellm.callbacks:
+            if not isinstance(callback, CustomGuardrail):
+                continue
+            if id(callback) in _already_run:
+                continue
+            if not callback.should_run_guardrail(
+                data=self.request_data,
+                event_type=GuardrailEventHooks.realtime_audio,
+            ):
+                continue
+            _already_run.add(id(callback))
+            try:
+                await callback.apply_guardrail(
+                    inputs={"texts": [], "images": [], "audio": [frame]},
+                    request_data={"user_api_key_dict": self.user_api_key_dict},
+                    input_type="request" if speaker == "user" else "response",
+                )
+            except Exception as e:  # noqa: BLE001 - must classify block vs bug, as the text path does
+                # Same contract as the text path: a policy block raises with
+                # status_code/detail. Anything else is a bug in the guardrail and
+                # must not silently discard the caller's audio.
+                is_guardrail_block: Final = hasattr(e, "status_code") or isinstance(e, ValueError)
+                if not is_guardrail_block:
+                    verbose_logger.exception("[realtime audio guardrail] unexpected error: %s", e)
+                    continue
+                return True
+        return False
+
+    def _audio_sample_rate_hz(self, speaker: Literal["user", "model"]) -> int:
+        """Sample rate for ``speaker``, from the session config where declared.
+
+        Falls back per direction rather than to a single default: ``_AUDIO_FORMAT_MAP``
+        carries the 24 kHz model rate for ``pcm16``, which is wrong for the client mic.
+        """
+        declared: Final = self._client_audio_format if speaker == "user" else self._model_audio_format
+        if declared is not None:
+            rate = self._AUDIO_FORMAT_MAP.get(declared, {}).get("rate")
+            if isinstance(rate, int):
+                return rate
+        return self._DEFAULT_AUDIO_SAMPLE_RATE_HZ[speaker]
+
+    def _remember_declared_audio_formats(self, msg_obj: dict) -> None:
+        """Record audio formats from a client ``session.update``/``session.create``."""
+        session = msg_obj.get("session")
+        if not isinstance(session, dict):
+            return
+        for key, attr in (
+            ("input_audio_format", "_client_audio_format"),
+            ("output_audio_format", "_model_audio_format"),
+        ):
+            value = session.get(key)
+            if isinstance(value, str):
+                setattr(self, attr, value)
 
     def _has_audio_transcription_guardrails(self) -> bool:
         """Return True when a guardrail is configured for the audio/VAD transcript path.
@@ -1193,6 +1330,21 @@ class RealTimeStreaming:
 
                     msg_obj = json.loads(message)
                     msg_type = msg_obj.get("type")
+
+                    if msg_type in self._SESSION_CONFIG_CLIENT_TYPES:
+                        self._remember_declared_audio_formats(msg_obj)
+
+                    ## GUARDRAIL: hand raw client audio to realtime_audio guardrails.
+                    # Withholding halts the turn without closing the session, so a
+                    # guardrail can suppress speech without dropping the call.
+                    if msg_type == "input_audio_buffer.append" and self._has_realtime_audio_guardrails():
+                        client_audio = msg_obj.get("audio")
+                        if (
+                            isinstance(client_audio, str)
+                            and client_audio
+                            and await self.run_realtime_audio_guardrails(client_audio, speaker="user")
+                        ):
+                            continue  # do not relay violating client audio upstream
 
                     if msg_type == "conversation.item.create":
                         # Check user text messages for prompt injection

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -1062,6 +1062,7 @@ class GuardrailEventHooks(str, Enum):
     during_mcp_call = "during_mcp_call"
     post_mcp_call = "post_mcp_call"
     realtime_input_transcription = "realtime_input_transcription"
+    realtime_audio = "realtime_audio"
 
 
 class DynamicGuardrailParams(TypedDict):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -4076,9 +4076,25 @@ class PriorityReservationSettings(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
 
+class GuardrailAudioFrame(TypedDict, total=False):
+    """A single audio frame from a realtime session.
+
+    The sample rate travels with the frame because a realtime session carries
+    different rates in each direction (e.g. 16 kHz client mic, 24 kHz model
+    output), so it cannot be assumed per session.
+    """
+
+    speaker: Literal["user", "model"]
+    audio: str  # base64-encoded audio payload, exactly as it appears on the wire
+    encoding: str  # e.g. "pcm16", "g711_ulaw", "g711_alaw"
+    sample_rate_hz: int
+    sequence: int  # monotonic per speaker, so a guardrail can order and dedup frames
+
+
 class GenericGuardrailAPIInputs(TypedDict, total=False):
     texts: list[str]  # extracted text from the LLM response - for basic text guardrails
     images: list[str]  # extracted images from the LLM response - for image guardrails
+    audio: list[GuardrailAudioFrame]  # realtime audio frames - for audio guardrails
     tools: list[ChatCompletionToolParam]  # tools sent to the LLM
     tool_calls: list[ChatCompletionToolCallChunk] | list[ChatCompletionMessageToolCall]  # tool calls sent from the LLM
     structured_messages: list[

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -39,7 +39,7 @@ from pydantic import (
     field_serializer,
     field_validator,
 )
-from typing_extensions import Required, TypedDict
+from typing_extensions import ReadOnly, Required, TypedDict
 
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
@@ -4084,17 +4084,17 @@ class GuardrailAudioFrame(TypedDict, total=False):
     output), so it cannot be assumed per session.
     """
 
-    speaker: Literal["user", "model"]
-    audio: str  # base64-encoded audio payload, exactly as it appears on the wire
-    encoding: str  # e.g. "pcm16", "g711_ulaw", "g711_alaw"
-    sample_rate_hz: int
-    sequence: int  # monotonic per speaker, so a guardrail can order and dedup frames
+    speaker: ReadOnly[Literal["user", "model"]]
+    audio: ReadOnly[str]  # base64-encoded audio payload, exactly as it appears on the wire
+    encoding: ReadOnly[str]  # e.g. "pcm16", "g711_ulaw", "g711_alaw"
+    sample_rate_hz: ReadOnly[int]
+    sequence: ReadOnly[int]  # monotonic per speaker, so a guardrail can order and dedup frames
 
 
 class GenericGuardrailAPIInputs(TypedDict, total=False):
     texts: list[str]  # extracted text from the LLM response - for basic text guardrails
     images: list[str]  # extracted images from the LLM response - for image guardrails
-    audio: list[GuardrailAudioFrame]  # realtime audio frames - for audio guardrails
+    audio: ReadOnly[Sequence[GuardrailAudioFrame]]  # realtime audio frames - for audio guardrails
     tools: list[ChatCompletionToolParam]  # tools sent to the LLM
     tool_calls: list[ChatCompletionToolCallChunk] | list[ChatCompletionMessageToolCall]  # tool calls sent from the LLM
     structured_messages: list[

--- a/tests/test_litellm/litellm_core_utils/test_realtime_audio_guardrails.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_audio_guardrails.py
@@ -1,0 +1,220 @@
+import base64
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import litellm
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.litellm_core_utils.realtime_streaming import RealTimeStreaming
+from litellm.types.guardrails import GuardrailEventHooks
+
+AUDIO_B64 = base64.b64encode(b"\x00\x01" * 160).decode()
+
+
+class RecordingAudioGuardrail(CustomGuardrail):
+    """Records every audio frame handed to it; blocks model frames listed in block_seq."""
+
+    def __init__(self, block_seq=(), **kwargs):
+        self.seen: list[dict] = []
+        self.block_seq = set(block_seq)
+        super().__init__(guardrail_name="record-audio", **kwargs)
+
+    def should_run_guardrail(self, data, event_type) -> bool:
+        return event_type == GuardrailEventHooks.realtime_audio
+
+    async def apply_guardrail(self, inputs, request_data=None, input_type=None, logging_obj=None):
+        for frame in inputs.get("audio", []):
+            self.seen.append(frame)
+            if frame["speaker"] == "model" and frame["sequence"] in self.block_seq:
+                raise ValueError("blocked by audio guardrail")
+        return inputs
+
+
+class TranscriptOnlyGuardrail(CustomGuardrail):
+    """Opts into the transcript hook only, so it must never be handed audio."""
+
+    def __init__(self, **kwargs):
+        self.calls = 0
+        super().__init__(guardrail_name="transcript-only", **kwargs)
+
+    def should_run_guardrail(self, data, event_type) -> bool:
+        return event_type == GuardrailEventHooks.realtime_input_transcription
+
+    async def apply_guardrail(self, inputs, request_data=None, input_type=None, logging_obj=None):
+        self.calls += 1
+        return inputs
+
+
+def _streaming() -> RealTimeStreaming:
+    logging_obj = MagicMock()
+    logging_obj.async_success_handler = AsyncMock()
+    websocket = MagicMock()
+    websocket.send_text = AsyncMock()
+    backend_ws = MagicMock()
+    backend_ws.send = AsyncMock()
+    return RealTimeStreaming(websocket, backend_ws, logging_obj, request_data={})
+
+
+def _audio_delta(event_type: str = "response.audio.delta") -> tuple[dict, str]:
+    event = {"type": event_type, "delta": AUDIO_B64}
+    return event, json.dumps(event)
+
+
+@pytest.fixture(autouse=True)
+def _reset_callbacks():
+    original = litellm.callbacks
+    yield
+    litellm.callbacks = original
+
+
+@pytest.mark.asyncio
+async def test_guardrail_receives_frame_with_speaker_rate_and_sequence():
+    guardrail = RecordingAudioGuardrail()
+    litellm.callbacks = [guardrail]
+    streaming = _streaming()
+
+    withheld = await streaming.run_realtime_audio_guardrails(AUDIO_B64, speaker="user")
+
+    assert withheld is False
+    assert len(guardrail.seen) == 1
+    frame = guardrail.seen[0]
+    assert frame["speaker"] == "user"
+    assert frame["encoding"] == "pcm16"
+    assert frame["sequence"] == 0
+    assert base64.b64decode(frame["audio"]) == b"\x00\x01" * 160
+
+
+@pytest.mark.asyncio
+async def test_default_sample_rates_differ_by_direction():
+    guardrail = RecordingAudioGuardrail()
+    litellm.callbacks = [guardrail]
+    streaming = _streaming()
+
+    await streaming.run_realtime_audio_guardrails(AUDIO_B64, speaker="user")
+    await streaming.run_realtime_audio_guardrails(AUDIO_B64, speaker="model")
+
+    rates = {f["speaker"]: f["sample_rate_hz"] for f in guardrail.seen}
+    assert rates == {"user": 16000, "model": 24000}
+
+
+@pytest.mark.asyncio
+async def test_declared_session_format_overrides_default_rate():
+    guardrail = RecordingAudioGuardrail()
+    litellm.callbacks = [guardrail]
+    streaming = _streaming()
+
+    streaming._remember_declared_audio_formats(
+        {"session": {"input_audio_format": "g711_ulaw", "output_audio_format": "g711_alaw"}}
+    )
+    await streaming.run_realtime_audio_guardrails(AUDIO_B64, speaker="user")
+    await streaming.run_realtime_audio_guardrails(AUDIO_B64, speaker="model")
+
+    rates = {f["speaker"]: f["sample_rate_hz"] for f in guardrail.seen}
+    assert rates == {"user": 8000, "model": 8000}
+
+
+@pytest.mark.asyncio
+async def test_sequence_is_monotonic_per_speaker():
+    guardrail = RecordingAudioGuardrail()
+    litellm.callbacks = [guardrail]
+    streaming = _streaming()
+
+    for _ in range(3):
+        await streaming.run_realtime_audio_guardrails(AUDIO_B64, speaker="user")
+    await streaming.run_realtime_audio_guardrails(AUDIO_B64, speaker="model")
+
+    assert [f["sequence"] for f in guardrail.seen if f["speaker"] == "user"] == [0, 1, 2]
+    assert [f["sequence"] for f in guardrail.seen if f["speaker"] == "model"] == [0]
+
+
+@pytest.mark.asyncio
+async def test_model_frame_is_withheld_and_session_stays_open():
+    guardrail = RecordingAudioGuardrail(block_seq={1})
+    litellm.callbacks = [guardrail]
+    streaming = _streaming()
+
+    results = []
+    for _ in range(3):
+        event, event_str = _audio_delta()
+        results.append(await streaming._send_event_to_client(event, event_str))
+
+    # Frame seq=1 withheld; the other two reach the client.
+    assert results == [True, False, True]
+    assert streaming.websocket.send_text.await_count == 2
+    assert len(guardrail.seen) == 3
+    streaming.websocket.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ga_spelling_of_audio_delta_is_screened_too():
+    guardrail = RecordingAudioGuardrail()
+    litellm.callbacks = [guardrail]
+    streaming = _streaming()
+
+    event, event_str = _audio_delta("response.output_audio.delta")
+    await streaming._send_event_to_client(event, event_str)
+
+    assert len(guardrail.seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_non_audio_events_are_untouched():
+    guardrail = RecordingAudioGuardrail()
+    litellm.callbacks = [guardrail]
+    streaming = _streaming()
+
+    event = {"type": "session.created", "session": {"id": "s1"}}
+    sent = await streaming._send_event_to_client(event, json.dumps(event))
+
+    assert sent is True
+    assert guardrail.seen == []
+
+
+@pytest.mark.asyncio
+async def test_transcript_only_guardrail_never_sees_audio_and_adds_no_path():
+    guardrail = TranscriptOnlyGuardrail()
+    litellm.callbacks = [guardrail]
+    streaming = _streaming()
+
+    assert streaming._has_realtime_audio_guardrails() is False
+
+    event, event_str = _audio_delta()
+    sent = await streaming._send_event_to_client(event, event_str)
+
+    # Forwarded verbatim; the guardrail is never invoked. Zero cost when unused.
+    assert sent is True
+    assert guardrail.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_crashing_guardrail_does_not_discard_audio():
+    class Exploding(CustomGuardrail):
+        def should_run_guardrail(self, data, event_type) -> bool:
+            return event_type == GuardrailEventHooks.realtime_audio
+
+        async def apply_guardrail(self, inputs, **kwargs):
+            raise RuntimeError("bug in guardrail, not a policy block")
+
+    litellm.callbacks = [Exploding(guardrail_name="boom")]
+    streaming = _streaming()
+
+    withheld = await streaming.run_realtime_audio_guardrails(AUDIO_B64, speaker="model")
+
+    assert withheld is False
+
+
+@pytest.mark.asyncio
+async def test_empty_or_missing_delta_is_not_screened():
+    guardrail = RecordingAudioGuardrail()
+    litellm.callbacks = [guardrail]
+    streaming = _streaming()
+
+    for event in ({"type": "response.audio.delta"}, {"type": "response.audio.delta", "delta": ""}):
+        assert await streaming._send_event_to_client(event, json.dumps(event)) is True
+    assert guardrail.seen == []


### PR DESCRIPTION
## The gap

Realtime guardrails today receive only the provider's own transcription, via `run_realtime_guardrails(transcript: str)` → `apply_guardrail(inputs={"texts": [transcript], "images": []})`. And the only enforcement available mid-session is `end_session_after_n_fails`, which closes the connection.

That leaves two things a voice guardrail can't do:

1. **Apply its own speech models.** `GenericGuardrailAPIInputs` carries `texts` and `images` only, so a guardrail inherits the provider's transcription quality, timing and vocabulary rather than transcribing itself.
2. **Suppress a fragment of speech.** Blocking hangs up the call. There's no way to withhold one frame and let the conversation continue.

## What this adds

The audio counterpart to the `stream_holdback_chars` pattern already in `GenericGuardrailAPIInputs`.

- **`GuardrailAudioFrame`** + an `audio` key on `GenericGuardrailAPIInputs`. The sample rate travels *with the frame*, because a realtime session carries different rates in each direction (commonly 16 kHz client mic, 24 kHz model output) and so it can't be assumed per session. Read from `input_audio_format` / `output_audio_format` when the session declares them, with per-direction defaults otherwise.
- **`GuardrailEventHooks.realtime_audio`**, so opting in is explicit and separate from the transcript hook.
- **`run_realtime_audio_guardrails()`** on both directions:
  - client `input_audio_buffer.append` frames are screened in `client_ack_messages` before being relayed upstream;
  - model audio deltas are screened in `_send_event_to_client`, which already funnels every backend event, so the raw and `provider_config` paths (Gemini/Vertex) behave identically without duplicating logic.
- A withheld frame is **dropped while the session stays open**.

## Costs nothing when unused

`_has_realtime_audio_guardrails()` gates the whole path, so a session with only text guardrails does no extra parse, no await before forwarding, and takes no added latency. This mirrors how `_has_audio_transcription_guardrails()` already scopes the VAD auto-response behaviour.

A guardrail that raises a non-block error is logged and skipped rather than silently discarding the caller's audio — same contract as the text path.

## Tests

10 new cases in `tests/test_litellm/litellm_core_utils/test_realtime_audio_guardrails.py`:

- frame contents (speaker, encoding, sequence, round-tripped payload)
- per-direction default sample rates
- declared session formats overriding those defaults
- per-speaker monotonic sequencing
- a model frame withheld without the session closing
- both beta (`response.audio.delta`) and GA (`response.output_audio.delta`) spellings
- non-audio events forwarded untouched
- missing/empty `delta` not screened
- a transcript-only guardrail never handed audio, and `_has_realtime_audio_guardrails()` false for it
- a crashing guardrail not causing audio to be dropped

`tests/test_litellm/litellm_core_utils/test_realtime_streaming.py` (101 tests) unaffected. No new `ruff-strict-budget` findings; `ruff format` clean.

## Notes for reviewers

- Happy to change the hook name, the frame shape, or split the two directions into separate hooks if you'd prefer a different surface.
- Left as draft because I'd like your read on the shape before I add docs to `docs/my-website/docs/proxy/guardrails/` and a realtime-audio example.
- Motivation: building a voice guardrail that needs first-party transcription and the ability to withhold a fragment without dropping the call. Happy to share more detail if useful.