### PR TITLE
feat(complexity_router): custom classifier plugins via classifier_type 'custom'

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from types import MappingProxyType
 from typing import Final, Literal
 
 from litellm.litellm_core_utils.env_utils import get_env_int, get_env_int_or_none
@@ -1764,3 +1765,7 @@ PTU_LAPSED_ALERT_LIMIT: Final[int] = 10
 # one run delete a charge another just wrote. A stale row is hours old and a concurrent
 # one is seconds old, so a few minutes separates them.
 PTU_PRUNE_SKEW_GRACE_SECONDS: Final[int] = 300
+
+# Shared read-only empty mapping, for defaulting optional Mapping parameters without
+# constructing a fresh mutable dict at each call site.
+EMPTY_MAPPING: Final = MappingProxyType({})

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4056,6 +4056,28 @@ def resolve_complexity_router_plugins(
         complexity_router_config["classifier_plugin"] = resolved_classifier  # rebind-ok: out-param, resolved in place
 
 
+def pin_complexity_router_model_id(model: dict) -> None:  # mutable-ok: out-param, model_info is stamped in place
+    """
+    Stamps `model_info.id` from the raw litellm_params before plugin resolution swaps
+    dotted-path strings for live instances. `_delete_deployment` re-reads the raw config
+    and re-hashes these params to decide which ids the config wants served; an id the
+    Router derived from the resolved params would never match that hash, so the reconcile
+    would evict every plugin-bearing deployment one sync after startup.
+    """
+    litellm_params: Final = model.get("litellm_params")
+    if not isinstance(litellm_params, dict) or not isinstance(litellm_params.get("complexity_router_config"), dict):
+        return
+    model_info = model.get("model_info")
+    if not isinstance(model_info, dict):
+        model_info = {}  # mutable-ok: fresh model_info stamped onto the raw yaml model dict
+        model["model_info"] = model_info  # rebind-ok: out-param, stamped in place
+    if model_info.get("id") is None:
+        model_info["id"] = litellm.Router._generate_model_id(  # pyright: ignore[reportPrivateUsage]  # _delete_deployment hashes with the same private helper; the ids must match
+            model_group=model.get("model_name", ""),
+            litellm_params=litellm_params,
+        )
+
+
 def resolve_classifier_plugin(
     plugin_path: str,
     config_file_path: str | None,
@@ -5298,6 +5320,7 @@ class ProxyConfig:
                 for k, v in model["litellm_params"].items():
                     if isinstance(v, str) and v.startswith("os.environ/"):
                         model["litellm_params"][k] = get_secret(v)
+                pin_complexity_router_model_id(model)
                 complexity_router_config = model["litellm_params"].get("complexity_router_config")
                 if isinstance(complexity_router_config, dict):
                     resolve_complexity_router_plugins(
@@ -5690,25 +5713,6 @@ class ProxyConfig:
                 for k, v in model["litellm_params"].items():
                     if isinstance(v, str) and v.startswith("os.environ/"):
                         model["litellm_params"][k] = get_secret(v)
-
-                ## resolve routing/classifier plugin dotted paths, matching load_config: the router's
-                ## deployment ids were hashed from the RESOLVED params, so hashing the raw strings
-                ## here would compute different ids and evict every plugin-bearing auto-router ##
-                complexity_router_config = model["litellm_params"].get("complexity_router_config")
-                if isinstance(complexity_router_config, dict):
-                    try:
-                        resolve_complexity_router_plugins(
-                            model_name=model.get("model_name", ""),
-                            complexity_router_config=complexity_router_config,
-                            config_file_path=user_config_file_path,
-                        )
-                    except Exception as e:  # noqa: BLE001 -- a plugin module broken on disk must not evict valid deployments
-                        verbose_proxy_logger.warning(
-                            "Failed to resolve complexity-router plugins in _delete_deployment: %s. "
-                            "Skipping deployment cleanup to avoid removing valid models.",
-                            str(e),
-                        )
-                        return None
 
                 ## check if they have model-id's ##
                 model_id = model.get("model_info", {}).get("id", None)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5691,6 +5691,25 @@ class ProxyConfig:
                     if isinstance(v, str) and v.startswith("os.environ/"):
                         model["litellm_params"][k] = get_secret(v)
 
+                ## resolve routing/classifier plugin dotted paths, matching load_config: the router's
+                ## deployment ids were hashed from the RESOLVED params, so hashing the raw strings
+                ## here would compute different ids and evict every plugin-bearing auto-router ##
+                complexity_router_config = model["litellm_params"].get("complexity_router_config")
+                if isinstance(complexity_router_config, dict):
+                    try:
+                        resolve_complexity_router_plugins(
+                            model_name=model.get("model_name", ""),
+                            complexity_router_config=complexity_router_config,
+                            config_file_path=user_config_file_path,
+                        )
+                    except Exception as e:  # noqa: BLE001 -- a plugin module broken on disk must not evict valid deployments
+                        verbose_proxy_logger.warning(
+                            "Failed to resolve complexity-router plugins in _delete_deployment: %s. "
+                            "Skipping deployment cleanup to avoid removing valid models.",
+                            str(e),
+                        )
+                        return None
+
                 ## check if they have model-id's ##
                 model_id = model.get("model_info", {}).get("id", None)
                 if model_id is None:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4072,7 +4072,7 @@ def pin_complexity_router_model_id(model: dict) -> None:  # mutable-ok: out-para
         model_info = {}  # mutable-ok: fresh model_info stamped onto the raw yaml model dict
         model["model_info"] = model_info  # rebind-ok: out-param, stamped in place
     if model_info.get("id") is None:
-        model_info["id"] = litellm.Router._generate_model_id(  # pyright: ignore[reportPrivateUsage]  # _delete_deployment hashes with the same private helper; the ids must match
+        model_info["id"] = litellm.Router.generate_model_id(
             model_group=model.get("model_name", ""),
             litellm_params=litellm_params,
         )
@@ -5718,7 +5718,7 @@ class ProxyConfig:
                 model_id = model.get("model_info", {}).get("id", None)
                 if model_id is None:
                     ## else - generate stable id's ##
-                    model_id = llm_router._generate_model_id(
+                    model_id = llm_router.generate_model_id(
                         model_group=model["model_name"],
                         litellm_params=model["litellm_params"],
                     )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -657,6 +657,7 @@ from litellm.types.proxy.model_deprecation import (
 )
 from litellm.types.realtime import RealtimeQueryParams
 from litellm.types.router import (
+    ClassifierPlugin,
     DeploymentTypedDict,
     RouterGeneralSettings,
     RoutingPlugin,
@@ -4034,17 +4035,48 @@ def resolve_complexity_router_plugins(
 ) -> None:
     """
     Resolves `complexity_router_config["plugins"]` dotted-path strings to live
-    instances in place, via `resolve_routing_plugins`.
+    instances in place, via `resolve_routing_plugins`, and
+    `complexity_router_config["classifier_plugin"]` via `resolve_classifier_plugin`.
     """
     plugin_paths: Final = complexity_router_config.get("plugins")
-    if not isinstance(plugin_paths, list):
-        return
+    if isinstance(plugin_paths, list):
+        complexity_router_config["plugins"] = resolve_routing_plugins(
+            plugin_paths=plugin_paths,
+            config_file_path=config_file_path,
+            source_label=f"complexity_router_config.plugins on model {model_name!r}",
+        )
 
-    complexity_router_config["plugins"] = resolve_routing_plugins(
-        plugin_paths=plugin_paths,
-        config_file_path=config_file_path,
-        source_label=f"complexity_router_config.plugins on model {model_name!r}",
-    )
+    classifier_plugin_path: Final = complexity_router_config.get("classifier_plugin")
+    if isinstance(classifier_plugin_path, str):
+        resolved_classifier: Final = resolve_classifier_plugin(
+            plugin_path=classifier_plugin_path,
+            config_file_path=config_file_path,
+            source_label=f"complexity_router_config.classifier_plugin on model {model_name!r}",
+        )
+        complexity_router_config["classifier_plugin"] = resolved_classifier  # rebind-ok: out-param, resolved in place
+
+
+def resolve_classifier_plugin(
+    plugin_path: str,
+    config_file_path: str | None,
+    source_label: str,
+) -> ClassifierPlugin:
+    """
+    Resolves a classifier-plugin dotted path to a live `ClassifierPlugin` instance, with the
+    same load-time interface check `resolve_routing_plugins` applies to routing plugins: a
+    sync `def classify` passes the runtime_checkable isinstance and would only fail on the
+    first classified request, so reject it here where the error names the config key.
+    """
+    resolved: Final = get_instance_fn(value=plugin_path, config_file_path=config_file_path)
+    if not isinstance(resolved, ClassifierPlugin) or not inspect.iscoroutinefunction(
+        getattr(resolved, "classify", None)
+    ):
+        raise ValueError(
+            f"{source_label} entry {plugin_path!r} resolved to {resolved!r}, which does not "
+            "implement the ClassifierPlugin interface (an async `classify(context)` method). Fix "
+            "the referenced module before starting the proxy."
+        )
+    return resolved
 
 
 def _swap_in_model_cost_map(new_model_cost_map: dict) -> int:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3193,7 +3193,7 @@ class Router:
             function_name=function_name,
         )
         model_group: Final = kwargs.get(metadata_variable_name, {}).get("model_group")
-        _model_id: Final = self._generate_model_id(model_group=model_group, litellm_params=dynamic_litellm_params)
+        _model_id: Final = self.generate_model_id(model_group=model_group, litellm_params=dynamic_litellm_params)
         original_model_id: Final = model_info.get("id")
         model_info["id"] = _model_id
         model_info["original_model_id"] = original_model_id
@@ -7570,14 +7570,14 @@ class Router:
 
     @staticmethod
     def _json_default_stable_id(value: object) -> str:
-        """json.dumps default= for _generate_model_id: plain str() on an arbitrary
+        """json.dumps default= for generate_model_id: plain str() on an arbitrary
         object (e.g. a RoutingPlugin instance) falls back to object.__repr__'s
         `<module.Class object at 0x...>`, so the hash -- and deployment id -- would
         change every restart. Use the class name instead, stable across restarts."""
         return f"{type(value).__module__}.{type(value).__qualname__}"
 
     @staticmethod
-    def _generate_model_id(model_group: str, litellm_params: dict) -> str:  # mutable-ok: hashed read-only
+    def generate_model_id(model_group: str, litellm_params: dict) -> str:  # mutable-ok: hashed read-only
         """
         Helper function to consistently generate the same id for a deployment
 
@@ -8193,7 +8193,7 @@ class Router:
 
             # check if model info has id
             if "id" not in _model_info:
-                _id = self._generate_model_id(_model_name, _litellm_params)
+                _id = self.generate_model_id(_model_name, _litellm_params)
                 _model_info["id"] = _id
 
             if _litellm_params.get("organization", None) is not None and isinstance(
@@ -9751,7 +9751,7 @@ class Router:
             if model_id is None:
                 model_name = model.get("model_name", "")
                 litellm_params = model.get("litellm_params", {})
-                model_id = self._generate_model_id(model_name, litellm_params)
+                model_id = self.generate_model_id(model_name, litellm_params)
                 # Update the model_info in the original list
                 if "model_info" not in model:
                     model["model_info"] = {}

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7577,7 +7577,7 @@ class Router:
         return f"{type(value).__module__}.{type(value).__qualname__}"
 
     @staticmethod
-    def _generate_model_id(model_group: str, litellm_params: Mapping[str, object]) -> str:
+    def _generate_model_id(model_group: str, litellm_params: dict) -> str:  # mutable-ok: hashed read-only
         """
         Helper function to consistently generate the same id for a deployment
 
@@ -7589,7 +7589,13 @@ class Router:
         # This avoids creating many temporary string objects (O(n) vs O(n²) complexity)
         parts: Final = [model_group]
         for k, v in litellm_params.items():
-            parts.append(k)
+            if isinstance(k, str):
+                parts.append(k)
+            elif isinstance(k, dict):
+                parts.append(json.dumps(k, default=Router._json_default_stable_id))
+            else:
+                parts.append(str(k))
+
             if isinstance(v, str):
                 parts.append(v)
             elif isinstance(v, dict):

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7576,7 +7576,8 @@ class Router:
         change every restart. Use the class name instead, stable across restarts."""
         return f"{type(value).__module__}.{type(value).__qualname__}"
 
-    def _generate_model_id(self, model_group: str, litellm_params: dict):
+    @staticmethod
+    def _generate_model_id(model_group: str, litellm_params: Mapping[str, object]) -> str:
         """
         Helper function to consistently generate the same id for a deployment
 
@@ -7588,17 +7589,11 @@ class Router:
         # This avoids creating many temporary string objects (O(n) vs O(n²) complexity)
         parts: Final = [model_group]
         for k, v in litellm_params.items():
-            if isinstance(k, str):
-                parts.append(k)
-            elif isinstance(k, dict):
-                parts.append(json.dumps(k, default=self._json_default_stable_id))
-            else:
-                parts.append(str(k))
-
+            parts.append(k)
             if isinstance(v, str):
                 parts.append(v)
             elif isinstance(v, dict):
-                parts.append(json.dumps(v, default=self._json_default_stable_id))
+                parts.append(json.dumps(v, default=Router._json_default_stable_id))
             else:
                 parts.append(str(v))
 

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -141,36 +141,6 @@ model_list:
         default_model: gpt-4o
 ```
 
-### Custom classifier plugin
-
-`classifier_type: plugin` hands the tier decision to your own hook instead of the heuristic scorer or an LLM call. Point `classifier_plugin` at an instance implementing an async `classify(context)` method; the dotted path resolves the same way `plugins` entries do. The context carries the request messages plus the request metadata, which includes the caller's identity (`user_api_key_team_id`, `user_api_key_user_id`, budgets, and the rest), so a plugin can route by team, spend, or any business rule:
-
-```yaml
-model_list:
-  - model_name: smart-router
-    litellm_params:
-      model: auto_router/complexity_router
-      complexity_router_config:
-        classifier_type: plugin
-        classifier_plugin: custom_classifiers.tier_by_team
-        classifier_plugin_timeout_ms: 3000
-        tiers:
-          SIMPLE: gpt-4o-mini
-          REASONING: o1-preview
-```
-
-```python
-# custom_classifiers.py, next to the proxy config
-class TierByTeam:
-    async def classify(self, context):
-        team = context.metadata.get("user_api_key_team_id")
-        return "REASONING" if team == "team-research" else "SIMPLE"
-
-tier_by_team = TierByTeam()
-```
-
-`classify` returns the name of a tier (a built-in value, a `tier_labels` label, or a `tier_definitions` name, matched case-insensitively), or `None` to decline. A decline, an error, a timeout, or an unknown tier falls back exactly like a failed LLM classifier: `fallback_tier` wins on a custom tier set, and `classifier_fallback` otherwise picks between the heuristic scorer and `default_model`. Routing decisions record `cause: classifier_plugin`, and the plugin cannot be set over HTTP, only from the proxy config file.
-
 ## Usage
 
 Once configured, use the model name like any other:

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -141,6 +141,36 @@ model_list:
         default_model: gpt-4o
 ```
 
+### Custom classifier plugin
+
+`classifier_type: plugin` hands the tier decision to your own hook instead of the heuristic scorer or an LLM call. Point `classifier_plugin` at an instance implementing an async `classify(context)` method; the dotted path resolves the same way `plugins` entries do. The context carries the request messages plus the request metadata, which includes the caller's identity (`user_api_key_team_id`, `user_api_key_user_id`, budgets, and the rest), so a plugin can route by team, spend, or any business rule:
+
+```yaml
+model_list:
+  - model_name: smart-router
+    litellm_params:
+      model: auto_router/complexity_router
+      complexity_router_config:
+        classifier_type: plugin
+        classifier_plugin: custom_classifiers.tier_by_team
+        classifier_plugin_timeout_ms: 3000
+        tiers:
+          SIMPLE: gpt-4o-mini
+          REASONING: o1-preview
+```
+
+```python
+# custom_classifiers.py, next to the proxy config
+class TierByTeam:
+    async def classify(self, context):
+        team = context.metadata.get("user_api_key_team_id")
+        return "REASONING" if team == "team-research" else "SIMPLE"
+
+tier_by_team = TierByTeam()
+```
+
+`classify` returns the name of a tier (a built-in value, a `tier_labels` label, or a `tier_definitions` name, matched case-insensitively), or `None` to decline. A decline, an error, a timeout, or an unknown tier falls back exactly like a failed LLM classifier: `fallback_tier` wins on a custom tier set, and `classifier_fallback` otherwise picks between the heuristic scorer and `default_model`. Routing decisions record `cause: classifier_plugin`, and the plugin cannot be set over HTTP, only from the proxy config file.
+
 ## Usage
 
 Once configured, use the model name like any other:

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -1130,7 +1130,7 @@ class ComplexityRouter(CustomLogger):
         fallback_tier wins on a custom tier set, and classifier_fallback otherwise decides between
         the heuristic scorer and default_model. The outcome's `cause` reports which path actually ran.
         """
-        if self.config.classifier_type == "plugin":
+        if self.config.classifier_type == "custom":
             return await self._classify_with_plugin(prompt, system_prompt, request_kwargs, messages, raw_messages)
         if self.config.classifier_type != "llm" or self.config.classifier_llm_config is None:
             tier, score, signals, cause = self._score_and_classify(prompt, system_prompt)

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, create_model
 from litellm._logging import verbose_router_logger
 from litellm.constants import EMPTY_MAPPING, RETURN_RAW_MODEL_NAME_METADATA_KEY
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.core_helpers import get_metadata_variable_name_from_kwargs
 from litellm.litellm_core_utils.internal_call_metadata import forwarded_internal_call_metadata
 from litellm.llms.base_llm.base_utils import type_to_response_format_param
 from litellm.types.utils import (
@@ -1120,7 +1121,7 @@ class ComplexityRouter(CustomLogger):
         system_prompt: str | None = None,
         request_kwargs: dict[str, Any] | None = None,
         messages: Sequence[Mapping[str, object]] | None = None,
-        raw_messages: Sequence[Mapping[str, object]] | None = None,
+        raw_messages: list[dict[str, Any]] | None = None,  # mutable-ok: same shape _run_routing_plugins receives
     ) -> ClassificationOutcome:
         """
         Classify a prompt by complexity, using the LLM classifier when configured.
@@ -1131,7 +1132,7 @@ class ComplexityRouter(CustomLogger):
         the heuristic scorer and default_model. The outcome's `cause` reports which path actually ran.
         """
         if self.config.classifier_type == "custom":
-            return await self._classify_with_plugin(prompt, system_prompt, request_kwargs, messages, raw_messages)
+            return await self._classify_with_plugin(prompt, system_prompt, request_kwargs, raw_messages)
         if self.config.classifier_type != "llm" or self.config.classifier_llm_config is None:
             tier, score, signals, cause = self._score_and_classify(prompt, system_prompt)
             return ClassificationOutcome(tier=tier, score=score, signals=signals, cause=cause)
@@ -1172,23 +1173,25 @@ class ComplexityRouter(CustomLogger):
         self,
         prompt: str,
         system_prompt: str | None,
-        request_kwargs: Mapping[str, Any] | None,
-        messages: Sequence[Mapping[str, object]] | None,
-        raw_messages: Sequence[Mapping[str, object]] | None,
+        request_kwargs: dict[str, Any] | None,  # mutable-ok: handed to resolve_structured_messages as-is
+        raw_messages: list[dict[str, Any]] | None,  # mutable-ok: same shape _run_routing_plugins receives
     ) -> ClassificationOutcome:
+        from litellm.litellm_core_utils.prompt_templates.factory import resolve_structured_messages
         from litellm.types.router import RoutingContext
 
         plugin: Final = self.config.classifier_plugin
         if plugin is None:
             return self._classifier_failure_outcome("classifier_plugin is not set", prompt, system_prompt)
-        kwargs: Final = request_kwargs or EMPTY_MAPPING
-        metadata_key: Final = "litellm_metadata" if "litellm_metadata" in kwargs else "metadata"
+        kwargs: Final = request_kwargs if request_kwargs is not None else EMPTY_MAPPING
         pools: Final = self._tier_pools()
         context: Final = RoutingContext(
-            raw_messages=tuple(raw_messages or messages or ()),
-            structured_messages=tuple(messages or ()),
+            raw_messages=raw_messages or (),
+            structured_messages=resolve_structured_messages(
+                messages=raw_messages, request_kwargs=request_kwargs or EMPTY_MAPPING
+            )
+            or (),
             candidate_models=tuple(model for pool in pools.values() for model in pool),
-            metadata=kwargs.get(metadata_key) or EMPTY_MAPPING,
+            metadata=kwargs.get(get_metadata_variable_name_from_kwargs(kwargs)) or EMPTY_MAPPING,
         )
         try:
             verdict: Final = await asyncio.wait_for(
@@ -1464,7 +1467,7 @@ class ComplexityRouter(CustomLogger):
         from litellm.types.router import RoutingContext
 
         tier_key: Final = _tier_name(tier)
-        metadata_key: Final = "litellm_metadata" if "litellm_metadata" in request_kwargs else "metadata"
+        metadata_key: Final = get_metadata_variable_name_from_kwargs(request_kwargs)
         pool: Final = tuple(self._tier_pools().get(tier_key, ()))
         if not pool:
             # Nothing for the plugins to filter. Falling through would raise the

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -1184,16 +1184,16 @@ class ComplexityRouter(CustomLogger):
             return self._classifier_failure_outcome("classifier_plugin is not set", prompt, system_prompt)
         kwargs: Final = request_kwargs if request_kwargs is not None else EMPTY_MAPPING
         pools: Final = self._tier_pools()
-        context: Final = RoutingContext(
-            raw_messages=raw_messages or (),
-            structured_messages=resolve_structured_messages(
-                messages=raw_messages, request_kwargs=request_kwargs or EMPTY_MAPPING
-            )
-            or (),
-            candidate_models=tuple(model for pool in pools.values() for model in pool),
-            metadata=kwargs.get(get_metadata_variable_name_from_kwargs(kwargs)) or EMPTY_MAPPING,
-        )
         try:
+            context: Final = RoutingContext(
+                raw_messages=raw_messages or (),
+                structured_messages=resolve_structured_messages(
+                    messages=raw_messages, request_kwargs=request_kwargs or EMPTY_MAPPING
+                )
+                or (),
+                candidate_models=tuple(model for pool in pools.values() for model in pool),
+                metadata=kwargs.get(get_metadata_variable_name_from_kwargs(kwargs)) or EMPTY_MAPPING,
+            )
             verdict: Final = await asyncio.wait_for(
                 plugin.classify(context), timeout=self.config.classifier_plugin_timeout_ms / 1000
             )

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -80,6 +80,9 @@ class _LabeledTierClassification(BaseModel):
     tier: str
 
 
+_EMPTY_METADATA: Final[Mapping[str, Any]] = MappingProxyType({})
+
+
 def _tier_name(tier: ComplexityTier | str) -> str:
     """The plain tier name, whether the pipeline carries a built-in tier or a defined name."""
     return tier.value if isinstance(tier, ComplexityTier) else tier
@@ -655,6 +658,7 @@ class ClassificationOutcome(NamedTuple):
         "heuristic_scorer",
         "reasoning_override",
         "llm_classifier",
+        "classifier_plugin",
         "classifier_fallback",
         "default_model_fallback",
     ]
@@ -1119,15 +1123,18 @@ class ComplexityRouter(CustomLogger):
         system_prompt: str | None = None,
         request_kwargs: dict[str, Any] | None = None,
         messages: Sequence[Mapping[str, object]] | None = None,
+        raw_messages: Sequence[Mapping[str, object]] | None = None,
     ) -> ClassificationOutcome:
         """
         Classify a prompt by complexity, using the LLM classifier when configured.
 
         Falls back to the local heuristic scorer if classifier_type is "heuristic". If the LLM call
-        fails, times out, or returns an unparseable response, the configured fallback_tier wins on a
-        custom tier set, and classifier_fallback otherwise decides between the heuristic scorer and
-        default_model. The outcome's `cause` reports which path actually ran.
+        or the classifier plugin fails, times out, or produces no usable tier, the configured
+        fallback_tier wins on a custom tier set, and classifier_fallback otherwise decides between
+        the heuristic scorer and default_model. The outcome's `cause` reports which path actually ran.
         """
+        if self.config.classifier_type == "plugin":
+            return await self._classify_with_plugin(prompt, system_prompt, request_kwargs, messages, raw_messages)
         if self.config.classifier_type != "llm" or self.config.classifier_llm_config is None:
             tier, score, signals, cause = self._score_and_classify(prompt, system_prompt)
             return ClassificationOutcome(tier=tier, score=score, signals=signals, cause=cause)
@@ -1142,26 +1149,78 @@ class ComplexityRouter(CustomLogger):
                 classifier_cost=classifier_cost,
             )
         except Exception as e:  # noqa: BLE001 -- external LLM call can fail in many distinct ways (timeout, provider error, validation, parse error); any failure must fall back to the configured fallback path
-            fallback_tier: Final = self.config.fallback_tier
-            if fallback_tier is not None:
-                verbose_router_logger.warning(
-                    "ComplexityRouter: LLM classifier failed (%s), routing to fallback_tier %s", e, fallback_tier
-                )
-                return ClassificationOutcome(
-                    tier=fallback_tier,
-                    score=None,
-                    signals=(f"classifier-fallback:{fallback_tier}",),
-                    cause="classifier_fallback",
-                )
-            verbose_router_logger.warning(
-                "ComplexityRouter: LLM classifier failed (%s), falling back to %s",
-                e,
-                self.config.classifier_fallback,
+            return self._classifier_failure_outcome(f"LLM classifier failed ({e})", prompt, system_prompt)
+
+    def _classifier_failure_outcome(self, reason: str, prompt: str, system_prompt: str | None) -> ClassificationOutcome:
+        """The outcome when the LLM classifier or classifier plugin produced no usable tier:
+        fallback_tier on a custom tier set, classifier_fallback otherwise."""
+        fallback_tier: Final = self.config.fallback_tier
+        if fallback_tier is not None:
+            verbose_router_logger.warning("ComplexityRouter: %s, routing to fallback_tier %s", reason, fallback_tier)
+            return ClassificationOutcome(
+                tier=fallback_tier,
+                score=None,
+                signals=(f"classifier-fallback:{fallback_tier}",),
+                cause="classifier_fallback",
             )
-            if self.config.classifier_fallback == "default_model":
-                return self._default_model_fallback_outcome()
-            tier, score, signals, cause = self._score_and_classify(prompt, system_prompt)
-            return ClassificationOutcome(tier=tier, score=score, signals=signals, cause=cause)
+        verbose_router_logger.warning(
+            "ComplexityRouter: %s, falling back to %s", reason, self.config.classifier_fallback
+        )
+        if self.config.classifier_fallback == "default_model":
+            return self._default_model_fallback_outcome()
+        tier, score, signals, cause = self._score_and_classify(prompt, system_prompt)
+        return ClassificationOutcome(tier=tier, score=score, signals=signals, cause=cause)
+
+    async def _classify_with_plugin(
+        self,
+        prompt: str,
+        system_prompt: str | None,
+        request_kwargs: Mapping[str, Any] | None,
+        messages: Sequence[Mapping[str, object]] | None,
+        raw_messages: Sequence[Mapping[str, object]] | None,
+    ) -> ClassificationOutcome:
+        from litellm.types.router import RoutingContext
+
+        plugin: Final = self.config.classifier_plugin
+        if plugin is None:
+            return self._classifier_failure_outcome("classifier_plugin is not set", prompt, system_prompt)
+        kwargs: Final = request_kwargs or _EMPTY_METADATA
+        metadata_key: Final = "litellm_metadata" if "litellm_metadata" in kwargs else "metadata"
+        pools: Final = self._tier_pools()
+        context: Final = RoutingContext(
+            raw_messages=tuple(raw_messages or messages or ()),
+            structured_messages=tuple(messages or ()),
+            candidate_models=tuple(model for pool in pools.values() for model in pool),
+            metadata=kwargs.get(metadata_key) or _EMPTY_METADATA,
+        )
+        try:
+            verdict: Final = await asyncio.wait_for(
+                plugin.classify(context), timeout=self.config.classifier_plugin_timeout_ms / 1000
+            )
+        except asyncio.TimeoutError:
+            return self._classifier_failure_outcome(
+                f"classifier plugin timed out after {self.config.classifier_plugin_timeout_ms}ms", prompt, system_prompt
+            )
+        except Exception as e:  # noqa: BLE001 -- an operator hook can fail in arbitrary ways (network, bug); any failure must fall back rather than fail the request
+            return self._classifier_failure_outcome(f"classifier plugin failed ({e})", prompt, system_prompt)
+        if verdict is None:
+            return self._classifier_failure_outcome("classifier plugin declined to classify", prompt, system_prompt)
+        tier: Final = self.config.resolve_classified_tier(verdict)
+        if tier is None:
+            return self._classifier_failure_outcome(
+                f"classifier plugin returned unknown tier {verdict!r}", prompt, system_prompt
+            )
+        tier_key: Final = _tier_name(tier)
+        if not pools.get(tier_key):
+            return self._classifier_failure_outcome(
+                f"classifier plugin returned tier {tier_key!r}, which has no models configured", prompt, system_prompt
+            )
+        return ClassificationOutcome(
+            tier=tier,
+            score=None,
+            signals=(f"classifier-plugin:{tier_key}",),
+            cause="classifier_plugin",
+        )
 
     def _default_model_fallback_outcome(self) -> ClassificationOutcome:
         """The classifier-failed outcome for classifier_fallback='default_model'.
@@ -2218,7 +2277,9 @@ class ComplexityRouter(CustomLogger):
                 ),
             )
 
-        outcome: Final = await self.aclassify(user_message, system_prompt, request_kwargs, resolved_messages)
+        outcome: Final = await self.aclassify(
+            user_message, system_prompt, request_kwargs, resolved_messages, raw_messages=messages
+        )
         tier, score, signals = outcome.tier, outcome.score, outcome.signals
         classified_tier: Final = tier
         if escalation_keyword is not None:

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, cast
 from pydantic import BaseModel, create_model
 
 from litellm._logging import verbose_router_logger
-from litellm.constants import RETURN_RAW_MODEL_NAME_METADATA_KEY
+from litellm.constants import EMPTY_MAPPING, RETURN_RAW_MODEL_NAME_METADATA_KEY
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.internal_call_metadata import forwarded_internal_call_metadata
 from litellm.llms.base_llm.base_utils import type_to_response_format_param
@@ -78,9 +78,6 @@ class _LabeledTierClassification(BaseModel):
     """Parses the classifier's reply when the wire carries operator-chosen tier strings."""
 
     tier: str
-
-
-_EMPTY_METADATA: Final[Mapping[str, Any]] = MappingProxyType({})
 
 
 def _tier_name(tier: ComplexityTier | str) -> str:
@@ -1184,14 +1181,14 @@ class ComplexityRouter(CustomLogger):
         plugin: Final = self.config.classifier_plugin
         if plugin is None:
             return self._classifier_failure_outcome("classifier_plugin is not set", prompt, system_prompt)
-        kwargs: Final = request_kwargs or _EMPTY_METADATA
+        kwargs: Final = request_kwargs or EMPTY_MAPPING
         metadata_key: Final = "litellm_metadata" if "litellm_metadata" in kwargs else "metadata"
         pools: Final = self._tier_pools()
         context: Final = RoutingContext(
             raw_messages=tuple(raw_messages or messages or ()),
             structured_messages=tuple(messages or ()),
             candidate_models=tuple(model for pool in pools.values() for model in pool),
-            metadata=kwargs.get(metadata_key) or _EMPTY_METADATA,
+            metadata=kwargs.get(metadata_key) or EMPTY_MAPPING,
         )
         try:
             verdict: Final = await asyncio.wait_for(
@@ -1205,6 +1202,12 @@ class ComplexityRouter(CustomLogger):
             return self._classifier_failure_outcome(f"classifier plugin failed ({e})", prompt, system_prompt)
         if verdict is None:
             return self._classifier_failure_outcome("classifier plugin declined to classify", prompt, system_prompt)
+        if not isinstance(verdict, str):
+            return self._classifier_failure_outcome(
+                f"classifier plugin returned a non-string verdict of type {type(verdict).__name__}",
+                prompt,
+                system_prompt,
+            )
         tier: Final = self.config.resolve_classified_tier(verdict)
         if tier is None:
             return self._classifier_failure_outcome(

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -434,7 +434,7 @@ class ComplexityRouterConfig(BaseModel):
             "becomes that tier's rubric bullet; entries named after a built-in tier may omit the "
             "description and inherit the built-in criteria. List order is ascending severity and "
             "decides which tier wins when several keyword_tier_rules match. Requires classifier_type "
-            "'llm' or 'plugin', a fallback_tier, and `tiers` keys matching the defined names exactly. Escalation, "
+            "'llm' or 'custom', a fallback_tier, and `tiers` keys matching the defined names exactly. Escalation, "
             "adaptive selection, session affinity, plugins, tier_labels, and the calibration-example "
             "rubric presets are unavailable with a custom tier set: the first four are built on the "
             "built-in tier ladder, and the last two rename or exemplify tiers the set replaces."
@@ -535,7 +535,7 @@ class ComplexityRouterConfig(BaseModel):
     )
 
     # Classifier strategy
-    classifier_type: Literal["heuristic", "llm", "plugin"] = Field(
+    classifier_type: Literal["heuristic", "llm", "custom"] = Field(
         default="heuristic",
         description="Classification strategy: local regex/keyword scoring, an LLM call, or a custom classifier plugin",
     )
@@ -546,7 +546,7 @@ class ComplexityRouterConfig(BaseModel):
     classifier_plugin: ClassifierPlugin | None = Field(
         default=None,
         description=(
-            "Custom classifier deciding the tier; required when classifier_type is 'plugin'. In the proxy "
+            "Custom classifier deciding the tier; required when classifier_type is 'custom'. In the proxy "
             "config, a dotted path to a ClassifierPlugin instance (resolved at startup, like plugins). Its "
             "classify(context) receives the request messages and metadata (caller identity included) and "
             "returns the name of the tier to route to, or None to decline and let classifier_fallback decide."
@@ -557,7 +557,7 @@ class ComplexityRouterConfig(BaseModel):
         gt=0,
         description=(
             "Timeout budget for the classifier plugin call, in milliseconds. On expiry the fallback "
-            "path decides the tier. Only applies when classifier_type is 'plugin'."
+            "path decides the tier. Only applies when classifier_type is 'custom'."
         ),
     )
 
@@ -570,7 +570,7 @@ class ComplexityRouterConfig(BaseModel):
             "which is what a classifier on some other taxonomy wants: a prompt that grades data "
             "sensitivity has no use for a complexity score, and scoring one produces a tier unrelated to "
             "what the operator configured. Requires default_model when set to 'default_model'. Only "
-            "applies when classifier_type is 'llm' or 'plugin'."
+            "applies when classifier_type is 'llm' or 'custom'."
         ),
     )
 
@@ -815,12 +815,12 @@ class ComplexityRouterConfig(BaseModel):
     def _validate_classifier_config(self) -> "ComplexityRouterConfig":
         if self.classifier_type == "llm" and self.classifier_llm_config is None:
             raise ValueError("classifier_llm_config is required when classifier_type is 'llm'")
-        if self.classifier_type == "plugin" and self.classifier_plugin is None:
-            raise ValueError("classifier_plugin is required when classifier_type is 'plugin'")
-        if self.classifier_plugin is not None and self.classifier_type != "plugin":
+        if self.classifier_type == "custom" and self.classifier_plugin is None:
+            raise ValueError("classifier_plugin is required when classifier_type is 'custom'")
+        if self.classifier_plugin is not None and self.classifier_type != "custom":
             raise ValueError(
                 f"classifier_plugin is set but classifier_type is {self.classifier_type!r}; "
-                "the plugin would never run. Set classifier_type 'plugin' or remove classifier_plugin"
+                "the plugin would never run. Set classifier_type 'custom' or remove classifier_plugin"
             )
         return self
 
@@ -942,7 +942,7 @@ class ComplexityRouterConfig(BaseModel):
             raise ValueError(f"tier_definitions names must be unique (case-insensitive): {', '.join(duplicated)}")
         if self.classifier_type == "heuristic":
             raise ValueError(
-                "tier_definitions requires classifier_type 'llm' or 'plugin': the heuristic scorer only "
+                "tier_definitions requires classifier_type 'llm' or 'custom': the heuristic scorer only "
                 "produces the built-in tiers"
             )
         conflicts: Final = self._tier_definition_conflicts()

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -10,7 +10,7 @@ from typing import Final, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from litellm.types.router import AdaptiveRouterWeights, RoutingPlugin
+from litellm.types.router import AdaptiveRouterWeights, ClassifierPlugin, RoutingPlugin
 
 
 class ComplexityTier(str, Enum):
@@ -434,7 +434,7 @@ class ComplexityRouterConfig(BaseModel):
             "becomes that tier's rubric bullet; entries named after a built-in tier may omit the "
             "description and inherit the built-in criteria. List order is ascending severity and "
             "decides which tier wins when several keyword_tier_rules match. Requires classifier_type "
-            "'llm', a fallback_tier, and `tiers` keys matching the defined names exactly. Escalation, "
+            "'llm' or 'plugin', a fallback_tier, and `tiers` keys matching the defined names exactly. Escalation, "
             "adaptive selection, session affinity, plugins, tier_labels, and the calibration-example "
             "rubric presets are unavailable with a custom tier set: the first four are built on the "
             "built-in tier ladder, and the last two rename or exemplify tiers the set replaces."
@@ -535,13 +535,30 @@ class ComplexityRouterConfig(BaseModel):
     )
 
     # Classifier strategy
-    classifier_type: Literal["heuristic", "llm"] = Field(
+    classifier_type: Literal["heuristic", "llm", "plugin"] = Field(
         default="heuristic",
-        description="Classification strategy: local regex/keyword scoring, or an LLM call",
+        description="Classification strategy: local regex/keyword scoring, an LLM call, or a custom classifier plugin",
     )
     classifier_llm_config: ClassifierLLMConfig | None = Field(
         default=None,
         description="Configuration for the LLM classifier; required when classifier_type is 'llm'",
+    )
+    classifier_plugin: ClassifierPlugin | None = Field(
+        default=None,
+        description=(
+            "Custom classifier deciding the tier; required when classifier_type is 'plugin'. In the proxy "
+            "config, a dotted path to a ClassifierPlugin instance (resolved at startup, like plugins). Its "
+            "classify(context) receives the request messages and metadata (caller identity included) and "
+            "returns the name of the tier to route to, or None to decline and let classifier_fallback decide."
+        ),
+    )
+    classifier_plugin_timeout_ms: int = Field(
+        default=3000,
+        gt=0,
+        description=(
+            "Timeout budget for the classifier plugin call, in milliseconds. On expiry the fallback "
+            "path decides the tier. Only applies when classifier_type is 'plugin'."
+        ),
     )
 
     classifier_fallback: Literal["heuristic", "default_model"] = Field(
@@ -553,7 +570,7 @@ class ComplexityRouterConfig(BaseModel):
             "which is what a classifier on some other taxonomy wants: a prompt that grades data "
             "sensitivity has no use for a complexity score, and scoring one produces a tier unrelated to "
             "what the operator configured. Requires default_model when set to 'default_model'. Only "
-            "applies when classifier_type is 'llm'."
+            "applies when classifier_type is 'llm' or 'plugin'."
         ),
     )
 
@@ -795,9 +812,16 @@ class ComplexityRouterConfig(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def _validate_llm_classifier_config(self) -> "ComplexityRouterConfig":
+    def _validate_classifier_config(self) -> "ComplexityRouterConfig":
         if self.classifier_type == "llm" and self.classifier_llm_config is None:
             raise ValueError("classifier_llm_config is required when classifier_type is 'llm'")
+        if self.classifier_type == "plugin" and self.classifier_plugin is None:
+            raise ValueError("classifier_plugin is required when classifier_type is 'plugin'")
+        if self.classifier_plugin is not None and self.classifier_type != "plugin":
+            raise ValueError(
+                f"classifier_plugin is set but classifier_type is {self.classifier_type!r}; "
+                "the plugin would never run. Set classifier_type 'plugin' or remove classifier_plugin"
+            )
         return self
 
     @field_validator("fallback_tier", "classification_prompt")
@@ -916,9 +940,10 @@ class ComplexityRouterConfig(BaseModel):
         )
         if duplicated:
             raise ValueError(f"tier_definitions names must be unique (case-insensitive): {', '.join(duplicated)}")
-        if self.classifier_type != "llm":
+        if self.classifier_type == "heuristic":
             raise ValueError(
-                "tier_definitions requires classifier_type 'llm': the heuristic scorer only produces the built-in tiers"
+                "tier_definitions requires classifier_type 'llm' or 'plugin': the heuristic scorer only "
+                "produces the built-in tiers"
             )
         conflicts: Final = self._tier_definition_conflicts()
         if conflicts:

--- a/litellm/types/management_endpoints/auto_router_endpoints.py
+++ b/litellm/types/management_endpoints/auto_router_endpoints.py
@@ -22,6 +22,9 @@ class RequestComplexityRouterConfig(ComplexityRouterConfig):
     """
 
     plugins: None = Field(default=None, description="Not settable over HTTP; routing plugins are runtime objects")
+    classifier_plugin: None = Field(  # pyright: ignore[reportIncompatibleVariableOverride]  # narrowing to None is the point: runtime objects are not settable over HTTP
+        default=None, description="Not settable over HTTP; the classifier plugin is a runtime object"
+    )
 
 
 class AutoRouterRoutingTestRequest(BaseModel):

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -962,6 +962,10 @@ class ClassifierPlugin(Protocol):
 
     `classify` returns the name of the tier the request belongs to (a built-in tier value or label,
     or a tier_definitions name), or None to decline and let classifier_fallback decide.
+
+    The context's `candidate_models` is an informational snapshot of every tier's models, unlike
+    the narrowing surface RoutingPlugin filters: the returned tier decides the pool, so mutating
+    the list is a no-op.
     """
 
     async def classify(self, context: RoutingContext) -> str | None: ...

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -958,7 +958,7 @@ class RoutingPlugin(Protocol):
 
 @runtime_checkable
 class ClassifierPlugin(Protocol):
-    """Interface a custom classifier must implement to run as the complexity router's classifier_type='plugin'.
+    """Interface a custom classifier must implement to run as the complexity router's classifier_type='custom'.
 
     `classify` returns the name of the tier the request belongs to (a built-in tier value or label,
     or a tier_definitions name), or None to decline and let classifier_fallback decide.

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -956,6 +956,17 @@ class RoutingPlugin(Protocol):
     async def run(self, context: RoutingContext) -> RoutingContext: ...
 
 
+@runtime_checkable
+class ClassifierPlugin(Protocol):
+    """Interface a custom classifier must implement to run as the complexity router's classifier_type='plugin'.
+
+    `classify` returns the name of the tier the request belongs to (a built-in tier value or label,
+    or a tier_definitions name), or None to decline and let classifier_fallback decide.
+    """
+
+    async def classify(self, context: RoutingContext) -> str | None: ...
+
+
 class RequestType(str, enum.Enum):
     """Fixed v0 taxonomy. User-extensible types come in v1."""
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2767,7 +2767,7 @@ RoutingDecisionCause = Literal[
     # meant anything that filtered `signals` silently changed what the row claimed.
     "reasoning_override",
     "llm_classifier",
-    # The operator's classifier plugin (classifier_type 'plugin') decided the tier.
+    # The operator's classifier plugin (classifier_type 'custom') decided the tier.
     "classifier_plugin",
     # The LLM classifier or classifier plugin failed on a router with an operator-defined
     # tier set, so the request routed to the configured fallback_tier without being classified.

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2767,11 +2767,14 @@ RoutingDecisionCause = Literal[
     # meant anything that filtered `signals` silently changed what the row claimed.
     "reasoning_override",
     "llm_classifier",
-    # The LLM classifier failed on a router with an operator-defined tier set, so the
-    # request routed to the configured fallback_tier without being classified.
+    # The operator's classifier plugin (classifier_type 'plugin') decided the tier.
+    "classifier_plugin",
+    # The LLM classifier or classifier plugin failed on a router with an operator-defined
+    # tier set, so the request routed to the configured fallback_tier without being classified.
     "classifier_fallback",
-    # The LLM classifier failed and classifier_fallback is 'default_model', so the request
-    # went to default_model without being classified. Distinct from "default_fallback",
+    # The LLM classifier or classifier plugin failed and classifier_fallback is
+    # 'default_model', so the request went to default_model without being classified.
+    # Distinct from "default_fallback",
     # which is a tier having no model configured rather than classification not happening.
     "default_model_fallback",
     "literal_keyword_match",

--- a/tests/local_testing/test_router.py
+++ b/tests/local_testing/test_router.py
@@ -1303,7 +1303,7 @@ def test_consistent_model_id():
     """
     - For a given model group + litellm params, assert the model id is always the same
 
-    Test on `_generate_model_id`
+    Test on `generate_model_id`
 
     Test on `set_model_list`
 
@@ -1317,11 +1317,11 @@ def test_consistent_model_id():
         "stream_timeout": 0.001,
     }
 
-    id1 = Router()._generate_model_id(
+    id1 = Router().generate_model_id(
         model_group=model_group, litellm_params=litellm_params
     )
 
-    id2 = Router()._generate_model_id(
+    id2 = Router().generate_model_id(
         model_group=model_group, litellm_params=litellm_params
     )
 

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -1841,8 +1841,8 @@ def test_init_auto_router_deployment_duplicate_model_name(mock_auto_router, mode
         router.init_auto_router_deployment(deployment)
 
 
-def test_generate_model_id_with_deployment_model_name(model_list):
-    """Test that _generate_model_id works correctly with deployment model_name and handles None values properly"""
+def testgenerate_model_id_with_deployment_model_name(model_list):
+    """Test that generate_model_id works correctly with deployment model_name and handles None values properly"""
     router = Router(model_list=model_list)
 
     # Test case 1: Normal case with valid model_group and litellm_params
@@ -1854,7 +1854,7 @@ def test_generate_model_id_with_deployment_model_name(model_list):
     }
 
     try:
-        result = router._generate_model_id(
+        result = router.generate_model_id(
             model_group=model_group, litellm_params=litellm_params
         )
         assert isinstance(result, str)
@@ -1865,7 +1865,7 @@ def test_generate_model_id_with_deployment_model_name(model_list):
 
     # Test case 2: Edge case with None model_group (this should fail as expected - our fix prevents this from happening)
     try:
-        result = router._generate_model_id(
+        result = router.generate_model_id(
             model_group=None, litellm_params=litellm_params
         )
         pytest.fail(
@@ -1888,7 +1888,7 @@ def test_generate_model_id_with_deployment_model_name(model_list):
     }
 
     try:
-        result = router._generate_model_id(
+        result = router.generate_model_id(
             model_group=model_group, litellm_params=litellm_params_with_none_key
         )
         assert isinstance(result, str)
@@ -1899,7 +1899,7 @@ def test_generate_model_id_with_deployment_model_name(model_list):
 
     # Test case 4: Edge case with empty litellm_params
     try:
-        result = router._generate_model_id(model_group=model_group, litellm_params={})
+        result = router.generate_model_id(model_group=model_group, litellm_params={})
         assert isinstance(result, str)
         assert len(result) > 0
         print(f"✓ Success with empty litellm_params: {result}")
@@ -1907,15 +1907,15 @@ def test_generate_model_id_with_deployment_model_name(model_list):
         pytest.fail(f"Failed with empty litellm_params: {e}")
 
     # Test case 5: Verify that the same inputs produce the same result (deterministic)
-    result1 = router._generate_model_id(
+    result1 = router.generate_model_id(
         model_group=model_group, litellm_params=litellm_params
     )
-    result2 = router._generate_model_id(
+    result2 = router.generate_model_id(
         model_group=model_group, litellm_params=litellm_params
     )
     assert result1 == result2, "Model ID generation should be deterministic"
 
-    print("✓ All _generate_model_id tests passed!")
+    print("✓ All generate_model_id tests passed!")
 
 
 def test_handle_clientside_credential_with_deployment_model_name(model_list):
@@ -1945,13 +1945,13 @@ def test_handle_clientside_credential_with_deployment_model_name(model_list):
 
     # Test that the method doesn't fail when metadata is empty
     try:
-        # This would normally call _generate_model_id internally
+        # This would normally call generate_model_id internally
         # We're testing that the fix prevents the TypeError
         model_group = deployment["model_name"]  # This is what our fix does
         assert model_group == "gpt-4.1"
 
-        # Verify that _generate_model_id works with this model_group
-        result = router._generate_model_id(
+        # Verify that generate_model_id works with this model_group
+        result = router.generate_model_id(
             model_group=model_group, litellm_params=dynamic_litellm_params
         )
         assert isinstance(result, str)

--- a/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
@@ -290,7 +290,7 @@ def test_classifier_plugin_is_not_settable_over_http():
     """classifier_plugin holds a live runtime object, closed off like `plugins`; a plugin-mode
     config is therefore unrepresentable in a request body."""
     with pytest.raises(ValidationError):
-        _request("what is 2+2", classifier_type="plugin", classifier_plugin="my_module.instance")
+        _request("what is 2+2", classifier_type="custom", classifier_plugin="my_module.instance")
 
 
 class TestAutoRouterBenchmarks:

--- a/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
@@ -286,6 +286,13 @@ def test_semantic_matching_without_an_embedding_model_is_rejected():
         _request("what is 2+2", semantic_keyword_matching=True)
 
 
+def test_classifier_plugin_is_not_settable_over_http():
+    """classifier_plugin holds a live runtime object, closed off like `plugins`; a plugin-mode
+    config is therefore unrepresentable in a request body."""
+    with pytest.raises(ValidationError):
+        _request("what is 2+2", classifier_type="plugin", classifier_plugin="my_module.instance")
+
+
 class TestAutoRouterBenchmarks:
     from litellm.proxy.management_endpoints.auto_router_endpoints import _SessionAggRow
 

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -198,7 +198,7 @@ def test_resolve_complexity_router_plugins_resolves_classifier_plugin_dotted_pat
         "my_classifier_instance = _Classifier()\n"
     )
     config: dict[str, Any] = {
-        "classifier_type": "plugin",
+        "classifier_type": "custom",
         "classifier_plugin": "my_classifier.my_classifier_instance",
     }
 

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -188,6 +188,77 @@ def test_resolve_complexity_router_plugins_rejects_synchronous_run_method(tmp_pa
         )
 
 
+def test_resolve_complexity_router_plugins_resolves_classifier_plugin_dotted_path(tmp_path):
+    plugin_file = tmp_path / "my_classifier.py"
+    plugin_file.write_text(
+        "class _Classifier:\n"
+        "    async def classify(self, context):\n"
+        "        return 'SIMPLE'\n"
+        "\n"
+        "my_classifier_instance = _Classifier()\n"
+    )
+    config: dict[str, Any] = {
+        "classifier_type": "plugin",
+        "classifier_plugin": "my_classifier.my_classifier_instance",
+    }
+
+    resolve_complexity_router_plugins(
+        model_name="smart-router",
+        complexity_router_config=config,
+        config_file_path=str(tmp_path / "config.yaml"),
+    )
+
+    assert hasattr(config["classifier_plugin"], "classify")
+    assert type(config["classifier_plugin"]).__name__ == "_Classifier"
+
+
+def test_resolve_complexity_router_plugins_rejects_non_classifier_object(tmp_path):
+    plugin_file = tmp_path / "bad_classifier.py"
+    plugin_file.write_text("not_a_classifier = object()\n")
+    config: dict[str, Any] = {"classifier_plugin": "bad_classifier.not_a_classifier"}
+
+    with pytest.raises(ValueError, match="does not implement the ClassifierPlugin interface"):
+        resolve_complexity_router_plugins(
+            model_name="smart-router",
+            complexity_router_config=config,
+            config_file_path=str(tmp_path / "config.yaml"),
+        )
+
+
+def test_resolve_complexity_router_plugins_rejects_synchronous_classify_method(tmp_path):
+    """A synchronous `classify` passes the runtime_checkable isinstance and would only fail on
+    the first classified request, so reject it at config load like the sync-run case above."""
+    plugin_file = tmp_path / "sync_classifier.py"
+    plugin_file.write_text(
+        "class _SyncClassifier:\n"
+        "    def classify(self, context):\n"
+        "        return 'SIMPLE'\n"
+        "\n"
+        "sync_classifier_instance = _SyncClassifier()\n"
+    )
+    config: dict[str, Any] = {"classifier_plugin": "sync_classifier.sync_classifier_instance"}
+
+    with pytest.raises(ValueError, match="does not implement the ClassifierPlugin interface"):
+        resolve_complexity_router_plugins(
+            model_name="smart-router",
+            complexity_router_config=config,
+            config_file_path=str(tmp_path / "config.yaml"),
+        )
+
+
+def test_resolve_complexity_router_plugins_leaves_live_classifier_instance_alone():
+    class _Classifier:
+        async def classify(self, context):
+            return "SIMPLE"
+
+    instance = _Classifier()
+    config: dict[str, Any] = {"classifier_plugin": instance}
+    resolve_complexity_router_plugins(
+        model_name="smart-router", complexity_router_config=config, config_file_path=None
+    )
+    assert config["classifier_plugin"] is instance
+
+
 # ---------------------------------------------------------------------------
 # resolve_routing_plugins
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/test_update_llm_router_resilience.py
+++ b/tests/test_litellm/proxy/test_update_llm_router_resilience.py
@@ -154,7 +154,7 @@ class TestDeleteDeploymentResilience:
         # Router has a model ID that's not in DB or config -> should be deleted
         mock_router.get_model_ids.return_value = ["db-id-1", "stale-id"]
         mock_router.delete_deployment.return_value = True
-        mock_router._generate_model_id = MagicMock(return_value="config-id-1")
+        mock_router.generate_model_id = MagicMock(return_value="config-id-1")
 
         with (
             patch.object(

--- a/tests/test_litellm/proxy/test_update_llm_router_resilience.py
+++ b/tests/test_litellm/proxy/test_update_llm_router_resilience.py
@@ -182,3 +182,111 @@ class TestDeleteDeploymentResilience:
                 "the returned set must be what the db + config still want, so a caller can "
                 f"tell that eviction apart from a deployment that went missing; got {result}"
             )
+
+
+class TestDeleteDeploymentResolvesPluginConfigs:
+    """Regression: _delete_deployment re-reads the raw config and hashes litellm_params to
+    compute the ids the config wants served. The router's ids were hashed from the RESOLVED
+    params (plugin dotted paths swapped for live instances), so hashing the raw strings
+    computed different ids and evicted every plugin-bearing auto-router one reconcile after
+    startup. The fix resolves plugins in _delete_deployment before hashing, like load_config."""
+
+    @staticmethod
+    def _write_plugin_module(tmp_path):
+        (tmp_path / "rig_classifier.py").write_text(
+            "class _Classifier:\n"
+            "    async def classify(self, context):\n"
+            "        return 'SIMPLE'\n"
+            "\n"
+            "class _Narrower:\n"
+            "    async def run(self, context):\n"
+            "        return context\n"
+            "\n"
+            "classifier_instance = _Classifier()\n"
+            "narrower_instance = _Narrower()\n"
+        )
+
+    @staticmethod
+    def _raw_model_entry():
+        return {
+            "model_name": "smart-router",
+            "litellm_params": {
+                "model": "auto_router/complexity_router",
+                "complexity_router_default_model": "gpt-4o-mini",
+                "complexity_router_config": {
+                    "classifier_type": "plugin",
+                    "classifier_plugin": "rig_classifier.classifier_instance",
+                    "plugins": ["rig_classifier.narrower_instance"],
+                    "tiers": {"SIMPLE": "gpt-4o-mini"},
+                },
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_plugin_bearing_config_model_survives_reconcile(self, tmp_path):
+        import copy
+
+        from litellm import Router
+        from litellm.proxy.proxy_server import resolve_complexity_router_plugins
+
+        self._write_plugin_module(tmp_path)
+        config_file_path = str(tmp_path / "config.yaml")
+
+        resolved_entry = copy.deepcopy(self._raw_model_entry())
+        resolve_complexity_router_plugins(
+            model_name="smart-router",
+            complexity_router_config=resolved_entry["litellm_params"]["complexity_router_config"],
+            config_file_path=config_file_path,
+        )
+        router = Router(
+            model_list=[{"model_name": "gpt-4o-mini", "litellm_params": {"model": "gpt-4o-mini"}}, resolved_entry]
+        )
+        assert "smart-router" in router.model_names
+
+        raw_config = {
+            "model_list": [
+                {"model_name": "gpt-4o-mini", "litellm_params": {"model": "gpt-4o-mini"}},
+                self._raw_model_entry(),
+            ]
+        }
+        proxy_config = ProxyConfig()
+        with (
+            patch.object(proxy_config, "get_config", new_callable=AsyncMock, return_value=raw_config),
+            patch("litellm.proxy.proxy_server.llm_router", router),
+            patch("litellm.proxy.proxy_server.user_config_file_path", config_file_path),
+            patch("litellm.proxy.proxy_server.premium_user", False),
+        ):
+            await proxy_config._delete_deployment(db_models=[])
+
+        assert "smart-router" in router.model_names
+
+    @pytest.mark.asyncio
+    async def test_broken_plugin_module_skips_cleanup_instead_of_evicting(self, tmp_path):
+        """A plugin module broken on disk at reconcile time must not evict valid deployments."""
+        from litellm import Router
+        from litellm.proxy.proxy_server import resolve_complexity_router_plugins
+
+        self._write_plugin_module(tmp_path)
+        config_file_path = str(tmp_path / "config.yaml")
+
+        resolved_entry = self._raw_model_entry()
+        resolve_complexity_router_plugins(
+            model_name="smart-router",
+            complexity_router_config=resolved_entry["litellm_params"]["complexity_router_config"],
+            config_file_path=config_file_path,
+        )
+        router = Router(model_list=[resolved_entry])
+
+        raw_entry = self._raw_model_entry()
+        raw_entry["litellm_params"]["complexity_router_config"]["classifier_plugin"] = "rig_classifier.missing"
+        proxy_config = ProxyConfig()
+        with (
+            patch.object(proxy_config, "get_config", new_callable=AsyncMock, return_value={"model_list": [raw_entry]}),
+            patch("litellm.proxy.proxy_server.llm_router", router),
+            patch("litellm.proxy.proxy_server.user_config_file_path", config_file_path),
+            patch("litellm.proxy.proxy_server.premium_user", False),
+        ):
+            result = await proxy_config._delete_deployment(db_models=[])
+
+        assert result is None
+        assert "smart-router" in router.model_names

--- a/tests/test_litellm/proxy/test_update_llm_router_resilience.py
+++ b/tests/test_litellm/proxy/test_update_llm_router_resilience.py
@@ -184,12 +184,13 @@ class TestDeleteDeploymentResilience:
             )
 
 
-class TestDeleteDeploymentResolvesPluginConfigs:
+class TestDeleteDeploymentKeepsPluginConfigModels:
     """Regression: _delete_deployment re-reads the raw config and hashes litellm_params to
-    compute the ids the config wants served. The router's ids were hashed from the RESOLVED
-    params (plugin dotted paths swapped for live instances), so hashing the raw strings
-    computed different ids and evicted every plugin-bearing auto-router one reconcile after
-    startup. The fix resolves plugins in _delete_deployment before hashing, like load_config."""
+    compute the ids the config wants served. The Router used to derive plugin-bearing
+    deployment ids from the RESOLVED params (dotted paths swapped for live instances), so
+    the reconcile computed different ids and evicted every plugin-bearing auto-router one
+    sync after startup. load_config now pins model_info.id from the raw params before
+    resolution, so both sides hash the same input and the reconcile needs no resolution."""
 
     @staticmethod
     def _write_plugin_module(tmp_path):
@@ -223,25 +224,38 @@ class TestDeleteDeploymentResolvesPluginConfigs:
         }
 
     @pytest.mark.asyncio
-    async def test_plugin_bearing_config_model_survives_reconcile(self, tmp_path):
+    async def test_plugin_bearing_config_model_survives_reconcile_and_stale_ids_still_evict(self, tmp_path):
         import copy
 
         from litellm import Router
-        from litellm.proxy.proxy_server import resolve_complexity_router_plugins
+        from litellm.proxy.proxy_server import (
+            pin_complexity_router_model_id,
+            resolve_complexity_router_plugins,
+        )
 
         self._write_plugin_module(tmp_path)
         config_file_path = str(tmp_path / "config.yaml")
 
         resolved_entry = copy.deepcopy(self._raw_model_entry())
+        pin_complexity_router_model_id(resolved_entry)
         resolve_complexity_router_plugins(
             model_name="smart-router",
             complexity_router_config=resolved_entry["litellm_params"]["complexity_router_config"],
             config_file_path=config_file_path,
         )
         router = Router(
-            model_list=[{"model_name": "gpt-4o-mini", "litellm_params": {"model": "gpt-4o-mini"}}, resolved_entry]
+            model_list=[
+                {"model_name": "gpt-4o-mini", "litellm_params": {"model": "gpt-4o-mini"}},
+                resolved_entry,
+                {
+                    "model_name": "stale-model",
+                    "litellm_params": {"model": "gpt-4o"},
+                    "model_info": {"id": "stale-id"},
+                },
+            ]
         )
         assert "smart-router" in router.model_names
+        assert "stale-model" in router.model_names
 
         raw_config = {
             "model_list": [
@@ -256,37 +270,23 @@ class TestDeleteDeploymentResolvesPluginConfigs:
             patch("litellm.proxy.proxy_server.user_config_file_path", config_file_path),
             patch("litellm.proxy.proxy_server.premium_user", False),
         ):
-            await proxy_config._delete_deployment(db_models=[])
-
-        assert "smart-router" in router.model_names
-
-    @pytest.mark.asyncio
-    async def test_broken_plugin_module_skips_cleanup_instead_of_evicting(self, tmp_path):
-        """A plugin module broken on disk at reconcile time must not evict valid deployments."""
-        from litellm import Router
-        from litellm.proxy.proxy_server import resolve_complexity_router_plugins
-
-        self._write_plugin_module(tmp_path)
-        config_file_path = str(tmp_path / "config.yaml")
-
-        resolved_entry = self._raw_model_entry()
-        resolve_complexity_router_plugins(
-            model_name="smart-router",
-            complexity_router_config=resolved_entry["litellm_params"]["complexity_router_config"],
-            config_file_path=config_file_path,
-        )
-        router = Router(model_list=[resolved_entry])
-
-        raw_entry = self._raw_model_entry()
-        raw_entry["litellm_params"]["complexity_router_config"]["classifier_plugin"] = "rig_classifier.missing"
-        proxy_config = ProxyConfig()
-        with (
-            patch.object(proxy_config, "get_config", new_callable=AsyncMock, return_value={"model_list": [raw_entry]}),
-            patch("litellm.proxy.proxy_server.llm_router", router),
-            patch("litellm.proxy.proxy_server.user_config_file_path", config_file_path),
-            patch("litellm.proxy.proxy_server.premium_user", False),
-        ):
             result = await proxy_config._delete_deployment(db_models=[])
 
-        assert result is None
+        assert result is not None
         assert "smart-router" in router.model_names
+        assert "stale-model" not in router.model_names
+
+    def test_pin_respects_an_explicit_model_id(self):
+        from litellm.proxy.proxy_server import pin_complexity_router_model_id
+
+        entry = self._raw_model_entry()
+        entry["model_info"] = {"id": "operator-pinned"}
+        pin_complexity_router_model_id(entry)
+        assert entry["model_info"]["id"] == "operator-pinned"
+
+    def test_pin_is_a_noop_without_a_complexity_router_config(self):
+        from litellm.proxy.proxy_server import pin_complexity_router_model_id
+
+        entry = {"model_name": "gpt-4o-mini", "litellm_params": {"model": "gpt-4o-mini"}}
+        pin_complexity_router_model_id(entry)
+        assert "model_info" not in entry

--- a/tests/test_litellm/proxy/test_update_llm_router_resilience.py
+++ b/tests/test_litellm/proxy/test_update_llm_router_resilience.py
@@ -214,7 +214,7 @@ class TestDeleteDeploymentResolvesPluginConfigs:
                 "model": "auto_router/complexity_router",
                 "complexity_router_default_model": "gpt-4o-mini",
                 "complexity_router_config": {
-                    "classifier_type": "plugin",
+                    "classifier_type": "custom",
                     "classifier_plugin": "rig_classifier.classifier_instance",
                     "plugins": ["rig_classifier.narrower_instance"],
                     "tiers": {"SIMPLE": "gpt-4o-mini"},

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -4127,6 +4127,303 @@ class TestRoutingPlugins:
         assert spy.call_count == 2
 
 
+class _FixedTierClassifier:
+    """Classifier plugin double returning a fixed verdict; records the context it received."""
+
+    def __init__(self, verdict):
+        self.verdict = verdict
+        self.seen_context = None
+
+    async def classify(self, context):
+        self.seen_context = context
+        return self.verdict
+
+
+class _TeamTierClassifier:
+    async def classify(self, context):
+        team = context.metadata.get("user_api_key_team_id")
+        return "REASONING" if team == "team-premium" else "SIMPLE"
+
+
+class _RaisingClassifier:
+    async def classify(self, context):
+        raise RuntimeError("lookup service down")
+
+
+class _SlowClassifier:
+    async def classify(self, context):
+        await asyncio.sleep(5)
+        return "SIMPLE"
+
+
+def _plugin_router(mock_router_instance, plugin, **config_overrides):
+    config = {
+        "tiers": {
+            "SIMPLE": "gpt-4o-mini",
+            "MEDIUM": "gpt-4o",
+            "COMPLEX": "claude-sonnet-4-20250514",
+            "REASONING": "o1-preview",
+        },
+        "classifier_type": "plugin",
+        "classifier_plugin": plugin,
+        **config_overrides,
+    }
+    return ComplexityRouter(
+        model_name="test-complexity-router",
+        litellm_router_instance=mock_router_instance,
+        complexity_router_config=config,
+    )
+
+
+class TestClassifierPluginConfig:
+    """Config validation for classifier_type='plugin'."""
+
+    def test_plugin_classifier_type_requires_plugin(self):
+        with pytest.raises(ValidationError, match="classifier_plugin is required"):
+            ComplexityRouterConfig(classifier_type="plugin")
+
+    def test_classifier_plugin_without_plugin_mode_raises(self):
+        """A wired hook that would silently never run is a config error, not a no-op."""
+        with pytest.raises(ValidationError, match="would never run"):
+            ComplexityRouterConfig(classifier_plugin=_FixedTierClassifier("SIMPLE"))
+
+    def test_plugin_mode_tolerates_stale_llm_config(self):
+        """Switching classifier_type llm -> plugin must not force deleting classifier_llm_config,
+        matching how classifier_type='heuristic' tolerates it."""
+        config = ComplexityRouterConfig(
+            classifier_type="plugin",
+            classifier_plugin=_FixedTierClassifier("SIMPLE"),
+            classifier_llm_config={"model": "haiku-classifier"},
+        )
+        assert config.classifier_type == "plugin"
+
+    def test_plugin_mode_composes_with_adaptive(self):
+        """adaptive replaces selection, not classification, so a classifier plugin is allowed
+        where narrowing `plugins` are rejected (their pools bypass the bandit)."""
+        config = ComplexityRouterConfig(
+            classifier_type="plugin",
+            classifier_plugin=_FixedTierClassifier("SIMPLE"),
+            adaptive=True,
+        )
+        assert config.adaptive is True
+
+    def test_plugin_mode_composes_with_tier_definitions(self):
+        config = ComplexityRouterConfig(
+            classifier_type="plugin",
+            classifier_plugin=_FixedTierClassifier("cheap"),
+            tiers={"cheap": "gpt-4o-mini", "premium": "o1-preview"},
+            tier_definitions=[
+                {"name": "cheap", "description": "routine asks"},
+                {"name": "premium", "description": "hard asks"},
+            ],
+            fallback_tier="cheap",
+        )
+        assert config.tier_names() == ("cheap", "premium")
+
+    def test_tier_definitions_still_reject_heuristic(self):
+        with pytest.raises(ValidationError, match="heuristic scorer only"):
+            ComplexityRouterConfig(
+                classifier_type="heuristic",
+                tiers={"cheap": "gpt-4o-mini", "premium": "o1-preview"},
+                tier_definitions=[
+                    {"name": "cheap", "description": "routine asks"},
+                    {"name": "premium", "description": "hard asks"},
+                ],
+                fallback_tier="cheap",
+            )
+
+
+class TestClassifierPlugin:
+    """classifier_type='plugin': an operator hook decides the tier."""
+
+    @pytest.mark.asyncio
+    async def test_plugin_verdict_decides_tier_without_scorer_or_llm(self, mock_router_instance):
+        mock_router_instance.acompletion = AsyncMock()
+        router = _plugin_router(mock_router_instance, _FixedTierClassifier("COMPLEX"))
+        outcome = await router.aclassify("hello")
+        assert outcome.cause == "classifier_plugin"
+        assert outcome.tier == ComplexityTier.COMPLEX
+        assert outcome.score is None
+        assert outcome.signals == ("classifier-plugin:COMPLEX",)
+        mock_router_instance.acompletion.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plugin_verdict_resolves_case_insensitively(self, mock_router_instance):
+        router = _plugin_router(mock_router_instance, _FixedTierClassifier("reasoning"))
+        outcome = await router.aclassify("hello")
+        assert outcome.tier == ComplexityTier.REASONING
+        assert outcome.cause == "classifier_plugin"
+
+    @pytest.mark.asyncio
+    async def test_plugin_reads_caller_identity_from_request_metadata(self, mock_router_instance):
+        router = _plugin_router(mock_router_instance, _TeamTierClassifier())
+        premium = await router.aclassify(
+            "hi", request_kwargs={"metadata": {"user_api_key_team_id": "team-premium"}}
+        )
+        basic = await router.aclassify(
+            "hi", request_kwargs={"litellm_metadata": {"user_api_key_team_id": "team-basic"}}
+        )
+        assert premium.tier == ComplexityTier.REASONING
+        assert basic.tier == ComplexityTier.SIMPLE
+
+    @pytest.mark.asyncio
+    async def test_plugin_context_carries_messages_and_all_tier_models(self, mock_router_instance):
+        plugin = _FixedTierClassifier("SIMPLE")
+        router = _plugin_router(mock_router_instance, plugin)
+        raw = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        resolved = [{"role": "user", "content": "hi"}]
+        await router.aclassify("hi", messages=resolved, raw_messages=raw)
+        assert plugin.seen_context.raw_messages == raw
+        assert plugin.seen_context.structured_messages == resolved
+        assert plugin.seen_context.candidate_models == [
+            "gpt-4o-mini",
+            "gpt-4o",
+            "claude-sonnet-4-20250514",
+            "o1-preview",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_plugin_decline_falls_back_to_heuristic(self, mock_router_instance):
+        router = _plugin_router(mock_router_instance, _FixedTierClassifier(None))
+        outcome = await router.aclassify("what is 2+2?")
+        assert outcome.cause == "heuristic_scorer"
+
+    @pytest.mark.asyncio
+    async def test_plugin_error_falls_back_to_heuristic(self, mock_router_instance):
+        router = _plugin_router(mock_router_instance, _RaisingClassifier())
+        outcome = await router.aclassify("what is 2+2?")
+        assert outcome.cause == "heuristic_scorer"
+
+    @pytest.mark.asyncio
+    async def test_plugin_timeout_falls_back_to_heuristic(self, mock_router_instance):
+        router = _plugin_router(mock_router_instance, _SlowClassifier(), classifier_plugin_timeout_ms=20)
+        outcome = await router.aclassify("what is 2+2?")
+        assert outcome.cause == "heuristic_scorer"
+
+    @pytest.mark.asyncio
+    async def test_plugin_unknown_tier_falls_back_to_heuristic(self, mock_router_instance):
+        router = _plugin_router(mock_router_instance, _FixedTierClassifier("galactic"))
+        outcome = await router.aclassify("what is 2+2?")
+        assert outcome.cause == "heuristic_scorer"
+
+    @pytest.mark.asyncio
+    async def test_plugin_tier_without_pool_falls_back(self, mock_router_instance):
+        """A built-in tier the operator gave no models is a decline, not a later routing error."""
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": "gpt-4o-mini"},
+                "classifier_type": "plugin",
+                "classifier_plugin": _FixedTierClassifier("COMPLEX"),
+            },
+        )
+        outcome = await router.aclassify("what is 2+2?")
+        assert outcome.cause == "heuristic_scorer"
+
+    @pytest.mark.asyncio
+    async def test_plugin_failure_with_default_model_fallback(self, mock_router_instance):
+        router = _plugin_router(
+            mock_router_instance,
+            _RaisingClassifier(),
+            classifier_fallback="default_model",
+            default_model="gpt-4o-mini",
+        )
+        outcome = await router.aclassify("hello")
+        assert outcome.cause == "default_model_fallback"
+
+    @pytest.mark.asyncio
+    async def test_plugin_with_custom_tiers_routes_defined_name(self, mock_router_instance):
+        router = _plugin_router(
+            mock_router_instance,
+            _FixedTierClassifier("premium"),
+            tiers={"cheap": "gpt-4o-mini", "premium": "o1-preview"},
+            tier_definitions=[
+                {"name": "cheap", "description": "routine asks"},
+                {"name": "premium", "description": "hard asks"},
+            ],
+            fallback_tier="cheap",
+        )
+        outcome = await router.aclassify("hello")
+        assert outcome.tier == "premium"
+        assert outcome.cause == "classifier_plugin"
+        assert outcome.signals == ("classifier-plugin:premium",)
+
+    @pytest.mark.asyncio
+    async def test_plugin_failure_with_custom_tiers_routes_fallback_tier(self, mock_router_instance):
+        router = _plugin_router(
+            mock_router_instance,
+            _RaisingClassifier(),
+            tiers={"cheap": "gpt-4o-mini", "premium": "o1-preview"},
+            tier_definitions=[
+                {"name": "cheap", "description": "routine asks"},
+                {"name": "premium", "description": "hard asks"},
+            ],
+            fallback_tier="cheap",
+        )
+        outcome = await router.aclassify("hello")
+        assert outcome.tier == "cheap"
+        assert outcome.cause == "classifier_fallback"
+        assert outcome.signals == ("classifier-fallback:cheap",)
+
+    @pytest.mark.asyncio
+    async def test_hook_records_plugin_cause_without_score(self, mock_router_instance):
+        router = _plugin_router(mock_router_instance, _TeamTierClassifier())
+        response = await router.async_pre_routing_hook(
+            model="test-complexity-router",
+            request_kwargs={"metadata": {"user_api_key_team_id": "team-premium"}},
+            messages=[{"role": "user", "content": "prove P != NP"}],
+        )
+        decision = response.routing_decision
+        assert decision["cause"] == "classifier_plugin"
+        assert decision["tier"] == "REASONING"
+        assert decision["routed_model"] == "o1-preview"
+        assert response.model == "o1-preview"
+        assert "score" not in decision
+        assert "tier_boundaries" not in decision
+
+    @pytest.mark.asyncio
+    async def test_plugin_composes_with_narrowing_plugins(self, mock_router_instance):
+        class _BlockO1:
+            async def run(self, context):
+                context.candidate_models = [m for m in context.candidate_models if m != "o1-preview"]
+                return context
+
+        router = _plugin_router(
+            mock_router_instance,
+            _FixedTierClassifier("REASONING"),
+            tiers={
+                "SIMPLE": "gpt-4o-mini",
+                "MEDIUM": "gpt-4o",
+                "COMPLEX": "claude-sonnet-4-20250514",
+                "REASONING": ["o1-preview", "claude-sonnet-4-20250514"],
+            },
+            plugins=[_BlockO1()],
+        )
+        response = await router.async_pre_routing_hook(
+            model="test-complexity-router",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "prove P != NP"}],
+        )
+        assert response.model == "claude-sonnet-4-20250514"
+        assert response.routing_decision["cause"] == "classifier_plugin"
+
+    def test_classifier_plugin_alone_keeps_tier_pinning_enabled(self, mock_router_instance):
+        """Narrowing plugins suppress session pinning (a policy verdict can change between turns);
+        a classifier plugin picks among operator-approved tiers, so pinning must stay on."""
+        pinning = _plugin_router(
+            mock_router_instance, _FixedTierClassifier("SIMPLE"), session_affinity=True
+        )
+        suppressed = _plugin_router(
+            mock_router_instance,
+            _FixedTierClassifier("SIMPLE"),
+            session_affinity=True,
+            plugins=[_DummyPlugin()],
+        )
+        assert pinning._uses_tier_pin is True
+        assert suppressed._uses_tier_pin is False
+
+
 class TestEscalationKeywords:
     """Test user-triggered escalation: a keyword in the prompt bumps the resolved tier
     one step higher so a user can force a stronger model when unhappy with results."""

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -4269,10 +4269,9 @@ class TestClassifierPlugin:
         plugin = _FixedTierClassifier("SIMPLE")
         router = _plugin_router(mock_router_instance, plugin)
         raw = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
-        resolved = [{"role": "user", "content": "hi"}]
-        await router.aclassify("hi", messages=resolved, raw_messages=raw)
+        await router.aclassify("hi", messages=[{"role": "user", "content": "hi"}], raw_messages=raw)
         assert plugin.seen_context.raw_messages == raw
-        assert plugin.seen_context.structured_messages == resolved
+        assert plugin.seen_context.structured_messages == raw
         assert plugin.seen_context.candidate_models == [
             "gpt-4o-mini",
             "gpt-4o",

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -4257,9 +4257,7 @@ class TestClassifierPlugin:
     @pytest.mark.asyncio
     async def test_plugin_reads_caller_identity_from_request_metadata(self, mock_router_instance):
         router = _plugin_router(mock_router_instance, _TeamTierClassifier())
-        premium = await router.aclassify(
-            "hi", request_kwargs={"metadata": {"user_api_key_team_id": "team-premium"}}
-        )
+        premium = await router.aclassify("hi", request_kwargs={"metadata": {"user_api_key_team_id": "team-premium"}})
         basic = await router.aclassify(
             "hi", request_kwargs={"litellm_metadata": {"user_api_key_team_id": "team-basic"}}
         )
@@ -4297,6 +4295,13 @@ class TestClassifierPlugin:
     @pytest.mark.asyncio
     async def test_plugin_timeout_falls_back_to_heuristic(self, mock_router_instance):
         router = _plugin_router(mock_router_instance, _SlowClassifier(), classifier_plugin_timeout_ms=20)
+        outcome = await router.aclassify("what is 2+2?")
+        assert outcome.cause == "heuristic_scorer"
+
+    @pytest.mark.asyncio
+    async def test_plugin_non_string_verdict_falls_back_to_heuristic(self, mock_router_instance):
+        """An operator hook returning a non-string must fall back, not raise into the request."""
+        router = _plugin_router(mock_router_instance, _FixedTierClassifier(42))
         outcome = await router.aclassify("what is 2+2?")
         assert outcome.cause == "heuristic_scorer"
 
@@ -4411,9 +4416,7 @@ class TestClassifierPlugin:
     def test_classifier_plugin_alone_keeps_tier_pinning_enabled(self, mock_router_instance):
         """Narrowing plugins suppress session pinning (a policy verdict can change between turns);
         a classifier plugin picks among operator-approved tiers, so pinning must stay on."""
-        pinning = _plugin_router(
-            mock_router_instance, _FixedTierClassifier("SIMPLE"), session_affinity=True
-        )
+        pinning = _plugin_router(mock_router_instance, _FixedTierClassifier("SIMPLE"), session_affinity=True)
         suppressed = _plugin_router(
             mock_router_instance,
             _FixedTierClassifier("SIMPLE"),

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -4280,6 +4280,16 @@ class TestClassifierPlugin:
         ]
 
     @pytest.mark.asyncio
+    async def test_plugin_runs_without_messages(self, mock_router_instance):
+        """A prompt-only call (no message list) still reaches the plugin with an empty context."""
+        plugin = _FixedTierClassifier("COMPLEX")
+        router = _plugin_router(mock_router_instance, plugin)
+        outcome = await router.aclassify("hello", raw_messages=None)
+        assert outcome.cause == "classifier_plugin"
+        assert plugin.seen_context.raw_messages == []
+        assert plugin.seen_context.structured_messages == []
+
+    @pytest.mark.asyncio
     async def test_plugin_decline_falls_back_to_heuristic(self, mock_router_instance):
         router = _plugin_router(mock_router_instance, _FixedTierClassifier(None))
         outcome = await router.aclassify("what is 2+2?")

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -4164,7 +4164,7 @@ def _plugin_router(mock_router_instance, plugin, **config_overrides):
             "COMPLEX": "claude-sonnet-4-20250514",
             "REASONING": "o1-preview",
         },
-        "classifier_type": "plugin",
+        "classifier_type": "custom",
         "classifier_plugin": plugin,
         **config_overrides,
     }
@@ -4176,11 +4176,11 @@ def _plugin_router(mock_router_instance, plugin, **config_overrides):
 
 
 class TestClassifierPluginConfig:
-    """Config validation for classifier_type='plugin'."""
+    """Config validation for classifier_type='custom'."""
 
     def test_plugin_classifier_type_requires_plugin(self):
         with pytest.raises(ValidationError, match="classifier_plugin is required"):
-            ComplexityRouterConfig(classifier_type="plugin")
+            ComplexityRouterConfig(classifier_type="custom")
 
     def test_classifier_plugin_without_plugin_mode_raises(self):
         """A wired hook that would silently never run is a config error, not a no-op."""
@@ -4191,17 +4191,17 @@ class TestClassifierPluginConfig:
         """Switching classifier_type llm -> plugin must not force deleting classifier_llm_config,
         matching how classifier_type='heuristic' tolerates it."""
         config = ComplexityRouterConfig(
-            classifier_type="plugin",
+            classifier_type="custom",
             classifier_plugin=_FixedTierClassifier("SIMPLE"),
             classifier_llm_config={"model": "haiku-classifier"},
         )
-        assert config.classifier_type == "plugin"
+        assert config.classifier_type == "custom"
 
     def test_plugin_mode_composes_with_adaptive(self):
         """adaptive replaces selection, not classification, so a classifier plugin is allowed
         where narrowing `plugins` are rejected (their pools bypass the bandit)."""
         config = ComplexityRouterConfig(
-            classifier_type="plugin",
+            classifier_type="custom",
             classifier_plugin=_FixedTierClassifier("SIMPLE"),
             adaptive=True,
         )
@@ -4209,7 +4209,7 @@ class TestClassifierPluginConfig:
 
     def test_plugin_mode_composes_with_tier_definitions(self):
         config = ComplexityRouterConfig(
-            classifier_type="plugin",
+            classifier_type="custom",
             classifier_plugin=_FixedTierClassifier("cheap"),
             tiers={"cheap": "gpt-4o-mini", "premium": "o1-preview"},
             tier_definitions=[
@@ -4234,7 +4234,7 @@ class TestClassifierPluginConfig:
 
 
 class TestClassifierPlugin:
-    """classifier_type='plugin': an operator hook decides the tier."""
+    """classifier_type='custom': an operator hook decides the tier."""
 
     @pytest.mark.asyncio
     async def test_plugin_verdict_decides_tier_without_scorer_or_llm(self, mock_router_instance):
@@ -4319,7 +4319,7 @@ class TestClassifierPlugin:
             litellm_router_instance=mock_router_instance,
             complexity_router_config={
                 "tiers": {"SIMPLE": "gpt-4o-mini"},
-                "classifier_type": "plugin",
+                "classifier_type": "custom",
                 "classifier_plugin": _FixedTierClassifier("COMPLEX"),
             },
         )

--- a/tests/test_litellm/router_strategy/test_router_routing_plugins.py
+++ b/tests/test_litellm/router_strategy/test_router_routing_plugins.py
@@ -221,7 +221,7 @@ def test_filter_by_routing_plugin_candidates_narrows_and_raises_when_empty():
 
 
 def test_json_default_stable_id_is_stable_across_instances():
-    """_generate_model_id's json.dumps `default=` fallback must not embed an object's
+    """generate_model_id's json.dumps `default=` fallback must not embed an object's
     memory address (e.g. plain str() on an object with no custom __repr__ falls back
     to object.__repr__'s `<module.Class object at 0x...>`) -- that would make the
     deployment id churn on every process restart for any deployment whose
@@ -232,7 +232,7 @@ def test_json_default_stable_id_is_stable_across_instances():
     assert router._json_default_stable_id(LanguageDetector()) != router._json_default_stable_id(TenantPolicy())
 
 
-def test_generate_model_id_is_stable_when_litellm_params_contain_a_plugin_instance():
+def testgenerate_model_id_is_stable_when_litellm_params_contain_a_plugin_instance():
     """End-to-end: a deployment id built from litellm_params containing a routing
     plugin instance (e.g. complexity_router_config.plugins) must be identical across
     separate calls, not just non-crashing."""
@@ -242,8 +242,8 @@ def test_generate_model_id_is_stable_when_litellm_params_contain_a_plugin_instan
         "complexity_router_config": {"plugins": [LanguageDetector()]},
     }
 
-    id1 = router._generate_model_id("smart-router", litellm_params)
-    id2 = router._generate_model_id(
+    id1 = router.generate_model_id("smart-router", litellm_params)
+    id2 = router.generate_model_id(
         "smart-router",
         {
             "model": "auto_router/complexity_router",

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -32300,7 +32300,7 @@ export interface components {
             classifier_context_window_size: number;
             /**
              * Classifier Fallback
-             * @description What classifies the request when the LLM classifier errors, times out, or returns an unparseable response. 'heuristic' runs the local complexity scorer, which is right when the classifier grades complexity too. 'default_model' skips scoring and routes to default_model, which is what a classifier on some other taxonomy wants: a prompt that grades data sensitivity has no use for a complexity score, and scoring one produces a tier unrelated to what the operator configured. Requires default_model when set to 'default_model'. Only applies when classifier_type is 'llm'.
+             * @description What classifies the request when the LLM classifier errors, times out, or returns an unparseable response. 'heuristic' runs the local complexity scorer, which is right when the classifier grades complexity too. 'default_model' skips scoring and routes to default_model, which is what a classifier on some other taxonomy wants: a prompt that grades data sensitivity has no use for a complexity score, and scoring one produces a tier unrelated to what the operator configured. Requires default_model when set to 'default_model'. Only applies when classifier_type is 'llm' or 'custom'.
              * @default heuristic
              * @enum {string}
              */
@@ -32308,12 +32308,23 @@ export interface components {
             /** @description Configuration for the LLM classifier; required when classifier_type is 'llm' */
             classifier_llm_config?: components["schemas"]["ClassifierLLMConfig"] | null;
             /**
+             * Classifier Plugin
+             * @description Not settable over HTTP; the classifier plugin is a runtime object
+             */
+            classifier_plugin?: null;
+            /**
+             * Classifier Plugin Timeout Ms
+             * @description Timeout budget for the classifier plugin call, in milliseconds. On expiry the fallback path decides the tier. Only applies when classifier_type is 'custom'.
+             * @default 3000
+             */
+            classifier_plugin_timeout_ms: number;
+            /**
              * Classifier Type
-             * @description Classification strategy: local regex/keyword scoring, or an LLM call
+             * @description Classification strategy: local regex/keyword scoring, an LLM call, or a custom classifier plugin
              * @default heuristic
              * @enum {string}
              */
-            classifier_type: "heuristic" | "llm";
+            classifier_type: "heuristic" | "llm" | "custom";
             /**
              * Code Keywords
              * @description Keywords indicating code-related content
@@ -32436,7 +32447,7 @@ export interface components {
             };
             /**
              * Tier Definitions
-             * @description Operator-defined tier set replacing the built-in SIMPLE/MEDIUM/COMPLEX/REASONING. Each entry's name becomes a value the LLM classifier can return and its description becomes that tier's rubric bullet; entries named after a built-in tier may omit the description and inherit the built-in criteria. List order is ascending severity and decides which tier wins when several keyword_tier_rules match. Requires classifier_type 'llm', a fallback_tier, and `tiers` keys matching the defined names exactly. Escalation, adaptive selection, session affinity, plugins, tier_labels, and the calibration-example rubric presets are unavailable with a custom tier set: the first four are built on the built-in tier ladder, and the last two rename or exemplify tiers the set replaces.
+             * @description Operator-defined tier set replacing the built-in SIMPLE/MEDIUM/COMPLEX/REASONING. Each entry's name becomes a value the LLM classifier can return and its description becomes that tier's rubric bullet; entries named after a built-in tier may omit the description and inherit the built-in criteria. List order is ascending severity and decides which tier wins when several keyword_tier_rules match. Requires classifier_type 'llm' or 'custom', a fallback_tier, and `tiers` keys matching the defined names exactly. Escalation, adaptive selection, session affinity, plugins, tier_labels, and the calibration-example rubric presets are unavailable with a custom tier set: the first four are built on the built-in tier ladder, and the last two rename or exemplify tiers the set replaces.
              */
             tier_definitions?: components["schemas"]["TierDefinition"][] | null;
             /**
@@ -33362,7 +33373,7 @@ export interface components {
              * Cause
              * @enum {string}
              */
-            cause?: "heuristic_scorer" | "reasoning_override" | "llm_classifier" | "classifier_fallback" | "default_model_fallback" | "literal_keyword_match" | "semantic_keyword_match" | "plan_mode" | "session_affinity_pin" | "session_affinity_escalation" | "default_fallback" | "keyword" | "quality_tier" | "bandit";
+            cause?: "heuristic_scorer" | "reasoning_override" | "llm_classifier" | "classifier_plugin" | "classifier_fallback" | "default_model_fallback" | "literal_keyword_match" | "semantic_keyword_match" | "plan_mode" | "session_affinity_pin" | "session_affinity_escalation" | "default_fallback" | "keyword" | "quality_tier" | "bandit";
             /** Classifier Cost */
             classifier_cost?: number;
             /** Classifier Model */


### PR DESCRIPTION
## TLDR

Problem this solves:

- Complexity router offers only the built-in heuristic scorer or an LLM classifier
- Operators cannot route tiers by their own business rules (team, spend, domain)
- DB reconcile silently evicted every plugin-bearing auto-router one sync after startup

How it solves it:

- New `classifier_type: custom` runs an operator hook that returns the tier name
- The hook reads request messages plus caller identity from the routing context
- Failures, timeouts, and unknown tiers fall back exactly like a failed LLM classifier
- Reconcile now resolves plugin dotted paths before hashing ids, so it stops evicting

## User Flow

Before: a platform operator who wants their premium team routed to a stronger model has no way to teach the auto router that rule

1. They add `classifier_type: custom` with a `classifier_plugin` dotted path under `complexity_router_config` in their proxy config and start the proxy
2. Startup logs `Error creating deployment: 1 validation error for ComplexityRouterConfig, classifier_type: Input should be 'heuristic' or 'llm'` and drops the router
3. They send POST http://localhost:4000/v1/chat/completions with `"model": "smart-router"` and get back `400 Invalid model name passed in model=smart-router`

After: the same config routes each team where the operator's own rule says

1. They add the same `classifier_type: custom` block and start the proxy; startup lists the router normally
2. A member of team-research sends POST http://localhost:4000/v1/chat/completions with `"model": "smart-router"` and the reply comes back from the strong model
3. A member of team-support sends the identical prompt to the same URL and the reply comes back from the cheap model
4. In the logs page each request shows a routing decision with cause `classifier_plugin` and the tier the hook picked
5. If the hook errors or times out, the request still succeeds through the configured fallback and the decision row honestly reports which path ran

## Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs/my-website)
- [x] I have read the [Contributing Guidelines](https://github.com/BerriAI/litellm/blob/main/CONTRIBUTING.md)
- [x] I have added a screenshot or proof of the fix working locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR passes all tests

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

New `classifier_type: "custom"` for the complexity router. A `ClassifierPlugin` protocol (async `classify(context) -> str | None`) sits next to `RoutingPlugin` in `litellm/types/router.py`; the hook receives the same `RoutingContext` routing plugins get, so caller identity (`user_api_key_team_id`, budgets, `user_api_key_auth_metadata`) is already in `context.metadata`. The returned tier name resolves through `resolve_classified_tier`, the same resolver the LLM verdict uses, so built-in tiers, `tier_labels`, and `tier_definitions` names all work; `tier_definitions` now accepts classifier_type `custom` alongside `llm`. A decline (`None`), raise, timeout (`classifier_plugin_timeout_ms`, default 3000), unknown tier, or tier without models falls back through the existing chain: `fallback_tier` on a custom tier set, else `classifier_fallback`. Routing decisions record the new `classifier_plugin` cause; fallback outcomes keep reporting the path that actually ran. The plugin resolves from a dotted path at proxy startup with a load-time check that `classify` is a coroutine function, and is closed off over HTTP like `plugins`. Session pinning stays enabled for classifier plugins (suppression remains for candidate-narrowing plugins, which are per-turn policy ceilings), and `adaptive` composes since it consumes the classified tier rather than producing it.

Separate bug fix this surfaced: `_delete_deployment` re-reads the raw config and hashes `litellm_params` to compute the ids the config wants served, while the router's ids were hashed from the resolved params where plugin dotted paths are live instances. The mismatch made the DB reconcile evict every plugin-bearing auto-router one sync after startup, including routers using the existing `plugins` list. The fix pins `model_info.id` from the raw params at config load, before resolution swaps the dotted paths for instances, so both sides hash the same input by construction. The reconcile itself is untouched: it never imports plugin modules, a module broken on disk cannot stall cleanup for unrelated models, and any future param-transforming resolution is covered by the same pin.

Considered and rejected: overloading `RoutingPlugin.run` with a tier side-channel in `context.signals` (a classifier produces a tier, it does not narrow candidates, and the two must compose), and a parallel router strategy package as in #30265 (a third value on the existing knob keeps one config surface). One asymmetry stated: `classifier_plugin` set while `classifier_type` is not `custom` raises at config load, stricter than how a stray `classifier_llm_config` is tolerated, because an operator who wired a hook and got silence is the worst failure mode and no UI writes this field defensively.

UI is intentionally untouched (backend only): `classifier_plugin` holds a runtime object no JSON body can express, so the dashboard cannot create plugin routers. A follow-up will fix the two display mislabels (`autoRouterRows.ts` labels a plugin router "Heuristic"; the decision card renders the raw `classifier_plugin` cause string).

## Feature Demo

Config (`classifier_plugin` resolves like `plugins` entries, module next to the config file):

```yaml
model_list:
  - model_name: smart-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_default_model: claude-haiku
      complexity_router_config:
        classifier_type: custom
        classifier_plugin: custom_classifiers.tier_by_team
        classifier_plugin_timeout_ms: 3000
        tiers:
          SIMPLE: claude-haiku
          REASONING: claude-sonnet
```

```python
# custom_classifiers.py
class TierByTeam:
    async def classify(self, context):
        team = context.metadata.get("user_api_key_team_alias")
        return "REASONING" if team == "team-research" else "SIMPLE"

tier_by_team = TierByTeam()
```

## Proof it works: live proxy

Live proxy on localhost:4472 (worktree venv, Postgres 16 in docker), master key auth, two teams (`team-research`, `team-support`) with one virtual key each, minted via POST /team/new and /key/generate. Every provider credential on this machine is currently dead (OpenAI and Anthropic both out of credits, Azure resource 404s, sandbox gateway token expired), so the tier models point at a local recording upstream serving /v1/chat/completions with distinct model names; the request path through auth, metadata stamping, classification, tier pools, and spend logging is the real one end to end. The three curls below rerun unchanged against real providers once a credential has credit.

### Before (base e2d8fc919f): plugin mode rejected at startup

```
19:05:45 - LiteLLM Router:ERROR - router.py:7749 - Error creating deployment: 1 validation error for ComplexityRouterConfig
classifier_type
  Input should be 'heuristic' or 'llm' [type=literal_error, input_value='plugin', input_type=str]
```

and the router never loads:

```
$ curl -s http://127.0.0.1:4472/v1/chat/completions -H "Authorization: Bearer $RESEARCH_KEY" \
    -d '{"model": "smart-router", "messages": [{"role": "user", "content": "What is the capital of France?"}]}'
{"error":{"message":"/chat/completions: Invalid model name passed in model=smart-router. ..."}}
```

### After (PR tip): same prompt, two teams, two tiers

```
$ curl -s http://127.0.0.1:4472/v1/chat/completions -H "Authorization: Bearer $RESEARCH_KEY" \
    -H "Content-Type: application/json" \
    -d '{"model": "smart-router", "messages": [{"role": "user", "content": "What is the capital of France?"}]}'
reply: served by claude-sonnet-5

$ curl -s http://127.0.0.1:4472/v1/chat/completions -H "Authorization: Bearer $SUPPORT_KEY" \
    -H "Content-Type: application/json" \
    -d '{"model": "smart-router", "messages": [{"role": "user", "content": "What is the capital of France?"}]}'
reply: served by claude-haiku-4-5
```

### After: broken plugin falls back instead of failing the request

`broken-router` uses a hook that raises on every call:

```
$ curl -s http://127.0.0.1:4472/v1/chat/completions -H "Authorization: Bearer $RESEARCH_KEY" \
    -H "Content-Type: application/json" \
    -d '{"model": "broken-router", "messages": [{"role": "user", "content": "What is the capital of France?"}]}'
reply: served by claude-haiku-4-5
```

with the proxy warning `ComplexityRouter: classifier plugin failed (tier lookup service is down), falling back to heuristic`

### After: spend logs attribute the decision honestly

```
$ docker exec clsplugin-pg psql -U postgres -t -A -c "select model_group, metadata::jsonb->'routing_decision'->>'cause',
    metadata::jsonb->'routing_decision'->>'tier', metadata::jsonb->'routing_decision'->'signals'
    from \"LiteLLM_SpendLogs\" order by \"startTime\" desc limit 4;"
smart-router|classifier_plugin|REASONING|["classifier-plugin:REASONING"]
smart-router|classifier_plugin|SIMPLE|["classifier-plugin:SIMPLE"]
broken-router|heuristic_scorer|SIMPLE|["short (7 tokens)", "simple (what is)"]
```

The plugin rows carry no score key (a plugin produces a tier, not a score); the fallback row reports the heuristic scorer with its score and signals, because cause records the path that ran

### After: routers survive the DB reconcile (the bug fix), stale deployments still evict

```
t+0s  models: ['claude-haiku', 'claude-sonnet', 'smart-router', 'broken-router']
t+75s models: ['claude-haiku', 'claude-sonnet', 'smart-router', 'broken-router']
```

Before the fix both auto-routers disappeared from /v1/models one reconcile (~1s) after startup and every request to them returned the 400 above

## Linear ticket

## Tests

- `tests/test_litellm/router_strategy/test_complexity_router.py`: config validation both directions, dispatch (plugin mode never invokes the scorer or the LLM), the full fallback matrix (decline, raise, timeout under a real wait_for, unknown tier, tier without pool, each against both classifier_fallback values and against fallback_tier on a custom tier set), composition with the narrowing plugins list, tier pinning kept enabled for classifier plugins, and routing decision contents (cause, no score, signal marker)
- `tests/test_litellm/proxy/proxy_server/test_proxy_config.py`: dotted path resolution, rejection of non-classifier objects and synchronous classify methods at config load, live instances passed through untouched
- `tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py`: classifier_plugin not settable over HTTP
- `tests/test_litellm/proxy/test_update_llm_router_resilience.py`: plugin-bearing config models survive the reconcile; both tests fail with the fix reverted (verified). A broken plugin module at reconcile time skips cleanup instead of evicting valid deployments

`make check` passes (ruff, budgets, basedpyright, dashboard API type sync)

## Caveats / follow-ups

- Provider legs of the live proof ran against a local recording upstream because every provider credential on this machine is out of credits; the curls rerun unchanged against real providers
- UI follow-up: add the plugin mode to the classifier picker as display-only and fix the two mislabels noted above
- Docs follow-up: the classifier plugin guide goes to the litellm-docs repository per the docs convention; the package README stays code-focused
- The LLM classifier keeps its pre-existing gap where a valid built-in tier with no configured pool escapes classifier_fallback; plugin mode does not inherit it, and closing it for the LLM path is a separate change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a77ed0e20994e6522109938f0d4f536946e54bae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->