### PR TITLE
fix(shadow_eval): drop unused judge reasoning field and salvage truncated verdicts

### DIFF
--- a/litellm/integrations/shadow_eval_logger.py
+++ b/litellm/integrations/shadow_eval_logger.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 from itertools import groupby
 from operator import itemgetter
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, Literal
 
 from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError, field_validator, model_validator
 
@@ -33,6 +33,7 @@ from litellm.litellm_core_utils.llm_judge import (
     parse_json_verdict,
 )
 from litellm.litellm_core_utils.redact_messages import should_redact_message_logging
+from litellm.llms.base_llm.base_utils import type_to_response_format_param
 from litellm.types.management_endpoints.auto_router_endpoints import ShadowEvalDirection
 from litellm.types.utils import SHADOW_EVAL_JUDGE_CALL_ORIGIN, SHADOW_EVAL_ROUTER_CALL_ORIGIN
 
@@ -306,16 +307,21 @@ Criteria: correctness, completeness, clarity, conciseness.
 Return ONLY valid JSON in this exact format, no other text:
 {
   "preference": "A" | "B" | "tie",
-  "confidence": <0.0 to 1.0>,
-  "reasoning": "<one sentence>"
+  "confidence": <0.0 to 1.0>
 }"""
 
 
 class PairwiseVerdict(BaseModel):
-    """The judge's blind A/B verdict, validated at the parse boundary."""
+    """The judge's blind A/B verdict: the response_format schema sent with the judge call
+    and the validation contract on its reply. Both fields are required and preference is
+    closed over the prompt's labels, so a malformed or truncated reply is an
+    unparseable-verdict error row, never a defaulted or fabricated verdict."""
 
-    preference: str = "tie"
-    confidence: float = 0.0
+    preference: Literal["A", "B", "tie"]
+    confidence: float
+
+
+PAIRWISE_JUDGE_RESPONSE_FORMAT: Final = type_to_response_format_param(PairwiseVerdict)
 
 
 def _sample_hits(request_id: str, job_id: str, percentage: float) -> bool:
@@ -826,6 +832,7 @@ class ShadowEvalLogger(CustomLogger):
                 judge_messages,  # pyright: ignore[reportArgumentType]  # plain SDK message dicts
                 temperature=0,
                 max_tokens=JUDGE_MAX_OUTPUT_TOKENS,
+                response_format=PAIRWISE_JUDGE_RESPONSE_FORMAT,
                 metadata=judge_metadata,
             )
         except Exception as e:  # noqa: BLE001  # judge outages become error rows, not crashes

--- a/tests/test_litellm/integrations/test_shadow_eval_logger.py
+++ b/tests/test_litellm/integrations/test_shadow_eval_logger.py
@@ -15,6 +15,7 @@ from litellm.integrations.shadow_eval_logger import (
     _MAX_ERROR_CHARS,
     _MAX_JUDGE_PROMPT_CHARS,
     JUDGE_MAX_OUTPUT_TOKENS,
+    PAIRWISE_JUDGE_RESPONSE_FORMAT,
     ActiveShadowEvalJob,
     ShadowEvalLogger,
     _failure_detail,
@@ -493,6 +494,26 @@ class TestSuccessHookSkipChain:
         assert row["error"] is None
         assert prisma.db.litellm_shadowevaljob.find_many.await_count == 0
 
+    async def test_judge_call_carries_the_verdict_schema(self, monkeypatch: pytest.MonkeyPatch):
+        import litellm as litellm_module
+
+        monkeypatch.setattr(litellm_module, "completion_cost", lambda completion_response: 0.005)
+        router = _router()
+        logger = _logger(router=router, prisma=_prisma(), jobs=(_job(),))
+
+        await logger.async_log_success_event(_success_kwargs(), RESPONSE, None, None)
+        await _drain(logger)
+
+        judge_call = next(
+            c.kwargs
+            for c in router.acompletion.call_args_list
+            if c.kwargs["metadata"].get(INTERNAL_CALL_ORIGIN_METADATA_KEY) == SHADOW_EVAL_JUDGE_CALL_ORIGIN
+        )
+        assert judge_call["response_format"] == PAIRWISE_JUDGE_RESPONSE_FORMAT
+        schema = judge_call["response_format"]["json_schema"]["schema"]
+        assert schema["required"] == ["preference", "confidence"]
+        assert schema["properties"]["preference"]["enum"] == ["A", "B", "tie"]
+
     async def test_shadow_call_messages_survive_in_place_provider_rewrites(self, monkeypatch: pytest.MonkeyPatch):
         """Provider transforms (anthropic factory, cache-control hook) rewrite messages with
         `messages[i] = ...`; the logger's immutable snapshot must never reach them directly."""
@@ -760,8 +781,17 @@ class TestShadowPipeline:
         [
             (lambda: _failing_router(), "provider exploded", 0.0),
             (lambda: _router(judge_json="I prefer response A, definitely"), "unparseable judge verdict", 0.007),
+            (lambda: _router(judge_json='{"preference": "'), "unparseable judge verdict", 0.007),
+            (lambda: _router(judge_json="{}"), "unparseable judge verdict", 0.007),
+            (lambda: _router(judge_json='{"preference": "A", "confidence": "0.8'), "unparseable judge verdict", 0.007),
         ],
-        ids=["shadow-call-fails", "judge-verdict-unparseable"],
+        ids=[
+            "shadow-call-fails",
+            "judge-verdict-unparseable",
+            "verdict-truncated-before-fields",
+            "verdict-empty-object",
+            "verdict-truncated-inside-confidence",
+        ],
     )
     async def test_failures_become_error_rows_and_keep_billed_judge_cost(
         self, router_factory, expected_error, expected_cost, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## TLDR

Problem this solves:

- Judge verdicts truncate at the output cap and get discarded
- The prompt requests a "reasoning" sentence nothing ever reads
- Malformed replies could persist as defaulted tie verdicts

How it solves it:

- Judge output is schema-constrained, same pattern as the LLM classifier
- Verdict shrinks to the two consumed fields, both required
- Anything not matching the schema is an honest error row

## User Flow

Before: an admin running a shadow eval loses judged turns to verdict truncation

1. They start a shadow eval via POST http://localhost:4000/auto_router/shadow_eval/start and keep sending traffic
2. On busy comparisons the dashboard banner shows "Last failure: unparseable judge verdict: Unterminated string starting at: line 1 column 55 (char 54)" or "Expecting value: line 1 column 1 (char 0)"
3. The judge spend for those turns is billed but the verdict is thrown away

After: the same traffic keeps producing verdicts

1. They start the same shadow eval and send the same traffic
2. The judge is asked for, and structurally constrained to, just a winner and a confidence score, a couple dozen tokens that fit any output cap
3. The turn shows up as a judged verdict; a judge reply that still manages to be malformed becomes an error row rather than a fabricated tie

## Relevant issues

Follow-up to #37232, which raised the judge output cap; this removes the reason verdicts ever grew past it

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The verdict model only reads `preference` and `confidence`, yet the prompt also demanded a trailing `"reasoning"` sentence that was parsed and discarded. That unbounded string was the sole cause of cap truncation. This PR drops it and applies the auto-router classifier's established mechanism to the judge call: a Literal-constrained Pydantic model converted with `type_to_response_format_param` and sent as `response_format`, with the existing `drop_params=True` covering providers that cannot honor it. Both verdict fields are required, so a reply missing either one is recorded as an unparseable-verdict error row instead of persisting a defaulted tie

### Before (5277dab4f2)

Observed on a live deployment running this code, reading its database directly

1. `select judge_cost, error from "LiteLLM_ShadowEvalAttempt" where error like 'unparseable%' order by created_at desc limit 2`
2. Observed: `0.0238065 | unparseable judge verdict: Unterminated string starting at: line 1 column 55 (char 54)` and `0.0238065 | unparseable judge verdict: Expecting value: line 1 column 1 (char 0)`
3. Char 54 is exactly where the `"reasoning"` string value opens in the requested schema; the matching judge spend rows show `completion_tokens = 500`, the output cap, so the reply died inside the reasoning sentence and $0.024 of judge spend was discarded per failure

### After (37d863ac71)

Live rig: `/tmp/shadowfix_config.yaml` with `claude-main` (bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0, live AWS Bedrock) and auto-router `tin-shadow-router`

1. `python litellm/proxy/proxy_cli.py --config /tmp/shadowfix_config.yaml --port 4020 --use_v2_migration_resolver`
2. `curl -X POST http://localhost:4020/key/generate -H "Authorization: Bearer sk-..." -d '{"key_alias": "verdict-proof"}'`
3. `curl -X POST http://localhost:4020/auto_router/shadow_eval/start -H "Authorization: Bearer sk-..." -d '{"api_key_id": "<token_id>", "router_name": "tin-shadow-router", "shadow_percentage": 100.0, "judge_model": "claude-main", "duration_days": 1}'` returned job `cmsxy2pjh0000mgkofl5ahxl6`
4. `curl -X POST http://localhost:4020/v1/messages -H "Authorization: Bearer <key>"` with a plain question, answered by Bedrock with `stop_reason: end_turn`
5. `select outcome, tier, confidence, judge_cost, error from "LiteLLM_ShadowEvalAttempt" order by created_at desc limit 1`
6. Observed: `shadow | SIMPLE | 0.72 | 0.0007447 | (null)`; the schema-constrained verdict parsed cleanly against live Bedrock and judge cost fell by more than an order of magnitude versus the truncated failures

## Type

🐛 Bug Fix

## Caveats (if any)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
