### PR TITLE
fix(mcp): scope authorization server issuer for named MCP servers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -2416,7 +2416,8 @@ def _build_oauth_authorization_server_response(
     _raise_unless_oauth2_discovery_server(mcp_server, mcp_server_name, "not an OAuth authorization server")
 
     return {
-        "issuer": request_base_url,  # point to your proxy
+        # Match the per-server identifier advertised in protected-resource metadata.
+        "issuer": f"{request_base_url}/{mcp_server_name}" if mcp_server_name else request_base_url,
         "authorization_endpoint": authorization_endpoint,
         "token_endpoint": token_endpoint,
         "response_types_supported": ["code"],

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -2416,8 +2416,10 @@ def _build_oauth_authorization_server_response(
 
     _raise_unless_oauth2_discovery_server(mcp_server, mcp_server_name, "not an OAuth authorization server")
 
+    issuer: Final = f"{request_base_url}/{mcp_server_name}" if explicitly_named else request_base_url
+
     return {
-        "issuer": f"{request_base_url}/{mcp_server_name}" if explicitly_named else request_base_url,
+        "issuer": issuer,
         "authorization_endpoint": authorization_endpoint,
         "token_endpoint": token_endpoint,
         "response_types_supported": ["code"],

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -2397,6 +2397,7 @@ def _build_oauth_authorization_server_response(
 
     request_base_url: Final = get_request_base_url(request)
     client_ip: Final = IPAddressUtils.get_mcp_client_ip(request)
+    explicitly_named: Final = mcp_server_name is not None
 
     # When no server name provided, try to resolve the single OAuth2 server
     if mcp_server_name is None:
@@ -2416,8 +2417,7 @@ def _build_oauth_authorization_server_response(
     _raise_unless_oauth2_discovery_server(mcp_server, mcp_server_name, "not an OAuth authorization server")
 
     return {
-        # Match the per-server identifier advertised in protected-resource metadata.
-        "issuer": f"{request_base_url}/{mcp_server_name}" if mcp_server_name else request_base_url,
+        "issuer": f"{request_base_url}/{mcp_server_name}" if explicitly_named else request_base_url,
         "authorization_endpoint": authorization_endpoint,
         "token_endpoint": token_endpoint,
         "response_types_supported": ["code"],

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -3161,6 +3161,7 @@ def _create_oauth2_server(
     client_id="test_client_id",
     client_secret="test_client_secret",
     available_on_public_internet=True,
+    delegate_auth_to_upstream=False,
 ):
     """Helper to create a mock OAuth2 MCPServer."""
     from litellm.proxy._types import MCPTransport
@@ -3180,6 +3181,7 @@ def _create_oauth2_server(
         token_url="https://provider.com/oauth/token",
         scopes=["read", "write"],
         available_on_public_internet=available_on_public_internet,
+        delegate_auth_to_upstream=delegate_auth_to_upstream,
     )
 
 
@@ -8163,9 +8165,71 @@ async def test_bare_origin_discovery_resolves_single_server_not_aggregate():
         )
         # per-server, not aggregate: the single server's name is in the endpoints
         assert "/test_oauth/authorize" in authorization_response["authorization_endpoint"]
-        expected_issuer = "https://llm.example.com/test_oauth"
-        assert authorization_response["issuer"] == expected_issuer
-        assert resource_response["authorization_servers"] == [expected_issuer]
+        assert authorization_response["issuer"] == "https://llm.example.com"
+        assert resource_response["authorization_servers"] == ["https://llm.example.com/test_oauth"]
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+
+@pytest.mark.asyncio
+async def test_named_discovery_issuer_matches_protected_resource_authorization_servers():
+    """RFC 8414 requires the issuer to equal the authorization server identifier the client
+    resolved the metadata from, which is the protected-resource authorization_servers entry."""
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _build_oauth_authorization_server_response,
+        _build_oauth_protected_resource_response,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    global_mcp_server_manager.registry.clear()
+    server = _create_oauth2_server(delegate_auth_to_upstream=True)
+    global_mcp_server_manager.registry[server.server_id] = server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://llm.example.com/"
+    mock_request.headers = {}
+
+    try:
+        resource_response = await _build_oauth_protected_resource_response(
+            request=mock_request, mcp_server_name="test_oauth", use_standard_pattern=True
+        )
+        authorization_response = _build_oauth_authorization_server_response(
+            request=mock_request, mcp_server_name="test_oauth"
+        )
+        assert resource_response["authorization_servers"] == ["https://llm.example.com/test_oauth"]
+        assert authorization_response["issuer"] == resource_response["authorization_servers"][0]
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+
+@pytest.mark.asyncio
+async def test_openid_configuration_issuer_stays_bare_origin_for_single_oauth2_server():
+    """The OIDC discovery document is served from the bare origin, so its issuer must stay the
+    bare origin even when root discovery resolves the one configured OAuth2 server."""
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        openid_configuration,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    global_mcp_server_manager.registry.clear()
+    server = _create_oauth2_server()
+    global_mcp_server_manager.registry[server.server_id] = server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://llm.example.com/"
+    mock_request.headers = {}
+
+    try:
+        response = await openid_configuration(mock_request)
+        assert response["issuer"] == "https://llm.example.com"
     finally:
         global_mcp_server_manager.registry.clear()
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -8163,8 +8163,9 @@ async def test_bare_origin_discovery_resolves_single_server_not_aggregate():
         )
         # per-server, not aggregate: the single server's name is in the endpoints
         assert "/test_oauth/authorize" in authorization_response["authorization_endpoint"]
-        assert authorization_response["issuer"] == "https://llm.example.com"
-        assert resource_response["authorization_servers"] == ["https://llm.example.com/test_oauth"]
+        expected_issuer = "https://llm.example.com/test_oauth"
+        assert authorization_response["issuer"] == expected_issuer
+        assert resource_response["authorization_servers"] == [expected_issuer]
     finally:
         global_mcp_server_manager.registry.clear()
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -3161,7 +3161,7 @@ def _create_oauth2_server(
     client_id="test_client_id",
     client_secret="test_client_secret",
     available_on_public_internet=True,
-    delegate_auth_to_upstream=False,
+    delegate_auth_to_upstream: bool = False,
 ):
     """Helper to create a mock OAuth2 MCPServer."""
     from litellm.proxy._types import MCPTransport


### PR DESCRIPTION
## TLDR

Problem this solves:

- Named MCP OAuth discovery advertises two different issuer values
- Strict RFC 8414 clients reject discovery before authorization starts

How it solves it:

- Scope the issuer only when the URL carried a server name
- Keep the bare origin for root and OIDC discovery

## User Flow

Before: a developer pointing an OAuth client at a named MCP server behind the gateway cannot get past discovery

1. They point their MCP client at `https://litellm-domain/mcp/example_server` and the client fetches `GET https://litellm-domain/.well-known/oauth-protected-resource/mcp/example_server`
2. That response names `https://litellm-domain/example_server` as the authorization server
3. The client follows it to `GET https://litellm-domain/.well-known/oauth-authorization-server/example_server`
4. That response comes back with `"issuer": "https://litellm-domain"`, which does not equal the value from step 2
5. The client aborts with an issuer mismatch, so no browser sign-in ever opens and the MCP server stays unusable

After: the same client completes discovery and reaches sign-in

1. They point their MCP client at `https://litellm-domain/mcp/example_server` and the client fetches `GET https://litellm-domain/.well-known/oauth-protected-resource/mcp/example_server`
2. That response names `https://litellm-domain/example_server` as the authorization server
3. The client follows it to `GET https://litellm-domain/.well-known/oauth-authorization-server/example_server`
4. That response now comes back with `"issuer": "https://litellm-domain/example_server"`, matching step 2
5. The client accepts discovery and continues to the authorize step, so the user gets their browser sign-in
6. A client that instead fetches `GET https://litellm-domain/.well-known/openid-configuration` still sees `"issuer": "https://litellm-domain"`, so that flow keeps working unchanged

## Relevant issues

Fixes #36479

## Linear ticket

Resolves LIT-5625

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, one named OAuth2 MCP server, which is the single-server shape the issue reports

```yaml
model_list:
  - model_name: fake-model
    litellm_params:
      model: openai/fake
      api_key: fake-key

mcp_servers:
  delegated_server:
    url: "http://localhost:8766/mcp"
    transport: "http"
    auth_type: "oauth2"
    oauth2_flow: "authorization_code"
    delegate_auth_to_upstream: true
    client_id: "test-client-2"
    client_secret: "test-secret-2"
    authorization_url: "https://idp.example.com/authorize"
    token_url: "https://idp.example.com/token"
    scopes: ["read"]
```

```
python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug
```

### Before (d5b91b94d38a9ae8be959c0a44fb1a9a1d48ba1b)

1. Read the protected-resource metadata the client starts from

```
$ curl -s http://localhost:4000/.well-known/oauth-protected-resource/mcp/delegated_server | jq -c '{issuer, authorization_servers}'
{"issuer":null,"authorization_servers":["http://localhost:4000/delegated_server"]}
```

2. Follow that authorization server identifier, and observe the issuer does not match it

```
$ curl -s http://localhost:4000/.well-known/oauth-authorization-server/delegated_server | jq -c '{issuer, authorization_servers}'
{"issuer":"http://localhost:4000","authorization_servers":null}
```

3. Read the OIDC document, which correctly reports the bare origin

```
$ curl -s http://localhost:4000/.well-known/openid-configuration | jq -c '{issuer, authorization_servers}'
{"issuer":"http://localhost:4000","authorization_servers":null}
```

### After (bed0c8870471926db3256726b09daf5f6f7e4aef)

1. Read the protected-resource metadata the client starts from

```
$ curl -s http://localhost:4000/.well-known/oauth-protected-resource/mcp/delegated_server | jq -c '{issuer, authorization_servers}'
{"issuer":null,"authorization_servers":["http://localhost:4000/delegated_server"]}
```

2. Follow that authorization server identifier, and observe the issuer now matches it exactly

```
$ curl -s http://localhost:4000/.well-known/oauth-authorization-server/delegated_server | jq -c '{issuer, authorization_servers}'
{"issuer":"http://localhost:4000/delegated_server","authorization_servers":null}
```

3. Read the OIDC document, which still reports the bare origin, so root discovery is unchanged

```
$ curl -s http://localhost:4000/.well-known/openid-configuration | jq -c '{issuer, authorization_servers}'
{"issuer":"http://localhost:4000","authorization_servers":null}
```

## Credit

Adopted from #36482 by @irosh-colombage-ZocDoc2, who also reported #36479. Mirrored onto a `litellm_` branch so CircleCI and the internal lint workflow run. The follow-up commit narrows the scoping condition and adds the regression tests

## Type

🐛 Bug Fix

## Caveats (if any)

- Two-segment discovery routes stay non-conformant, unchanged here
- A conformant client never resolves those two routes

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/37204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to OAuth discovery JSON for explicitly named servers; behavior for aggregate/root OIDC paths is preserved and covered by new tests.
> 
> **Overview**
> Fixes **issuer mismatch** for named MCP OAuth discovery so strict RFC 8414 clients can finish metadata discovery and reach authorize.
> 
> When discovery is requested with an explicit server name (e.g. `/.well-known/oauth-authorization-server/{server}`), the authorization-server document now sets **`issuer`** to `{base}/{server_name}` instead of the bare proxy origin. That matches the **`authorization_servers`** entry the protected-resource metadata already advertises for the same server.
> 
> **Root and OIDC discovery are unchanged:** if the handler only *resolves* a single configured OAuth2 server because no name was in the URL, **`issuer`** stays the bare origin (including `/.well-known/openid-configuration`).
> 
> Regression tests cover named issuer parity with protected-resource metadata and bare-origin OIDC when one OAuth2 server is auto-resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df526c7c54d5a1e30a3955de4e262422e7e79e2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->