### PR TITLE
fix(fireworks): skip accounts/ rewrite for FW-* Foundry deployment ids

### DIFF
--- a/litellm/llms/fireworks_ai/common_utils.py
+++ b/litellm/llms/fireworks_ai/common_utils.py
@@ -29,14 +29,12 @@ def get_fireworks_session_id(litellm_params: dict) -> str | None:
     return None
 
 
+AZURE_FOUNDRY_FIREWORKS_MODEL_ID_PREFIX: Final = "FW-"
+
+
 def resolve_fireworks_resource_name(model: str) -> str:
     stripped: Final = model.removeprefix("fireworks_ai/")
-    if stripped.startswith("accounts/") or "#" in stripped:
-        return stripped
-    # Azure AI Foundry (and similar OpenAI-compat hosts) expose Fireworks
-    # deployments as ids like ``FW-Kimi-K3``. Rewriting those to
-    # ``accounts/fireworks/models/FW-…`` yields DeploymentNotFound.
-    if stripped.startswith("FW-"):
+    if stripped.startswith(("accounts/", AZURE_FOUNDRY_FIREWORKS_MODEL_ID_PREFIX)) or "#" in stripped:
         return stripped
     if stripped.startswith(("routers/", "models/")):
         return f"accounts/fireworks/{stripped}"

--- a/litellm/llms/fireworks_ai/common_utils.py
+++ b/litellm/llms/fireworks_ai/common_utils.py
@@ -33,6 +33,11 @@ def resolve_fireworks_resource_name(model: str) -> str:
     stripped: Final = model.removeprefix("fireworks_ai/")
     if stripped.startswith("accounts/") or "#" in stripped:
         return stripped
+    # Azure AI Foundry (and similar OpenAI-compat hosts) expose Fireworks
+    # deployments as ids like ``FW-Kimi-K3``. Rewriting those to
+    # ``accounts/fireworks/models/FW-…`` yields DeploymentNotFound.
+    if stripped.startswith("FW-"):
+        return stripped
     if stripped.startswith(("routers/", "models/")):
         return f"accounts/fireworks/{stripped}"
     if stripped.endswith("-fast"):

--- a/tests/test_litellm/llms/fireworks_ai/test_fireworks_ai_common_utils.py
+++ b/tests/test_litellm/llms/fireworks_ai/test_fireworks_ai_common_utils.py
@@ -39,6 +39,9 @@ from litellm.llms.fireworks_ai.common_utils import resolve_fireworks_resource_na
             "glm-4p6#accounts/gitlab/deployments/2fb7764c",
             "glm-4p6#accounts/gitlab/deployments/2fb7764c",
         ),
+        ("FW-Kimi-K3", "FW-Kimi-K3"),
+        ("fireworks_ai/FW-Kimi-K3", "FW-Kimi-K3"),
+        ("FW-GLM-5.2-Fast", "FW-GLM-5.2-Fast"),
     ],
 )
 def test_resolve_fireworks_resource_name(model, expected):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bare Fireworks names always get the `accounts/fireworks/models/` prefix
- Foundry hosts Fireworks models as `FW-Kimi-K3` style deployments
- The prefixed id makes Foundry answer `404 DeploymentNotFound` on every call

How it solves it:

- Names starting with `FW-` are sent to the endpoint unchanged
- Native names like `kimi-k3` or `glm-5p2-fast` are still rewritten as before

## User Flow

Before: a team routing `fireworks_ai/FW-Kimi-K3` at a Foundry endpoint gets a 404 on every request and the deployment ends up in cooldown

