### PR TITLE
fix(anthropic): emit tool_use content_block_start without awaiting the next chunk

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -624,6 +624,12 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     return self.chunk_queue.popleft()
 
                 if processed_chunk["type"] == "content_block_delta" and not self._delta_has_content(processed_chunk):
+                    # A tool_use block opens with empty arguments (Bedrock Converse's
+                    # ``contentBlockStart``, OpenAI's ``arguments: ""``), so flush the
+                    # block start queued above instead of waiting for the next upstream
+                    # chunk, which on a trailing-burst provider is the whole generation.
+                    if self.chunk_queue:
+                        return self.chunk_queue.popleft()
                     continue
 
                 if processed_chunk["type"] == "message_delta" and self.sent_content_block_finish is False:
@@ -847,6 +853,9 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     if processed_chunk["type"] == "content_block_delta" and not self._delta_has_content(
                         processed_chunk
                     ):
+                        # See ``__next__``: flush the queued block start (issue #32004).
+                        if self.chunk_queue:
+                            return self.chunk_queue.popleft()
                         continue
 
                     if processed_chunk["type"] == "message_delta" and self.sent_content_block_finish is False:

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
@@ -916,3 +916,117 @@ def test_mixed_finish_chunk_emits_usage_once_sync():
     assert message_deltas[0]["usage"]["output_tokens"] == 7
     assert _text_deltas(events) == ["Hi"]
     _assert_deltas_match_their_block_type(events)
+
+
+class _CountingSyncStream:
+    """Sync stream recording how many upstream chunks have been pulled."""
+
+    def __init__(self, items: List[MagicMock]):
+        self._items = list(items)
+        self.pulled = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.pulled >= len(self._items):
+            raise StopIteration
+        item = self._items[self.pulled]
+        self.pulled += 1
+        return item
+
+
+class _CountingAsyncStream(_CountingSyncStream):
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+def _bedrock_tool_open_then_args() -> List[MagicMock]:
+    """The Bedrock Converse shape: ``contentBlockStart`` names the tool and
+    carries empty arguments, the arguments arrive in later events.
+    """
+    return [
+        _tool_chunk("call_1", "Write", ""),
+        _tool_chunk("call_1", None, '{"file_text":'),
+        _tool_chunk("call_1", None, ' "hello"}'),
+        _make_chunk(Delta(content=None), finish_reason="tool_calls"),
+    ]
+
+
+def test_tool_block_start_emitted_without_awaiting_the_next_chunk_sync():
+    """Regression test for issue #32004.
+
+    A tool_use block opened by a chunk whose delta is empty (Bedrock Converse
+    sends the tool id/name and its arguments in separate events) must emit
+    ``content_block_start`` off that chunk alone. Holding it until the next
+    upstream chunk arrives means a provider that delivers tool arguments as a
+    trailing burst leaves the client with nothing after ``message_start`` for
+    the whole generation, tripping client and load-balancer idle timeouts.
+    """
+    stream = _CountingSyncStream(_bedrock_tool_open_then_args())
+    wrapper = AnthropicStreamWrapper(completion_stream=stream, model="claude-x")
+
+    assert next(wrapper)["type"] == "message_start"
+    assert stream.pulled == 0
+
+    start = next(wrapper)
+    assert start["type"] == "content_block_start"
+    assert start["content_block"] == {
+        "type": "tool_use",
+        "id": "call_1",
+        "name": "Write",
+        "input": {},
+    }
+    assert stream.pulled == 1, (
+        f"content_block_start was withheld until {stream.pulled} upstream chunks had arrived"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_block_start_emitted_without_awaiting_the_next_chunk_async():
+    """Async twin of the sync regression test above (issue #32004)."""
+    stream = _CountingAsyncStream(_bedrock_tool_open_then_args())
+    wrapper = AnthropicStreamWrapper(completion_stream=stream, model="claude-x")
+
+    assert (await wrapper.__anext__())["type"] == "message_start"
+    assert stream.pulled == 0
+
+    start = await wrapper.__anext__()
+    assert start["type"] == "content_block_start"
+    assert start["content_block"]["name"] == "Write"
+    assert stream.pulled == 1, (
+        f"content_block_start was withheld until {stream.pulled} upstream chunks had arrived"
+    )
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.asyncio
+async def test_tool_block_start_flush_does_not_duplicate_or_drop_events(is_async: bool):
+    """Flushing the queued ``content_block_start`` early must not duplicate it,
+    lose the empty opening delta's successors, or break event ordering.
+    """
+    chunks = _bedrock_tool_open_then_args()
+    if is_async:
+        wrapper = AnthropicStreamWrapper(completion_stream=_AsyncStream(chunks), model="claude-x")
+        events = await _drain_async(wrapper)
+    else:
+        wrapper = AnthropicStreamWrapper(completion_stream=iter(chunks), model="claude-x")
+        events = _drain_sync(wrapper)
+
+    assert [e["type"] for e in events] == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    assert _input_json_deltas(events) == ['{"file_text":', ' "hello"}']
+    _assert_deltas_match_their_block_type(events)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/messages` withholds a tool call's `content_block_start`
- It waits for the next upstream chunk to arrive
- On a bursty provider the client sees nothing for minutes

How it solves it:

- Emit the queued `content_block_start` immediately instead of continuing
- Applied in both the sync and async stream paths

## User Flow

Before: a developer whose agent calls a Bedrock Claude model through `/v1/messages` gets no sign a tool call started, so their client times out

1. They send POST https://litellm-domain/v1/messages with `"stream": true`, a `Write` tool, and a prompt that makes the model write a large file
2. They receive `event: message_start` right away
3. Nothing further arrives, not even the name of the tool being called, because the model's tool arguments are still being generated upstream
4. Their client, reverse proxy, or load balancer hits its idle timeout and closes the connection
5. From the client's seat the request looks truncated even though the model was still working

After: the same request names the tool immediately, so the client can render "calling Write" and stays inside its idle budget

1. They send the same POST https://litellm-domain/v1/messages with `"stream": true` and the same `Write` tool
2. They receive `event: message_start` right away
3. `event: content_block_start` follows as soon as the model commits to the tool, carrying `{"type": "tool_use", "name": "Write", "id": "toolu_..."}`
4. The `input_json_delta` frames stream in as the arguments are produced, ending in `content_block_stop` and `message_stop`

## Relevant issues

Relates to #32004

## Linear ticket

Resolves LIT-5727

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup. `AnthropicStreamWrapper` synthesizes the `content_block_start` for the first content block, queues it, then hits a bare `continue` when that same upstream chunk's translated delta is empty. The queue is only drained at the top of the next `__next__` / `__anext__`, so the queued event waits for a further upstream chunk. An empty delta on the opening chunk is the normal tool-call shape: Bedrock Converse's `contentBlockStart` carries the tool id and name with no arguments, and OpenAI-format streams send `arguments: ""` on the chunk that names the function.

Config used for case 1 (`lit5727_config.yaml`), proxy on port 4727:

```yaml
model_list:
  - model_name: tool-caller
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-lit5727

litellm_settings:
  anthropic_sse_ping_interval_seconds: 0
```

Request used for case 1, streamed with `curl -sN` and stamped per SSE frame:

```bash
curl -sN -X POST http://127.0.0.1:4727/v1/messages \
  -H "Authorization: Bearer sk-lit5727" -H "content-type: application/json" \
  -d '{"model":"tool-caller","max_tokens":1024,"stream":true,
       "tool_choice":{"type":"tool","name":"Write"},
       "tools":[{"name":"Write","description":"Write a file to disk",
                 "input_schema":{"type":"object","properties":{
                   "file_path":{"type":"string"},"file_text":{"type":"string"}},
                   "required":["file_path","file_text"]}}],
       "messages":[{"role":"user","content":"Write /tmp/poem.txt containing a 40 line poem about streaming servers. Use the Write tool."}]}'
```

Case 2 replays a Bedrock `ConverseStream` at one event every 400ms so the withheld event is visible at the cadence the issue reports. The frames are real Bedrock wire format (CRC-framed, parsed by botocore's own `EventStreamBuffer` and `EventStreamJSONParser`) driven through the real `AWSEventStreamDecoder` -> `CustomStreamWrapper` -> `/v1/messages` adapter. `IN` is a Bedrock event arriving, `OUT` is an Anthropic SSE frame reaching the client.

### Before (e09bbe9a14)

#### Case 1: live proxy, real OpenAI tool call on /v1/messages

1. Start the proxy on the merge-base tree and confirm the fix is absent: `grep -c 'issue #32004' litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py` prints `0`
2. Run the curl above five times. Runs 1 and 2:

```
   473.6 ms  message_start
  1288.1 ms  content_block_start  {"type": "tool_use", "name": "Write", "id": "call_U1cQXYRYwkTBOUul5pT3SyMa"}
  1288.2 ms  content_block_delta/input_json_delta  (first of many)
  4941.7 ms  content_block_stop
  5043.9 ms  message_stop
          input_json_delta frames: 382
          GAP content_block_start -> first input_json_delta: 0.1 ms

   186.1 ms  message_start
   897.0 ms  content_block_start  {"type": "tool_use", "name": "Write", "id": "call_v7qPC4j8qNg7m52wCOISMMnt"}
   897.1 ms  content_block_delta/input_json_delta  (first of many)
  4869.6 ms  content_block_stop
  4874.1 ms  message_stop
          input_json_delta frames: 423
          GAP content_block_start -> first input_json_delta: 0.1 ms
```

3. Gaps across the five runs: 0.1, 0.1, 11.7, 24.0, 39.5 ms. The 0.1 ms runs are the withholding: `content_block_start` and the first `input_json_delta` both come off the queue, having ridden the same upstream chunk

#### Case 2: Bedrock ConverseStream at 400ms per event

1. `grep -c 'issue #32004' ...streaming_iterator.py` prints `0`
2. Replay the stream and log arrivals against emissions:

```
=== BEFORE (fix sites in tree: 0) ===
 0.021s  OUT  message_start
 0.421s  IN   messageStart
 0.902s  IN   toolUseStart
 1.306s  IN   frag0
 1.307s  OUT  content_block_start
 1.307s  OUT  content_block_delta "f0",
 1.708s  IN   frag1
 1.709s  OUT  content_block_delta "f1",
 2.110s  IN   frag2
 2.111s  OUT  content_block_delta "f2",
 ...
 4.120s  IN   messageStop
 4.123s  OUT  content_block_stop
 4.524s  IN   metadata
 4.534s  OUT  message_delta
 4.534s  OUT  message_stop
