### PR TITLE
fix(get_api_base): read stream from the parsed params, not the raw dict

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/get_api_base.py
+++ b/litellm/litellm_core_utils/llm_response_utils/get_api_base.py
@@ -62,7 +62,7 @@ def get_api_base(model: str, optional_params: dict | LiteLLM_Params) -> str | No
     if dynamic_api_base is not None:
         return dynamic_api_base
 
-    stream: Final[bool] = getattr(optional_params, "stream", False)
+    stream: Final[bool] = getattr(_optional_params, "stream", False)
 
     if _optional_params.vertex_location is not None and _optional_params.vertex_project is not None:
         from litellm.llms.vertex_ai.vertex_llm_base import VertexBase

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_get_api_base.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_get_api_base.py
@@ -1,0 +1,46 @@
+"""
+Tests for litellm.litellm_core_utils.llm_response_utils.get_api_base
+
+`optional_params` is documented as accepting either a plain dict or a
+LiteLLM_Params object, so both shapes must resolve `stream` the same way and
+report the same streaming vs non-streaming Gemini / Vertex URL.
+"""
+
+import pytest
+
+from litellm.litellm_core_utils.llm_response_utils.get_api_base import get_api_base
+from litellm.types.router import LiteLLM_Params
+
+GEMINI_STREAM = "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:streamGenerateContent"
+GEMINI_NON_STREAM = "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent"
+
+
+@pytest.mark.parametrize(
+    "optional_params, expected_api_base",
+    [
+        ({"stream": True}, GEMINI_STREAM),
+        ({"stream": False}, GEMINI_NON_STREAM),
+        ({}, GEMINI_NON_STREAM),
+        (LiteLLM_Params(model="gemini/gemini-pro", stream=True), GEMINI_STREAM),
+        (LiteLLM_Params(model="gemini/gemini-pro"), GEMINI_NON_STREAM),
+    ],
+)
+def test_get_api_base_gemini_stream(
+    optional_params: dict[str, bool] | LiteLLM_Params, expected_api_base: str
+) -> None:
+    assert get_api_base(model="gemini/gemini-pro", optional_params=optional_params) == expected_api_base
+
+
+@pytest.mark.parametrize("stream, suffix", [(True, "streamGenerateContent"), (False, "generateContent")])
+def test_get_api_base_vertex_stream_from_dict(stream: bool, suffix: str) -> None:
+    api_base = get_api_base(
+        model="gemini-pro",
+        optional_params={
+            "stream": stream,
+            "vertex_location": "us-central1",
+            "vertex_project": "my-project",
+        },
+    )
+
+    assert api_base is not None
+    assert api_base.endswith(f":{suffix}")


### PR DESCRIPTION
## Title

fix(get_api_base): read `stream` from the parsed params, not the raw dict

## Relevant issues

None filed. Found while reading the alerting / hidden-params path that reports `api_base` back to callers.

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory: `tests/test_litellm/litellm_core_utils/llm_response_utils/test_get_api_base.py`
- [x] I have added a screenshot of my new test passing locally (output below)
- [x] My PR passes all unit tests on `make test-unit` for the touched area
- [x] My PR's scope is as isolated as possible: one line of behaviour change plus a new test file

## Type

🐛 Bug Fix

## Changes

`get_api_base()` documents `optional_params` as accepting either a plain dict (the `litellm_params` from `router.completion`, or extra params passed to `litellm.completion`) or a `LiteLLM_Params` object. It converts the dict into `_optional_params` up front and every field it needs afterwards is read off that parsed object, with one exception:

```python
stream: Final[bool] = getattr(optional_params, "stream", False)
```

That reads the **raw** argument. A dict has no `stream` attribute, so `getattr` always falls through to `False` for the dict shape, and the function reports the non-streaming URL even when the caller asked for streaming. Passing the same thing as a `LiteLLM_Params` object works, only because that model allows extra fields, so the two documented input shapes disagree.

On `litellm_internal_staging` before this change:

```
>>> litellm.get_api_base(model="gemini/gemini-pro", optional_params={"stream": True})
'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent'   # wrong
>>> litellm.get_api_base(model="gemini/gemini-pro", optional_params=LiteLLM_Params(model="gemini/gemini-pro", stream=True))
'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:streamGenerateContent'
```

The same `stream` value also feeds the Vertex branch (`VertexBase.create_vertex_url(..., stream=stream)` and the `:streamGenerateContent` / `:generateContent` string), so the Vertex URL is wrong for dict callers too.

Downstream this wrong `api_base` reaches response hidden params / the proxy's `api_base` metadata (`response_metadata.py` passes the raw kwargs dict, which does carry `stream=True`), Slack alerting, cooldown callbacks and exception-mapping messages.

The fix is to read `stream` from the same place as every other field:

```python
stream: Final[bool] = getattr(_optional_params, "stream", False)
```

`LiteLLM_Params` is configured with `extra="allow"`, so `stream` survives the dict conversion, and when a `LiteLLM_Params` instance is passed in, `_optional_params` *is* that instance, so that path is unchanged.

## Testing

New file `tests/test_litellm/litellm_core_utils/llm_response_utils/test_get_api_base.py`, covered by the existing `tests/test_litellm/litellm_core_utils` CI job.

```
$ pytest tests/test_litellm/litellm_core_utils/llm_response_utils/test_get_api_base.py -q
# before the fix
FAILED ...::test_get_api_base_gemini_stream[optional_params0-...streamGenerateContent]
FAILED ...::test_get_api_base_vertex_stream_from_dict[True-streamGenerateContent]
2 failed, 5 passed

# after the fix
7 passed
```

The two non-stream / existing-behaviour cases from `tests/logging_callback_tests/test_alerting.py::test_get_api_base_unit_test` (`openai/my-fake-model` with an explicit `api_base`, and `gpt-5-mini` returning `https://api.openai.com`) were also re-checked by hand and are unchanged.