1. The proxy admin adds a `kimi-k3-foundry` deployment with `model: fireworks_ai/FW-Kimi-K3`, `api_base: https://<resource>.services.ai.azure.com/openai/v1` and their Foundry key
2. A developer sends POST https://litellm-domain/v1/chat/completions with `{"model": "kimi-k3-foundry", "messages": [{"role": "user", "content": "Reply with exactly: pong"}]}`
3. They get HTTP 404 with `DeploymentNotFound: The API deployment for this resource does not exist`, because the request that reached Foundry named the model `accounts/fireworks/models/FW-Kimi-K3`
4. POST https://litellm-domain/v1/messages and POST https://litellm-domain/v1/responses with the same model fail the same way, and once the deployment is cooled down the next calls get HTTP 429 `No deployments available for selected model`

After: the same route answers 200 on all three endpoints

1. The proxy admin adds a `kimi-k3-foundry` deployment with `model: fireworks_ai/FW-Kimi-K3`, `api_base: https://<resource>.services.ai.azure.com/openai/v1` and their Foundry key
2. A developer sends POST https://litellm-domain/v1/chat/completions with `{"model": "kimi-k3-foundry", "messages": [{"role": "user", "content": "Reply with exactly: pong"}]}`
3. They get HTTP 200 with `pong` and real usage, because the request that reached Foundry named the model `FW-Kimi-K3`
4. POST https://litellm-domain/v1/messages and POST https://litellm-domain/v1/responses answer HTTP 200 the same way, and a sibling route to native Fireworks (`fireworks_ai/kimi-k3`) still goes out as `accounts/fireworks/models/kimi-k3`

## Relevant issues

## Linear ticket

Resolves LIT-5710

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real Foundry (Fireworks on Foundry, `FW-Kimi-K3` pay-per-token deployment on an `eastus` Foundry resource) and real Fireworks (`accounts/fireworks/models/kimi-k3`), no mocks. Both proxies booted with `python litellm/proxy/proxy_cli.py --config qa.yaml --port <port> --detailed_debug`, Before from a worktree at the merge base, After from a worktree at the PR tip

Shared config `qa.yaml`:

```yaml
model_list:
  - model_name: kimi-k3-foundry
    litellm_params:
      model: fireworks_ai/FW-Kimi-K3
      api_base: os.environ/FOUNDRY_FW_API_BASE   # https://<resource>.services.ai.azure.com/openai/v1
      api_key: os.environ/FOUNDRY_FW_API_KEY
  - model_name: kimi-k3-fireworks
    litellm_params:
      model: fireworks_ai/kimi-k3
      api_key: os.environ/FIREWORKS_AI_API_KEY

general_settings:
  master_key: sk-1234
```

Shared payloads:

```bash
CHAT='{"model":"MODEL","messages":[{"role":"user","content":"Reply with exactly: pong"}],"max_tokens":50}'
MSGS='{"model":"kimi-k3-foundry","max_tokens":200,"messages":[{"role":"user","content":"Reply with exactly: pong"}]}'
RESP='{"model":"kimi-k3-foundry","input":"Reply with exactly: pong","max_output_tokens":200}'
COMP='{"model":"kimi-k3-foundry","prompt":"Reply with exactly: pong","max_tokens":50}'
```

### Before (175b639bc3)

