### PR TITLE
test(e2e): assert the guardrail enforces before asserting a team bypasses it

### DIFF
--- a/tests/e2e/guardrails/test_team_disable_global_guardrail_e2e.py
+++ b/tests/e2e/guardrails/test_team_disable_global_guardrail_e2e.py
@@ -16,22 +16,28 @@ from e2e_config import unique_marker
 from e2e_http import UnknownApiError, unwrap
 from guardrails_client import GuardrailsClient
 from lifecycle import ResourceManager
+from models import ChatResponse
 
 pytestmark = pytest.mark.e2e
 
 MODEL = "gemini-2.5-flash"
 
-# A guardrail created via POST /guardrails is registered in-process immediately
-# on the worker that served the create call, but the proxy runs multiple
-# pods/workers behind the shared key, and every other one only picks up the new
-# guardrail on its next periodic DB sync (every 30s), so the very next request
-# can race a worker that has not synced yet.
+# register() already settles the config reload, but a replica that missed its window serves the old config.
 GUARDRAIL_PROPAGATION_DEADLINE_SECONDS = 40.0
 GUARDRAIL_PROPAGATION_POLL_INTERVAL_SECONDS = 5.0
+
+_BLOCK_MARKER = "content blocked"
 
 
 def _prompt_with(banned_keyword: str) -> str:
     return f"Reply with the single word OK. {banned_keyword}"
+
+
+def _first_content(response: ChatResponse) -> str:
+    if not response.choices:
+        return ""
+    message = response.choices[0].message
+    return (message.content if message else None) or ""
 
 
 def _assert_eventually_blocked(client: GuardrailsClient, key: str, banned: str) -> None:
@@ -41,7 +47,7 @@ def _assert_eventually_blocked(client: GuardrailsClient, key: str, banned: str) 
         match result:
             case UnknownApiError(status_code=status, body=body):
                 assert status == 400, f"expected a 400 guardrail block, got {status}: {body[:300]}"
-                assert "content blocked" in body.lower() or banned in body, (
+                assert _BLOCK_MARKER in body.lower() or banned in body, (
                     f"block response missing content-filter reason: {body[:300]}"
                 )
                 return
@@ -73,7 +79,7 @@ class TestTeamDisableGlobalGuardrail:
         exercised_on=["chat_completions"],
     )
     def test_team_with_disable_flag_bypasses_global_guardrail(
-        self, client: GuardrailsClient, resources: ResourceManager
+        self, client: GuardrailsClient, resources: ResourceManager, scoped_key: str
     ) -> None:
         banned = unique_marker()
         guardrail_id = client.create_content_filter_guardrail(f"e2e-content-filter-{banned}", banned)
@@ -84,9 +90,20 @@ class TestTeamDisableGlobalGuardrail:
         key = client.create_key_in_team(team_id)
         resources.defer(lambda: client.proxy.delete_key(key))
 
-        chat = unwrap(client.chat(key, MODEL, _prompt_with(banned)))
+        _assert_eventually_blocked(client, scoped_key, banned)
+
+        chat = unwrap(client.chat(key, MODEL, _prompt_with(banned), max_tokens=256))
 
         assert chat.choices, (
             f"team opted out of global guardrails, so the banned keyword must pass "
             f"through and the call must succeed, but no choices came back: {chat}"
+        )
+        text = _first_content(chat)
+        assert _BLOCK_MARKER not in text.lower(), (
+            f"the guardrail intercepted a key on a team opted out of global guardrails, "
+            f"returning the content-blocked message instead of the model's answer: {text[:300]!r}"
+        )
+        assert chat.usage is not None and (chat.usage.prompt_tokens or 0) > 0, (
+            f"the opted-out call must reach the model, but the model was never "
+            f"invoked; usage was {chat.usage}"
         )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Guardrail bypass test passed even when the guardrail was off
- It never proved its own guardrail was enforcing
- A fully broken `disable_global_guardrails` stayed green

How it solves it:

- Prove the guardrail blocks a key outside the team first
- Then assert the opted-out key gets through
- Require the model actually ran, not just a 200

## User Flow

This is a test-only change, so the end user sees no behavior difference. The flow below is the behavior the test is meant to protect, which is unchanged by this PR

Before: an admin turns on a default-on content filter, and a team opted out of global guardrails still reaches the model

1. They POST https://litellm-domain/guardrails with a default-on content filter blocking a keyword
2. A key with no team opt-out POSTs https://litellm-domain/v1/chat/completions with that keyword and gets `400 Content blocked: keyword '...' detected`
3. A key on a team created with `disable_global_guardrails` sends the same prompt and gets `200` with the model's own answer

After: identical, step for step. What changed is that the suite now fails when step 2 stops blocking, instead of reporting success off step 3 alone

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: a proxy on port 4110 against an isolated Postgres, one deployment `gemini-2.5-flash` backed by real Gemini, master key `sk-1234`. Every call below is a live provider call

### Before (4fd7a73)

The old assertion was `assert chat.choices` on the opted-out key alone. Case 3 shows that same observable holds with the guardrail not enforcing at all, so a passing run said nothing about the opt-out

#### Case 1: default-on guardrail blocks a key with no opt-out

1. Create the guardrail

```
curl -s -X POST http://localhost:4110/guardrails -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
 -d '{"guardrail":{"guardrail_name":"pr-demo-zzsecretword1","litellm_params":{"guardrail":"litellm_content_filter","mode":"pre_call","default_on":true,"blocked_words":[{"keyword":"zzsecretword1","action":"BLOCK"}]}}}'
```

