### PR TITLE
fix(realtime): preserve custom api base paths

### DIFF
--- a/litellm/llms/openai/realtime/handler.py
+++ b/litellm/llms/openai/realtime/handler.py
@@ -84,17 +84,20 @@ class OpenAIRealtime(OpenAIChatCompletion):
         """
         Construct the backend websocket URL with all query parameters (including 'model').
         """
-        from httpx import URL
+        from httpx import URL, QueryParams
 
-        api_base = api_base.replace("https://", "wss://")
-        api_base = api_base.replace("http://", "ws://")
-        url = URL(api_base)
-        # Set the correct path
-        url = url.copy_with(path="/v1/realtime")
-        # Include all query parameters including 'model'
-        if query_params:
-            url = url.copy_with(params=query_params)
-        return str(url)
+        api_base_url: Final = URL(api_base)
+        websocket_scheme: Final = {"https": "wss", "http": "ws"}.get(api_base_url.scheme, api_base_url.scheme)
+        base_path: Final = api_base_url.path.rstrip("/")
+        realtime_path: Final = (
+            base_path
+            if base_path.endswith("/v1/realtime")
+            else f"{base_path}/realtime"
+            if base_path.endswith("/v1")
+            else f"{base_path}/v1/realtime"
+        )
+        merged_params: Final = QueryParams(query_params).merge(api_base_url.params)
+        return str(api_base_url.copy_with(scheme=websocket_scheme, path=realtime_path, params=merged_params))
 
     def _make_event_normalizer(self) -> RealtimeEventNormalizer | None:
         """Return a per-session GA event normalizer, or None for passthrough.

--- a/tests/test_litellm/llms/openai/realtime/test_openai_realtime_handler.py
+++ b/tests/test_litellm/llms/openai/realtime/test_openai_realtime_handler.py
@@ -14,9 +14,16 @@ sys.path.insert(
 
 
 @pytest.mark.parametrize(
-    "api_base", ["https://api.openai.com/v1", "https://api.openai.com"]
+    ("api_base", "expected_scheme", "expected_path"),
+    [
+        ("https://api.openai.com", "wss", "/v1/realtime"),
+        ("https://api.openai.com/v1", "wss", "/v1/realtime"),
+        ("https://api.openai.com/v1/realtime", "wss", "/v1/realtime"),
+        ("http://localhost:8000/gateway/openai", "ws", "/gateway/openai/v1/realtime"),
+        ("https://gateway.example.com/tenant/openai/v1/", "wss", "/tenant/openai/v1/realtime"),
+    ],
 )
-def test_openai_realtime_handler_url_construction(api_base):
+def test_openai_realtime_handler_url_construction(api_base, expected_scheme, expected_path):
     from litellm.llms.openai.realtime.handler import OpenAIRealtime
 
     handler = OpenAIRealtime()
@@ -26,9 +33,10 @@ def test_openai_realtime_handler_url_construction(api_base):
             "model": "gpt-4o-realtime-preview-2024-10-01",
         },
     )
-    # Model parameter should be included in the URL
-    assert url.startswith("wss://api.openai.com/v1/realtime?")
-    assert "model=gpt-4o-realtime-preview-2024-10-01" in url
+    parsed_url = httpx.URL(url)
+    assert parsed_url.scheme == expected_scheme
+    assert parsed_url.path == expected_path
+    assert parsed_url.params["model"] == "gpt-4o-realtime-preview-2024-10-01"
 
 
 def test_openai_realtime_handler_url_with_extra_params():
@@ -36,16 +44,21 @@ def test_openai_realtime_handler_url_with_extra_params():
     from litellm.types.realtime import RealtimeQueryParams
 
     handler = OpenAIRealtime()
-    api_base = "https://api.openai.com/v1"
+    api_base = (
+        "https://gateway.example.com/tenant/openai/v1"
+        "?gateway_route=europe&gateway_route=backup"
+        "&model=gateway-model&intent=gateway-intent"
+    )
     query_params: RealtimeQueryParams = {
         "model": "gpt-4o-realtime-preview-2024-10-01",
         "intent": "chat",
     }
     url = handler._construct_url(api_base=api_base, query_params=query_params)
-    # Both 'model' and other params should be included in the query string
-    assert url.startswith("wss://api.openai.com/v1/realtime?")
-    assert "model=gpt-4o-realtime-preview-2024-10-01" in url
-    assert "intent=chat" in url
+    parsed_url = httpx.URL(url)
+    assert parsed_url.path == "/tenant/openai/v1/realtime"
+    assert parsed_url.params.get_list("gateway_route") == ["europe", "backup"]
+    assert parsed_url.params["model"] == "gateway-model"
+    assert parsed_url.params["intent"] == "gateway-intent"
 
 
 def test_openai_realtime_handler_model_parameter_inclusion():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Realtime WebSockets discard custom `api_base` path prefixes
- Path-routed gateways receive connections at the wrong endpoint

How it solves it:

- Preserve configured paths when appending the Realtime endpoint
- Merge existing base queries with Realtime query parameters

## User Flow

Before: a developer routing Realtime through a path-based gateway gets a failed WebSocket connection because the gateway prefix disappears

1. They configure `api_base: https://gateway.example.com/tenant/openai/v1` for an OpenAI Realtime deployment
2. They connect to `GET wss://litellm-domain/v1/realtime?model=gpt-realtime`
3. The gateway receives `wss://gateway.example.com/v1/realtime?model=gpt-realtime` and returns 404

After: the same developer connects successfully because the configured gateway prefix is preserved

1. They configure `api_base: https://gateway.example.com/tenant/openai/v1` for an OpenAI Realtime deployment
2. They connect to `GET wss://litellm-domain/v1/realtime?model=gpt-realtime`
3. The gateway receives `wss://gateway.example.com/tenant/openai/v1/realtime?model=gpt-realtime` and upgrades the connection

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Shared setup: `api_base=https://gateway.example.com/tenant/openai/v1`, `model=gpt-realtime`

### Before (973329e9864154d429a7d739fb6a552fe03a9b3e)

1. Run `py -c "from litellm.llms.openai.realtime.handler import OpenAIRealtime; print(OpenAIRealtime()._construct_url('https://gateway.example.com/tenant/openai/v1', {'model': 'gpt-realtime'}))"`
2. Observe `wss://gateway.example.com/v1/realtime?model=gpt-realtime`

### After (9c1b3bd6ccee2bf6717a95898dbb225440d79c40)

1. Run the same command
2. Observe `wss://gateway.example.com/tenant/openai/v1/realtime?model=gpt-realtime`

## Type

Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
