### PR TITLE
fix(proxy): accept slashes in the model id on GET /v1/models/{model_id}

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -9694,12 +9694,12 @@ async def model_list(
 
 
 @router.get(
-    "/v1/models/{model_id}",
+    "/v1/models/{model_id:path}",
     dependencies=[Depends(user_api_key_auth)],
     tags=["model management"],
 )
 @router.get(
-    "/models/{model_id}",
+    "/models/{model_id:path}",
     dependencies=[Depends(user_api_key_auth)],
     tags=["model management"],
 )

--- a/tests/test_litellm/proxy/proxy_server/test_routes_models.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_models.py
@@ -265,3 +265,32 @@ def test_anthropic_format_returns_public_team_model_name(
     assert response.status_code == 200
     assert [m["id"] for m in response.json()["data"]] == ["gpt-4-team"]
     assert internal_name not in response.text
+
+
+@pytest.mark.parametrize("prefix", ["/v1/models", "/models"])
+def test_get_model_by_id_accepts_slash_in_model_name(
+    client, auth_as, patched_models, monkeypatch, prefix
+):
+    """Regression: a model group named ``provider/model`` is listed under that id,
+    so retrieve has to match the whole id rather than its first path segment."""
+    from litellm.proxy import utils as proxy_utils
+
+    model_id = "mistralai/mistral-7b-instruct"
+
+    async def _fake_get_available_models_for_user(**kwargs):
+        return [model_id]
+
+    monkeypatch.setattr(
+        proxy_utils,
+        "get_available_models_for_user",
+        _fake_get_available_models_for_user,
+    )
+    patched_models.get_model_names = MagicMock(return_value=[model_id])
+
+    with auth_as():
+        listed = client.get(prefix)
+        retrieved = client.get(f"{prefix}/{model_id}")
+
+    assert [entry["id"] for entry in listed.json()["data"]] == [model_id]
+    assert retrieved.status_code == 200
+    assert retrieved.json()["id"] == model_id


### PR DESCRIPTION
## TLDR

Problem this solves:

- Retrieve 404s for model names containing a slash
- The id `/v1/models` advertises cannot be fetched back

How it solves it:

- Use the path converter on the retrieve route
- Add a regression test covering a slashed model group

## User Flow

Before: a developer pointing an OpenAI compatible client at the gateway cannot confirm a model exists when its name has a slash in it, so the client marks it unusable

1. They send GET http://litellm-domain/v1/models with their key and get one entry back, `"id": "mistralai/mistral-7b-instruct"`
2. Their client calls retrieve on that exact id, GET http://litellm-domain/v1/models/mistralai/mistral-7b-instruct
3. The gateway answers `404 {"detail":"Not Found"}`, the same body it gives for a URL it does not serve at all
4. They retry with the slash percent encoded, GET http://litellm-domain/v1/models/mistralai%2Fmistral-7b-instruct, and get the same 404
5. The client concludes the model is missing and stops there, even though POST http://litellm-domain/v1/chat/completions with `"model": "mistralai/mistral-7b-instruct"` reaches the provider fine

After: the same client gets the model back and carries on

1. They send GET http://litellm-domain/v1/models with their key and get one entry back, `"id": "mistralai/mistral-7b-instruct"`
2. Their client calls retrieve on that exact id, GET http://litellm-domain/v1/models/mistralai/mistral-7b-instruct
3. The gateway answers `200` with the model object, `"id": "mistralai/mistral-7b-instruct"`, matching what the listing advertised
4. The percent encoded form also returns the same `200` and the same body
5. The client proceeds to POST http://litellm-domain/v1/chat/completions with that model

## Relevant issues

Fixes #37271

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup. Config the proxy ran with:

```yaml
model_list:
  - model_name: mistralai/mistral-7b-instruct
    litellm_params:
      model: openrouter/mistralai/mistral-7b-instruct
      api_key: os.environ/OPENROUTER_API_KEY
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234
```

`OPENROUTER_API_KEY` and `OPENAI_API_KEY` were placeholders. Neither models endpoint calls a provider, so the run costs nothing. The chat completion in each case is there to show the same slashed name routes, and it reaches OpenRouter and returns a real provider 401 for the placeholder key

Started with:

```
CONFIG_FILE_PATH=config.yaml LITELLM_MASTER_KEY=sk-1234 \
  python -m uvicorn litellm.proxy.proxy_server:app --host 127.0.0.1 --port 4000
```

### Before (4fd7a73)

1. `curl -s http://localhost:4000/v1/models -H "Authorization: Bearer sk-1234" | jq -c`

   ```
   {"data":[{"id":"mistralai/mistral-7b-instruct","object":"model","created":1677610602,"owned_by":"openai"},{"id":"gpt-4o-mini","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":128000,"max_output_tokens":16384}],"object":"list"}
   ```

2. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:4000/v1/models/gpt-4o-mini -H "Authorization: Bearer sk-1234"`

   ```
   {"id":"gpt-4o-mini","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":128000,"max_output_tokens":16384}
   HTTP 200
   ```

3. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:4000/v1/models/mistralai/mistral-7b-instruct -H "Authorization: Bearer sk-1234"`

   ```
   {"detail":"Not Found"}
   HTTP 404
   ```

4. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:4000/v1/models/mistralai%2Fmistral-7b-instruct" -H "Authorization: Bearer sk-1234"`

   ```
   {"detail":"Not Found"}
   HTTP 404
   ```

5. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:4000/models/mistralai/mistral-7b-instruct -H "Authorization: Bearer sk-1234"`

   ```
   {"detail":"Not Found"}
   HTTP 404
   ```

6. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{\"model\": \"mistralai/mistral-7b-instruct\", \"messages\": [{\"role\": \"user\", \"content\": \"hi\"}]}"`

   ```
   {"error":{"message":"litellm.AuthenticationError: AuthenticationError: OpenrouterException - {\"error\":{\"message\":\"Missing Authentication header\",\"code\":401}}. Received Model Group=mistralai/mistral-7b-instruct\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
   HTTP 401
   ```

### After (b253bb9)

1. `curl -s http://localhost:4000/v1/models -H "Authorization: Bearer sk-1234" | jq -c`

   ```
   {"data":[{"id":"mistralai/mistral-7b-instruct","object":"model","created":1677610602,"owned_by":"openai"},{"id":"gpt-4o-mini","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":128000,"max_output_tokens":16384}],"object":"list"}
   ```

2. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:4000/v1/models/gpt-4o-mini -H "Authorization: Bearer sk-1234"`

   ```
   {"id":"gpt-4o-mini","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":128000,"max_output_tokens":16384}
   HTTP 200
   ```

3. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:4000/v1/models/mistralai/mistral-7b-instruct -H "Authorization: Bearer sk-1234"`

   ```
   {"id":"mistralai/mistral-7b-instruct","object":"model","created":1677610602,"owned_by":"openrouter"}
   HTTP 200
   ```

4. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:4000/v1/models/mistralai%2Fmistral-7b-instruct" -H "Authorization: Bearer sk-1234"`

   ```
   {"id":"mistralai/mistral-7b-instruct","object":"model","created":1677610602,"owned_by":"openrouter"}
   HTTP 200
   ```

5. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:4000/models/mistralai/mistral-7b-instruct -H "Authorization: Bearer sk-1234"`

   ```
   {"id":"mistralai/mistral-7b-instruct","object":"model","created":1677610602,"owned_by":"openrouter"}
   HTTP 200
   ```

6. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{\"model\": \"mistralai/mistral-7b-instruct\", \"messages\": [{\"role\": \"user\", \"content\": \"hi\"}]}"`

   ```
   {"error":{"message":"litellm.AuthenticationError: AuthenticationError: OpenrouterException - {\"error\":{\"message\":\"Missing Authentication header\",\"code\":401}}. Received Model Group=mistralai/mistral-7b-instruct\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
   HTTP 401
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

- Same shape as #32770 on the fallback routes
- The listing still reports `owned_by: openai` for that model, pre-existing and untouched here
- Virtual keys scoped to `llm_api_routes` still get 403 here, separate classification issue

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
