### PR TITLE
fix: expose CLI SSO token expiry

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -48,6 +48,7 @@ from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
 from litellm.caching.dual_cache import DualCache
 from litellm.constants import (
+    CLI_JWT_EXPIRATION_HOURS,
     CLI_SSO_CLAIM_MAP,
     CLI_SSO_CLAIM_MAX_SCALAR_LENGTH,
     CLI_SSO_SESSION_CACHE_KEY_PREFIX,
@@ -2512,6 +2513,7 @@ async def cli_poll_key(
             poll_response = {
                 "status": "ready",
                 "key": jwt_token,
+                "expires_in": CLI_JWT_EXPIRATION_HOURS * 3600,
                 "user_id": user_id,
                 "team_id": team_id,
                 "teams": user_teams,

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -16,6 +16,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 import litellm
+from litellm.constants import CLI_JWT_EXPIRATION_HOURS
 from litellm.proxy._types import LiteLLM_UserTable, NewUserResponse
 from litellm.proxy.auth.handle_jwt import JWTHandler
 from litellm.proxy.management_endpoints.sso import CustomMicrosoftSSO
@@ -3244,6 +3245,7 @@ class TestCLIKeyRegenerationFlow:
             assert result["user_id"] == "test-user-789"
             assert result["team_id"] == selected_team
             assert result["teams"] == ["team-a", "team-b", "team-c"]
+            assert result["expires_in"] == CLI_JWT_EXPIRATION_HOURS * 3600
 
             # Verify JWT was generated with correct team and no budget cap
             # (team lookup failed, but team_id is set, so fallback cap must not apply)


### PR DESCRIPTION
## TLDR

Return the configured CLI JWT lifetime as `expires_in` when CLI SSO polling succeeds.

## Type

- [x] Bug fix

## Details

The proxy already uses `CLI_JWT_EXPIRATION_HOURS` when minting the CLI JWT. The successful token-bearing poll response now exposes the same lifetime in seconds so clients can persist the credential with the correct expiry.

Pending and error responses are unchanged.

## Testing

- focused CLI key-regeneration poll test: 1 passed, 243 deselected
- `ruff check litellm/proxy/management_endpoints/ui_sso.py`
- `git diff --check upstream/litellm_internal_staging...HEAD`

The focused endpoint test asserts that a successful response contains `expires_in == CLI_JWT_EXPIRATION_HOURS * 3600`.
