### PR TITLE
fix(guardrails): retry usage upserts only on connection errors

### DIFF
--- a/litellm/proxy/guardrails/usage_endpoints.py
+++ b/litellm/proxy/guardrails/usage_endpoints.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from typing_extensions import NotRequired, ReadOnly, TypedDict
 
+from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.repositories.table_repositories import (
@@ -111,7 +112,16 @@ async def _find_daily_guardrail_usage_units(
     prisma_client: "PrismaClient",
     where: "prisma_types.LiteLLM_DailyGuardrailUsageUnitsWhereInput",
 ) -> "Sequence[prisma_models.LiteLLM_DailyGuardrailUsageUnits]":
-    return await _daily_guardrail_usage_units_table(prisma_client).find_many(where=where)
+    from prisma.errors import TableNotFoundError
+
+    try:
+        return await _daily_guardrail_usage_units_table(prisma_client).find_many(where=where)
+    except TableNotFoundError as e:
+        verbose_proxy_logger.warning(
+            "Guardrail usage units are unavailable until the LiteLLM_DailyGuardrailUsageUnits migration is applied: %s",
+            e,
+        )
+        return ()
 
 
 def _counter_name(row: "prisma_models.LiteLLM_DailyGuardrailUsageUnits") -> str:

--- a/litellm/proxy/guardrails/usage_tracking.py
+++ b/litellm/proxy/guardrails/usage_tracking.py
@@ -15,6 +15,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, NamedTuple, TypeVar
 
 from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import DB_RETRY_SAFE_ERROR_TYPES
 from litellm.proxy.utils import PrismaClient
 from litellm.repositories.table_repositories import (
     DailyGuardrailMetricsRepository,
@@ -63,11 +64,21 @@ async def _upsert_rows_with_retry(
     retries_left: int = _UPSERT_RETRY_TIMES,
 ) -> None:
     outcomes: Final = {key: await _attempt_upsert(upsert_row, key, value) for key, value in rows.items()}
-    failed: Final = MappingProxyType({key: rows[key] for key, error in outcomes.items() if error is not None})
-    if not failed:
+    for key, error in outcomes.items():
+        if error is not None and not isinstance(error, DB_RETRY_SAFE_ERROR_TYPES):
+            verbose_proxy_logger.warning(
+                "Guardrail usage tracking: %s upsert failed for %s and is not safe to retry (non-fatal): %s",
+                label,
+                key,
+                error,
+            )
+    retryable: Final = MappingProxyType(
+        {key: rows[key] for key, error in outcomes.items() if isinstance(error, DB_RETRY_SAFE_ERROR_TYPES)}
+    )
+    if not retryable:
         return
     if retries_left == 0:
-        for key in failed:
+        for key in retryable:
             verbose_proxy_logger.warning(
                 "Guardrail usage tracking: %s upsert failed for %s after %d retries (non-fatal): %s",
                 label,
@@ -77,7 +88,7 @@ async def _upsert_rows_with_retry(
             )
         return
     await sleep(2 ** (_UPSERT_RETRY_TIMES - retries_left))
-    await _upsert_rows_with_retry(failed, upsert_row, label, sleep, retries_left - 1)
+    await _upsert_rows_with_retry(retryable, upsert_row, label, sleep, retries_left - 1)
 
 
 def _guardrail_status_to_action(status: str | None) -> str:

--- a/tests/test_litellm/proxy/guardrails/test_usage_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_usage_endpoints.py
@@ -19,6 +19,7 @@ import pytest
 sys.path.insert(0, os.path.abspath("../../.."))
 
 from fastapi import HTTPException
+from prisma.errors import TableNotFoundError
 
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.guardrails.guardrail_registry import InMemoryGuardrailHandler
@@ -293,6 +294,44 @@ async def test_detail_breaks_units_down_by_day_team_and_key():
     }
     units_where = prisma.db.litellm_dailyguardrailusageunits.find_many.call_args.kwargs["where"]
     assert units_where == {"guardrail_id": {"in": ["yaml-pii", "yaml-1"]}, "date": {"gte": START, "lte": END}}
+
+
+def _units_table_missing() -> TableNotFoundError:
+    return TableNotFoundError(
+        data={"user_facing_error": {"meta": {"table": "public.LiteLLM_DailyGuardrailUsageUnits"}}}
+    )
+
+
+@pytest.mark.asyncio
+async def test_overview_degrades_units_to_empty_when_units_table_is_missing():
+    prisma = _prisma(metrics=[_metric("yaml-pii", requests=4, passed=3, blocked=1)])
+    prisma.db.litellm_dailyguardrailusageunits.find_many = AsyncMock(side_effect=_units_table_missing())
+    handler = _config_handler(_yaml_guardrail(guardrail_id="yaml-uuid", name="yaml-pii"))
+    p1, p2 = _patches(prisma, handler)
+    with p1, p2:
+        resp = await guardrails_usage_overview(start_date=START, end_date=END, user_api_key_dict=ADMIN)
+    row = next(r for r in resp.rows if r.id == "yaml-uuid")
+    assert (row.requestsEvaluated, row.usageUnits) == (4, {})
+    assert (resp.totalRequests, resp.totalBlocked, resp.totalUsageUnits) == (4, 1, {})
+
+
+@pytest.mark.asyncio
+async def test_detail_degrades_units_to_empty_when_units_table_is_missing():
+    prisma = _prisma(metrics=[_metric("yaml-pii", requests=4, passed=3, blocked=1)])
+    prisma.db.litellm_dailyguardrailusageunits.find_many = AsyncMock(side_effect=_units_table_missing())
+    handler = _config_handler(_yaml_guardrail())
+    p1, p2 = _patches(prisma, handler)
+    with p1, p2:
+        resp = await guardrails_usage_detail(
+            guardrail_id="yaml-1", start_date=START, end_date=END, user_api_key_dict=ADMIN
+        )
+    assert (resp.requestsEvaluated, resp.failRate) == (4, 25.0)
+    assert (resp.usage_units, list(resp.usage_units_daily), resp.usage_units_by_team, resp.usage_units_by_key) == (
+        {},
+        [],
+        {},
+        {},
+    )
 
 
 # ---- logs -------------------------------------------------------------------

--- a/tests/test_litellm/proxy/guardrails/test_usage_tracking.py
+++ b/tests/test_litellm/proxy/guardrails/test_usage_tracking.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from litellm.proxy.guardrails.usage_tracking import process_spend_logs_guardrail_usage
@@ -94,8 +95,8 @@ async def test_one_failing_upsert_does_not_drop_remaining_writes():
     permanently under-report billable counters.
     """
     prisma = _prisma()
-    prisma.db.litellm_dailyguardrailmetrics.upsert.side_effect = RuntimeError("db down")
-    prisma.db.litellm_dailyguardrailusageunits.upsert.side_effect = [RuntimeError("db down"), None, None]
+    prisma.db.litellm_dailyguardrailmetrics.upsert.side_effect = httpx.ConnectError("db down")
+    prisma.db.litellm_dailyguardrailusageunits.upsert.side_effect = [httpx.ConnectError("db down"), None, None]
     sleep, _ = _fake_sleep()
     logs = [
         _payload("r1", usage={"topicPolicyUnits": 1}),
@@ -113,12 +114,13 @@ async def test_one_failing_upsert_does_not_drop_remaining_writes():
 @pytest.mark.asyncio
 async def test_transient_upsert_failure_is_retried_with_backoff_for_failed_rows_only():
     """
-    A transient DB error must not permanently drop billed units from the
-    aggregates: only the rows that failed are re-sent, after exponential
-    backoff, and the batch ends once every row has landed.
+    A connection error (the write provably never reached the database) must
+    not permanently drop billed units from the aggregates: only the rows that
+    failed are re-sent, after exponential backoff, and the batch ends once
+    every row has landed.
     """
     prisma = _prisma()
-    prisma.db.litellm_dailyguardrailusageunits.upsert.side_effect = [RuntimeError("blip"), None, None]
+    prisma.db.litellm_dailyguardrailusageunits.upsert.side_effect = [httpx.ConnectError("blip"), None, None]
     sleep, delays = _fake_sleep()
     logs = [
         _payload("r1", usage={"topicPolicyUnits": 1}),
@@ -136,7 +138,7 @@ async def test_transient_upsert_failure_is_retried_with_backoff_for_failed_rows_
 @pytest.mark.asyncio
 async def test_persistent_upsert_failure_stops_after_three_retries():
     prisma = _prisma()
-    prisma.db.litellm_dailyguardrailmetrics.upsert.side_effect = RuntimeError("db down")
+    prisma.db.litellm_dailyguardrailmetrics.upsert.side_effect = httpx.ConnectError("db down")
     sleep, delays = _fake_sleep()
 
     await process_spend_logs_guardrail_usage(prisma, [_payload("r1", usage={"topicPolicyUnits": 1})], sleep=sleep)
@@ -144,6 +146,61 @@ async def test_persistent_upsert_failure_stops_after_three_retries():
     assert prisma.db.litellm_dailyguardrailmetrics.upsert.call_count == 4
     assert delays == [1, 2, 4]
     assert prisma.db.litellm_dailyguardrailusageunits.upsert.call_count == 1
+
+
+def _units_upsert_wheres(prisma: MagicMock) -> list[tuple]:
+    return [
+        tuple(
+            c.kwargs["where"]["guardrail_id_date_team_id_api_key_usage_unit"][k]
+            for k in ("guardrail_id", "date", "team_id", "api_key", "usage_unit")
+        )
+        for c in prisma.db.litellm_dailyguardrailusageunits.upsert.call_args_list
+    ]
+
+
+@pytest.mark.asyncio
+async def test_post_send_failure_is_never_retried_so_increments_cannot_double_count():
+    """
+    Follow-up to #37225: the units upsert is a non-idempotent increment, so an
+    ambiguous post-send failure (read timeout after the statement may have
+    committed) must be attempted exactly once. Re-sending it stacks a second
+    increment and inflates billable unit totals. Only a connection error proves
+    the write never reached the database and may be retried; the other rows in
+    the batch still land either way.
+    """
+    prisma = _prisma()
+    prisma.db.litellm_dailyguardrailusageunits.upsert.side_effect = [
+        httpx.ReadTimeout("read timed out"),
+        httpx.ConnectError("refused"),
+        None,
+    ]
+    sleep, delays = _fake_sleep()
+    logs = [
+        _payload("r1", usage={"topicPolicyUnits": 1}),
+        _payload("r2", team_id=None, api_key="hashed-key-2", usage={"topicPolicyUnits": 1}),
+    ]
+
+    await process_spend_logs_guardrail_usage(prisma, logs, sleep=sleep)
+
+    timed_out_row = ("bedrock-guard", "2026-08-17", "", "hashed-key-2", "topicPolicyUnits")
+    refused_row = ("bedrock-guard", "2026-08-17", "team-a", "hashed-key-1", "topicPolicyUnits")
+    assert _units_upsert_wheres(prisma) == [timed_out_row, refused_row, refused_row]
+    assert delays == [1]
+
+
+@pytest.mark.asyncio
+async def test_generic_upsert_exception_is_terminal_for_that_row_only():
+    prisma = _prisma()
+    prisma.db.litellm_dailyguardrailmetrics.upsert.side_effect = RuntimeError("constraint violation")
+    sleep, delays = _fake_sleep()
+
+    await process_spend_logs_guardrail_usage(prisma, [_payload("r1", usage={"topicPolicyUnits": 1})], sleep=sleep)
+
+    assert prisma.db.litellm_dailyguardrailmetrics.upsert.call_count == 1
+    assert delays == []
+    assert _units_upserts(prisma) == {
+        ("bedrock-guard", "2026-08-17", "team-a", "hashed-key-1", "topicPolicyUnits"): 1,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Usage-unit upserts retried on every exception, even after the write committed
- One request could bill twice per unit whenever a flush stalled
- Un-migrated databases (units table missing) got 500s from overview and detail
- Each flush there also stalled ~7s retrying the missing table

How it solves it:

- Retry only `DB_RETRY_SAFE_ERROR_TYPES` (connection errors), like the spend writer
- Any other failure is terminal for that row: one warning, no resend
- Sibling rows in the batch still land and still retry connection errors
- Missing units table: overview and detail return metrics with empty units, one warning
- The migration ships with the next litellm-proxy-extras bump, not in this PR

Behavior change inherited from #37225, no code change here:

- Blocked requests now record guardrail information on all three unified endpoints
- Overview `passRate` / `status` shift on upgrade: identical traffic read 6/0/healthy before, 9/3/critical after

## User Flow

Before: a proxy admin billing teams by Bedrock guardrail units sees inflated totals whenever the database stalls mid-flush, so a single request is billed twice

1. A developer sends POST https://litellm-domain/v1/chat/completions with a key whose team has a Bedrock guardrail attached, and gets a 200 with the usual chat completion
2. Bedrock reports `topicPolicyUnits: 1` and `contentPolicyUnits: 1` consumed for that one request
3. During the next spend-log flush the database connection is slow: the write commits, but the proxy only sees a read timeout instead of the acknowledgement, retries, and the same units land a second time
4. The admin opens GET https://litellm-domain/guardrails/usage/detail/{guardrail_id} and reads `"usage_units": {"topicPolicyUnits": 2, "contentPolicyUnits": 2}` for a day with exactly one request
5. GET https://litellm-domain/guardrails/usage/overview lists that guardrail's `usageUnits` doubled the same way, and the per-team and per-key breakdowns on https://litellm-domain/ui/?page=guardrails bill the team for two invocations

After: the same stall leaves the totals exactly matching what Bedrock billed

1. A developer sends POST https://litellm-domain/v1/chat/completions with a key whose team has a Bedrock guardrail attached, and gets a 200 with the usual chat completion
2. Bedrock reports `topicPolicyUnits: 1` and `contentPolicyUnits: 1` consumed for that one request
3. During the next spend-log flush the database connection is slow: the write commits, the proxy sees a read timeout, logs a one-line warning, and does not resend those units (a refused connection, where nothing reached the database, is still retried with backoff as before)
4. The admin opens GET https://litellm-domain/guardrails/usage/detail/{guardrail_id} and reads `"usage_units": {"topicPolicyUnits": 1, "contentPolicyUnits": 1}` for that day
5. GET https://litellm-domain/guardrails/usage/overview and the per-team and per-key breakdowns on https://litellm-domain/ui/?page=guardrails bill the team for exactly one invocation

Before (database without the units migration): a pip-installed proxy on litellm-proxy-extras 0.4.86 with `DISABLE_SCHEMA_UPDATE=true` loses its whole guardrail usage page after upgrading

1. An admin upgrades to a litellm build that includes #37225 and restarts with `DISABLE_SCHEMA_UPDATE=true`, so the `LiteLLM_DailyGuardrailUsageUnits` table is never created
2. Guarded traffic keeps flowing: POST https://litellm-domain/v1/chat/completions returns 200 as usual, but each spend-log flush stalls ~7s retrying the missing table three times
3. The admin opens GET https://litellm-domain/guardrails/usage/overview and gets 500 "The table `public.LiteLLM_DailyGuardrailUsageUnits` does not exist in the current database"
4. GET https://litellm-domain/guardrails/usage/detail/{guardrail_id} returns 500 "Internal server error", so https://litellm-domain/ui/?page=guardrails cannot render pass rates or request counts either

After (database without the units migration): the same admin keeps the metrics they had before the upgrade and only the unit totals wait for the migration

1. An admin upgrades to a litellm build that includes #37225 and restarts with `DISABLE_SCHEMA_UPDATE=true`, so the `LiteLLM_DailyGuardrailUsageUnits` table is never created
2. Guarded traffic keeps flowing: POST https://litellm-domain/v1/chat/completions returns 200, and each flush logs one warning per unit naming the missing table without stalling
3. GET https://litellm-domain/guardrails/usage/overview returns 200 with `requestsEvaluated`, `passRate`, and `status` populated and `usageUnits: {}`
4. GET https://litellm-domain/guardrails/usage/detail/{guardrail_id} returns 200 with `requestsEvaluated`, `failRate`, and `status` populated and empty `usage_units`, `usage_units_daily`, and `usage_units_by_key`, and one warning in the proxy log names the migration to apply

## Relevant issues

Follows up #37225 (bugbot thread on `_upsert_rows_with_retry`, "Retry double-counts usage increments", and the /live-pr-risk findings on that PR's un-migrated-database behavior)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two live proxies, one booted from the merge base and one from this PR's tip, each in its own worktree, venv, database, and random port, all hitting the real Bedrock guardrail `gf3sc1mzinjw` (DRAFT, us-east-1) in front of `bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0`. Both legs ran the same commands in the same order

Shared config (`qa37247_config.yaml`):

```yaml
model_list:
  - model_name: bedrock-claude-haiku-4-5
    litellm_params:
      model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: us-east-1

guardrails:
  - guardrail_name: bedrock-lit5650
    litellm_params:
      guardrail: bedrock
      mode: pre_call
      guardrailIdentifier: gf3sc1mzinjw
      guardrailVersion: DRAFT
      aws_region_name: us-east-1
      default_on: true

general_settings:
  master_key: sk-1234
```

The ambiguous post-send failure is injected by a small TCP proxy between the LiteLLM proxy and Postgres. While an arm file exists, the first statement touching `LiteLLM_DailyGuardrailUsageUnits` is let through and committed server-side, then its response is dropped and the client socket closed, so the write landed but the proxy only sees an error. Each `touch ARMED` fires once, so the client's own retry (and the boot-time schema push) pass through normally

<details>
<summary>pg_fault_proxy.py (the fault harness)</summary>

```python
"""
TCP proxy in front of Postgres that reproduces an ambiguous post-send DB
failure: while --arm-file exists, the first statement whose bytes contain
--marker is let through to the server, and once the server has executed and
committed it (ReadyForQuery(idle) after the Execute round trip), the response
is dropped and the client socket is closed. The write landed; the client only
sees an error. Each arming fires once (the arm file is removed on arming), so
boot-time schema pushes and the client's own retry pass through untouched.

Prisma's driver sends Parse+Describe+Sync (carries the SQL text) and then
Bind+Execute+Sync as two round trips, so the proxy arms on the marker chunk and
waits for an Execute before treating the next ReadyForQuery(idle) as committed.
Append ?statement_cache_size=0 to DATABASE_URL so every execution carries the
SQL text (Prisma otherwise re-executes cached prepared statements by name).

  python3 pg_fault_proxy.py --listen 21638 --upstream 127.0.0.1:5432 \
      --marker LiteLLM_DailyGuardrailUsageUnits --times 10 --arm-file /path/ARMED
"""

import argparse
import asyncio
import os
import sys
from datetime import datetime, timezone

READY_FOR_QUERY_IDLE = b"Z\x00\x00\x00\x05I"


def log(msg: str) -> None:
    print(f"[{datetime.now(timezone.utc).isoformat(timespec='seconds')}] {msg}", flush=True)


def frontend_tags(chunk: bytes) -> str:
    tags = []
    i = 0
    while i + 5 <= len(chunk):
        tag = chr(chunk[i])
        length = int.from_bytes(chunk[i + 1 : i + 5], "big")
        if length < 4:
            tags.append("?")
            break
        tags.append(tag)
        i += 1 + length
    if i < len(chunk):
        tags.append("...")
    return "".join(tags)


class Fault:
    def __init__(self, marker: bytes, times: int, arm_file: str | None) -> None:
        self.marker = marker
        self.remaining = times
        self.arm_file = arm_file

    def try_arm(self) -> bool:
        if self.arm_file is not None and not os.path.exists(self.arm_file):
            return False
        if self.remaining <= 0:
            return False
        self.remaining -= 1
        if self.arm_file is not None:
            os.remove(self.arm_file)
        return True


async def pipe_client_to_server(reader, writer, conn_id, fault, state):
    try:
        while True:
            data = await reader.read(65536)
            if not data:
                break
            tags = frontend_tags(data)
            has_marker = fault.marker in data
            if state["pending"]:
                if "E" in tags:
                    state["executed"] = True
                log(f"conn {conn_id}: client chunk tags={tags} marker={has_marker} (pending, executed={state['executed']})")
            elif has_marker:
                if fault.try_arm():
                    state["pending"] = True
                    state["executed"] = "E" in tags
                    log(
                        f"conn {conn_id}: marker seen in client->server bytes (tags={tags}); will drop the response after the Execute round trip commits ({fault.remaining} sabotage(s) left)"
                    )
                else:
                    log(f"conn {conn_id}: marker seen but fault is disarmed (tags={tags}); forwarding normally")
            writer.write(data)
            await writer.drain()
    except (ConnectionResetError, BrokenPipeError, asyncio.CancelledError):
        pass
    finally:
        try:
            writer.close()
        except Exception:
            pass


async def pipe_server_to_client(reader, writer, conn_id, state, upstream_writer):
    try:
        while True:
            data = await reader.read(65536)
            if not data:
                break
            if state["pending"] and READY_FOR_QUERY_IDLE in data:
                if state["executed"]:
                    log(
                        f"conn {conn_id}: server sent ReadyForQuery(idle) after the marked statement's Execute, i.e. it committed; DROPPING {len(data)} response bytes and closing the client socket"
                    )
                    state["pending"] = False
                    writer.close()
                    upstream_writer.close()
                    return
                log(
                    f"conn {conn_id}: server sent ReadyForQuery(idle) after the marked statement's prepare round trip (no Execute yet); forwarding {len(data)} bytes and staying armed"
                )
            writer.write(data)
            await writer.drain()
    except (ConnectionResetError, BrokenPipeError, asyncio.CancelledError):
        pass
    finally:
        try:
            writer.close()
        except Exception:
            pass


async def handle(client_reader, client_writer, upstream_host, upstream_port, fault, counter):
    counter[0] += 1
    conn_id = counter[0]
    try:
        server_reader, server_writer = await asyncio.open_connection(upstream_host, upstream_port)
    except OSError as e:
        log(f"conn {conn_id}: upstream connect failed: {e}")
        client_writer.close()
        return
    log(f"conn {conn_id}: opened")
    state = {"pending": False, "executed": False}
    await asyncio.gather(
        pipe_client_to_server(client_reader, server_writer, conn_id, fault, state),
        pipe_server_to_client(server_reader, client_writer, conn_id, state, server_writer),
    )
    log(f"conn {conn_id}: closed")


async def main() -> None:
    parser = argparse.ArgumentParser()
    parser.add_argument("--listen", type=int, required=True)
    parser.add_argument("--upstream", default="127.0.0.1:5432")
    parser.add_argument("--marker", default="LiteLLM_DailyGuardrailUsageUnits")
    parser.add_argument("--times", type=int, default=1)
    parser.add_argument("--arm-file", default=None, help="only sabotage while this file exists")
    args = parser.parse_args()
    host, port = args.upstream.rsplit(":", 1)
    fault = Fault(args.marker.encode(), args.times, args.arm_file)
    counter = [0]
    server = await asyncio.start_server(
        lambda r, w: handle(r, w, host, int(port), fault, counter), "127.0.0.1", args.listen
    )
    log(f"listening on 127.0.0.1:{args.listen} -> {host}:{port}; marker={args.marker!r} times={args.times} arm_file={args.arm_file}")
    async with server:
        await server.serve_forever()


if __name__ == "__main__":
    try:
        asyncio.run(main())
    except KeyboardInterrupt:
        sys.exit(0)
```

</details>

Boot, per leg (`FAULT_PORT` / `PROXY_PORT` random and verified free, `DB` fresh):

```bash
createdb -h 127.0.0.1 $DB
nohup python3 pg_fault_proxy.py --listen $FAULT_PORT --upstream 127.0.0.1:5432 --marker LiteLLM_DailyGuardrailUsageUnits --times 10 --arm-file $PWD/ARMED > fault_proxy.log 2>&1 &
DATABASE_URL="postgresql://mateo@127.0.0.1:$FAULT_PORT/$DB?statement_cache_size=0" python litellm/proxy/proxy_cli.py --config qa37247_config.yaml --port $PROXY_PORT --detailed_debug > proxy.log 2>&1 &
curl -s -X POST http://localhost:$PROXY_PORT/team/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"team_alias":"qa37247-team"}'
for case in chat messages responses; do curl -s -X POST http://localhost:$PROXY_PORT/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"team_id":"<team_id>","key_alias":"qa37247-'$case'"}'; done
```

Each fault case is: `touch ARMED`, one request with that case's key, wait for the harness to log `DROPPING` plus 15s for the flush, then read the usage endpoints. The overview reads (`... | jq '{rows: [.rows[] | {id, requestsEvaluated, usageUnits}], totalRequests, totalUsageUnits}'`) and detail reads (`... | jq '{requestsEvaluated, usage_units, usage_units_by_key}'`) below are trimmed with those jq filters. The guardrail's overview id was `036fc511-2102-5736-add6-29a0f9c0299c` on both legs. Bedrock reported `topicPolicyUnits 1, contentPolicyUnits 1` for every request in every case (each request's spend log carries that under `metadata.guardrail_information[0].guardrail_usage`), and the harness dropped the `contentPolicyUnits` upsert each time, so a correct ledger reads `{"contentPolicyUnits":1,"topicPolicyUnits":1}` per key

The un-migrated case drops the units table (`psql $DB -c 'DROP TABLE "LiteLLM_DailyGuardrailUsageUnits"'`) and reboots straight against Postgres with `DISABLE_SCHEMA_UPDATE=true`, the state of a pip install on litellm-proxy-extras 0.4.86, then sends one guarded chat request on the master key and reads the endpoints

### Before (4d57bf0bdd)

#### /v1/chat/completions

1. `touch ARMED; curl -sD - -X POST http://localhost:39004/v1/chat/completions -H "Authorization: Bearer $CHAT_KEY" -H 'Content-Type: application/json' -d '{"model":"bedrock-claude-haiku-4-5","messages":[{"role":"user","content":"Say hello in five words or fewer."}]}'`
   ```
   HTTP/1.1 200 OK
   x-litellm-call-id: 5f7db563-9045-4d57-8437-2521c359e2e2
   x-litellm-applied-guardrails: bedrock-lit5650
   {"id":"chatcmpl-246549e6-6850-482e-8bdb-4b37879b8dc4", ... "content":"Hello there!" ...}
   ```
2. `fault_proxy.log`
   ```
   [02:34:12] conn 8: marker seen in client->server bytes (tags=PDS); will drop the response after the Execute round trip commits (9 sabotage(s) left)
   [02:34:12] conn 8: server sent ReadyForQuery(idle) after the marked statement's prepare round trip (no Execute yet); forwarding 302 bytes and staying armed
   [02:34:12] conn 8: client chunk tags=BES marker=False (pending, executed=True)
   [02:34:12] conn 8: server sent ReadyForQuery(idle) after the marked statement's Execute, i.e. it committed; DROPPING 233 response bytes and closing the client socket
   [02:34:12] conn 5: marker seen but fault is disarmed (tags=PDS); forwarding normally
   [02:34:13] conn 6: marker seen but fault is disarmed (tags=PDS); forwarding normally
   ```
   `grep "Guardrail usage tracking" proxy.log` -> no lines (the retry is silent)
3. `curl -s "http://localhost:39004/guardrails/usage/overview" -H 'Authorization: Bearer sk-1234' | jq ...`
   ```json
   {"rows":[{"id":"036fc511-2102-5736-add6-29a0f9c0299c","requestsEvaluated":1,"usageUnits":{"contentPolicyUnits":2,"topicPolicyUnits":1}}],"totalRequests":1,"totalUsageUnits":{"contentPolicyUnits":2,"topicPolicyUnits":1}}
   ```
4. `curl -s "http://localhost:39004/guardrails/usage/detail/036fc511-2102-5736-add6-29a0f9c0299c" -H 'Authorization: Bearer sk-1234' | jq ...`
   ```json
   {"requestsEvaluated":1,"usage_units":{"contentPolicyUnits":2,"topicPolicyUnits":1},"usage_units_by_key":{"350000ae7046af62f7ae853f0dd1a683ef3210f8e9d4dbd84683258d595601d9":{"contentPolicyUnits":2,"topicPolicyUnits":1}}}
   ```
5. `curl -s "http://localhost:39004/spend/logs?request_id=chatcmpl-246549e6-6850-482e-8bdb-4b37879b8dc4" -H 'Authorization: Bearer sk-1234' | jq '.[0] | {request_id, call_type, gi: (.metadata.guardrail_information[0] | {guardrail_status, guardrail_usage})}'`
   ```json
   {"request_id":"chatcmpl-246549e6-6850-482e-8bdb-4b37879b8dc4","call_type":"acompletion","gi":{"guardrail_status":"success","guardrail_usage":{"wordPolicyUnits":0,"topicPolicyUnits":1,"contentPolicyUnits":1,"contentPolicyImageUnits":0,"automatedReasoningPolicies":0,"automatedReasoningPolicyUnits":0,"contextualGroundingPolicyUnits":0,"sensitiveInformationPolicyUnits":0,"sensitiveInformationPolicyFreeUnits":0}}}
   ```

#### /v1/messages

1. `touch ARMED; curl -sD - -X POST http://localhost:39004/v1/messages -H "Authorization: Bearer $MESSAGES_KEY" -H 'Content-Type: application/json' -d '{"model":"bedrock-claude-haiku-4-5","max_tokens":64,"messages":[{"role":"user","content":"Name one primary color."}]}'`
   ```
   HTTP/1.1 200 OK
   x-litellm-call-id: 54a4baff-9794-4cd1-a32f-ce44e70a2f1a
   x-litellm-applied-guardrails: bedrock-lit5650
   {"model":"bedrock-claude-haiku-4-5","id":"msg_bdrk_014V1TKKA1hbUH2wemhJGP72","type":"message","role":"assistant","content":[{"type":"text","text":"Red."}], ...}
   ```
2. `fault_proxy.log`
   ```
   [02:35:31] conn 5: marker seen in client->server bytes (tags=PDS); will drop the response after the Execute round trip commits (8 sabotage(s) left)
   [02:35:31] conn 5: client chunk tags=BES marker=False (pending, executed=True)
   [02:35:31] conn 5: server sent ReadyForQuery(idle) after the marked statement's Execute, i.e. it committed; DROPPING 233 response bytes and closing the client socket
   [02:35:31] conn 6: marker seen but fault is disarmed (tags=PDS); forwarding normally
   [02:35:32] conn 6: marker seen but fault is disarmed (tags=PDS); forwarding normally
   ```
3. overview
   ```json
   {"rows":[{"id":"036fc511-2102-5736-add6-29a0f9c0299c","requestsEvaluated":2,"usageUnits":{"contentPolicyUnits":4,"topicPolicyUnits":2}}],"totalRequests":2,"totalUsageUnits":{"contentPolicyUnits":4,"topicPolicyUnits":2}}
   ```
4. detail
   ```json
   {"requestsEvaluated":2,"usage_units":{"contentPolicyUnits":4,"topicPolicyUnits":2},"usage_units_by_key":{"350000ae7046af62f7ae853f0dd1a683ef3210f8e9d4dbd84683258d595601d9":{"contentPolicyUnits":2,"topicPolicyUnits":1},"cb1e52277b40a7300e3615f7c3961caca98b356d8d4f3aefe57e63ff710601d0":{"contentPolicyUnits":2,"topicPolicyUnits":1}}}
   ```
5. `curl -s "http://localhost:39004/spend/logs" -H 'Authorization: Bearer sk-1234' | jq '[.[] | select(.metadata.user_api_key_alias=="qa37247-messages")][0] | {request_id, call_type, gi: (.metadata.guardrail_information[0] | {guardrail_status, guardrail_usage})}'`
   ```json
   {"request_id":"chatcmpl-b6428dbf-0a03-4546-9f2e-e4622d8091ff","call_type":"anthropic_messages","gi":{"guardrail_status":"success","guardrail_usage":{"wordPolicyUnits":0,"topicPolicyUnits":1,"contentPolicyUnits":1, ...}}}
   ```

#### /v1/responses

1. `touch ARMED; curl -sD - -X POST http://localhost:39004/v1/responses -H "Authorization: Bearer $RESPONSES_KEY" -H 'Content-Type: application/json' -d '{"model":"bedrock-claude-haiku-4-5","input":"Name one ocean."}'`
   ```
   HTTP/1.1 200 OK
   x-litellm-call-id: 20971867-9d33-4ad3-96e4-7ec7f1360f12
   x-litellm-applied-guardrails: bedrock-lit5650
   {"id":"resp_mgNfYT7Bi5_...", ... "output":[{"type":"message","id":"chatcmpl-1372a6b3-b843-4023-a0ba-aba83bef9d25","status":"completed","role":"assistant","content":[{"type":"output_text","text":"The Atlantic Ocean.","annotations":[]}]}], ...}
   ```
2. `fault_proxy.log`
   ```
   [02:36:10] conn 7: marker seen in client->server bytes (tags=PDS); will drop the response after the Execute round trip commits (7 sabotage(s) left)
   [02:36:10] conn 7: client chunk tags=BES marker=False (pending, executed=True)
   [02:36:10] conn 7: server sent ReadyForQuery(idle) after the marked statement's Execute, i.e. it committed; DROPPING 233 response bytes and closing the client socket
   [02:36:10] conn 9: marker seen but fault is disarmed (tags=PDS); forwarding normally
   [02:36:11] conn 9: marker seen but fault is disarmed (tags=PDS); forwarding normally
   ```
3. overview
   ```json
   {"rows":[{"id":"036fc511-2102-5736-add6-29a0f9c0299c","requestsEvaluated":3,"usageUnits":{"contentPolicyUnits":6,"topicPolicyUnits":3}}],"totalRequests":3,"totalUsageUnits":{"contentPolicyUnits":6,"topicPolicyUnits":3}}
   ```
4. detail
   ```json
   {"requestsEvaluated":3,"usage_units":{"contentPolicyUnits":6,"topicPolicyUnits":3},"usage_units_by_key":{"0bb099cb8c8f0612b75150de9200811c631dbf34417b948b8599da9f8e64f680":{"contentPolicyUnits":2,"topicPolicyUnits":1},"350000ae7046af62f7ae853f0dd1a683ef3210f8e9d4dbd84683258d595601d9":{"contentPolicyUnits":2,"topicPolicyUnits":1},"cb1e52277b40a7300e3615f7c3961caca98b356d8d4f3aefe57e63ff710601d0":{"contentPolicyUnits":2,"topicPolicyUnits":1}}}
   ```
5. spend row for `qa37247-responses`
   ```json
   {"request_id":"chatcmpl-1372a6b3-b843-4023-a0ba-aba83bef9d25","call_type":"aresponses","gi":{"guardrail_status":"success","guardrail_usage":{"wordPolicyUnits":0,"topicPolicyUnits":1,"contentPolicyUnits":1, ...}}}
   ```

#### Control (no fault, master key)

1. `curl -sD - -X POST http://localhost:39004/v1/chat/completions -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"model":"bedrock-claude-haiku-4-5","messages":[{"role":"user","content":"Say hello in five words or fewer."}]}'` -> `HTTP/1.1 200 OK`, `x-litellm-call-id: c2e55ebb-c3c5-4b62-9e09-14c4ff06e4e6`, `"content":"Hello, how are you?"`; 25s later `fault_proxy.log` shows only `marker seen but fault is disarmed (tags=PDS); forwarding normally` lines, no `DROPPING`
2. overview
   ```json
   {"rows":[{"id":"036fc511-2102-5736-add6-29a0f9c0299c","requestsEvaluated":4,"usageUnits":{"contentPolicyUnits":7,"topicPolicyUnits":4}}],"totalRequests":4,"totalUsageUnits":{"contentPolicyUnits":7,"topicPolicyUnits":4}}
   ```
3. detail
   ```json
   {"requestsEvaluated":4,"usage_units":{"contentPolicyUnits":7,"topicPolicyUnits":4},"usage_units_by_key":{"0bb099cb8c8f0612b75150de9200811c631dbf34417b948b8599da9f8e64f680":{"contentPolicyUnits":2,"topicPolicyUnits":1},"350000ae7046af62f7ae853f0dd1a683ef3210f8e9d4dbd84683258d595601d9":{"contentPolicyUnits":2,"topicPolicyUnits":1},"cb1e52277b40a7300e3615f7c3961caca98b356d8d4f3aefe57e63ff710601d0":{"contentPolicyUnits":2,"topicPolicyUnits":1},"litellm_proxy_master_key":{"contentPolicyUnits":1,"topicPolicyUnits":1}}}
   ```
4. `curl -s "http://localhost:39004/guardrails/usage/logs?guardrail_id=bedrock-lit5650" -H 'Authorization: Bearer sk-1234' | jq '{total, actions: [.logs[].action]}'` -> `{"total":4,"actions":["passed","passed","passed","passed"]}`; four requests evaluated, seven `contentPolicyUnits` billed

#### Un-migrated database (units table missing, DISABLE_SCHEMA_UPDATE=true)

1. `psql -h 127.0.0.1 litellm_qa37247_before2 -c 'DROP TABLE "LiteLLM_DailyGuardrailUsageUnits"'` -> `DROP TABLE`; reboot with `DISABLE_SCHEMA_UPDATE=true DATABASE_URL="postgresql://mateo@127.0.0.1:5432/litellm_qa37247_before2" python litellm/proxy/proxy_cli.py --config qa37247_config.yaml --port 20001 --detailed_debug`; boot logs `check_migration.py:100 - prisma schema out of sync with db. Consider running these sql_commands to sync the two - ['CREATE TABLE "LiteLLM_DailyGuardrailUsageUnits" (...)' ...]` and comes up
2. `curl -sD - -X POST http://localhost:20001/v1/chat/completions -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"model":"bedrock-claude-haiku-4-5","messages":[{"role":"user","content":"Say hello in five words or fewer."}]}'` -> `HTTP/1.1 200 OK`, `x-litellm-call-id: d9d4e490-b5cd-4b53-b9d8-8d16c304c47c`, `x-litellm-applied-guardrails: bedrock-lit5650`, id `chatcmpl-fea8926e-3875-4b44-910a-2b0dfc1ca346`, `"Hello! How are you?"`
3. `proxy.log` around the flush (spend batch flushed 19:41:36, both unit warnings 19:41:43: the flush stalled ~7s on 1s + 2s + 4s backoff)
   ```
   19:41:36 - LiteLLM Proxy:DEBUG: utils.py:5906 - Flushed 1 logs to the DB.
   19:41:43 - LiteLLM Proxy:WARNING: usage_tracking.py:71 - Guardrail usage tracking: usage unit upsert failed for _UsageUnitKey(guardrail_id='bedrock-lit5650', date='2026-08-18', team_id='', api_key='REDACTED', usage_unit='contentPolicyUnits') after 3 retries (non-fatal): The table `public.LiteLLM_DailyGuardrailUsageUnits` does not exist in the current database.
   19:41:43 - LiteLLM Proxy:WARNING: usage_tracking.py:71 - Guardrail usage tracking: usage unit upsert failed for _UsageUnitKey(guardrail_id='bedrock-lit5650', date='2026-08-18', team_id='', api_key='REDACTED', usage_unit='topicPolicyUnits') after 3 retries (non-fatal): The table `public.LiteLLM_DailyGuardrailUsageUnits` does not exist in the current database.
   ```
4. `curl -s -w '\nHTTP %{http_code}\n' "http://localhost:20001/guardrails/usage/overview" -H 'Authorization: Bearer sk-1234'`
   ```
   {"error":{"message":"The table `public.LiteLLM_DailyGuardrailUsageUnits` does not exist in the current database.","type":"internal_server_error","param":"None","code":"500"}}
   HTTP 500
   ```
5. `curl -s -w '\nHTTP %{http_code}\n' "http://localhost:20001/guardrails/usage/detail/036fc511-2102-5736-add6-29a0f9c0299c" -H 'Authorization: Bearer sk-1234'`
   ```
   {"error":{"message":"Internal server error","type":"internal_server_error"}}
   HTTP 500
   ```
6. `curl -s -w '\nHTTP %{http_code}\n' "http://localhost:20001/guardrails/usage/logs?guardrail_id=bedrock-lit5650" -H 'Authorization: Bearer sk-1234' | jq '{total, actions: [.logs[].action]}'` -> `{"total":5,"actions":["passed","passed","passed","passed","passed"]}` `HTTP 200` (the request was evaluated and logged; only the two units-backed endpoints are down)

#### Daily metrics under the same fault (marker `LiteLLM_DailyGuardrailMetrics`, fresh database)

1. `touch ARMED; curl -sD - -X POST http://localhost:27439/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"bedrock-claude-haiku-4-5","messages":[{"role":"user","content":"Say hello in five words or fewer."}]}'` -> `HTTP/1.1 200 OK`, `x-litellm-call-id: 91bfde6d-9d9c-412f-a8f0-38bf97b70dcf`, id `chatcmpl-b2b7c9a8-1085-4127-9f50-3c8eb55b6077`, `"Hello!"`
2. `fault_proxy.log`
   ```
   [03:02:04] conn 7: marker seen in client->server bytes (tags=PDS); will drop the response after the Execute round trip commits (4 sabotage(s) left)
   [03:02:04] conn 7: server sent ReadyForQuery(idle) after the marked statement's Execute, i.e. it committed; DROPPING 147 response bytes and closing the client socket
   [03:02:05] conn 9: marker seen but fault is disarmed (tags=PDS); forwarding normally
   ```
   `grep "Guardrail usage tracking" proxy.log` -> nothing (the retry is silent)
3. `curl -s "http://localhost:27439/guardrails/usage/overview" -H 'Authorization: Bearer sk-1234' | jq -c '{rows: [.rows[] | {id, requestsEvaluated, usageUnits, status}], totalRequests, totalBlocked, passRate}'`
   ```json
   {"rows":[{"id":"036fc511-2102-5736-add6-29a0f9c0299c","requestsEvaluated":2,"usageUnits":{"contentPolicyUnits":1,"topicPolicyUnits":1},"status":"healthy"}],"totalRequests":2,"totalBlocked":0,"passRate":100.0}
   ```
   One request, `requestsEvaluated` 2

#### Dashboard http://localhost:30020/ui/guardrails-monitor (un-migrated database)

1. Log in as `admin` with the master key, open http://localhost:30020/ui/guardrails-monitor: the summary cards read `Total Evaluations 0`, `Active Guardrails 0`, and the Guardrail Performance table stays on `Loading…`, so `bedrock-lit5650` never appears and its detail cannot be opened
2. The page's network log shows four `GET /guardrails/usage/overview?start_date=2026-08-10&end_date=2026-08-17` calls, all `500`, and the console logs `Failed to get guardrails usage overview: Error: The table \`public.LiteLLM_DailyGuardrailUsageUnits\` does not exist in the current database.` for each

### After (15823b1be3)

#### /v1/chat/completions

1. `touch ARMED; curl -sD - -X POST http://localhost:52619/v1/chat/completions -H "Authorization: Bearer $CHAT_KEY" -H 'Content-Type: application/json' -d '{"model":"bedrock-claude-haiku-4-5","messages":[{"role":"user","content":"Say hello in five words or fewer."}]}'`
   ```
   HTTP/1.1 200 OK
   x-litellm-call-id: dbd07f97-6e8a-425a-ac0a-b108d1e84284
   x-litellm-applied-guardrails: bedrock-lit5650
   {"id":"chatcmpl-12baf850-2b36-4db9-98fe-32ce384ee835", ... "content":"Hello!" ...}
   ```
2. `fault_proxy.log`
   ```
   [02:41:39] conn 6: marker seen in client->server bytes (tags=PDS); will drop the response after the Execute round trip commits (9 sabotage(s) left)
   [02:41:39] conn 6: server sent ReadyForQuery(idle) after the marked statement's prepare round trip (no Execute yet); forwarding 302 bytes and staying armed
   [02:41:39] conn 6: client chunk tags=BES marker=False (pending, executed=True)
   [02:41:39] conn 6: server sent ReadyForQuery(idle) after the marked statement's Execute, i.e. it committed; DROPPING 233 response bytes and closing the client socket
   [02:41:39] conn 5: marker seen but fault is disarmed (tags=PDS); forwarding normally
   ```
   `grep "Guardrail usage tracking" proxy.log` (the `REDACTED'` token is the proxy's own log redaction of the `api_key=` field)
   ```
   19:41:39 - LiteLLM Proxy:WARNING: usage_tracking.py:69 - Guardrail usage tracking: usage unit upsert failed for _UsageUnitKey(guardrail_id='bedrock-lit5650', date='2026-08-18', team_id='9d4085f2-bc58-4091-b1f7-fd0ea41a94d6', REDACTED', usage_unit='contentPolicyUnits') and is not safe to retry (non-fatal): 'NoneType' object has no attribute 'get'
   ```
   No retry, no second `DROPPING`, no `disarmed` re-send of that statement
3. `curl -s "http://localhost:52619/guardrails/usage/overview" -H 'Authorization: Bearer sk-1234' | jq ...`
   ```json
   {"rows":[{"id":"036fc511-2102-5736-add6-29a0f9c0299c","requestsEvaluated":1,"usageUnits":{"contentPolicyUnits":1,"topicPolicyUnits":1}}],"totalRequests":1,"totalUsageUnits":{"contentPolicyUnits":1,"topicPolicyUnits":1}}
   ```
4. `curl -s "http://localhost:52619/guardrails/usage/detail/036fc511-2102-5736-add6-29a0f9c0299c" -H 'Authorization: Bearer sk-1234' | jq ...`
   ```json
   {"requestsEvaluated":1,"usage_units":{"contentPolicyUnits":1,"topicPolicyUnits":1},"usage_units_by_key":{"98917eceeeeb96d515416f42915d3456022e4fe851d09e27687324090ea90f10":{"contentPolicyUnits":1,"topicPolicyUnits":1}}}
   ```
5. `curl -s "http://localhost:52619/spend/logs?request_id=chatcmpl-12baf850-2b36-4db9-98fe-32ce384ee835" -H 'Authorization: Bearer sk-1234' | jq '.[0] | {request_id, call_type, gi: (.metadata.guardrail_information[0] | {guardrail_status, guardrail_usage})}'`
   ```json
   {"request_id":"chatcmpl-12baf850-2b36-4db9-98fe-32ce384ee835","call_type":"acompletion","gi":{"guardrail_status":"success","guardrail_usage":{"wordPolicyUnits":0,"topicPolicyUnits":1,"contentPolicyUnits":1,"contentPolicyImageUnits":0,"automatedReasoningPolicies":0,"automatedReasoningPolicyUnits":0,"contextualGroundingPolicyUnits":0,"sensitiveInformationPolicyUnits":0,"sensitiveInformationPolicyFreeUnits":0}}}
   ```

#### /v1/messages

1. `touch ARMED; curl -sD - -X POST http://localhost:52619/v1/messages -H "Authorization: Bearer $MESSAGES_KEY" -H 'Content-Type: application/json' -d '{"model":"bedrock-claude-haiku-4-5","max_tokens":64,"messages":[{"role":"user","content":"Name one primary color."}]}'`
   ```
   HTTP/1.1 200 OK
   x-litellm-call-id: 967ca929-833e-4399-ac7b-5a896ed6112e
   x-litellm-applied-guardrails: bedrock-lit5650
   {"model":"bedrock-claude-haiku-4-5","id":"msg_bdrk_01MDAG6Lw74YGNZniNL9Fhzi","type":"message","role":"assistant","content":[{"type":"text","text":"Red."}], ...}
   ```
2. `fault_proxy.log`
   ```
   [02:42:47] conn 7: marker seen in client->server bytes (tags=PDS); will drop the response after the Execute round trip commits (8 sabotage(s) left)
   [02:42:47] conn 7: client chunk tags=BES marker=False (pending, executed=True)
   [02:42:47] conn 7: server sent ReadyForQuery(idle) after the marked statement's Execute, i.e. it committed; DROPPING 233 response bytes and closing the client socket
   [02:42:47] conn 8: marker seen but fault is disarmed (tags=PDS); forwarding normally
   ```
   `proxy.log`
   ```
   19:42:47 - LiteLLM Proxy:WARNING: usage_tracking.py:69 - Guardrail usage tracking: usage unit upsert failed for _UsageUnitKey(guardrail_id='bedrock-lit5650', date='2026-08-18', team_id='9d4085f2-bc58-4091-b1f7-fd0ea41a94d6', REDACTED', usage_unit='contentPolicyUnits') and is not safe to retry (non-fatal): 'NoneType' object has no attribute 'get'
   ```
3. overview
   ```json
   {"rows":[{"id":"036fc511-2102-5736-add6-29a0f9c0299c","requestsEvaluated":2,"usageUnits":{"contentPolicyUnits":2,"topicPolicyUnits":2}}],"totalRequests":2,"totalUsageUnits":{"contentPolicyUnits":2,"topicPolicyUnits":2}}
   ```
4. detail
   ```json
   {"requestsEvaluated":2,"usage_units":{"contentPolicyUnits":2,"topicPolicyUnits":2},"usage_units_by_key":{"133b45ca2830acdbd29d1690e5d87d7164720fbac7cf9bc92ddded8a0ca83c53":{"contentPolicyUnits":1,"topicPolicyUnits":1},"98917eceeeeb96d515416f42915d3456022e4fe851d09e27687324090ea90f10":{"contentPolicyUnits":1,"topicPolicyUnits":1}}}
   ```
5. spend row for `qa37247-messages`
   ```json
   {"request_id":"chatcmpl-2bded86d-684d-4d61-916f-202c9d7d11ba","call_type":"anthropic_messages","gi":{"guardrail_status":"success","guardrail_usage":{"wordPolicyUnits":0,"topicPolicyUnits":1,"contentPolicyUnits":1, ...}}}
   ```

#### /v1/responses

1. `touch ARMED; curl -sD - -X POST http://localhost:52619/v1/responses -H "Authorization: Bearer $RESPONSES_KEY" -H 'Content-Type: application/json' -d '{"model":"bedrock-claude-haiku-4-5","input":"Name one ocean."}'`
   ```
   HTTP/1.1 200 OK
   x-litellm-call-id: 2c32d15f-54af-45dd-97c9-f4ea03c061aa
   x-litellm-applied-guardrails: bedrock-lit5650
   {"id":"resp_0iu-OOChEU5d3NoBXO565sBxZpd-...", ... "content":[{"type":"output_text","text":"The Atlantic Ocean.","annotations":[]}] ...}
   ```
2. `fault_proxy.log`
   ```
   [02:43:31] conn 5: marker seen in client->server bytes (tags=PDS); will drop the response after the Execute round trip commits (7 sabotage(s) left)
   [02:43:31] conn 5: client chunk tags=BES marker=False (pending, executed=True)
   [02:43:31] conn 5: server sent ReadyForQuery(idle) after the marked statement's Execute, i.e. it committed; DROPPING 233 response bytes and closing the client socket
   [02:43:31] conn 8: marker seen but fault is disarmed (tags=PDS); forwarding normally
   ```
   `proxy.log`
   ```
   19:43:31 - LiteLLM Proxy:WARNING: usage_tracking.py:69 - Guardrail usage tracking: usage unit upsert failed for _UsageUnitKey(guardrail_id='bedrock-lit5650', date='2026-08-18', team_id='9d4085f2-bc58-4091-b1f7-fd0ea41a94d6', REDACTED', usage_unit='contentPolicyUnits') and is not safe to retry (non-fatal): 'NoneType' object has no attribute 'get'
   ```
3. overview
   ```json
   {"rows":[{"id":"036fc511-2102-5736-add6-29a0f9c0299c","requestsEvaluated":3,"usageUnits":{"contentPolicyUnits":3,"topicPolicyUnits":3}}],"totalRequests":3,"totalUsageUnits":{"contentPolicyUnits":3,"topicPolicyUnits":3}}
   ```
4. detail
   ```json
   {"requestsEvaluated":3,"usage_units":{"contentPolicyUnits":3,"topicPolicyUnits":3},"usage_units_by_key":{"133b45ca2830acdbd29d1690e5d87d7164720fbac7cf9bc92ddded8a0ca83c53":{"contentPolicyUnits":1,"topicPolicyUnits":1},"98917eceeeeb96d515416f42915d3456022e4fe851d09e27687324090ea90f10":{"contentPolicyUnits":1,"topicPolicyUnits":1},"aacf96abcc1b2db315fae04595560d4dd46fb0e0870e7f3551af1d24b7494050":{"contentPolicyUnits":1,"topicPolicyUnits":1}}}
   ```
5. spend row for `qa37247-responses`
   ```json
   {"request_id":"chatcmpl-040cdbc8-3fba-429f-ac9f-2f19c883c502","call_type":"aresponses","gi":{"guardrail_status":"success","guardrail_usage":{"wordPolicyUnits":0,"topicPolicyUnits":1,"contentPolicyUnits":1, ...}}}
   ```

#### Control (no fault, master key)

1. `curl -sD - -X POST http://localhost:52619/v1/chat/completions -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"model":"bedrock-claude-haiku-4-5","messages":[{"role":"user","content":"Say hello in five words or fewer."}]}'` -> `HTTP/1.1 200 OK`, `x-litellm-call-id: 1122cf9b-737b-4296-bdc2-5212ec86604c`, `"content":"Hello! How are you?"`; 28s later `fault_proxy.log` shows only `marker seen but fault is disarmed (tags=PDS); forwarding normally` lines, no `DROPPING`, and the warning count in `proxy.log` is still 3
2. overview
   ```json
   {"rows":[{"id":"036fc511-2102-5736-add6-29a0f9c0299c","requestsEvaluated":4,"usageUnits":{"contentPolicyUnits":4,"topicPolicyUnits":4}}],"totalRequests":4,"totalUsageUnits":{"contentPolicyUnits":4,"topicPolicyUnits":4}}
   ```
3. detail: `"usage_units":{"contentPolicyUnits":4,"topicPolicyUnits":4}`, `usage_units_by_key` = the three case keys at `{"contentPolicyUnits":1,"topicPolicyUnits":1}` each plus `"litellm_proxy_master_key":{"contentPolicyUnits":1,"topicPolicyUnits":1}`
4. `curl -s "http://localhost:52619/guardrails/usage/logs?guardrail_id=bedrock-lit5650" -H 'Authorization: Bearer sk-1234' | jq '{total, actions: [.logs[].action]}'` -> `{"total":4,"actions":["passed","passed","passed","passed"]}`; four requests evaluated, four `contentPolicyUnits` billed

#### Un-migrated database (units table missing, DISABLE_SCHEMA_UPDATE=true)

1. `psql -h 127.0.0.1 litellm_qa37247_after3 -c 'DROP TABLE "LiteLLM_DailyGuardrailUsageUnits"'` -> `DROP TABLE`; reboot with `DISABLE_SCHEMA_UPDATE=true DATABASE_URL="postgresql://mateo@127.0.0.1:5432/litellm_qa37247_after3" python litellm/proxy/proxy_cli.py --config qa37247_config.yaml --port 33471 --detailed_debug`; table confirmed still absent after boot
2. `curl -sD - -X POST http://localhost:33471/v1/chat/completions -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"model":"bedrock-claude-haiku-4-5","messages":[{"role":"user","content":"Say hello in five words or fewer."}]}'` -> `HTTP/1.1 200 OK`, `x-litellm-call-id: 25c4d3f0-5b8d-4db3-9268-95b99c7cde1e`, id `chatcmpl-019e612a-2c3d-4d37-8a94-0265c5340e33`, `"Hello! How are you?"`
3. `proxy.log` around the flush (request returned 19:45:49; flush, both unit warnings, and the next unrelated log line all land inside the same second, no backoff)
   ```
   19:45:49 - LiteLLM Proxy:DEBUG: utils.py:5906 - Flushed 1 logs to the DB.
   19:45:49 - LiteLLM Proxy:WARNING: usage_tracking.py:69 - Guardrail usage tracking: usage unit upsert failed for _UsageUnitKey(guardrail_id='bedrock-lit5650', date='2026-08-18', team_id='', REDACTED', usage_unit='contentPolicyUnits') and is not safe to retry (non-fatal): The table `public.LiteLLM_DailyGuardrailUsageUnits` does not exist in the current database.
   19:45:49 - LiteLLM Proxy:WARNING: usage_tracking.py:69 - Guardrail usage tracking: usage unit upsert failed for _UsageUnitKey(guardrail_id='bedrock-lit5650', date='2026-08-18', team_id='', REDACTED', usage_unit='topicPolicyUnits') and is not safe to retry (non-fatal): The table `public.LiteLLM_DailyGuardrailUsageUnits` does not exist in the current database.
   ```
4. `curl -s -w '\nHTTP %{http_code}\n' "http://localhost:33471/guardrails/usage/overview" -H 'Authorization: Bearer sk-1234' | jq '{rows: [.rows[] | {id, requestsEvaluated, usageUnits, status}], totalRequests, totalBlocked, passRate, totalUsageUnits}'`
   ```
   {"rows":[{"id":"036fc511-2102-5736-add6-29a0f9c0299c","requestsEvaluated":5,"usageUnits":{},"status":"healthy"}],"totalRequests":5,"totalBlocked":0,"passRate":100.0,"totalUsageUnits":{}}
   HTTP 200
   ```
5. `curl -s -w '\nHTTP %{http_code}\n' "http://localhost:33471/guardrails/usage/detail/036fc511-2102-5736-add6-29a0f9c0299c" -H 'Authorization: Bearer sk-1234' | jq '{requestsEvaluated, failRate, status, usage_units, usage_units_daily, usage_units_by_key}'`
   ```
   {"requestsEvaluated":5,"failRate":0.0,"status":"healthy","usage_units":{},"usage_units_daily":[],"usage_units_by_key":{}}
   HTTP 200
   ```
   `proxy.log` for those two reads
   ```
   19:46:24 - LiteLLM Proxy:WARNING: usage_endpoints.py:120 - Guardrail usage units are unavailable until the LiteLLM_DailyGuardrailUsageUnits migration is applied: The table `public.LiteLLM_DailyGuardrailUsageUnits` does not exist in the current database.
   19:46:31 - LiteLLM Proxy:WARNING: usage_endpoints.py:120 - Guardrail usage units are unavailable until the LiteLLM_DailyGuardrailUsageUnits migration is applied: The table `public.LiteLLM_DailyGuardrailUsageUnits` does not exist in the current database.
   ```
6. `curl -s -w '\nHTTP %{http_code}\n' "http://localhost:33471/guardrails/usage/logs?guardrail_id=bedrock-lit5650" -H 'Authorization: Bearer sk-1234' | jq '{total, actions: [.logs[].action]}'` -> `{"total":5,"actions":["passed","passed","passed","passed","passed"]}` `HTTP 200`

#### Daily metrics under the same fault (marker `LiteLLM_DailyGuardrailMetrics`, fresh database)

1. `touch ARMED; curl -sD - -X POST http://localhost:45841/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"bedrock-claude-haiku-4-5","messages":[{"role":"user","content":"Say hello in five words or fewer."}]}'` -> `HTTP/1.1 200 OK`, `x-litellm-call-id: f774eaef-1f69-409d-bc1d-f6a85d0a0a14`, id `chatcmpl-a8e07e52-d3a8-4419-9292-d99fef2a358a`, `"Hello there!"`
2. `fault_proxy.log`
   ```
   [03:02:04] conn 9: marker seen in client->server bytes (tags=PDS); will drop the response after the Execute round trip commits (4 sabotage(s) left)
   [03:02:04] conn 9: server sent ReadyForQuery(idle) after the marked statement's Execute, i.e. it committed; DROPPING 147 response bytes and closing the client socket
   ```
   `proxy.log`
   ```
   20:02:04 - LiteLLM Proxy:WARNING: usage_tracking.py:69 - Guardrail usage tracking: daily metrics upsert failed for _MetricsKey(guardrail_id='bedrock-lit5650', date='2026-08-18') and is not safe to retry (non-fatal): 'NoneType' object has no attribute 'get'
   ```
   No second marker statement, no resend
3. `curl -s "http://localhost:45841/guardrails/usage/overview" -H 'Authorization: Bearer sk-1234' | jq -c '{rows: [.rows[] | {id, requestsEvaluated, usageUnits, status}], totalRequests, totalBlocked, passRate}'`
   ```json
   {"rows":[{"id":"036fc511-2102-5736-add6-29a0f9c0299c","requestsEvaluated":1,"usageUnits":{"contentPolicyUnits":1,"topicPolicyUnits":1},"status":"healthy"}],"totalRequests":1,"totalBlocked":0,"passRate":100.0}
   ```
   One request, `requestsEvaluated` 1

#### Dashboard http://localhost:41878/ui/guardrails-monitor (un-migrated database)

1. Log in as `admin` with the master key, open http://localhost:41878/ui/guardrails-monitor: `Active Guardrails 1`, and the Guardrail Performance table lists `bedrock-lit5650 | bedrock | Healthy`
2. Clicking the row opens the detail view (`Back to Overview`, `bedrock-lit5650`, `Healthy`, `bedrock`, Overview and Logs tabs) and the page's network log shows `200` for `GET /guardrails/usage/overview?...`, `GET /guardrails/usage/detail/036fc511-2102-5736-add6-29a0f9c0299c?...`, and `GET /guardrails/usage/logs?guardrail_id=036fc511-...`; the only console error is the same asset 404 the base page also logs

Observations from the run, none caused by this PR:

- Dropped-response error surfaces as `'NoneType' object has no attribute 'get'` (prisma-client-py), left alone
- Master-key rows carry `team_id=''` in the ledger and warning, left alone
- Log redaction rewrites `api_key='...'` to a bare `REDACTED'` mid-tuple, left alone
- Detail endpoint's missing-table traceback logged twice per request at base, gone with the degrade
- Daily guardrail metrics still count requests while units are missing, expected
- Dashboard date range is local-day while metrics rows key on UTC date, left alone
- Dashboard does not render unit fields yet, so empty units are invisible there

## Type

🐛 Bug Fix

## Caveats (if any)

- Ambiguous failures now under-count instead of over-count; idempotent ledger is a follow-up
- A connection dropped before Execute now loses those units too (retry used to land them)
- Postgres failures surface as prisma `DataError`/`AttributeError`, so they never retry
- Only an unreachable query engine retries, as in sibling writers
- Each unit is its own upsert; one stalled flush can land topic units and lose content units
- Un-migrated databases show empty units plus one warning until the extras bump ships the migration

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 15823b1be3 passes /live-pr-risk
