### PR TITLE
fix(mcp): challenge on a bare 401 for an invalid DCR bridge envelope

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import Sequence
 from datetime import datetime, timezone
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Final, cast
 
 from fastapi import HTTPException
@@ -13,6 +14,7 @@ import litellm
 from litellm._logging import verbose_logger
 from litellm.proxy._experimental.mcp_server.oauth_utils import (
     get_passthrough_resource_metadata_url,
+    get_passthrough_www_authenticate,
     get_request_base_url,
     well_known_root_suffix,
 )
@@ -769,7 +771,10 @@ class MCPRequestHandler:
         mutating the input. Fails closed with a 401 on an invalid or expired envelope, or
         when the referenced key is missing, blocked, or expired, its owner is
         SCIM-deactivated, or the centralized policy gate rejects it (blocked team or
-        project, org or budget limits).
+        project, org or budget limits). The 401 carries the server's RFC 9728
+        ``WWW-Authenticate`` challenge with RFC 6750 ``error="invalid_token"``, matching
+        :meth:`_admit_gateway_session`'s ``SessionBearerInvalid`` arm, so a DCR client
+        re-authorizes instead of surfacing an opaque failure.
 
         The sealed token is keyed alias-first, matching the order egress resolves
         (``lookup_mcp_server_auth_in_headers`` tries ``alias`` before ``server_name``). Keying
@@ -797,7 +802,20 @@ class MCPRequestHandler:
                 new_headers: Final = {**(mcp_server_auth_headers or {}), **injected}
                 return admitted, new_headers
             case BridgeEnvelopeInvalid() | NotBridgeEnvelope():
-                raise HTTPException(status_code=401, detail="Invalid or expired credential")
+                raise HTTPException(
+                    status_code=401,
+                    detail="Invalid or expired credential",
+                    headers=MappingProxyType(
+                        {
+                            "www-authenticate": get_passthrough_www_authenticate(
+                                scope=request.scope,
+                                # _single_dcr_bridge_delegate_target already requires one of these.
+                                server_name=server.alias or server.server_name or "",
+                                invalid_token=True,
+                            )
+                        }
+                    ),
+                )
             case _:
                 assert_never(result)
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -5890,7 +5890,9 @@ class TestMCPDcrBridgeDelegateAdmission:
 
     async def test_expired_envelope_fails_closed_401(self):
         """An envelope whose exp is in the past must fail closed with a 401, never fall through to
-        anonymous admission."""
+        anonymous admission. The 401 must carry a WWW-Authenticate challenge (RFC 9728 resource
+        metadata + RFC 6750 invalid_token), matching the gateway session arm's equivalent failure,
+        so a DCR client can discover where to re-authorize instead of seeing a bare 401."""
         expired = self._mint_bridge_envelope(
             expires_in=60,
             minted_at=datetime.now(timezone.utc) - timedelta(hours=2),
@@ -5899,7 +5901,10 @@ class TestMCPDcrBridgeDelegateAdmission:
             "type": "http",
             "method": "POST",
             "path": "/mcp/bridge_delegate_server",
-            "headers": [(b"authorization", f"Bearer {expired}".encode("latin-1"))],
+            "headers": [
+                (b"host", b"testserver"),
+                (b"authorization", f"Bearer {expired}".encode("latin-1")),
+            ],
         }
 
         with (
@@ -5916,6 +5921,13 @@ class TestMCPDcrBridgeDelegateAdmission:
 
         assert exc_info.value.status_code == 401
         mock_auth.assert_not_called()
+        challenge = (exc_info.value.headers or {}).get("www-authenticate")
+        assert challenge is not None
+        assert 'error="invalid_token"' in challenge
+        assert (
+            'resource_metadata="http://testserver/.well-known/oauth-protected-resource/mcp/bridge_delegate_server"'
+            in challenge
+        )
 
     async def test_envelope_minted_for_a_different_server_fails_closed_401(self):
         """An envelope sealed for another server_id must be rejected when presented to this server,


### PR DESCRIPTION
## TLDR

Problem this solves:

- An expired or tampered DCR bridge envelope gets a bare 401 with no challenge
- The sibling gateway-session arm already relays a challenge for the same failure
- A DCR client has no signal telling it where to re-authorize

How it solves it:

- Bridge envelope admission now raises the per-server RFC 9728 challenge with RFC 6750 `error="invalid_token"` on an invalid or expired envelope, matching the gateway-session arm

## User Flow

Before: a person using an MCP client connected through the proxy in `dcr_bridge` + `oauth_delegate` mode has their credential expire

1. Their MCP client sends a request to the server's MCP route with the expired credential as the bearer
2. The response is 401 with body `{"detail":"Invalid or expired credential"}` and no `WWW-Authenticate` header
3. Their client has no machine-readable way to discover where to re-authorize, so the person has to notice the opaque failure and manually restart the login flow

After: the same expired credential gets a challenge the client can act on

1. Their MCP client sends the same request with the expired credential as the bearer
2. The response is still 401, but now carries a `WWW-Authenticate` header naming the resource metadata URL and `error="invalid_token"`
3. Their client discovers the authorization server from that header and re-runs the OAuth flow on its own, or the person is prompted once instead of hitting an opaque failure

## Relevant issues

Fixes #37210

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy, no mocks, real `dcr_bridge` + `oauth_delegate` admission code path. Minting a signed bridge envelope requires the proxy's own master-key-derived signing keys, which only LiteLLM's own DCR flow can produce, so the envelope below is minted by calling LiteLLM's actual `mint_envelope` function directly with an expiry in the past, the same function the real flow calls, then the same envelope is sent as a bearer to a running proxy with curl.

Config used for both runs:

```yaml
general_settings:
  master_key: sk-1234

mcp_servers:
  bridge_test_server:
    url: http://127.0.0.1:9/mcp
    transport: http
    auth_type: oauth_delegate
    dcr_bridge: true
```

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --port 4001
```

```bash
curl -sS -i http://127.0.0.1:4001/bridge_test_server/mcp \
  -H "Authorization: Bearer $EXPIRED_ENVELOPE" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
```

### Before (9cd7696156)

1. `curl` the command above with an envelope minted 2 hours ago
2. Response: `HTTP/1.1 401 Unauthorized`, body `{"detail":"Invalid or expired credential"}`, no `www-authenticate` header in the response at all

### After (5da33e5b28)

1. Same `curl` command, same expired envelope
2. Response: `HTTP/1.1 401 Unauthorized`, body `{"detail":"Invalid or expired credential"}`, and now:
   ```
   www-authenticate: Bearer error="invalid_token", resource_metadata="http://127.0.0.1:4001/.well-known/oauth-protected-resource/bridge_test_server/mcp"
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

- Only fixes the REST and connect-time admission paths. A mid-session tool call still degrades to an `isError` JSON-RPC result instead of a raw 401, since the MCP session manager serializes handler exceptions; that is a separate limitation the issue itself calls out as out of scope

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
