### PR TITLE
fix(proxy): return 400 naming the missing required param on POST /v1/batches

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -40,6 +40,7 @@ from litellm.proxy.openai_files_endpoints.common_utils import (
     update_batch_in_database,
     validate_managed_id_requirement,
 )
+from litellm.proxy.route_llm_request import raise_if_required_body_param_missing
 from litellm.proxy.utils import handle_exception_on_proxy, is_known_model
 from litellm.repositories.table_repositories import ManagedFileRepository
 from litellm.types.llms.openai import LiteLLMBatchCreateRequest
@@ -139,6 +140,8 @@ async def create_batch(
             route_type="acreate_batch",
         )
         data["metadata"] = sanitize_openai_provider_metadata(data.get("metadata"))
+
+        raise_if_required_body_param_missing(route_type="acreate_batch", data=data)
 
         ## check if model is a loadbalanced model
         router_model: str | None = None

--- a/litellm/proxy/route_llm_request.py
+++ b/litellm/proxy/route_llm_request.py
@@ -6,7 +6,7 @@ import httpx
 from fastapi import HTTPException, status
 
 import litellm
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.router_utils.common_utils import _is_proxy_admin_request
 
 # Client-supplied params that make the router or the call path fabricate a
@@ -141,6 +141,7 @@ ROUTE_ENDPOINT_MAPPING: Final = {
     "aget_run": "/evals/{eval_id}/runs/{run_id}",
     "acancel_run": "/evals/{eval_id}/runs/{run_id}/cancel",
     "adelete_run": "/evals/{eval_id}/runs/{run_id}",
+    "acreate_batch": "/batches",
 }
 
 
