### PR TITLE
fix(langfuse_otel): set observation output for rerank responses

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -213,6 +213,14 @@ class LangfuseOtelLogger(OpenTelemetry):
                     safe_dumps(output_items_data),
                 )
 
+        rerank_results: Final = response_obj.get("results")
+        if rerank_results:
+            safe_set_attribute(
+                span,
+                LangfuseSpanAttributes.OBSERVATION_OUTPUT.value,
+                safe_dumps(rerank_results),
+            )
+
     @staticmethod
     def _set_langfuse_specific_attributes(span: Span, kwargs, response_obj):
         """

--- a/tests/test_litellm/integrations/langfuse/test_langfuse_otel_rerank_output.py
+++ b/tests/test_litellm/integrations/langfuse/test_langfuse_otel_rerank_output.py
@@ -1,0 +1,62 @@
+"""
+Unit tests for LangfuseOtelLogger._set_observation_output.
+
+Regression for #36537: with ``success_callback: ["langfuse_otel"]`` the
+``/v1/rerank`` span reached Langfuse with Input set but Output always empty,
+while the legacy ``langfuse`` callback populated it. The OTEL helper handled
+``choices`` (chat completions) and ``output`` (Responses API items) but never
+``RerankResponse.results``.
+"""
+from unittest.mock import MagicMock
+
+from litellm.integrations.langfuse.langfuse_otel import LangfuseOtelLogger
+from litellm.types.integrations.langfuse_otel import LangfuseSpanAttributes
+from litellm.types.utils import RerankResponse
+
+
+def _make_span():
+    span = MagicMock()
+    span.set_attribute = MagicMock()
+    return span
+
+
+def _extract_output(span) -> str:
+    """Pull the value written to OBSERVATION_OUTPUT by set_attribute."""
+    for args, _ in span.set_attribute.call_args_list:
+        if args[0] == LangfuseSpanAttributes.OBSERVATION_OUTPUT.value:
+            return args[1]
+    return None
+
+
+def test_rerank_response_sets_observation_output():
+    span = _make_span()
+    response = RerankResponse(
+        results=[
+            {"index": 2, "relevance_score": 0.98},
+            {"index": 0, "relevance_score": 0.41},
+        ]
+    )
+
+    LangfuseOtelLogger._set_observation_output(span=span, response_obj=response)
+
+    output = _extract_output(span)
+    assert output is not None
+    assert "0.98" in output
+    assert "0.41" in output
+
+
+def test_rerank_without_results_sets_no_output():
+    span = _make_span()
+    response = RerankResponse(results=None)
+
+    LangfuseOtelLogger._set_observation_output(span=span, response_obj=response)
+
+    assert _extract_output(span) is None
+
+
+def test_none_response_is_noop():
+    span = _make_span()
+
+    LangfuseOtelLogger._set_observation_output(span=span, response_obj=None)
+
+    span.set_attribute.assert_not_called()


### PR DESCRIPTION
Fixes berriai/litellm#36537

## Summary
With `success_callback: ["langfuse_otel"]`, `/v1/rerank` spans reached Langfuse with Input and metadata set but Output always empty, while the legacy `langfuse` callback populated it.

`LangfuseOtelLogger._set_observation_output` handled `choices` (chat completions) and `output` (Responses API items) but never handled rerank responses, whose results live in `RerankResponse.results` (list of `{index, relevance_score, document}`).

Added a branch that serializes `response_obj.get("results")` into `OBSERVATION_OUTPUT`, matching what the legacy `LangFuseLogger` path already returns for the same `RerankResponse`.
