### PR TITLE
feat(proxy): add max_file_size_mb to size-limit file uploads separately

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2416,6 +2416,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="max request size in MB, if a request is larger than this size it will be rejected",
     )
+    max_file_size_mb: int | None = Field(
+        None,
+        description="max size in MB for file uploads to /v1/files, overriding max_request_size_mb on that route so batch input files are not capped by the global request limit. Falls back to max_request_size_mb when unset",
+    )
     max_response_size_mb: int | None = Field(
         None,
         description="max response size in MB, if a response is larger than this size it will be rejected",

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -22,6 +22,7 @@ from litellm.litellm_core_utils.url_utils import (
 )
 from litellm.proxy._types import *
 from litellm.proxy.common_utils.http_parsing_utils import extract_nested_form_metadata
+from litellm.proxy.common_utils.request_route_scoping import strip_root_path
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_ENDPOINT_MARKER,
 )
@@ -518,7 +519,13 @@ async def pre_db_read_auth_checks(
     from litellm.proxy.proxy_server import general_settings, llm_router, premium_user
 
     # Check 1. request size
-    await check_if_request_size_is_safe(request=request)
+    await check_if_request_size_is_safe(
+        request=request,
+        route=route,
+        max_request_size_mb=general_settings.get("max_request_size_mb", None),
+        max_file_size_mb=general_settings.get("max_file_size_mb", None),
+        is_premium_user=premium_user is True,
+    )
 
     # Check 2. Request body is safe
     is_request_body_safe(
@@ -624,17 +631,10 @@ def get_request_route(request: Request) -> str:
         if not isinstance(scope, dict):
             return str(request.url.path)
         raw_path: Final[str] = str(scope.get("path", request.url.path))
-        root_path: Final[str] = str(scope.get("app_root_path", scope.get("root_path", ""))).rstrip("/")
+        root_path: Final[str] = str(scope.get("app_root_path", scope.get("root_path", "")))
         if not isinstance(raw_path, str):
             return str(request.url.path)
-        # Strip root_path only when it matches whole path segments — guarding
-        # against sibling paths like "/apifoo" being truncated under
-        # root_path="/api". Trailing slashes on root_path are stripped above,
-        # so bare "/" or "/prefix/" still leave the leading "/" intact.
-        if root_path and (raw_path == root_path or raw_path.startswith(root_path + "/")):
-            stripped: Final = raw_path[len(root_path) :]
-            return stripped or "/"
-        return raw_path
+        return strip_root_path(path=raw_path, root_path=root_path)
     except Exception as e:
         verbose_proxy_logger.debug(
             "error on get_request_route: %s, defaulting to request.url.path=%s", e, request.url.path
@@ -776,63 +776,64 @@ def normalize_request_route(route: str) -> str:
     return route
 
 
-async def check_if_request_size_is_safe(request: Request) -> bool:
+async def check_if_request_size_is_safe(
+    request: Request,
+    route: str,
+    max_request_size_mb: float | None,
+    max_file_size_mb: float | None,
+    is_premium_user: bool,
+) -> bool:
     """
     Enterprise Only:
         - Checks if the request size is within the limit
 
+    File uploads are limited by ``max_file_size_mb`` when it is set, so a global
+    limit tuned for chat payloads does not also cap batch input files.
+
     Args:
-        request (Request): The incoming request.
+        request: The incoming request.
+        route: The request route with ``root_path`` stripped, from ``get_request_route``.
+        max_request_size_mb: ``general_settings["max_request_size_mb"]``.
+        max_file_size_mb: ``general_settings["max_file_size_mb"]``.
+        is_premium_user: Whether the enterprise license is active.
 
     Returns:
         bool: True if the request size is within the limit
 
     Raises:
         ProxyException: If the request size is too large
-
     """
-    from litellm.proxy.proxy_server import general_settings, premium_user
+    from litellm.proxy.middleware.request_size_limit_middleware import resolve_max_size_mb
 
-    max_request_size_mb: Final = general_settings.get("max_request_size_mb", None)
+    max_size_mb: Final = resolve_max_size_mb(
+        method=str(request.scope.get("method", "")),
+        route=route,
+        max_request_size_mb=max_request_size_mb,
+        max_file_size_mb=max_file_size_mb,
+    )
+    if max_size_mb is None or max_size_mb <= 0:
+        return True
 
-    if max_request_size_mb is not None:
-        # Check if premium user
-        if premium_user is not True:
-            verbose_proxy_logger.warning(
-                "using max_request_size_mb - not checking -  this is an enterprise only feature. %s",
-                CommonProxyErrors.not_premium_user.value,
-            )
-            return True
+    if not is_premium_user:
+        verbose_proxy_logger.warning(
+            "using max_request_size_mb / max_file_size_mb - not checking - this is an enterprise only feature. %s",
+            CommonProxyErrors.not_premium_user.value,
+        )
+        return True
 
-        # Get the request body
-        content_length: Final = request.headers.get("content-length")
+    content_length: Final = request.headers.get("content-length")
+    request_size_mb: Final = bytes_to_mb(
+        bytes_value=int(content_length) if content_length else len(await request.body())
+    )
+    verbose_proxy_logger.debug("request size in MB=%s", request_size_mb)
 
-        if content_length:
-            header_size: Final = int(content_length)
-            header_size_mb: Final = bytes_to_mb(bytes_value=header_size)
-            verbose_proxy_logger.debug("content_length request size in MB=%s", header_size_mb)
-
-            if header_size_mb > max_request_size_mb:
-                raise ProxyException(
-                    message=f"Request size is too large. Request size is {header_size_mb} MB. Max size is {max_request_size_mb} MB",
-                    type=ProxyErrorTypes.bad_request_error.value,
-                    code=400,
-                    param="content-length",
-                )
-        else:
-            # If Content-Length is not available, read the body
-            body: Final = await request.body()
-            body_size: Final = len(body)
-            request_size_mb: Final = bytes_to_mb(bytes_value=body_size)
-
-            verbose_proxy_logger.debug("request body request size in MB=%s", request_size_mb)
-            if request_size_mb > max_request_size_mb:
-                raise ProxyException(
-                    message=f"Request size is too large. Request size is {request_size_mb} MB. Max size is {max_request_size_mb} MB",
-                    type=ProxyErrorTypes.bad_request_error.value,
-                    code=400,
-                    param="content-length",
-                )
+    if request_size_mb > max_size_mb:
+        raise ProxyException(
+            message=f"Request size is too large. Request size is {request_size_mb} MB. Max size is {max_size_mb} MB",
+            type=ProxyErrorTypes.bad_request_error.value,
+            code=400,
+            param="content-length",
+        )
 
     return True
 

--- a/litellm/proxy/common_utils/request_route_scoping.py
+++ b/litellm/proxy/common_utils/request_route_scoping.py
@@ -1,0 +1,37 @@
+"""
+Pure route predicates shared by the request-size limit's two enforcement layers.
+
+The ASGI middleware sees a raw scope and the auth layer sees a Starlette
+Request, so neither can reuse the other's helpers. Both need the same answers
+about a path, so they live here with no framework or proxy dependencies.
+"""
+
+import re
+from typing import Final
+
+_FILE_UPLOAD_ROUTE_PATTERN: Final = re.compile(r"^(?:/files|(?:/[^/]+)?/v1/files)$")
+
+
+def strip_root_path(path: str, root_path: str) -> str:
+    """
+    Normalize a sub-path deployment, e.g. ``/genai/v1/files`` -> ``/v1/files``.
+
+    Strips only on whole segment boundaries, so a sibling path like ``/apifoo``
+    is left intact under ``root_path="/api"``.
+    """
+    normalized_root: Final = root_path.rstrip("/")
+    if normalized_root and (path == normalized_root or path.startswith(normalized_root + "/")):
+        return path[len(normalized_root) :] or "/"
+    return path
+
+
+def is_file_upload_route(method: str, route: str) -> bool:
+    """
+    True for the routes that upload a file body: ``POST`` to ``/files``,
+    ``/v1/files``, or ``/{provider}/v1/files``.
+
+    Matches the paths ``create_file`` is mounted on, and deliberately not
+    ``/v1/vector_stores/{vector_store_id}/files``, which takes a JSON body
+    referencing an already-uploaded file.
+    """
+    return method.upper() == "POST" and _FILE_UPLOAD_ROUTE_PATTERN.match(route) is not None

--- a/litellm/proxy/middleware/request_size_limit_middleware.py
+++ b/litellm/proxy/middleware/request_size_limit_middleware.py
@@ -4,6 +4,11 @@ from typing import Final
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from litellm.proxy.common_utils.request_route_scoping import (
+    is_file_upload_route,
+    strip_root_path,
+)
+
 MaxRequestSizeGetter = Callable[[], int | float | None]
 RequestSizeLimitEnabledGetter = Callable[[], bool]
 
@@ -19,16 +24,22 @@ class RequestSizeLimitMiddleware:
     Content-Length can be rejected without reading any body bytes. Requests
     without Content-Length are counted as the ASGI stream is consumed, limiting
     memory exposure to the configured threshold plus the current chunk.
+
+    File uploads use ``max_file_size_mb`` when it is set: batch input files are
+    routinely orders of magnitude larger than a chat payload, so they cannot
+    share one limit.
     """
 
     def __init__(
         self,
         app: ASGIApp,
         get_max_request_size_mb: MaxRequestSizeGetter,
+        get_max_file_size_mb: MaxRequestSizeGetter,
         is_request_size_limit_enabled: RequestSizeLimitEnabledGetter,
     ) -> None:
         self.app = app
         self.get_max_request_size_mb = get_max_request_size_mb
+        self.get_max_file_size_mb = get_max_file_size_mb
         self.is_request_size_limit_enabled = is_request_size_limit_enabled
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
@@ -36,7 +47,15 @@ class RequestSizeLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        max_request_size_mb: Final = self.get_max_request_size_mb()
+        max_request_size_mb: Final = resolve_max_size_mb(
+            method=str(scope.get("method", "")),
+            route=strip_root_path(
+                path=str(scope.get("path", "")),
+                root_path=str(scope.get("app_root_path", scope.get("root_path", ""))),
+            ),
+            max_request_size_mb=self.get_max_request_size_mb(),
+            max_file_size_mb=self.get_max_file_size_mb(),
+        )
         max_request_size_bytes: Final = _mb_to_bytes(max_request_size_mb)
         if max_request_size_bytes is None or not self.is_request_size_limit_enabled():
             await self.app(scope, receive, send)
@@ -75,6 +94,21 @@ class RequestSizeLimitMiddleware:
             if response_started:
                 raise
             await _send_request_too_large(send=send, max_request_size_mb=max_request_size_mb)
+
+
+def resolve_max_size_mb(
+    method: str,
+    route: str,
+    max_request_size_mb: float | None,
+    max_file_size_mb: float | None,
+) -> float | None:
+    """
+    The size limit that applies to one request. ``max_file_size_mb`` overrides
+    the global limit on file-upload routes; unset falls back to it.
+    """
+    if max_file_size_mb is not None and is_file_upload_route(method=method, route=route):
+        return max_file_size_mb
+    return max_request_size_mb
 
 
 def _mb_to_bytes(max_request_size_mb: float | None) -> int | None:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15566,6 +15566,7 @@ _GENERAL_SETTINGS_CONFIG_LIST_FIELD_TYPES: Final[Mapping[str, str]] = MappingPro
         "max_parallel_requests": "Integer",
         "global_max_parallel_requests": "Integer",
         "max_request_size_mb": "Integer",
+        "max_file_size_mb": "Integer",
         "max_response_size_mb": "Integer",
         "proxy_config_reload_interval_seconds": "Integer",
         "pass_through_endpoints": "PydanticModel",
@@ -17196,6 +17197,7 @@ attach_lazy_features(app)
 app.add_middleware(
     RequestSizeLimitMiddleware,
     get_max_request_size_mb=lambda: general_settings.get("max_request_size_mb"),
+    get_max_file_size_mb=lambda: general_settings.get("max_file_size_mb"),
     is_request_size_limit_enabled=lambda: premium_user is True,
 )
 

--- a/tests/proxy_unit_tests/test_request_size_limit_middleware.py
+++ b/tests/proxy_unit_tests/test_request_size_limit_middleware.py
@@ -21,6 +21,7 @@ def test_request_size_limit_middleware_rejects_content_length_before_body_read()
         RequestSizeLimitMiddleware(
             app,
             get_max_request_size_mb=lambda: 1,
+            get_max_file_size_mb=lambda: None,
             is_request_size_limit_enabled=lambda: True,
         )
     )
@@ -50,6 +51,7 @@ def test_request_size_limit_middleware_zero_limit_disables_guard():
         RequestSizeLimitMiddleware(
             app,
             get_max_request_size_mb=lambda: 0,
+            get_max_file_size_mb=lambda: None,
             is_request_size_limit_enabled=lambda: True,
         )
     )
@@ -85,6 +87,7 @@ async def test_request_size_limit_middleware_rejects_streamed_body_without_conte
     middleware = RequestSizeLimitMiddleware(
         app,
         get_max_request_size_mb=lambda: 1,
+        get_max_file_size_mb=lambda: None,
         is_request_size_limit_enabled=lambda: True,
     )
     sent_messages: list[Message] = []
@@ -133,3 +136,195 @@ async def test_request_size_limit_middleware_rejects_streamed_body_without_conte
         "more_body": False,
     }
     assert received_body_bytes == 1024 * 1024
+
+
+def _size_limited_client(
+    max_request_size_mb: float | None,
+    max_file_size_mb: float | None,
+    root_path: str = "",
+) -> TestClient:
+    async def app(scope, receive, send):
+        response = JSONResponse({"ok": True})
+        await response(scope, receive, send)
+
+    return TestClient(
+        RequestSizeLimitMiddleware(
+            app,
+            get_max_request_size_mb=lambda: max_request_size_mb,
+            get_max_file_size_mb=lambda: max_file_size_mb,
+            is_request_size_limit_enabled=lambda: True,
+        ),
+        root_path=root_path,
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/files",
+        "/v1/files",
+        "/openai/v1/files",
+        "/azure/v1/files",
+    ],
+)
+def test_file_upload_routes_use_max_file_size_mb(path):
+    client = _size_limited_client(max_request_size_mb=1, max_file_size_mb=5)
+
+    response = client.post(path, content=b"x" * (2 * 1024 * 1024))
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_file_upload_override_does_not_leak_to_other_routes():
+    client = _size_limited_client(max_request_size_mb=1, max_file_size_mb=5)
+
+    response = client.post("/chat/completions", content=b"x" * (2 * 1024 * 1024))
+
+    assert response.status_code == 413
+    assert response.json() == {"error": "Request size is too large. Max size is 1 MB"}
+
+
+@pytest.mark.parametrize("root_path", ["/api/genai", "/api/genai/"])
+def test_file_upload_override_applies_under_server_root_path(root_path):
+    # A multi-segment prefix so an unstripped path cannot match the
+    # /{provider}/v1/files pattern by accident.
+    client = _size_limited_client(max_request_size_mb=1, max_file_size_mb=5, root_path=root_path)
+
+    response = client.post("/api/genai/v1/files", content=b"x" * (2 * 1024 * 1024))
+
+    assert response.status_code == 200
+
+
+def test_root_path_is_only_stripped_on_segment_boundaries():
+    # "/v" is a character-wise prefix of "/v1/files" but not a segment of it,
+    # so stripping it would mangle the path into "1/files" and lose the match.
+    client = _size_limited_client(max_request_size_mb=1, max_file_size_mb=5, root_path="/v")
+
+    response = client.post("/v1/files", content=b"x" * (2 * 1024 * 1024))
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_app_root_path_takes_precedence_over_root_path():
+    downstream_called = False
+
+    async def app(scope, receive, send):
+        nonlocal downstream_called
+        downstream_called = True
+        response = JSONResponse({"ok": True})
+        await response(scope, receive, send)
+
+    middleware = RequestSizeLimitMiddleware(
+        app,
+        get_max_request_size_mb=lambda: 1,
+        get_max_file_size_mb=lambda: 5,
+        is_request_size_limit_enabled=lambda: True,
+    )
+    body_size = 2 * 1024 * 1024
+
+    async def receive():
+        return {"type": "http.request", "body": b"x" * body_size, "more_body": False}
+
+    async def send(message):
+        return None
+
+    await middleware(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/genai/v1/files",
+            "app_root_path": "/api/genai",
+            "root_path": "/api/genai/v1/files",
+            "headers": [(b"content-length", str(body_size).encode("latin-1"))],
+        },
+        receive,
+        send,
+    )
+
+    assert downstream_called is True
+
+
+def test_file_upload_over_its_own_limit_is_rejected():
+    client = _size_limited_client(max_request_size_mb=1, max_file_size_mb=5)
+
+    response = client.post("/v1/files", content=b"x" * (5 * 1024 * 1024 + 1))
+
+    assert response.status_code == 413
+    assert response.json() == {"error": "Request size is too large. Max size is 5 MB"}
+
+
+def test_file_upload_falls_back_to_max_request_size_mb_when_unset():
+    client = _size_limited_client(max_request_size_mb=1, max_file_size_mb=None)
+
+    response = client.post("/v1/files", content=b"x" * (2 * 1024 * 1024))
+
+    assert response.status_code == 413
+    assert response.json() == {"error": "Request size is too large. Max size is 1 MB"}
+
+
+def test_zero_max_file_size_mb_uncaps_uploads_only():
+    client = _size_limited_client(max_request_size_mb=1, max_file_size_mb=0)
+
+    assert client.post("/v1/files", content=b"x" * (2 * 1024 * 1024)).status_code == 200
+    assert client.post("/chat/completions", content=b"x" * (2 * 1024 * 1024)).status_code == 413
+
+
+def test_vector_store_files_route_is_not_a_file_upload_route():
+    client = _size_limited_client(max_request_size_mb=1, max_file_size_mb=5)
+
+    response = client.post("/v1/vector_stores/vs_1/files", content=b"x" * (2 * 1024 * 1024))
+
+    assert response.status_code == 413
+
+
+def test_non_post_requests_to_files_route_use_the_global_limit():
+    client = _size_limited_client(max_request_size_mb=1, max_file_size_mb=5)
+
+    response = client.request("PUT", "/v1/files", content=b"x" * (2 * 1024 * 1024))
+
+    assert response.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_streamed_file_upload_rejected_at_max_file_size_mb():
+    async def app(scope, receive, send):
+        while True:
+            message = await receive()
+            if message["type"] == "http.disconnect" or not message.get("more_body", False):
+                break
+        response = JSONResponse({"ok": True})
+        await response(scope, receive, send)
+
+    middleware = RequestSizeLimitMiddleware(
+        app,
+        get_max_request_size_mb=lambda: 1,
+        get_max_file_size_mb=lambda: 2,
+        is_request_size_limit_enabled=lambda: True,
+    )
+    sent_messages: list[Message] = []
+    receive_messages: list[Message] = [
+        {"type": "http.request", "body": b"x" * (2 * 1024 * 1024), "more_body": True},
+        {"type": "http.request", "body": b"y", "more_body": False},
+    ]
+
+    async def receive():
+        return receive_messages.pop(0)
+
+    async def send(message):
+        sent_messages.append(message)
+
+    await middleware(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/files",
+            "headers": [(b"content-type", b"multipart/form-data; boundary=x")],
+        },
+        receive,
+        send,
+    )
+
+    assert sent_messages[0]["status"] == 413
+    assert sent_messages[1]["body"] == b'{"error":"Request size is too large. Max size is 2 MB"}'

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -9,11 +9,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import Request
 
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.proxy.auth.auth_utils import (
     _get_customer_id_from_standard_headers,
     abbreviate_api_key,
     check_complete_credentials,
+    check_if_request_size_is_safe,
     custom_auth_common_checks_warning,
     warn_once_if_custom_auth_skips_common_checks,
     get_end_user_id_from_request_body,
@@ -3200,3 +3201,167 @@ class TestIsRequestBodySafeBlocksAwsIdentitySelectors:
             )
             is True
         )
+
+
+def _sized_request(method: str, path: str, size_mb: float) -> Request:
+    content_length = str(int(size_mb * 1024 * 1024))
+    return Request(
+        scope={
+            "type": "http",
+            "method": method,
+            "path": path,
+            "headers": [(b"content-length", content_length.encode("latin-1"))],
+        }
+    )
+
+
+class TestCheckIfRequestSizeIsSafe:
+    """The auth-layer half of the request size limit. It runs after the ASGI
+    middleware and re-checks, so file uploads must be scoped here too or a
+    raised max_file_size_mb still 400s on /v1/files."""
+
+    @pytest.mark.asyncio
+    async def test_oversized_chat_request_is_rejected(self):
+        with pytest.raises(ProxyException) as exc_info:
+            await check_if_request_size_is_safe(
+                request=_sized_request("POST", "/chat/completions", size_mb=2),
+                route="/chat/completions",
+                max_request_size_mb=1,
+                max_file_size_mb=100,
+                is_premium_user=True,
+            )
+
+        assert "Max size is 1 MB" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("route", ["/files", "/v1/files", "/openai/v1/files"])
+    async def test_file_upload_uses_max_file_size_mb(self, route):
+        assert (
+            await check_if_request_size_is_safe(
+                request=_sized_request("POST", route, size_mb=2),
+                route=route,
+                max_request_size_mb=1,
+                max_file_size_mb=100,
+                is_premium_user=True,
+            )
+            is True
+        )
+
+    @pytest.mark.asyncio
+    async def test_file_upload_over_its_own_limit_is_rejected(self):
+        with pytest.raises(ProxyException) as exc_info:
+            await check_if_request_size_is_safe(
+                request=_sized_request("POST", "/v1/files", size_mb=101),
+                route="/v1/files",
+                max_request_size_mb=1,
+                max_file_size_mb=100,
+                is_premium_user=True,
+            )
+
+        assert "Max size is 100 MB" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_file_upload_falls_back_to_max_request_size_mb_when_unset(self):
+        with pytest.raises(ProxyException) as exc_info:
+            await check_if_request_size_is_safe(
+                request=_sized_request("POST", "/v1/files", size_mb=2),
+                route="/v1/files",
+                max_request_size_mb=1,
+                max_file_size_mb=None,
+                is_premium_user=True,
+            )
+
+        assert "Max size is 1 MB" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_non_premium_user_is_not_limited(self):
+        assert (
+            await check_if_request_size_is_safe(
+                request=_sized_request("POST", "/chat/completions", size_mb=2),
+                route="/chat/completions",
+                max_request_size_mb=1,
+                max_file_size_mb=None,
+                is_premium_user=False,
+            )
+            is True
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_limit_configured_is_not_limited(self):
+        assert (
+            await check_if_request_size_is_safe(
+                request=_sized_request("POST", "/chat/completions", size_mb=2048),
+                route="/chat/completions",
+                max_request_size_mb=None,
+                max_file_size_mb=None,
+                is_premium_user=True,
+            )
+            is True
+        )
+
+    @pytest.mark.asyncio
+    async def test_zero_max_file_size_mb_uncaps_uploads_only(self):
+        assert (
+            await check_if_request_size_is_safe(
+                request=_sized_request("POST", "/v1/files", size_mb=2048),
+                route="/v1/files",
+                max_request_size_mb=1,
+                max_file_size_mb=0,
+                is_premium_user=True,
+            )
+            is True
+        )
+
+        with pytest.raises(ProxyException):
+            await check_if_request_size_is_safe(
+                request=_sized_request("POST", "/chat/completions", size_mb=2),
+                route="/chat/completions",
+                max_request_size_mb=1,
+                max_file_size_mb=0,
+                is_premium_user=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_zero_max_request_size_mb_means_unlimited(self):
+        """Matches the middleware's `<= 0 disables the guard` semantics, which
+        this layer used to contradict by rejecting everything above 0 MB."""
+        assert (
+            await check_if_request_size_is_safe(
+                request=_sized_request("POST", "/chat/completions", size_mb=2048),
+                route="/chat/completions",
+                max_request_size_mb=0,
+                max_file_size_mb=None,
+                is_premium_user=True,
+            )
+            is True
+        )
+
+    @pytest.mark.asyncio
+    async def test_body_is_measured_when_content_length_is_absent(self):
+        request = Request(
+            scope={
+                "type": "http",
+                "method": "POST",
+                "path": "/chat/completions",
+                "headers": [],
+            },
+            receive=_body_receiver(b"x" * (2 * 1024 * 1024)),
+        )
+
+        with pytest.raises(ProxyException) as exc_info:
+            await check_if_request_size_is_safe(
+                request=request,
+                route="/chat/completions",
+                max_request_size_mb=1,
+                max_file_size_mb=None,
+                is_premium_user=True,
+            )
+
+        assert "Max size is 1 MB" in exc_info.value.message
+
+
+def _body_receiver(body: bytes):
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return receive

--- a/tests/test_litellm/proxy/common_utils/test_request_route_scoping.py
+++ b/tests/test_litellm/proxy/common_utils/test_request_route_scoping.py
@@ -1,0 +1,63 @@
+import pytest
+
+from litellm.proxy.common_utils.request_route_scoping import (
+    is_file_upload_route,
+    strip_root_path,
+)
+
+
+@pytest.mark.parametrize(
+    "path, root_path, expected",
+    [
+        ("/v1/files", "", "/v1/files"),
+        ("/v1/files", "/", "/v1/files"),
+        ("/genai/v1/files", "/genai", "/v1/files"),
+        ("/genai/v1/files", "/genai/", "/v1/files"),
+        ("/api/genai/v1/files", "/api/genai", "/v1/files"),
+        ("/api", "/api", "/"),
+        # "/apifoo" is not a segment match for "/api", so it survives intact
+        # rather than being truncated to "foo".
+        ("/apifoo/v1/files", "/api", "/apifoo/v1/files"),
+        ("/v1/files", "/v", "/v1/files"),
+    ],
+)
+def test_strip_root_path(path, root_path, expected):
+    assert strip_root_path(path=path, root_path=root_path) == expected
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/files",
+        "/v1/files",
+        "/openai/v1/files",
+        "/azure/v1/files",
+    ],
+)
+def test_file_upload_routes_are_matched(route):
+    assert is_file_upload_route(method="POST", route=route) is True
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/chat/completions",
+        "/v1/files/file-abc123",
+        "/v1/files/file-abc123/content",
+        "/v1/vector_stores/vs_1/files",
+        "/genai/openai/v1/files",
+        "/v1/audio/transcriptions",
+        "/fine_tuning/jobs",
+    ],
+)
+def test_non_upload_routes_are_not_matched(route):
+    assert is_file_upload_route(method="POST", route=route) is False
+
+
+@pytest.mark.parametrize("method", ["GET", "DELETE", "PUT", ""])
+def test_only_post_is_an_upload(method):
+    assert is_file_upload_route(method=method, route="/v1/files") is False
+
+
+def test_method_casing_is_normalized():
+    assert is_file_upload_route(method="post", route="/v1/files") is True

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23725,6 +23725,11 @@ export interface components {
              */
             master_key?: string | null;
             /**
+             * Max File Size Mb
+             * @description max size in MB for file uploads to /v1/files, overriding max_request_size_mb on that route so batch input files are not capped by the global request limit. Falls back to max_request_size_mb when unset
+             */
+            max_file_size_mb?: number | null;
+            /**
              * Max Parallel Requests
              * @description maximum parallel requests for each api key
              */


### PR DESCRIPTION
## TLDR

Problem this solves:

- `max_request_size_mb` also caps Files API batch uploads
- Batch input files are far larger than chat payloads
- Raising the global limit weakens it for every route

How it solves it:

- New `general_settings` key `max_file_size_mb` for upload routes
- Applied in both size-limit layers, middleware and auth
- Unset falls back to `max_request_size_mb`, so nothing changes

## User Flow

Before: a developer uploading a batch input file is rejected by a limit meant for chat payloads, and the only workaround loosens that limit everywhere

1. Their proxy admin sets `max_request_size_mb: 10` to bound chat request bodies
2. They send POST https://litellm-domain/v1/files with `purpose=batch` and a 40 MB `.jsonl`
3. The upload comes back 413 `Request size is too large. Max size is 10 MB`, with no file id
4. They cannot reach POST https://litellm-domain/v1/batches at all, since there is no `input_file_id`
5. Their admin's only option is raising `max_request_size_mb` to 500, which also lets a 500 MB chat body through

After: the same upload succeeds while chat requests stay bounded

1. Their proxy admin keeps `max_request_size_mb: 10` and adds `max_file_size_mb: 500`
2. They send the same POST https://litellm-domain/v1/files with `purpose=batch` and the 40 MB `.jsonl`
3. The upload returns 200 with a file id shaped like `file-abc123`
4. They send POST https://litellm-domain/v1/batches with that `input_file_id` and the batch starts
5. Sending a 40 MB body to https://litellm-domain/v1/chat/completions still returns 413 naming the 10 MB limit

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both size limits only take effect for premium users, and the only license available in my local env expired on 2026-08-08, so neither limit is enforced on my machine. I confirmed the gate is off rather than the limit being broken: at the merge base with `max_request_size_mb: 1`, a 1.2 MB chat body returned 200 instead of 413. The runbook below is the exact capture; it needs a proxy running with a valid enterprise license.

Shared setup:

```bash
cat > /tmp/cfg.yaml <<'EOF'
model_list:
  - model_name: gpt-5
    litellm_params:
      model: openai/gpt-5
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  max_request_size_mb: 1
  max_file_size_mb: 100
EOF

python - <<'EOF'
import json
pad = "The quick brown fox jumps over the lazy dog. " * 420
open("/tmp/batch.jsonl", "w").write("\n".join(
    json.dumps({"custom_id": f"req-{i}", "method": "POST", "url": "/v1/chat/completions",
                "body": {"model": "gpt-5", "max_completion_tokens": 16,
                         "messages": [{"role": "user", "content": f"Ignore this filler: {pad}\nReply with the single word ok"}]}})
    for i in range(1, 61)) + "\n")
EOF

python -c 'import json;print(json.dumps({"model":"gpt-5","messages":[{"role":"user","content":"x"*1200000}]}))' > /tmp/big_chat.json

python -m litellm.proxy.proxy_cli --config /tmp/cfg.yaml --detailed_debug
```

`/tmp/batch.jsonl` is 1.095 MB, just over the 1 MB global limit and well under the 100 MB file limit.

### Before (973329e986)

#### Batch input file upload

1. `curl -sS -w '\n%{http_code}\n' http://localhost:4000/v1/files -H "Authorization: Bearer $LITELLM_MASTER_KEY" -F purpose="batch" -F file="@/tmp/batch.jsonl"`
2. Expect 413 `Request size is too large. Max size is 1 MB`, no file id, so `/v1/batches` is unreachable

#### Oversized chat request

1. `curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'content-type: application/json' --data-binary @/tmp/big_chat.json`
2. Expect 413

### After (d80227531d)

#### Batch input file upload

1. `curl -sS -w '\n%{http_code}\n' http://localhost:4000/v1/files -H "Authorization: Bearer $LITELLM_MASTER_KEY" -F purpose="batch" -F file="@/tmp/batch.jsonl"`
2. Expect 200 and a `file-...` id
3. `curl -sS http://localhost:4000/v1/batches -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'content-type: application/json' -d '{"input_file_id":"<id from step 2>","endpoint":"/v1/chat/completions","completion_window":"24h"}'`
4. Poll `curl -sS http://localhost:4000/v1/batches/<batch_id> -H "Authorization: Bearer $LITELLM_MASTER_KEY"` until `completed`, then check real spend at http://localhost:4000/ui/?page=logs

#### Oversized chat request

1. `curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'content-type: application/json' --data-binary @/tmp/big_chat.json`
2. Expect 413, unchanged, since the override is scoped to the upload routes

#### Default unchanged

1. Restart with `max_file_size_mb` removed from the config
2. Re-run the upload from case 1 and expect 413 again, which together with that case passing on the same build shows the fallback rather than a no-op

## Type

🆕 New Feature

## Caveats (if any)

- Scoped by route, since `purpose` is unknown pre-parse
- Covers all `/v1/files` uploads, not just batch ones
- Audio and image uploads still use `max_request_size_mb`
- Auth layer now treats `<= 0` as unlimited, matching middleware
- Batch output downloads are unaffected, no response-size cap applies

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
