### PR TITLE
fix: correct module path in vertex_ai cost_per_character debug logs

### DIFF
--- a/litellm/llms/vertex_ai/cost_calculator.py
+++ b/litellm/llms/vertex_ai/cost_calculator.py
@@ -114,7 +114,7 @@ def cost_per_character(
                 prompt_cost = prompt_characters * model_info["input_cost_per_character"]
         except Exception as e:
             verbose_logger.debug(
-                "litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occured - %s\nDefaulting to None",
+                "litellm.llms.vertex_ai.cost_calculator.py::cost_per_character(): Exception occured - %s\nDefaulting to None",
                 e,
             )
             prompt_cost, _ = cost_per_token(
@@ -153,7 +153,7 @@ def cost_per_character(
                 completion_cost = completion_characters * model_info["output_cost_per_character"]
         except Exception as e:
             verbose_logger.debug(
-                "litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occured - %s\nDefaulting to None",
+                "litellm.llms.vertex_ai.cost_calculator.py::cost_per_character(): Exception occured - %s\nDefaulting to None",
                 e,
             )
             _, completion_cost = cost_per_token(

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -736,7 +736,7 @@ def test_vertex_ai_embedding_completion_cost(caplog):
     for item in captured_logs:
         print("\nitem:{}\n".format(item))
         if (
-            "litellm.litellm_core_utils.llm_cost_calc.google.cost_per_character(): Exception occured "
+            "litellm.llms.vertex_ai.cost_calculator.py::cost_per_character(): Exception occured "
             in item
         ):
             raise Exception("Error log raised for calculating embedding cost")


### PR DESCRIPTION
## What

Two `verbose_logger.debug` calls in `cost_per_character` report their source as `litellm.litellm_core_utils.llm_cost_calc.google.py`. That module does not exist  
`litellm/litellm_core_utils/llm_cost_calc/` contains only `tiered_pricing.py`, `tool_call_cost_tracking.py`, `usage_object_transformation.py` and `utils.py`.

The code lives in `litellm/llms/vertex_ai/cost_calculator.py`, function `cost_per_character` (lines 117 and 156).

## The test guarding these logs no longer matches them

`tests/local_testing/test_completion_cost.py:739` scans captured logs and fails if
this message appears:

```python
if (
    "litellm.litellm_core_utils.llm_cost_calc.google.cost_per_character(): Exception occured "
    in item
):
    raise Exception("Error log raised for calculating embedding cost")
```

That substring uses `google.cost_per_character()` — a plain `.` — while the emitted message uses `google.py::cost_per_character()`. It cannot match, so the guard has been vacuous independently of the module-path issue. This PR updates the substring to match the corrected message, so the guard does what it was written to do.

## Why it matters

These fire when Vertex character-based pricing is missing from the model map and cost calculation silently falls back to token pricing. Someone investigating a cost discrepancy sees the message, greps `litellm/litellm_core_utils/llm_cost_calc/google.py`, and finds no such file.

## Scope and risk

- Log message strings plus one test substring. No control flow, no behavior change.
- `ruff format --check` and `ruff check` pass on the changed source file.
- After this change, `grep -rn "llm_cost_calc.google" . --include="*.py"` returns nothing.
- The test calls `cost_per_token` directly, so `cost_per_character` is not on its path — correcting the substring restores the guard without changing what the test asserts today.

## Related, not in this PR

`cost_per_character` calls `litellm.get_model_info(...)` twice in a row with identical arguments (lines 82 and 85); the first result is immediately overwritten. Left out to keep this diff to logging. Happy to send it separately.