### PR TITLE
fix: apply DB-stored litellm_settings.max_budget on config reload

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1574,6 +1574,8 @@ LITELLM_SETTINGS_SAFE_DB_OVERRIDES: Final = [
     "cost_discount_config",
     "cost_margin_config",
     "budget_exceeded_throttle_percentage",
+    # Proxy-wide budget stored via POST /config/update; applied to litellm.max_budget on reload.
+    "max_budget",
     # Every field editable from the Admin UI (proxy_server._GENERAL_SETTINGS_UI_LITELLM_FIELDS)
     # must be listed here so a DB write from one worker overrides the live litellm attribute on
     # the others when config reloads; otherwise peer workers stay on their startup value.

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3763,6 +3763,27 @@ def _scrub_guardrail_inner(inner: dict[str, JsonValue]) -> None:
         inner["guardrail"] = None
 
 
+def _apply_safe_db_litellm_setting(key: str, value: object) -> None:
+    """Apply a DB-overlaid ``litellm_settings`` key to the live ``litellm`` module.
+
+    ``max_budget`` is coerced to float to match startup config loading
+    (``ProxyConfig.load_config``). A ``None`` DB value leaves the current
+    runtime attribute unchanged; a non-numeric value is ignored (with a
+    warning) rather than aborting the reload of an already-running proxy.
+    """
+    if key == "max_budget":
+        if value is None:
+            return
+        try:
+            budget = float(value)
+        except (TypeError, ValueError):
+            verbose_proxy_logger.warning("Ignoring non-numeric DB litellm_settings.max_budget override: %r", value)
+            return
+        litellm.max_budget = budget
+        return
+    setattr(litellm, key, value)
+
+
 def _scrub_db_overlay_remote_module_loads(section: str, db_value: JsonValue) -> JsonValue:
     """Strip ``s3://`` / ``gcs://`` entries from the DB-overlay value for
     fields whose contents reach ``get_instance_fn``. The same scheme is
@@ -6405,7 +6426,7 @@ class ProxyConfig:
         elif param_name == "litellm_settings" and isinstance(db_param_value, dict):
             for key, value in db_param_value.items():
                 if key in LITELLM_SETTINGS_SAFE_DB_OVERRIDES:  # params that are safe to override with db values
-                    setattr(litellm, key, value)
+                    _apply_safe_db_litellm_setting(key, value)
 
         # If param doesn't exist in config, add it
         if param_name not in current_config:

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9641,6 +9641,67 @@ def test_prompt_caching_settings_propagate_on_config_reload(monkeypatch, field_n
     assert getattr(litellm, field_name) == db_value
 
 
+@pytest.mark.parametrize(
+    "db_value, expected",
+    [
+        (10, 10.0),
+        ("10", 10.0),
+        (0.5, 0.5),
+    ],
+)
+def test_max_budget_propagates_on_config_reload(monkeypatch, db_value, expected):
+    """Regression for #36533: a DB-stored litellm_settings.max_budget must overlay the live
+    litellm.max_budget when config reloads (STORE_MODEL_IN_DB=True). It was absent from
+    LITELLM_SETTINGS_SAFE_DB_OVERRIDES, so peer workers kept enforcing the stale config.yaml value."""
+    import litellm.proxy.proxy_server as ps
+
+    # peer worker booted with the stale config.yaml value
+    monkeypatch.setattr(litellm, "max_budget", 0.00001)
+
+    pc = ps.ProxyConfig()
+    pc._update_config_fields(
+        current_config={"litellm_settings": {}},
+        param_name="litellm_settings",
+        db_param_value={"max_budget": db_value},
+    )
+
+    assert litellm.max_budget == expected
+    assert isinstance(litellm.max_budget, float)
+
+
+def test_max_budget_none_db_value_leaves_runtime_unchanged(monkeypatch):
+    """A null DB max_budget must not clobber the running litellm.max_budget."""
+    import litellm.proxy.proxy_server as ps
+
+    monkeypatch.setattr(litellm, "max_budget", 7.5)
+
+    pc = ps.ProxyConfig()
+    pc._update_config_fields(
+        current_config={"litellm_settings": {}},
+        param_name="litellm_settings",
+        db_param_value={"max_budget": None},
+    )
+
+    assert litellm.max_budget == 7.5
+
+
+def test_max_budget_invalid_db_value_is_ignored(monkeypatch):
+    """A non-numeric DB max_budget must be skipped (logged), not abort the reload of a
+    running proxy or clobber the live litellm.max_budget."""
+    import litellm.proxy.proxy_server as ps
+
+    monkeypatch.setattr(litellm, "max_budget", 7.5)
+
+    pc = ps.ProxyConfig()
+    pc._update_config_fields(
+        current_config={"litellm_settings": {}},
+        param_name="litellm_settings",
+        db_param_value={"max_budget": "not-a-number"},
+    )
+
+    assert litellm.max_budget == 7.5
+
+
 def test_get_config_list_marks_untouched_prompt_caching_flag_as_not_set(monkeypatch):
     """The flag defaults to False rather than None, so a plain 'is not None' check would
     report the default as 'In Config' and imply an admin had set it."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- A DB-stored proxy-wide `max_budget` is silently ignored after a restart
- The proxy keeps enforcing the old `config.yaml` value instead

How it solves it:

- Add `max_budget` to the DB-override allowlist so reload applies it
- Coerce to float (matching startup); a `None` DB value changes nothing

## User Flow

Before: an operator whose `config.yaml` is immutable stores a new proxy-wide budget in the database, but after a restart the proxy still enforces the old file value.

1. They set `max_budget: 0.00001` in `config.yaml` (the immutable file value)
2. They send `POST https://litellm-domain/config/update` with `{"litellm_settings": {"max_budget": 10}}` and get back `Config updated successfully`
3. They restart the proxy, then set the proxy-wide spend counter to `1.0`
4. Their next request is rejected with a budget-exceeded error — the proxy is still enforcing the `0.00001` file value, so a spend of `1.0` counts as over budget. The stored `10` was never applied.

After: the same stored budget is applied on restart, so the database value is what gets enforced.

1. They set `max_budget: 0.00001` in `config.yaml`
2. They send `POST https://litellm-domain/config/update` with `{"litellm_settings": {"max_budget": 10}}` and get back `Config updated successfully`
3. They restart the proxy, then set the proxy-wide spend counter to `1.0`
4. The same request now succeeds — the enforced budget is the stored `10`, and a spend of `1.0` is under it.

## Relevant issues

Fixes #36533

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`litellm_settings.max_budget` written to the DB via `POST /config/update` was merged into the returned config but never applied to the live `litellm.max_budget`, because `max_budget` was missing from `LITELLM_SETTINGS_SAFE_DB_OVERRIDES`. On config reload, `ProxyConfig._update_config_fields` only `setattr`s allowlisted keys, so after a restart the runtime budget stayed on the `config.yaml` value and the DB override was silently dropped.

- Add `"max_budget"` to `LITELLM_SETTINGS_SAFE_DB_OVERRIDES`.
- Apply it through a small `_apply_safe_db_litellm_setting` helper that coerces the value to `float` (matching the startup `load_config` path, which already does `litellm.max_budget = float(value)`) and leaves the runtime attribute unchanged when the DB value is `None`. The helper keeps `_update_config_fields` at its existing cyclomatic complexity.
- Tests mirror the existing `test_prompt_caching_settings_propagate_on_config_reload`: `test_max_budget_propagates_on_config_reload` (parametrized `10`, `"10"`, `0.5` → live float) and `test_max_budget_none_db_value_leaves_runtime_unchanged`.
