### PR TITLE
fix(shadow_eval): copy messages before router call and raise judge output cap

### DIFF
--- a/litellm/integrations/shadow_eval_logger.py
+++ b/litellm/integrations/shadow_eval_logger.py
@@ -331,7 +331,7 @@ def _failure_detail(e: BaseException) -> str:
     the faulty code path without needing debug logs on the pod."""
     frames: Final = traceback.extract_tb(e.__traceback__)
     location: Final = f" at {frames[-1].filename.rsplit('/', 1)[-1]}:{frames[-1].lineno}" if frames else ""
-    return f"{type(e).__name__}: {e}{location}"
+    return f"{type(e).__name__}{location}: {e}"
 
 
 def _judge_call_cost(response: object) -> float:

--- a/litellm/integrations/shadow_eval_logger.py
+++ b/litellm/integrations/shadow_eval_logger.py
@@ -9,6 +9,7 @@ across pods or stop races; the hook reads active jobs through a short-TTL cache.
 import asyncio
 import hashlib
 import random
+import traceback
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -55,7 +56,7 @@ _MAX_JUDGE_PROMPT_CHARS: Final = 24_000
 
 # The judge answers with a small JSON object; a tighter budget truncates the JSON
 # mid-object and the attempt is lost to an error row.
-JUDGE_MAX_OUTPUT_TOKENS: Final = 500
+JUDGE_MAX_OUTPUT_TOKENS: Final = 1500
 
 _MAX_ERROR_CHARS: Final = 500
 
@@ -323,6 +324,14 @@ def _sample_hits(request_id: str, job_id: str, percentage: float) -> bool:
     digest: Final = hashlib.sha256(f"{job_id}:{request_id}".encode()).digest()
     bucket: Final = int.from_bytes(digest[:8], "big") / float(2**64)
     return bucket * 100.0 < percentage
+
+
+def _failure_detail(e: BaseException) -> str:
+    """Exception class, message, and the raising frame, so an attempt's error row names
+    the faulty code path without needing debug logs on the pod."""
+    frames: Final = traceback.extract_tb(e.__traceback__)
+    location: Final = f" at {frames[-1].filename.rsplit('/', 1)[-1]}:{frames[-1].lineno}" if frames else ""
+    return f"{type(e).__name__}: {e}{location}"
 
 
 def _judge_call_cost(response: object) -> float:
@@ -764,7 +773,9 @@ class ShadowEvalLogger(CustomLogger):
         try:
             response: Final = await router.acompletion(
                 model=target_model,
-                messages=messages,  # pyright: ignore[reportArgumentType]  # snapshot of the SDK's own message dicts
+                messages=[  # mutable-ok: provider transforms rewrite messages in place, so the router gets its own copy
+                    dict(m) for m in messages
+                ],  # pyright: ignore[reportArgumentType]  # snapshot of the SDK's own message dicts
                 metadata=shadow_metadata,
                 num_retries=0,
                 fallbacks=[],  # mutable-ok: SDK kwarg; a failed shadow is a recorded error, never a spend multiplier
@@ -772,7 +783,7 @@ class ShadowEvalLogger(CustomLogger):
             )
         except Exception as e:  # noqa: BLE001  # provider errors become error rows, not crashes
             verbose_logger.debug("shadow_eval: router call failed: %s", e)
-            return _CallFailure(f"shadow router call failed: {e}")
+            return _CallFailure(f"shadow router call failed: {_failure_detail(e)}")
         text: Final = _chat_final_text(response)
         if not text:
             return _CallFailure("shadow router returned an empty response")

--- a/tests/test_litellm/integrations/test_shadow_eval_logger.py
+++ b/tests/test_litellm/integrations/test_shadow_eval_logger.py
@@ -16,6 +16,7 @@ from litellm.integrations.shadow_eval_logger import (
     JUDGE_MAX_OUTPUT_TOKENS,
     ActiveShadowEvalJob,
     ShadowEvalLogger,
+    _failure_detail,
     _judge_user_prompt,
     _sample_hits,
     _unmask_preference,
@@ -438,6 +439,15 @@ def test_unmask_preference(raw, real_is_a, expected):
     assert _unmask_preference(raw, real_is_a) == expected
 
 
+def test_failure_detail_names_the_raising_frame():
+    try:
+        raise TypeError("'tuple' object does not support item assignment")
+    except TypeError as e:
+        detail = _failure_detail(e)
+        lineno = e.__traceback__.tb_lineno
+    assert detail == f"TypeError: 'tuple' object does not support item assignment at test_shadow_eval_logger.py:{lineno}"
+
+
 def test_judge_prompt_is_bounded_however_large_the_inputs():
     prompt = _judge_user_prompt("c" * 200_000, "a" * 200_000, "b" * 200_000)
     assert len(prompt) < _MAX_JUDGE_PROMPT_CHARS + 100
@@ -475,6 +485,30 @@ class TestSuccessHookSkipChain:
         assert row["judge_cost"] == 0.005
         assert row["error"] is None
         assert prisma.db.litellm_shadowevaljob.find_many.await_count == 0
+
+    async def test_shadow_call_messages_survive_in_place_provider_rewrites(self, monkeypatch: pytest.MonkeyPatch):
+        """Provider transforms (anthropic factory, cache-control hook) rewrite messages with
+        `messages[i] = ...`; the logger's immutable snapshot must never reach them directly."""
+        import litellm as litellm_module
+
+        monkeypatch.setattr(litellm_module, "completion_cost", lambda completion_response: 0.005)
+        prisma = _prisma()
+        router = _router()
+        inner = router.acompletion.side_effect
+
+        async def mutating_acompletion(**kwargs):
+            kwargs["messages"][0] = dict(kwargs["messages"][0])
+            return await inner(**kwargs)
+
+        router.acompletion = MagicMock(side_effect=mutating_acompletion)
+        logger = _logger(router=router, prisma=prisma, jobs=(_job(),))
+
+        await logger.async_log_success_event(_success_kwargs(), RESPONSE, None, None)
+        await _drain(logger)
+
+        row = prisma.db.litellm_shadowevalattempt.create.call_args.kwargs["data"]
+        assert row["error"] is None
+        assert row["outcome"] in ("real", "shadow", "tie")
 
     @pytest.mark.parametrize(
         "kwargs_mutation,job_mutation",

--- a/tests/test_litellm/integrations/test_shadow_eval_logger.py
+++ b/tests/test_litellm/integrations/test_shadow_eval_logger.py
@@ -12,6 +12,7 @@ from litellm.caching.in_memory_cache import InMemoryCache
 from litellm.constants import INTERNAL_CALL_ORIGIN_METADATA_KEY
 from litellm.integrations.shadow_eval_logger import (
     _MAX_CONCURRENT_SHADOW_TASKS,
+    _MAX_ERROR_CHARS,
     _MAX_JUDGE_PROMPT_CHARS,
     JUDGE_MAX_OUTPUT_TOKENS,
     ActiveShadowEvalJob,
@@ -445,7 +446,13 @@ def test_failure_detail_names_the_raising_frame():
     except TypeError as e:
         detail = _failure_detail(e)
         lineno = e.__traceback__.tb_lineno
-    assert detail == f"TypeError: 'tuple' object does not support item assignment at test_shadow_eval_logger.py:{lineno}"
+    assert detail == f"TypeError at test_shadow_eval_logger.py:{lineno}: 'tuple' object does not support item assignment"
+
+    try:
+        raise ValueError("p" * 5 * _MAX_ERROR_CHARS)
+    except ValueError as long_e:
+        truncated_row_error = _failure_detail(long_e)[:_MAX_ERROR_CHARS]
+    assert "ValueError at test_shadow_eval_logger.py:" in truncated_row_error
 
 
 def test_judge_prompt_is_bounded_however_large_the_inputs():
@@ -509,6 +516,37 @@ class TestSuccessHookSkipChain:
         row = prisma.db.litellm_shadowevalattempt.create.call_args.kwargs["data"]
         assert row["error"] is None
         assert row["outcome"] in ("real", "shadow", "tie")
+
+    async def test_pipeline_continues_judging_after_a_failed_attempt(self, monkeypatch: pytest.MonkeyPatch):
+        import litellm as litellm_module
+
+        monkeypatch.setattr(litellm_module, "completion_cost", lambda completion_response: 0.005)
+        prisma = _prisma()
+        router = _router()
+        inner = router.acompletion.side_effect
+        shadow_calls = {"count": 0}
+
+        async def flaky_acompletion(**kwargs):
+            if kwargs["metadata"].get(INTERNAL_CALL_ORIGIN_METADATA_KEY) == SHADOW_EVAL_ROUTER_CALL_ORIGIN:
+                shadow_calls["count"] += 1
+                if shadow_calls["count"] == 1:
+                    raise RuntimeError("provider exploded")
+            return await inner(**kwargs)
+
+        router.acompletion = MagicMock(side_effect=flaky_acompletion)
+        logger = _logger(router=router, prisma=prisma, jobs=(_job(),))
+
+        await logger.async_log_success_event(_success_kwargs(), RESPONSE, None, None)
+        await _drain(logger)
+        await logger.async_log_success_event(_success_kwargs(request_id="req-2"), RESPONSE, None, None)
+        await _drain(logger)
+
+        rows = [c.kwargs["data"] for c in prisma.db.litellm_shadowevalattempt.create.call_args_list]
+        assert [rows[0]["outcome"], rows[1]["outcome"] in ("real", "shadow")] == ["error", True]
+        assert "provider exploded" in rows[0]["error"]
+        assert rows[1]["request_id"] == "req-2"
+        assert rows[1]["error"] is None
+        assert logger._inflight_shadow_tasks == 0
 
     @pytest.mark.parametrize(
         "kwargs_mutation,job_mutation",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Shadow eval turns die with "'tuple' object does not support item assignment"
- Long comparisons die with "unparseable judge verdict" at char 0
- Error rows never say where in the stack the shadow call failed

How it solves it:

- Shadow router call gets a fresh mutable copy of the messages
- Judge output cap raised from 500 to 1500 tokens
- Shadow call failures lead with exception class and raising code line
- Regression test pins that a failed turn never stalls later ones

## User Flow

Before: an admin shadow-evaluating an auto-router watches turns burn as error rows instead of verdicts

1. They start a shadow eval on their key via POST http://localhost:4000/auto_router/shadow_eval/start
2. They keep sending their normal traffic, e.g. POST http://localhost:4000/v1/messages with tool results and cached system blocks
3. On the dashboard's Auto-Router Shadow Evals tab the banner reads "Last failure: shadow router call failed: 'tuple' object does not support item assignment" and the judged count stalls
4. On long conversations the banner instead reads "Last failure: unparseable judge verdict: Expecting value: line 1 column 1 (char 0)" because the judge ran out of output room before finishing its verdict

After: the same traffic produces judged verdicts

1. They start the same shadow eval via POST http://localhost:4000/auto_router/shadow_eval/start
2. They send the same POST http://localhost:4000/v1/messages traffic
3. The dashboard shows the turn as a judged verdict (win, loss, or tie) instead of a failure banner
4. Long conversations get complete verdicts, and if a shadow call ever does fail, the banner names the exception class and the code line that raised it

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: `/tmp/shadowfix_config.yaml` defines `claude-main` (bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0, live AWS Bedrock) and auto-router `tin-shadow-router` whose tiers all point at it. The tuple failure needs production traffic shapes to trigger on demand, so Before is read from a live deployment running the merge-base code

### Before (6a0bd0dffb)

#### Shadow call survives in-place message rewrites

1. `select outcome, error from "LiteLLM_ShadowEvalAttempt" where outcome = 'error' order by created_at desc limit 1`
2. Observed: `error | shadow router call failed: 'tuple' object does not support item assignment`, the turn consumed budget and produced no verdict

#### Judge verdict fits the output cap

1. `select outcome, judge_cost, error from "LiteLLM_ShadowEvalAttempt" where error like 'unparseable%' limit 1`
2. Observed: `error | 0.008454 | unparseable judge verdict: Expecting value: line 1 column 1 (char 0)`
3. `select model, completion_tokens, spend from "LiteLLM_SpendLogs" where request_id = 'chatcmpl-75d913f3-ed3a-40f5-89f2-7b5a44b73ef9'`
4. Observed: `anthropic/claude-sonnet-5 | 500 | 0.008454`, exactly the old 500 token cap and the same spend as the errored attempt's judge_cost, so the verdict was truncated mid-generation

### After (790c209d30)

#### Shadow call survives in-place message rewrites

1. `python litellm/proxy/proxy_cli.py --config /tmp/shadowfix_config.yaml --port 4020 --use_v2_migration_resolver`
2. `curl -X POST http://localhost:4020/key/generate -H "Authorization: Bearer sk-..." -d '{"key_alias": "shadowfix-proof"}'` returned token_id `c7a6ac...c2ac0`
3. `curl -X POST http://localhost:4020/auto_router/shadow_eval/start -H "Authorization: Bearer sk-..." -d '{"api_key_id": "c7a6ac...c2ac0", "router_name": "tin-shadow-router", "shadow_percentage": 100.0, "judge_model": "claude-main", "duration_days": 1}'` returned job `cmsxtxj9p0000mgjr8275sv5h`
4. `curl -X POST http://localhost:4020/v1/messages -H "Authorization: Bearer <key>"` with an agentic-shaped body: system blocks with `cache_control`, a `tools` array, an assistant `tool_use` turn, and a `tool_result` block; Bedrock answered `stop_reason: end_turn`, "The config.yaml file specifies that the application runs on port 4000 and uses the Claude model."
5. `select outcome, tier, real_model, shadow_model, confidence, judge_cost, error from "LiteLLM_ShadowEvalAttempt" order by created_at desc limit 1`
6. Observed: `tie | SIMPLE | bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0 | us.anthropic.claude-haiku-4-5-20251001-v1:0 | 0.99 | 0.0006204 | (null)`, the turn was shadowed through the router and judged with no error row

#### Judge verdict fits the output cap

1. Same run as above: the judge (also live Bedrock) returned a complete JSON verdict, recorded as `confidence 0.99, judge_cost 0.0006204` in the attempt row from step 6, with no truncation error

## Type

🐛 Bug Fix

## Caveats (if any)

- The exact production mutation site is unconfirmed; the new error detail will name it if any path still mutates nested state

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
