### PR TITLE
fix: correct module and function names in router strategy exception logs

### DIFF
--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -171,7 +171,7 @@ class LowestCostLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - %s", e
+                "litellm.router_strategy.lowest_cost.py::async_log_success_event(): Exception occured - %s", e
             )
 
     async def async_get_available_deployments(

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -160,7 +160,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - %s", e
+                "litellm.router_strategy.lowest_latency.py::log_success_event(): Exception occured - %s", e
             )
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
@@ -217,7 +217,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 return
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - %s", e
+                "litellm.router_strategy.lowest_latency.py::async_log_failure_event(): Exception occured - %s", e
             )
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):

--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -74,7 +74,7 @@ class LowestTPMLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_router_logger.error(
-                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occured - %s", e
+                "litellm.router_strategy.lowest_tpm_rpm.py::log_success_event(): Exception occured - %s", e
             )
             verbose_router_logger.debug(traceback.format_exc())
 

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -245,7 +245,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                 self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.lowest_tpm_rpm_v2.py::log_success_event(): Exception occured - %s", e
+                "litellm.router_strategy.lowest_tpm_rpm_v2.py::log_success_event(): Exception occured - %s", e
             )
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
@@ -289,7 +289,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                 self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.lowest_tpm_rpm_v2.py::async_log_success_event(): Exception occured - %s", e
+                "litellm.router_strategy.lowest_tpm_rpm_v2.py::async_log_success_event(): Exception occured - %s", e
             )
 
     def _return_potential_deployments(


### PR DESCRIPTION
## What

Six `verbose_logger.exception` / `verbose_router_logger.error` calls in `litellm/router_strategy/` report a source location that does not match where the exception was actually caught. This corrects each string to name its own module
and enclosing function.

| File | Line | Reported (before) | Actual |
|---|---|---|---|
| `lowest_latency.py` | 163 | `litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook()` | `log_success_event()` |
| `lowest_latency.py` | 220 | `litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook()` | `async_log_failure_event()` |
| `lowest_cost.py` | 174 | `litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook()` | `async_log_success_event()` |
| `lowest_tpm_rpm.py` | 77 | `...lowest_tpm_rpm.py::async_log_success_event()` | `log_success_event()` (sync) |
| `lowest_tpm_rpm_v2.py` | 248 | `litellm.proxy.hooks.lowest_tpm_rpm_v2.py::...` | `litellm.router_strategy.lowest_tpm_rpm_v2.py::...` |
| `lowest_tpm_rpm_v2.py` | 292 | `litellm.proxy.hooks.lowest_tpm_rpm_v2.py::...` | `litellm.router_strategy.lowest_tpm_rpm_v2.py::...` |

## Why

These are the log lines an operator sees when routing misbehaves under `latency-based-routing`, `cost-based-routing`, or `usage-based-routing`.

Two of the reported paths don't exist in the repo at all —
`litellm/proxy/hooks/lowest_tpm_rpm_v2.py` is not a file, and `prompt_injection_detection.py::async_pre_call_hook` is a real but unrelated function. Grepping the reported location returns nothing, so the log sends someone debugging a production proxy to the wrong place.

I hit this running LiteLLM as a gateway in Docker and went looking for `litellm/proxy/hooks/lowest_tpm_rpm_v2.py`, which does not exist.

## Scope and risk

- Log message strings only. No control flow, no signatures, no behavior change.
- The already-correct strings in these same files (`lowest_latency.py:353`, `lowest_cost.py:95`, `lowest_tpm_rpm.py:139`) were used as the reference format and are unchanged.
- `grep -rn "prompt_injection_detection.py::async_pre_call_hook" tests/ enterprise/` and the equivalent for `proxy.hooks.lowest_tpm_rpm_v2` return no matches — no test asserts on these strings.
- `ruff format --check` and `ruff check` pass on all four files.

No tests added: this changes no behavior and there is no existing test asserting on log text in these modules. Happy to add one if you'd prefer.

## Possible follow-up (not in this PR)

`Exception occured` (missing the second `r`) appears ~120 times across the package, including in the lines touched here. Left alone to keep this diff isolated — glad to send a separate sweep if wanted.