### PR TITLE
fix(proxy): reject out-of-range limit on GET /v1/batches with OpenAI-parity 400

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -431,6 +431,9 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         if target_model_names:
             raise Exception("Filtering by 'target_model_names' is not supported when using managed batches.")
 
+        if limit == 0:
+            return build_list_page([])
+
         owner_filter = build_owner_filter(user_api_key_dict)
         if owner_filter is None:
             return build_list_page([])

--- a/litellm/proxy/batches_endpoints/common_utils.py
+++ b/litellm/proxy/batches_endpoints/common_utils.py
@@ -1,0 +1,18 @@
+from litellm.proxy._types import ProxyException
+
+
+def validate_batch_list_limit(limit: int | None) -> None:
+    if limit is None or 0 <= limit <= 100:
+        return
+    bound, expected, openai_code = (
+        ("below minimum", ">= 0", "integer_below_min_value")
+        if limit < 0
+        else ("above maximum", "<= 100", "integer_above_max_value")
+    )
+    raise ProxyException(
+        message=f"Invalid 'limit': integer {bound} value. Expected a value {expected}, but got {limit} instead.",
+        type="invalid_request_error",
+        param="limit",
+        code=400,
+        openai_code=openai_code,
+    )

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -642,6 +642,23 @@ async def retrieve_batch(
         raise handle_exception_on_proxy(e)
 
 
+def validate_batch_list_limit(limit: int | None) -> None:
+    if limit is None or 0 <= limit <= 100:
+        return
+    bound, expected, openai_code = (
+        ("below minimum", ">= 0", "integer_below_min_value")
+        if limit < 0
+        else ("above maximum", "<= 100", "integer_above_max_value")
+    )
+    raise ProxyException(
+        message=f"Invalid 'limit': integer {bound} value. Expected a value {expected}, but got {limit} instead.",
+        type="invalid_request_error",
+        param="limit",
+        code=400,
+        openai_code=openai_code,
+    )
+
+
 @router.get(
     "/{provider}/v1/batches",
     dependencies=[Depends(user_api_key_auth)],
@@ -679,6 +696,7 @@ async def list_batches(
 
     ```
     """
+    validate_batch_list_limit(limit)
     from litellm.proxy.proxy_server import (
         general_settings,
         llm_router,

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -14,6 +14,7 @@ from litellm._logging import verbose_proxy_logger
 from litellm.batches.main import CancelBatchRequest, RetrieveBatchRequest
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.batches_endpoints.common_utils import validate_batch_list_limit
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.common_utils.callback_utils import sanitize_openai_provider_metadata
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
@@ -640,23 +641,6 @@ async def retrieve_batch(
         )
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.retrieve_batch(): Exception occured - %s", e)
         raise handle_exception_on_proxy(e)
-
-
-def validate_batch_list_limit(limit: int | None) -> None:
-    if limit is None or 0 <= limit <= 100:
-        return
-    bound, expected, openai_code = (
-        ("below minimum", ">= 0", "integer_below_min_value")
-        if limit < 0
-        else ("above maximum", "<= 100", "integer_above_max_value")
-    )
-    raise ProxyException(
-        message=f"Invalid 'limit': integer {bound} value. Expected a value {expected}, but got {limit} instead.",
-        type="invalid_request_error",
-        param="limit",
-        code=400,
-        openai_code=openai_code,
-    )
 
 
 @router.get(

--- a/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
+++ b/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
@@ -45,6 +45,7 @@ from litellm.llms.base_llm.managed_resources.isolation import (
     can_access_resource,
 )
 from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.batches_endpoints.common_utils import validate_batch_list_limit
 from litellm.repositories.table_repositories import (
     ManagedFileRepository,
     ManagedObjectRepository,
@@ -1029,12 +1030,16 @@ async def list_passthrough_ids_from_db(
     if resource_kind is None:
         return None
 
+    raw_limit, fetch_limit = _parse_list_limit(query_params)
+    if resource_kind == "batches":
+        validate_batch_list_limit(raw_limit)
+        if raw_limit == 0:
+            return _empty_list_response()
+
     owner_filter: Final = build_owner_filter(user_api_key_dict)
     if owner_filter is None:
         verbose_proxy_logger.warning("managed_id_rewriter: list denied — caller has no user_id or team_id")
         return _empty_list_response()
-
-    raw_limit, fetch_limit = _parse_list_limit(query_params)
     where, fetch_order = await _build_list_where_with_cursor(
         prisma_client, resource_kind, provider, owner_filter, query_params
     )

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1538,6 +1538,8 @@ async def pass_through_request(
 
         #########################################################
 
+        if isinstance(e, ProxyException):
+            raise
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(getattr(e, "detail", str(e)))),

--- a/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
+++ b/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
@@ -98,6 +98,25 @@ async def test_async_pre_call_hook_batch_retrieve():
 
 
 @pytest.mark.asyncio
+async def test_list_user_batches_limit_zero_returns_empty_page_without_db_query():
+    """OpenAI parity for GET /v1/batches?limit=0: an empty page, never the
+    default page of 20 (issue #37149). `min(limit or 20, 100)` treated 0 as
+    unset before this regression guard existed."""
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    prisma_client = MagicMock()
+    proxy_managed_files = _PROXY_LiteLLMManagedFiles(DualCache(), prisma_client=prisma_client)
+
+    page = await proxy_managed_files.list_user_batches(
+        user_api_key_dict=UserAPIKeyAuth(user_id="123"),
+        limit=0,
+    )
+
+    assert page == {"object": "list", "data": [], "first_id": None, "last_id": None, "has_more": False}
+    prisma_client.db.litellm_managedobjecttable.find_many.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_async_pre_call_deployment_hook_resolves_model_id_from_litellm_metadata():
     """
     For batch operations the router stores model_info under

--- a/tests/pass_through_unit_tests/test_passthrough_managed_ids.py
+++ b/tests/pass_through_unit_tests/test_passthrough_managed_ids.py
@@ -31,7 +31,7 @@ import litellm
 from litellm.llms.base_llm.managed_resources.utils import (
     resolve_passthrough_managed_id_provider,
 )
-from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.pass_through_endpoints.managed_id_codec import (
     decode,
     encode,
@@ -1795,84 +1795,6 @@ class TestListPassthroughIdsFromDb:
         assert len(result["data"]) == 1
         assert result["data"][0]["id"] == managed_id
         assert result["data"][0]["object"] == "batch"
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "limit,expected_message,expected_openai_code",
-        [
-            (
-                "-1",
-                "Invalid 'limit': integer below minimum value. Expected a value >= 0, but got -1 instead.",
-                "integer_below_min_value",
-            ),
-            (
-                "101",
-                "Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 101 instead.",
-                "integer_above_max_value",
-            ),
-        ],
-    )
-    async def test_list_batches_out_of_range_limit_raises_400(
-        self, limit, expected_message, expected_openai_code
-    ):
-        pc = _prisma_with_list(
-            batch_rows=[_fake_batch_row(new_managed_id("openai", "batch_abc"))]
-        )
-
-        with pytest.raises(ProxyException) as exc:
-            await list_passthrough_ids_from_db(
-                provider="openai",
-                route="/openai/v1/batches",
-                user_api_key_dict=_user(),
-                prisma_client=pc,
-                query_params={"limit": limit},
-            )
-
-        assert exc.value.code == "400"
-        assert exc.value.param == "limit"
-        assert exc.value.type == "invalid_request_error"
-        assert exc.value.openai_code == expected_openai_code
-        assert exc.value.message == expected_message
-        pc.db.litellm_managedobjecttable.find_many.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_list_batches_limit_zero_returns_empty_page_without_db_query(self):
-        pc = _prisma_with_list(
-            batch_rows=[_fake_batch_row(new_managed_id("openai", "batch_abc"))]
-        )
-
-        result = await list_passthrough_ids_from_db(
-            provider="openai",
-            route="/openai/v1/batches",
-            user_api_key_dict=_user(),
-            prisma_client=pc,
-            query_params={"limit": "0"},
-        )
-
-        assert result == {
-            "object": "list",
-            "data": [],
-            "first_id": None,
-            "last_id": None,
-            "has_more": False,
-        }
-        pc.db.litellm_managedobjecttable.find_many.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_list_files_limit_above_batch_cap_still_served(self):
-        managed_id = new_managed_id("openai", "file-abc")
-        pc = _prisma_with_list(file_rows=[_fake_file_row(managed_id)])
-
-        result = await list_passthrough_ids_from_db(
-            provider="openai",
-            route="/openai/v1/files",
-            user_api_key_dict=_user(),
-            prisma_client=pc,
-            query_params={"limit": "101"},
-        )
-
-        assert result is not None
-        assert [item["id"] for item in result["data"]] == [managed_id]
 
     @pytest.mark.asyncio
     async def test_list_files_admin_gets_all_rows(self):

--- a/tests/pass_through_unit_tests/test_passthrough_managed_ids.py
+++ b/tests/pass_through_unit_tests/test_passthrough_managed_ids.py
@@ -31,7 +31,7 @@ import litellm
 from litellm.llms.base_llm.managed_resources.utils import (
     resolve_passthrough_managed_id_provider,
 )
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.proxy.pass_through_endpoints.managed_id_codec import (
     decode,
     encode,
@@ -1795,6 +1795,84 @@ class TestListPassthroughIdsFromDb:
         assert len(result["data"]) == 1
         assert result["data"][0]["id"] == managed_id
         assert result["data"][0]["object"] == "batch"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "limit,expected_message,expected_openai_code",
+        [
+            (
+                "-1",
+                "Invalid 'limit': integer below minimum value. Expected a value >= 0, but got -1 instead.",
+                "integer_below_min_value",
+            ),
+            (
+                "101",
+                "Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 101 instead.",
+                "integer_above_max_value",
+            ),
+        ],
+    )
+    async def test_list_batches_out_of_range_limit_raises_400(
+        self, limit, expected_message, expected_openai_code
+    ):
+        pc = _prisma_with_list(
+            batch_rows=[_fake_batch_row(new_managed_id("openai", "batch_abc"))]
+        )
+
+        with pytest.raises(ProxyException) as exc:
+            await list_passthrough_ids_from_db(
+                provider="openai",
+                route="/openai/v1/batches",
+                user_api_key_dict=_user(),
+                prisma_client=pc,
+                query_params={"limit": limit},
+            )
+
+        assert exc.value.code == "400"
+        assert exc.value.param == "limit"
+        assert exc.value.type == "invalid_request_error"
+        assert exc.value.openai_code == expected_openai_code
+        assert exc.value.message == expected_message
+        pc.db.litellm_managedobjecttable.find_many.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_batches_limit_zero_returns_empty_page_without_db_query(self):
+        pc = _prisma_with_list(
+            batch_rows=[_fake_batch_row(new_managed_id("openai", "batch_abc"))]
+        )
+
+        result = await list_passthrough_ids_from_db(
+            provider="openai",
+            route="/openai/v1/batches",
+            user_api_key_dict=_user(),
+            prisma_client=pc,
+            query_params={"limit": "0"},
+        )
+
+        assert result == {
+            "object": "list",
+            "data": [],
+            "first_id": None,
+            "last_id": None,
+            "has_more": False,
+        }
+        pc.db.litellm_managedobjecttable.find_many.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_files_limit_above_batch_cap_still_served(self):
+        managed_id = new_managed_id("openai", "file-abc")
+        pc = _prisma_with_list(file_rows=[_fake_file_row(managed_id)])
+
+        result = await list_passthrough_ids_from_db(
+            provider="openai",
+            route="/openai/v1/files",
+            user_api_key_dict=_user(),
+            prisma_client=pc,
+            query_params={"limit": "101"},
+        )
+
+        assert result is not None
+        assert [item["id"] for item in result["data"]] == [managed_id]
 
     @pytest.mark.asyncio
     async def test_list_files_admin_gets_all_rows(self):

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -1513,6 +1513,59 @@ async def test_list__managed_files_beats_model_param(list_harness):
     list_harness.creds_resolver.assert_not_called()
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "limit, expected_message, expected_openai_code",
+    [
+        (
+            -1,
+            "Invalid 'limit': integer below minimum value. Expected a value >= 0, but got -1 instead.",
+            "integer_below_min_value",
+        ),
+        (
+            101,
+            "Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 101 instead.",
+            "integer_above_max_value",
+        ),
+        (
+            1000,
+            "Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 1000 instead.",
+            "integer_above_max_value",
+        ),
+    ],
+)
+async def test_list__out_of_range_limit_rejected_with_400(list_harness, limit, expected_message, expected_openai_code):
+    """OpenAI parity: GET /v1/batches rejects limit < 0 and limit > 100 with an
+    OpenAI-shaped 400 before any listing branch runs (issue #37149)."""
+    list_user_batches = list_harness.set_managed_files(FakeListPage([]))
+
+    with pytest.raises(ProxyException) as exc:
+        await call_list(list_harness, limit=limit)
+
+    assert exc.value.code == "400"
+    assert exc.value.param == "limit"
+    assert exc.value.type == "invalid_request_error"
+    assert exc.value.openai_code == expected_openai_code
+    assert exc.value.message == expected_message
+    list_user_batches.assert_not_called()
+    list_harness.litellm_alist.assert_not_called()
+    list_harness.router_alist.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [None, 0, 1, 100])
+async def test_list__in_range_limit_dispatches(list_harness, limit):
+    """OpenAI parity: live OpenAI accepts limit=0 (empty page) and 1..100, so
+    those values must keep flowing through to the listing branch untouched."""
+    page = FakeListPage([])
+    list_user_batches = list_harness.set_managed_files(page)
+
+    resp = await call_list(list_harness, limit=limit)
+
+    assert resp is page
+    assert list_user_batches.call_args.kwargs["limit"] == limit
+
+
 # --------------------------------------------------------------------------- #
 # Branch 2 - model from body/query/header. The endpoint resolves credentials
 # for the body model, forwards custom_llm_provider once (it pops it from data

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_managed_id_rewriter.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_managed_id_rewriter.py
@@ -1,0 +1,128 @@
+import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+from litellm.proxy.pass_through_endpoints.managed_id_codec import new_managed_id
+from litellm.proxy.pass_through_endpoints.managed_id_rewriter import (
+    list_passthrough_ids_from_db,
+)
+
+
+def _user() -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(user_id="user-1", team_id="team-1")
+
+
+def _prisma_client(file_rows=None, batch_rows=None) -> MagicMock:
+    pc = MagicMock()
+    pc.db = MagicMock()
+    pc.db.litellm_managedfiletable = MagicMock()
+    pc.db.litellm_managedfiletable.find_first = AsyncMock(return_value=None)
+    pc.db.litellm_managedfiletable.find_many = AsyncMock(
+        side_effect=lambda *args, take=None, **kwargs: list(file_rows or [])[:take]
+    )
+    pc.db.litellm_managedobjecttable = MagicMock()
+    pc.db.litellm_managedobjecttable.find_first = AsyncMock(return_value=None)
+    pc.db.litellm_managedobjecttable.find_many = AsyncMock(
+        side_effect=lambda *args, take=None, **kwargs: list(batch_rows or [])[:take]
+    )
+    return pc
+
+
+def _file_row(unified_id: str) -> MagicMock:
+    row = MagicMock()
+    row.unified_file_id = unified_id
+    row.created_by = "user-1"
+    row.team_id = "team-1"
+    row.file_object = {"filename": "test.jsonl", "bytes": 42, "purpose": "batch"}
+    row.created_at = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+    return row
+
+
+def _batch_row(unified_id: str) -> MagicMock:
+    row = MagicMock()
+    row.unified_object_id = unified_id
+    row.created_by = "user-1"
+    row.team_id = "team-1"
+    row.file_object = {"status": "completed", "input_file_id": "file-managed-1"}
+    row.file_purpose = "batch"
+    row.created_at = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+    return row
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "limit,expected_message,expected_openai_code",
+    [
+        (
+            "-1",
+            "Invalid 'limit': integer below minimum value. Expected a value >= 0, but got -1 instead.",
+            "integer_below_min_value",
+        ),
+        (
+            "101",
+            "Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 101 instead.",
+            "integer_above_max_value",
+        ),
+    ],
+)
+async def test_list_batches_out_of_range_limit_raises_400(
+    limit, expected_message, expected_openai_code
+):
+    pc = _prisma_client(batch_rows=[_batch_row(new_managed_id("openai", "batch_abc"))])
+
+    with pytest.raises(ProxyException) as exc:
+        await list_passthrough_ids_from_db(
+            provider="openai",
+            route="/openai/v1/batches",
+            user_api_key_dict=_user(),
+            prisma_client=pc,
+            query_params={"limit": limit},
+        )
+
+    assert exc.value.code == "400"
+    assert exc.value.param == "limit"
+    assert exc.value.type == "invalid_request_error"
+    assert exc.value.openai_code == expected_openai_code
+    assert exc.value.message == expected_message
+    pc.db.litellm_managedobjecttable.find_many.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_batches_limit_zero_returns_empty_page_without_db_query():
+    pc = _prisma_client(batch_rows=[_batch_row(new_managed_id("openai", "batch_abc"))])
+
+    result = await list_passthrough_ids_from_db(
+        provider="openai",
+        route="/openai/v1/batches",
+        user_api_key_dict=_user(),
+        prisma_client=pc,
+        query_params={"limit": "0"},
+    )
+
+    assert result == {
+        "object": "list",
+        "data": [],
+        "first_id": None,
+        "last_id": None,
+        "has_more": False,
+    }
+    pc.db.litellm_managedobjecttable.find_many.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_files_limit_above_batch_cap_still_served():
+    managed_id = new_managed_id("openai", "file-abc")
+    pc = _prisma_client(file_rows=[_file_row(managed_id)])
+
+    result = await list_passthrough_ids_from_db(
+        provider="openai",
+        route="/openai/v1/files",
+        user_api_key_dict=_user(),
+        prisma_client=pc,
+        query_params={"limit": "101"},
+    )
+
+    assert result is not None
+    assert [item["id"] for item in result["data"]] == [managed_id]

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -33,7 +33,7 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     websocket_passthrough_request,
 )
 from litellm.integrations.custom_logger import CustomLogger
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
 )
@@ -364,6 +364,39 @@ async def test_pass_through_request_failure_handler():
                     call_args["original_exception"], TypeError
                 )  # Now expecting TypeError
                 assert "traceback_str" in call_args
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_preserves_proxy_exception_status():
+    original = ProxyException(
+        message="Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 101 instead.",
+        type="invalid_request_error",
+        param="limit",
+        code=400,
+        openai_code="integer_above_max_value",
+    )
+
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
+        mock_proxy_logging.post_call_failure_hook = AsyncMock()
+        mock_proxy_logging.pre_call_hook = AsyncMock(side_effect=original)
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "GET"
+        mock_request.body = AsyncMock(return_value=b"")
+        mock_request.headers = Headers({})
+        mock_request.query_params = QueryParams({"limit": "101"})
+
+        with pytest.raises(ProxyException) as exc:
+            await pass_through_request(
+                request=mock_request,
+                target="http://test.com/v1/batches",
+                custom_headers={},
+                user_api_key_dict=MagicMock(),
+            )
+
+        assert exc.value is original
+        assert exc.value.code == "400"
+        assert exc.value.param == "limit"
 
 
 def test_is_langfuse_route():


### PR DESCRIPTION
## TLDR

Problem this solves:

- GET /v1/batches accepted any integer `limit` with HTTP 200
- `limit=0` silently returned a default page of 20 records
- `limit=-1` returned an empty page claiming `has_more: true`, spinning paginators

How it solves it:

- Rejects `limit < 0` and `limit > 100` with OpenAI's exact 400 error
- `limit=0` now returns an empty page, matching live api.openai.com
- The same bounds now cover managed passthrough batch listings (GET /openai/v1/batches served from the gateway DB under `passthrough_managed_object_ids`), which previously returned 200 for any limit and, for `limit=0`, an empty page claiming `has_more: true`

## User Flow

Before: a script paginating batch history through the gateway receives records it never asked for, and one malformed value hands it a page that keeps it looping

1. The script sends GET https://litellm-domain/v1/batches?limit=100 with its key and processes the returned page
2. Its remaining-count arithmetic yields 0 on the final iteration, so it sends GET https://litellm-domain/v1/batches?limit=0
3. The response is 200 carrying a default page of up to 20 records, so the script processes records it did not request
4. A call with ?limit=101 or ?limit=1000 returns 200 with a full page instead of an error
5. A call with ?limit=-1 returns 200 with zero records but `"has_more": true`, so a paginator that trusts `has_more` loops forever
6. The same calls sent to https://api.openai.com/v1/batches behave differently: limit=0 returns 200 with an empty list, and -1, 101, and 1000 return 400 with `"Invalid 'limit'"` and `"param": "limit"`

After: the same script gets api.openai.com's exact behavior from the gateway

1. The script sends GET https://litellm-domain/v1/batches?limit=100 with its key and processes the returned page
2. Its remaining-count arithmetic yields 0 on the final iteration, so it sends GET https://litellm-domain/v1/batches?limit=0
3. The response is 200 with an empty `data` list and `"has_more": false`, exactly like api.openai.com, so the loop ends cleanly
4. ?limit=101 and ?limit=1000 return 400 with `"Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 101 instead."` and `"param": "limit"`
5. ?limit=-1 returns 400 with `"Invalid 'limit': integer below minimum value. Expected a value >= 0, but got -1 instead."` and `"param": "limit"`

## Relevant issues

Fixes #37149

## Linear ticket

Resolves LIT-5660

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Each leg ran a live proxy from a worktree at the named hash against its own fresh postgres DB, hitting real api.openai.com (real file uploads, real batches, real $). Config: one azure model, one `openai/gpt-5` model, and `general_settings.passthrough_managed_object_ids: true`, so both listing surfaces are live. Seeds per leg: 3 managed batches created through POST /v1/batches plus 1 passthrough batch created through POST /openai_passthrough/v1/batches, all `"status": "validating"`. The commits after 6e55a21ebb are non-behavioral (09c8d1f1f5 merges the updated base; 91c12ec810 relocates the managed passthrough limit tests into the CI-run suite), so the behavioral tip QA'd here is 6e55a21ebb

```
DATABASE_URL="postgresql://mateo@localhost:5432/<leg db>" LITELLM_MASTER_KEY=$MASTER_KEY \
  .venv/bin/python litellm/proxy/proxy_cli.py --config lit5660_qa_config.yaml --port <leg port>
for L in 0 -1 1 2 5 101 1000; do echo "== limit=$L"; curl -s -w '\nHTTP %{http_code}\n' \
  "http://localhost:<leg port>/v1/batches?limit=$L" -H "Authorization: Bearer $MASTER_KEY"; done
```

### Before (merge base 3b6ae75f73, port 52734)

GET /v1/batches: HTTP 200 for every value

```
limit=0    -> HTTP 200 | 4 records, has_more=false   (a full default page the client asked to receive none of)
limit=-1   -> HTTP 200 | {"object":"list","data":[],"first_id":null,"last_id":null,"has_more":true}
limit=1    -> HTTP 200 | 1 record,  has_more=true
limit=2    -> HTTP 200 | 2 records, has_more=true
limit=5    -> HTTP 200 | 4 records, has_more=false
limit=101  -> HTTP 200 | 4 records, has_more=false
limit=1000 -> HTTP 200 | 4 records, has_more=false
```

GET /openai_passthrough/v1/batches (managed passthrough listing, served from the gateway DB): HTTP 200 for every value

```
limit=0    -> HTTP 200 | {"object": "list", "data": [], "first_id": null, "last_id": null, "has_more": true}
limit=-1   -> HTTP 200 | {"object": "list", "data": [], "first_id": null, "last_id": null, "has_more": true}
limit=1    -> HTTP 200 | 1 record, has_more=false
limit=101  -> HTTP 200 | 1 record, has_more=false
limit=1000 -> HTTP 200 | 1 record, has_more=false
```

GET /openai/v1/batches (provider-scoped route): every limit, valid or not, returned the pre-existing HTTP 500 `Filtering by 'provider' is not supported when using managed batches.`, so no limit ever reached validation there

### After (6e55a21ebb, port 52619)

GET /v1/batches:

```
limit=0    -> HTTP 200 | {"object":"list","data":[],"first_id":null,"last_id":null,"has_more":false}
limit=-1   -> HTTP 400 | {"error":{"message":"Invalid 'limit': integer below minimum value. Expected a value >= 0, but got -1 instead.","type":"invalid_request_error","param":"limit","code":"400"}}
limit=1    -> HTTP 200 | 1 record,  has_more=true
limit=2    -> HTTP 200 | 2 records, has_more=true
limit=5    -> HTTP 200 | 4 records, has_more=false
limit=101  -> HTTP 400 | {"error":{"message":"Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 101 instead.","type":"invalid_request_error","param":"limit","code":"400"}}
limit=1000 -> HTTP 400 | {"error":{"message":"Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 1000 instead.","type":"invalid_request_error","param":"limit","code":"400"}}
```

GET /openai_passthrough/v1/batches:

```
limit=0    -> HTTP 200 | {"object": "list", "data": [], "first_id": null, "last_id": null, "has_more": false}
limit=-1   -> HTTP 400 | {"error":{"message":"Invalid 'limit': integer below minimum value. Expected a value >= 0, but got -1 instead.","type":"invalid_request_error","param":"limit","code":"400"}}
limit=1    -> HTTP 200 | 1 record, has_more=false
limit=101  -> HTTP 400 | {"error":{"message":"Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 101 instead.","type":"invalid_request_error","param":"limit","code":"400"}}
limit=1000 -> HTTP 400 | {"error":{"message":"Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 1000 instead.","type":"invalid_request_error","param":"limit","code":"400"}}
```

GET /openai/v1/batches (provider-scoped route): -1, 101, and 1000 now return the same 400s first; in-range limits still hit the pre-existing provider-filter 500, unchanged by this PR

### Same sweep straight at api.openai.com (parity target)

`for L in 0 -1 101 1000; do curl -s -w '\nHTTP %{http_code}\n' "https://api.openai.com/v1/batches?limit=$L" -H "Authorization: Bearer $OPENAI_API_KEY"; done` on the same account:

```
limit=0    -> HTTP 200 {"object":"list","data":[],"first_id":null,"last_id":null,"has_more":false}
limit=-1   -> HTTP 400 {"error":{"message":"Invalid 'limit': integer below minimum value. Expected a value >= 0, but got -1 instead.","type":"invalid_request_error","param":"limit","code":"integer_below_min_value"}}
limit=101  -> HTTP 400 {"error":{"message":"Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 101 instead.","type":"invalid_request_error","param":"limit","code":"integer_above_max_value"}}
limit=1000 -> HTTP 400 {"error":{"message":"Invalid 'limit': integer above maximum value. Expected a value <= 100, but got 1000 instead.","type":"invalid_request_error","param":"limit","code":"integer_above_max_value"}}
```

## Type

🐛 Bug Fix

## Caveats (if any)

- OpenAI docs say limit is 1-100, but the live API accepts 0; this PR follows live behavior
- Error body `code` is `"400"`, not OpenAI's snake_case code, per the gateway's long-standing error contract
- Azure's provider-side list_batches call forwards neither `after` nor `limit`, so Azure ignores every limit value today; pre-existing and untouched here
- The provider-scoped GET /openai/v1/batches route 500s on every in-range limit (`Filtering by 'provider' is not supported when using managed batches.`) whenever managed passthrough is on; pre-existing at the merge base and untouched here, while out-of-range limits on that route now 400 before reaching it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

