### PR TITLE
fix(proxy): let org admins view their organization's usage

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -805,6 +805,9 @@ class LiteLLMRoutes(enum.Enum):
         "/model/delete",
         "/user/daily/activity",
         "/user/daily/activity/aggregated",
+        # Endpoint restricts results to organizations the caller is ORG_ADMIN
+        # of; a caller who administers none gets an empty result set.
+        "/organization/daily/activity",
         "/user/available_roles",  # read-only role metadata; any authenticated user may read
         "/user/list",  # org admins checked in endpoint; non-admins get 403
         "/model/{model_id}/update",

--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -559,7 +559,7 @@ async def get_organization_daily_activity(
 
     # Fetch organization aliases for metadata
     where_condition: Final = _STR_OBJECT_DICT_ADAPTER.validate_python({})
-    if org_ids_list:
+    if org_ids_list is not None:
         where_condition["organization_id"] = {"in": list(org_ids_list)}
     org_aliases: Final = await _table(OrganizationRepository(prisma_client)).find_many(where=where_condition)
 

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(
@@ -9,7 +10,14 @@ sys.path.insert(
 import pytest
 from fastapi import HTTPException, Request
 
-from litellm.proxy._types import LiteLLM_UserTable, LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy._types import (
+    LiteLLM_OrganizationMembershipTable,
+    LiteLLM_UserTable,
+    LiteLLMRoutes,
+    LitellmUserRoles,
+    UserAPIKeyAuth,
+)
+from litellm.proxy.auth.auth_checks_organization import _user_is_org_admin
 from litellm.proxy.auth.route_checks import RouteChecks
 
 
@@ -3297,4 +3305,77 @@ def test_user_daily_activity_aggregated_not_covered_by_prefix_match():
     assert not RouteChecks.check_route_access(
         route="/user/daily/activity/aggregated",
         allowed_routes=["/user/daily/activity"],
+    )
+
+
+@pytest.mark.parametrize(
+    "user_role",
+    [
+        LitellmUserRoles.INTERNAL_USER.value,
+        LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value,
+    ],
+)
+def test_organization_daily_activity_reachable_by_non_admin_roles(user_role):
+    """The Organization Usage dashboard calls /organization/daily/activity, whose
+    handler restricts results to organizations the caller is ORG_ADMIN of (and
+    403s on any other org). That scoping is unreachable unless the route layer
+    lets a non-proxy-admin through first: the route belongs to no info /
+    management / org_admin_only list, so self_managed_routes is the only entry
+    granting it, and dropping it 401s every org admin's Organization Usage view
+    before the handler ever runs.
+    """
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        user_email="test@example.com",
+        user_role=user_role,
+    )
+    valid_token = UserAPIKeyAuth(user_id="test_user", user_role=user_role)
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=user_role,
+        route="/organization/daily/activity",
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
+
+
+def test_organization_daily_activity_not_granted_by_org_admin_request_data_branch():
+    """The org-admin branch of the route gate cannot grant this route, so the
+    self_managed_routes entry is load-bearing rather than redundant.
+
+    Query params do reach request_data, so the reason is not body-vs-query: it
+    is the key name. _user_is_org_admin reads ``organization_id`` (singular) and
+    ``organizations``, while this endpoint's filter is ``organization_ids``
+    (plural), and the dashboard's first page load sends no organization filter
+    at all. Both shapes are pinned below because renaming the query param would
+    otherwise silently change which gate is doing the work.
+    """
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        user_email="test@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        organization_memberships=[
+            LiteLLM_OrganizationMembershipTable(
+                user_id="test_user",
+                organization_id="org-a",
+                user_role=LitellmUserRoles.ORG_ADMIN.value,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            )
+        ],
+    )
+
+    # The dashboard's default page load: no organization filter at all.
+    assert not _user_is_org_admin(request_data={}, user_object=user_obj)
+    # The filtered load, naming an org this user really does administer.
+    assert not _user_is_org_admin(request_data={"organization_ids": "org-a"}, user_object=user_obj)
+    # The key name the helper would have had to see to grant it.
+    assert _user_is_org_admin(request_data={"organization_id": "org-a"}, user_object=user_obj)
+    assert not RouteChecks.check_route_access(
+        route="/organization/daily/activity",
+        allowed_routes=LiteLLMRoutes.org_admin_only_routes.value,
     )

