### PR TITLE
fix: Anthropic /v1/messages pass-through drops input_image detail, mislabels thinking, drops input_text, ignores chat-completions opt-out

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -346,6 +346,9 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         if custom_llm_provider != "openai":
             return
 
+        if litellm.use_chat_completions_url_for_anthropic_messages:
+            return
+
         if not isinstance(thinking, dict) or thinking.get("type") != "enabled":
             return
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -13,6 +13,7 @@ from litellm.llms.anthropic.experimental_pass_through.utils import (
 OPENAI_MAX_TOOL_NAME_LENGTH: Final = 64
 TOOL_NAME_HASH_LENGTH: Final = 8
 TOOL_NAME_PREFIX_LENGTH: Final = OPENAI_MAX_TOOL_NAME_LENGTH - TOOL_NAME_HASH_LENGTH - 1  # 55
+TEXT_BLOCK_TYPES: Final = ("text", "input_text")
 
 
 def truncate_tool_name(name: str) -> str:
@@ -364,7 +365,7 @@ class LiteLLMAnthropicMessagesAdapter:
                     user_message = ChatCompletionUserMessage(role="user", content=message_content)
                 elif message_content and isinstance(message_content, list):
                     for content in message_content:
-                        if content.get("type") == "text":
+                        if content.get("type") in TEXT_BLOCK_TYPES:
                             text_obj = ChatCompletionTextObject(type="text", text=content.get("text", ""))
                             self._add_cache_control_if_applicable(content, text_obj, model)
                             new_user_content_list.append(text_obj)
@@ -424,7 +425,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                         self._add_cache_control_if_applicable(content, tool_result, model)
                                         tool_message_list.append(tool_result)
                                     elif isinstance(c, dict):
-                                        if c.get("type") == "text":
+                                        if c.get("type") in TEXT_BLOCK_TYPES:
                                             tool_result = ChatCompletionToolMessage(
                                                 role="tool",
                                                 tool_call_id=content.get("tool_use_id", ""),
@@ -453,7 +454,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                         if isinstance(c, str):
                                             combined_content_parts.append(ChatCompletionTextObject(type="text", text=c))
                                         elif isinstance(c, dict):
-                                            if c.get("type") == "text":
+                                            if c.get("type") in TEXT_BLOCK_TYPES:
                                                 combined_content_parts.append(
                                                     ChatCompletionTextObject(
                                                         type="text",
@@ -497,7 +498,7 @@ class LiteLLMAnthropicMessagesAdapter:
                         if isinstance(content, str):
                             assistant_message_str = str(content)
                         elif isinstance(content, dict):
-                            if content.get("type") == "text":
+                            if content.get("type") in TEXT_BLOCK_TYPES:
                                 text_block: dict[str, Any] = {
                                     "type": "text",
                                     "text": content.get("text", ""),
@@ -856,7 +857,7 @@ class LiteLLMAnthropicMessagesAdapter:
             return None
         text_parts: Final[list[ChatCompletionTextObject]] = []  # mutable-ok: API message payload
         for block in content:
-            if not isinstance(block, dict) or block.get("type") != "text":  # pyright: ignore[reportUnnecessaryIsInstance]  # untrusted client payload
+            if not isinstance(block, dict) or block.get("type") not in TEXT_BLOCK_TYPES:  # pyright: ignore[reportUnnecessaryIsInstance]  # untrusted client payload
                 continue
             text = block.get("text")
             if not text:
@@ -888,7 +889,7 @@ class LiteLLMAnthropicMessagesAdapter:
             openai_system_content: Final[list[dict[str, Any]]] = []
             model_name: Final = anthropic_message_request.get("model", "")
             for block in system_content:
-                if isinstance(block, dict) and block.get("type") == "text":
+                if isinstance(block, dict) and block.get("type") in TEXT_BLOCK_TYPES:
                     text_block: dict[str, Any] = {
                         "type": "text",
                         "text": block.get("text", ""),

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -150,7 +150,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                         elif btype == "image":
                             url = self._translate_anthropic_image_source_to_url(cast(dict, block.get("source", {})))
                             if url:
-                                user_parts.append({"type": "input_image", "image_url": url})
+                                user_parts.append({"type": "input_image", "image_url": url, "detail": "auto"})
                         elif btype == "tool_result":
                             tool_use_id = block.get("tool_use_id", "")
                             inner = block.get("content")
@@ -176,7 +176,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                         else TOOL_RESULT_IMAGE_PLACEHOLDER
                                     )
                                     tool_image_parts.extend(
-                                        {"type": "input_image", "image_url": url}  # mutable-ok: json content part
+                                        {"type": "input_image", "image_url": url, "detail": "auto"}  # mutable-ok: json content part
                                         for url in image_urls
                                     )
                             else:
@@ -240,7 +240,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                         elif btype == "thinking":
                             thinking_text = block.get("thinking", "")
                             if thinking_text:
-                                asst_parts.append({"type": "output_text", "text": thinking_text})
+                                input_items.append({"type": "reasoning", "id": block.get("signature") or f"reasoning_{len(input_items)}", "summary": [{"type": "summary_text", "text": thinking_text}]})
                     if asst_parts:
                         input_items.append(
                             {

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -162,7 +162,9 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                 output_text = inner
                             elif isinstance(inner, list):
                                 parts = [
-                                    c.get("text", "") for c in inner if isinstance(c, dict) and c.get("type") in TEXT_BLOCK_TYPES
+                                    c.get("text", "")
+                                    for c in inner
+                                    if isinstance(c, dict) and c.get("type") in TEXT_BLOCK_TYPES
                                 ]
                                 output_text = "\n".join(parts)
                                 image_candidates = tuple(
@@ -178,7 +180,11 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                         else TOOL_RESULT_IMAGE_PLACEHOLDER
                                     )
                                     tool_image_parts.extend(
-                                        {"type": "input_image", "image_url": url, "detail": "auto"}  # mutable-ok: json content part
+                                        {  # mutable-ok: json content part
+                                            "type": "input_image",
+                                            "image_url": url,
+                                            "detail": "auto",
+                                        }
                                         for url in image_urls
                                     )
                             else:
@@ -242,7 +248,13 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                         elif btype == "thinking":
                             thinking_text = block.get("thinking", "")
                             if thinking_text:
-                                input_items.append({"type": "reasoning", "id": block.get("signature") or f"reasoning_{len(input_items)}", "summary": [{"type": "summary_text", "text": thinking_text}]})
+                                input_items.append(
+                                    {
+                                        "type": "reasoning",
+                                        "id": block.get("signature") or f"reasoning_{len(input_items)}",
+                                        "summary": [{"type": "summary_text", "text": thinking_text}],
+                                    }
+                                )
                     if asst_parts:
                         input_items.append(
                             {

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -36,6 +36,8 @@ from litellm.types.llms.anthropic_messages.anthropic_response import (
 )
 from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
 
+TEXT_BLOCK_TYPES: Final = ("text", "input_text")
+
 
 class LiteLLMAnthropicToResponsesAPIAdapter:
     """
@@ -93,7 +95,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
         return [  # mutable-ok: API message payload
             {"type": "input_text", "text": text}  # mutable-ok: API message payload
             for block in content
-            if isinstance(block, dict) and block.get("type") == "text" and (text := block.get("text"))  # pyright: ignore[reportUnnecessaryIsInstance]  # untrusted client payload
+            if isinstance(block, dict) and block.get("type") in TEXT_BLOCK_TYPES and (text := block.get("text"))  # pyright: ignore[reportUnnecessaryIsInstance]  # untrusted client payload
         ]
 
     def translate_messages_to_responses_input(
@@ -145,7 +147,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                         if not isinstance(block, dict):
                             continue
                         btype = block.get("type")
-                        if btype == "text":
+                        if btype in TEXT_BLOCK_TYPES:
                             user_parts.append({"type": "input_text", "text": block.get("text", "")})
                         elif btype == "image":
                             url = self._translate_anthropic_image_source_to_url(cast(dict, block.get("source", {})))
@@ -160,7 +162,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                 output_text = inner
                             elif isinstance(inner, list):
                                 parts = [
-                                    c.get("text", "") for c in inner if isinstance(c, dict) and c.get("type") == "text"
+                                    c.get("text", "") for c in inner if isinstance(c, dict) and c.get("type") in TEXT_BLOCK_TYPES
                                 ]
                                 output_text = "\n".join(parts)
                                 image_candidates = tuple(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -417,10 +417,52 @@ def test_translate_anthropic_messages_to_openai_tool_message_placement():
     ), "Tool message should be placed before user message"
 
 
+def test_translate_anthropic_messages_to_openai_accepts_input_text_blocks():
+    """Claude Code / Claude Agent SDK send `input_text` blocks instead of `text`;
+    these must translate the same as `text` blocks instead of being silently dropped."""
+
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[{"type": "input_text", "text": "What's the weather in Boston?"}],
+        ),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[{"type": "input_text", "text": "Let me check."}],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_01234",
+                    "content": [{"type": "input_text", "text": "Sunny, 75°F"}],
+                }
+            ],
+        ),
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
+
+    assert result[0]["content"][0]["type"] == "text"
+    assert result[0]["content"][0]["text"] == "What's the weather in Boston?"
+    # A single-block assistant message collapses to a plain string; only assert the text survived.
+    assistant_content = result[1]["content"]
+    assistant_text = assistant_content[0]["text"] if isinstance(assistant_content, list) else assistant_content
+    assert assistant_text == "Let me check."
+    tool_message = next(msg for msg in result if msg.get("role") == "tool")
+    assert tool_message["content"] == "Sunny, 75°F"
+
+
 @pytest.mark.parametrize(
     ("system_content", "expected_content"),
     [
         ("Use the corrected result.", "Use the corrected result."),
+        (
+            [{"type": "input_text", "text": "Use the corrected result."}],
+            [{"type": "text", "text": "Use the corrected result."}],
+        ),
         (
             [{"type": "text", "text": "Use the corrected result."}],
             [{"type": "text", "text": "Use the corrected result."}],

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_output_config_passthrough.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_output_config_passthrough.py
@@ -38,6 +38,7 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../.."))
 )
 
+import litellm
 from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
     ANTHROPIC_ONLY_REQUEST_KEYS,
     LiteLLMMessagesToCompletionTransformationHandler,
@@ -230,3 +231,35 @@ class TestEmptyExtraKwargsPath:
         # dict-like result.
         completion_kwargs = result[0] if isinstance(result, tuple) else result
         assert isinstance(completion_kwargs, dict)
+
+
+class TestThinkingAutoRoutingRespectsChatCompletionsOptOut:
+    """When ``LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES`` is set,
+    thinking requests to OpenAI models must stay on Chat Completions instead of
+    being auto-routed to the Responses API via the ``responses/`` prefix."""
+
+    def setup_method(self):
+        self._original_flag = litellm.use_chat_completions_url_for_anthropic_messages
+
+    def teardown_method(self):
+        litellm.use_chat_completions_url_for_anthropic_messages = self._original_flag
+
+    def test_prefix_not_added_when_opted_out(self):
+        litellm.use_chat_completions_url_for_anthropic_messages = True
+        completion_kwargs = {"model": "gpt-5.1", "custom_llm_provider": "openai"}
+
+        LiteLLMMessagesToCompletionTransformationHandler._route_openai_thinking_to_responses_api_if_needed(
+            completion_kwargs, thinking={"type": "enabled"}
+        )
+
+        assert completion_kwargs["model"] == "gpt-5.1"
+
+    def test_prefix_still_added_by_default(self):
+        litellm.use_chat_completions_url_for_anthropic_messages = False
+        completion_kwargs = {"model": "gpt-5.1", "custom_llm_provider": "openai"}
+
+        LiteLLMMessagesToCompletionTransformationHandler._route_openai_thinking_to_responses_api_if_needed(
+            completion_kwargs, thinking={"type": "enabled"}
+        )
+
+        assert completion_kwargs["model"] == "responses/gpt-5.1"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -207,6 +207,24 @@ class TestTranslateMessagesToResponsesInput:
             }
         ]
 
+    def test_user_input_text_block(self):
+        """Claude Code / Claude Agent SDK send `input_text` blocks; these must
+        translate the same as `text` blocks instead of being silently dropped."""
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "What is 2+2?"}],
+            }
+        ]
+        result = _translate_messages(messages)
+        assert result == [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "What is 2+2?"}],
+            }
+        ]
+
     def test_user_multiple_text_blocks(self):
         """Multiple text blocks in a user message are all converted."""
         messages = [
@@ -289,6 +307,19 @@ class TestTranslateMessagesToResponsesInput:
             },
         ]
 
+    def test_midturn_system_correction_accepts_input_text_blocks(self):
+        """System content blocks using `input_text` translate the same as `text`."""
+        messages = [
+            {"role": "system", "content": [{"type": "input_text", "text": "Use the corrected result."}]},
+            {"role": "user", "content": "Continue."},
+        ]
+        result = _translate_messages(messages)
+        assert result[0] == {
+            "type": "message",
+            "role": "system",
+            "content": [{"type": "input_text", "text": "Use the corrected result."}],
+        }
+
     def test_midturn_system_correction_keeps_multiple_text_blocks(self):
         messages = [
             {
@@ -344,7 +375,9 @@ class TestTranslateMessagesToResponsesInput:
         ]
         result = _translate_messages(messages)
         assert len(result) == 1
-        assert result[0]["content"] == [{"type": "input_image", "image_url": "data:image/png;base64,abc123"}]
+        assert result[0]["content"] == [
+            {"type": "input_image", "image_url": "data:image/png;base64,abc123", "detail": "auto"}
+        ]
 
     def test_user_url_image(self):
         """User message with URL image source becomes input_image with the URL."""
@@ -360,7 +393,9 @@ class TestTranslateMessagesToResponsesInput:
             }
         ]
         result = _translate_messages(messages)
-        assert result[0]["content"] == [{"type": "input_image", "image_url": "https://example.com/img.jpg"}]
+        assert result[0]["content"] == [
+            {"type": "input_image", "image_url": "https://example.com/img.jpg", "detail": "auto"}
+        ]
 
     def test_user_base64_image_empty_data_skipped(self):
         """Base64 image with empty data is skipped (no URL can be formed)."""
@@ -418,6 +453,26 @@ class TestTranslateMessagesToResponsesInput:
                         "content": [
                             {"type": "text", "text": "Line 1"},
                             {"type": "text", "text": "Line 2"},
+                        ],
+                    }
+                ],
+            }
+        ]
+        result = _translate_messages(messages)
+        assert result[0]["output"] == "Line 1\nLine 2"
+
+    def test_user_tool_result_input_text_list_content(self):
+        """tool_result content blocks using `input_text` are joined the same as `text`."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_xyz",
+                        "content": [
+                            {"type": "input_text", "text": "Line 1"},
+                            {"type": "input_text", "text": "Line 2"},
                         ],
                     }
                 ],
@@ -485,8 +540,9 @@ class TestTranslateMessagesToResponsesInput:
             }
         ]
 
-    def test_assistant_thinking_block_becomes_output_text(self):
-        """Assistant thinking block text is included as output_text."""
+    def test_assistant_thinking_block_becomes_reasoning_item(self):
+        """Assistant thinking block becomes a top-level reasoning item, not output_text,
+        so the model can tell its own prior reasoning apart from prior final answers."""
         messages = [
             {
                 "role": "assistant",
@@ -494,7 +550,26 @@ class TestTranslateMessagesToResponsesInput:
             }
         ]
         result = _translate_messages(messages)
-        assert result[0]["content"] == [{"type": "output_text", "text": "Let me reason step by step."}]
+        assert result == [
+            {
+                "type": "reasoning",
+                "id": "reasoning_0",
+                "summary": [{"type": "summary_text", "text": "Let me reason step by step."}],
+            }
+        ]
+
+    def test_assistant_thinking_block_uses_signature_as_id(self):
+        """A thinking block's signature, when present, becomes the reasoning item id."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Step by step.", "signature": "sig_abc123"}
+                ],
+            }
+        ]
+        result = _translate_messages(messages)
+        assert result[0]["id"] == "sig_abc123"
 
     def test_assistant_empty_thinking_block_skipped(self):
         """Assistant thinking block with empty thinking text is skipped."""
@@ -561,6 +636,7 @@ class TestTranslateMessagesToResponsesInput:
         assert result[0]["content"][1] == {
             "type": "input_image",
             "image_url": "https://example.com/cat.jpg",
+            "detail": "auto",
         }
 
     def test_unknown_image_source_type_skipped(self):
@@ -1315,7 +1391,7 @@ class TestToolResultImages:
 
         assert self._image_message(items)["content"] == [
             {"type": "input_text", "text": TOOL_RESULT_IMAGE_BOUNDARY},
-            {"type": "input_image", "image_url": self.DATA_URI},
+            {"type": "input_image", "image_url": self.DATA_URI, "detail": "auto"},
         ]
 
     def test_sibling_user_blocks_stay_out_of_boundary_message(self):
@@ -1328,7 +1404,7 @@ class TestToolResultImages:
 
         assert self._image_message(items)["content"] == [
             {"type": "input_text", "text": TOOL_RESULT_IMAGE_BOUNDARY},
-            {"type": "input_image", "image_url": self.DATA_URI},
+            {"type": "input_image", "image_url": self.DATA_URI, "detail": "auto"},
         ]
         assert any(
             part == {"type": "input_text", "text": "what changed?"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Images sent through the Responses API bridge get rejected with a masked 400
- Replayed `thinking` blocks lose their reasoning type on the next turn
- Claude Code / Claude Agent SDK `input_text` blocks are silently dropped
- `LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES` is ignored by the thinking auto-router

How it solves it:

- Add the required `detail` field to every `input_image` part built by the adapter
- Emit a proper `reasoning` item for `thinking` blocks instead of folding them into `output_text`
- Accept `input_text` alongside `text` everywhere both adapters check content-block type
- Check the opt-out flag before auto-adding the `responses/` prefix for thinking requests

## Relevant issues

Fixes #37175
Related to #23841 (this PR fixes 3 of its 5 bugs; see Caveats)

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem area (this one file family)
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Details

In `translate_messages_to_responses_input` (Anthropic `/v1/messages` -> Responses API request translation):

1. **`input_image` missing required `detail` field.** Both direct user images and images embedded in `tool_result` blocks were built without `detail` on `ResponseInputImageParam`. The Responses API requires this field; without it the backend rejects the whole request with a large Pydantic union-validation error, which litellm's own `MaskedHTTPStatusError` then hides from its logs. Confirmed by reproducing the identical error directly against a self-hosted vLLM `/v1/responses` backend with the field missing, and confirmed fixed by adding it.

2. **`thinking` blocks mislabeled as `output_text`.** Assistant `thinking` content was folded into a plain `output_text` content part instead of becoming a proper top-level `reasoning` item. On multi-turn replay this means the model can no longer distinguish its own prior reasoning from prior final answers. The response-side translation in this same file already builds real `ResponseReasoningItem` objects (see `translate_response`); this change brings the request-side history-replay path in line with that.

3. **`input_text` blocks silently dropped.** Claude Code / Claude Agent SDK send content blocks typed `input_text` instead of `text`. Both `adapters/transformation.py` (Chat Completions path) and `responses_adapters/transformation.py` (Responses API path) only matched on `text`, in six and three places respectively, so these blocks vanished from user/assistant/system/tool_result content, producing empty input and a downstream 422. Both files now accept either type via a shared `TEXT_BLOCK_TYPES` tuple.

4. **Chat-completions opt-out ignored by thinking auto-routing.** When `LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES` is set, `thinking` requests to OpenAI models were still auto-routed to the Responses API via the `responses/` prefix. `_route_openai_thinking_to_responses_api_if_needed` now checks the flag first.

## Caveats (if any)

- #23841 also lists two more spots that should check the opt-out flag: `responses_api_bridge_check` in `main.py` and `should_use_token_counting_api`. Both are shared by every OpenAI completion/token-counting call, not just this Anthropic pass-through, so checking the flag there would suppress unrelated Responses API routing for direct OpenAI users. #23841's own PR (#23844) added that check and reverted it after review for this exact reason. Left unfixed pending a way to scope the check to requests that actually came from `/v1/messages`.
- No live-proxy / real-API-key run was available in this environment for an end-to-end proof; verification here is `python3 -m py_compile` plus the full targeted pytest suite (242 passed) covering both adapters and the routing helper, including regression tests for all four fixes above.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR