### PR TITLE
fix(caching): guard RedisCache.disconnect against None connection pool in cluster mode

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -1370,7 +1370,8 @@ class RedisCache(BaseCache):
         self.redis_client.flushall()
 
     async def disconnect(self):
-        await self.async_redis_conn_pool.disconnect(inuse_connections=True)
+        if self.async_redis_conn_pool is not None:
+            await self.async_redis_conn_pool.disconnect(inuse_connections=True)
         try:
             self.redis_client.close()
         except Exception as e:

--- a/litellm/caching/redis_cluster_cache.py
+++ b/litellm/caching/redis_cluster_cache.py
@@ -56,6 +56,11 @@ class RedisClusterCache(RedisCache):
         async_redis_cluster_client: Final = self.init_async_client()
         return await async_redis_cluster_client.mget_nonatomic(keys=keys)
 
+    async def disconnect(self):
+        if self.redis_async_redis_cluster_client is not None:
+            await self.redis_async_redis_cluster_client.aclose()
+        await super().disconnect()
+
     async def test_connection(self) -> dict:
         """
         Test the Redis Cluster connection.

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -908,7 +908,10 @@ async def proxy_shutdown_event(worker_heartbeat: ProxyWorkerHeartbeat | None = N
         await prisma_client.disconnect()
 
     if litellm.cache is not None:
-        await litellm.cache.disconnect()
+        try:
+            await litellm.cache.disconnect()
+        except Exception as e:
+            verbose_proxy_logger.debug("Error disconnecting litellm.cache: %s", e)
 
     await jwt_handler.close()
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -910,7 +910,7 @@ async def proxy_shutdown_event(worker_heartbeat: ProxyWorkerHeartbeat | None = N
     if litellm.cache is not None:
         try:
             await litellm.cache.disconnect()
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001  # cache teardown must not abort remaining shutdown steps
             verbose_proxy_logger.debug("Error disconnecting litellm.cache: %s", e)
 
     await jwt_handler.close()

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -465,6 +465,21 @@ def test_delete_cache_namespaces_key(namespace, expected, monkeypatch, redis_no_
     mock_client.delete.assert_called_once_with(expected)
 
 
+@pytest.mark.asyncio
+async def test_disconnect_with_no_connection_pool_does_not_raise():
+    """RedisCache.disconnect() must not blow up when async_redis_conn_pool is None,
+    which is the case in cluster mode (get_redis_connection_pool returns None for
+    startup_nodes configs). Regression test for
+    https://github.com/BerriAI/litellm/issues/37137."""
+    redis_cache = RedisCache.__new__(RedisCache)
+    redis_cache.async_redis_conn_pool = None
+    redis_cache.redis_client = MagicMock()
+
+    await redis_cache.disconnect()
+
+    redis_cache.redis_client.close.assert_called_once()
+
+
 def _closed_port() -> int:
     """A port with nothing listening, so Redis calls fail fast and deterministically."""
     import socket

--- a/tests/test_litellm/caching/test_redis_cluster_cache.py
+++ b/tests/test_litellm/caching/test_redis_cluster_cache.py
@@ -1,5 +1,7 @@
 import json
