### PR TITLE
feat: add openrouter/deepseek-v4-pro and deepseek-v4-flash to model prices

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -32378,6 +32378,38 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/deepseek/deepseek-v4-pro": {
+        "input_cost_per_token": 6.067e-07,
+        "input_cost_per_token_cache_hit": 5.056e-08,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 1.213e-06,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "openrouter/deepseek/deepseek-v4-flash": {
+        "input_cost_per_token": 6.79e-08,
+        "input_cost_per_token_cache_hit": 1.68e-08,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 1.68e-07,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "openrouter/google/gemini-2.0-flash-001": {
         "deprecation_date": "2026-06-01",
         "input_cost_per_audio_token": 7e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -32378,6 +32378,38 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/deepseek/deepseek-v4-pro": {
+        "input_cost_per_token": 6.067e-07,
+        "input_cost_per_token_cache_hit": 5.056e-08,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 1.213e-06,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "openrouter/deepseek/deepseek-v4-flash": {
+        "input_cost_per_token": 6.79e-08,
+        "input_cost_per_token_cache_hit": 1.68e-08,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 1.68e-07,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "openrouter/google/gemini-2.0-flash-001": {
         "deprecation_date": "2026-06-01",
         "input_cost_per_audio_token": 7e-07,


### PR DESCRIPTION
## TLDR

Problem this solves:

- openrouter/deepseek/deepseek-v4-pro and deepseek-v4-flash missing from model pricing

How it solves it:

- Adds both model entries to model_prices_and_context_window.json and the backup file

## User Flow

Before: a developer routing through OpenRouter to DeepSeek V4 Pro or V4 Flash gets no cost tracking because the model is not in the pricing map

1. They send POST https://litellm-domain/v1/chat/completions with model "openrouter/deepseek/deepseek-v4-pro"
2. The request succeeds but https://litellm-domain/ui/?page=logs shows $0 spend

After: the same request shows correct spend

1. They send POST https://litellm-domain/v1/chat/completions with model "openrouter/deepseek/deepseek-v4-pro"
2. https://litellm-domain/ui/?page=logs shows the request with correct spend based on OpenRouter pricing

## Relevant issues

Fixes #37142

## Linear ticket



## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

JSON-only change adding two model entries. Pricing sourced from OpenRouter's model pages:
- deepseek-v4-pro: $0.6067/M input, $1.213/M output, $0.05056/M cache hit, 1M context, 384K max output
- deepseek-v4-flash: $0.0679/M input, $0.168/M output, $0.0168/M cache hit, 1M context, 384K max output

## Type

🆕 New Feature