### PR TITLE
fix(proxy): strip callback credentials from the auth object stamped into request metadata

### DIFF
--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -39,10 +39,10 @@ _EXTRA_SENSITIVE_CALLBACK_KEYS: Final = {"gcs_path_service_account"}
 # already-encrypted input cheaply (no decrypt-attempt round trip) and
 # avoid double-encrypting if `LITELLM_SALT_KEY` is rotated between writes.
 _CALLBACK_VAR_ENCRYPTED_PREFIX: Final = "litellm_enc::"
-# Metadata slots that hold operator-configured callback setup (and therefore
-# integration credentials). Resolved from UserAPIKeyAuth during pre-call setup,
-# never read back off the copies stamped into request metadata.
-_CALLBACK_CONFIG_SLOTS: Final = frozenset({"logging", "callback_settings"})
+# Metadata slots that hold operator-configured callback and secret-manager setup
+# (and therefore integration credentials). Resolved from UserAPIKeyAuth during
+# pre-call setup, never read back off the copies stamped into request metadata.
+_CALLBACK_CONFIG_SLOTS: Final = frozenset({"logging", "callback_settings", "secret_manager_settings"})
 
 blue_color_code: Final = "\033[94m"
 reset_color_code: Final = "\033[0m"

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1303,8 +1303,15 @@ class LiteLLMProxyRequestSetup:
         )
         if user_api_key_dict.budget_reservation is not None:
             data[_metadata_variable_name]["user_api_key_budget_reservation"] = user_api_key_dict.budget_reservation
-        # Add the full UserAPIKeyAuth object for MCP server access control
-        data[_metadata_variable_name]["user_api_key_auth"] = user_api_key_dict
+        # UserAPIKeyAuth for MCP server access control, minus the credential-bearing slots
+        data[_metadata_variable_name]["user_api_key_auth"] = user_api_key_dict.model_copy(
+            update={
+                "metadata": strip_callback_config(user_api_key_dict.metadata),
+                "team_metadata": strip_callback_config(user_api_key_dict.team_metadata),
+                "project_metadata": strip_callback_config(user_api_key_dict.project_metadata),
+                "organization_metadata": strip_callback_config(user_api_key_dict.organization_metadata),
+            }
+        )
         return data
 
     @staticmethod
@@ -1326,10 +1333,11 @@ class LiteLLMProxyRequestSetup:
         )
 
         # ignore any special fields
-        added_metadata: Final = {}
-        for k, v in management_endpoint_metadata.items():
-            if k not in (LiteLLM_ManagementEndpoint_MetadataFields_Premium + LiteLLM_ManagementEndpoint_MetadataFields):
-                added_metadata[k] = v
+        added_metadata: Final = {
+            k: v
+            for k, v in (strip_callback_config(management_endpoint_metadata) or {}).items()
+            if k not in (LiteLLM_ManagementEndpoint_MetadataFields_Premium + LiteLLM_ManagementEndpoint_MetadataFields)
+        }
         if data[_metadata_variable_name].get("user_api_key_auth_metadata") is None:
             data[_metadata_variable_name]["user_api_key_auth_metadata"] = {}
         data[_metadata_variable_name]["user_api_key_auth_metadata"].update(added_metadata)

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1303,7 +1303,7 @@ class LiteLLMProxyRequestSetup:
         )
         if user_api_key_dict.budget_reservation is not None:
             data[_metadata_variable_name]["user_api_key_budget_reservation"] = user_api_key_dict.budget_reservation
-        # UserAPIKeyAuth for MCP server access control, minus the credential-bearing slots
+        # UserAPIKeyAuth object for MCP server access control
         data[_metadata_variable_name]["user_api_key_auth"] = user_api_key_dict.model_copy(
             update={
                 "metadata": strip_callback_config(user_api_key_dict.metadata),

--- a/tests/test_litellm/proxy/common_utils/test_callback_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_callback_utils.py
@@ -492,6 +492,7 @@ def test_strip_callback_config_drops_credential_bearing_slots():
             }
         ],
         "callback_settings": {"callback_vars": {"langfuse_secret_key": "litellm_enc::other"}},
+        "secret_manager_settings": {"vault_token": "vt-secret"},
         "priority": "high",
         "guardrails": ["presidio"],
         "langsmith_provisioning": {"api_key_id": "prov-1"},
@@ -501,6 +502,7 @@ def test_strip_callback_config_drops_credential_bearing_slots():
 
     assert "logging" not in stripped
     assert "callback_settings" not in stripped