@@ -152,27 +153,33 @@ class ProxyModelNotFoundError(HTTPException):
         super().__init__(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
 
 
-REQUIRED_BODY_PARAM_BY_ROUTE: Final[Mapping[str, str]] = {
-    "acompletion": "messages",
-    "aembedding": "input",
+REQUIRED_BODY_PARAMS_BY_ROUTE: Final[Mapping[str, tuple[str, ...]]] = {
+    "acompletion": ("messages",),
+    "aembedding": ("input",),
+    "acreate_batch": ("input_file_id", "endpoint", "completion_window"),
 }
 
 
-class ProxyMissingRequiredParamError(HTTPException):
+class ProxyMissingRequiredParamError(ProxyException):
     def __init__(self, route: str, param: str):
-        detail: Final = {"error": f"{route}: Missing required parameter: '{param}'."}
-        super().__init__(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
-        self.type = "invalid_request_error"
-        self.param = param
+        super().__init__(
+            message=f"{route}: Missing required parameter: '{param}'.",
+            type="invalid_request_error",
+            param=param,
+            code=status.HTTP_400_BAD_REQUEST,
+        )
 
 
 def raise_if_required_body_param_missing(route_type: str, data: Mapping[str, object]) -> None:
-    required_param: Final = REQUIRED_BODY_PARAM_BY_ROUTE.get(route_type)
-    if required_param is None or data.get(required_param) is not None:
+    missing_param: Final = next(
+        (param for param in REQUIRED_BODY_PARAMS_BY_ROUTE.get(route_type, ()) if data.get(param) is None),
+        None,
+    )
+    if missing_param is None:
         return
     raise ProxyMissingRequiredParamError(
         route=ROUTE_ENDPOINT_MAPPING.get(route_type, route_type),
-        param=required_param,
+        param=missing_param,
     )
 
 

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -758,12 +758,6 @@ async def test_create__model_encoded_beats_loadbalancing(harness):
     harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
 
 
-# =========================================================================== #
-# Missing required body params - 400 naming the field, never a 500 TypeError
-# from acreate_batch() (https://github.com/BerriAI/litellm/issues/37146).
-# =========================================================================== #
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "body, missing_param",

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -759,6 +759,36 @@ async def test_create__model_encoded_beats_loadbalancing(harness):
 
 
 # =========================================================================== #
+# Missing required body params - 400 naming the field, never a 500 TypeError
+# from acreate_batch() (https://github.com/BerriAI/litellm/issues/37146).
+# =========================================================================== #
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body, missing_param",
+    [
+        ({"endpoint": "/v1/chat/completions", "completion_window": "24h"}, "input_file_id"),
+        ({"input_file_id": "file-abc", "completion_window": "24h"}, "endpoint"),
+        ({"input_file_id": "file-abc", "endpoint": "/v1/chat/completions"}, "completion_window"),
+        ({}, "input_file_id"),
+    ],
+)
+async def test_create__missing_required_param_is_400(harness, body, missing_param):
+    set_body(harness, body)
+
+    with pytest.raises(ProxyException) as exc_info:
+        await call_create(harness)
+
+    assert exc_info.value.code == "400"
+    assert exc_info.value.type == "invalid_request_error"
+    assert exc_info.value.param == missing_param
+    assert exc_info.value.message == f"/batches: Missing required parameter: '{missing_param}'."
+    harness.litellm_acreate.assert_not_called()
+    harness.router_acreate.assert_not_called()
+
+
+# =========================================================================== #
 # Team-level batch expiry enforcement (independent of routing).
 # =========================================================================== #
 

--- a/tests/test_litellm/proxy/test_route_llm_request.py
+++ b/tests/test_litellm/proxy/test_route_llm_request.py
@@ -1042,9 +1042,10 @@ async def test_route_request_override_enable_tag_filtering_beats_body_value():
     [
         ("acompletion", "messages", "/chat/completions"),
         ("aembedding", "input", "/embeddings"),
+        ("acreate_batch", "input_file_id", "/batches"),
     ],
 )
-@pytest.mark.parametrize("data_extra", [{}, {"messages": None, "input": None}])
+@pytest.mark.parametrize("data_extra", [{}, {"messages": None, "input": None, "input_file_id": None}])
 def test_raise_if_required_body_param_missing_rejects_missing_param(route_type, param, route, data_extra):
     from litellm.proxy.route_llm_request import (
         ProxyMissingRequiredParamError,
@@ -1054,10 +1055,31 @@ def test_raise_if_required_body_param_missing_rejects_missing_param(route_type, 
     with pytest.raises(ProxyMissingRequiredParamError) as exc_info:
         raise_if_required_body_param_missing(route_type=route_type, data={"model": "gpt-4o", **data_extra})
 
-    assert exc_info.value.status_code == 400
+    assert exc_info.value.code == "400"
     assert exc_info.value.param == param
     assert exc_info.value.type == "invalid_request_error"
-    assert exc_info.value.detail == {"error": f"{route}: Missing required parameter: '{param}'."}
+    assert exc_info.value.message == f"{route}: Missing required parameter: '{param}'."
+
+
+@pytest.mark.parametrize(
+    "data, param",
+    [
+        ({"endpoint": "/v1/chat/completions", "completion_window": "24h"}, "input_file_id"),
+        ({"input_file_id": "file-abc", "completion_window": "24h"}, "endpoint"),
+        ({"input_file_id": "file-abc", "endpoint": "/v1/chat/completions"}, "completion_window"),
+        ({}, "input_file_id"),
+    ],
+)
+def test_raise_if_required_body_param_missing_names_first_missing_batch_param(data, param):
+    from litellm.proxy.route_llm_request import (
+        ProxyMissingRequiredParamError,
+        raise_if_required_body_param_missing,
+    )
+
+    with pytest.raises(ProxyMissingRequiredParamError) as exc_info:
+        raise_if_required_body_param_missing(route_type="acreate_batch", data=data)
+
+    assert exc_info.value.param == param
 
 
 @pytest.mark.parametrize(
@@ -1069,6 +1091,10 @@ def test_raise_if_required_body_param_missing_rejects_missing_param(route_type, 
         ("aembedding", {"model": "text-embedding-3-small", "input": "hi"}),
         ("arerank", {"model": "rerank-model"}),
         ("aimage_generation", {"model": "dall-e-3"}),
+        (
+            "acreate_batch",
+            {"input_file_id": "file-abc", "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+        ),
     ],
 )
 def test_raise_if_required_body_param_missing_allows_valid_requests(route_type, data):
@@ -1088,7 +1114,7 @@ async def test_route_request_rejects_chat_completion_without_messages():
     with pytest.raises(ProxyMissingRequiredParamError) as exc_info:
         await route_request({"model": "gpt-4o"}, llm_router, None, "acompletion")
 
-    assert exc_info.value.status_code == 400
+    assert exc_info.value.code == "400"
     assert exc_info.value.param == "messages"
     llm_router.acompletion.assert_not_called()
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- POST /v1/batches with a required field absent returned HTTP 500
- The error text was a raw Python TypeError from inside the proxy
- SDKs that retry on 5xx kept resending the doomed request

How it solves it:

- Validates input_file_id, endpoint, and completion_window before dispatch
- Returns 400 invalid_request_error naming the missing parameter
- Reuses the shared required-param check behind /chat/completions and /embeddings

## User Flow

Before: a developer submitting a nightly bulk classification job omits one field and receives a 500

1. They send POST https://litellm-domain/v1/files with `purpose=batch` and their JSONL, and receive a file ID
2. They send POST https://litellm-domain/v1/batches with `{"endpoint": "/v1/chat/completions", "completion_window": "24h"}`, omitting `input_file_id`
3. The response is 500 with the message `acreate_batch() missing 1 required positional argument: 'input_file_id'` and `"type": "internal_server_error"`
4. Their SDK, which retries on 5xx, resends the same request and receives the same 500 each time

After: the same request returns 400 naming the absent field

1. They send POST https://litellm-domain/v1/files with `purpose=batch` and their JSONL, and receive a file ID
2. They send POST https://litellm-domain/v1/batches with `{"endpoint": "/v1/chat/completions", "completion_window": "24h"}`, omitting `input_file_id`
3. The response is 400 with `"/batches: Missing required parameter: 'input_file_id'."`, `"type": "invalid_request_error"`, and `"param": "input_file_id"`
4. Their SDK does not retry a 4xx, so the actionable message surfaces immediately

## Relevant issues

Fixes #37146

## Linear ticket

Resolves LIT-5657

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy from the worktree, port checked free first (`lsof -nP -iTCP:23866 -sTCP:LISTEN`), booted with `.venv/bin/python litellm/proxy/proxy_cli.py --config lit5657_repro_config.yaml --port 23866` and this config:

```yaml
model_list:
  - model_name: gpt-5-batch
    litellm_params:
      model: azure/gpt-5-batch-2025-08-07
      api_base: os.environ/AZURE_FOUNDRY_API_BASE
      api_key: os.environ/AZURE_FOUNDRY_API_KEY

files_settings:
  - custom_llm_provider: openai
    api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  database_url: os.environ/DATABASE_URL
```

OpenAI's own behavior for the same bodies (control, identical on both sides): 400 with `{"error": {"message": "Missing required parameter: 'input_file_id'.", "type": "invalid_request_error", "param": "input_file_id", "code": "missing_required_parameter"}}`

### Before (3b6ae75f735e47ef160bf91b7c6510629e7c7aa4)

#### Required field absent returns 500 with a TypeError message

1. ```
   for body in '{"endpoint": "/v1/chat/completions", "completion_window": "24h"}' \
               '{"input_file_id": "file-abc", "completion_window": "24h"}' \
               '{"input_file_id": "file-abc", "endpoint": "/v1/chat/completions"}' \
               '{}'; do
     echo "--- body: $body"
     curl -s -w '\nHTTP %{http_code}\n' http://localhost:23866/v1/batches \
       -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
       -H 'Content-Type: application/json' -d "$body"
   done
   ```
2. ```
   --- body: {"endpoint": "/v1/chat/completions", "completion_window": "24h"}
   {"error":{"message":"acreate_batch() missing 1 required positional argument: 'input_file_id'","type":"internal_server_error","param":"None","code":"500"}}
   HTTP 500
   --- body: {"input_file_id": "file-abc", "completion_window": "24h"}
   {"error":{"message":"acreate_batch() missing 1 required positional argument: 'endpoint'","type":"internal_server_error","param":"None","code":"500"}}
   HTTP 500
   --- body: {"input_file_id": "file-abc", "endpoint": "/v1/chat/completions"}
   {"error":{"message":"acreate_batch() missing 1 required positional argument: 'completion_window'","type":"internal_server_error","param":"None","code":"500"}}
   HTTP 500
   --- body: {}
   {"error":{"message":"acreate_batch() missing 3 required positional arguments: 'completion_window', 'endpoint', and 'input_file_id'","type":"internal_server_error","param":"None","code":"500"}}
   HTTP 500
   ```

#### All fields present still creates a real OpenAI batch

1. ```
   curl -s http://localhost:23866/v1/files -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
     -F purpose=batch -F file=@batch_input.jsonl
   ```
2. `{"id":"file-RdVqhPBRbdS215wzbYoeSq","bytes":222,...,"purpose":"batch","status":"processed",...}`
3. ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:23866/v1/batches \
     -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
     -d '{"input_file_id":"file-RdVqhPBRbdS215wzbYoeSq","endpoint":"/v1/chat/completions","completion_window":"24h"}'
   ```
4. `{"id":"batch_6a8356d32c848190acccea9354e4c336","completion_window":"24h",...,"status":"validating",...}` then `HTTP 200`

### After (e4ce5269005e62b70a79fd62548a7441108737c9)

The only commit since, a9bb09905d, removes a test comment banner and cannot change behavior, so this proof covers the tip

#### Required field absent returns 400 naming the field

1. ```
   for body in '{"endpoint": "/v1/chat/completions", "completion_window": "24h"}' \
               '{"input_file_id": "file-abc", "completion_window": "24h"}' \
               '{"input_file_id": "file-abc", "endpoint": "/v1/chat/completions"}' \
               '{}'; do
     echo "--- body: $body"
     curl -s -w '\nHTTP %{http_code}\n' http://localhost:23866/v1/batches \
       -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
       -H 'Content-Type: application/json' -d "$body"
   done
   ```
2. ```
   --- body: {"endpoint": "/v1/chat/completions", "completion_window": "24h"}
   {"error":{"message":"/batches: Missing required parameter: 'input_file_id'.","type":"invalid_request_error","param":"input_file_id","code":"400"}}
   HTTP 400
   --- body: {"input_file_id": "file-abc", "completion_window": "24h"}
   {"error":{"message":"/batches: Missing required parameter: 'endpoint'.","type":"invalid_request_error","param":"endpoint","code":"400"}}
   HTTP 400
   --- body: {"input_file_id": "file-abc", "endpoint": "/v1/chat/completions"}
   {"error":{"message":"/batches: Missing required parameter: 'completion_window'.","type":"invalid_request_error","param":"completion_window","code":"400"}}
   HTTP 400
   --- body: {}
   {"error":{"message":"/batches: Missing required parameter: 'input_file_id'.","type":"invalid_request_error","param":"input_file_id","code":"400"}}
   HTTP 400
   ```

#### All fields present still creates a real OpenAI batch

1. ```
   curl -s http://localhost:23866/v1/files -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
     -F purpose=batch -F file=@batch_input.jsonl
   ```
2. `{"id":"file-FTDLibSzXz44ZYqptY3fwi","bytes":222,...,"purpose":"batch","status":"processed",...}`
3. ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:23866/v1/batches \
     -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
     -d '{"input_file_id":"file-FTDLibSzXz44ZYqptY3fwi","endpoint":"/v1/chat/completions","completion_window":"24h"}'
   ```
4. `{"id":"batch_6a8358a227788190814abb0862851ed7","completion_window":"24h",...,"status":"validating",...}` then `HTTP 200`

## Type

🐛 Bug Fix

## Caveats (if any)

- Chat/embeddings missing-param 400s drop the redundant provider_specific_fields echo of the message

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a9bb09905d2f14fd50d62ff0badf7e64c3c87fef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->