```

3. `toolUseStart` arrives at 0.902s and `content_block_start` reaches the client at 1.307s, held 405ms, exactly until the first argument fragment arrives. Had that fragment been 110s away, so would `content_block_start`

### After (3d868ca6af)

Captured at `3d868ca6af`. Head is now `af7538fc37`; the only delta is comment wording in the same file, which cannot move these numbers.

#### Case 1: live proxy, real OpenAI tool call on /v1/messages

1. Restart the proxy on the PR tip: `grep -c 'issue #32004' ...streaming_iterator.py` prints `2`
2. Run the same curl five times. Runs 1 and 2:

```
   545.6 ms  message_start
   640.8 ms  content_block_start  {"type": "tool_use", "name": "Write", "id": "call_Pw2Xn0DZuJh1iCJIQdx2JGSu"}
   653.2 ms  content_block_delta/input_json_delta  (first of many)
  4047.2 ms  content_block_stop
  4113.1 ms  message_stop
          input_json_delta frames: 375
          GAP content_block_start -> first input_json_delta: 12.4 ms

   238.5 ms  message_start
   727.6 ms  content_block_start  {"type": "tool_use", "name": "Write", "id": "call_JhtOr083tjdWKsLOP4fGunGE"}
   739.0 ms  content_block_delta/input_json_delta  (first of many)
  4280.2 ms  content_block_stop
  4476.6 ms  message_stop
          input_json_delta frames: 401
          GAP content_block_start -> first input_json_delta: 11.4 ms
```

3. Gaps across the five runs: 12.4, 11.4, 24.4, 9.3, 7.5 ms. No run collapses to 0.1 ms any more, and the stream still completes with 317 to 418 argument frames in Anthropic order

#### Case 2: Bedrock ConverseStream at 400ms per event

1. `grep -c 'issue #32004' ...streaming_iterator.py` prints `2`
2. Replay the identical stream:

```
=== AFTER (fix sites in tree: 2) ===
 0.021s  OUT  message_start
 0.422s  IN   messageStart
 0.861s  IN   toolUseStart
 0.863s  OUT  content_block_start
 1.264s  IN   frag0
 1.265s  OUT  content_block_delta "f0",
 1.666s  IN   frag1
 1.668s  OUT  content_block_delta "f1",
 2.069s  IN   frag2
 2.070s  OUT  content_block_delta "f2",
 ...
 4.078s  IN   messageStop
 4.083s  OUT  content_block_stop
 4.485s  IN   metadata
 4.500s  OUT  message_delta
 4.500s  OUT  message_stop
```

3. `toolUseStart` arrives at 0.861s and `content_block_start` reaches the client at 0.863s, 2ms later instead of 405ms, off that chunk alone. Every argument fragment still forwards within 1 to 2ms of its arrival, and event order is unchanged

## Type

🐛 Bug Fix

## Caveats (if any)

- No AWS credentials here, so case 2 is a wire-format replay
- The live OpenAI A/B is noise-limited: its inter-chunk gap matches SSE jitter
- #32004 also asks to un-buffer `input_json_delta`; measurements below say it already is

## Review notes

#32004 attributes the silence to litellm buffering `input_json_delta` until the tool block completes. Three independent measurements on current staging say it does not, including the byte and decoder segment that the issue thread's own harnesses did not cover:

- A Bedrock ConverseStream replay of 40 argument fragments fed over 2.543s emitted 40 `input_json_delta` frames spread across 2.041s, tracking arrivals chunk for chunk
- Per-fragment cost over 3000 fragments is flat at 0.19ms, last-decile over first-decile ratio 0.97x, so there is no accumulating work that could stall the loop and then flush
- At 400ms per event every fragment leaves within 1 to 2ms of arriving (case 2 above, on both legs)

So the remaining silence originates at Bedrock, and litellm cannot un-buffer what has not arrived. The idle-timeout symptom is already covered by `litellm.anthropic_sse_ping_interval_seconds` (default 15s) and the `X-Accel-Buffering: no` header on streaming responses. What was still broken is the piece this PR fixes: the one event that a client can be given immediately, naming the tool, was being held back too. That is why the issue is linked rather than closed by this PR.

The sibling block-transition path a few lines above already returns from the queue, so only the first-block-open case changes. Regression tests assert on how many upstream chunks had been pulled when `content_block_start` was emitted, which is timing-independent, and each of the two sites was mutated back to a bare `continue` separately with its own test failing.

Greptile's 4/5 on `3d868ca6af` asked for the duplicated explanatory comments to be shortened. Taken: the sync site keeps a four-line note and the async site now points at it, and both mutation checks were re-run after the trim so neither mutant silently survived the edit.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
