### PR TITLE
fix: stop rust flag from leaking into upstream provider request bodies

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3519,6 +3519,7 @@ all_litellm_params = (
         "litellm_session_id",
         "use_litellm_proxy",
         "use_chat_completions_api",
+        "rust",
         "prompt_label",
         "shared_session",
         "search_tool_name",

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4795,3 +4795,49 @@ def test_bedrock_batch_params_never_reach_the_provider():
         "credential normalization dropped batch params before the transformation: "
         f"{sorted(f for f in bedrock_batch_litellm_params if normalized.get(f) != configured[f])}"
     )
+
+
+def test_rust_flag_not_forwarded_as_provider_param():
+    forwarded = get_non_default_completion_params({"rust": True, "temperature": 0.5})
+    assert "rust" not in forwarded
+
+
+def test_completion_does_not_leak_rust_flag_into_provider_request_body():
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": "gpt-4o-mini",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+        },
+    }
+
+    mock_raw_response = MagicMock()
+    mock_raw_response.headers = {}
+    mock_raw_response.parse.return_value = mock_response
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.with_raw_response.create.return_value = mock_raw_response
+
+    litellm.completion(
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        rust=True,
+        api_key="sk-test",
+        client=mock_client,
+    )
+
+    create_kwargs = mock_client.chat.completions.with_raw_response.create.call_args.kwargs
+    assert "rust" not in create_kwargs
+    assert "rust" not in (create_kwargs.get("extra_body") or {})

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -5,7 +5,11 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("../.."))
 
-from litellm.types.utils import HiddenParams
+from litellm.types.utils import HiddenParams, all_litellm_params
+
+
+def test_rust_is_a_known_litellm_param():
+    assert "rust" in all_litellm_params
 
 
 def test_hidden_params_response_ms():


### PR DESCRIPTION
## TLDR

Problem this solves:

- deployments with `rust: true` 400 on /v1/chat/completions and /v1/responses
- the provider rejects the leaked flag: `rust: Extra inputs are not permitted`

How it solves it:

- registers `rust` as a LiteLLM-level param
- the flag is now stripped from provider-bound request bodies

## User Flow

Before: a user whose config deployment `azure_ai/claude-haiku-4-5` sets `rust: true` gets 400s on chat completions and responses because the flag reaches the provider

1. They send POST http://localhost:4000/v1/chat/completions with the haiku model and get HTTP 400 `rust: Extra inputs are not permitted`
2. They send POST http://localhost:4000/v1/responses with the same model and get the same HTTP 400
3. They send POST http://localhost:4000/v1/messages with the same model and get 200 with a real completion

After: the same deployment serves all three endpoints

1. They send POST http://localhost:4000/v1/chat/completions with the haiku model and get 200 with a real completion
2. They send POST http://localhost:4000/v1/responses with the same model and get 200 with a real completion
3. They send POST http://localhost:4000/v1/messages with the same model and get 200 with a real completion

## Relevant issues

## Linear ticket

Resolves LIT-5675

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Shared setup for both legs: live proxy booted from a fresh worktree against the real Azure AI Foundry `claude-haiku-4-5` deployment (real provider calls), config below, boot command `.venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port <port> --detailed_debug`. The before leg ran at the merge base on port 51837, the after leg at this PR's tip on port 55812

```yaml
model_list:
  - model_name: haiku
    litellm_params:
      model: azure_ai/claude-haiku-4-5
      api_base: os.environ/AZURE_AI_API_BASE
      api_key: os.environ/AZURE_AI_API_KEY
      rust: true
general_settings:
  master_key: sk-lit5675
```

### Before (c1fc5983ca)

#### POST /v1/chat/completions

1. Run:
   ```bash
   curl -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://localhost:51837/v1/chat/completions \
     -H "Authorization: Bearer sk-lit5675" -H "Content-Type: application/json" \
     -d '{"model":"haiku","messages":[{"role":"user","content":"Say hi"}],"max_tokens":32}'
   ```
2. Observed:
   ```
   {"error":{"message":"litellm.BadRequestError: Azure_aiException - {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"rust: Extra inputs are not permitted\"},\"request_id\":\"req_011Ce94XetvG3hBTtwZ3Dior\"}. Received Model Group=haiku\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
   HTTP_STATUS:400
   ```

#### POST /v1/chat/completions (stream)

