### PR TITLE
feat(chatgpt): opt-in stable session id derived from the conversation prefix

### DIFF
--- a/litellm/llms/chatgpt/common_utils.py
+++ b/litellm/llms/chatgpt/common_utils.py
@@ -2,8 +2,10 @@
 Constants and helpers for ChatGPT subscription OAuth.
 """
 
+import json
 import os
 import platform
+from hashlib import sha256
 from typing import Any, Final
 from uuid import uuid4
 
@@ -268,7 +270,7 @@ def _normalize_litellm_params(litellm_params: Any | None) -> dict:
     return {}
 
 
-def get_chatgpt_session_id(litellm_params: Any | None) -> str | None:
+def get_explicit_chatgpt_session_id(litellm_params: object) -> str | None:
     params: Final = _normalize_litellm_params(litellm_params)
     for key in ("litellm_session_id", "session_id"):
         value = params.get(key)
@@ -279,6 +281,14 @@ def get_chatgpt_session_id(litellm_params: Any | None) -> str | None:
         value = metadata.get("session_id")
         if value:
             return str(value)
+    return None
+
+
+def get_chatgpt_session_id(litellm_params: object) -> str | None:
+    explicit: Final = get_explicit_chatgpt_session_id(litellm_params)
+    if explicit:
+        return explicit
+    params: Final = _normalize_litellm_params(litellm_params)
     for key in ("litellm_trace_id", "litellm_call_id"):
         value = params.get(key)
         if value:
@@ -288,3 +298,23 @@ def get_chatgpt_session_id(litellm_params: Any | None) -> str | None:
 
 def ensure_chatgpt_session_id(litellm_params: Any | None) -> str:
     return get_chatgpt_session_id(litellm_params) or str(uuid4())
+
+
+def should_derive_chatgpt_session_id(litellm_params: object) -> bool:
+    value: Final = _normalize_litellm_params(litellm_params).get("chatgpt_derive_session_id")
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    return value is True
+
+
+def derive_chatgpt_session_id(litellm_params: object, instructions: str | None, input: object) -> str:
+    params: Final = _normalize_litellm_params(litellm_params)
+    metadata: Final = params.get("litellm_metadata") or params.get("metadata")
+    tenant: Final = str(metadata.get("user_api_key_hash") or "") if isinstance(metadata, dict) else ""
+    first_item: Final = input[0] if isinstance(input, list) and input else input
+    anchor: Final = json.dumps(
+        (tenant, instructions or "", first_item),
+        sort_keys=True,
+        default=str,
+    )
+    return f"litellm-derived-{sha256(anchor.encode('utf-8')).hexdigest()[:32]}"

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -23,9 +23,12 @@ from ..authenticator import Authenticator
 from ..common_utils import (
     CHATGPT_API_BASE,
     GetAccessTokenError,
+    derive_chatgpt_session_id,
     ensure_chatgpt_session_id,
     get_chatgpt_default_headers,
     get_chatgpt_default_instructions,
+    get_explicit_chatgpt_session_id,
+    should_derive_chatgpt_session_id,
 )
 
 
@@ -82,6 +85,10 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             request["instructions"] = base_instructions
         request["store"] = False
         request["stream"] = True
+        should_derive: Final = should_derive_chatgpt_session_id(litellm_params)
+        if should_derive and get_explicit_chatgpt_session_id(litellm_params) is None:
+            derived: Final = derive_chatgpt_session_id(litellm_params, request.get("instructions"), input)
+            headers["session_id"] = derived  # rebind-ok: must land in the dict validate_environment built
         include: Final = list(request.get("include") or [])
         if "reasoning.encrypted_content" not in include:
             include.append("reasoning.encrypted_content")

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -158,6 +158,109 @@ class TestChatGPTResponsesAPITransformation:
             "function": {"name": "hello"},
         }
 
+    def _transform_headers(
+        self, input: list[dict[str, str]], litellm_params: GenericLiteLLMParams
+    ) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        ChatGPTResponsesAPIConfig().transform_responses_api_request(
+            model="chatgpt/gpt-5.4",
+            input=input,
+            response_api_optional_request_params={},
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+        return headers
+
+    def test_derived_session_id_is_stable_as_conversation_grows(self):
+        params = GenericLiteLLMParams(chatgpt_derive_session_id=True)
+        first_turn = [{"role": "user", "content": "start of conversation"}]
+        later_turn = first_turn + [
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "follow-up"},
+        ]
+
+        headers_one = self._transform_headers(first_turn, params)
+        headers_two = self._transform_headers(later_turn, params)
+
+        assert headers_one["session_id"].startswith("litellm-derived-")
+        assert headers_one["session_id"] == headers_two["session_id"]
+
+    def test_derived_session_id_differs_across_conversations(self):
+        params = GenericLiteLLMParams(chatgpt_derive_session_id=True)
+
+        headers_one = self._transform_headers(
+            [{"role": "user", "content": "conversation a"}], params
+        )
+        headers_two = self._transform_headers(
+            [{"role": "user", "content": "conversation b"}], params
+        )
+
+        assert headers_one["session_id"] != headers_two["session_id"]
+
+    def test_explicit_session_id_wins_over_derivation(self):
+        params = GenericLiteLLMParams(
+            chatgpt_derive_session_id=True, litellm_session_id="explicit-1"
+        )
+
+        headers = self._transform_headers([{"role": "user", "content": "hi"}], params)
+
+        assert "session_id" not in headers
+
+    def test_proxy_trace_id_does_not_block_derivation(self):
+        params = GenericLiteLLMParams(
+            chatgpt_derive_session_id=True,
+            litellm_trace_id="b6c2977a-0652-43de-a9a6-165822f439f6",
+        )
+        headers = {"session_id": params.litellm_trace_id}
+
+        ChatGPTResponsesAPIConfig().transform_responses_api_request(
+            model="chatgpt/gpt-5.4",
+            input=[{"role": "user", "content": "hi"}],
+            response_api_optional_request_params={},
+            litellm_params=params,
+            headers=headers,
+        )
+
+        assert headers["session_id"].startswith("litellm-derived-")
+
+    def test_different_api_keys_derive_different_session_ids(self):
+        input = [{"role": "user", "content": "shared prefix"}]
+        params_a = GenericLiteLLMParams(
+            chatgpt_derive_session_id=True,
+            litellm_metadata={"user_api_key_hash": "key-a"},
+        )
+        params_b = GenericLiteLLMParams(
+            chatgpt_derive_session_id=True,
+            litellm_metadata={"user_api_key_hash": "key-b"},
+        )
+
+        headers_a = self._transform_headers(input, params_a)
+        headers_b = self._transform_headers(input, params_b)
+
+        assert headers_a["session_id"] != headers_b["session_id"]
+        assert headers_a["session_id"] == self._transform_headers(input, params_a)["session_id"]
+
+    def test_quoted_false_string_does_not_enable_derivation(self):
+        params = GenericLiteLLMParams(chatgpt_derive_session_id="false")
+
+        headers = self._transform_headers([{"role": "user", "content": "hi"}], params)
+
+        assert "session_id" not in headers
+
+    def test_quoted_true_string_enables_derivation(self):
+        params = GenericLiteLLMParams(chatgpt_derive_session_id="true")
+
+        headers = self._transform_headers([{"role": "user", "content": "hi"}], params)
+
+        assert headers["session_id"].startswith("litellm-derived-")
+
+    def test_no_derivation_without_flag(self):
+        headers = self._transform_headers(
+            [{"role": "user", "content": "hi"}], GenericLiteLLMParams()
+        )
+
+        assert "session_id" not in headers
+
     @pytest.mark.parametrize(
         ("model_name", "response_model"),
         [


### PR DESCRIPTION
## TLDR

Problem this solves:

- chatgpt/ requests send a fresh random session id every call
- upstream prompt cache hits only by routing luck, most turns bill full input

How it solves it:

- new opt-in deployment flag `chatgpt_derive_session_id`
- derives a stable session id from caller key, instructions, first input item
- same conversation then lands on the same cache shard every turn
- explicit session ids still win, and without the flag nothing changes

## User Flow

Before: a developer whose agent resends the whole conversation each turn never hits the upstream prompt cache, so every turn bills the full input

1. The proxy admin sets `chatgpt_derive_session_id: true` on the chatgpt/ deployment and restarts the proxy
2. The developer's app sends POST http://localhost:4000/v1/responses with a long conversation and no session field
3. The `response.completed` event reports `"cached_tokens": 0`, the expected cold first turn
4. A minute later the app sends the next turn carrying the same conversation prefix, again with no session field
5. The response still reports `"cached_tokens": 0`, a hit needs routing luck, so most turns bill the resent history at full price

After: the same second turn now comes back mostly cached

1. The proxy admin sets `chatgpt_derive_session_id: true` on the chatgpt/ deployment and restarts the proxy
2. The developer's app sends POST http://localhost:4000/v1/responses with a long conversation and no session field
3. The `response.completed` event reports `"cached_tokens": 0`, the expected cold first turn
4. A minute later the app sends the next turn carrying the same conversation prefix, again with no session field
5. The response now reports most of the input as cached, for example `"cached_tokens": 6912` of 7045 input tokens

## Relevant issues

Fixes #37280

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup. Two configs, identical except for the new flag:

```yaml
# config-flag.yaml
model_list:
  - model_name: codex
    litellm_params:
      model: chatgpt/gpt-5.4
      chatgpt_derive_session_id: true
```

```yaml
# config-plain.yaml
model_list:
  - model_name: codex
    litellm_params:
      model: chatgpt/gpt-5.4
```

One deterministic payload per conversation, each with unique filler so every pair starts from a cold cache, none carrying any session field:

```bash
python3 - <<'PY'
import json
for tag in ("xi", "phi", "chi", "psi", "omega", "aleph", "bet"):
    fill = " ".join(f"{tag}{i} ledger row entry{i} state green" for i in range(600))
    body = {"model": "codex",
            "input": [{"role": "user",
                       "content": "Reference document: " + fill +
                                  "\n\nIn one short sentence, what is this document about?"}]}
    open(f"run_{tag}.json", "w").write(json.dumps(body))
PY
```

Every case below sends the same payload twice, 60 seconds apart (`sleep 60` between the two curls, the upstream cache write needs time to land), and reads `usage` out of the `response.completed` SSE event. All calls returned HTTP 200 and hit the real ChatGPT backend

### Before (4fd7a73ef5)

Flag present in config but silently ignored, so the repeat request still misses the cache

1. `litellm --config config-flag.yaml --port 4000`
2. `curl -sS http://localhost:4000/v1/responses -H "Content-Type: application/json" -d @run_xi.json`, observed usage: `{"input_tokens": 6445, "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0}, "output_tokens": 23, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 6468}`
3. `sleep 60`, then the identical curl again, observed usage: `{"input_tokens": 6445, "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0}, "output_tokens": 25, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 6470}`

### After (9256f7cb81)

Both proxies ran simultaneously and the twelve calls were interleaved across them in alternating order, so both arms saw identical timing. Without a stable session id a repeat can still hit by landing on the right shard by chance, so the arms differ in reliability: across every 60-second-gap trial run during development the flagged arm hit 10 of 10 repeats while the unflagged arm hit 4 of 10

#### Flag set: repeat request hits the cache, 3 of 3 conversations

1. `litellm --config config-flag.yaml --port 4000`
2. Cold call per conversation: `curl -sS http://localhost:4000/v1/responses -H "Content-Type: application/json" -d @run_phi.json` (same for chi, psi)
3. `sleep 60`, then the identical curls again, observed usage on the repeats:

```
phi    {"input_tokens": 6445, "input_tokens_details": {"cached_tokens": 5888, "cache_write_tokens": 0}, "output_tokens": 25, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 6470}
chi    {"input_tokens": 6445, "input_tokens_details": {"cached_tokens": 5888, "cache_write_tokens": 0}, "output_tokens": 28, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 6473}
psi    {"input_tokens": 6445, "input_tokens_details": {"cached_tokens": 5888, "cache_write_tokens": 0}, "output_tokens": 28, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 6473}
```

#### Flag absent: default unchanged, repeat hits stay routing luck, 1 of 3 conversations this run

1. `litellm --config config-plain.yaml --port 4001`
2. Cold call per conversation: `curl -sS http://localhost:4001/v1/responses -H "Content-Type: application/json" -d @run_omega.json` (same for aleph, bet)
3. `sleep 60`, then the identical curls again, observed usage on the repeats:

```
omega  {"input_tokens": 6445, "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0}, "output_tokens": 29, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 6474}
aleph  {"input_tokens": 7045, "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0}, "output_tokens": 30, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 7075}
bet    {"input_tokens": 6445, "input_tokens_details": {"cached_tokens": 5888, "cache_write_tokens": 0}, "output_tokens": 20, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 6465}
```

## Type

🆕 New Feature

## Caveats (if any)

- upstream cache write takes about a minute, back-to-back repeats miss
- conversations are distinguished by instructions plus their first input item
- proxy-generated trace ids no longer count as an explicit session id
- flag parses quoted "true"/"false" strictly, anything else stays off
- anchor is namespaced by hashed api key, tenants cannot share entries

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