-from unittest.mock import MagicMock, patch
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -114,6 +116,44 @@ def test_cache_init_creates_redis_cache_without_cluster_config(
     cache = Cache(type="redis")
     assert isinstance(cache.cache, RedisCache)
     assert not isinstance(cache.cache, RedisClusterCache)
+
+
+@pytest.mark.asyncio
+@patch("litellm._redis.init_redis_cluster")
+async def test_disconnect_closes_cluster_client_without_raising(mock_init_redis_cluster):
+    """Shutting down a proxy in cluster mode used to always raise AttributeError,
+    since RedisCache.disconnect() unconditionally dereferences async_redis_conn_pool,
+    which is None by design in cluster mode. Regression test for
+    https://github.com/BerriAI/litellm/issues/37137."""
+    cache = RedisClusterCache(
+        startup_nodes=[{"host": "localhost", "port": 6379}],
+        password="hello",
+    )
+    assert cache.async_redis_conn_pool is None
+
+    mock_cluster_client = AsyncMock()
+    cache.redis_async_redis_cluster_client = mock_cluster_client
+    cache.redis_client = MagicMock()
+
+    await cache.disconnect()
+
+    mock_cluster_client.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("litellm._redis.init_redis_cluster")
+async def test_disconnect_without_cluster_client_does_not_raise(mock_init_redis_cluster):
+    """disconnect() must be a no-op for the cluster client when it was never
+    initialized (e.g. shutdown before any request touched Redis)."""
+    cache = RedisClusterCache(
+        startup_nodes=[{"host": "localhost", "port": 6379}],
+        password="hello",
+    )
+    cache.redis_client = MagicMock()
+
+    await cache.disconnect()
+
+    cache.redis_client.close.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/caching/test_redis_cluster_cache.py
+++ b/tests/test_litellm/caching/test_redis_cluster_cache.py
@@ -119,8 +119,8 @@ def test_cache_init_creates_redis_cache_without_cluster_config(
 
 
 @pytest.mark.asyncio
-@patch("litellm._redis.init_redis_cluster")
-async def test_disconnect_closes_cluster_client_without_raising(mock_init_redis_cluster):
+@patch("redis.RedisCluster")
+async def test_disconnect_closes_cluster_client_without_raising(mock_redis_cluster):
     """Shutting down a proxy in cluster mode used to always raise AttributeError,
     since RedisCache.disconnect() unconditionally dereferences async_redis_conn_pool,
     which is None by design in cluster mode. Regression test for
@@ -131,29 +131,37 @@ async def test_disconnect_closes_cluster_client_without_raising(mock_init_redis_
     )
     assert cache.async_redis_conn_pool is None
 
-    mock_cluster_client = AsyncMock()
-    cache.redis_async_redis_cluster_client = mock_cluster_client
+    closed = False
+
+    class _ClusterClient:
+        async def aclose(self):
+            nonlocal closed
+            closed = True
+
+    cache.redis_async_redis_cluster_client = _ClusterClient()
     cache.redis_client = MagicMock()
 
     await cache.disconnect()
 
-    mock_cluster_client.aclose.assert_awaited_once()
+    assert closed is True
 
 
 @pytest.mark.asyncio
-@patch("litellm._redis.init_redis_cluster")
-async def test_disconnect_without_cluster_client_does_not_raise(mock_init_redis_cluster):
+@patch("redis.RedisCluster")
+async def test_disconnect_without_cluster_client_does_not_raise(mock_redis_cluster):
     """disconnect() must be a no-op for the cluster client when it was never
-    initialized (e.g. shutdown before any request touched Redis)."""
+    initialized (e.g. shutdown before any request touched Redis), rather than
+    raising on the absent client or the None connection pool."""
     cache = RedisClusterCache(
         startup_nodes=[{"host": "localhost", "port": 6379}],
         password="hello",
     )
     cache.redis_client = MagicMock()
 
-    await cache.disconnect()
+    assert cache.redis_async_redis_cluster_client is None
+    assert cache.async_redis_conn_pool is None
 
-    cache.redis_client.close.assert_called_once()
+    await cache.disconnect()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
+++ b/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
@@ -205,6 +205,31 @@ async def test_proxy_shutdown_event_prisma_disconnect_raises_error(monkeypatch):
         await proxy_shutdown_event()
 
 
+@pytest.mark.asyncio
+async def test_proxy_shutdown_event_cache_disconnect_error_does_not_abort_shutdown(monkeypatch):
+    """A cache backend failing to disconnect must not skip the jwt_handler close
+    that runs after it, unlike a prisma disconnect failure which does abort.
+    """
+    monkeypatch.setattr(ps, "prisma_client", None, raising=False)
+
+    fake_jwt = MagicMock()
+    fake_jwt.close = AsyncMock()
+    monkeypatch.setattr(ps, "jwt_handler", fake_jwt, raising=False)
+    monkeypatch.setattr(ps, "db_writer_client", None, raising=False)
+
+    import litellm
+
+    fake_cache = MagicMock()
+    fake_cache.disconnect = AsyncMock(side_effect=RuntimeError("redis gone"))
+    monkeypatch.setattr(litellm, "cache", fake_cache, raising=False)
+    monkeypatch.setattr(litellm, "success_callback", [], raising=False)
+
+    await proxy_shutdown_event()
+
+    assert fake_cache.disconnect.await_count == 1
+    assert fake_jwt.close.await_count == 1
+
+
 # ---------------------------------------------------------------------------
 # _flush_spend_logs_queue_on_shutdown
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TLDR

Problem this solves:

- In Redis cluster mode, the proxy raises an unhandled AttributeError on every shutdown, aborting cleanup before the JWT handler close, DB writer close, billing metrics flush, and langfuse flush run

How it solves it:

- Guards the None connection pool dereference in RedisCache.disconnect(), gives RedisClusterCache its own disconnect() that tears down the cluster client, and wraps the shutdown-path cache disconnect call in try/except so a cache teardown failure can't cascade into skipping the rest of shutdown

## User Flow

Anyone running the proxy against a cluster-mode Redis (any deployment using REDIS_CLUSTER_NODES or startup_nodes, including managed offerings that are always cluster-mode) currently sees shutdown fail with an AttributeError on every restart, and with it, up to one export interval of billing data plus the final langfuse flush silently dropped. After this fix, shutdown completes cleanly.

## Relevant issues

Fixes #37137

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

I could not exercise this against a live Redis Cluster instance in this environment (no cluster-mode Redis available, and the bug is specifically in a shutdown code path rather than a request-serving one, so there is no useful curl against a running proxy to demonstrate it). Instead, added regression tests in tests/test_litellm/caching/test_redis_cache.py and tests/test_litellm/caching/test_redis_cluster_cache.py that reproduce the exact failure: constructing a cache with async_redis_conn_pool None (the cluster-mode condition) and calling disconnect() raised AttributeError before this change and passes after it. Ran locally with pytest and confirmed all three new tests fail on the pre-fix code and pass on the post-fix code.

If a maintainer can point me to a way to spin up a cluster-mode Redis in this environment, or can verify it against one in review, that would close the gap this test-only verification leaves.

## Type

🐛 Bug Fix
✅ Test

## Changes

- litellm/caching/redis_cache.py: RedisCache.disconnect() now checks async_redis_conn_pool is not None before calling disconnect on it
- litellm/caching/redis_cluster_cache.py: RedisClusterCache now overrides disconnect() to close redis_async_redis_cluster_client via aclose() before delegating to the base class
- litellm/proxy/proxy_server.py: proxy_shutdown_event() now wraps the litellm.cache.disconnect() call in try/except so a cache teardown failure can't skip the jwt handler close, db writer close, billing metrics flush, and langfuse flush that follow it
- tests/test_litellm/caching/test_redis_cache.py: added a regression test for disconnect() with no connection pool
- tests/test_litellm/caching/test_redis_cluster_cache.py: added regression tests for RedisClusterCache.disconnect() both with and without an initialized cluster client

## QA runbook

1. Point the proxy at a cluster-mode Redis (REDIS_CLUSTER_NODES set, or any deployment that is always cluster-mode)
2. Start the proxy, then send SIGTERM
3. Before this fix: shutdown log shows an unhandled AttributeError and skips the steps after cache disconnect. After this fix: shutdown completes and logs proceed through JWT handler close, DB writer close, billing flush, and langfuse flush

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
