### PR TITLE
fix(proxy): validate batches list limit

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -7,7 +7,7 @@
 import asyncio
 from typing import Any, Final, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, Response
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -661,7 +661,7 @@ async def list_batches(
     request: Request,
     fastapi_response: Response,
     provider: str | None = None,
-    limit: int | None = None,
+    limit: int | None = Query(default=None, ge=1, le=100),
     after: str | None = None,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     target_model_names: str | None = None,

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -53,7 +53,8 @@ from litellm.router import Router
 from litellm.types.llms.openai import BatchJobStatus
 from litellm.types.utils import CredentialItem, LiteLLMBatch
 
-from fastapi import Response
+from fastapi import FastAPI, Response
+from fastapi.testclient import TestClient
 
 # --------------------------------------------------------------------------- #
 # Fixtures: distinguishable credentials per model so a wrong/hardcoded model_id
@@ -1664,6 +1665,37 @@ async def test_list__exception_calls_failure_hook(list_harness):
 
     list_harness.logging.post_call_failure_hook.assert_called_once()
     assert list_harness.logging.post_call_failure_hook.call_args.kwargs["original_exception"].args[0] == "provider boom"
+
+
+@pytest.fixture
+def list_route_client(list_harness):
+    app = FastAPI()
+    app.dependency_overrides[endpoints.user_api_key_auth] = lambda: UserAPIKeyAuth(api_key="sk-test")
+    app.include_router(endpoints.router)
+    return TestClient(app)
+
+
+@pytest.mark.parametrize("path", ["/v1/batches", "/batches", "/openai/v1/batches"])
+@pytest.mark.parametrize("limit", [None, 1, 100], ids=["omitted", "minimum", "maximum"])
+def test_list_route_accepts_valid_limit_values(list_route_client, list_harness, path, limit):
+    params = {} if limit is None else {"limit": limit}
+
+    response = list_route_client.get(path, params=params)
+
+    assert response.status_code == 200, response.text
+    assert list_harness.litellm_alist.call_count == 1
+    assert list_harness.litellm_alist.call_args.kwargs["limit"] == limit
+    list_harness.router_alist.assert_not_called()
+
+
+@pytest.mark.parametrize("path", ["/v1/batches", "/batches", "/openai/v1/batches"])
+@pytest.mark.parametrize("limit", [0, -1, 101, 1000])
+def test_list_route_rejects_invalid_limit_values_without_downstream_calls(list_route_client, list_harness, path, limit):
+    response = list_route_client.get(path, params={"limit": limit})
+
+    assert response.status_code == 422, response.text
+    list_harness.litellm_alist.assert_not_called()
+    list_harness.router_alist.assert_not_called()
 
 
 # =========================================================================== #


### PR DESCRIPTION
## TLDR

Problem this solves:

- Batch list accepts unsupported `limit` values.
- Invalid values can reach batch-list processing.

How it solves it:

- Adds FastAPI-native bounds validation for `limit`.
- Keeps omitted, 1, and 100 requests unchanged.

## User Flow

Before: A client can receive a batch list for an unsupported limit.

1. They send `GET https://litellm-domain/v1/batches?limit=0`.
2. They observe HTTP 200 and a batch-list response.

After: The same client gets a validation response before processing.

1. They send `GET https://litellm-domain/v1/batches?limit=0`.
2. They observe FastAPI's native HTTP 422 response before batch processing.

## Relevant issues

Fixes #37149

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: the tests exercise the production batch router through FastAPI's TestClient. No live provider or database credentials were used.

### Before (973329e9864154d429a7d739fb6a552fe03a9b3e)

#### invalid limit

1. The base endpoint has no FastAPI bounds validation for `limit`, matching the behavior reported in #37149.
2. A live provider/database replay was not run.

### After (86ab312dbe64e3ad060a9dcf8f1a50f559bee328)

#### invalid limit

1. Run `uv run --no-sync pytest tests/test_litellm/proxy/batches_endpoints/test_endpoints.py -k 'list_route' -q`.
2. 21 tests pass: omitted, 1, and 100 forward; 0, -1, 101, and 1000 return FastAPI-native 422 across all three batch-list aliases, without downstream calls.
3. Run `uv run --no-sync pytest tests/test_litellm/proxy/batches_endpoints/test_endpoints.py -q`; 118 tests pass.

## Type

🐛 Bug Fix

## Caveats (if any)

- `make test-unit` exits 2 during collection on an existing duplicate `test_models.py` import-file-mismatch; 0 tests run.
- No live provider or database tests were run.
- Verified: `make lint`, `make format-check`, `make check-import-safety`, `make check-circular-imports`, and `git diff --check`.

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR