### PR TITLE
fix(proxy): return 404 instead of 500 for unresolvable batch and file ids on /v1/batches

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -41,6 +41,7 @@ from litellm.proxy._types import (
     CallTypes,
     LiteLLM_ManagedFileTable,
     LiteLLM_ManagedObjectTable,
+    ProxyException,
     UserAPIKeyAuth,
 )
 from litellm.proxy.openai_files_endpoints.common_utils import (
@@ -423,13 +424,23 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         # This is because the encoded object ids stored in the managed objects table do not contain the provider information
         # To support provider filtering, we would need to store the provider information in the encoded object ids
         if provider:
-            raise Exception("Filtering by 'provider' is not supported when using managed batches.")
+            raise ProxyException(
+                message="Filtering by 'provider' is not supported when using managed batches.",
+                type="invalid_request_error",
+                param="provider",
+                code=400,
+            )
 
         # Model name filtering is not supported for managed batches
         # This is because the encoded object ids stored in the managed objects table do not contain the model name
         # A hash of the model name + litellm_params for the model name is encoded as the model id. This is not sufficient to reliably map the target model names to the model ids.
         if target_model_names:
-            raise Exception("Filtering by 'target_model_names' is not supported when using managed batches.")
+            raise ProxyException(
+                message="Filtering by 'target_model_names' is not supported when using managed batches.",
+                type="invalid_request_error",
+                param="target_model_names",
+                code=400,
+            )
 
         owner_filter = build_owner_filter(user_api_key_dict)
         if owner_filter is None:

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -5,6 +5,8 @@
 
 ######################################################################
 import asyncio
+import os
+from collections.abc import Mapping
 from typing import Any, Final, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
@@ -45,6 +47,23 @@ from litellm.repositories.table_repositories import ManagedFileRepository
 from litellm.types.llms.openai import LiteLLMBatchCreateRequest
 
 router: Final = APIRouter()
+
+
+def _raise_not_found_when_openai_fallback_unservable(
+    requested_provider: "str | None",
+    data: Mapping[str, object],
+    not_found_message: str,
+) -> None:
+    if requested_provider is not None:
+        return
+    if data.get("api_key") or litellm.api_key or litellm.openai_key or os.getenv("OPENAI_API_KEY"):
+        return
+    raise ProxyException(
+        message=not_found_message,
+        type="invalid_request_error",
+        param=None,
+        code=404,
+    )
 
 
 async def _resolve_managed_input_file_storage_url(input_file_id: str) -> "str | None":
@@ -147,12 +166,12 @@ async def create_batch(
             router_model = data.get("model", None)
             is_router_model = is_known_model(model=router_model, llm_router=llm_router)
 
-        custom_llm_provider: Final = (
+        requested_provider: Final = (
             provider
             or data.pop("custom_llm_provider", None)
             or get_custom_llm_provider_from_request_headers(request=request)
-            or "openai"
         )
+        custom_llm_provider: Final = requested_provider or "openai"
         _create_batch_data: Final = LiteLLMBatchCreateRequest(**data)
 
         # Apply team-level batch output expiry enforcement
@@ -313,6 +332,11 @@ async def create_batch(
                     llm_router=llm_router,
                     user_api_key_dict=user_api_key_dict,
                     custom_llm_provider=custom_llm_provider,
+                )
+                _raise_not_found_when_openai_fallback_unservable(
+                    requested_provider=requested_provider,
+                    data=cast(dict, _create_batch_data),  # cast-ok: TypedDict is a dict at runtime
+                    not_found_message=f"No such File object: {input_file_id}",
                 )
                 response = await litellm.acreate_batch(
                     custom_llm_provider=custom_llm_provider,
@@ -563,17 +587,22 @@ async def retrieve_batch(
 
         # SCENARIO 3: Fallback to custom_llm_provider (uses env variables)
         else:
-            custom_llm_provider: Final = (
+            requested_provider: Final = (
                 provider
                 or get_custom_llm_provider_from_request_headers(request=request)
                 or get_custom_llm_provider_from_request_query(request=request)
-                or "openai"
             )
+            custom_llm_provider: Final = requested_provider or "openai"
             apply_team_provider_credentials(
                 data=data,
                 llm_router=llm_router,
                 user_api_key_dict=user_api_key_dict,
                 custom_llm_provider=custom_llm_provider,
+            )
+            _raise_not_found_when_openai_fallback_unservable(
+                requested_provider=requested_provider,
+                data=data,
+                not_found_message=f"No batch found with id '{batch_id}'.",
             )
             response = await litellm.aretrieve_batch(
                 custom_llm_provider=custom_llm_provider,
@@ -967,13 +996,13 @@ async def cancel_batch(
         # SCENARIO 3: Fallback to custom_llm_provider (uses env variables)
         else:
             body_custom_llm_provider = data.pop("custom_llm_provider", None)
-            custom_llm_provider: Final = (
+            requested_provider: Final = (
                 provider
                 or body_custom_llm_provider
                 or get_custom_llm_provider_from_request_headers(request=request)
                 or get_custom_llm_provider_from_request_query(request=request)
-                or "openai"
             )
+            custom_llm_provider: Final = requested_provider or "openai"
             # Extract batch_id from data to avoid "multiple values for keyword argument" error
             # data was cast from CancelBatchRequest which already contains batch_id
             data.pop("batch_id", None)
@@ -982,6 +1011,11 @@ async def cancel_batch(
                 llm_router=llm_router,
                 user_api_key_dict=user_api_key_dict,
                 custom_llm_provider=custom_llm_provider,
+            )
+            _raise_not_found_when_openai_fallback_unservable(
+                requested_provider=requested_provider,
+                data=data,
+                not_found_message=f"No batch found with id '{batch_id}'.",
             )
             _cancel_batch_data: Final = CancelBatchRequest(batch_id=batch_id, **data)
             response = await litellm.acancel_batch(

--- a/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
+++ b/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
@@ -3147,3 +3147,43 @@ async def test_file_list_cursors_follow_the_owner_scoped_page():
     assert response.first_id == "litellm_proxy:mine"
     assert response.last_id == "litellm_proxy:mine"
     assert response.has_more is False
+
+
+@pytest.mark.asyncio
+async def test_list_user_batches_provider_filter_rejected_with_400():
+    from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+
+    proxy_managed_files = _PROXY_LiteLLMManagedFiles(
+        DualCache(), prisma_client=MagicMock()
+    )
+
+    with pytest.raises(ProxyException) as exc:
+        await proxy_managed_files.list_user_batches(
+            user_api_key_dict=UserAPIKeyAuth(user_id="123"),
+            provider="openai",
+        )
+
+    assert exc.value.code == "400"
+    assert exc.value.type == "invalid_request_error"
+    assert exc.value.param == "provider"
+    assert exc.value.message == "Filtering by 'provider' is not supported when using managed batches."
+
+
+@pytest.mark.asyncio
+async def test_list_user_batches_target_model_names_filter_rejected_with_400():
+    from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+
+    proxy_managed_files = _PROXY_LiteLLMManagedFiles(
+        DualCache(), prisma_client=MagicMock()
+    )
+
+    with pytest.raises(ProxyException) as exc:
+        await proxy_managed_files.list_user_batches(
+            user_api_key_dict=UserAPIKeyAuth(user_id="123"),
+            target_model_names="gpt-4o",
+        )
+
+    assert exc.value.code == "400"
+    assert exc.value.type == "invalid_request_error"
+    assert exc.value.param == "target_model_names"
+    assert exc.value.message == "Filtering by 'target_model_names' is not supported when using managed batches."

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -117,6 +117,21 @@ class FakeRequest:
         self.query_params = query or {}
 
 
+@pytest.fixture
+def openai_env_creds(monkeypatch):
+    """Deterministic env creds so the implicit-openai fallback forwards instead
+    of tripping the no-creds 404 gate, regardless of the host environment."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-openai")
+
+
+@pytest.fixture
+def no_openai_creds(monkeypatch):
+    """Neutralize every credential source the 404 gate checks."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.setattr(litellm, "openai_key", None)
+
+
 @dataclass
 class Harness:
     """Holds every mocked seam so a test can configure inputs and assert calls."""
@@ -409,7 +424,7 @@ async def test_create__body_model_beats_header_and_query(harness):
 
 
 @pytest.mark.asyncio
-async def test_create__fallback_default_openai(harness):
+async def test_create__fallback_default_openai(harness, openai_env_creds):
     set_body(
         harness,
         {
@@ -424,6 +439,63 @@ async def test_create__fallback_default_openai(harness):
     assert harness.litellm_acreate.call_count == 1
     harness.router_acreate.assert_not_called()
     harness.creds_resolver.assert_not_called()  # inverse-bug guard
+    assert harness.acreate_kwargs()["custom_llm_provider"] == "openai"
+
+
+@pytest.mark.asyncio
+async def test_create__fallback_no_creds_404(harness, no_openai_creds):
+    set_body(
+        harness,
+        {
+            "input_file_id": "file-plain",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        },
+    )
+
+    with pytest.raises(ProxyException) as exc:
+        await call_create(harness)
+
+    assert exc.value.code == "404"
+    assert exc.value.type == "invalid_request_error"
+    assert exc.value.param is None
+    assert exc.value.message == "No such File object: file-plain"
+    harness.litellm_acreate.assert_not_called()
+    harness.router_acreate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create__fallback_explicit_provider_bypasses_not_found_gate(harness, no_openai_creds):
+    set_body(
+        harness,
+        {
+            "input_file_id": "file-plain",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        },
+    )
+
+    await call_create(harness, provider="anthropic")
+
+    assert harness.acreate_kwargs()["custom_llm_provider"] == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_create__fallback_env_key_alone_forwards(harness, monkeypatch):
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.setattr(litellm, "openai_key", None)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-openai")
+    set_body(
+        harness,
+        {
+            "input_file_id": "file-plain",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        },
+    )
+
+    await call_create(harness)
+
     assert harness.acreate_kwargs()["custom_llm_provider"] == "openai"
 
 
@@ -771,7 +843,7 @@ def _user_with_expiry(expiry: Any) -> UserAPIKeyAuth:
 
 
 @pytest.mark.asyncio
-async def test_create__team_expiry_injected(harness):
+async def test_create__team_expiry_injected(harness, openai_env_creds):
     set_body(
         harness,
         {
@@ -790,7 +862,7 @@ async def test_create__team_expiry_injected(harness):
 
 
 @pytest.mark.asyncio
-async def test_create__no_team_expiry_not_injected(harness):
+async def test_create__no_team_expiry_not_injected(harness, openai_env_creds):
     set_body(
         harness,
         {
@@ -838,7 +910,7 @@ async def test_create__team_expiry_malformed_500(harness, expiry):
 
 
 @pytest.mark.asyncio
-async def test_create__uses_acreate_batch_route_type(harness):
+async def test_create__uses_acreate_batch_route_type(harness, openai_env_creds):
     set_body(
         harness,
         {
@@ -854,7 +926,7 @@ async def test_create__uses_acreate_batch_route_type(harness):
 
 
 @pytest.mark.asyncio
-async def test_create__metadata_sanitized_before_forwarding(harness):
+async def test_create__metadata_sanitized_before_forwarding(harness, openai_env_creds):
     set_body(
         harness,
         {
@@ -872,7 +944,7 @@ async def test_create__metadata_sanitized_before_forwarding(harness):
 
 
 @pytest.mark.asyncio
-async def test_create__exception_calls_failure_hook(harness):
+async def test_create__exception_calls_failure_hook(harness, openai_env_creds):
     set_body(
         harness,
         {
@@ -1180,7 +1252,7 @@ async def test_retrieve__loadbalancing_raw_id_routes_to_router(retrieve_harness)
 
 
 @pytest.mark.asyncio
-async def test_retrieve__fallback_default_openai(retrieve_harness):
+async def test_retrieve__fallback_default_openai(retrieve_harness, openai_env_creds):
     await call_retrieve(retrieve_harness, "batch-raw-xyz")
 
     assert retrieve_harness.litellm_aretrieve.call_count == 1
@@ -1191,6 +1263,40 @@ async def test_retrieve__fallback_default_openai(retrieve_harness):
         "batch_id": "batch-raw-xyz",
     }
     assert retrieve_harness.update_batch_in_db.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retrieve__fallback_no_creds_404(retrieve_harness, no_openai_creds):
+    with pytest.raises(ProxyException) as exc:
+        await call_retrieve(retrieve_harness, "batch-raw-xyz")
+
+    assert exc.value.code == "404"
+    assert exc.value.type == "invalid_request_error"
+    assert exc.value.param is None
+    assert exc.value.message == "No batch found with id 'batch-raw-xyz'."
+    retrieve_harness.litellm_aretrieve.assert_not_called()
+    retrieve_harness.router_aretrieve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retrieve__fallback_explicit_provider_bypasses_not_found_gate(retrieve_harness, no_openai_creds):
+    await call_retrieve(retrieve_harness, "batch-raw-xyz", provider="anthropic")
+
+    assert retrieve_harness.aretrieve_kwargs()["custom_llm_provider"] == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_retrieve__fallback_env_key_alone_forwards(retrieve_harness, monkeypatch):
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.setattr(litellm, "openai_key", None)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-openai")
+
+    await call_retrieve(retrieve_harness, "batch-raw-xyz")
+
+    assert retrieve_harness.aretrieve_kwargs() == {
+        "custom_llm_provider": "openai",
+        "batch_id": "batch-raw-xyz",
+    }
 
 
 @pytest.mark.asyncio
@@ -1278,7 +1384,7 @@ async def test_retrieve__db_terminal_unified_resolves_file_ids(retrieve_harness)
 
 
 @pytest.mark.asyncio
-async def test_retrieve__db_non_terminal_state_syncs_with_provider(retrieve_harness):
+async def test_retrieve__db_non_terminal_state_syncs_with_provider(retrieve_harness, openai_env_creds):
     """A non-terminal DB row must NOT short-circuit; the endpoint syncs with the
     provider to refresh state."""
     db_response = make_batch(id="batch-from-db", status="validating")
@@ -1297,14 +1403,14 @@ async def test_retrieve__db_non_terminal_state_syncs_with_provider(retrieve_harn
 
 
 @pytest.mark.asyncio
-async def test_retrieve__uses_aretrieve_batch_route_type(retrieve_harness):
+async def test_retrieve__uses_aretrieve_batch_route_type(retrieve_harness, openai_env_creds):
     await call_retrieve(retrieve_harness, "batch-raw-xyz")
 
     assert retrieve_harness.pre_call.call_args.kwargs["route_type"] == "aretrieve_batch"
 
 
 @pytest.mark.asyncio
-async def test_retrieve__exception_calls_failure_hook(retrieve_harness):
+async def test_retrieve__exception_calls_failure_hook(retrieve_harness, openai_env_creds):
     retrieve_harness.litellm_aretrieve.side_effect = ValueError("provider boom")
 
     with pytest.raises(Exception):
@@ -1585,7 +1691,9 @@ async def test_list__target_model_names_takes_first_only(list_harness):
 
 
 @pytest.mark.asyncio
-async def test_list__fallback_default_openai(list_harness):
+async def test_list__fallback_default_openai(list_harness, no_openai_creds):
+    """list stays ungated by the no-creds 404 guard: it answers about a
+    collection, not a specific id, so there is nothing to 404 about."""
     await call_list(list_harness)
 
     assert list_harness.litellm_alist.call_count == 1
@@ -1936,7 +2044,7 @@ async def test_cancel__unified_no_router_500(cancel_harness):
 
 
 @pytest.mark.asyncio
-async def test_cancel__fallback_default_openai(cancel_harness):
+async def test_cancel__fallback_default_openai(cancel_harness, openai_env_creds):
     await call_cancel(cancel_harness, "batch-raw-xyz")
 
     assert cancel_harness.litellm_acancel.call_count == 1
@@ -1948,6 +2056,40 @@ async def test_cancel__fallback_default_openai(cancel_harness):
         "batch_id": "batch-raw-xyz",
     }
     assert cancel_harness.update_batch_in_db.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cancel__fallback_no_creds_404(cancel_harness, no_openai_creds):
+    with pytest.raises(ProxyException) as exc:
+        await call_cancel(cancel_harness, "batch-raw-xyz")
+
+    assert exc.value.code == "404"
+    assert exc.value.type == "invalid_request_error"
+    assert exc.value.param is None
+    assert exc.value.message == "No batch found with id 'batch-raw-xyz'."
+    cancel_harness.litellm_acancel.assert_not_called()
+    cancel_harness.router_acancel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancel__fallback_explicit_provider_bypasses_not_found_gate(cancel_harness, no_openai_creds):
+    await call_cancel(cancel_harness, "batch-raw-xyz", provider="anthropic")
+
+    assert cancel_harness.acancel_kwargs()["custom_llm_provider"] == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_cancel__fallback_env_key_alone_forwards(cancel_harness, monkeypatch):
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.setattr(litellm, "openai_key", None)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-openai")
+
+    await call_cancel(cancel_harness, "batch-raw-xyz")
+
+    assert cancel_harness.acancel_kwargs() == {
+        "custom_llm_provider": "openai",
+        "batch_id": "batch-raw-xyz",
+    }
 
 
 @pytest.mark.asyncio
@@ -2004,14 +2146,14 @@ async def test_cancel__fallback_provider_precedence_path_over_body(cancel_harnes
 
 
 @pytest.mark.asyncio
-async def test_cancel__uses_acancel_batch_route_type(cancel_harness):
+async def test_cancel__uses_acancel_batch_route_type(cancel_harness, openai_env_creds):
     await call_cancel(cancel_harness, "batch-raw-xyz")
 
     assert cancel_harness.pre_call.call_args.kwargs["route_type"] == "acancel_batch"
 
 
 @pytest.mark.asyncio
-async def test_cancel__exception_calls_failure_hook(cancel_harness):
+async def test_cancel__exception_calls_failure_hook(cancel_harness, openai_env_creds):
     cancel_harness.litellm_acancel.side_effect = ValueError("provider boom")
 
     with pytest.raises(Exception):
@@ -2333,7 +2475,7 @@ async def test_create__model_encoded_input_file_id_rejected_when_managed_files_r
 
 
 @pytest.mark.asyncio
-async def test_create__raw_input_file_id_allowed_when_managed_files_not_required(harness):
+async def test_create__raw_input_file_id_allowed_when_managed_files_not_required(harness, openai_env_creds):
     set_body(
         harness,
         {
@@ -2435,7 +2577,7 @@ async def test_retrieve__managed_batch_still_accounts_inline_without_a_poller(re
 
 
 @pytest.mark.asyncio
-async def test_retrieve__raw_batch_id_is_untouched_by_the_poller_handoff(retrieve_harness):
+async def test_retrieve__raw_batch_id_is_untouched_by_the_poller_handoff(retrieve_harness, openai_env_creds):
     with patch.object(endpoints, "batch_cost_poller_is_active", MagicMock(return_value=True)):
         await call_retrieve(retrieve_harness, "batch-raw-xyz")
 

--- a/tests/test_litellm/proxy/test_batch_x_litellm_model_encoding.py
+++ b/tests/test_litellm/proxy/test_batch_x_litellm_model_encoding.py
@@ -287,12 +287,14 @@ async def test_create_batch_with_x_litellm_model_encodes_output_and_error_file_i
 
 
 @pytest.mark.asyncio
-async def test_create_batch_without_x_litellm_model_returns_raw_ids():
+async def test_create_batch_without_x_litellm_model_returns_raw_ids(monkeypatch):
     """
     Without x-litellm-model header, create_batch should NOT encode batch IDs
     (falls through to Scenario 3 / custom_llm_provider fallback).
     """
     from litellm.proxy.batches_endpoints.endpoints import create_batch
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-openai")
 
     raw_batch_id = "batch_abc123"
     mock_response = _make_batch_response(batch_id=raw_batch_id)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Unknown batch and file ids on /v1/batches returned 500
- The error demanded OPENAI_API_KEY instead of naming the missing object
- The provider filter on managed batch lists also returned 500

How it solves it:

- Credential-less implicit openai fallback now returns 404 naming the object
- Explicit providers and available credentials still forward exactly as before
- Unsupported managed list filters now return 400 invalid_request_error

## User Flow

Before: an operator whose proxy only has Azure credentials asks about a batch id that does not exist and gets a 500 blaming a missing OpenAI key

1. They send GET https://litellm-domain/v1/batches/batch_does_not_exist_12345 with their proxy key
2. Back comes HTTP 500 with "The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
3. POST https://litellm-domain/v1/batches/batch_does_not_exist_12345/cancel returns the same 500
4. POST https://litellm-domain/v1/batches with `{"input_file_id": "file-does-not-exist-12345", ...}` returns the same 500
5. GET https://litellm-domain/v1/batches?limit=5&provider=openai returns HTTP 500 "Filtering by 'provider' is not supported when using managed batches."

After: the same requests come back as client errors that name the missing object, the way OpenAI itself answers

1. They send GET https://litellm-domain/v1/batches/batch_does_not_exist_12345 with their proxy key
2. Back comes HTTP 404 with `{"message": "No batch found with id 'batch_does_not_exist_12345'.", "type": "invalid_request_error"}`
3. POST https://litellm-domain/v1/batches/batch_does_not_exist_12345/cancel returns the same 404
4. POST https://litellm-domain/v1/batches with `{"input_file_id": "file-does-not-exist-12345", ...}` returns HTTP 404 "No such File object: file-does-not-exist-12345"
5. GET https://litellm-domain/v1/batches?limit=5&provider=openai returns HTTP 400 saying the provider filter is not supported
6. Uploading a real file via POST https://litellm-domain/v1/files and creating a batch with its id still returns 200 with a validating batch

## Relevant issues

Fixes #37148

## Linear ticket

Resolves LIT-5659

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: each leg boots its own proxy from source at its commit, on its own port with a fresh Postgres DB, one Azure deployment (`model_name: gpt-5-batch`), master key `sk-repro-37148`, and no OPENAI_API_KEY or OPENAI_API_BASE anywhere in its environment (verified via `ps eww`)

### Before (3b6ae75f73)

#### Retrieve unknown batch id

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:53817/v1/batches/batch_does_not_exist_12345 -H "Authorization: Bearer sk-repro-37148"`
2. `{"error":{"message":"The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable","type":"internal_server_error","param":"None","code":"500"}}` with HTTP 500

#### Cancel unknown batch id

1. `curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:53817/v1/batches/batch_does_not_exist_12345/cancel -H "Authorization: Bearer sk-repro-37148"`
2. Same api_key 500 as above

#### Create with unknown input_file_id

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:53817/v1/batches -H "Authorization: Bearer sk-repro-37148" -H 'Content-Type: application/json' -d '{"input_file_id":"file-does-not-exist-12345","endpoint":"/v1/chat/completions","completion_window":"24h"}'`
2. Same api_key 500 as above

#### List with provider filter

1. `curl -s -w '\nHTTP %{http_code}\n' 'http://localhost:53817/v1/batches?limit=5&provider=openai' -H "Authorization: Bearer sk-repro-37148"`
2. `{"error":{"message":"Filtering by 'provider' is not supported when using managed batches.","type":"internal_server_error","param":"None","code":"500"}}` with HTTP 500

#### Control: real upload then create against live Azure

1. Upload `batch_input.jsonl` to POST /v1/files with `purpose=batch` and `target_model_names=gpt-5-batch`, then POST /v1/batches with the returned id
2. HTTP 200 with a managed batch id and `"status":"validating"`

### After (73ae9c65dd)

#### Retrieve unknown batch id

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:54291/v1/batches/batch_does_not_exist_12345 -H "Authorization: Bearer sk-repro-37148"`
2. `{"error":{"message":"No batch found with id 'batch_does_not_exist_12345'.","type":"invalid_request_error","param":null,"code":"404"}}` with HTTP 404

#### Cancel unknown batch id

1. `curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:54291/v1/batches/batch_does_not_exist_12345/cancel -H "Authorization: Bearer sk-repro-37148"`
2. Same 404 body as above with HTTP 404

#### Create with unknown input_file_id

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:54291/v1/batches -H "Authorization: Bearer sk-repro-37148" -H 'Content-Type: application/json' -d '{"input_file_id":"file-does-not-exist-12345","endpoint":"/v1/chat/completions","completion_window":"24h"}'`
2. `{"error":{"message":"No such File object: file-does-not-exist-12345","type":"invalid_request_error","param":null,"code":"404"}}` with HTTP 404

#### List with provider filter

1. `curl -s -w '\nHTTP %{http_code}\n' 'http://localhost:54291/v1/batches?limit=5&provider=openai' -H "Authorization: Bearer sk-repro-37148"`
2. `{"error":{"message":"Filtering by 'provider' is not supported when using managed batches.","type":"invalid_request_error","param":"provider","code":"400"}}` with HTTP 400

#### Control: real upload then create against live Azure

1. Upload `batch_input.jsonl` to POST /v1/files with `purpose=batch` and `target_model_names=gpt-5-batch`, then POST /v1/batches with the returned id
2. HTTP 200 with `"object":"batch"`, `"status":"validating"`, and a managed batch id, and GET /v1/batches/{that id} then returns HTTP 200

#### Control: same tip with OPENAI_API_KEY present still forwards

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:55107/v1/batches/batch_does_not_exist_12345 -H "Authorization: Bearer sk-repro-37148"` against a second proxy booted from this tip with a real OPENAI_API_KEY in its environment
2. HTTP 404 forwarded from OpenAI itself: `{"error":{"message":"Error code: 404 - {'error': {'message': \"No batch found with id 'batch_does_not_exist_12345'.\", 'type': 'invalid_request_error', 'param': None, 'code': None}}","type":"internal_server_error","param":null,"code":"404"}}`

QA observations:

- Explicit `?custom_llm_provider=openai` without creds still 500s, untouched by this PR
- Credentialed passthrough 404 keeps type internal_server_error, pre-existing, left alone
- OpenAI live accepts unknown input_file_id, validates asynchronously, unrelated

## Type

🐛 Bug Fix

## Caveats (if any)

- Only the credential-less implicit openai fallback is gated; explicit providers bypass it
- OpenAI itself now accepts unknown input_file_id and validates asynchronously
- GET /v1/batches list stays ungated: no specific id to 404 about

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4a7dfd75fce4702c55387d37004206f2e6e8427e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