2. Send the banned keyword on a plain key

```
curl -s -X POST http://localhost:4110/v1/chat/completions -H "Authorization: Bearer $PLAIN" -H "Content-Type: application/json" \
 -d '{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"Reply with the single word OK. zzsecretword1"}],"max_tokens":256}'

{"error":{"message":"Content blocked: keyword 'zzsecretword1' detected","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Content blocked: keyword 'zzsecretword1' detected","keyword":"zzsecretword1","description":null,"guardrail_name":"pr-demo-zzsecretword1","guardrail_mode":"pre_call"}}}
HTTP 400
```

#### Case 2: a team opted out of global guardrails gets through

1. Create the team and a key on it

```
curl -s -X POST http://localhost:4110/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
 -d '{"team_alias":"pr-demo-optout2","metadata":{"disable_global_guardrails":true}}'

team_id=9ed42b6f-c23a-47f4-8ef1-3c4bf89abdce
```

2. Send the same banned keyword on that team's key

```
curl -s -X POST http://localhost:4110/v1/chat/completions -H "Authorization: Bearer $TKEY" -H "Content-Type: application/json" \
 -d '{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"Reply with the single word OK. zzsecretword1"}],"max_tokens":256}'

{"id":"ZoKEapz_C-2vjrEPkZLyqAw","created":1787069030,"model":"gemini-2.5-flash","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"OK zzsecretword1","role":"assistant","images":[],"thinking_blocks":[]}}],"usage":{"completion_tokens":44,"prompt_tokens":12,"total_tokens":56,"completion_tokens_details":{"reasoning_tokens":39,"text_tokens":5},"prompt_tokens_details":{"text_tokens":12}},"service_tier":"default"}
```

#### Case 3: the blind spot, a default-on guardrail that never matches

1. Create a default-on guardrail blocking a word the prompt will not contain

```
curl -s -X POST http://localhost:4110/guardrails -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
 -d '{"guardrail":{"guardrail_name":"pr-demo-inert","litellm_params":{"guardrail":"litellm_content_filter","mode":"pre_call","default_on":true,"blocked_words":[{"keyword":"zzneverappears","action":"BLOCK"}]}}}'
```

2. Send a prompt on a key with NO opt-out at all

```
curl -s -X POST http://localhost:4110/v1/chat/completions -H "Authorization: Bearer $PLAIN" -H "Content-Type: application/json" \
 -d '{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"Reply with the single word OK. zzsecretword2"}],"max_tokens":256}'

{"id":"iYKEavKUF6_wjrEPkoP0-Ag","created":1787069065,"model":"gemini-2.5-flash","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"OK","role":"assistant","images":[],"thinking_blocks":[]}}],"usage":{"completion_tokens":70,"prompt_tokens":12,"total_tokens":82,...}}
```

3. A `200` with choices came back on a key that was never opted out. That is the exact observation the old assertion treated as proof the opt-out worked

### After (da8e2c4)

#### Case 1: default-on guardrail blocks a key with no opt-out

1. Unchanged. Same commands, same `400 Content blocked: keyword 'zzsecretword1' detected`

#### Case 2: a team opted out of global guardrails gets through

1. Unchanged. Same commands, same `200` with `"content":"OK zzsecretword1"` and `prompt_tokens: 12`

#### Case 3: the blind spot, a default-on guardrail that never matches

1. Same product behavior, `200` with choices. The difference is on the suite side: the test now runs case 1 against its own guardrail before making the case 2 assertion, so a run in which the guardrail is not enforcing fails on the enforcement check rather than passing on case 2

```
Failed: default-on guardrail never blocked the banned keyword within 40.0s; got kind='success' status_code=200 ...
```

## Type

✅ Test

## Caveats (if any)

- Adds roughly 15s to the bypass test for the enforcement check
- A content-filter regression now reddens both tests, not one

## QA runbook

- tests/e2e/guardrails/test_team_disable_global_guardrail_e2e.py::TestTeamDisableGlobalGuardrail::test_team_with_disable_flag_bypasses_global_guardrail - a team carrying `disable_global_guardrails` reaches the model on a prompt that a live default-on content filter is blocking for everyone else
  - [ ] Needs `GEMINI_API_KEY` and a `gemini-2.5-flash` deployment on the proxy
  - [ ] POST /guardrails with the master key, `guardrail: litellm_content_filter`, `mode: pre_call`, `default_on: true`, and one blocked word
  - [ ] POST /key/generate with the master key and no team, then POST /v1/chat/completions with that key and a prompt containing the blocked word; expect `400` naming the keyword and the guardrail
  - [ ] POST /team/new with `metadata.disable_global_guardrails: true`, then POST /key/generate with that `team_id`
  - [ ] POST /v1/chat/completions with the team key and the same prompt; expect `200`, an assistant message that is not the content-blocked text, and `usage.prompt_tokens` above zero
  - [ ] To see the test earn its keep, re-run the first four steps with the guardrail's blocked word changed to something absent from the prompt; the third step returns `200` instead of `400` and the test fails there
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/guardrails/test_team_disable_global_guardrail_e2e.py::TestTeamDisableGlobalGuardrail::test_global_guardrail_blocks_key_without_team_opt_out - unchanged in behavior, now takes `scoped_key` explicitly
  - [ ] Same first three steps as above; expect the `400` block
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