+    assert "secret_manager_settings" not in stripped
     assert stripped["priority"] == "high"
     assert stripped["guardrails"] == ["presidio"]
     assert stripped["langsmith_provisioning"] == {"api_key_id": "prov-1"}

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2306,6 +2306,129 @@ def test_add_user_api_key_auth_to_request_metadata():
     assert result["messages"] == [{"role": "user", "content": "Hello"}]
 
 
+def _auth_with_callback_credentials() -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        api_key="hashed-test-key-123",
+        key_alias="test-key-alias",
+        team_id="test-team-789",
+        team_alias="test-team-alias",
+        metadata={
+            "logging": [{"callback_name": "langfuse", "callback_vars": {"langfuse_secret_key": "sk-KEY-CANARY"}}],
+            "rpm_limit_type": "guaranteed_throughput",
+        },
+        team_metadata={
+            "callback_settings": {"langfuse": {"callback_vars": {"langfuse_secret_key": "sk-TEAM-CANARY"}}},
+            "secret_manager_settings": {"vault_token": "vt-TEAM-CANARY"},
+            "model_rpm_limit": {"gpt-4": 10},
+        },
+        project_metadata={
+            "logging": [{"callback_vars": {"langfuse_secret_key": "sk-PROJECT-CANARY"}}],
+            "project_tier": "gold",
+        },
+        organization_metadata={
+            "secret_manager_settings": {"vault_token": "vt-ORG-CANARY"},
+            "org_tier": "platinum",
+        },
+    )
+
+
+def test_stamped_auth_object_carries_no_callback_credentials():
+    """
+    Regression (LIT-5487): the UserAPIKeyAuth stamped into request metadata reaches every
+    raw-metadata logging integration, so it must not carry team/key callback credentials.
+    """
+    user_api_key_dict = _auth_with_callback_credentials()
+    otel_span = object()
+    user_api_key_dict.parent_otel_span = otel_span
+    user_api_key_dict.budget_reservation = {"amount": 1.0}
+    user_api_key_dict.via_virtual_key = True
+    data = {"litellm_metadata": {}}
+
+    result = LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata(
+        data=data,
+        user_api_key_dict=user_api_key_dict,
+        _metadata_variable_name="litellm_metadata",
+    )
+
+    stamped = result["litellm_metadata"]["user_api_key_auth"]
+    emitted = json.dumps(
+        {
+            "metadata": stamped.metadata,
+            "team_metadata": stamped.team_metadata,
+            "project_metadata": stamped.project_metadata,
+            "organization_metadata": stamped.organization_metadata,
+        },
+        default=str,
+    )
+    assert "sk-KEY-CANARY" not in emitted
+    assert "sk-TEAM-CANARY" not in emitted
+    assert "vt-TEAM-CANARY" not in emitted
+    assert "sk-PROJECT-CANARY" not in emitted
+    assert "vt-ORG-CANARY" not in emitted
+
+    # consumers keep the type and the non-credential slots they read
+    assert isinstance(stamped, UserAPIKeyAuth)
+    assert stamped.key_alias == "test-key-alias"
+    assert stamped.team_id == "test-team-789"
+    assert stamped.team_alias == "test-team-alias"
+    assert stamped.api_key == "hashed-test-key-123"
+    assert stamped.metadata["rpm_limit_type"] == "guaranteed_throughput"
+    assert stamped.team_metadata["model_rpm_limit"] == {"gpt-4": 10}
+    assert stamped.project_metadata["project_tier"] == "gold"
+    assert stamped.organization_metadata["org_tier"] == "platinum"
+
+    # server-only markers are excluded from model_dump, so rebuilding the object
+    # instead of copying it would silently drop them
+    assert stamped.via_virtual_key is True
+    assert stamped.budget_reservation == {"amount": 1.0}
+    assert stamped.parent_otel_span is otel_span
+
+
+def test_stamping_does_not_mutate_the_cached_auth_object():
+    """
+    Regression (LIT-5487): UserAPIKeyAuth is cached and model_copy is shallow, so stripping
+    in place would poison the shared dicts and silently kill team callbacks fleet-wide.
+    """
+    user_api_key_dict = _auth_with_callback_credentials()
+    metadata_before = copy.deepcopy(user_api_key_dict.metadata)
+    team_metadata_before = copy.deepcopy(user_api_key_dict.team_metadata)
+
+    LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata(
+        data={"litellm_metadata": {}},
+        user_api_key_dict=user_api_key_dict,
+        _metadata_variable_name="litellm_metadata",
+    )
+
+    assert user_api_key_dict.metadata == metadata_before
+    assert user_api_key_dict.team_metadata == team_metadata_before
+
+
+def test_management_endpoint_metadata_drops_callback_credentials():
+    """
+    Regression (LIT-5487): user_api_key_auth_metadata is part of StandardLoggingPayload, so a
+    callback_settings-shaped team must not push credentials into it.
+    """
+    data = {"litellm_metadata": {}}
+
+    result = LiteLLMProxyRequestSetup.add_management_endpoint_metadata_to_request_metadata(
+        data=data,
+        management_endpoint_metadata={
+            "callback_settings": {"langfuse": {"callback_vars": {"langfuse_secret_key": "sk-TEAM-CANARY"}}},
+            "secret_manager_settings": {"vault_token": "vt-TEAM-CANARY"},
+            "logging": [{"callback_vars": {"langfuse_secret_key": "sk-LOGGING-CANARY"}}],
+            "other_field": "value",
+        },
+        _metadata_variable_name="litellm_metadata",
+    )
+
+    auth_metadata = result["litellm_metadata"]["user_api_key_auth_metadata"]
+    emitted = json.dumps(auth_metadata, default=str)
+    assert "sk-TEAM-CANARY" not in emitted
+    assert "vt-TEAM-CANARY" not in emitted
+    assert "sk-LOGGING-CANARY" not in emitted
+    assert auth_metadata["other_field"] == "value"
+
+
 @pytest.mark.parametrize(
     "data, model_group_settings, expected_headers_added",
     [

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -230,6 +230,43 @@ async def test_add_litellm_data_to_request_parses_string_metadata():
 
 
 @pytest.mark.asyncio
+async def test_stamped_auth_object_reflects_header_derived_identity():
+    """
+    Regression (LIT-5487): the stamped object is a copy taken partway through request setup,
+    so it only carries header-derived identity if the stamp still runs after those fields are
+    resolved. Moving the stamp earlier would silently misattribute spend.
+    """
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    request_mock = MagicMock(spec=Request)
+    request_mock.url = MagicMock()
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {"Content-Type": "application/json", "user": "end-user-from-header"}
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+
+    user_api_key_dict = UserAPIKeyAuth(api_key="hashed-key", metadata={}, team_metadata={})
+
+    updated_data = await add_litellm_data_to_request(
+        data={"model": "gpt-3.5-turbo"},
+        request=request_mock,
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={"user_header_name": "user"},
+        version="test-version",
+    )
+
+    # precondition: the header was actually resolved onto the live object
+    assert user_api_key_dict.end_user_id == "end-user-from-header"
+
+    stamped = updated_data["metadata"]["user_api_key_auth"]
+    assert stamped.end_user_id == "end-user-from-header"
+
+
+@pytest.mark.asyncio
 async def test_add_litellm_data_to_request_strips_admin_injection_slots():
     """User-supplied user_api_key_metadata / user_api_key_team_metadata /
     _pipeline_managed_guardrails must be stripped from both metadata keys


### PR DESCRIPTION
## TLDR

Problem this solves:

- The proxy stamps the live auth object into request metadata
- That object carries team, key, project and org callback credentials
- Every integration that logs raw metadata therefore receives them
- Legacy rows hold those credentials in plaintext, not ciphertext

How it solves it:

- Stamp a sanitized copy instead, so all consumers are covered at once
- `secret_manager_settings` joins the credential-bearing slot set
- Team metadata reaching `user_api_key_auth_metadata` is stripped too

## User Flow

Before: an admin gives a team its own Langfuse project, then finds that team's Langfuse secret key sitting inside the traces and spend logs anyone on the team can read

1. The admin creates a team with `POST https://litellm-domain/team/new`, sending `metadata.logging` with the team's `langfuse_public_key` and `langfuse_secret_key`
2. A developer on that team sends `POST https://litellm-domain/v1/chat/completions` and gets a normal 200 back
3. The request is logged to whichever destinations the proxy is configured for, and the payload carries the team's own `langfuse_secret_key` in it
4. The admin opens `https://litellm-domain/ui/?page=logs`, opens that request, and reads the team's Langfuse secret key out of the stored request
5. Anyone who can read logs for that team can reuse those credentials against the team's Langfuse project

After: the same setup logs the same request without the credentials

1. The admin creates the same team the same way
2. The developer sends the same `POST https://litellm-domain/v1/chat/completions` and gets the same 200 back
3. The request is logged to the same destinations, and the payload no longer contains the team's `langfuse_secret_key`
4. `https://litellm-domain/ui/?page=logs` shows the same request with the credentials absent, while the team name, key alias and rate limit settings are all still there
5. Reading logs for that team no longer hands over credentials for the team's Langfuse project

## Relevant issues

## Linear ticket

Refs LIT-5487

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy on a real Postgres, real provider call returning 200 on both legs. The team row holds credentials in both supported shapes plus a non-credential setting, so one run covers the leak and the preservation:

```json
{"logging": [{"callback_name": "langfuse", "callback_type": "success",
              "callback_vars": {"langfuse_host": "http://127.0.0.1:8487",
                                "langfuse_public_key": "pk-lf-LEAKPUB5487",
                                "langfuse_secret_key": "sk-lf-LEAKSEC5487"}}],
 "callback_settings": {"langfuse": {"callback_vars": {"langfuse_secret_key": "sk-CBSETLEAK5487"}}},
 "model_rpm_limit": {"gemini-flash": 100}}
```

Only `logging[].callback_vars` is encrypted at rest. `callback_settings` and `secret_manager_settings` are not, so on a team created through the ordinary `/team/new` API today those two leak as usable plaintext. The Admin UI capture below uses exactly that path, with no direct row writes.

### Before (50e71313b7)

#### Credentials reaching a logging destination

1. `curl -X POST http://127.0.0.1:4587/v1/chat/completions -H "Authorization: Bearer $TEAM_KEY" -d '{"model":"gemini-flash","messages":[{"role":"user","content":"Say the single word: canary"}],"max_tokens":200}'`
2. `http_status=200`, response text `'canary'`
3. Recording what an integration that logs raw request metadata receives:

```
team callback credential (logging shape)      reachable: True
team callback credential (callback_settings)  reachable: True
non-credential team config preserved (model_rpm_limit): True
stamped object type: UserAPIKeyAuth
```

#### Credentials reaching Postgres

4. `SELECT ... FROM "LiteLLM_SpendLogs" ORDER BY "startTime" DESC LIMIT 1`
5. The row's `proxy_server_request` contains the credentials verbatim:

```
"team_metadata": {"logging": [{"callback_name": "langfuse", "callback_type": "success",
 "callback_vars": {"langfuse_host": "http://127.0.0.1:8487",
 "langfuse_public_key": "pk-lf-LEAKPUB5487", "langfuse_secret_key": "sk-lf-LEAKSEC5487"}}],
 "model_rpm_limit": {"gemini-flash": 100}, "callback_settings": {"langfuse" ...
```


#### Admin UI, what an operator sees on the logs page

6. Open `http://127.0.0.1:4587/ui/?page=logs`, click the newest request for team `payments`, expand Request & Response, switch to JSON, scroll to `team_metadata`
7. The team's own credentials are rendered in the request log:

![before](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr37233/assets/before-team-metadata-leak.png)

### After (dc63988d3c)

#### Credentials reaching a logging destination

1. Same curl, same team, same key
2. `http_status=200`, response text `'canary'`
3. Same recording:

```
team callback credential (logging shape)      reachable: False
team callback credential (callback_settings)  reachable: False
non-credential team config preserved (model_rpm_limit): True
stamped object type: UserAPIKeyAuth
team callback still dispatched to destination: ['/api/public/ingestion', '/generic']
```

#### Credentials reaching Postgres

4. Same query against the row written by this leg
5. `rows_with_canary` is 0, while the before-leg row in the same table still shows 1

#### Prometheus labels still populate

6. `curl -sL http://127.0.0.1:4587/metrics/ -H "Authorization: Bearer $MASTER_KEY"`

```
api_key_alias="lit5487-probe-key"
hashed_api_key="6c0cea30689d2a3cfc8e745ba7c7f18dbd7c1ece63c8740b473370e65287bf1b"
team_alias="lit5487-canary-team"
team="c1375c0f-e643-422d-9f64-dabc4657fa35"
```

Team callbacks still dispatch on both legs, which is the regression that would matter most here: the dispatcher reads the auth object directly rather than the stamped copy, so sanitizing the copy does not disturb it.


#### Admin UI, what an operator sees on the logs page

7. Same page, same team, same panel, scrolled to the same `team_metadata` block
8. The credentials are gone and the non-credential team config survives:

![after](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr37233/assets/after-team-metadata-clean.png)

## Type

🐛 Bug Fix

## Caveats (if any)

- Three producers bypass this stamp and still emit raw slots
- Widest is the MCP pre-call hook object handed to guardrail vendors
- Those stay open, so this says Refs rather than Resolves
- Only `logging` is encrypted at rest; the other two leak plaintext
- Stamped object is now a copy, so identity comparison would break

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/37233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9b881386603dbab0da7497437105c3bf206dc8b2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