--- a/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
@@ -992,3 +992,51 @@ def test_build_budget_write_data_clears_reset_at_with_null_duration():
     data = build_budget_write_data({"budget_duration": None}, "admin-1")
     assert data["budget_duration"] is None
     assert data["budget_reset_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_organization_daily_activity_non_admin_without_org_admin_role_sees_nothing(
+    monkeypatch,
+):
+    """A caller who is ORG_ADMIN of no organization must resolve to an EMPTY id
+    list, never to None. None means "no entity filter" downstream, i.e. every
+    organization's spend, so the natural simplification of falling back to None
+    on an empty membership set turns a scoping rule into a proxy-wide leak. The
+    organization-alias lookup must be scoped by that same empty list rather than
+    reading the whole table.
+    """
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints import organization_endpoints
+    from litellm.proxy.management_endpoints.organization_endpoints import (
+        get_organization_daily_activity,
+    )
+
+    mock_prisma_client = AsyncMock()
+    org_table_find_many = AsyncMock(return_value=[])
+    mock_prisma_client.db.litellm_organizationtable.find_many = org_table_find_many
+    mock_prisma_client.db.litellm_organizationmembership.find_many = AsyncMock(return_value=[])
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.organization_endpoints._user_has_admin_view",
+        lambda _: False,
+    )
+
+    get_daily_activity_mock = AsyncMock(return_value=MagicMock(name="SpendAnalyticsPaginatedResponse"))
+    monkeypatch.setattr(organization_endpoints, "get_daily_activity", get_daily_activity_mock)
+
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER, user_id="no-orgs-user")
+    await get_organization_daily_activity(
+        organization_ids=None,
+        start_date="2024-04-01",
+        end_date="2024-04-30",
+        model=None,
+        api_key=None,
+        page=1,
+        page_size=10,
+        exclude_organization_ids=None,
+        user_api_key_dict=auth,
+    )
+
+    assert get_daily_activity_mock.call_args.kwargs["entity_id"] == []
+    assert org_table_find_many.call_args.kwargs["where"] == {"organization_id": {"in": []}}

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.test.tsx
@@ -904,6 +904,26 @@ describe("EntityUsage", () => {
       expect(call()).not.toHaveBeenCalled();
     });
 
