### PR TITLE
fix: derive DeepSeek prompt tokens from cache buckets

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1742,20 +1742,22 @@ class Usage(SafeAttributeModel, CompletionUsage):
             elif isinstance(prompt_tokens_details, PromptTokensDetailsWrapper):
                 _prompt_tokens_details = prompt_tokens_details
 
-        deepseek_cache_hit_tokens = _non_negative_token_count(params.get("prompt_cache_hit_tokens"))
-        deepseek_cache_miss_tokens = _non_negative_token_count(params.get("prompt_cache_miss_tokens"))
+        deepseek_cache_hit_tokens: Final = _non_negative_token_count(params.get("prompt_cache_hit_tokens"))
+        deepseek_cache_miss_tokens: Final = _non_negative_token_count(params.get("prompt_cache_miss_tokens"))
 
         ## DEEPSEEK MAPPING ##
         if deepseek_cache_hit_tokens is not None:
             if _prompt_tokens_details is None:
-                _prompt_tokens_details = PromptTokensDetailsWrapper(cached_tokens=deepseek_cache_hit_tokens)
+                _prompt_tokens_details = PromptTokensDetailsWrapper(
+                    cached_tokens=deepseek_cache_hit_tokens
+                )  # rebind-ok: builds prompt details from provider cache metadata
             else:
                 _prompt_tokens_details.cached_tokens = deepseek_cache_hit_tokens
 
-        if not prompt_tokens:
-            deepseek_prompt_tokens = (deepseek_cache_hit_tokens or 0) + (deepseek_cache_miss_tokens or 0)
-            if deepseek_prompt_tokens:
-                prompt_tokens = deepseek_prompt_tokens
+        deepseek_prompt_tokens: Final = (deepseek_cache_hit_tokens or 0) + (deepseek_cache_miss_tokens or 0)
+        effective_prompt_tokens: Final = (
+            deepseek_prompt_tokens if not prompt_tokens and deepseek_prompt_tokens else prompt_tokens or 0
+        )
 
         ## ANTHROPIC MAPPING ##
         if "cache_read_input_tokens" in params and isinstance(params["cache_read_input_tokens"], int):
