### PR TITLE
feat(ui): plan-mode override tier in the auto-router create and edit forms

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -785,3 +785,61 @@ describe("ComplexityRouterConfig default model", () => {
     expect(screen.getByRole("radio", { name: /Route to the default model \(claude-3-opus\)/ })).toBeInTheDocument();
   });
 });
+
+describe("plan-mode override", () => {
+  const openPanel = () => fireEvent.click(screen.getByText("Advanced: Plan-Mode Override"));
+  const switchName = "Route plan-mode requests to a minimum tier";
+
+  it("toggling on floors at the highest tier that has models", async () => {
+    const onChange = vi.fn();
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} onChange={onChange} />);
+    openPanel();
+    fireEvent.click(await screen.findByRole("switch", { name: switchName }));
+    expect(onChange.mock.calls.at(-1)?.[0].plan_mode_min_tier).toBe("REASONING");
+  });
+
+  it("toggling off drops the key entirely instead of storing an empty value", async () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <ComplexityRouterConfig
+        {...baseProps}
+        value={{ ...defaultValue, plan_mode_min_tier: "COMPLEX" }}
+        onChange={onChange}
+      />,
+    );
+    openPanel();
+    const control = await screen.findByRole("switch", { name: switchName });
+    expect(control).toBeChecked();
+    fireEvent.click(control);
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated.plan_mode_min_tier).toBeUndefined();
+  });
+
+  it("only offers tiers that have models, since the backend rejects a floor at an empty tier", async () => {
+    renderWithProviders(
+      <ComplexityRouterConfig
+        {...baseProps}
+        value={{
+          ...defaultValue,
+          tiers: { ...defaultValue.tiers, REASONING: [] },
+          plan_mode_min_tier: "COMPLEX",
+        }}
+      />,
+    );
+    openPanel();
+    fireEvent.mouseDown(await screen.findByRole("combobox", { name: "Plan-mode minimum tier" }));
+    expect(await screen.findByTitle("Medium")).toBeInTheDocument();
+    expect(screen.queryByTitle("Reasoning")).not.toBeInTheDocument();
+  });
+
+  it("disables the toggle until some tier has models", async () => {
+    renderWithProviders(
+      <ComplexityRouterConfig
+        {...baseProps}
+        value={{ ...defaultValue, tiers: { SIMPLE: [], MEDIUM: [], COMPLEX: [], REASONING: [] } }}
+      />,
+    );
+    openPanel();
+    expect(await screen.findByRole("switch", { name: switchName })).toBeDisabled();
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -4,9 +4,9 @@ import React from "react";
 import { ModelGroup } from "@/components/llm_calls/fetch_models";
 import AdaptiveRoutingConfig from "./AdaptiveRoutingConfig";
 import ClassificationMethodConfig from "./ClassificationMethodConfig";
-import { resolveComplexityDefaultModel } from "./complexity_router_tiers";
+import { resolveComplexityDefaultModel, tierOptions } from "./complexity_router_tiers";
 import EscalationKeywords from "./EscalationKeywords";
-import KeywordTierRules, { KeywordTierRule, tierOptions } from "./KeywordTierRules";
+import KeywordTierRules, { KeywordTierRule } from "./KeywordTierRules";
 import SemanticKeywordMatching from "./SemanticKeywordMatching";
 import { type DimensionWeights, type TierBoundaries, type TokenThresholds } from "./heuristic_scoring_knobs";
 

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -211,6 +211,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
   onEscalationKeywordsChange,
   showValidationErrors = false,
 }) => {
+  const planModeTiers = planModeEligibleTiers(value.tiers);
   const derivedDefaultModel = resolveComplexityDefaultModel(value.tiers);
   const defaultModel = resolveComplexityDefaultModel(value.tiers, value.default_model);
 
@@ -435,12 +436,9 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
                 <div className="flex items-center gap-2 mb-2">
                   <Switch
                     checked={value.plan_mode_min_tier !== undefined}
-                    disabled={planModeEligibleTiers(value.tiers).length === 0}
+                    disabled={planModeTiers.length === 0}
                     onChange={(enabled) =>
-                      onChange({
-                        ...value,
-                        plan_mode_min_tier: enabled ? planModeEligibleTiers(value.tiers).at(-1) : undefined,
-                      })
+                      onChange({ ...value, plan_mode_min_tier: enabled ? planModeTiers.at(-1) : undefined })
                     }
                     aria-label="Route plan-mode requests to a minimum tier"
                   />
@@ -449,7 +447,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
                 <Text type="secondary" style={{ display: "block", fontSize: 12, marginBottom: 12 }}>
                   Requests from coding agents in plan mode (Claude Code, GitHub Copilot) route to at least this tier.
                   The classifier still wins when it picks higher, and the override only lasts while plan mode is active.
-                  {planModeEligibleTiers(value.tiers).length === 0 && " Add models to a tier to enable this."}
+                  {planModeTiers.length === 0 && " Add models to a tier to enable this."}
                 </Text>
                 {value.plan_mode_min_tier !== undefined && (
                   <div style={{ maxWidth: 320 }}>
@@ -458,7 +456,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
                       style={{ width: "100%" }}
                       value={value.plan_mode_min_tier}
                       options={tierOptions(value.tier_labels).filter((option) =>
-                        planModeEligibleTiers(value.tiers).some((tier) => tier === option.value),
+                        (planModeTiers as string[]).includes(option.value),
                       )}
                       onChange={(tier: string) => onChange({ ...value, plan_mode_min_tier: tier })}
                     />

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -6,7 +6,7 @@ import AdaptiveRoutingConfig from "./AdaptiveRoutingConfig";
 import ClassificationMethodConfig from "./ClassificationMethodConfig";
 import { resolveComplexityDefaultModel } from "./complexity_router_tiers";
 import EscalationKeywords from "./EscalationKeywords";
-import KeywordTierRules, { KeywordTierRule } from "./KeywordTierRules";
+import KeywordTierRules, { KeywordTierRule, tierOptions } from "./KeywordTierRules";
 import SemanticKeywordMatching from "./SemanticKeywordMatching";
 import { type DimensionWeights, type TierBoundaries, type TokenThresholds } from "./heuristic_scoring_knobs";
 
@@ -121,6 +121,8 @@ export interface ComplexityRouterConfigValue {
   classifier_fallback?: ClassifierFallback;
   session_affinity?: boolean;
   deployment_affinity?: boolean;
+  /** Tier floor for coding-agent plan-mode requests. Unset means detection is off, matching the backend. */
+  plan_mode_min_tier?: string;
   adaptive?: boolean;
   adaptive_weights?: AdaptiveRouterWeights;
   tier_distance_penalty?: number;
@@ -186,6 +188,10 @@ export const TIER_KEYS = Object.keys(TIER_DESCRIPTIONS) as Array<keyof Complexit
 
 export const effectiveTierLabel = (tier: keyof ComplexityTiers, tierLabels: ComplexityTierLabels | undefined): string =>
   tierLabels?.[tier]?.trim() || TIER_DESCRIPTIONS[tier].label;
+
+/** Tiers the plan-mode floor may name: the backend rejects a floor whose tier has no models. */
+export const planModeEligibleTiers = (tiers: ComplexityTiers): Array<keyof ComplexityTiers> =>
+  TIER_KEYS.filter((tier) => (tiers[tier] ?? []).length > 0);
 
 const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
   modelInfo,
@@ -414,6 +420,50 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
                   Keeps a session on its first turn&apos;s model instead of re-classifying each turn. Also pins the
                   deployment.
                 </Text>
+              </>
+            ),
+          },
+          {
+            key: "plan-mode",
+            label: (
+              <Text strong style={{ color: "#374151" }}>
+                Advanced: Plan-Mode Override
+              </Text>
+            ),
+            children: (
+              <>
+                <div className="flex items-center gap-2 mb-2">
+                  <Switch
+                    checked={value.plan_mode_min_tier !== undefined}
+                    disabled={planModeEligibleTiers(value.tiers).length === 0}
+                    onChange={(enabled) =>
+                      onChange({
+                        ...value,
+                        plan_mode_min_tier: enabled ? planModeEligibleTiers(value.tiers).at(-1) : undefined,
+                      })
+                    }
+                    aria-label="Route plan-mode requests to a minimum tier"
+                  />
+                  <Text strong>Route plan-mode requests to a minimum tier</Text>
+                </div>
+                <Text type="secondary" style={{ display: "block", fontSize: 12, marginBottom: 12 }}>
+                  Requests from coding agents in plan mode (Claude Code, GitHub Copilot) route to at least this tier.
+                  The classifier still wins when it picks higher, and the override only lasts while plan mode is active.
+                  {planModeEligibleTiers(value.tiers).length === 0 && " Add models to a tier to enable this."}
+                </Text>
+                {value.plan_mode_min_tier !== undefined && (
+                  <div style={{ maxWidth: 320 }}>
+                    <AntdSelect
+                      aria-label="Plan-mode minimum tier"
+                      style={{ width: "100%" }}
+                      value={value.plan_mode_min_tier}
+                      options={tierOptions(value.tier_labels).filter((option) =>
+                        planModeEligibleTiers(value.tiers).some((tier) => tier === option.value),
+                      )}
+                      onChange={(tier: string) => onChange({ ...value, plan_mode_min_tier: tier })}
+                    />
+                  </div>
+                )}
               </>
             ),
           },

--- a/ui/litellm-dashboard/src/components/add_model/KeywordTierRules.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/KeywordTierRules.tsx
@@ -3,6 +3,7 @@ import { Button, Card, Empty, Select as AntdSelect, Tooltip, Typography } from "
 import React from "react";
 
 import { emptyKeywordTierRuleIndexes } from "./complexity_router_keywords";
+import { tierOptions } from "./complexity_router_tiers";
 
 const { Text } = Typography;
 
@@ -19,20 +20,6 @@ interface KeywordTierRulesProps {
   onChange: (rules: KeywordTierRule[]) => void;
   tierLabels?: Partial<Record<ComplexityTier, string>>;
 }
-
-const DEFAULT_TIER_LABELS: Record<ComplexityTier, string> = {
-  SIMPLE: "Simple",
-  MEDIUM: "Medium",
-  COMPLEX: "Complex",
-  REASONING: "Reasoning",
-};
-
-const TIER_ORDER: ComplexityTier[] = ["SIMPLE", "MEDIUM", "COMPLEX", "REASONING"];
-
-export const tierOptions = (
-  tierLabels: Partial<Record<ComplexityTier, string>> | undefined,
-): { value: ComplexityTier; label: string }[] =>
-  TIER_ORDER.map((tier) => ({ value: tier, label: tierLabels?.[tier]?.trim() || DEFAULT_TIER_LABELS[tier] }));
 
 // A row exists only because the caller asked for it, so it reports its own gap straight away
 // rather than waiting for a submit; the submit button is disabled while one is outstanding, so

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -673,6 +673,53 @@ describe("AddAutoRouterTab", () => {
     });
   });
 
+  describe("plan-mode override", () => {
+    beforeEach(() => {
+      mockFetchAvailableModels.mockResolvedValue(ALL_FAMILY_MODELS);
+    });
+
+    const waitForPresetEnabled = async (label: string) => {
+      openTemplateDropdown();
+      await waitFor(() => {
+        expect(isOptionDisabled(optionByLabel(label)!)).toBe(false);
+      });
+    };
+
+    it("omits plan_mode_min_tier from the payload when never touched", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Harness />);
+
+      await waitForPresetEnabled("Anthropic Family");
+      fireEvent.click(optionByLabel("Anthropic Family")!);
+      await user.type(screen.getByPlaceholderText(/smart_router/i), "no-plan-router");
+      await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+      await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+      expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).not.toHaveProperty(
+        "plan_mode_min_tier",
+      );
+    });
+
+    it("carries the enabled override through to the create payload", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Harness />);
+
+      await waitForPresetEnabled("Anthropic Family");
+      fireEvent.click(optionByLabel("Anthropic Family")!);
+      expandDetailedConfiguration();
+      await user.click(screen.getByText("Advanced: Plan-Mode Override"));
+      await user.click(await screen.findByRole("switch", { name: "Route plan-mode requests to a minimum tier" }));
+
+      await user.type(screen.getByPlaceholderText(/smart_router/i), "plan-router");
+      await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+      await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+      expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
+        plan_mode_min_tier: "REASONING",
+      });
+    });
+  });
+
   describe("deployment-matched presets", () => {
     const renamedDeploymentsFor = (presetKey: string) =>
       [...getRequiredModelsInPreset(getPresetByKey(presetKey)!)].map((model, index) => ({

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -26,6 +26,7 @@ import {
   buildComplexityRouterConfig,
   getKeywordTierRulesError,
   getMissingTiersError,
+  getPlanModeTierError,
   getSemanticConfigError,
   getTierLabelsError,
 } from "./build_complexity_router_config";
@@ -118,6 +119,7 @@ const getSubmitBlockedReason = (
 ): string | null =>
   getMissingTiersError(config.tiers) ??
   getTierLabelsError(config.tier_labels) ??
+  getPlanModeTierError(config.plan_mode_min_tier, config.tiers) ??
   getKeywordTierRulesError(keywordTierRules) ??
   getReferencedModelsError(referencedModelsParams, availability);
 
@@ -283,6 +285,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   const complexityRouterConfigParams: BuildComplexityRouterConfigParams = {
     tiers: complexityRouterConfig.tiers,
     defaultModel: complexityRouterConfig.default_model,
+    planModeMinTier: complexityRouterConfig.plan_mode_min_tier,
     tierLabels: complexityRouterConfig.tier_labels,
     classifierType: complexityRouterConfig.classifier_type,
     classifierLlmConfig: complexityRouterConfig.classifier_llm_config,

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
@@ -1,5 +1,6 @@
 import {
   buildComplexityRouterConfig,
+  getPlanModeTierError,
   normalizeClassifierLlmConfig,
   getKeywordTierRulesError,
   getMissingTiersError,
@@ -599,5 +600,38 @@ describe("buildComplexityRouterConfig scorer knobs", () => {
 
   it("drops them when the classifier falls back to the default model and nothing is scored", () => {
     expect(buildComplexityRouterConfig(llmWithDefaultFallback)).not.toHaveProperty("tier_boundaries");
+  });
+});
+
+describe("plan-mode minimum tier", () => {
+  it("omits plan_mode_min_tier when unset, so the backend default (off) is preserved", () => {
+    const config = buildComplexityRouterConfig({ ...baseParams, planModeMinTier: undefined });
+    expect(config).not.toHaveProperty("plan_mode_min_tier");
+  });
+
+  it("writes the selected tier", () => {
+    const config = buildComplexityRouterConfig({ ...baseParams, planModeMinTier: "COMPLEX" });
+    expect(config.plan_mode_min_tier).toBe("COMPLEX");
+  });
+
+  it("never writes an empty string, which the backend rejects instead of treating as off", () => {
+    const config = buildComplexityRouterConfig({ ...baseParams, planModeMinTier: "  " });
+    expect(config).not.toHaveProperty("plan_mode_min_tier");
+  });
+});
+
+describe("getPlanModeTierError", () => {
+  const tiersWithEmptyComplex = { SIMPLE: ["m1"], MEDIUM: ["m1"], COMPLEX: [], REASONING: [] };
+
+  it("passes when the override is off", () => {
+    expect(getPlanModeTierError(undefined, tiersWithEmptyComplex)).toBeNull();
+  });
+
+  it("passes when the named tier has models", () => {
+    expect(getPlanModeTierError("MEDIUM", tiersWithEmptyComplex)).toBeNull();
+  });
+
+  it("blocks a tier whose models were removed, which the backend would reject with a 400", () => {
+    expect(getPlanModeTierError("COMPLEX", tiersWithEmptyComplex)).toContain("COMPLEX");
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
@@ -71,6 +71,7 @@ const scorerKnobPayload = ({
 export interface BuildComplexityRouterConfigParams {
   tiers: ComplexityTiers;
   defaultModel: string | undefined;
+  planModeMinTier: string | undefined;
   tierLabels: ComplexityTierLabels | undefined;
   classifierType: ClassifierType;
   classifierLlmConfig: ClassifierLLMConfig | undefined;
@@ -99,6 +100,7 @@ export interface BuildComplexityRouterConfigParams {
 export interface ComplexityRouterConfigPayload {
   tiers: ComplexityTiers;
   default_model?: string;
+  plan_mode_min_tier?: string;
   tier_labels?: ComplexityTierLabels;
   classifier_type: ClassifierType;
   classifier_llm_config?: ClassifierLLMConfig;
@@ -172,6 +174,16 @@ export const getMissingTiersError = (tiers: ComplexityTiers): string | null => {
   return `Select a model for the following tier(s): ${missing.join(", ")}`;
 };
 
+// The backend rejects a plan-mode floor naming a tier with no models. The create form's
+// getMissingTiersError makes this unreachable there; the edit modal allows partially filled
+// tiers, so both gates call this to keep the two forms symmetric.
+export const getPlanModeTierError = (planModeMinTier: string | undefined, tiers: ComplexityTiers): string | null => {
+  if (!planModeMinTier) return null;
+  const models = tiers[planModeMinTier as keyof ComplexityTiers] ?? [];
+  if (models.length > 0) return null;
+  return `The plan-mode minimum tier (${planModeMinTier}) has no models. Add one or turn the override off.`;
+};
+
 export const getKeywordTierRulesError = (keywordTierRules: KeywordTierRule[]): string | null => {
   const emptyRows = emptyKeywordTierRuleIndexes(keywordTierRules);
   if (emptyRows.length === 0) return null;
@@ -194,6 +206,7 @@ export const getSemanticConfigError = ({
 export const buildComplexityRouterConfig = ({
   tiers,
   defaultModel,
+  planModeMinTier,
   tierLabels,
   classifierType,
   classifierLlmConfig,
@@ -227,6 +240,7 @@ export const buildComplexityRouterConfig = ({
   return {
     tiers,
     ...(defaultModel?.trim() && { default_model: defaultModel }),
+    ...(planModeMinTier?.trim() && { plan_mode_min_tier: planModeMinTier }),
     ...(cleanedTierLabels && { tier_labels: cleanedTierLabels }),
     classifier_type: classifierType,
     ...(classifierType === "llm" &&

--- a/ui/litellm-dashboard/src/components/add_model/complexity_router_tiers.ts
+++ b/ui/litellm-dashboard/src/components/add_model/complexity_router_tiers.ts
@@ -1,4 +1,5 @@
 import type { ComplexityTiers } from "./ComplexityRouterConfig";
+import type { ComplexityTier } from "./KeywordTierRules";
 
 /**
  * A complexity tier maps to `str | list[str]` on the backend
@@ -22,3 +23,17 @@ export const normalizeTierModels = (value: unknown): string[] => {
  */
 export const resolveComplexityDefaultModel = (tiers: ComplexityTiers, pinned?: string): string | undefined =>
   pinned?.trim() || tiers.MEDIUM[0] || tiers.SIMPLE[0];
+
+export const DEFAULT_TIER_LABELS: Record<ComplexityTier, string> = {
+  SIMPLE: "Simple",
+  MEDIUM: "Medium",
+  COMPLEX: "Complex",
+  REASONING: "Reasoning",
+};
+
+export const TIER_ORDER: ComplexityTier[] = ["SIMPLE", "MEDIUM", "COMPLEX", "REASONING"];
+
+export const tierOptions = (
+  tierLabels: Partial<Record<ComplexityTier, string>> | undefined,
+): { value: ComplexityTier; label: string }[] =>
+  TIER_ORDER.map((tier) => ({ value: tier, label: tierLabels?.[tier]?.trim() || DEFAULT_TIER_LABELS[tier] }));

--- a/ui/litellm-dashboard/src/components/edit_auto_router/build_updated_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/build_updated_complexity_router_config.test.ts
@@ -314,3 +314,26 @@ describe("buildUpdatedComplexityRouterConfig scorer knobs", () => {
     expect(buildUpdatedComplexityRouterConfig(STORED, FORM_VALUE)).not.toHaveProperty("tier_boundaries");
   });
 });
+
+describe("buildUpdatedComplexityRouterConfig plan-mode minimum tier", () => {
+  it("round-trips a stored tier through an untouched open-and-save", () => {
+    const result = buildUpdatedComplexityRouterConfig(
+      { ...STORED, plan_mode_min_tier: "COMPLEX" },
+      { ...FORM_VALUE, plan_mode_min_tier: "COMPLEX" },
+    );
+    expect(result.plan_mode_min_tier).toBe("COMPLEX");
+  });
+
+  it("stops a stored tier from surviving a save that turned the override off", () => {
+    const result = buildUpdatedComplexityRouterConfig({ ...STORED, plan_mode_min_tier: "COMPLEX" }, FORM_VALUE);
+    expect(result).not.toHaveProperty("plan_mode_min_tier");
+  });
+
+  it("writes a newly selected tier over the stored one", () => {
+    const result = buildUpdatedComplexityRouterConfig(
+      { ...STORED, plan_mode_min_tier: "COMPLEX" },
+      { ...FORM_VALUE, plan_mode_min_tier: "MEDIUM" },
+    );
+    expect(result.plan_mode_min_tier).toBe("MEDIUM");
+  });
+});

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
@@ -750,3 +750,60 @@ describe("EditAutoRouterModal default model", () => {
     expect(savedConfig()).not.toHaveProperty("default_model");
   });
 });
+
+describe("EditAutoRouterModal plan-mode minimum tier", () => {
+  beforeEach(() => {
+    modelPatchUpdateCall.mockClear();
+  });
+
+  const renderWithStoredTier = (plan_mode_min_tier?: string) =>
+    renderWithProviders(
+      <EditAutoRouterModal
+        isVisible
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        modelData={{
+          ...MODEL_DATA,
+          litellm_params: {
+            ...MODEL_DATA.litellm_params,
+            complexity_router_config: { ...STORED_CONFIG, ...(plan_mode_min_tier && { plan_mode_min_tier }) },
+          },
+        }}
+        accessToken="token"
+        userRole="Admin"
+      />,
+    );
+
+  const openPlanModePanel = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(await screen.findByText("Advanced: Plan-Mode Override"));
+  };
+
+  it("shows a stored tier as an enabled override, so the saved value is not a hidden one", async () => {
+    const user = userEvent.setup();
+    renderWithStoredTier("MEDIUM");
+    await openPlanModePanel(user);
+    expect(await screen.findByRole("switch", { name: "Route plan-mode requests to a minimum tier" })).toBeChecked();
+  });
+
+  it("preserves a stored tier through an untouched open-and-save", async () => {
+    const user = userEvent.setup();
+    renderWithStoredTier("MEDIUM");
+
+    await user.click(await screen.findByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig()).toMatchObject({ plan_mode_min_tier: "MEDIUM" });
+  });
+
+  it("turning the override off removes the stored tier from the saved config", async () => {
+    const user = userEvent.setup();
+    renderWithStoredTier("MEDIUM");
+    await openPlanModePanel(user);
+    await user.click(await screen.findByRole("switch", { name: "Route plan-mode requests to a minimum tier" }));
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig()).not.toHaveProperty("plan_mode_min_tier");
+  });
+});

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -9,6 +9,7 @@ import { isComplexityRouter } from "../add_model/auto_router_strategies";
 import {
   getKeywordTierRulesError,
   getSemanticConfigError,
+  getPlanModeTierError,
   getTierLabelsError,
   hydrateTierLabels,
   normalizeClassifierLlmConfig,
@@ -56,6 +57,7 @@ interface EditAutoRouterModalProps {
 const MANAGED_COMPLEXITY_ROUTER_KEYS = new Set([
   "tiers",
   "default_model",
+  "plan_mode_min_tier",
   "tier_labels",
   "classifier_type",
   "classifier_llm_config",
@@ -140,6 +142,7 @@ export const buildUpdatedComplexityRouterConfig = (
     ...preservedConfig,
     tiers: value.tiers,
     ...(value.default_model?.trim() && { default_model: value.default_model }),
+    ...(value.plan_mode_min_tier?.trim() && { plan_mode_min_tier: value.plan_mode_min_tier }),
     ...(serializedTierLabels && { tier_labels: serializedTierLabels }),
     classifier_type: value.classifier_type,
     ...(value.classifier_type === "llm" && value.classifier_llm_config
@@ -226,6 +229,7 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
         ? "Please select at least one model for a complexity tier"
         : null) ??
       getTierLabelsError(complexityRouterConfig.tier_labels) ??
+      getPlanModeTierError(complexityRouterConfig.plan_mode_min_tier, complexityRouterConfig.tiers) ??
       getKeywordTierRulesError(keywordTierRules);
 
   useEffect(() => {
@@ -284,6 +288,10 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
             modelData.litellm_params?.complexity_router_default_model,
             hydratedTiers,
           ),
+          plan_mode_min_tier:
+            typeof parsedConfig.plan_mode_min_tier === "string" && parsedConfig.plan_mode_min_tier.trim() !== ""
+              ? parsedConfig.plan_mode_min_tier
+              : undefined,
           tier_labels: hydrateTierLabels(parsedConfig.tier_labels),
           classifier_type: parsedConfig.classifier_type || "heuristic",
           classifier_llm_config: parsedConfig.classifier_llm_config,


### PR DESCRIPTION
## TLDR

Problem this solves:

- plan_mode_min_tier (#37230) is API-only; the dashboard cannot set it
- A stored override is invisible in the edit modal
- Operators must hand-edit config blobs to use the feature

How it solves it:

- New Advanced: Plan-Mode Override panel in both auto-router forms
- Toggle plus tier dropdown writing plan_mode_min_tier
- Dropdown offers only tiers with models, matching backend validation
- Edit modal round-trips, clears cleanly, preserves unmanaged keys

## User Flow

Before: an operator who wants plan-mode requests floored to a premium tier cannot do it from the dashboard

1. They open http://localhost:4000/ui/ then Models + Endpoints, Auto-Routers tab, Add Auto Router, and expand Detailed Configuration
2. The Advanced sections show Classification Method, Adaptive Routing, Affinity, Response Format, Escalation Keywords, and Keyword/Semantic Matching; nothing mentions plan mode
3. They set plan_mode_min_tier by hand-crafting a POST /model/new body instead
4. Opening that router's edit modal later shows no trace of the override, so a teammate cannot see it is on or turn it off without another API call

After: the override is a visible dashboard control on both forms

1. They open the same Add Auto Router form and expand Detailed Configuration
2. A new Advanced: Plan-Mode Override section holds a toggle; turning it on selects the highest tier that has models, and a dropdown lets them pick another tier, offering only tiers with models
3. The created router's config carries plan_mode_min_tier, and a Claude Code plan-mode request through the router routes to that tier's model
4. Opening the edit modal on a router with a stored override shows the toggle on with the stored tier selected; turning it off and saving removes the key from the stored config, and the next plan-mode request classifies normally

## Relevant issues

## Linear ticket

Resolves LIT-5643

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix
<img width="1101" height="238" alt="image" src="https://github.com/user-attachments/assets/770e0893-58af-4ae2-b8ba-eb795250d7e9" />


Shared setup: a live proxy with Postgres (store_model_in_db) on localhost:4585 serving the packaged dashboard bundle, rebuilt from this branch via npm run build and copied into litellm/proxy/_experimental/out for the After run (the copy is not committed; the tracked bundle is restored). Tier models are anthropic/claude-haiku-4-5 (SIMPLE, MEDIUM) and anthropic/claude-sonnet-5 (COMPLEX). Local provider credentials are all out of credit, so both models point api_base at a local Anthropic-shaped upstream that echoes the requested model id; the routing decision under test happens in the proxy before that hop and a real-provider re-run is owed. Routing curls use return_raw_model_name so the response model names the routed deployment

### Before (8159f240c4)

#### The create form has no plan-mode control

1. Open /ui/ then Models + Endpoints, Auto-Routers, Add Auto Router, expand Detailed Configuration
2. The Advanced panel list reads: Classification Method, Adaptive Routing, Affinity, Response Format, Escalation Keywords, Keyword/Semantic Matching

#### A stored override is invisible and unsettable

1. `curl -s http://localhost:4585/model/new -H "Authorization: Bearer sk-1234" -d '{"model_name": "plan-router", "litellm_params": {"model": "auto_router/complexity_router", "complexity_router_config": {"tiers": {"SIMPLE": "claude-haiku-4-5", "MEDIUM": "claude-haiku-4-5", "COMPLEX": "claude-sonnet-5"}, "plan_mode_min_tier": "COMPLEX", "return_raw_model_name": true}}}'`
2. /v2/model/info returns the stored config with plan_mode_min_tier COMPLEX, and a plan-mode request routes claude-sonnet-5, yet the edit modal renders nothing about it

### After (2fc1018c07)

#### The panel exists and gates on configured tiers

1. Same navigation; the panel list now includes Advanced: Plan-Mode Override between Affinity and Response Format
2. With no tier models selected yet, the toggle is disabled with the hint "Add models to a tier to enable this"

#### The edit modal hydrates a stored override

1. Open the router created above, Edit Auto Router, expand Advanced: Plan-Mode Override
2. The toggle is on and the tier select shows Complex

#### Turning the override off actually clears it

1. Toggle off, Save Changes
2. `curl -s http://localhost:4585/v2/model/info -H "Authorization: Bearer sk-1234"` shows the router's config with no plan_mode_min_tier key, while return_raw_model_name and the tiers survive untouched

#### Re-enabling from the UI routes plan-mode traffic to the floor

1. Toggle on (it defaults to Complex, the highest tier with models on this router), Save Changes; /v2/model/info shows plan_mode_min_tier COMPLEX
2. `curl -s http://localhost:4585/v1/chat/completions -H "Authorization: Bearer sk-1234" -d '{"model": "plan-router", "max_tokens": 20, "messages": [{"role": "user", "content": "add a hello endpoint"}]}'` routes claude-haiku-4-5
3. The same request with the Claude Code sentinel appended (`{"role": "system", "content": "Plan mode is active. Do not execute."}`) routes claude-sonnet-5

Screenshot steps if wanted: http://localhost:4000/ui/ then Models + Endpoints, Auto-Routers tab, Add Auto Router, expand Detailed Configuration, open Advanced: Plan-Mode Override (disabled toggle with hint); then pick any auto-router row, Edit Auto Router, same panel showing the stored tier

## Type

🆕 New Feature

## Caveats (if any)

- Routing QA upstream was a local mock; real-provider re-run owed
- Dropdown shows the four built-in tiers; custom tier sets (#37246) are a follow-up
- plan_mode_patterns stays config-only by design
- Open PRs #37304 and #37246 touch these forms; small conflict expected

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2fc1018c07fc3c2abecd40cdaee02fe197773839. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->