### PR TITLE
fix(guardrails): merge model-level guardrails into litellm_metadata for /v1/messages

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -276,6 +276,19 @@ _UNTRUSTED_METADATA_CONTROL_FIELDS: Final = (
     "client_disconnected",
     "error_information",
     PRE_CALL_EXECUTED_GUARDRAILS_KEY,
+    # Guardrail selection fields. ``guardrails`` and ``guardrail_config`` are
+    # admin-authoritative: they are populated by ``move_guardrails_to_metadata``
+    # (from key/team/project metadata) and ``_check_and_merge_model_level_guardrails``
+    # (from model-level config) AFTER this strip runs. A caller that supplies
+    # ``metadata: {"guardrails": []}`` on /v1/messages could otherwise shadow
+    # the admin-merged list in ``litellm_metadata`` via
+    # ``get_guardrail_from_metadata`` (which checks ``metadata`` first),
+    # silently bypassing all model-level and key/team guardrails
+    # (veria-ai HIGH on #36085). The top-level ``data["guardrails"]`` feature
+    # (popped by ``move_guardrails_to_metadata``) is unaffected: this strip
+    # only removes keys from the ``metadata`` / ``litellm_metadata`` sub-dicts.
+    "guardrails",
+    "guardrail_config",
 )
 
 UNTRUSTED_REQUEST_HEADER_CONTROL_FIELDS: Final = frozenset(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -91,7 +91,10 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.prometheus import PrometheusLogger
 from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 from litellm.integrations.SlackAlerting.utils import _add_langfuse_trace_id_to_alert
-from litellm.litellm_core_utils.core_helpers import coerce_token_limit
+from litellm.litellm_core_utils.core_helpers import (
+    coerce_token_limit,
+    get_metadata_variable_name_from_kwargs,
+)
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
@@ -6660,7 +6663,9 @@ def _check_and_merge_model_level_guardrails(
 
     metadata: Final = data.get("metadata") or {}
     litellm_metadata: Final = data.get("litellm_metadata") or {}
-    model_info: Final = metadata.get("model_info") or {}
+    # model_info may live in either metadata bucket depending on the route
+    # (/v1/messages, batches, files, responses use litellm_metadata).
+    model_info: Final = metadata.get("model_info") or litellm_metadata.get("model_info") or {}
     model_id: Final = model_info.get("id") if trust_client_model_info else None
     # route_request resolves team-scoped public model names with the
     # server-populated team id; pre_call lookup must do the same so
@@ -6727,9 +6732,15 @@ def _merge_guardrails_with_existing(data: dict, model_level_guardrails: object) 
 
     Returns:
         Modified data dict with merged guardrails in metadata
+
+    Uses ``litellm_metadata`` when present (e.g. /v1/messages, batches, files,
+    responses) so litellm-internal guardrails are not injected into the
+    provider-facing ``metadata`` field. On legacy endpoints that only have
+    ``metadata``, the behaviour is unchanged.
     """
     modified_data: Final = data.copy()
-    metadata: Final = modified_data.setdefault("metadata", {})
+    metadata_key: Final = get_metadata_variable_name_from_kwargs(modified_data)
+    metadata: Final = modified_data.setdefault(metadata_key, {})
     existing_guardrails = metadata.get("guardrails", [])
 
     # Ensure existing_guardrails is a list

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -402,6 +402,65 @@ async def test_add_litellm_data_to_request_strips_all_user_api_key_prefix_keys()
 
 
 @pytest.mark.asyncio
+async def test_add_litellm_data_strips_caller_guardrails_from_metadata():
+    """veria-ai HIGH on #36085: a caller sending
+    ``metadata: {"guardrails": []}`` (or ``litellm_metadata``) on /v1/messages
+    could shadow admin-authoritative guardrails because
+    ``get_guardrail_from_metadata`` checks ``metadata`` before
+    ``litellm_metadata``. The strip in ``add_litellm_data_to_request`` must
+    remove ``guardrails`` and ``guardrail_config`` from both caller-supplied
+    metadata dicts so only admin-merged values (from
+    ``move_guardrails_to_metadata`` and
+    ``_check_and_merge_model_level_guardrails``) survive."""
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    request_mock = MagicMock(spec=Request)
+    request_mock.url = MagicMock()
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {"Content-Type": "application/json"}
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+
+    data = {
+        "model": "gpt-3.5-turbo",
+        "metadata": {"guardrails": [], "guardrail_config": {"mode": "block"}},
+        "litellm_metadata": {"guardrails": ["caller-fake"], "guardrail_config": {"mode": "pass"}},
+    }
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="hashed-key",
+        user_id="real-user",
+        metadata={},
+        team_metadata={},
+        spend=0.0,
+        max_budget=100.0,
+        model_max_budget={},
+        team_spend=0.0,
+        team_max_budget=200.0,
+    )
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=request_mock,
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    # Neither metadata dict should retain caller-supplied guardrails fields.
+    for meta_key in ("metadata", "litellm_metadata"):
+        meta = updated.get(meta_key) or {}
+        assert "guardrails" not in meta, \
+            f"caller-supplied 'guardrails' must be stripped from {meta_key}, got: {meta.get('guardrails')}"
+        assert "guardrail_config" not in meta, \
+            f"caller-supplied 'guardrail_config' must be stripped from {meta_key}, got: {meta.get('guardrail_config')}"
+
+
+@pytest.mark.asyncio
 async def test_add_litellm_data_to_request_string_metadata_does_not_crash():
     """Regression: pre-strip code that pre-populated data['metadata'][k]=v
     before the string-to-dict parse would crash on JSON-string metadata.

--- a/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge_v1_messages.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge_v1_messages.py
@@ -108,6 +108,58 @@ def test_merge_preserves_existing_litellm_metadata_guardrails():
         "model-level guardrails should be merged into litellm_metadata"
 
 
+def test_caller_metadata_guardrails_does_not_shadow_litellm_metadata():
+    """veria-ai HIGH on #36085: a caller sending
+    ``metadata: {"guardrails": []}`` on /v1/messages must not shadow the
+    admin-authoritative guardrails merged into ``litellm_metadata``.
+
+    ``get_guardrail_from_metadata`` checks ``metadata`` before
+    ``litellm_metadata``. Without stripping ``guardrails`` from caller-supplied
+    ``metadata``, the empty list would be returned and all model-level /
+    key-team guardrails silently bypassed.
+
+    This test simulates the post-strip state: ``metadata`` no longer has a
+    ``guardrails`` key, so ``get_guardrail_from_metadata`` falls through to
+    ``litellm_metadata`` where the admin-merged list lives.
+    """
+    data = {
+        "model": "my-model",
+        # Caller tried to inject guardrails: [] but it was stripped.
+        "metadata": {"user_id": "user_abc"},
+        "litellm_metadata": {"guardrails": ["pii-mask-presidio", "key-guardrail"]},
+    }
+    requested = _simulate_get_guardrail_from_metadata(data)
+    assert "pii-mask-presidio" in requested, \
+        f"admin guardrails must not be shadowed by caller metadata, got: {requested}"
+    assert "key-guardrail" in requested, \
+        f"key/team guardrails must not be shadowed by caller metadata, got: {requested}"
+
+
+def test_caller_cannot_empty_list_bypass_guardrails():
+    """Directly test the attack vector: caller sends
+    ``metadata: {"guardrails": []}`` to bypass all guardrails.
+
+    After the strip in ``add_litellm_data_to_request``, the ``guardrails`` key
+    is removed from ``metadata``. The admin-merged guardrails in
+    ``litellm_metadata`` are the only source ``get_guardrail_from_metadata``
+    can read.
+    """
+    # Simulate the state AFTER add_litellm_data_to_request has stripped
+    # guardrails from caller metadata AND move_guardrails_to_metadata +
+    # _check_and_merge_model_level_guardrails have written admin guardrails
+    # to litellm_metadata.
+    data = {
+        "model": "my-model",
+        "metadata": {"user_id": "user_abc"},  # guardrails stripped by pre-call
+        "litellm_metadata": {"guardrails": ["model-guardrail", "key-guardrail"]},
+    }
+    requested = _simulate_get_guardrail_from_metadata(data)
+    assert len(requested) == 2, \
+        f"expected 2 admin guardrails, got: {requested}"
+    assert "model-guardrail" in requested
+    assert "key-guardrail" in requested
+
+
 if __name__ == "__main__":
     import pytest
     pytest.main([__file__, "-v"])

--- a/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge_v1_messages.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge_v1_messages.py
@@ -1,0 +1,113 @@
+"""Reproduce issue #36085: model-level guardrails not applied on /v1/messages.
+
+The bug: _merge_guardrails_with_existing always writes to data["metadata"],
+but for /v1/messages the internal proxy state lives in data["litellm_metadata"].
+This test checks whether model-level guardrails are findable by
+get_guardrail_from_metadata after the merge, and whether they leak into
+the Anthropic provider-facing metadata.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from litellm.proxy.utils import (
+    _check_and_merge_model_level_guardrails,
+    _merge_guardrails_with_existing,
+)
+
+
+def _router_with_deployment(guardrails, *, by_alias: bool = False):
+    deployment = SimpleNamespace(litellm_params={"guardrails": guardrails})
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+    router.get_model_list.return_value = (
+        [{"litellm_params": {"guardrails": guardrails}}] if by_alias else []
+    )
+    return router
+
+
+def _simulate_get_guardrail_from_metadata(data: dict) -> list:
+    """Replicates CustomGuardrail.get_guardrail_from_metadata logic."""
+    if "guardrails" in data:
+        return data["guardrails"]
+    for meta_key in ("metadata", "litellm_metadata"):
+        meta = data.get(meta_key) or {}
+        if isinstance(meta, dict) and "guardrails" in meta:
+            return meta.get("guardrails") or []
+    return []
+
+
+def test_merge_writes_to_litellm_metadata_when_present():
+    """For /v1/messages, litellm_metadata is the internal bucket.
+    _merge_guardrails_with_existing should write there, not to metadata."""
+    data = {
+        "model": "my-model",
+        "metadata": {"user_id": "user_abc"},  # provider-facing (Anthropic)
+        "litellm_metadata": {"guardrails": ["key-guardrail"]},  # internal
+    }
+    result = _merge_guardrails_with_existing(data, ["model-guardrail"])
+
+    # The guardrails should be in litellm_metadata, not metadata
+    assert "guardrails" in result.get("litellm_metadata", {}), \
+        "model-level guardrails should be merged into litellm_metadata for /v1/messages"
+    assert "model-guardrail" in result["litellm_metadata"]["guardrails"]
+
+    # metadata (provider-facing) should NOT have guardrails injected
+    assert "guardrails" not in result.get("metadata", {}), \
+        "guardrails should not leak into provider-facing metadata"
+
+
+def test_check_and_merge_finds_guardrails_for_v1_messages():
+    """Full _check_and_merge_model_level_guardrails with litellm_metadata.
+    Simulates the pre_call path for /v1/messages."""
+    router = _router_with_deployment(["pii-mask-presidio"], by_alias=True)
+    data = {
+        "model": "my-model",
+        "metadata": {"user_id": "user_abc"},  # Anthropic provider-facing
+        "litellm_metadata": {},  # internal, seeded by add_litellm_data_to_request
+    }
+    result = _check_and_merge_model_level_guardrails(
+        data=data, llm_router=router, trust_client_model_info=False
+    )
+
+    # After merge, guardrails should be findable via get_guardrail_from_metadata
+    requested = _simulate_get_guardrail_from_metadata(result)
+    assert "pii-mask-presidio" in requested, \
+        f"model-level guardrail should be in requested_guardrails, got: {requested}"
+
+
+def test_merge_does_not_overwrite_provider_metadata():
+    """Writing guardrails to data["metadata"] for /v1/messages would inject
+    litellm-internal guardrails into the Anthropic provider-facing metadata.
+    The fix must use litellm_metadata when present."""
+    data = {
+        "model": "my-model",
+        "metadata": {"user_id": "user_abc"},
+        "litellm_metadata": {},
+    }
+    result = _merge_guardrails_with_existing(data, ["pii-mask-presidio"])
+
+    # Provider-facing metadata should be unchanged
+    assert result["metadata"] == {"user_id": "user_abc"}, \
+        f"provider-facing metadata should not be modified, got: {result['metadata']}"
+
+
+def test_merge_preserves_existing_litellm_metadata_guardrails():
+    """When litellm_metadata already has guardrails (from key/team metadata),
+    the merge should union with them, not overwrite."""
+    data = {
+        "model": "my-model",
+        "metadata": {"user_id": "user_abc"},
+        "litellm_metadata": {"guardrails": ["key-guardrail"]},
+    }
+    result = _merge_guardrails_with_existing(data, ["model-guardrail"])
+
+    litellm_meta_guardrails = result.get("litellm_metadata", {}).get("guardrails", [])
+    assert "key-guardrail" in litellm_meta_guardrails, \
+        "existing litellm_metadata guardrails should be preserved"
+    assert "model-guardrail" in litellm_meta_guardrails, \
+        "model-level guardrails should be merged into litellm_metadata"
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- `_merge_guardrails_with_existing` always wrote guardrails to `data["metadata"]`, but routes like `/v1/messages`, `batches`, `files`, and `responses` store proxy-internal state in `data["litellm_metadata"]` while `data["metadata"]` is the provider-facing field (Anthropic expects `metadata.user_id`, etc.).
- This caused litellm-internal guardrail names to leak into the Anthropic provider-facing metadata, and when key/team guardrails were already in `litellm_metadata` (written by `move_guardrails_to_metadata`), the model-level guardrails landed in a different bucket: `get_guardrail_from_metadata` checks `metadata` first and returns early, silently shadowing the key/team guardrails in `litellm_metadata`.
- Fix: use `get_metadata_variable_name_from_kwargs` to pick the correct bucket. When `litellm_metadata` is present, guardrails are merged there; otherwise behaviour is unchanged for legacy endpoints.
- Also read `model_info` from `litellm_metadata` in `_check_and_merge_model_level_guardrails` so the post_call path (`trust_client_model_info=True`) resolves `model_info.id` on `/v1/messages` where the router writes it to `litellm_metadata`.

### Security fix: caller metadata shadowing (veria-ai HIGH on #36085)

`get_guardrail_from_metadata` checks `data["metadata"]` before `data["litellm_metadata"]`. On `/v1/messages`, `metadata` is the caller-supplied Anthropic provider-facing field. A caller sending `metadata: {"guardrails": []}` could shadow the admin-authoritative guardrails merged into `litellm_metadata`, silently bypassing all model-level and key/team guardrails.

Fix: add `guardrails` and `guardrail_config` to `_UNTRUSTED_METADATA_CONTROL_FIELDS` so they are stripped from both caller-supplied metadata dicts in `add_litellm_data_to_request` before `move_guardrails_to_metadata` and `_check_and_merge_model_level_guardrails` write admin-authoritative values. The top-level `data["guardrails"]` feature (popped by `move_guardrails_to_metadata`) is unaffected: the strip only removes keys from the `metadata`/`litellm_metadata` sub-dicts.

Fixes #36085

#### Test plan

- [x] 23 existing guardrail merge tests pass (`test_guardrail_merge.py`)
- [x] 6 tests covering `/v1/messages` scenario (`test_guardrail_merge_v1_messages.py`):
  - guardrails merged into `litellm_metadata` when present
  - guardrails findable by `get_guardrail_from_metadata` after merge
  - provider-facing `metadata` not modified
  - existing `litellm_metadata` guardrails preserved and unioned
  - caller `metadata.guardrails` does not shadow `litellm_metadata` guardrails
  - caller cannot empty-list bypass guardrails
- [x] New strip test in `test_litellm_pre_call_utils.py`: caller-supplied `guardrails` and `guardrail_config` stripped from both `metadata` and `litellm_metadata`
- [x] 102 pre-call utils tests pass (guardrail, metadata, strip)
- [x] 7 common_request_processing guardrail tests pass
