### PR TITLE
fix: default reasoning_tokens to 0 in output_tokens_details when absent

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2303,6 +2303,8 @@ class LiteLLMCompletionResponsesConfig:
                 output_details_dict["image_tokens"] = completion_details.image_tokens
 
             if output_details_dict:
+                if "reasoning_tokens" not in output_details_dict:
+                    output_details_dict["reasoning_tokens"] = 0
                 response_usage.output_tokens_details = OutputTokensDetails(**output_details_dict)
 
         return response_usage

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2537,24 +2537,24 @@ class TestUsageTransformation:
         assert response_usage.output_tokens_details.text_tokens == 50
         assert response_usage.output_tokens_details.image_tokens == 100
 
-    def test_reasoning_tokens_not_forced_to_zero_when_absent(self):
-        # Regression: previously the else branch wrote reasoning_tokens=0 even when
-        # completion_tokens_details had no reasoning (reasoning_tokens=None). That caused
-        # the proxy to always report reasoning_tokens=0 for non-thinking responses.
+    def test_reasoning_tokens_defaults_to_zero_when_absent_but_other_details_present(self):
+        # Regression for #37264: when output_tokens_details is populated (e.g. text_tokens is
+        # present) but reasoning_tokens is absent, OpenAI Responses schema requires reasoning_tokens
+        # to be 0. Codex aborts with "missing field reasoning_tokens" otherwise.
         usage = Usage(
             prompt_tokens=10,
             completion_tokens=50,
             total_tokens=60,
             completion_tokens_details=CompletionTokensDetailsWrapper(
                 text_tokens=50,
-                # reasoning_tokens intentionally absent -> None
+                # reasoning_tokens intentionally absent -> None (Gemini no-thinking case)
             ),
         )
 
         chat_completion_response = ModelResponse(
             id="test-response-id",
             created=1234567890,
-            model="claude-haiku-4-5",
+            model="gemini-3.7-flash",
             object="chat.completion",
             usage=usage,
             choices=[
@@ -2571,7 +2571,8 @@ class TestUsageTransformation:
         )
 
         assert response_usage.output_tokens_details is not None
-        assert response_usage.output_tokens_details.reasoning_tokens is None
+        assert response_usage.output_tokens_details.reasoning_tokens == 0
+        assert response_usage.output_tokens_details.text_tokens == 50
 
     def test_reasoning_tokens_preserved_when_thinking_occurred(self):
         # Regression: reasoning_tokens must survive the chat->responses translation


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini responses with no thinking tokens produce `output_tokens_details` that omits `reasoning_tokens`, violating the OpenAI Responses schema
- Codex (and other strict clients) abort with "missing field `reasoning_tokens`" when parsing the `response.completed` SSE event

How it solves it:

- When `output_tokens_details` is populated but `reasoning_tokens` was not set by the provider, default it to `0` so the serialized object is schema-valid

## User Flow

Before: a developer streaming through `/v1/responses` with a Gemini model and `reasoning.effort: "low"` sees the stream aborted by their client

1. POST `https://<litellm-host>/v1/responses` with model `gemini-3.7-flash`, `"stream": true`, `"reasoning": {"effort": "low"}`, and a short text prompt
2. Gemini completes without using thinking tokens
3. The `response.completed` SSE event arrives with `"output_tokens_details": {"text_tokens": 1}`, missing `reasoning_tokens`
4. Codex prints `failed to parse ResponseCompleted: missing field reasoning_tokens` and aborts

After: the same request completes successfully

1. POST `https://<litellm-host>/v1/responses` with the same inputs
2. Gemini completes without using thinking tokens
3. The `response.completed` SSE event arrives with `"output_tokens_details": {"text_tokens": 1, "reasoning_tokens": 0}`
4. Codex parses the response and finishes the task

## Relevant issues

Fixes #37264

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Screenshots / Proof of Fix

This is a serialization-level fix in the Responses API translation layer; validating it requires a live Gemini endpoint with `reasoning.effort: "low"` that returns no thinking tokens. The unit regression test covers the exact shape produced before and after.