+    // An org admin's session role is "Internal User", so the row above cannot
+    // distinguish them. Gating the fetch on the session role alone left the
+    // Organization Usage panel rendered but permanently empty, because the
+    // request was never issued even though the proxy would have served it.
+    it.each([
+      ["organization", () => mockOrganizationDailyActivityCall, true],
+      ["agent", () => mockAgentDailyActivityCall, false],
+    ] as const)("fetches %s activity for an org admin: %s", async (entityType, call, expected) => {
+      render(<EntityUsage {...defaultProps} entityType={entityType} userRole="Internal User" isOrgAdmin={true} />);
+
+      if (expected) {
+        await waitFor(() => {
+          expect(call()).toHaveBeenCalled();
+        });
+      } else {
+        expect(await screen.findByText("Agent Spend Overview")).toBeInTheDocument();
+        expect(call()).not.toHaveBeenCalled();
+      }
+    });
+
     it("keeps the team breakdown but drops its agent sub-fetch for an internal user", async () => {
       render(<EntityUsage {...defaultProps} entityType="team" userRole="Internal User" />);
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
@@ -84,6 +84,7 @@ interface EntityUsageProps {
   entityList: EntityList[] | null;
   premiumUser: boolean;
   dateValue: DateRangePickerValue;
+  isOrgAdmin?: boolean;
 }
 
 const ENTITY_FETCH_FNS: Record<EntityType, (...args: any[]) => Promise<any>> = {
@@ -107,6 +108,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
   entityList,
   userRole,
   dateValue,
+  isOrgAdmin = false,
 }) => {
   const { teams } = useTeams();
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -126,7 +128,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
 
   const fetchFn = ENTITY_FETCH_FNS[entityType];
   const entityCapability = ENTITY_CAPABILITIES[entityType];
-  const canViewEntity = entityCapability === undefined || hasCapability(userRole, entityCapability);
+  const canViewEntity = entityCapability === undefined || hasCapability(userRole, entityCapability, isOrgAdmin);
   const showAgentBreakdown = entityType === "team" && hasCapability(userRole, "viewAgentUsage");
   const hasRequestWindow = !!accessToken && !!startTime && !!endTime;
   const enabled = hasRequestWindow && canViewEntity;

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.test.tsx
@@ -1,6 +1,7 @@
 import { useAgents } from "@/app/(dashboard)/hooks/agents/useAgents";
 import { useCustomers } from "@/app/(dashboard)/hooks/customers/useCustomers";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import useIsOrgAdmin from "@/app/(dashboard)/hooks/useIsOrgAdmin";
 import { useCurrentUser } from "@/app/(dashboard)/hooks/users/useCurrentUser";
 import { useInfiniteUsers } from "@/app/(dashboard)/hooks/users/useUsers";
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
@@ -134,6 +135,11 @@ vi.mock("@/app/(dashboard)/hooks/agents/useAgents", () => ({
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   __esModule: true,
   default: vi.fn(),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/useIsOrgAdmin", () => ({
+  __esModule: true,
+  default: vi.fn(() => false),
 }));
 
 vi.mock("@/app/(dashboard)/hooks/users/useCurrentUser", () => ({
@@ -612,6 +618,49 @@ describe("UsagePage", () => {
     await waitFor(() => {
       const entityUsageElements = screen.getAllByText("Entity Usage");
       expect(entityUsageElements.length).toBeGreaterThan(0);
+    });
+  });
+
+  // Org-admin membership comes from the server, so it can be revoked while the
+  // page is open. The Organization Usage option and its panel both disappear,
+  // and without a fallback the selector keeps a value it no longer offers,
+  // leaving the user on a blank trigger over a blank panel with nothing to
+  // click. An internal user is used because that is the session role an org
+  // admin actually carries.
+  it("should leave the organization view when org-admin membership is revoked mid-session", async () => {
+    const mockUseIsOrgAdmin = vi.mocked(useIsOrgAdmin);
+    mockUseIsOrgAdmin.mockReturnValue(true);
+    mockUseAuthorized.mockReturnValue({
+      isLoading: false,
+      isAuthorized: true,
+      token: "mock-token",
+      accessToken: "test-token",
+      userId: "user-123",
+      userEmail: "test@example.com",
+      userRole: "Internal User",
+      premiumUser: true,
+      disabledPersonalKeyCreation: false,
+      showSSOBanner: false,
+    } as any);
+
+    const { rerender } = renderWithProviders(<UsagePage {...defaultProps} organizations={mockOrganizations} />);
+
+    const usageSelect = screen.getByTestId("usage-view-select");
+    act(() => {
+      fireEvent.change(usageSelect, { target: { value: "organization" } });
+    });
+    await waitFor(() => {
+      expect(screen.getAllByText("Entity Usage").length).toBeGreaterThan(0);
+    });
+    expect((usageSelect as HTMLSelectElement).value).toBe("organization");
+
+    mockUseIsOrgAdmin.mockReturnValue(false);
+    act(() => {
+      rerender(<UsagePage {...defaultProps} organizations={mockOrganizations} />);
+    });
+
+    await waitFor(() => {
+      expect((screen.getByTestId("usage-view-select") as HTMLSelectElement).value).toBe("global");
     });
   });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
@@ -21,6 +21,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useAgents } from "@/app/(dashboard)/hooks/agents/useAgents";
 import { useCustomers } from "@/app/(dashboard)/hooks/customers/useCustomers";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import useIsOrgAdmin from "@/app/(dashboard)/hooks/useIsOrgAdmin";
 import { useCurrentUser } from "@/app/(dashboard)/hooks/users/useCurrentUser";
 import { useInfiniteUsers } from "@/app/(dashboard)/hooks/users/useUsers";
 import { hasCapability } from "@/utils/capabilities";
@@ -101,7 +102,8 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
   const { data: currentUser } = useCurrentUser();
   const isAdmin = all_admin_roles.includes(userRole || "");
   const canViewTagUsage = isAdmin || internalUserRoles.includes(userRole || "");
-  const canViewOrganizationUsage = hasCapability(userRole, "viewOrganizationUsage");
+  const isOrgAdmin = useIsOrgAdmin();
+  const canViewOrganizationUsage = hasCapability(userRole, "viewOrganizationUsage", isOrgAdmin);
   const canViewAgentUsage = hasCapability(userRole, "viewAgentUsage");
 
   const [settledUserSearch, setSettledUserSearch] = useState("");
@@ -142,7 +144,14 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
   const [isCloudZeroModalOpen, setIsCloudZeroModalOpen] = useState(false);
   const [isGlobalExportModalOpen, setIsGlobalExportModalOpen] = useState(false);
   const [isAiChatOpen, setIsAiChatOpen] = useState(false);
-  const [usageView, setUsageView] = useState<UsageOption>("global");
+  const [selectedUsageView, setUsageView] = useState<UsageOption>("global");
+  // Org-admin membership is read from the server, so unlike the other usage
+  // views this one can be revoked while the page is open. Derive the view in
+  // render rather than storing it, so the fallback lands on the same paint and
+  // the selector never holds a value it no longer offers.
+  const usageView: UsageOption =
+    selectedUsageView === "organization" && !canViewOrganizationUsage ? "global" : selectedUsageView;
+
   const [showCredentialBanner, setShowCredentialBanner] = useState(true);
   const [topKeysLimit, setTopKeysLimit] = useState<number>(5);
   const [topModelsLimit, setTopModelsLimit] = useState<number>(5);
@@ -492,6 +501,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
               onChange={(value) => setUsageView(value)}
               userRole={userRole}
               canViewTagUsage={canViewTagUsage}
+              isOrgAdmin={isOrgAdmin}
             />
             <AdvancedDatePicker value={dateValue} onValueChange={handleDateChange} />
           </div>
@@ -942,6 +952,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
               entityType="organization"
               userID={userID}
               userRole={userRole}
+              isOrgAdmin={isOrgAdmin}
               dateValue={dateValue}
               entityList={
                 organizations?.map((organization) => ({

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsageViewSelect/UsageViewSelect.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsageViewSelect/UsageViewSelect.test.tsx
@@ -79,6 +79,24 @@ describe("UsageViewSelect", () => {
     expect(offers(container, optionName)).toBe(false);
   });
 
+  // An org admin's session role is "Internal User" — org-admin-ness lives in the
+  // membership table — so the two rows above cannot tell them apart from a plain
+  // internal user. Organization Usage must open for them, and only that option:
+  // the proxy serves them /organization/daily/activity scoped to the orgs they
+  // administer, but still refuses the agent usage route.
+  it.each([
+    ["Organization Usage", true],
+    ["Agent Usage (A2A)", false],
+  ] as const)("should offer %s to an org admin: %s", async (optionName, expected) => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <UsageViewSelect value="global" onChange={mockOnChange} userRole="Internal User" isOrgAdmin={true} />,
+    );
+
+    await openMenu(user);
+    expect(offers(container, optionName)).toBe(expected);
+  });
+
   it.each(["Team Usage", "Tag Usage"])("should keep %s available to an internal user", async (optionName) => {
     const user = userEvent.setup();
     const { container } = render(

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsageViewSelect/UsageViewSelect.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsageViewSelect/UsageViewSelect.tsx
@@ -19,6 +19,7 @@ export interface UsageViewSelectProps {
   onChange: (value: UsageOption) => void;
   userRole: string | null;
   canViewTagUsage?: boolean;
+  isOrgAdmin?: boolean;
   title?: string;
   description?: string;
   "data-id"?: string;
@@ -108,6 +109,7 @@ export const UsageViewSelect: React.FC<UsageViewSelectProps> = ({
   onChange,
   userRole,
   canViewTagUsage = false,
+  isOrgAdmin = false,
   title = "Usage View",
   description = "Select the usage data you want to view",
   "data-id": dataId,
@@ -116,7 +118,7 @@ export const UsageViewSelect: React.FC<UsageViewSelectProps> = ({
   const getFilteredOptions = () => {
     return OPTIONS.filter((option) => {
       if (option.capability) {
-        return hasCapability(userRole, option.capability);
+        return hasCapability(userRole, option.capability, isOrgAdmin);
       }
       if (option.value === "tag" && canViewTagUsage) {
         return true;

--- a/ui/litellm-dashboard/src/utils/capabilities.test.ts
+++ b/ui/litellm-dashboard/src/utils/capabilities.test.ts
@@ -49,6 +49,7 @@ const SESSION_ROLE_AN_ORG_ADMIN_ACTUALLY_CARRIES = "Internal User";
 
 const ORG_ADMIN_BACKEND_ACCESS: ReadonlyArray<readonly [Capability, string, boolean]> = [
   ["viewDeletedTeams", "GET /v2/team/list?status=deleted -> 200 (scoped to their orgs)", true],
+  ["viewOrganizationUsage", "GET /organization/daily/activity -> 200 (scoped to orgs they administer)", true],
   ["viewToolPolicies", "GET /v1/tool/list -> 401", false],
   ["viewPolicies", "GET /policies/list -> 401", false],
   ["viewPrompts", "GET /prompts/list -> 401", false],
@@ -64,6 +65,14 @@ describe("hasCapability for organization admins", () => {
     expect(hasCapability(role, "viewDeletedTeams", true)).toBe(true);
   });
 
+  // An org admin is an internal_user whose org-admin-ness lives in the
+  // membership table, so their session role never distinguishes them. Gating
+  // the Organization Usage view on the session role alone hid the whole view
+  // from them and left the tab's data fetch disabled.
+  it.each(NON_ADMIN_ROLES)("grants viewOrganizationUsage to an org admin whose session role is %s", (role) => {
+    expect(hasCapability(role, "viewOrganizationUsage", true)).toBe(true);
+  });
+
   it.each(ADMIN_ONLY_CAPABILITIES)("leaves %s denied when the caller is not an org admin", (capability) => {
     expect(hasCapability(SESSION_ROLE_AN_ORG_ADMIN_ACTUALLY_CARRIES, capability, false)).toBe(false);
     expect(hasCapability(SESSION_ROLE_AN_ORG_ADMIN_ACTUALLY_CARRIES, capability)).toBe(false);
@@ -73,7 +82,7 @@ describe("hasCapability for organization admins", () => {
     const orgAdminCapabilities = ADMIN_ONLY_CAPABILITIES.filter((capability) =>
       hasCapability(SESSION_ROLE_AN_ORG_ADMIN_ACTUALLY_CARRIES, capability, true),
     );
-    expect(orgAdminCapabilities).toEqual(["viewDeletedTeams"]);
+    expect(orgAdminCapabilities).toEqual(["viewDeletedTeams", "viewOrganizationUsage"]);
   });
 
   it("does not let the org-admin allowance reopen the proxy-admin-only viewGlobalSpend gate", () => {

--- a/ui/litellm-dashboard/src/utils/capabilities.ts
+++ b/ui/litellm-dashboard/src/utils/capabilities.ts
@@ -19,7 +19,10 @@ const CAPABILITY_ROLES = {
 
 export type Capability = keyof typeof CAPABILITY_ROLES;
 
-const ORG_ADMIN_CAPABILITIES: ReadonlySet<Capability> = new Set<Capability>(["viewDeletedTeams"]);
+const ORG_ADMIN_CAPABILITIES: ReadonlySet<Capability> = new Set<Capability>([
+  "viewDeletedTeams",
+  "viewOrganizationUsage",
+]);
 
 export const hasCapability = (
   userRole: string | null | undefined,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Org admins saw an empty Organization Usage dashboard
- Only a proxy-admin promotion made their org spend appear
- Key activity and endpoint activity were empty too

How it solves it:

- Route layer now admits the org daily-activity route
- Handler already scoped results to orgs they administer
- Dashboard grants the org-usage view to org admins

## User Flow

Before: a department owner who administers an organization opens the Usage page to check their department's spend, and finds nothing there

1. They sign in at https://litellm-domain/ui/ as an internal user who is an org admin of their department's organization
2. They open https://litellm-domain/ui/?page=usage and the Usage View selector offers Your Usage, Team Usage and Tag Usage, with no Organization Usage entry at all
3. They pick Team Usage instead and their team's spend renders correctly, so the data plainly exists
4. Calling the same data directly, GET https://litellm-domain/organization/daily/activity?organization_ids=<their org>&start_date=...&end_date=... returns 401 `Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/organization/daily/activity. Your role=internal_user`
5. A proxy admin promotes them to proxy admin, and the same page and the same request immediately return their organization's spend, along with every other organization's

After: the same owner sees their department's spend without any promotion, and still cannot see anyone else's

1. They sign in at https://litellm-domain/ui/ as an internal user who is an org admin of their department's organization
2. They open https://litellm-domain/ui/?page=usage and the Usage View selector now offers Organization Usage
3. They select it, pick their organization, and the page shows the organization's spend, its Key Activity rows and its Model / Endpoint Activity rows
4. GET https://litellm-domain/organization/daily/activity?organization_ids=<their org>&start_date=...&end_date=... returns 200 with the same totals a proxy admin sees for that organization
5. The Export button on that same panel now produces a CSV or JSON of their organization's usage, which is what they need for internal cross-charging
6. Asking for an organization they do not administer returns 403 `User is not org_admin for Organization= <id>`, and a colleague who administers no organization gets 200 with an empty result set rather than anyone else's spend

## Relevant issues

## Linear ticket

Resolves LIT-5697

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, run once against a live proxy on Postgres with a real OpenAI key. `engineering-dept` is the organization `dept-owner` administers, `finance-dept` is one they have no membership in. Both organizations were given a team and a key, and real `gpt-4o-mini` traffic was billed through both, so `LiteLLM_DailyOrganizationSpend` holds a row per organization:

```
organization_id                      |    date    |  spend    | api_requests
-------------------------------------+------------+-----------+-------------
81746a61-...-0d626208ed62 (eng)      | 2026-08-17 | 8.1e-06   |      3
e01115c0-...-7a329c0d5547 (finance)  | 2026-08-17 | 5.4e-06   |      2
```

`dept-owner` is an internal user, org admin of `engineering-dept` only, and a team admin of the team inside it. `$USER_KEY` is their key, `$MASTER` the proxy admin's.

### Before (973329e9864154d429a7d739fb6a552fe03a9b3e)

#### Proxy admin can read the organization's spend

1. `curl -s "$B/organization/daily/activity?organization_ids=$ORG_A&start_date=$TODAY&end_date=$TODAY" -H "Authorization: Bearer $MASTER"`
2. `{"total_spend": 8.099999999999999e-06, "total_api_requests": 3, "results": 1}`

#### The same org admin can read their TEAM usage

1. `curl -s "$B/team/daily/activity?team_ids=$TEAM_A&start_date=$TODAY&end_date=$TODAY" -H "Authorization: Bearer $USER_KEY"`
2. `{"total_spend": 8.099999999999999e-06, "total_api_requests": 3, "results": 1}`

#### The org admin asks for their ORGANIZATION usage

1. `curl -s "$B/organization/daily/activity?organization_ids=$ORG_A&start_date=$TODAY&end_date=$TODAY" -H "Authorization: Bearer $USER_KEY"`
2. `http_code: 401`
3. `{"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/organization/daily/activity. Your role=internal_user. Your user_id=dept-o**er","type":"auth_error","param":"None","code":"401"}}`

#### The org admin with no explicit filter, which is what the dashboard sends

1. `curl -s "$B/organization/daily/activity?start_date=$TODAY&end_date=$TODAY" -H "Authorization: Bearer $USER_KEY"`
2. `http_code: 401`, same message naming the route

#### The organization selector itself is fine, so the data is reachable and only the usage read is refused

1. `curl -s "$B/organization/list" -H "Authorization: Bearer $USER_KEY"`
2. `[('engineering-dept', [('dept-owner', 'org_admin')])]`

### After (72f18a2c3e)

#### Proxy admin can read the organization's spend

1. `curl -s "$B/organization/daily/activity?organization_ids=$ORG_A&start_date=$TODAY&end_date=$TODAY" -H "Authorization: Bearer $MASTER"`
2. `{"total_spend": 8.099999999999999e-06, "total_api_requests": 3, "results": 1}`

#### The same org admin can read their TEAM usage

1. `curl -s "$B/team/daily/activity?team_ids=$TEAM_A&start_date=$TODAY&end_date=$TODAY" -H "Authorization: Bearer $USER_KEY"`
2. `{"total_spend": 8.099999999999999e-06, "total_api_requests": 3, "results": 1}`

#### The org admin asks for their ORGANIZATION usage

1. `curl -s "$B/organization/daily/activity?organization_ids=$ORG_A&start_date=$TODAY&end_date=$TODAY" -H "Authorization: Bearer $USER_KEY"`
2. `http_code: 200`
3. `{"results":[{"date":"2026-08-17","metrics":{"spend":8.099999999999999e-6,...,"total_tokens":45,"successful_requests":3,"failed_requests":0,"api_requests":3},"breakdown":{"models":{"openai/gpt-4o-mini":{...}}, ...`

#### The org admin with no explicit filter, which is what the dashboard sends

1. `curl -s "$B/organization/daily/activity?start_date=$TODAY&end_date=$TODAY" -H "Authorization: Bearer $USER_KEY"`
2. `http_code: 200`, same totals, defaulted to the organizations they administer

#### Key Activity and Endpoint Activity populate for the same scope

1. Reading the `breakdown` off that same 200 response:
2. `api_keys (Key Activity): {"7aea7f07...fba98": {"spend": 8.099999999999999e-06, "requests": 3, "alias": "eng-workload"}}`
3. `models (Endpoint Activity): {"openai/gpt-4o-mini": {"spend": 8.099999999999999e-06, "requests": 3}}`

#### The org admin and the proxy admin agree on the number

1. Same request as each principal in turn
2. `total_spend = 8.099999999999999e-06` and `total_spend = 8.099999999999999e-06`

#### An organization they do NOT administer stays refused

1. `curl -s "$B/organization/daily/activity?organization_ids=$ORG_B&start_date=$TODAY&end_date=$TODAY" -H "Authorization: Bearer $USER_KEY"`
2. `http_code: 403`
3. `{"detail":{"error":"User is not org_admin for Organization= e01115c0-9a29-4181-a42e-7a329c0d5547."}}`

#### An internal user who administers NO organization sees nothing, not someone else's spend

1. Mint a key for a fresh internal user with no organization membership, and prove the key works before believing any refusal: `curl -s -o /dev/null -w '%{http_code}' "$B/user/daily/activity?start_date=$TODAY&end_date=$TODAY" -H "Authorization: Bearer $PLAIN_KEY"` returns `200`
2. `curl -s "$B/organization/daily/activity?start_date=$TODAY&end_date=$TODAY" -H "Authorization: Bearer $PLAIN_KEY"` returns `http_code: 200` and `{"results": 0, "total_spend": 0.0, "total_api_requests": 0}`
3. `curl -s "$B/organization/daily/activity?organization_ids=$ORG_A&..." -H "Authorization: Bearer $PLAIN_KEY"` returns `http_code: 403` and `{"detail":{"error":"User is not org_admin for Organization= 81746a61-...-0d626208ed62."}}`

The UI change is the Organization Usage entry appearing in the Usage View
selector. Screenshots of that flow are still to come; the terminal evidence
above is the same request the page issues, driven as the org admin.

## Type

🐛 Bug Fix

## Caveats (if any)

- Handler-level org scoping already existed and was unreachable
- Usage view resets to global if org-admin access is revoked
- Export needed no change; it serializes the same payload

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
