### PR TITLE
fix(model-prices): declare Azure audio capabilities

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4828,6 +4828,8 @@
             "text",
             "audio"
         ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
         "supports_function_calling": true,
         "supports_native_streaming": true,
         "supports_parallel_function_calling": true,
@@ -4860,6 +4862,8 @@
             "text",
             "audio"
         ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
         "supports_function_calling": true,
         "supports_native_streaming": true,
         "supports_parallel_function_calling": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4828,6 +4828,8 @@
             "text",
             "audio"
         ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
         "supports_function_calling": true,
         "supports_native_streaming": true,
         "supports_parallel_function_calling": true,
@@ -4860,6 +4862,8 @@
             "text",
             "audio"
         ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
         "supports_function_calling": true,
         "supports_native_streaming": true,
         "supports_parallel_function_calling": true,

--- a/tests/test_litellm/test_model_prices_schema.py
+++ b/tests/test_litellm/test_model_prices_schema.py
@@ -11,7 +11,14 @@ import pytest
 REPO_ROOT = Path(__file__).parents[2]
 GENERATOR_PATH = REPO_ROOT / "ci_cd" / "generate_model_prices_schema.py"
 PRICES_PATH = REPO_ROOT / "model_prices_and_context_window.json"
+BACKUP_PRICES_PATH = (
+    REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json"
+)
 SCHEMA_PATH = REPO_ROOT / "model_prices_and_context_window.schema.json"
+AZURE_AUDIO_MODELS = (
+    "azure/gpt-audio-1.5-2026-02-23",
+    "azure/gpt-audio-mini-2025-10-06",
+)
 
 
 def build_validator(schema: dict) -> jsonschema.Draft202012Validator:
@@ -34,6 +41,20 @@ def committed_schema() -> dict:
 @pytest.fixture(scope="module")
 def prices() -> dict:
     return json.loads(PRICES_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def backup_prices() -> dict:
+    return json.loads(BACKUP_PRICES_PATH.read_text())
+
+
+@pytest.mark.parametrize("model", AZURE_AUDIO_MODELS)
+def test_azure_audio_models_support_audio_input_and_output(
+    prices: dict, backup_prices: dict, model: str
+):
+    assert prices[model]["supports_audio_input"] is True
+    assert prices[model]["supports_audio_output"] is True
+    assert backup_prices[model] == prices[model]
 
 
 def test_committed_schema_matches_generator_output(prices: dict, committed_schema: dict):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Dated Azure audio aliases omit capability flags

How it solves it:

- Declares both audio directions in shipped model metadata
- Verifies root and bundled maps stay equivalent

## User Flow

Before: a developer selecting either dated Azure audio model sees incomplete capability metadata

1. They configure `azure/gpt-audio-1.5-2026-02-23` or `azure/gpt-audio-mini-2025-10-06`
2. Their integration inspects the published capabilities before allowing audio requests
3. It sees audio modalities but no explicit input or output support flag

After: the same developer sees explicit, complete capability metadata

1. They configure the same dated Azure audio model
2. Their integration inspects the published capabilities before allowing audio requests
3. It sees audio modalities plus explicit input and output support flags

## Relevant issues

Fixes #37169
Fixes #37170

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a static shipped-metadata correction; it does not change an HTTP handler or provider request path.

### Before (`973329e9864154d429a7d739fb6a552fe03a9b3e`)

1. Inspect the canonical and bundled entries for both dated Azure audio models
2. Each entry lacks both explicit audio capability flags

### After (`fa720894188d67a4d9caacd023c24d56bd22c221`)

1. Run the focused model-price schema test in `tests/test_litellm/test_model_prices_schema.py`
2. The focused regression passes 21 tests and checks both flags plus root/bundled entry parity

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

- Provider-backed validation remains for repository CI

### Final Attestation

- [x] The regression checks both corrected aliases and map parity