1. Run:
   ```bash
   curl -N -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://localhost:51837/v1/chat/completions \
     -H "Authorization: Bearer sk-lit5675" -H "Content-Type: application/json" \
     -d '{"model":"haiku","messages":[{"role":"user","content":"Say hi"}],"max_tokens":32,"stream":true}'
   ```
2. Observed:
   ```
   {"error":{"message":"litellm.BadRequestError: Azure_aiException - b'{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"rust: Extra inputs are not permitted\"},\"request_id\":\"req_011Ce94Y3dtrvR3McMMJAqHH\"}'. Received Model Group=haiku\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
   HTTP_STATUS:400
   ```

#### POST /v1/responses

1. Run:
   ```bash
   curl -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://localhost:51837/v1/responses \
     -H "Authorization: Bearer sk-lit5675" -H "Content-Type: application/json" \
     -d '{"model":"haiku","input":"Say hi","max_output_tokens":32}'
   ```
2. Observed:
   ```
   {"error":{"message":"litellm.BadRequestError: Azure_aiException - {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"rust: Extra inputs are not permitted\"},\"request_id\":\"req_011Ce94YLDnx2kAge3moWyiK\"}. Received Model Group=haiku\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
   HTTP_STATUS:400
   ```

#### POST /v1/responses (stream)

1. Run:
   ```bash
   curl -N -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://localhost:51837/v1/responses \
     -H "Authorization: Bearer sk-lit5675" -H "Content-Type: application/json" \
     -d '{"model":"haiku","input":"Say hi","max_output_tokens":32,"stream":true}'
   ```
2. Observed:
   ```
   {"error":{"message":"litellm.BadRequestError: Azure_aiException - b'{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"rust: Extra inputs are not permitted\"},\"request_id\":\"req_011Ce94YeDX2cUd3B5VKi2M7\"}'. Received Model Group=haiku\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
   HTTP_STATUS:400
   ```

#### POST /v1/messages

1. Run:
   ```bash
   curl -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://localhost:51837/v1/messages \
     -H "Authorization: Bearer sk-lit5675" -H "Content-Type: application/json" \
     -d '{"model":"haiku","max_tokens":32,"messages":[{"role":"user","content":"Say hi"}]}'
   ```
2. Observed:
   ```
   {"content":[{"text":"Hi! 👋 How can I help you today?","type":"text"}],"id":"msg_011Ce94Z5mAjbH64hp66Ykhu","model":"haiku","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"not_available","input_tokens":9,"output_tokens":16,"service_tier":"standard"}}
   HTTP_STATUS:200
   ```

#### POST /v1/messages (stream)

1. Run:
   ```bash
   curl -N -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://localhost:51837/v1/messages \
     -H "Authorization: Bearer sk-lit5675" -H "Content-Type: application/json" \
     -d '{"model":"haiku","max_tokens":32,"messages":[{"role":"user","content":"Say hi"}],"stream":true}'
   ```
2. Observed (start of stream, then final event; middle elided):
   ```
   event: message_start
   data: {"type": "message_start", "message": {"id": "msg_011Ce94ZhPnsWHhJpmzCJgtv", "type": "message", "role": "assistant", "model": "claude-haiku-4-5-20251001", "content": [], "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 9, "output_tokens": 0}}}

   event: content_block_delta
   data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hi! 👋 How's it going? What can I help you with?"}}
   ...
   event: message_stop
   HTTP_STATUS:200
   ```

### After (ce82a440d3)

#### POST /v1/chat/completions

1. Run:
   ```bash
   curl -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://localhost:55812/v1/chat/completions \
     -H 'Authorization: Bearer sk-lit5675' -H 'Content-Type: application/json' \
     -d '{"model":"haiku","messages":[{"role":"user","content":"Say hi"}],"max_tokens":32}'
   ```
2. Observed:
   ```
   {"id":"chatcmpl-490e8f3c-0924-4274-912f-aaa2d0a8cb18","created":1787003539,"model":"haiku","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hi! 👋 How's it going?","role":"assistant","provider_specific_fields":{"citations":null,"thinking_blocks":null}}}],"usage":{"completion_tokens":14,"prompt_tokens":9,"total_tokens":23,...}}
   HTTP_STATUS:200
   ```

#### POST /v1/chat/completions (stream)

1. Run:
   ```bash
   curl -sS -N -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://localhost:55812/v1/chat/completions \
     -H 'Authorization: Bearer sk-lit5675' -H 'Content-Type: application/json' \
     -d '{"model":"haiku","messages":[{"role":"user","content":"Say hi"}],"max_tokens":32,"stream":true}'
   ```