@@ -1773,7 +1775,7 @@ class Usage(SafeAttributeModel, CompletionUsage):
                 _prompt_tokens_details.cache_write_tokens = params["cache_creation_input_tokens"]
 
         super().__init__(
-            prompt_tokens=prompt_tokens or 0,
+            prompt_tokens=effective_prompt_tokens,
             completion_tokens=completion_tokens or 0,
             total_tokens=total_tokens or 0,
             completion_tokens_details=_completion_tokens_details or None,
@@ -1801,8 +1803,8 @@ class Usage(SafeAttributeModel, CompletionUsage):
             self._cache_read_input_tokens = params["cache_read_input_tokens"]
 
         ## DEEPSEEK MAPPING ##
-        if "prompt_cache_hit_tokens" in params and isinstance(params["prompt_cache_hit_tokens"], int):
-            self._cache_read_input_tokens = params["prompt_cache_hit_tokens"]
+        if deepseek_cache_hit_tokens is not None:
+            self._cache_read_input_tokens = deepseek_cache_hit_tokens
 
         for k, v in params.items():
             setattr(self, k, v)

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1650,6 +1650,12 @@ class PromptTokensDetailsWrapper(
             del self.cache_creation_token_details
 
 
+def _non_negative_token_count(value: object) -> int | None:
+    if type(value) is int and value >= 0:
+        return value
+    return None
+
+
 class ServerToolUse(BaseModel):
     web_search_requests: int | None = None
     tool_search_requests: int | None = None
@@ -1736,12 +1742,20 @@ class Usage(SafeAttributeModel, CompletionUsage):
             elif isinstance(prompt_tokens_details, PromptTokensDetailsWrapper):
                 _prompt_tokens_details = prompt_tokens_details
 
+        deepseek_cache_hit_tokens = _non_negative_token_count(params.get("prompt_cache_hit_tokens"))
+        deepseek_cache_miss_tokens = _non_negative_token_count(params.get("prompt_cache_miss_tokens"))
+
         ## DEEPSEEK MAPPING ##
-        if "prompt_cache_hit_tokens" in params and isinstance(params["prompt_cache_hit_tokens"], int):
+        if deepseek_cache_hit_tokens is not None:
             if _prompt_tokens_details is None:
-                _prompt_tokens_details = PromptTokensDetailsWrapper(cached_tokens=params["prompt_cache_hit_tokens"])
+                _prompt_tokens_details = PromptTokensDetailsWrapper(cached_tokens=deepseek_cache_hit_tokens)
             else:
-                _prompt_tokens_details.cached_tokens = params["prompt_cache_hit_tokens"]
+                _prompt_tokens_details.cached_tokens = deepseek_cache_hit_tokens
+
+        if not prompt_tokens:
+            deepseek_prompt_tokens = (deepseek_cache_hit_tokens or 0) + (deepseek_cache_miss_tokens or 0)
+            if deepseek_prompt_tokens:
+                prompt_tokens = deepseek_prompt_tokens
 
         ## ANTHROPIC MAPPING ##
         if "cache_read_input_tokens" in params and isinstance(params["cache_read_input_tokens"], int):

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3330,6 +3330,61 @@ def test_extract_cache_creation_tokens_zero_when_missing():
     )
 
 
+def test_usage_maps_deepseek_cache_hit_and_miss_tokens():
+    usage = Usage(
+        completion_tokens=50,
+        prompt_cache_hit_tokens=75,
+        prompt_cache_miss_tokens=25,
+    )
+
+    assert usage.prompt_tokens == 100
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cached_tokens == 75
+    assert usage._cache_read_input_tokens == 75
+
+
+def test_usage_does_not_override_reported_prompt_tokens():
+    usage = Usage(
+        prompt_tokens=120,
+        completion_tokens=50,
+        prompt_cache_hit_tokens=75,
+        prompt_cache_miss_tokens=25,
+    )
+
+    assert usage.prompt_tokens == 120
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cached_tokens == 75
+
+
+def test_usage_ignores_malformed_deepseek_cache_bucket_tokens():
+    usage = Usage(
+        completion_tokens=50,
+        prompt_cache_hit_tokens="75",
+        prompt_cache_miss_tokens=True,
+    )
+
+    assert usage.prompt_tokens == 0
+    assert usage.prompt_tokens_details is None
+    assert usage._cache_read_input_tokens == 0
+
+
+def test_usage_preserves_cache_read_and_write_mappings():
+    usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=50,
+        cache_read_input_tokens=30,
+        cache_creation_input_tokens=10,
+    )
+
+    assert usage.prompt_tokens == 100
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cached_tokens == 30
+    assert usage.prompt_tokens_details.cache_write_tokens == 10
+    assert usage.prompt_tokens_details.cache_creation_tokens == 10
+    assert usage._cache_read_input_tokens == 30
+    assert usage._cache_creation_input_tokens == 10
+
+
 def test_custom_pricing_anthropic_style_cache_tokens_not_double_counted():
     """
     Anthropic providers report cache tokens at the top level of Usage, and

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3330,61 +3330,6 @@ def test_extract_cache_creation_tokens_zero_when_missing():
     )
 
 
-def test_usage_maps_deepseek_cache_hit_and_miss_tokens():
-    usage = Usage(
-        completion_tokens=50,
-        prompt_cache_hit_tokens=75,
-        prompt_cache_miss_tokens=25,
-    )
-
-    assert usage.prompt_tokens == 100
-    assert usage.prompt_tokens_details is not None
-    assert usage.prompt_tokens_details.cached_tokens == 75
-    assert usage._cache_read_input_tokens == 75
-
-
-def test_usage_does_not_override_reported_prompt_tokens():
-    usage = Usage(
-        prompt_tokens=120,
-        completion_tokens=50,
-        prompt_cache_hit_tokens=75,
-        prompt_cache_miss_tokens=25,
-    )
-
-    assert usage.prompt_tokens == 120
-    assert usage.prompt_tokens_details is not None
-    assert usage.prompt_tokens_details.cached_tokens == 75
-
-
-def test_usage_ignores_malformed_deepseek_cache_bucket_tokens():
-    usage = Usage(
-        completion_tokens=50,
-        prompt_cache_hit_tokens="75",
-        prompt_cache_miss_tokens=True,
-    )
-
-    assert usage.prompt_tokens == 0
-    assert usage.prompt_tokens_details is None
-    assert usage._cache_read_input_tokens == 0
-
-
-def test_usage_preserves_cache_read_and_write_mappings():
-    usage = Usage(
-        prompt_tokens=100,
-        completion_tokens=50,
-        cache_read_input_tokens=30,
-        cache_creation_input_tokens=10,
-    )
-
-    assert usage.prompt_tokens == 100
-    assert usage.prompt_tokens_details is not None
-    assert usage.prompt_tokens_details.cached_tokens == 30
-    assert usage.prompt_tokens_details.cache_write_tokens == 10
-    assert usage.prompt_tokens_details.cache_creation_tokens == 10
-    assert usage._cache_read_input_tokens == 30
-    assert usage._cache_creation_input_tokens == 10
-
-
 def test_custom_pricing_anthropic_style_cache_tokens_not_double_counted():
     """
     Anthropic providers report cache tokens at the top level of Usage, and

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -113,6 +113,69 @@ def test_usage_converts_server_tool_use_dict():
     assert round_trip.server_tool_use.tool_search_requests == 1
 
 
