### PR TITLE
fix(schema): index LiteLLM_SpendLogs on (api_key, startTime)

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260817120000_add_spendlogs_api_key_starttime_idx/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260817120000_add_spendlogs_api_key_starttime_idx/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx" ON "LiteLLM_SpendLogs"("api_key", "startTime");

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -645,6 +645,7 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+  @@index([api_key, startTime])
 }
 
 // View spend, model, api_key per request

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -645,6 +645,7 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+  @@index([api_key, startTime])
 }
 
 // View spend, model, api_key per request

--- a/schema.prisma
+++ b/schema.prisma
@@ -645,6 +645,7 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+  @@index([api_key, startTime])
 }
 
 // View spend, model, api_key per request


### PR DESCRIPTION
## Problem

`SpendCounterReseed.window_from_spend_logs()` (`litellm/proxy/db/spend_counter_reseed.py`) recomputes a budget-window spend counter straight from the raw spend logs:

```python
await SpendLogsRepository(prisma_client).table.group_by(
    by=[group_field],                       # "api_key"
    where=where,                            # {"api_key": ..., "startTime": {"gte": window_start}}
    sum={"spend": True},
)
```

which reaches Postgres as:

```sql
SELECT api_key, SUM(spend) FROM "LiteLLM_SpendLogs"
WHERE api_key = $1 AND "startTime" >= $2
GROUP BY api_key
```

`LiteLLM_SpendLogs` has no index that covers this predicate — the closest is `@@index([startTime])`. So Postgres scans the entire time window and drops every row that belongs to a different key. Cost therefore scales with **total** traffic in the window rather than with the key's own traffic, and grows with the length of the budget window.

On a deployment with a spend-log table in the 10^7-row range and a 30-day window, we measured a single such call at **~97 seconds**, discarding >99% of the rows it read. Because the Prisma Python client's default HTTP timeout is 30s (`prisma/http_abstract.py`), calls past that threshold surface as `httpx.ReadTimeout` instead of slow-but-successful queries, and the retries make the user-visible latency land on multiples of ~30s.

## Fix

Add `@@index([api_key, startTime])` to `LiteLLM_SpendLogs` (both `schema.prisma` copies) plus the corresponding migration.

## Measurements

Same query, same 30-day window, same key, before and after (identifiers parameterised, absolute call counts omitted):

```
-- Before
GroupAggregate  (actual time=96692.790..96693.024 rows=1 loops=1)
  Buffers: shared hit=3559452 read=945268
  ->  Parallel Index Scan using "LiteLLM_SpendLogs_startTime_idx" on "LiteLLM_SpendLogs"
        Index Cond: ("startTime" >= $2)
        Filter: (api_key = $1)
        Rows Removed by Filter: 3844217
Execution Time: 96693.124 ms

-- After
GroupAggregate  (actual time=369.557..369.559 rows=1 loops=1)
  Buffers: shared hit=67236 read=12103
  ->  Index Only Scan using "LiteLLM_SpendLogs_api_key_startTime_idx" on "LiteLLM_SpendLogs"
        Index Cond: ((api_key = $1) AND ("startTime" >= $2))
        Heap Fetches: 63040
Execution Time: 369.592 ms
```

Roughly three orders of magnitude in execution time and ~57x fewer buffers touched. Index size was ~780 MB for that table.

To be precise about what was measured: the "After" plan comes from a local variant of the index that adds `INCLUDE (spend)`, which is why it reports `Index Only Scan`. Prisma cannot express covering indexes, so this PR ships the plain two-column index. That one produces the same key-bounded index scan — the win here is not reading rows of other keys — with a heap fetch per matched row instead of the covering shortcut.

## Note for operators of large tables

The migration uses plain `CREATE INDEX` (matching the convention of the existing migrations, and required because Prisma runs migrations inside a transaction where `CONCURRENTLY` is not allowed). On a large, busy `LiteLLM_SpendLogs` that takes a write lock for the duration of the build. Operators can avoid it by creating the index ahead of the upgrade:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx"
  ON "LiteLLM_SpendLogs" ("api_key", "startTime");
```

The migration's `IF NOT EXISTS` then makes it a no-op.

## Related, not addressed here

The reseed is described as coalesced and cache-backed, yet in our deployment it ran often enough to dominate total database time — so the counter cache appears not to hold in a multi-worker setup. There is also a broader question of why the budget window is recomputed from raw spend logs at all when daily aggregate tables (`LiteLLM_DailyUserSpend`, `LiteLLM_DailyTeamSpend`, ...) are maintained alongside. Both feel like separate issues; happy to open one if maintainers agree.