2. Observed:
   ```
   data: {"id":"chatcmpl-8e5d176d-fd00-4806-a53f-399ab191e983","object":"chat.completion.chunk","created":1787003548,"model":"haiku","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi!"}}]}

   data: {"id":"chatcmpl-8e5d176d-fd00-4806-a53f-399ab191e983","object":"chat.completion.chunk","created":1787003548,"model":"haiku","choices":[{"index":0,"delta":{"content":" 👋 How can I help you today?"}}]}

   data: {"id":"chatcmpl-8e5d176d-fd00-4806-a53f-399ab191e983","object":"chat.completion.chunk","created":1787003548,"model":"haiku","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}

   data: [DONE]
   HTTP_STATUS:200
   ```

#### POST /v1/responses

1. Run:
   ```bash
   curl -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://localhost:55812/v1/responses \
     -H 'Authorization: Bearer sk-lit5675' -H 'Content-Type: application/json' \
     -d '{"model":"haiku","input":"Say hi","max_output_tokens":32}'
   ```
2. Observed (response id truncated):
   ```
   {"id":"resp_BvXuOG8lTnz7kWKhYzTIV2fy...","created_at":1787003554,"error":null,...,"model":"haiku","object":"response","output":[{"type":"message","id":"chatcmpl-577cc3fd-e096-4e45-a568-90e1300ade4f","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hi! 👋 How can I help you today?","annotations":[]}],"phase":null}],...,"status":"completed","usage":{"input_tokens":9,...,"output_tokens":16,...,"total_tokens":25,...}}
   HTTP_STATUS:200
   ```

#### POST /v1/responses (stream)

1. Run:
   ```bash
   curl -sS -N -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://localhost:55812/v1/responses \
     -H 'Authorization: Bearer sk-lit5675' -H 'Content-Type: application/json' \
     -d '{"model":"haiku","input":"Say hi","max_output_tokens":32,"stream":true}'
   ```
2. Observed (first and last events; middle elided, ids truncated):
   ```
   data: {"type":"response.created","response":{"id":"resp_fw5a3c4sAmca...","created_at":1787003563,...}}

   data: {"type":"response.output_text.delta","item_id":"msg_d4bccc91-817b-4276-89e8-70b34cefa736","output_index":0,"content_index":0,"delta":"Hi","model":"haiku"}
   ...
   data: {"type":"response.completed","response":{"id":"resp_NG-060TU8Fxvmu4irNVgTEad...",...}}
   HTTP_STATUS:200
   ```

#### POST /v1/messages

1. Run:
   ```bash
   curl -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://localhost:55812/v1/messages \
     -H 'Authorization: Bearer sk-lit5675' -H 'Content-Type: application/json' \
     -d '{"model":"haiku","max_tokens":32,"messages":[{"role":"user","content":"Say hi"}]}'
   ```
2. Observed:
   ```
   {"content":[{"text":"Hi! 👋 How's it going?","type":"text"}],"id":"msg_011Ce94bfdBb2ZLzopV28JPe","model":"haiku","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{...,"input_tokens":9,"output_tokens":14,"service_tier":"standard"}}
   HTTP_STATUS:200
   ```

#### POST /v1/messages (stream)

1. Run:
   ```bash
   curl -sS -N -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://localhost:55812/v1/messages \
     -H 'Authorization: Bearer sk-lit5675' -H 'Content-Type: application/json' \
     -d '{"model":"haiku","max_tokens":32,"messages":[{"role":"user","content":"Say hi"}],"stream":true}'
   ```
2. Observed (start of stream, then final status; middle elided):
   ```
   event: message_start
   data: {"type": "message_start", "message": {"id": "msg_011Ce94e1qfRDhFydb4nqbbC", "type": "message", "role": "assistant", "model": "claude-haiku-4-5-20251001", "content": [], "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 9, "output_tokens": 0}}}

   event: content_block_delta
   data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hi! 👋 How's it going?"}}
   ...
   HTTP_STATUS:200
   ```

Notes from the QA run:

- Streaming errors return JSON 400, not SSE; unchanged by PR
- Streaming 400 embeds upstream error bytes-repr'd; unchanged by PR
- /v1/messages kept its Rust-served fast path after this fix

## Type

🐛 Bug Fix

## Caveats (if any)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
