### PR TITLE
fix(anthropic): preserve model output limit with reasoning

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1566,6 +1566,10 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         self.update_optional_params_with_thinking_tokens(
             non_default_params=non_default_params, optional_params=optional_params
         )
+        if self.is_thinking_enabled(optional_params) and not self.is_max_tokens_in_request(non_default_params):
+            optional_params["max_tokens"] = (  # rebind-ok: provider request params are built in place
+                self.get_max_tokens_for_model(model)
+            )
 
         return optional_params
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -51,6 +51,7 @@ from litellm.types.llms.openai import (
     ChatCompletionToolParamFunctionChunk,
     ChatCompletionUserMessage,
     GenericChatCompletionMessage,
+    IncompleteDetails,
     InputTokensDetails,
     OpenAIChatCompletionTextObject,
     OpenAIMcpServerTool,
@@ -1754,6 +1755,16 @@ class LiteLLMCompletionResponsesConfig:
             return "completed"
 
     @staticmethod
+    def _map_chat_completion_finish_reason_to_incomplete_details(
+        finish_reason: str | None,
+    ) -> IncompleteDetails | None:
+        if finish_reason == "length":
+            return IncompleteDetails(reason="max_output_tokens")
+        if finish_reason in {"content_filter", "refusal"}:
+            return IncompleteDetails(reason="content_filter")
+        return None
+
+    @staticmethod
     def _tool_call_id_from_responses_item(item_id: str | None, call_id: str | None) -> str:
         """Bedrock Mantle returns a non-unique, index-based ``call_id`` (``call_0``,
         ``call_1``, ... that resets every response) alongside a unique ``id``
@@ -1874,7 +1885,8 @@ class LiteLLMCompletionResponsesConfig:
             model=chat_completion_response.model,
             object="response",
             error=getattr(chat_completion_response, "error", None),
-            incomplete_details=getattr(chat_completion_response, "incomplete_details", None),
+            incomplete_details=getattr(chat_completion_response, "incomplete_details", None)
+            or LiteLLMCompletionResponsesConfig._map_chat_completion_finish_reason_to_incomplete_details(finish_reason),
             instructions=getattr(chat_completion_response, "instructions", None),
             metadata=getattr(chat_completion_response, "metadata", {}),
             output=LiteLLMCompletionResponsesConfig._transform_chat_completion_choices_to_responses_output(

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -2479,6 +2479,27 @@ def test_transform_request_respects_user_max_tokens():
     assert result["max_tokens"] == 1000
 
 
+def test_transform_request_uses_model_max_tokens_with_reasoning_effort():
+    config = AnthropicConfig()
+    optional_params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "low"},
+        optional_params={},
+        model="claude-haiku-4-5",
+        drop_params=False,
+    )
+
+    result = config.transform_request(
+        model="claude-haiku-4-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert result["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+    assert result["max_tokens"] == 64000
+
+
 def test_calculate_usage_completion_tokens_details_always_populated():
     """
     Test that completion_tokens_details is always populated in Usage object,

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -532,6 +532,33 @@ class TestLiteLLMCompletionResponsesConfig:
         )
 
         assert responses_api_response.status == "incomplete"
+        assert responses_api_response.incomplete_details is not None
+        assert responses_api_response.incomplete_details.reason == "content_filter"
+
+    def test_transform_chat_completion_response_incomplete_details_with_length(self):
+        chat_completion_response = ModelResponse(
+            id="test-response-id",
+            created=1234567890,
+            model="claude-haiku-4-5",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="length",
+                    index=0,
+                    message=Message(content="", role="assistant"),
+                )
+            ],
+        )
+
+        responses_api_response = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+            request_input="this is a test",
+            responses_api_request={},
+            chat_completion_response=chat_completion_response,
+        )
+
+        assert responses_api_response.status == "incomplete"
+        assert responses_api_response.incomplete_details is not None
+        assert responses_api_response.incomplete_details.reason == "max_output_tokens"
 
     def test_transform_chat_completion_response_preserves_hidden_params(self):
         """Test that _hidden_params from chat completion response are preserved in responses API response"""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic reasoning silently lowers the model output limit
- Length stops lose their Responses API reason

How it solves it:

- Preserve Anthropic's model-aware limit when callers omit one
- Map completion stop reasons into incomplete response details

## User Flow

Before: a developer runs a tool-heavy Anthropic Responses turn and receives no final answer

1. They send POST https://litellm.example/v1/responses with Claude Haiku 4.5 and low reasoning
2. They omit `max_output_tokens` and allow the model to call tools
3. The response stops after an implicit 5,120-token limit with no useful incomplete reason

After: the same turn retains the model limit and completes with a final answer

1. They send POST https://litellm.example/v1/responses with Claude Haiku 4.5 and low reasoning
2. They omit `max_output_tokens` and allow the model to call tools
3. Anthropic receives its 64,000-token model limit and the response completes normally
4. A genuine length stop reports `incomplete_details.reason` as `max_output_tokens`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

### Before (fac1a18c0a)

1. Sovara ran its real Claude Haiku 4.5 compatibility workflow with low reasoning and application tools
2. The lesson polish turn consumed the implicit 5,120-token output allowance without returning final structured output

### After (bd758b8e34)

1. Sovara ran the same live compatibility workflow against the patch-equivalent fork staging commit `5be5db8580`
2. Brain text, internal tools, MCP, annotation, lesson polish, lesson suggest, and lesson submit all passed
3. The transformed Haiku request used the model-aware 64,000-token output limit

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
