### PR TITLE
fix(anthropic/adapter): drop null provider_specific_fields from tool_use response blocks

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1246,7 +1246,10 @@ class LiteLLMAnthropicMessagesAdapter:
                     # Add provider_specific_fields if signature is present
                     if provider_specific_fields:
                         tool_use_block.provider_specific_fields = provider_specific_fields
-                    new_content.append(tool_use_block.model_dump())
+                    # exclude_none: avoid emitting ``provider_specific_fields: null`` (and any
+                    # other unset optional field) — strict Anthropic-compatible backends reject
+                    # unrecognized keys on tool_use blocks with 400 "Extra inputs are not permitted".
+                    new_content.append(tool_use_block.model_dump(exclude_none=True))
 
         return new_content
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -3741,3 +3741,82 @@ def test_tool_result_plain_text_unchanged_by_openai_transform():
     assert len(tool_messages) == 1
     assert tool_messages[0]["content"] == "42 files found"
     assert _image_urls_in_user_messages(result) == []
+
+
+def test_translate_openai_content_to_anthropic_tool_use_no_null_provider_specific_fields():
+    """Regression test: a tool_use block without a signature must not emit
+    ``provider_specific_fields`` at all.
+
+    Previously the block was serialized with ``model_dump()`` (no ``exclude_none``),
+    which leaked ``"provider_specific_fields": null`` into the Anthropic response.
+    Strict Anthropic-compatible backends reject unrecognized keys on tool_use
+    blocks with ``400 ... provider_specific_fields: Extra inputs are not
+    permitted``. Clients (e.g. Claude Code) persist the response, so the stray
+    null later breaks the conversation when it is replayed to the real API.
+    """
+    openai_choices = [
+        Choices(
+            message=Message(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    ChatCompletionAssistantToolCall(
+                        id="call_no_signature",
+                        type="function",
+                        function=Function(
+                            name="get_weather",
+                            arguments='{"city": "SF"}',
+                        ),
+                    )
+                ],
+            )
+        )
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter._translate_openai_content_to_anthropic(choices=openai_choices)
+
+    assert len(result) == 1
+    assert result[0]["type"] == "tool_use"
+    assert result[0]["id"] == "call_no_signature"
+    assert result[0]["name"] == "get_weather"
+    assert result[0]["input"] == {"city": "SF"}
+    assert (
+        "provider_specific_fields" not in result[0]
+    ), "tool_use block must not contain a null/empty provider_specific_fields key"
+
+
+def test_translate_openai_content_to_anthropic_tool_use_preserves_signature():
+    """When a thought signature is present, ``provider_specific_fields`` must be
+    preserved on the tool_use block (it carries real data, not a null)."""
+    openai_choices = [
+        Choices(
+            message=Message(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    ChatCompletionAssistantToolCall(
+                        id="call_with_signature",
+                        type="function",
+                        function=Function(
+                            name="get_weather",
+                            arguments='{"city": "SF"}',
+                        ),
+                    )
+                ],
+            )
+        )
+    ]
+    # Pydantic coerces the TypedDict tool_call into ChatCompletionMessageToolCall;
+    # attach the provider-specific thought signature to the coerced object.
+    openai_choices[0].message.tool_calls[0].provider_specific_fields = {
+        "thought_signature": "sigABC123"
+    }
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter._translate_openai_content_to_anthropic(choices=openai_choices)
+
+    assert len(result) == 1
+    assert result[0]["type"] == "tool_use"
+    assert result[0]["id"] == "call_with_signature"
+    assert result[0].get("provider_specific_fields") == {"signature": "sigABC123"}


### PR DESCRIPTION
## Problem

`LiteLLMAnthropicMessagesAdapter._translate_openai_content_to_anthropic` serializes each
tool_use block with `model_dump()` (no `exclude_none`). Because
`AnthropicResponseContentBlockToolUse.provider_specific_fields` is an optional field, every
tool_use block **without** a signature is emitted as:

```json
{"type":"tool_use","id":"...","name":"...","input":{...},"provider_specific_fields":null}
```

Strict Anthropic-compatible backends reject that unrecognized key:

```
API Error: 400 messages.N.content.M.tool_use.provider_specific_fields: Extra inputs are not permitted
```

This is especially harmful because clients persist the response. For example, Claude Code
stores the assistant message in its session transcript; when the same conversation is later
replayed to the real Anthropic API (e.g. after switching away from a proxy / another
provider), the stored `provider_specific_fields: null` causes the 400 above — even though
the original call succeeded. Users currently work around it by hand-editing the transcript.

## Root cause

`litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`

```python
# Add provider_specific_fields if signature is present
if provider_specific_fields:
    tool_use_block.provider_specific_fields = provider_specific_fields
new_content.append(tool_use_block.model_dump())   # <- emits provider_specific_fields: null
```

`provider_specific_fields` is only set when a thought-signature is present; otherwise it is
`None`, but `model_dump()` still includes it as `null`.

## Fix

Serialize with `exclude_none=True` so unset optional fields are omitted:

```python
new_content.append(tool_use_block.model_dump(exclude_none=True))
```

When a signature **is** present, `provider_specific_fields` is non-null and is still emitted
unchanged, so thought-signature pass-through is preserved.

## Verification

- Reproduced on litellm **1.94.0** and **1.97.0**: a tool_use block without a signature
  contains `"provider_specific_fields": null`.
- After the fix, the key is absent; with a signature it is preserved as
  `{"signature": "..."}`.
- Added two regression tests in
  `tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py`:
  - `test_translate_openai_content_to_anthropic_tool_use_no_null_provider_specific_fields`
    — fails before the fix (catches the leak), passes after.
  - `test_translate_openai_content_to_anthropic_tool_use_preserves_signature` — passes before
    and after (guards intended signature pass-through).

Confirmed against the released package: with the bug present the first test fails
(`AssertionError: null leak present ... 'provider_specific_fields': None`); applying this
patch makes both tests pass.