### PR TITLE
fix(chatgpt): keep structured output text.format in Responses API requests

### DIFF
--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -31,6 +31,17 @@ from ..common_utils import (
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
+_STRUCTURED_OUTPUT_FORMAT_TYPES: Final = frozenset({"json_schema", "json_object"})
+
+
+def _has_structured_output_format(text: object) -> bool:
+    if not isinstance(text, dict):
+        return False
+    format_config: Final = text.get("format")
+    if not isinstance(format_config, dict):
+        return False
+    return format_config.get("type") in _STRUCTURED_OUTPUT_FORMAT_TYPES
+
 
 class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
     def __init__(self) -> None:
@@ -102,6 +113,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             "reasoning",
             "previous_response_id",
             "truncation",
+            *(("text",) if _has_structured_output_format(request.get("text")) else ()),
         }
 
         return {k: v for k, v in request.items() if k in allowed_keys}

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -156,6 +156,55 @@ class TestChatGPTResponsesAPITransformation:
         }
 
     @pytest.mark.parametrize(
+        "text_param",
+        [
+            {
+                "format": {
+                    "type": "json_schema",
+                    "name": "verdict",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"block": {"type": "boolean"}},
+                        "required": ["block"],
+                    },
+                }
+            },
+            {"format": {"type": "json_object"}},
+        ],
+    )
+    def test_chatgpt_preserves_structured_output_text(self, text_param):
+        config = ChatGPTResponsesAPIConfig()
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.3-codex",
+            input="hi",
+            response_api_optional_request_params={"text": text_param},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert request["text"] == text_param
+
+    @pytest.mark.parametrize(
+        "text_param",
+        [
+            {"format": {"type": "text"}},
+            {"verbosity": "low"},
+            "not-a-dict",
+        ],
+    )
+    def test_chatgpt_drops_non_structured_text_param(self, text_param):
+        config = ChatGPTResponsesAPIConfig()
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.3-codex",
+            input="hi",
+            response_api_optional_request_params={"text": text_param},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert "text" not in request
+
+    @pytest.mark.parametrize(
         ("model_name", "response_model"),
         [
             ("chatgpt/gpt-5.2-codex", "gpt-5.2-codex"),


### PR DESCRIPTION
## TLDR

Problem this solves:

- Structured output silently ignored on the ChatGPT provider
- json_schema and json_object formats never reach the upstream API
- Callers get schema-nonconforming output instead of schema-shaped JSON

How it solves it:

- Keep the text param when its format type is json_schema or json_object
- Other text configs stay filtered out, as before

## User Flow

Before: a developer requesting schema-shaped JSON through the ChatGPT provider gets output that ignores the schema, and their validator rejects it

1. They send POST https://litellm-domain/v1/responses with a chatgpt model and `"text": {"format": {"type": "json_schema", "name": "verdict", "schema": {"type": "object", "properties": {"answer": {"type": "boolean"}}, "required": ["answer"], "additionalProperties": false}}}`
2. The response comes back 200, but the request config echoed in the response body shows `"format": {"type": "text"}`: the schema never left the proxy
3. The output text is `{"answer":"No.","reasoning":"...","confidence":0.99}`: a string where the schema demands a boolean, plus keys forbidden by `additionalProperties: false`
4. Their schema validator rejects the output and the calling agent misbehaves

After: the same request returns JSON matching the schema

1. They send the same POST https://litellm-domain/v1/responses with the same `text.format` schema
2. The response comes back 200 and the echoed config shows the full json_schema format with `strict: true`
3. The output text is `{"answer":false}`, conforming exactly to the schema
4. Their validator accepts it

## Relevant issues

None found for this bug; hit in production via an agent harness whose safety classifier depends on structured output

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4000, real ChatGPT backend (device-code login), config:

```yaml
model_list:
  - model_name: codex
    litellm_params:
      model: chatgpt/gpt-5.6-sol
```

Notes on the setup: the rerun uses `chatgpt/gpt-5.6-sol` (the account's current Codex model), and the provider forces `stream=true` upstream, so the non-streaming /v1/responses response arrives as an SSE body on both commits (pre-existing, unrelated to this fix); the values below are read from its `response.completed` event

Request used identically in both runs:

```bash
curl -s http://localhost:4000/v1/responses -H "Content-Type: application/json" \
  -d '{"model":"codex","input":[{"role":"user","content":"Is the sky green? Answer using the schema."}],
       "text":{"format":{"type":"json_schema","name":"verdict","schema":
       {"type":"object","properties":{"answer":{"type":"boolean"}},"required":["answer"],"additionalProperties":false}}}}'
```

### Before (5c034fda74)

1. Start the proxy at the merge base and send the curl above
2. HTTP 200; the `response.completed` event echoes the request's text config as `{"format": {"type": "text"}, "verbosity": "medium"}`, showing the schema was stripped before reaching the backend
3. Output text ignores the schema: `{"answer":"Yes","qualification":"The daytime sky typically appears blue under clear conditions due to Rayleigh scattering."}` (string where a boolean is required, plus a key forbidden by `additionalProperties: false`)

### After (82b7c7f893)

1. Restart the proxy on this PR's branch and send the identical curl
2. HTTP 200; the `response.completed` event echoes the full json_schema format with `strict: true`
3. Output text is `{"answer":true}`, exact schema conformance

## Type

🐛 Bug Fix

## Caveats (if any)

- Proof captured on /v1/responses; the change sits in the provider transformation shared by all entry routes
- text with format type "text" or bare verbosity stays filtered, as before

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


