### PR TITLE
fix: let s3_bucket_name reach litellm_params

### DIFF
--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -35,6 +35,7 @@ OPTIONAL_KWARGS_KEYS: Final = (
             "azure_scope",
             "timeout",
             "gcs_bucket_name",
+            "s3_bucket_name",
             "bucket_name",
             "vertex_credentials",
             "vertex_project",

--- a/tests/test_litellm/litellm_core_utils/test_get_litellm_params.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_litellm_params.py
@@ -73,6 +73,17 @@ class TestGetLitellmParamsKwargsExtraction:
         for key in _OPTIONAL_KWARGS_KEYS:
             assert result[key] == f"val_{key}"
 
+    def test_s3_bucket_name_survives_extraction(self):
+        """s3_bucket_name reaches litellm_params, like its gcs_bucket_name counterpart.
+
+        Bedrock file retrieval resolves the bucket from litellm_params or the
+        AWS_S3_BUCKET_NAME environment variable. Dropping the key here left the
+        environment variable as the only way to configure it.
+        """
+        result = get_litellm_params(s3_bucket_name="my-bucket", gcs_bucket_name="my-gcs-bucket")
+        assert result["s3_bucket_name"] == "my-bucket"
+        assert result["gcs_bucket_name"] == "my-gcs-bucket"
+
 
 class TestGetLitellmParamsBaseModel:
     """Verify base_model resolution precedence."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- `s3_bucket_name` in a model's `litellm_params` is silently dropped
- Bedrock batch output cannot be downloaded without an env var
- `gcs_bucket_name` works, so Vertex users never hit this

How it solves it:

- Adds `s3_bucket_name` to `OPTIONAL_KWARGS_KEYS`
- One-line change, plus a regression test

## User Flow

Before: someone running Claude batch jobs on Bedrock configures the bucket on the model, submits a job that completes, and then cannot fetch the results

1. They set `s3_bucket_name` on their Bedrock deployment in `config.yaml` and start the proxy with no `AWS_S3_BUCKET_NAME` in the environment
2. They `POST /v1/files` with `purpose=batch` and a JSONL of requests, and get a file ID back
3. They `POST /v1/batches` with that file ID, and get a batch ID back
4. They poll `GET /v1/batches/{id}` until it reports `completed`, with an empty failure message and no error file
5. They `GET /v1/files/{output_file_id}/content` and get `500 {"error":{"message":"S3 bucket_name is required. Set 's3_bucket_name' in proxy config or AWS_S3_BUCKET_NAME for Bedrock file content retrieval."}}`
6. The results are unreachable through the gateway even though the job succeeded and was billed, and the only way out is to restart the proxy with the environment variable set

After: the same configuration works, and the results come back

1. They set `s3_bucket_name` on their Bedrock deployment in `config.yaml` and start the proxy with no `AWS_S3_BUCKET_NAME` in the environment
2. They `POST /v1/files` with `purpose=batch` and a JSONL of requests, and get a file ID back
3. They `POST /v1/batches` with that file ID, and get a batch ID back
4. They poll `GET /v1/batches/{id}` until it reports `completed`, with an empty failure message and no error file
5. They `GET /v1/files/{output_file_id}/content` and get `200` with one JSONL line per record
6. They read the results, matching each line back to their input by ID

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Captured against a deployed proxy on `v1.91.3`, which carries the same allowlist as the merge base, rather than against the two commit hashes. The reproduction is a real Bedrock batch job in `eu-west-1` billed to a real account, and the download is the exact call an end user makes. A run at the merge base and at the PR tip is still worth doing before merge; I could not stand up managed files locally because that path needs a database and the migration step did not complete under emulation on my machine.

Shared setup: one Bedrock deployment whose `litellm_params` carry `model`, `aws_access_key_id`, `aws_secret_access_key`, `aws_region_name` and `s3_bucket_name`, with `AWS_S3_BUCKET_NAME` absent from the process environment. Input is a 100 record JSONL, which is Bedrock's minimum.

### Before (allowlist without `s3_bucket_name`)

1. Upload the input

   ```
   POST /v1/files   purpose=batch, target_model_names=bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0
   200   status=uploaded
   ```

2. Create the batch

   ```
   POST /v1/batches
   200   status=validating
   ```

3. Poll until terminal

   ```
   GET /v1/batches/{id}
   200   status=completed   failure_message ''   error_file_id null
   job: arn:aws:bedrock:eu-west-1:...:model-invocation-job/kpiid5uv6b9l
   ```

4. Download the output, which is where it breaks

   ```
   GET /v1/files/{output_file_id}/content
   500 {"error":{"message":"S3 bucket_name is required. Set 's3_bucket_name' in proxy
        config or AWS_S3_BUCKET_NAME for Bedrock file content retrieval.","code":"500"}}
   ```

5. Repeat step 4 passing the model explicitly, since a caller would try that next, and get the same result

   ```
   GET /v1/files/{output_file_id}/content?model=bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0
   500   same error
   GET /v1/files/{output_file_id}/content    with header x-litellm-model
   500   same error
   ```

### After (`070320e94c`, and equivalently with the env var set)

1. Upload the input

   ```
   POST /v1/files
   200   status=uploaded
   ```

2. Create the batch

   ```
   POST /v1/batches
   200   status=validating
   ```

3. Poll until terminal

   ```
   GET /v1/batches/{id}
   200   status=completed   failure_message ''   error_file_id null
   ```

4. Download the output

   ```
   GET /v1/files/{output_file_id}/content
   200   59400 bytes, 100 JSONL records
   ```

5. Confirm every submitted record came back, keyed by ID

   ```
   matched 100/100
   ticket-0000 -> DELIVERY
   ticket-0001 -> BILLING
   ticket-0002 -> PROMO
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

- `s3_region_name` is likely dropped the same way, untested
- Proof captured on `v1.91.3`, not at the two hashes
