### PR TITLE
fix(cost): treat an explicit zero input_cost_per_token as priced, not…

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -112,7 +112,7 @@ def select_cost_metric_for_model(
     """
     if model_info.get("input_cost_per_character"):
         return "cost_per_character"
-    elif model_info.get("input_cost_per_token"):
+    elif model_info.get("input_cost_per_token") is not None:
         return "cost_per_token"
     else:
         raise ValueError(

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -3345,3 +3345,18 @@ def test_generic_cost_per_token_grok_46_long_context(_local_model_cost_map):
     )
     assert prompt_cost == pytest.approx(200_000 * 4e-06 + 50_000 * 1e-06)
     assert completion_cost == pytest.approx(1_000 * 1.2e-05)
+
+
+def test_select_cost_metric_for_model_treats_zero_token_cost_as_priced():
+    from litellm.litellm_core_utils.llm_cost_calc.utils import select_cost_metric_for_model
+
+    free_model = {"key": "free-model", "input_cost_per_token": 0.0}
+    assert select_cost_metric_for_model(free_model) == "cost_per_token"
+
+    char_model = {"key": "char-model", "input_cost_per_character": 1e-6, "input_cost_per_token": 0.0}
+    assert select_cost_metric_for_model(char_model) == "cost_per_character"
+
+    import pytest
+
+    with pytest.raises(ValueError):
+        select_cost_metric_for_model({"key": "no-pricing"})


### PR DESCRIPTION
## TLDR

Problem this solves:

- a model priced at `input_cost_per_token: 0` (free / BYOK tiers) raises ValueError instead of costing $0
- cost tracking for those deployments errors out instead of logging zero spend

How it solves it:

- treat an explicit `0` token cost as "priced" using an `is not None` check, not a truthiness check

## User Flow

Before: an admin configures a deployment with `input_cost_per_token: 0` and cost tracking errors on every call

1. They register a free or BYOK deployment with `input_cost_per_token: 0`
2. A request runs and the cost calculator calls `select_cost_metric_for_model`
3. The zero value is treated as missing, so it raises `ValueError: Model ... does not have 'input_cost_per_character' or 'input_cost_per_token'`

After: the same deployment logs $0 spend cleanly

1. They register the same `input_cost_per_token: 0` deployment
2. A request runs
3. `select_cost_metric_for_model` returns `cost_per_token` and the request is logged at $0

## Relevant issues

## Linear ticket

## Type

🐛 Bug Fix

## Changes

`select_cost_metric_for_model` picked the pricing metric with `elif model_info.get("input_cost_per_token"):`, so a legitimate zero rate was falsy and fell through to the `else`, which raises. A deployment deliberately priced at zero is priced, not unpriced, so this switches that branch to `is not None`. The character branch is unchanged, and the raise still fires when pricing is genuinely absent (`None`).

## Screenshots / Proof of Fix

```
>>> select_cost_metric_for_model({"key": "free-model", "input_cost_per_token": 0.0})
# before: ValueError: Model free-model does not have 'input_cost_per_character' or 'input_cost_per_token'
# after:  'cost_per_token'
```

Regression test in `tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py::test_select_cost_metric_for_model_treats_zero_token_cost_as_priced` (covers the zero-token case, the character-priced case, and the genuinely-unpriced raise). Passes; fails if the branch reverts to a truthiness check.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