#### Foundry route, POST /v1/chat/completions

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:44334/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "${CHAT/MODEL/kimi-k3-foundry}"`
2. Output:

```
{"error":{"message":"litellm.BadRequestError: Fireworks_aiException - {\n  \"error\": {\n    \"type\": \"invalid_request_error\",\n    \"code\": \"DeploymentNotFound\",\n    \"message\": \"The API deployment for this resource does not exist. If you created the deployment within the last 5 minutes, please wait a moment and try again.\"\n  }\n}. Received Model Group=kimi-k3-foundry\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"404"}}
HTTP 404
```

3. Outbound request in the proxy log (`--detailed_debug`), model id rewritten:

```
POST Request Sent from LiteLLM:
curl -X POST \
https://e2e-claude-foundry.services.ai.azure.com/openai/v1/chat/completions \
-d '{'model': 'accounts/fireworks/models/FW-Kimi-K3', 'messages': [{'role': 'user', 'content': 'Reply with exactly: pong'}], 'stream': False, 'max_tokens': 50}'
```

#### Foundry route, POST /v1/messages

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:44334/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "$MSGS"`
2. Output:

```
{"error":{"message":"litellm.BadRequestError: Fireworks_aiException - {\n  \"error\": {\n    \"type\": \"invalid_request_error\",\n    \"code\": \"DeploymentNotFound\",\n    \"message\": \"The API deployment for this resource does not exist. ...\"\n  }\n}. Received Model Group=kimi-k3-foundry\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"404"}}
HTTP 404
```

#### Foundry route, POST /v1/responses

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:44334/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "$RESP"`
2. Output:

```
{"error":{"message":"litellm.BadRequestError: Fireworks_aiException - {\n  \"error\": {\n    \"type\": \"invalid_request_error\",\n    \"code\": \"DeploymentNotFound\",\n    \"message\": \"The API deployment for this resource does not exist. ...\"\n  }\n}. Received Model Group=kimi-k3-foundry\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"404"}}
HTTP 404
```

#### Foundry route, POST /v1/completions

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:44334/v1/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "$COMP"`
2. Output, the same rewritten id rejected by Foundry:

```
{"error":{"message":"litellm.BadRequestError: OpenAIException - Error code: 404 - {'error': {'type': 'invalid_request_error', 'code': 'DeploymentNotFound', 'message': 'The API deployment for this resource does not exist. ...'}}. Received Model Group=kimi-k3-foundry\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"404"}}
HTTP 404
```

#### Native Fireworks control, POST /v1/chat/completions

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:44334/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "${CHAT/MODEL/kimi-k3-fireworks}"`
2. Output (trimmed to the fields that matter):

```
{"model":"kimi-k3-fireworks","choices":[{"message":{"role":"assistant","content":"pong"}}],"usage":{"prompt_tokens":93,"completion_tokens":43}}
HTTP 200
```

3. Outbound request in the proxy log:

```
https://api.fireworks.ai/inference/v1/chat/completions \
-d '{'model': 'accounts/fireworks/models/kimi-k3', 'messages': [{'role': 'user', 'content': 'Reply with exactly: pong'}], 'stream': False, 'max_tokens': 50}'
```

#### Real client: interactive Claude Code, Before

1. `env -u ANTHROPIC_API_KEY ANTHROPIC_BASE_URL=http://localhost:44334 ANTHROPIC_AUTH_TOKEN=sk-1234 ANTHROPIC_MODEL=kimi-k3-foundry claude` (interactive TUI under tmux), then type `Reply with exactly: pong`
2. What the user sees on screen:

```
> Reply with exactly: pong
* There's an issue with the selected model (kimi-k3-foundry). It may not exist or you may not have access to it. Run /model to pick a different model.
```

3. Proxy log for that turn shows the rewritten id going out: `POST https://e2e-claude-foundry.services.ai.azure.com/openai/v1/chat/completions` with `'model': 'accounts/fireworks/models/FW-Kimi-K3'`, answered by Foundry with 404 `DeploymentNotFound`

### After (8dc8cae0ec)

#### Foundry route, POST /v1/chat/completions

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:53375/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "${CHAT/MODEL/kimi-k3-foundry}"`
2. Output (trimmed to the fields that matter):

```
{"model":"kimi-k3-foundry","choices":[{"message":{"role":"assistant","content":"pong"}}],"usage":{"prompt_tokens":93,"completion_tokens":49}}
HTTP 200
```

3. Outbound request in the proxy log, model id passed through:

```
POST Request Sent from LiteLLM:
curl -X POST \
https://e2e-claude-foundry.services.ai.azure.com/openai/v1/chat/completions \
-d '{'model': 'FW-Kimi-K3', 'messages': [{'role': 'user', 'content': 'Reply with exactly: pong'}], 'stream': False, 'max_tokens': 50}'
```

#### Foundry route, POST /v1/messages

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:53375/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "$MSGS"`
2. Output (trimmed to the fields that matter):

```
{"type":"message","model":"kimi-k3-foundry","content":[{"type":"thinking",...},{"type":"text","text":"pong"}],"usage":{"input_tokens":93,"output_tokens":66}}
HTTP 200
```

#### Foundry route, POST /v1/responses

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:53375/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "$RESP"`
2. Output (trimmed to the fields that matter):

```
{"object":"response","status":"completed","model":"kimi-k3-foundry","output":[{"type":"reasoning",...},{"type":"message","content":[{"type":"output_text","text":"pong"}]}],"usage":{"input_tokens":93,"output_tokens":39}}
HTTP 200
```

#### Foundry route, POST /v1/completions

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:53375/v1/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "$COMP"`
2. Output, the id now reaches the deployment and Foundry reports that it does not serve the legacy completions API at all:

```
{"error":{"message":"litellm.NotFoundError: NotFoundError: OpenAIException - Error code: 404 - {'error': {'code': 'api_not_supported', 'message': 'Requested API is currently not supported', 'details': 'Requested API is currently not supported'}}. Received Model Group=kimi-k3-foundry\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"404"}}
HTTP 404
```

#### Native Fireworks control, POST /v1/chat/completions

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:53375/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "${CHAT/MODEL/kimi-k3-fireworks}"`
2. Output (trimmed to the fields that matter):

```
{"model":"kimi-k3-fireworks","choices":[{"message":{"role":"assistant","content":"..."}}],"usage":{"prompt_tokens":93,"completion_tokens":50}}
HTTP 200
```

3. Outbound request in the proxy log, still rewritten:

```
https://api.fireworks.ai/inference/v1/chat/completions \
-d '{'model': 'accounts/fireworks/models/kimi-k3', 'messages': [{'role': 'user', 'content': 'Reply with exactly: pong'}], 'stream': False, 'max_tokens': 50}'
```

#### Real client: interactive Claude Code, After

1. Same interactive session against the After proxy: `env -u ANTHROPIC_API_KEY ANTHROPIC_BASE_URL=http://localhost:53375 ANTHROPIC_AUTH_TOKEN=sk-1234 ANTHROPIC_MODEL=kimi-k3-foundry claude`, then `Reply with exactly: pong`
2. The proxy log now shows the id going out unrewritten, `'model': 'FW-Kimi-K3'`, and Foundry resolves the deployment: its answer flips from `DeploymentNotFound` to a rate limit scoped to that deployment

```
> Reply with exactly: pong
* API Error: Request rejected (429) · litellm.RateLimitError: RateLimitError: Fireworks_aiException -
  {"error":{"code":"RateLimitReached","message":"Your requests to FW-Kimi-K3 for FW-Kimi-K3 in eastus have exceeded rate limit."...
```

3. The 429 is a QA-subscription artifact, not proxy behavior: Azure caps `AIServices.DataZoneStandard.Fireworks` at 25K TPM in every region of the test subscription, and Claude Code's first turn is ~230 KB (~58K estimated tokens), so no request that size is ever admitted there. The customer runs with production quota. The 200-with-`pong` path through the very same After proxy and deployment is proven above on /v1/messages (the wire API Claude Code uses) and /v1/chat/completions

## Type

🐛 Bug Fix

## Caveats (if any)

- Only ids starting with `FW-` skip the rewrite; a custom-named Foundry deployment still gets prefixed
- `FW-*` names have no cost-map entry, so spend needs per-deployment `model_info` pricing
- Author's v1.93.0-shaped backport branch: https://github.com/bruno-olivia/litellm/compare/v1.93.0...bruno-olivia:litellm_fw_skip_prefix_rewrite_v1930

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 8dc8cae0ec passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8dc8cae0ec1482b635b369484455e52f5237c098. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->