### PR TITLE
feat(ui): add Ultra Lite heuristic auto-router preset

### DIFF
--- a/ui/litellm-dashboard/src/autorouter_presets.json
+++ b/ui/litellm-dashboard/src/autorouter_presets.json
@@ -52,5 +52,21 @@
       "session_affinity": false,
       "deployment_affinity": true
     }
+  },
+  "ultra_lite": {
+    "label": "Ultra Lite",
+    "description": "Cost-optimized routing across providers with no classifier call: DeepSeek V4 Flash for simple queries, MiniMax M3 for medium, DeepSeek V4 Pro for complex, Kimi K3 for reasoning-heavy requests. The heuristic scorer assigns tiers locally, so routing adds no per-request classification spend or latency.",
+    "complexity_router_config": {
+      "tiers": {
+        "SIMPLE": ["deepseek-v4-flash"],
+        "MEDIUM": ["minimax-m3"],
+        "COMPLEX": ["deepseek-v4-pro"],
+        "REASONING": ["kimi-k3"]
+      },
+      "classifier_type": "heuristic",
+      "escalation_keywords": ["LITELLM ESCALATE"],
+      "session_affinity": false,
+      "deployment_affinity": true
+    }
   }
 }

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -356,7 +356,7 @@ describe("AddAutoRouterTab", () => {
 
     const labels = visibleOptions().map((option) => option.querySelector(".font-medium")?.textContent);
 
-    expect(labels).toEqual(["Anthropic Family", "Lite", "OpenAI Family", "Custom Configuration"]);
+    expect(labels).toEqual(["Anthropic Family", "Lite", "OpenAI Family", "Ultra Lite", "Custom Configuration"]);
   });
 
   describe("routing test", () => {
@@ -744,7 +744,7 @@ describe("AddAutoRouterTab", () => {
         expect(isOptionDisabled(optionByLabel("Anthropic Family")!)).toBe(false);
       });
       const labels = visibleOptions().map((option) => option.querySelector(".font-medium")?.textContent);
-      expect(labels).toEqual(["Anthropic Family", "Lite", "OpenAI Family", "Custom Configuration"]);
+      expect(labels).toEqual(["Anthropic Family", "Lite", "OpenAI Family", "Ultra Lite", "Custom Configuration"]);
     });
 
     it.each([

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -20,7 +20,7 @@ const groupsOnly = (models: Iterable<string>) => buildModelAvailability(models, 
 describe("autorouter_presets", () => {
   it("loads exactly the bundled presets", () => {
     const presets = getAllPresets();
-    expect(presets.map((p) => p.label).sort()).toEqual(["Anthropic Family", "Lite", "OpenAI Family"]);
+    expect(presets.map((p) => p.label).sort()).toEqual(["Anthropic Family", "Lite", "OpenAI Family", "Ultra Lite"]);
     // Every preset carries all four fields the UI relies on; a JSON typo dropping one fails here.
     for (const p of presets) {
       expect(p).toMatchObject({ key: expect.any(String), label: expect.any(String), description: expect.any(String) });
@@ -72,6 +72,18 @@ describe("autorouter_presets", () => {
     expect(config.classifier_context_per_turn_chars).toBeUndefined();
     expect(getRequiredModelsInPreset(lite)).toEqual(
       new Set(["deepseek-v4-flash", "muse-spark-1.2", "kimi-k3", "claude-opus-5"]),
+    );
+  });
+
+  it("pins the ultra_lite preset to the heuristic scorer with no classifier call", () => {
+    const ultraLite = getPresetByKey("ultra_lite")!;
+    const config = ultraLite.complexity_router_config;
+    expect(config.classifier_type).toBe("heuristic");
+    expect(config.classifier_llm_config).toBeUndefined();
+    expect(config.classifier_context_window_size).toBeUndefined();
+    expect(config.classifier_fallback).toBeUndefined();
+    expect(getRequiredModelsInPreset(ultraLite)).toEqual(
+      new Set(["deepseek-v4-flash", "minimax-m3", "deepseek-v4-pro", "kimi-k3"]),
     );
   });
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- No bundled preset skips the classifier call
- Every cross-provider template bills per-request classification

How it solves it:

- Adds an Ultra Lite template on the heuristic scorer
- Tiers cost-ascending across four providers

## User Flow

Before: an admin who wants cross-provider cost routing has to accept a classifier call on every request

1. They open http://localhost:4000/ui/?page=llm-playground and start Add Auto Router
2. The Template dropdown offers Anthropic Family, Lite, OpenAI Family, Custom Configuration
3. Lite is the only mixed-provider option, and it routes through an LLM classifier, so every request pays a classification call before it reaches a model
4. To avoid that call they pick Custom Configuration and fill in all four tiers by hand

After: the same admin picks a mixed-provider template that classifies locally

1. They open http://localhost:4000/ui/?page=llm-playground and start Add Auto Router
2. The Template dropdown now also offers Ultra Lite
3. Selecting it fills SIMPLE with deepseek-v4-flash, MEDIUM with minimax-m3, COMPLEX with deepseek-v4-pro, REASONING with kimi-k3, and leaves the classifier set to heuristic
4. They save, and routed requests reach a model with no classification call ahead of them

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Setup: run the dashboard dev server with `npm run dev` in `ui/litellm-dashboard` against a proxy on port 4000, with deployments registered for deepseek-v4-flash, minimax-m3, deepseek-v4-pro, and kimi-k3 so the template is selectable rather than greyed out

### Before (4d57bf0bdd)

1. Open http://localhost:3000/ui/?page=llm-playground and start Add Auto Router
2. Open the Template dropdown, observe exactly Anthropic Family, Lite, OpenAI Family, Custom Configuration, with no Ultra Lite entry

### After (2bf5c60184)

1. Open http://localhost:3000/ui/?page=llm-playground and start Add Auto Router
2. Open the Template dropdown, observe Ultra Lite listed after OpenAI Family and selectable
3. Select Ultra Lite, expand Detailed Configuration, observe the four tiers filled with deepseek-v4-flash, minimax-m3, deepseek-v4-pro, kimi-k3 and the classifier left on heuristic
4. Save the router, send a chat completion through it, and observe the request reaching a model with no classifier call logged at http://localhost:4000/ui/?page=logs

## Type

🆕 New Feature

## Caveats (if any)

- Heuristic tiering is weaker than the LLM classifier
- Needs all four model groups registered to select
- kimi-k3 group must be named exactly: FW- prefix blocks auto-match

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
