### PR TITLE
fix(cache): InMemoryCache.async_get_ttl returns remaining seconds (gh-37261)

### DIFF
--- a/litellm/caching/in_memory_cache.py
+++ b/litellm/caching/in_memory_cache.py
@@ -265,8 +265,6 @@ class InMemoryCache(BaseCache):
 
     async def async_get_ttl(self, key: str) -> int | None:
         """Get the remaining TTL of a key in in-memory cache"""
-        Get the remaining TTL of a key in in-memory cache
-        """
         expiry = self.ttl_dict.get(key, None)
         if expiry is None:
             return None

--- a/litellm/caching/in_memory_cache.py
+++ b/litellm/caching/in_memory_cache.py
@@ -264,10 +264,13 @@ class InMemoryCache(BaseCache):
         self._remove_key(key)
 
     async def async_get_ttl(self, key: str) -> int | None:
-        """
+        """Get the remaining TTL of a key in in-memory cache"""
         Get the remaining TTL of a key in in-memory cache
         """
-        return self.ttl_dict.get(key, None)
+        expiry = self.ttl_dict.get(key, None)
+        if expiry is None:
+            return None
+        return max(0, expiry - time.time())
 
     async def async_get_oldest_n_keys(self, n: int) -> list[str]:
         """


### PR DESCRIPTION
## Summary
Fixes #37261. When `provider_budget_config` is used without Redis, `GET /provider/budgets` reports `budget_reset_at` ~57 years in the future because `InMemoryCache.async_get_ttl` returned an absolute expiry timestamp instead of remaining seconds.

## Root cause
`InMemoryCache` stores absolute expiry timestamps in `ttl_dict` (`time.time() + ttl`), but `async_get_ttl` returned that raw value. `budget_limiter.py` then added it directly to `datetime.now()`, producing `now + ~56.7 years`.

`RedisCache.async_get_ttl` correctly returns remaining seconds, so the mismatch only manifests when no Redis is configured.

## Fix
`InMemoryCache.async_get_ttl` now converts the stored absolute expiry to remaining seconds:
```python
expiry = self.ttl_dict.get(key, None)
if expiry is None:
    return None
return max(0, expiry - time.time())
```

This aligns both cache backends on the same contract (`remaining seconds`), matching the Redis behavior and what `budget_limiter.py` expects.

## Test plan
- Unit test for `InMemoryCache.async_get_ttl` returning remaining seconds
- Unit test for `_get_current_provider_budget_reset_at` without Redis: `budget_reset_at` is now `now + time_period`, not `now + 56.7 years`
- Existing budget-limiter tests pass; no behavior change for Redis deployments

Fixes #37261