+def test_usage_maps_deepseek_cache_hit_and_miss_tokens():
+    from litellm.types.utils import Usage
+
+    usage = Usage(
+        completion_tokens=50,
+        prompt_cache_hit_tokens=75,
+        prompt_cache_miss_tokens=25,
+    )
+
+    assert usage.prompt_tokens == 100
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cached_tokens == 75
+    assert usage._cache_read_input_tokens == 75
+
+
+def test_usage_does_not_override_reported_prompt_tokens():
+    from litellm.types.utils import Usage
+
+    usage = Usage(
+        prompt_tokens=120,
+        completion_tokens=50,
+        prompt_cache_hit_tokens=75,
+        prompt_cache_miss_tokens=25,
+    )
+
+    assert usage.prompt_tokens == 120
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cached_tokens == 75
+
+
+def test_usage_ignores_malformed_deepseek_cache_bucket_tokens():
+    from litellm.types.utils import Usage
+
+    usage = Usage(
+        completion_tokens=50,
+        prompt_cache_hit_tokens=True,
+        prompt_cache_miss_tokens="25",
+    )
+
+    assert usage.prompt_tokens == 0
+    assert usage.prompt_tokens_details is None
+    assert usage._cache_read_input_tokens == 0
+
+
+def test_usage_preserves_cache_read_and_write_mappings():
+    from litellm.types.utils import Usage
+
+    usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=50,
+        cache_read_input_tokens=30,
+        cache_creation_input_tokens=10,
+    )
+
+    assert usage.prompt_tokens == 100
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cached_tokens == 30
+    assert usage.prompt_tokens_details.cache_write_tokens == 10
+    assert usage.prompt_tokens_details.cache_creation_tokens == 10
+    assert usage._cache_read_input_tokens == 30
+    assert usage._cache_creation_input_tokens == 10
+
+
 def test_usage_completion_tokens_details_text_tokens():
     from litellm.types.utils import Usage
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- DeepSeek cache buckets can leave prompt tokens at zero
- Downstream ledgers then miss the real prompt total

How it solves it:

- Derives prompt tokens from cache hit plus miss buckets
- Preserves positive provider-reported prompt token totals
- Rejects malformed cache bucket values

## User Flow

Before: a developer sees DeepSeek cache hits but a zero prompt total, so their usage ledger is incomplete

1. They send POST https://litellm-domain/v1/chat/completions to a DeepSeek-compatible model
2. The provider returns usage with `prompt_cache_hit_tokens=75` and `prompt_cache_miss_tokens=25`, without `prompt_tokens`
3. Their app receives usage where `prompt_tokens` is `0` and cached tokens are `75`

After: the same response carries the derived prompt total, so the ledger can use provider truth

1. They send POST https://litellm-domain/v1/chat/completions to the same DeepSeek-compatible model
2. The provider returns the same usage with `prompt_cache_hit_tokens=75` and `prompt_cache_miss_tokens=25`, without `prompt_tokens`
3. Their app receives usage where `prompt_tokens` is `100` and cached tokens are `75`

## Relevant issues

Related downstream review: OpenHands/software-agent-sdk#4490

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Shared setup: local source checkout, no provider credentials needed because this bug is in usage normalization after response parsing

### Before (973329e)

1. Command: `/Users/tanishakatara/gtm-prs/litellm-shallow/.venv/bin/python -c "from litellm.types.utils import Usage; usage=Usage(completion_tokens=50, prompt_cache_hit_tokens=75, prompt_cache_miss_tokens=25); print({'prompt_tokens': usage.prompt_tokens, 'cached_tokens': usage.prompt_tokens_details.cached_tokens if usage.prompt_tokens_details else None})"`
2. Observed output: `{'prompt_tokens': 0, 'cached_tokens': 75}`

### After (9cc265d)

1. Command: `/Users/tanishakatara/gtm-prs/litellm-shallow/.venv/bin/python -c "from litellm.types.utils import Usage; usage=Usage(completion_tokens=50, prompt_cache_hit_tokens=75, prompt_cache_miss_tokens=25); print({'prompt_tokens': usage.prompt_tokens, 'cached_tokens': usage.prompt_tokens_details.cached_tokens if usage.prompt_tokens_details else None})"`
2. Observed output: `{'prompt_tokens': 100, 'cached_tokens': 75}`

## Type

Bug Fix

## Caveats (if any)

- Full CI will run on GitHub
- File-level test lint has pre-existing print warnings

## QA runbook


### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR