### PR TITLE
fix(proxy): bill cancelled and failed batches that still produced an output file

### DIFF
--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -291,6 +291,57 @@ class CheckBatchCost:
         return self.llm_router.get_deployment(model_id=model_id) is not None
 
     @staticmethod
+    def _is_output_file_gone_at_provider(error: Exception, output_file_id: Optional[str]) -> bool:
+        """A 404 naming the output file means there is nothing to fetch on this or any
+        later poll: providers like Vertex AI advertise an output path for every batch,
+        including terminal ones that never wrote it. Any other failure may be
+        transient, so it keeps retrying until the staleness sweep bounds it."""
+        import openai
+
+        from litellm.exceptions import NotFoundError
+
+        if not output_file_id:
+            return False
+        return isinstance(error, (NotFoundError, openai.NotFoundError)) and output_file_id in str(error)
+
+    async def _finalize_unbilled_terminal_job(
+        self, job: "LiteLLM_ManagedObjectTable", response: "LiteLLMBatch"
+    ) -> None:
+        """Persist a terminal batch that has nothing billable, converting any raw
+        provider file ids to managed ids, and take it out of the poll page."""
+        try:
+            from litellm.proxy.openai_files_endpoints.common_utils import (
+                _is_base64_encoded_unified_file_id,
+                ensure_batch_response_managed_file_ids,
+            )
+
+            response.id = job.unified_object_id
+            await ensure_batch_response_managed_file_ids(
+                response=response,
+                managed_files_obj=self.proxy_logging_obj.get_proxy_hook("managed_files"),
+                prisma_client=self.prisma_client,
+                verbose_proxy_logger=verbose_proxy_logger,
+                db_batch_object=job,
+                unified_batch_id=_is_base64_encoded_unified_file_id(job.unified_object_id),
+            )
+            update_data: Final[dict] = {
+                "status": response.status,
+                "file_object": response.model_dump_json(),
+                **({"batch_processed": True} if self._has_batch_processed_column else {}),
+            }
+            await self.prisma_client.db.litellm_managedobjecttable.update(
+                where={"id": job.id},
+                data=update_data,
+            )
+            verbose_proxy_logger.info(
+                f"CheckBatchCost: marked job {job.id} as {response.status} in DB"
+            )
+        except Exception as db_err:
+            verbose_proxy_logger.error(
+                f"CheckBatchCost: failed to mark job {job.id} as {response.status} in DB: {db_err}"
+            )
+
+    @staticmethod
     def _record_error(
         prom_logger: Optional["PrometheusLogger"], error_type: str
     ) -> None:
@@ -812,6 +863,15 @@ class CheckBatchCost:
                         prom_logger=prom_logger,
                     )
                 except Exception as tracking_err:
+                    if self._is_output_file_gone_at_provider(
+                        tracking_err, response.output_file_id
+                    ) and self._batch_deployment_exists(model_id):
+                        verbose_proxy_logger.warning(
+                            f"CheckBatchCost: output file {response.output_file_id} of batch {batch_id} "
+                            f"does not exist at the provider; retiring job {job.id} unbilled"
+                        )
+                        await self._finalize_unbilled_terminal_job(job, response)
+                        continue
                     verbose_proxy_logger.error(
                         f"CheckBatchCost: failed to track cost for batch {batch_id} "
                         f"(job {job.id}); leaving it unprocessed so the next poll retries: {tracking_err}"
@@ -842,38 +902,7 @@ class CheckBatchCost:
                     )
 
             elif response.status in PROVIDER_TERMINAL_BATCH_STATUSES:
-                try:
-                    from litellm.proxy.openai_files_endpoints.common_utils import (
-                        _is_base64_encoded_unified_file_id,
-                        ensure_batch_response_managed_file_ids,
-                    )
-
-                    response.id = job.unified_object_id
-                    await ensure_batch_response_managed_file_ids(
-                        response=response,
-                        managed_files_obj=self.proxy_logging_obj.get_proxy_hook("managed_files"),
-                        prisma_client=self.prisma_client,
-                        verbose_proxy_logger=verbose_proxy_logger,
-                        db_batch_object=job,
-                        unified_batch_id=_is_base64_encoded_unified_file_id(job.unified_object_id),
-                    )
-                    update_data = {
-                        "status": response.status,
-                        "file_object": response.model_dump_json(),
-                    }
-                    if self._has_batch_processed_column:
-                        update_data["batch_processed"] = True
-                    await self.prisma_client.db.litellm_managedobjecttable.update(
-                        where={"id": job.id},
-                        data=update_data,
-                    )
-                    verbose_proxy_logger.info(
-                        f"CheckBatchCost: marked job {job.id} as {response.status} in DB"
-                    )
-                except Exception as db_err:
-                    verbose_proxy_logger.error(
-                        f"CheckBatchCost: failed to mark job {job.id} as {response.status} in DB: {db_err}"
-                    )
+                await self._finalize_unbilled_terminal_job(job, response)
 
         # Record polling run metrics (always, even if nothing was processed)
         if prom_logger:

--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -24,12 +24,16 @@ if TYPE_CHECKING:
 
 CHECK_BATCH_COST_USER_AGENT = "LiteLLM Proxy/CheckBatchCost"
 
-TERMINAL_MANAGED_OBJECT_STATUSES: Final[Tuple[str, ...]] = (
+PROVIDER_TERMINAL_BATCH_STATUSES: Final[Tuple[str, ...]] = (
     "completed",
     "complete",
     "failed",
     "expired",
     "cancelled",
+)
+
+TERMINAL_MANAGED_OBJECT_STATUSES: Final[Tuple[str, ...]] = (
+    *PROVIDER_TERMINAL_BATCH_STATUSES,
     "stale_expired",
 )
 
@@ -796,7 +800,7 @@ class CheckBatchCost:
 
             ## RETRIEVE THE BATCH JOB OUTPUT FILE
             if (
-                response.status in ("completed", "complete", "expired")
+                response.status in PROVIDER_TERMINAL_BATCH_STATUSES
                 and response.output_file_id is not None
             ):
                 try:
@@ -837,13 +841,7 @@ class CheckBatchCost:
                         f"CheckBatchCost: failed to mark job {job.id} complete in DB: {db_err}"
                     )
 
-            elif response.status in (
-                "completed",
-                "complete",
-                "failed",
-                "expired",
-                "cancelled",
-            ):
+            elif response.status in PROVIDER_TERMINAL_BATCH_STATUSES:
                 try:
                     from litellm.proxy.openai_files_endpoints.common_utils import (
                         _is_base64_encoded_unified_file_id,

--- a/tests/proxy_unit_tests/test_check_batch_cost.py
+++ b/tests/proxy_unit_tests/test_check_batch_cost.py
@@ -817,12 +817,12 @@ class TestCheckBatchCost:
         mock_llm_router,
         terminal_status,
     ):
-        """A cancelled/failed batch with provider output files must be persisted with
-        unified managed file IDs, never raw provider IDs. Raw IDs written here leak
-        to every later GET /batches/{id} and GET /batches because the terminal row is
-        final (batch_processed=True) and read paths only resolve, never mint.
-        (Expired with an output file is billed through the completed path instead,
-        covered by test_expired_with_output_file_is_billed.)
+        """A cancelled/failed batch with a provider error file (and no output file) must
+        be persisted with unified managed file IDs, never raw provider IDs. Raw IDs
+        written here leak to every later GET /batches/{id} and GET /batches because the
+        terminal row is final (batch_processed=True) and read paths only resolve, never
+        mint. (Any terminal status with an output file is billed through the completed
+        path instead, covered by test_terminal_status_with_output_file_is_billed.)
         """
         import base64
         import json
@@ -832,14 +832,10 @@ class TestCheckBatchCost:
         unified_batch_uid = base64.urlsafe_b64encode(
             b"litellm_proxy;model_id:model-123;llm_batch_id:batch-456"
         ).decode()
-        raw_output_file_id = "file-terminal-out-abc"
         raw_error_file_id = "file-terminal-err-xyz"
         raw_input_file_id = "file-terminal-in-123"
         unified_input_file_id = base64.urlsafe_b64encode(
             b"litellm_proxy:application/octet-stream;unified_id,in-1;target_model_names,gpt-5-batch"
-        ).decode()
-        unified_output_file_id = base64.urlsafe_b64encode(
-            f"litellm_proxy:application/octet-stream;unified_id,u-1;llm_output_file_id,{raw_output_file_id}".encode()
         ).decode()
         unified_error_file_id = base64.urlsafe_b64encode(
             f"litellm_proxy:application/octet-stream;unified_id,u-2;llm_output_file_id,{raw_error_file_id}".encode()
@@ -884,16 +880,13 @@ class TestCheckBatchCost:
             input_file_id=raw_input_file_id,
             object="batch",
             status=terminal_status,
-            output_file_id=raw_output_file_id,
+            output_file_id=None,
             error_file_id=raw_error_file_id,
         )
         mock_llm_router.aretrieve_batch = AsyncMock(return_value=response)
 
         mock_hook = MagicMock()
-        mock_hook.get_unified_output_file_id.side_effect = [
-            unified_output_file_id,
-            unified_error_file_id,
-        ]
+        mock_hook.get_unified_output_file_id.side_effect = [unified_error_file_id]
         mock_hook.store_unified_file_id = AsyncMock()
         check_batch_cost_instance.proxy_logging_obj.get_proxy_hook.return_value = (
             mock_hook
@@ -901,12 +894,7 @@ class TestCheckBatchCost:
 
         await check_batch_cost_instance.check_batch_cost()
 
-        mock_hook.get_unified_output_file_id.assert_any_call(
-            output_file_id=raw_output_file_id,
-            model_id="model-123",
-            model_name="gpt-5-batch",
-        )
-        mock_hook.get_unified_output_file_id.assert_any_call(
+        mock_hook.get_unified_output_file_id.assert_called_once_with(
             output_file_id=raw_error_file_id,
             model_id="model-123",
             model_name="gpt-5-batch",
@@ -915,10 +903,7 @@ class TestCheckBatchCost:
             next(iter(c.kwargs["model_mappings"].values())): c.kwargs["file_id"]
             for c in mock_hook.store_unified_file_id.call_args_list
         }
-        assert stored == {
-            raw_output_file_id: unified_output_file_id,
-            raw_error_file_id: unified_error_file_id,
-        }
+        assert stored == {raw_error_file_id: unified_error_file_id}
         for store_call in mock_hook.store_unified_file_id.call_args_list:
             assert store_call.kwargs["user_api_key_dict"].user_id == "user-1"
             assert store_call.kwargs["user_api_key_dict"].team_id == "team-1"
@@ -932,9 +917,8 @@ class TestCheckBatchCost:
         persisted = json.loads(update_data["file_object"])
         assert persisted["id"] == unified_batch_uid
         assert persisted["input_file_id"] == unified_input_file_id
-        assert persisted["output_file_id"] == unified_output_file_id
+        assert persisted["output_file_id"] is None
         assert persisted["error_file_id"] == unified_error_file_id
-        assert raw_output_file_id not in update_data["file_object"]
         assert raw_error_file_id not in update_data["file_object"]
 
     @pytest.mark.asyncio
@@ -1067,12 +1051,17 @@ class TestCheckBatchCost:
         ), "a non-terminal batch must not be written back (would stop polling prematurely)"
 
     @pytest.mark.asyncio
-    async def test_expired_with_output_file_is_billed(
-        self, check_batch_cost_instance, mock_prisma_client, mock_llm_router
+    @pytest.mark.parametrize("terminal_status", ["expired", "cancelled", "failed"])
+    async def test_terminal_status_with_output_file_is_billed(
+        self,
+        check_batch_cost_instance,
+        mock_prisma_client,
+        mock_llm_router,
+        terminal_status,
     ):
-        """An expired batch that still produced an output file served real request lines,
-        so it must be billed (cost tracked) and then marked processed, not silently
-        marked terminal without billing.
+        """A terminal (expired/cancelled/failed) batch that still produced an output file
+        served real request lines, so it must be billed (cost tracked) and then marked
+        processed, not silently marked terminal without billing.
         """
         from unittest.mock import patch
 
@@ -1085,7 +1074,7 @@ class TestCheckBatchCost:
         )
 
         mock_job = MagicMock()
-        mock_job.id = "job-expired-with-output-1"
+        mock_job.id = "job-terminal-with-output-1"
         mock_job.unified_object_id = "dW5pZmllZF9iYXRjaF9pZA=="
         mock_job.created_by = "user-1"
 
@@ -1095,10 +1084,10 @@ class TestCheckBatchCost:
         )
 
         mock_response = MagicMock()
-        mock_response.status = "expired"
+        mock_response.status = terminal_status
         mock_response.output_file_id = "file-output-123"
         mock_response.model_dump_json.return_value = (
-            '{"id":"batch-1","status":"expired"}'
+            f'{{"id":"batch-1","status":"{terminal_status}"}}'
         )
 
         mock_llm_router.aretrieve_batch = AsyncMock(return_value=mock_response)
@@ -1164,7 +1153,7 @@ class TestCheckBatchCost:
 
         assert (
             mock_afile_content.await_count == 1
-        ), "expired batch with an output file must fetch results and be billed"
+        ), f"{terminal_status} batch with an output file must fetch results and be billed"
         mock_logging_obj.async_success_handler.assert_awaited_once()
         assert (
             mock_prisma_client.db.litellm_managedobjecttable.update.call_count == 1
@@ -1174,8 +1163,8 @@ class TestCheckBatchCost:
         ]["data"]
         assert update_data["batch_processed"] is True
         assert (
-            update_data["status"] == "expired"
-        ), "billed expired batch must keep its real terminal status in the DB"
+            update_data["status"] == terminal_status
+        ), f"billed {terminal_status} batch must keep its real terminal status in the DB"
 
     @pytest.mark.asyncio
     async def test_raw_output_file_id_converted_to_managed_id(

--- a/tests/proxy_unit_tests/test_check_batch_cost.py
+++ b/tests/proxy_unit_tests/test_check_batch_cost.py
@@ -1167,6 +1167,83 @@ class TestCheckBatchCost:
         ), f"billed {terminal_status} batch must keep its real terminal status in the DB"
 
     @pytest.mark.asyncio
+    async def test_terminal_batch_with_missing_output_file_is_retired_unbilled(
+        self, check_batch_cost_instance, mock_prisma_client, mock_llm_router
+    ):
+        """A terminal batch whose advertised output file 404s at the provider has
+        nothing to fetch on this or any later poll (Vertex AI advertises an output
+        path for every batch, even ones that never wrote it), so the job must be
+        retired as terminal on the first cycle instead of retrying until the
+        staleness sweep gives up on it.
+        """
+        import base64
+        from unittest.mock import patch
+
+        from litellm.exceptions import NotFoundError
+
+        mock_prisma_client.db.litellm_managedobjecttable.update_many = AsyncMock(
+            return_value=0
+        )
+        mock_prisma_client.db.litellm_managedobjecttable.update = AsyncMock()
+        mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+            return_value=None
+        )
+
+        mock_job = MagicMock()
+        mock_job.id = "job-output-gone-1"
+        mock_job.unified_object_id = base64.urlsafe_b64encode(
+            b"litellm_proxy;model_id:model-123;llm_batch_id:batch-456"
+        ).decode()
+        mock_job.created_by = "user-1"
+
+        assert check_batch_cost_instance._has_batch_processed_column is True
+        mock_prisma_client.db.litellm_managedobjecttable.find_many = AsyncMock(
+            return_value=[mock_job]
+        )
+
+        missing_output_file_id = "gs://batch-out/job-1/predictions.jsonl"
+        mock_response = MagicMock()
+        mock_response.status = "failed"
+        mock_response.output_file_id = missing_output_file_id
+        mock_response.error_file_id = None
+        mock_response.model_dump_json.return_value = (
+            '{"id":"batch-1","status":"failed"}'
+        )
+
+        mock_llm_router.aretrieve_batch = AsyncMock(return_value=mock_response)
+        mock_llm_router.get_deployment_credentials_with_provider = MagicMock(
+            return_value={"api_key": "sk-test"}
+        )
+
+        with (
+            patch(
+                "litellm.files.main.afile_content",
+                new_callable=AsyncMock,
+                side_effect=NotFoundError(
+                    message=f"404: output file {missing_output_file_id} does not exist",
+                    model="gemini-2.5-pro",
+                    llm_provider="vertex_ai",
+                ),
+            ) as mock_afile_content,
+            patch(
+                "litellm.batches.batch_utils.calculate_batch_cost_and_usage",
+                new_callable=AsyncMock,
+            ) as mock_calculate,
+        ):
+            await check_batch_cost_instance.check_batch_cost()
+
+        assert mock_afile_content.await_count == 1
+        mock_calculate.assert_not_awaited()
+        assert (
+            mock_prisma_client.db.litellm_managedobjecttable.update.call_count == 1
+        ), "a terminal batch with a 404ing output file must be retired, not retried forever"
+        update_data = mock_prisma_client.db.litellm_managedobjecttable.update.call_args[
+            1
+        ]["data"]
+        assert update_data["status"] == "failed"
+        assert update_data["batch_processed"] is True
+
+    @pytest.mark.asyncio
     async def test_raw_output_file_id_converted_to_managed_id(
         self, check_batch_cost_instance, mock_prisma_client, mock_llm_router
     ):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cancelled/failed batches with an output file were retired unbilled
- Provider bills the completed requests, gateway records zero spend forever

How it solves it:

- Poller now bills any terminal batch that produced an output file
- Shared constant lists provider terminal batch statuses once
- Terminal batches whose advertised output file 404s retire first cycle

## User Flow

Before: a developer cancels an in-progress batch, the provider still completes part of it and serves the results, and the gateway never records any spend for that work

1. They send POST https://litellm-domain/v1/files with purpose=batch and target_model_names to upload their requests JSONL
2. They send POST https://litellm-domain/v1/batches with the returned input_file_id and the batch starts at the provider
3. They send POST https://litellm-domain/v1/batches/{batch_id}/cancel and get HTTP 200; the provider finishes in-flight requests and finalizes the batch as cancelled with 142 of 2000 requests completed
4. GET https://litellm-domain/v1/batches/{batch_id} shows status cancelled, a populated output_file_id, and request_counts.completed 142
5. GET https://litellm-domain/v1/files/{output_file_id}/content returns HTTP 200 with 142 result lines carrying real token usage
6. GET https://litellm-domain/spend/logs?request_id={batch_id} shows only the $0 batch-creation row, and GET https://litellm-domain/key/info shows spend 0.0, permanently: the batch is never revisited

After: the same cancelled batch is billed for its completed work within one poll cycle

1. They send POST https://litellm-domain/v1/files with purpose=batch and target_model_names to upload their requests JSONL
2. They send POST https://litellm-domain/v1/batches with the returned input_file_id and the batch starts at the provider
3. They send POST https://litellm-domain/v1/batches/{batch_id}/cancel and get HTTP 200; the provider finishes in-flight requests and finalizes the batch as cancelled with partial completion
4. GET https://litellm-domain/v1/batches/{batch_id} shows status cancelled, a populated output_file_id, and non-zero request_counts.completed
5. GET https://litellm-domain/v1/files/{output_file_id}/content returns HTTP 200 with the completed result lines
6. Within one poll cycle GET https://litellm-domain/spend/logs?request_id={batch_id} gains a batch-retrieval row with the real cost and token counts of those completed requests, and GET https://litellm-domain/key/info shows the matching non-zero spend

## Relevant issues

Fixes #37156

## Linear ticket

Resolves LIT-5663

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy against the real OpenAI batch API, real $$$. Both legs ran the identical flow in their own worktree with a fresh Postgres DB, exported `PROXY_BATCH_POLLING_INTERVAL=10` (the interval the reporter used), a random free port, and this config

```yaml
model_list:
  - model_name: gpt-5.4-mini-batch
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      mode: batch
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  database_url: os.environ/DATABASE_URL
```

Note on statuses: the issue's headline `expired` case was already billed at the merge base (added by #35360), so the drop reproduces through `cancelled`, which hits the identical branch: OpenAI batches only expire after a real 24h window, while a cancel finalizes with a partial output file in minutes. A billed control leg during the repro (a completed 300-request batch at 3b6ae75f73) recorded `aretrieve_batch` spend 0.0048375, showing the pipeline prices this exact output-file accounting whenever the status is billable

The PR tip b34cbb18e2 is a base-sync merge touching only uv.lock, so 2f9d331b4c is the last behavioral commit. The core-fix commit 21984101e5 was also independently proven with the same flow (356/2000 completed, billed $0.0057405, tokens matching the output file)

### Before (badd737526, the merge base)

1. Create a key and upload a 2000-request JSONL for `gpt-5.4-mini-batch`:
   ```bash
   KEY=$(curl -s http://localhost:22679/key/generate -H "Authorization: Bearer $MASTER" -H 'Content-Type: application/json' -d '{"key_alias":"lit5663-qa-before","user_id":"lit5663-user","models":["gpt-5.4-mini-batch"]}' | jq -r .key)
   FILE=$(curl -s http://localhost:22679/v1/files -H "Authorization: Bearer $KEY" -F purpose=batch -F 'target_model_names=gpt-5.4-mini-batch' -F file=@cancelleg2.jsonl | jq -r .id)
   BATCH=$(curl -s http://localhost:22679/v1/batches -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d "{\"input_file_id\":\"$FILE\",\"endpoint\":\"/v1/chat/completions\",\"completion_window\":\"24h\"}" | jq -r .id)
   ```
2. Once the provider reports in_progress with completed >= 1 (here 33), cancel it: `curl -s -X POST "http://localhost:22679/v1/batches/$BATCH/cancel" -H "Authorization: Bearer $KEY"` returns HTTP 200 with status cancelling
3. Provider finalizes ~25 min later (batch_6a83619b03e481909e56da22a2670e17): `"status": "cancelled"`, `"output_file_id": "file-HzaqhkCafEGvQoTpB2QRrm"`, `"request_counts": {"total": 2000, "completed": 142, "failed": 0}`
4. `curl -s "http://localhost:22679/v1/batches/$BATCH" -H "Authorization: Bearer $KEY"` shows status cancelled with a populated (unified) output_file_id and counts 142/0/2000
5. `GET /v1/files/{output_file_id}/content` with the customer key returns HTTP 200 with 142 JSONL result lines totaling 2698 prompt + 568 completion = 3266 tokens of real billed work
6. `curl -s "http://localhost:22679/spend/logs?request_id=$BATCH" -H "Authorization: Bearer $MASTER"` shows only the $0 `acreate_batch` row (no `aretrieve_batch` row), and `/key/info` reports `"spend": 0.0`; both unchanged when re-checked 90 s later, after the proxy log's `CheckBatchCost: marked job 93dfe2e2-eec4-47fd-8199-1cdb0669e4ad as cancelled in DB` retired the batch for good

### After (2f9d331b4c, the PR's last behavioral commit)

1. Same key/file/batch creation as the before leg, port 43477:
   ```bash
   KEY=$(curl -s http://localhost:43477/key/generate -H "Authorization: Bearer $MASTER" -H 'Content-Type: application/json' -d '{"key_alias":"lit5663-qa-after2","user_id":"lit5663-user","models":["gpt-5.4-mini-batch"]}' | jq -r .key)
   FILE=$(curl -s http://localhost:43477/v1/files -H "Authorization: Bearer $KEY" -F purpose=batch -F 'target_model_names=gpt-5.4-mini-batch' -F file=@cancelleg2.jsonl | jq -r .id)
   BATCH=$(curl -s http://localhost:43477/v1/batches -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d "{\"input_file_id\":\"$FILE\",\"endpoint\":\"/v1/chat/completions\",\"completion_window\":\"24h\"}" | jq -r .id)
   ```
2. Cancel at in_progress with completed 19: `curl -s -X POST "http://localhost:43477/v1/batches/$BATCH/cancel" -H "Authorization: Bearer $KEY"` returns HTTP 200 with status cancelling
3. Provider finalizes 25 min later (batch_6a836348484c81909cd9ce50584baede): `"status": "cancelled"`, `"output_file_id": "file-8pYJexZwE5bM66N5TL9oAg"`, `"request_counts": {"total": 2000, "completed": 437, "failed": 0}`
4. `curl -s "http://localhost:43477/v1/batches/$BATCH" -H "Authorization: Bearer $KEY"` shows status cancelled with a populated (unified) output_file_id and counts 437/0/2000
5. `GET /v1/files/{output_file_id}/content` returns HTTP 200 with 437 JSONL result lines totaling 8303 prompt + 1748 completion = 10051 tokens
6. 11 seconds after provider finalization, `curl -s "http://localhost:43477/spend/logs?request_id=${BATCH}_batch_cost" -H "Authorization: Bearer $MASTER"` shows an `aretrieve_batch` row with `"spend": 0.007046625` and tokens 8303/1748/10051, exactly matching the output file, and `/key/info` reports `"spend": 0.007046625`

Observations from the runs:

- Spend row request_id gains a `_batch_cost` suffix; leaves bug alone
- Poller ticks ~2x the configured interval; leaves bug alone
- OpenAI cancels finalize ~25 minutes later; leaves bug alone
- Proxy batch GETs can clobber tracking status; worsens pickup
- Before-leg poller computed cost yet wrote nothing; the bug

## Type

🐛 Bug Fix

## Caveats (if any)

Vertex AI advertises an output path for every batch, including terminal ones that never wrote it. Since 2f9d331b4c a terminal batch whose advertised output file 404s at the provider is retired unbilled on the first poll cycle instead of retrying until the staleness sweep. Ambiguous failures (the Vertex GCS downloader raises one error for 404, 403, and network blips alike) still retry and stay bounded by the 7-day sweep

A client that polls its batch through the proxy can still lose the spend: the status poll records the provider's terminal status on the gateway's tracking row, and the poller skips rows already recorded as cancelled or failed, so a poll landing between provider finalization and the next poller cycle (up to an hour apart by default) hides the batch from billing. That race predates this PR (at the merge base every ordering went unbilled, so this PR strictly improves and regresses nothing), needs its own fix (the poller's pickup set plus an upgrade guard against retroactively billing old terminal rows), and is filed with live proof as #37217

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch cost polling and spend attribution for terminal statuses; incorrect 404 detection could skip billing or retire jobs early, but behavior is scoped to CheckBatchCost with new unit tests.
> 
> **Overview**
> Fixes **CheckBatchCost** so gateway spend matches provider batch work and terminal jobs do not poll forever.
> 
> **Billing:** Any **provider-terminal** batch (`completed`, `complete`, `failed`, `expired`, `cancelled`) with an **`output_file_id`** now goes through the same output fetch and **`aretrieve_batch`** cost path. **Cancelled/failed** batches that still produced partial results are billed instead of being finalized with **zero spend**.
> 
> **Retirement:** Terminal batches whose advertised output **404s** at the provider (e.g. Vertex paths with no file) are **finalized unbilled on the first cycle** via new **`_is_output_file_gone_at_provider`** and **`_finalize_unbilled_terminal_job`**, instead of retrying until the staleness sweep.
> 
> **Refactor:** **`PROVIDER_TERMINAL_BATCH_STATUSES`** centralizes terminal status checks; unbillable terminal handling is consolidated into **`_finalize_unbilled_terminal_job`** (managed file IDs + **`batch_processed`**). Tests cover billing for **expired/cancelled/failed** with output and **404 output** retirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b34cbb18e29ab775973c439018dc8ff67607cedb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->