### PR TITLE
fix(ui): stop pairing key spend with the team budget when a key has no budget

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -2947,9 +2947,6 @@
     "max-lines": {
       "count": 1
     },
-    "no-nested-ternary": {
-      "count": 1
-    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -62,6 +62,7 @@ vi.mock("@/app/(dashboard)/hooks/organizations/useOrganizations", () => ({
       },
     ],
   }),
+  useOrganization: vi.fn().mockReturnValue({ data: undefined }),
 }));
 
 const mockKey: KeyResponse = {

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/keyTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/keyTableColumns.tsx
@@ -5,6 +5,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import { Popover, Typography } from "antd";
 
 import { DataTableMultiSortHeader, DataTableSortHeader, type DataTableSortField } from "@/components/shared/DataTable";
+import { inheritedBudgetGates } from "@/components/shared/InheritedBudgetHint";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   DateCell,
@@ -304,13 +305,14 @@ export const getKeyTableColumns = ({
     size: 180,
     enableSorting: true,
     cell: ({ row }) => {
-      const teamId = row.original.team_id;
-      const team = allTeams.find((t) => t.team_id === teamId);
+      const team = allTeams.find((t) => t.team_id === row.original.team_id);
+      const orgId = row.original.organization_id || row.original.org_id || team?.organization_id;
+      const organization = organizations.find((o) => o.organization_id === orgId);
       return (
         <SpendBudgetCell
           spend={row.original.spend}
           maxBudget={row.original.max_budget}
-          teamMaxBudget={team?.max_budget ?? null}
+          inheritedGates={row.original.max_budget == null ? inheritedBudgetGates(team, organization) : []}
         />
       );
     },

--- a/ui/litellm-dashboard/src/components/shared/InheritedBudgetHint.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/InheritedBudgetHint.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { InheritedBudgetHint, inheritedBudgetGates } from "./InheritedBudgetHint";
+
+const team = { team_id: "team-1", team_alias: "Platform", max_budget: 1200, budget_duration: "30d" };
+const organization = {
+  organization_id: "org-1",
+  organization_alias: "Acme",
+  litellm_budget_table: { max_budget: 5000, budget_duration: null },
+};
+
+describe("inheritedBudgetGates", () => {
+  it("returns team then org gates when both have budgets", () => {
+    expect(inheritedBudgetGates(team, organization)).toEqual([
+      { scope: "Team", alias: "Platform", maxBudget: 1200, budgetDuration: "30d" },
+      { scope: "Organization", alias: "Acme", maxBudget: 5000, budgetDuration: null },
+    ]);
+  });
+
+  it("skips a team or org whose max_budget is null", () => {
+    expect(inheritedBudgetGates({ ...team, max_budget: null }, organization)).toEqual([
+      { scope: "Organization", alias: "Acme", maxBudget: 5000, budgetDuration: null },
+    ]);
+    expect(inheritedBudgetGates(team, { ...organization, litellm_budget_table: { max_budget: null } })).toEqual([
+      { scope: "Team", alias: "Platform", maxBudget: 1200, budgetDuration: "30d" },
+    ]);
+  });
+
+  it("returns nothing when team and org are missing or budgetless", () => {
+    expect(inheritedBudgetGates(null, undefined)).toEqual([]);
+    expect(
+      inheritedBudgetGates({ ...team, max_budget: null }, { ...organization, litellm_budget_table: null }),
+    ).toEqual([]);
+  });
+
+  it("falls back to ids when aliases are empty", () => {
+    expect(
+      inheritedBudgetGates({ ...team, team_alias: "" }, { ...organization, organization_alias: "" }).map(
+        (g) => g.alias,
+      ),
+    ).toEqual(["team-1", "org-1"]);
+  });
+});
+
+describe("InheritedBudgetHint", () => {
+  it("renders nothing without gates", () => {
+    const { container } = render(<InheritedBudgetHint gates={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows each gate with its budget and duration on hover", async () => {
+    render(<InheritedBudgetHint gates={inheritedBudgetGates(team, organization)} />);
+    await userEvent.setup().hover(screen.getByLabelText("question-circle"));
+    expect(screen.getByTestId("inherited-budget-hint")).toHaveTextContent("Team Platform: $1,200.00 / 30d");
+    expect(screen.getByTestId("inherited-budget-hint")).toHaveTextContent("Organization Acme: $5,000.00");
+    expect(screen.getByTestId("inherited-budget-hint")).not.toHaveTextContent("Organization Acme: $5,000.00 /");
+  });
+});

--- a/ui/litellm-dashboard/src/components/shared/InheritedBudgetHint.tsx
+++ b/ui/litellm-dashboard/src/components/shared/InheritedBudgetHint.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Tooltip } from "@/components/atoms/Tooltip";
+import type { Team } from "@/components/key_team_helpers/key_list";
+import type { Organization } from "@/components/networking";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
+
+export interface InheritedBudgetGate {
+  scope: "Team" | "Organization";
+  alias: string;
+  maxBudget: number;
+  budgetDuration: string | null;
+}
+
+type TeamBudgetSource = Pick<Team, "team_id" | "team_alias" | "max_budget" | "budget_duration">;
+type OrganizationBudgetSource = Pick<Organization, "organization_id" | "organization_alias" | "litellm_budget_table">;
+
+const teamGate = (team: TeamBudgetSource | null | undefined): InheritedBudgetGate | null =>
+  team && team.max_budget != null
+    ? {
+        scope: "Team",
+        alias: team.team_alias || team.team_id,
+        maxBudget: team.max_budget,
+        budgetDuration: team.budget_duration ?? null,
+      }
+    : null;
+
+const organizationGate = (organization: OrganizationBudgetSource | null | undefined): InheritedBudgetGate | null => {
+  const budgetTable: { max_budget?: number | null; budget_duration?: string | null } | null | undefined =
+    organization?.litellm_budget_table;
+  return organization && budgetTable?.max_budget != null
+    ? {
+        scope: "Organization",
+        alias: organization.organization_alias || organization.organization_id,
+        maxBudget: budgetTable.max_budget,
+        budgetDuration: budgetTable.budget_duration ?? null,
+      }
+    : null;
+};
+
+export const inheritedBudgetGates = (
+  team: TeamBudgetSource | null | undefined,
+  organization: OrganizationBudgetSource | null | undefined,
+): readonly InheritedBudgetGate[] => [teamGate(team), organizationGate(organization)].filter((gate) => gate !== null);
+
+const formatGate = (gate: InheritedBudgetGate): string =>
+  `${gate.scope} ${gate.alias}: $${formatNumberWithCommas(gate.maxBudget, 2)}${gate.budgetDuration ? ` / ${gate.budgetDuration}` : ""}`;
+
+interface InheritedBudgetHintProps {
+  gates: readonly InheritedBudgetGate[];
+}
+
+export function InheritedBudgetHint({ gates }: InheritedBudgetHintProps) {
+  if (gates.length === 0) return null;
+  return (
+    <Tooltip
+      content={
+        <div data-testid="inherited-budget-hint" className="flex flex-col gap-1">
+          <span>This key has no budget of its own, but its spend still counts toward:</span>
+          {gates.map((gate) => (
+            <span key={gate.scope}>{formatGate(gate)}</span>
+          ))}
+        </div>
+      }
+    />
+  );
+}

--- a/ui/litellm-dashboard/src/components/shared/table_cells/spend_budget_cell.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/spend_budget_cell.test.tsx
@@ -53,9 +53,24 @@ describe("SpendBudgetCell", () => {
     expect(indicator(container)?.className).toContain("bg-destructive");
   });
 
-  it("falls back to the team budget and labels it", () => {
-    render(<SpendBudgetCell spend={10} maxBudget={null} teamMaxBudget={200} />);
-    expect(screen.getByText("of $200 (Team)")).toBeInTheDocument();
-    expect(screen.getByRole("meter")).toHaveAttribute("aria-valuemax", "200");
+  it("never meters key spend against an inherited team/org budget", () => {
+    const gates = [{ scope: "Team" as const, alias: "Team A", maxBudget: 200, budgetDuration: "30d" }];
+    render(<SpendBudgetCell spend={10} maxBudget={null} inheritedGates={gates} />);
+    expect(screen.getByText("· Unlimited")).toBeInTheDocument();
+    expect(screen.queryByText(/\(Team\)/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("meter")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("question-circle")).toBeInTheDocument();
+  });
+
+  it("shows no inherited-budget hint when there is nothing to inherit", () => {
+    render(<SpendBudgetCell spend={10} maxBudget={null} inheritedGates={[]} />);
+    expect(screen.queryByLabelText("question-circle")).not.toBeInTheDocument();
+  });
+
+  it("shows no inherited-budget hint when the key has its own budget", () => {
+    const gates = [{ scope: "Team" as const, alias: "Team A", maxBudget: 200, budgetDuration: null }];
+    render(<SpendBudgetCell spend={10} maxBudget={50} inheritedGates={gates} />);
+    expect(screen.getByText("of $50")).toBeInTheDocument();
+    expect(screen.queryByLabelText("question-circle")).not.toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/shared/table_cells/spend_budget_cell.tsx
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/spend_budget_cell.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { InheritedBudgetHint, type InheritedBudgetGate } from "@/components/shared/InheritedBudgetHint";
 import { Meter, MeterIndicator, MeterTrack } from "@/components/ui/meter";
 import { formatNumberWithCommas, getSpendString } from "@/utils/dataUtils";
 
 interface SpendBudgetCellProps {
   spend: number | null | undefined;
   maxBudget: number | null | undefined;
-  teamMaxBudget?: number | null;
+  inheritedGates?: readonly InheritedBudgetGate[];
   spendDecimals?: number;
   budgetDecimals?: number;
 }
@@ -20,27 +21,24 @@ const meterTone = (pct: number): "default" | "warning" | "over" => {
 export function SpendBudgetCell({
   spend,
   maxBudget,
-  teamMaxBudget,
+  inheritedGates = [],
   spendDecimals = 4,
   budgetDecimals = 0,
 }: SpendBudgetCellProps) {
   const spendValue = typeof spend === "number" && !Number.isNaN(spend) ? spend : 0;
-  const budget = maxBudget ?? teamMaxBudget ?? null;
-  const isTeamBudget = maxBudget == null && teamMaxBudget != null;
+  const budget = maxBudget ?? null;
   const hasBudget = typeof budget === "number" && budget > 0;
   const pct = hasBudget ? (spendValue / budget) * 100 : 0;
 
   const spendText = spendValue > 0 ? getSpendString(spendValue, spendDecimals) : "$0.00";
-  const budgetLabel =
-    budget === null
-      ? "· Unlimited"
-      : `of $${formatNumberWithCommas(budget, budgetDecimals)}${isTeamBudget ? " (Team)" : ""}`;
+  const budgetLabel = budget === null ? "· Unlimited" : `of $${formatNumberWithCommas(budget, budgetDecimals)}`;
 
   return (
     <div className="flex min-w-[130px] flex-col gap-1">
       <div className="whitespace-nowrap text-xs">
         <span className="font-medium tabular-nums text-foreground">{spendText}</span>{" "}
         <span className="text-muted-foreground">{budgetLabel}</span>
+        {budget === null && <InheritedBudgetHint gates={inheritedGates} />}
       </div>
       {hasBudget && (
         <Meter

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.budget_display.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.budget_display.test.tsx
@@ -1,10 +1,13 @@
 import { renderWithProviders } from "../../../tests/test-utils";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { KeyResponse, Team } from "../key_team_helpers/key_list";
 import KeyInfoView from "./key_info_view";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import useTeams from "@/app/(dashboard)/hooks/useTeams";
+import { useOrganization } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
+import type { Organization } from "../networking";
 
 // IMPORTANT: do not mock `@/utils/dataUtils` here. We want to exercise the
 // real `formatNumberWithCommas` so this test catches the LIT-2845 regression
@@ -16,6 +19,7 @@ vi.mock("./key_edit_view", () => ({
 }));
 
 vi.mock("@/app/(dashboard)/hooks/useTeams", () => ({ default: vi.fn() }));
+vi.mock("@/app/(dashboard)/hooks/organizations/useOrganizations", () => ({ useOrganization: vi.fn() }));
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({ default: vi.fn() }));
 vi.mock("@/app/(dashboard)/hooks/projects/useProjects", () => ({
   useProjects: vi.fn().mockReturnValue({ data: [], isLoading: false }),
@@ -123,10 +127,34 @@ const makeTeam = (overrides: Partial<Team>): Team => ({
   ...overrides,
 });
 
+const makeOrganization = (overrides: Partial<Organization>): Organization =>
+  ({
+    organization_id: "org-1",
+    organization_alias: "Acme Org",
+    budget_id: "budget-1",
+    metadata: {},
+    models: [],
+    spend: 0,
+    model_spend: {},
+    created_at: "2026-01-01T00:00:00Z",
+    created_by: "admin",
+    updated_at: "2026-01-01T00:00:00Z",
+    updated_by: "admin",
+    litellm_budget_table: { max_budget: null, budget_duration: null },
+    teams: null,
+    users: null,
+    members: null,
+    ...overrides,
+  }) as Organization;
+
+const mockOrganization = (organization: Organization | undefined) =>
+  vi.mocked(useOrganization).mockReturnValue({ data: organization } as ReturnType<typeof useOrganization>);
+
 describe("KeyInfoView overview budget display (LIT-2845)", () => {
   beforeEach(() => {
     vi.mocked(useTeams).mockReturnValue({ teams: [], setTeams: vi.fn() });
     vi.mocked(useAuthorized).mockReturnValue(baseAuthorized);
+    mockOrganization(undefined);
   });
 
   it("renders a sub-dollar max_budget ($0.10) with 2-decimal precision in the overview Spend card", async () => {
@@ -181,7 +209,7 @@ describe("KeyInfoView overview budget display (LIT-2845)", () => {
     });
   });
 
-  it("renders team budget with alias and duration when key has no own budget but team has one", async () => {
+  it("never pairs key spend with the team budget: shows Unlimited plus an inherited-budget hint", async () => {
     vi.mocked(useTeams).mockReturnValue({
       teams: [makeTeam({ team_id: "team-123", team_alias: "Test Budget", max_budget: 1200, budget_duration: "30d" })],
       setTeams: vi.fn(),
@@ -196,15 +224,20 @@ describe("KeyInfoView overview budget display (LIT-2845)", () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getByText(/of \$1,200\.00 \(Team: Test Budget \/ 30d\)/)).toBeInTheDocument();
+      expect(screen.getByText(/of Unlimited/)).toBeInTheDocument();
     });
+    expect(screen.queryByText(/of \$1,200\.00/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\(Team: Test Budget/)).not.toBeInTheDocument();
+    await userEvent.setup().hover(screen.getByLabelText("question-circle"));
+    expect(screen.getByTestId("inherited-budget-hint")).toHaveTextContent("Team Test Budget: $1,200.00 / 30d");
   });
 
-  it("renders team budget without duration when team has no budget_duration", async () => {
+  it("lists the organization budget in the hint when the team's org has one", async () => {
     vi.mocked(useTeams).mockReturnValue({
-      teams: [makeTeam({ team_id: "team-456", team_alias: "No Duration Team", max_budget: 500 })],
+      teams: [makeTeam({ team_id: "team-456", team_alias: "Org Team", organization_id: "org-1" })],
       setTeams: vi.fn(),
     });
+    mockOrganization(makeOrganization({ litellm_budget_table: { max_budget: 5000, budget_duration: null } }));
     renderWithProviders(
       <KeyInfoView
         keyData={{ ...MOCK_KEY_DATA, max_budget: null, team_id: "team-456" } as unknown as KeyResponse}
@@ -215,11 +248,15 @@ describe("KeyInfoView overview budget display (LIT-2845)", () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getByText(/of \$500\.00 \(Team: No Duration Team\)/)).toBeInTheDocument();
+      expect(screen.getByText(/of Unlimited/)).toBeInTheDocument();
     });
+    expect(vi.mocked(useOrganization)).toHaveBeenLastCalledWith("org-1");
+    await userEvent.setup().hover(screen.getByLabelText("question-circle"));
+    expect(screen.getByTestId("inherited-budget-hint")).toHaveTextContent("Organization Acme Org: $5,000.00");
+    expect(screen.getByTestId("inherited-budget-hint")).not.toHaveTextContent("Team Org Team");
   });
 
-  it("renders 'Unlimited' when key has no budget and team also has no budget", async () => {
+  it("renders 'Unlimited' with no hint when neither key, team, nor org has a budget", async () => {
     vi.mocked(useTeams).mockReturnValue({
       teams: [makeTeam({ team_id: "team-789", team_alias: "Free Team" })],
       setTeams: vi.fn(),
@@ -236,6 +273,27 @@ describe("KeyInfoView overview budget display (LIT-2845)", () => {
     await waitFor(() => {
       expect(screen.getByText(/of Unlimited/)).toBeInTheDocument();
     });
+    expect(screen.queryByLabelText("question-circle")).not.toBeInTheDocument();
+  });
+
+  it("shows no hint when the key has its own budget even if the team has one", async () => {
+    vi.mocked(useTeams).mockReturnValue({
+      teams: [makeTeam({ team_id: "team-123", team_alias: "Test Budget", max_budget: 1200 })],
+      setTeams: vi.fn(),
+    });
+    renderWithProviders(
+      <KeyInfoView
+        keyData={{ ...MOCK_KEY_DATA, max_budget: 25, team_id: "team-123" } as unknown as KeyResponse}
+        onClose={() => {}}
+        keyId={"test-key-id"}
+        onKeyDataUpdate={() => {}}
+        teams={[]}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/of \$25\.00/)).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("question-circle")).not.toBeInTheDocument();
   });
 });
 
@@ -243,6 +301,7 @@ describe("KeyInfoView budget reset visibility", () => {
   beforeEach(() => {
     vi.mocked(useTeams).mockReturnValue({ teams: [], setTeams: vi.fn() });
     vi.mocked(useAuthorized).mockReturnValue(baseAuthorized);
+    mockOrganization(undefined);
   });
 
   const KEY_WITH_RESET = {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -2,6 +2,7 @@ import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { useProjects } from "@/app/(dashboard)/hooks/projects/useProjects";
 import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
 import useTeams from "@/app/(dashboard)/hooks/useTeams";
+import { useOrganization } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { mapEmptyStringToNull } from "@/utils/keyUpdateUtils";
 import { ArrowLeft } from "lucide-react";
@@ -33,6 +34,7 @@ import { extractMcpEntitlement } from "../mcp_server_management/mcpEntitlement";
 import ObjectPermissionsView from "../object_permissions_view";
 import { RegenerateKeyModal } from "../organisms/RegenerateKeyModal";
 import { parseErrorMessage } from "../shared/errorUtils";
+import { InheritedBudgetHint, inheritedBudgetGates } from "../shared/InheritedBudgetHint";
 import { KeyEditView } from "./key_edit_view";
 
 interface KeyInfoViewProps {
@@ -93,6 +95,11 @@ export default function KeyInfoView({
   const { mutate: setKeyBlockedState, isPending: blockLoading } = useSetKeyBlockedState();
   // Add local state to maintain key data and track regeneration
   const [currentKeyData, setCurrentKeyData] = useState<KeyResponse | undefined>(keyData);
+  const parentTeam = currentKeyData?.team_id
+    ? teamsData?.find((team) => team.team_id === currentKeyData.team_id)
+    : null;
+  const keyOrganizationId = currentKeyData?.organization_id || currentKeyData?.org_id;
+  const { data: parentOrganization } = useOrganization(keyOrganizationId || parentTeam?.organization_id || undefined);
   const [lastRegeneratedAt, setLastRegeneratedAt] = useState<Date | null>(null);
   const [isRecentlyRegenerated, setIsRecentlyRegenerated] = useState(false);
   const [policyGuardrails, setPolicyGuardrails] = useState<Record<string, string[]>>({});
@@ -452,14 +459,9 @@ export default function KeyInfoView({
 
   const lastConfiguredAt = currentKeyData.settings_updated_at || currentKeyData.created_at;
 
-  const parentTeam = currentKeyData.team_id ? teamsData?.find((team) => team.team_id === currentKeyData.team_id) : null;
-
-  const budgetDisplay =
-    currentKeyData.max_budget !== null
-      ? `$${formatNumberWithCommas(currentKeyData.max_budget, 2)}`
-      : parentTeam?.max_budget != null
-        ? `$${formatNumberWithCommas(parentTeam.max_budget, 2)} (Team: ${parentTeam.team_alias || parentTeam.team_id}${parentTeam.budget_duration ? ` / ${parentTeam.budget_duration}` : ""})`
-        : "Unlimited";
+  const hasOwnBudget = currentKeyData.max_budget !== null;
+  const budgetDisplay = hasOwnBudget ? `$${formatNumberWithCommas(currentKeyData.max_budget, 2)}` : "Unlimited";
+  const inheritedGates = hasOwnBudget ? [] : inheritedBudgetGates(parentTeam, parentOrganization);
 
   return (
     <div className="w-full h-full overflow-y-auto p-4">
@@ -605,7 +607,10 @@ export default function KeyInfoView({
                 <p className="text-sm">Spend</p>
                 <div className="mt-2">
                   <h3 className="text-lg font-medium">${formatNumberWithCommas(currentKeyData.spend, 4)}</h3>
-                  <p className="text-sm">of {budgetDisplay}</p>
+                  <p className="text-sm">
+                    of {budgetDisplay}
+                    <InheritedBudgetHint gates={inheritedGates} />
+                  </p>
                   {currentKeyData.budget_reset_at && (
                     <p className="text-sm">Resets {formatTimestamp(currentKeyData.budget_reset_at)}</p>
                   )}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Budgetless key on a budgeted team showed "spend of $team-budget"
- Key spend metered against the team's aggregate cap: a nonsense ratio
- Same mismatch on the key overview card and the Virtual Keys table

How it solves it:

- Budgetless keys show "Unlimited" again on both surfaces
- New hover hint lists inherited team and org budgets, if any
- Shared `InheritedBudgetHint` + `inheritedBudgetGates` helper, unit tested

## User Flow

Before: an admin opening a key that has no budget of its own but sits on a team with one is told the key has that team's budget

1. They open http://localhost:4000/ui/?page=api-keys and see the row for the key read `$0.00 of $1,200 (Team)` with a progress meter under it
2. They click the key and land on http://localhost:4000/ui/?page=api-keys&key=<key_id>
3. The Spend card reads `$0.0000 of $1,200.00 (Team: qa-budget-hint-team / 30d)`, as if this one key had a $1,200 cap and had used 0% of it
4. Nothing on either surface mentions that the $1,200 is shared by every key on the team, or that the team's organization caps it further at $5,000

After: the same key reads as unlimited, and hovering the hint explains what still gates it

1. They open http://localhost:4000/ui/?page=api-keys and see the row read `$0.00 · Unlimited` with a small question-mark icon and no meter
2. They click the key and land on http://localhost:4000/ui/?page=api-keys&key=<key_id>
3. The Spend card reads `$0.0000 of Unlimited` with the same question-mark icon next to it
4. Hovering the icon shows "This key has no budget of its own, but its spend still counts toward: Team qa-budget-hint-team: $1,200.00 / 30d, Organization qa-budget-hint-org: $5,000.00"
5. A key on a team with no budget shows `of Unlimited` with no icon; a key with its own budget shows `of $25.00` with no icon

## Relevant issues

Reverts the display fallback added in #30801

## Linear ticket

Resolves LIT-5649

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup, against the dev proxy on localhost:4000 with the master key:

```bash
ORG_ID=$(curl -s localhost:4000/organization/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"organization_alias":"qa-budget-hint-org","max_budget":5000}' | jq -r .organization_id)
TEAM_ID=$(curl -s localhost:4000/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"team_alias\":\"qa-budget-hint-team\",\"max_budget\":1200,\"budget_duration\":\"30d\",\"organization_id\":\"$ORG_ID\"}" | jq -r .team_id)
FREE_TEAM_ID=$(curl -s localhost:4000/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"team_alias":"qa-budget-hint-free-team"}' | jq -r .team_id)
for spec in "qa-hint-key-inherits:$TEAM_ID:null" "qa-hint-key-own-budget:$TEAM_ID:25" "qa-hint-key-free-team:$FREE_TEAM_ID:null"; do
  IFS=: read alias tid mb <<< "$spec"
  curl -s localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d "{\"key_alias\":\"$alias\",\"team_id\":\"$tid\",\"max_budget\":$mb}" | jq -r '"\(.key_alias) \(.token_id) max_budget=\(.max_budget)"'
done
```

Output:

```
qa-hint-key-inherits 81914ee31c24157c88efeed8ebdce45133c3bce4403b3bcc77bc14474a5aaaa5 max_budget=null
qa-hint-key-own-budget e06b011b8ff118ee400086192082e5d06763bf9d4d8ea33a86411c309d938622 max_budget=25
qa-hint-key-free-team c57580e9728993e24889b62e79944e856773916c5b1498178218fa4b9e478dc7 max_budget=null
```

### Before (1dbed6eb60)

#### Virtual Keys table

1. Open http://localhost:4000/ui/?page=api-keys and search `qa-hint`
2. `qa-hint-key-inherits` reads `$0.00 of $1,200 (Team)` with a meter under it

![before table](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5649_screenshots/before-table.png)

#### Key overview card

1. Click `qa-hint-key-inherits`
2. Spend card reads `$0.0000 of $1,200.00 (Team: qa-budget-hint-team / 30d)`

![before card](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5649_screenshots/before-card.png)

### After (6fc6f3cd9c)

#### Virtual Keys table

1. Open http://localhost:4000/ui/?page=api-keys and search `qa-hint`
2. `qa-hint-key-inherits` reads `$0.00 · Unlimited` with a question-mark icon and no meter; hovering the icon lists `Team qa-budget-hint-team: $1,200.00 / 30d` and `Organization qa-budget-hint-org: $5,000.00`
3. `qa-hint-key-free-team` reads `$0.00 · Unlimited` with no icon; `qa-hint-key-own-budget` reads `$0.00 of $25` with a meter and no icon

![after table, hint hovered](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5649_screenshots/after-table.png)

#### Key overview card

1. Click `qa-hint-key-inherits`
2. Spend card reads `$0.0000 of Unlimited` with the icon; hovering shows the same team and organization lines
3. `qa-hint-key-free-team` shows `of Unlimited` with no icon; `qa-hint-key-own-budget` shows `of $25.00` with no icon

![after card](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5649_screenshots/after-card.png)

![after card, hint hovered](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_5649_screenshots/after-card-hover.png)

## Type

🐛 Bug Fix

## Caveats (if any)

- Hint reads the org via the key's org, else the team's org
- User-level budgets are not listed in the hint

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
