### PR TITLE
fix(proxy): send SSE keepalives while a slow upstream is still silent

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1,14 +1,15 @@
 import asyncio
+import contextlib
 import json
 import logging
 import math
 import time
 import traceback
-from collections.abc import AsyncGenerator, Callable, Mapping
+from collections.abc import AsyncGenerator, Awaitable, Callable, Mapping
 from datetime import datetime
 from functools import lru_cache
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Protocol, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Protocol, TypeAlias, TypeVar, overload
 
 import anyio
 import httpx
@@ -47,7 +48,12 @@ from litellm.proxy.common_utils.callback_utils import (
     get_logging_caching_headers,
     get_remaining_tokens_and_requests_from_request_data,
 )
-from litellm.proxy.common_utils.sse_keepalive import wrap_sse_stream_with_keepalive_pings
+from litellm.proxy.common_utils.sse_keepalive import (
+    SSE_COMMENT_PING_BYTES,
+    coerce_keepalive_interval,
+    resolve_ttft_keepalive_interval,
+    wrap_sse_stream_with_keepalive_pings,
+)
 from litellm.proxy.dd_span_tagger import DDSpanTagger
 from litellm.proxy.route_llm_request import route_request
 from litellm.proxy.utils import ProxyLogging, _check_and_merge_model_level_guardrails
@@ -56,6 +62,100 @@ from litellm.router_utils.add_retry_fallback_headers import get_hidden_params_di
 from litellm.router_utils.common_utils import resolve_model_group_alias
 from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.router import RouterRateLimitError
+
+_LateResponseT = TypeVar("_LateResponseT", bound=Response)
+_LlmCallT = TypeVar("_LlmCallT")
+
+ProxyRouteType: TypeAlias = Literal[
+    "acompletion",
+    "aembedding",
+    "aresponses",
+    "_arealtime",
+    "_aresponses_websocket",
+    "acreate_realtime_client_secret",
+    "arealtime_calls",
+    "aget_responses",
+    "adelete_responses",
+    "acancel_responses",
+    "acompact_responses",
+    "acreate_batch",
+    "aretrieve_batch",
+    "alist_batches",
+    "acancel_batch",
+    "afile_content",
+    "afile_retrieve",
+    "afile_delete",
+    "atext_completion",
+    "acreate_fine_tuning_job",
+    "acancel_fine_tuning_job",
+    "alist_fine_tuning_jobs",
+    "aretrieve_fine_tuning_job",
+    "alist_input_items",
+    "aimage_edit",
+    "agenerate_content",
+    "agenerate_content_stream",
+    "allm_passthrough_route",
+    "avector_store_search",
+    "avector_store_create",
+    "avector_store_retrieve",
+    "avector_store_list",
+    "avector_store_update",
+    "avector_store_delete",
+    "avector_store_file_create",
+    "avector_store_file_list",
+    "avector_store_file_retrieve",
+    "avector_store_file_content",
+    "avector_store_file_update",
+    "avector_store_file_delete",
+    "aocr",
+    "asearch",
+    "avideo_generation",
+    "avideo_list",
+    "avideo_status",
+    "avideo_content",
+    "avideo_remix",
+    "avideo_create_character",
+    "avideo_get_character",
+    "avideo_edit",
+    "avideo_extension",
+    "acreate_container",
+    "alist_containers",
+    "aingest",
+    "aretrieve_container",
+    "adelete_container",
+    "aupload_container_file",
+    "alist_container_files",
+    "aretrieve_container_file",
+    "adelete_container_file",
+    "aretrieve_container_file_content",
+    "acreate_skill",
+    "alist_skills",
+    "aget_skill",
+    "adelete_skill",
+    "anthropic_messages",
+    "acreate_interaction",
+    "aget_interaction",
+    "adelete_interaction",
+    "acancel_interaction",
+    "acreate_agent",
+    "alist_agents",
+    "aget_agent",
+    "adelete_agent",
+    "alist_agent_versions",
+    "asend_message",
+    "call_mcp_tool",
+    "acreate_eval",
+    "alist_evals",
+    "aget_eval",
+    "aupdate_eval",
+    "adelete_eval",
+    "acancel_eval",
+    "acreate_run",
+    "alist_runs",
+    "aget_run",
+    "acancel_run",
+    "adelete_run",
+]
 from litellm.types.utils import ServerToolUse
 
 # Type alias for streaming chunk serializer (chunk after hooks + cost injection -> wire format)
@@ -559,6 +659,11 @@ class _UpstreamClosingStreamingResponse(StreamingResponse):
         super().__init__(content, status_code=status_code, headers=headers, media_type=media_type)
         self._upstream_generator = upstream_generator
 
+    @property
+    def upstream_generator(self) -> AsyncGenerator[str, None] | None:
+        """The upstream LLM stream, for a caller that has to run this response's cleanup itself."""
+        return self._upstream_generator
+
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         try:
             await super().__call__(scope, receive, send)
@@ -647,6 +752,39 @@ async def _buffer_first_chunk_honoring_disconnect(
             verbose_proxy_logger.debug("create_response: error closing generator on disconnect: %s", exc)
     verbose_proxy_logger.info("create_response: client disconnected before first chunk, upstream LLM request cancelled")
     raise _ClientDisconnectedBeforeFirstChunk()
+
+
+def _sse_error_payload(exc: BaseException) -> tuple[int, Mapping[str, object]]:
+    """Build the ProxyException-shaped ``{"error": ...}`` body used in SSE error frames.
+
+    Matches ``ProxyException.to_dict()`` so streaming and non-streaming error frames
+    are byte-identical.
+    """
+    # Preserve status code from HTTPException (e.g. guardrail blocks)
+    error_status: Final = getattr(exc, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR)
+    raw_detail: Final = _getattr_object(exc, "detail", "Error processing stream start")
+    message, structured_fields = _serialize_http_exception_detail(raw_detail)
+
+    existing_fields: Final = getattr(exc, "provider_specific_fields", None) or {}
+    merged_fields: Final = {**existing_fields, **structured_fields} if structured_fields else (existing_fields or None)
+
+    # Built in one statement then given its one optional key, rather than spread
+    # conditionally: the spread form costs two extra dict constructions, which
+    # type-discipline-budget.json's LIT002 ceiling has no room for.
+    error_obj: Final = {
+        "message": message,
+        "type": getattr(exc, "type", "None"),
+        "param": getattr(exc, "param", "None"),
+        "code": str(error_status),
+    }
+    if merged_fields:
+        error_obj["provider_specific_fields"] = merged_fields
+    return error_status, error_obj
+
+
+def _sse_error_frames(error_obj: Mapping[str, object]) -> tuple[str, str]:
+    """The two frames an SSE stream ends with once it can no longer raise."""
+    return f"data: {json.dumps({'error': error_obj})}\n\n", "data: [DONE]\n\n"
 
 
 async def create_response(
@@ -740,31 +878,11 @@ async def create_response(
         # Unexpected error consuming first chunk.
         verbose_proxy_logger.exception("Error consuming first chunk from generator: %s", e)
 
-        # Preserve status code from HTTPException (e.g., guardrail blocks)
-        error_status: Final = getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR)
-        raw_detail: Final = _getattr_object(e, "detail", "Error processing stream start")
-        message, structured_fields = _serialize_http_exception_detail(raw_detail)
-
-        existing_fields: Final = getattr(e, "provider_specific_fields", None) or {}
-        if structured_fields:
-            merged_fields: dict | None = {**existing_fields, **structured_fields}
-        else:
-            merged_fields = existing_fields or None
-
-        # Match ProxyException.to_dict() shape so streaming and non-streaming
-        # error frames are byte-identical.
-        error_obj: Final[dict[str, object]] = {
-            "message": message,
-            "type": getattr(e, "type", "None"),
-            "param": getattr(e, "param", "None"),
-            "code": str(error_status),
-        }
-        if merged_fields:
-            error_obj["provider_specific_fields"] = merged_fields
+        error_status, error_obj = _sse_error_payload(e)
 
         async def error_gen_message() -> AsyncGenerator[str, None]:
-            yield f"data: {json.dumps({'error': error_obj})}\n\n"
-            yield "data: [DONE]\n\n"
+            for frame in _sse_error_frames(error_obj):
+                yield frame
 
         return StreamingResponse(
             error_gen_message(),
@@ -794,6 +912,176 @@ async def create_response(
         headers=streaming_headers,
         status_code=final_status_code,
         upstream_generator=generator,
+    )
+
+
+_TTFT_KEEPALIVE_HEADERS: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "Cache-Control": "no-cache",
+        "X-Accel-Buffering": "no",
+    }
+)
+
+
+def ttft_keepalive_interval(request_data: Mapping[str, object], llm_router: Router | None = None) -> float | None:
+    """The operator's keepalive interval, but only for a request that asked to stream.
+
+    Resolved through the deployments the request could land on, so a deployment's
+    `keepalive_seconds: 0` stays the hard disable it is documented to be rather
+    than being switched back on by the global default.
+    """
+    if request_data.get("stream") is not True:
+        return None
+    requested_model: Final = request_data.get("model")
+    deployments: Final = (
+        llm_router.get_model_list(model_name=requested_model) or ()
+        if llm_router is not None and isinstance(requested_model, str)
+        else ()
+    )
+    return resolve_ttft_keepalive_interval(deployments, litellm.sse_keepalive_ping_interval_seconds)
+
+
+async def _aclose_late_response(produced: Response) -> None:
+    """Run the cleanup Starlette would have run, for a response it never called.
+
+    Closing an already-closed async generator is a no-op, so this is safe to call
+    from both the relay's own teardown and the outer one.
+    """
+    if not isinstance(produced, StreamingResponse):
+        return
+    targets: Final = (
+        (produced.body_iterator, produced.upstream_generator)
+        if isinstance(produced, _UpstreamClosingStreamingResponse)
+        else (produced.body_iterator,)
+    )
+    for target in targets:
+        aclose = getattr(target, "aclose", None)
+        if aclose is None:
+            continue
+        try:
+            await aclose()
+        except BaseException as exc:  # noqa: BLE001  # teardown must not mask why the stream ended
+            verbose_proxy_logger.debug("error closing relayed streaming generator: %s", exc)
+
+
+async def _relay_late_response(produced: Response) -> AsyncGenerator[bytes, None]:
+    """Replay a Response that was built after a keepalive had already opened the wire."""
+    if not isinstance(produced, StreamingResponse):
+        # The status line is already on the wire, so a non-streaming body, an error
+        # body included, can only reach the client as an SSE frame.
+        yield b"data: " + (bytes(produced.body) or b"{}") + b"\n\n"
+        yield b"data: [DONE]\n\n"
+        return
+
+    try:
+        async for chunk in produced.body_iterator:
+            yield chunk.encode("utf-8") if isinstance(chunk, str) else bytes(chunk)
+    finally:
+        # Starlette never called this response, so the cleanup its __call__ would
+        # have run has to happen here or the upstream LLM connection leaks.
+        with anyio.CancelScope(shield=True):
+            await _aclose_late_response(produced)
+
+
+async def _sanitized_late_failure(
+    exc: Exception,
+    on_late_failure: "Callable[[Exception], Awaitable[HTTPException | None]] | None",
+) -> Exception:
+    """Report a late failure and return whatever should reach the client.
+
+    ``post_call_failure_hook`` lets a callback replace the client-facing error, by
+    returning a replacement or by raising one, and both are used elsewhere in this
+    module. Serializing the original would leak provider detail a deployment had
+    configured away, so the hook's answer wins. A callback that fails some other
+    way is a bug in the callback, not a reason to lose the real error.
+    """
+    if on_late_failure is None:
+        return exc
+    try:
+        replacement: Final = await on_late_failure(exc)
+    except HTTPException as raised_replacement:
+        return raised_replacement
+    except Exception as hook_failure:  # noqa: BLE001  # a broken callback must not replace the real error
+        verbose_proxy_logger.exception("post_call_failure_hook raised while reporting a late failure: %s", hook_failure)
+        return exc
+    return replacement if replacement is not None else exc
+
+
+async def open_sse_before_first_byte(
+    produce_response: Awaitable[_LateResponseT],
+    ping_interval_seconds: float | str | None,
+    media_type: str = "text/event-stream",
+    on_late_failure: Callable[[Exception], Awaitable[HTTPException | None]] | None = None,
+) -> _LateResponseT | StreamingResponse:
+    """Write SSE keepalive comments while the upstream LLM call is still in flight.
+
+    The whole time-to-first-token is spent inside `produce_response`: the upstream
+    withholds its response headers until it emits its first token, so nothing has
+    entered the ASGI response phase yet and the proxy writes zero bytes. An
+    intermediary with an idle read timeout (AWS ALB and nginx both default to 60s)
+    then drops a connection that is perfectly healthy.
+
+    When `produce_response` does not finish within one interval, the response is
+    opened immediately and `: ping` comments, which every conformant SSE client
+    ignores, fill the wire until the real response is ready to be replayed onto it.
+    Committing the status line that early is the cost: a failure discovered after
+    the first ping reaches the client as an SSE error frame under a 200 rather than
+    as an HTTP error status, and LiteLLM's own `x-litellm-*` response headers are
+    not yet known. Both are why this stays off until an operator sets an interval.
+    """
+    interval: Final = coerce_keepalive_interval(ping_interval_seconds)
+    if interval is None:
+        return await produce_response
+
+    produce_task: Final = asyncio.ensure_future(produce_response)
+    await asyncio.wait((produce_task,), timeout=interval)
+    if produce_task.done():
+        # Fast path: the upstream answered inside one interval, so nothing was
+        # written early and this is byte-identical to not being wrapped at all.
+        return produce_task.result()
+
+    async def keepalive_then_relay() -> AsyncGenerator[bytes, None]:
+        try:
+            while not produce_task.done():
+                yield SSE_COMMENT_PING_BYTES
+                await asyncio.wait((produce_task,), timeout=interval)
+            try:
+                produced: Final = produce_task.result()
+            except Exception as exc:  # noqa: BLE001  # the status line is already sent; surface it as a frame
+                verbose_proxy_logger.exception(
+                    "request failed after its SSE keepalive had opened the response: %s", exc
+                )
+                # The caller's own `except` never sees this, so its failure hook
+                # would never fire and the failure would go unaudited. The hook
+                # also gets to sanitize what reaches the client, by returning or
+                # raising a replacement, so its answer decides the frame.
+                _, error_obj = _sse_error_payload(await _sanitized_late_failure(exc, on_late_failure))
+                for frame in _sse_error_frames(error_obj):
+                    yield frame.encode()
+                return
+            async for chunk in _relay_late_response(produced):
+                yield chunk
+        finally:
+            if not produce_task.done():
+                produce_task.cancel()
+                with anyio.CancelScope(shield=True):
+                    with contextlib.suppress(BaseException):
+                        await produce_task
+            elif not produce_task.cancelled():
+                # The upstream may have answered while nobody was draining this
+                # relay, e.g. the client vanished first. Nothing else holds that
+                # response, so its stream only gets closed here.
+                with anyio.CancelScope(shield=True):
+                    with contextlib.suppress(BaseException):
+                        await _aclose_late_response(produce_task.result())
+
+    verbose_proxy_logger.info(
+        "no upstream response after %ss, opening the SSE response early and sending keepalives", interval
+    )
+    return StreamingResponse(
+        keepalive_then_relay(),
+        media_type=media_type,
+        headers=_TTFT_KEEPALIVE_HEADERS,
     )
 
 
@@ -1043,7 +1331,7 @@ def _log_llm_api_exception(e: Exception) -> None:
 
 async def _cancel_llm_call_on_client_disconnect(
     request: Request,
-    llm_api_call: "asyncio.Future[object]",
+    llm_api_call: "asyncio.Future[_LlmCallT]",
     disconnect_event: asyncio.Event,
 ) -> None:
     try:
@@ -1062,8 +1350,8 @@ async def _cancel_llm_call_on_client_disconnect(
 
 async def _await_llm_call_cancelling_on_disconnect(
     request: Request,
-    llm_api_call: "asyncio.Future[Any]",
-) -> Any:
+    llm_api_call: "asyncio.Future[_LlmCallT]",
+) -> _LlmCallT:
     disconnect_event: Final = asyncio.Event()
     monitor: Final = asyncio.create_task(_cancel_llm_call_on_client_disconnect(request, llm_api_call, disconnect_event))
     try:
@@ -1714,100 +2002,11 @@ class ProxyBaseLLMRequestProcessing:
         request: Request,
         fastapi_response: Response,
         user_api_key_dict: UserAPIKeyAuth,
-        route_type: Literal[
-            "acompletion",
-            "aembedding",
-            "aresponses",
-            "_arealtime",
-            "_aresponses_websocket",
-            "acreate_realtime_client_secret",
-            "arealtime_calls",
-            "aget_responses",
-            "adelete_responses",
-            "acancel_responses",
-            "acompact_responses",
-            "acreate_batch",
-            "aretrieve_batch",
-            "alist_batches",
-            "acancel_batch",
-            "afile_content",
-            "afile_retrieve",
-            "afile_delete",
-            "atext_completion",
-            "acreate_fine_tuning_job",
-            "acancel_fine_tuning_job",
-            "alist_fine_tuning_jobs",
-            "aretrieve_fine_tuning_job",
-            "alist_input_items",
-            "aimage_edit",
-            "agenerate_content",
-            "agenerate_content_stream",
-            "allm_passthrough_route",
-            "avector_store_search",
-            "avector_store_create",
-            "avector_store_retrieve",
-            "avector_store_list",
-            "avector_store_update",
-            "avector_store_delete",
-            "avector_store_file_create",
-            "avector_store_file_list",
-            "avector_store_file_retrieve",
-            "avector_store_file_content",
-            "avector_store_file_update",
-            "avector_store_file_delete",
-            "aocr",
-            "asearch",
-            "avideo_generation",
-            "avideo_list",
-            "avideo_status",
-            "avideo_content",
-            "avideo_remix",
-            "avideo_create_character",
-            "avideo_get_character",
-            "avideo_edit",
-            "avideo_extension",
-            "acreate_container",
-            "alist_containers",
-            "aingest",
-            "aretrieve_container",
-            "adelete_container",
-            "aupload_container_file",
-            "alist_container_files",
-            "aretrieve_container_file",
-            "adelete_container_file",
-            "aretrieve_container_file_content",
-            "acreate_skill",
-            "alist_skills",
-            "aget_skill",
-            "adelete_skill",
-            "anthropic_messages",
-            "acreate_interaction",
-            "aget_interaction",
-            "adelete_interaction",
-            "acancel_interaction",
-            "acreate_agent",
-            "alist_agents",
-            "aget_agent",
-            "adelete_agent",
-            "alist_agent_versions",
-            "asend_message",
-            "call_mcp_tool",
-            "acreate_eval",
-            "alist_evals",
-            "aget_eval",
-            "aupdate_eval",
-            "adelete_eval",
-            "acancel_eval",
-            "acreate_run",
-            "alist_runs",
-            "aget_run",
-            "acancel_run",
-            "adelete_run",
-        ],
+        route_type: ProxyRouteType,
         proxy_logging_obj: ProxyLogging,
-        general_settings: dict,
+        general_settings: dict[str, object],
         proxy_config: ProxyConfig,
-        select_data_generator: Callable | None = None,
+        select_data_generator: Callable[..., object] | None = None,
         llm_router: Router | None = None,
         model: str | None = None,
         user_model: str | None = None,
@@ -1817,7 +2016,72 @@ class ProxyBaseLLMRequestProcessing:
         user_api_base: str | None = None,
         version: str | None = None,
         is_streaming_request: bool | None = False,
-        contents: list | None = None,  # Add contents parameter
+        contents: list[object] | None = None,
+        skip_pre_call_logic: bool = False,
+    ) -> Any:
+        """Run the request, sending SSE keepalives while the upstream is still silent.
+
+        Everything below this point, the upstream call included, happens before the
+        proxy can write a byte, so a slow time-to-first-token leaves the response
+        idle. See ``open_sse_before_first_byte``; unwrapped unless an operator sets
+        ``litellm_settings.sse_keepalive_ping_interval_seconds``.
+        """
+
+        async def _audit_late_failure(exc: Exception) -> HTTPException | None:
+            # Once a keepalive is on the wire this can no longer raise, so the
+            # caller's `except` never runs its own post_call_failure_hook.
+            return await proxy_logging_obj.post_call_failure_hook(
+                user_api_key_dict=user_api_key_dict,
+                original_exception=exc,
+                request_data=self.data,
+            )
+
+        return await open_sse_before_first_byte(
+            self._process_llm_request(
+                request=request,
+                fastapi_response=fastapi_response,
+                user_api_key_dict=user_api_key_dict,
+                route_type=route_type,
+                proxy_logging_obj=proxy_logging_obj,
+                general_settings=general_settings,
+                proxy_config=proxy_config,
+                select_data_generator=select_data_generator,
+                llm_router=llm_router,
+                model=model,
+                user_model=user_model,
+                user_temperature=user_temperature,
+                user_request_timeout=user_request_timeout,
+                user_max_tokens=user_max_tokens,
+                user_api_base=user_api_base,
+                version=version,
+                is_streaming_request=is_streaming_request,
+                contents=contents,
+                skip_pre_call_logic=skip_pre_call_logic,
+            ),
+            ping_interval_seconds=ttft_keepalive_interval(self.data, llm_router),
+            on_late_failure=_audit_late_failure,
+        )
+
+    async def _process_llm_request(
+        self,
+        request: Request,
+        fastapi_response: Response,
+        user_api_key_dict: UserAPIKeyAuth,
+        route_type: ProxyRouteType,
+        proxy_logging_obj: ProxyLogging,
+        general_settings: dict[str, object],
+        proxy_config: ProxyConfig,
+        select_data_generator: Callable[..., object] | None = None,
+        llm_router: Router | None = None,
+        model: str | None = None,
+        user_model: str | None = None,
+        user_temperature: float | None = None,
+        user_request_timeout: float | None = None,
+        user_max_tokens: int | None = None,
+        user_api_base: str | None = None,
+        version: str | None = None,
+        is_streaming_request: bool | None = False,
+        contents: list[object] | None = None,  # Add contents parameter
         skip_pre_call_logic: bool = False,
     ) -> Any:
         """

--- a/litellm/proxy/common_utils/sse_keepalive.py
+++ b/litellm/proxy/common_utils/sse_keepalive.py
@@ -1,15 +1,22 @@
 import asyncio
 import contextlib
 import math
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterable, Mapping
 from typing import Final
 
 import anyio
 
 ANTHROPIC_PING_SSE_CHUNK: Final = 'event: ping\ndata: {"type": "ping"}\n\n'
+SSE_COMMENT_PING_BYTES: Final = b": ping\n\n"
+# The byte form of proxy_server._SSE_FRAME_DELIMITERS, CR-only included: SSE
+# terminates a line with CRLF, LF or CR, so a blank line is any of these three.
+_SSE_FRAME_DELIMITERS: Final = (b"\r\n\r\n", b"\n\n", b"\r\r")
+_SSE_DELIMITER_LOOKBACK: Final = max(len(delimiter) for delimiter in _SSE_FRAME_DELIMITERS)
+_STREAM_START_TAIL: Final = b"\n\n"
+_SSE_MEDIA_TYPE: Final = "text/event-stream"
 
 
-def _coerce_interval(ping_interval_seconds: float | str | None) -> float | None:
+def coerce_keepalive_interval(ping_interval_seconds: float | str | None) -> float | None:
     if ping_interval_seconds is None:
         return None
     try:
@@ -28,7 +35,7 @@ def keepalive_ping_has_fired(elapsed_seconds: float, ping_interval_seconds: floa
     the status line is already on the wire. With pings disabled nothing flushes early, so a raise
     still carries its real status.
     """
-    interval: Final = _coerce_interval(ping_interval_seconds)
+    interval: Final = coerce_keepalive_interval(ping_interval_seconds)
     return interval is not None and elapsed_seconds >= interval
 
 
@@ -36,7 +43,7 @@ def wrap_sse_stream_with_keepalive_pings(
     stream: AsyncGenerator[str, None],
     ping_interval_seconds: float | str | None,
 ) -> AsyncGenerator[str, None]:
-    interval: Final = _coerce_interval(ping_interval_seconds)
+    interval: Final = coerce_keepalive_interval(ping_interval_seconds)
     if interval is None:
         return stream
     return _keepalive_ping_stream(stream=stream, ping_interval_seconds=interval)
@@ -66,3 +73,96 @@ async def _keepalive_ping_stream(
             with contextlib.suppress(BaseException):
                 await pending
             await stream.aclose()
+
+
+def is_sse_content_type(content_type: str | None) -> bool:
+    return content_type is not None and content_type.split(";", 1)[0].strip().lower() == _SSE_MEDIA_TYPE
+
+
+def wrap_passthrough_sse_bytes_with_keepalive_pings(
+    stream: AsyncGenerator[bytes, None],
+    ping_interval_seconds: float | str | None,
+    upstream_headers: Mapping[str, str],
+) -> AsyncGenerator[bytes, None]:
+    """Fill upstream silence on a byte-relaying passthrough stream with SSE comments.
+
+    Passthrough routes relay upstream bytes verbatim, so a model that thinks for
+    longer than an intermediary's idle read timeout has its connection dropped
+    before the first token. Only streams the upstream itself declares as
+    ``text/event-stream`` are wrapped: a comment spliced into a binary transport
+    (AWS event streams on ``/bedrock``, protobuf, NDJSON) would corrupt it.
+    """
+    interval: Final = coerce_keepalive_interval(ping_interval_seconds)
+    if interval is None or not is_sse_content_type(upstream_headers.get("content-type")):
+        return stream
+    return _keepalive_ping_byte_stream(stream=stream, ping_interval_seconds=interval)
+
+
+async def _keepalive_ping_byte_stream(
+    stream: AsyncGenerator[bytes, None],
+    ping_interval_seconds: float,
+) -> AsyncGenerator[bytes, None]:
+    pending = asyncio.ensure_future(
+        stream.__anext__()
+    )  # rebind-ok: re-armed with the next __anext__ after each delivered chunk
+    # The tail of the bytes relayed so far, long enough to hold any delimiter.
+    # Seeded as a delimiter because a stream starts at a frame boundary, and kept
+    # across chunks because a delimiter can be split between two transport reads,
+    # which testing only the latest chunk would miss for the rest of the stream.
+    recent_tail = _STREAM_START_TAIL  # rebind-ok: rolling window over the relayed bytes
+    try:
+        while True:
+            await asyncio.wait((pending,), timeout=ping_interval_seconds)
+            if not pending.done():
+                # The relayed chunks are raw transport reads, not whole SSE
+                # frames, so an upstream that stalls halfway through a frame
+                # must not have a comment spliced into it.
+                if recent_tail.endswith(_SSE_FRAME_DELIMITERS):
+                    yield SSE_COMMENT_PING_BYTES
+                continue
+            try:
+                chunk: bytes = pending.result()
+            except StopAsyncIteration:
+                return
+            if chunk:
+                recent_tail = (recent_tail + chunk)[-_SSE_DELIMITER_LOOKBACK:]
+            yield chunk
+            pending = asyncio.ensure_future(stream.__anext__())
+    finally:
+        pending.cancel()
+        with anyio.CancelScope(shield=True):
+            with contextlib.suppress(BaseException):
+                await pending
+            await stream.aclose()
+
+
+def resolve_ttft_keepalive_interval(
+    deployments: Iterable[Mapping[str, object]],
+    global_interval: float | str | None,
+) -> float | None:
+    """The keepalive interval to use before the upstream has answered at all.
+
+    No deployment has served the request yet, so a per-deployment
+    ``keepalive_seconds`` is only trusted when every candidate under the requested
+    model carries the same one, which is how the mid-stream engine treats its own
+    model_name fallback. Otherwise the operator's global default applies.
+
+    An explicit ``0`` survives as a disable, since coercion rejects it: that keeps
+    an operator's documented hard disable working on this path too, rather than
+    letting the global switch a deployment back on behind their back.
+
+    A client-supplied value is deliberately not consulted. Opening the response
+    early is an operator decision, and a request must not be able to enable it for
+    a deployment that never did.
+    """
+    configured: Final = frozenset(_keepalive_param(deployment) for deployment in deployments)
+    agreed: Final = next(iter(configured)) if len(configured) == 1 else None
+    return coerce_keepalive_interval(global_interval if agreed is None else agreed)
+
+
+def _keepalive_param(deployment: Mapping[str, object]) -> float | str | None:
+    params: Final = deployment.get("litellm_params")
+    if not isinstance(params, Mapping):
+        return None
+    value: Final = params.get("keepalive_seconds")
+    return value if isinstance(value, (int, float, str)) else None

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -61,10 +61,16 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+from litellm.proxy.common_request_processing import (
+    ProxyBaseLLMRequestProcessing,
+    open_sse_before_first_byte,
+)
 from litellm.proxy.common_utils.http_parsing_utils import (
     _read_request_body,
     _safe_get_request_headers,
+)
+from litellm.proxy.common_utils.sse_keepalive import (
+    wrap_passthrough_sse_bytes_with_keepalive_pings,
 )
 from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 from litellm.proxy.utils import normalize_route_for_root_path
@@ -1173,14 +1179,18 @@ async def pass_through_request(
                 _response_headers.update(callback_headers)
 
             return StreamingResponse(
-                PassThroughStreamingHandler.chunk_processor(
-                    response=response,
-                    request_body=_parsed_body,
-                    litellm_logging_obj=logging_obj,
-                    endpoint_type=endpoint_type,
-                    start_time=start_time,
-                    passthrough_success_handler_obj=pass_through_endpoint_logging,
-                    url_route=str(url),
+                wrap_passthrough_sse_bytes_with_keepalive_pings(
+                    stream=PassThroughStreamingHandler.chunk_processor(
+                        response=response,
+                        request_body=_parsed_body,
+                        litellm_logging_obj=logging_obj,
+                        endpoint_type=endpoint_type,
+                        start_time=start_time,
+                        passthrough_success_handler_obj=pass_through_endpoint_logging,
+                        url_route=str(url),
+                    ),
+                    ping_interval_seconds=litellm.sse_keepalive_ping_interval_seconds,
+                    upstream_headers=response.headers,
                 ),
                 headers=_response_headers,
                 status_code=response.status_code,
@@ -1245,14 +1255,18 @@ async def pass_through_request(
                 _response_headers.update(callback_headers)
 
             return StreamingResponse(
-                PassThroughStreamingHandler.chunk_processor(
-                    response=response,
-                    request_body=_parsed_body,
-                    litellm_logging_obj=logging_obj,
-                    endpoint_type=endpoint_type,
-                    start_time=start_time,
-                    passthrough_success_handler_obj=pass_through_endpoint_logging,
-                    url_route=str(url),
+                wrap_passthrough_sse_bytes_with_keepalive_pings(
+                    stream=PassThroughStreamingHandler.chunk_processor(
+                        response=response,
+                        request_body=_parsed_body,
+                        litellm_logging_obj=logging_obj,
+                        endpoint_type=endpoint_type,
+                        start_time=start_time,
+                        passthrough_success_handler_obj=pass_through_endpoint_logging,
+                        url_route=str(url),
+                    ),
+                    ping_interval_seconds=litellm.sse_keepalive_ping_interval_seconds,
+                    upstream_headers=response.headers,
                 ),
                 headers=_response_headers,
                 status_code=response.status_code,
@@ -1787,28 +1801,39 @@ def create_pass_through_route(
             elif isinstance(custom_body_data, dict):
                 final_custom_body = custom_body_data
 
-            try:
-                return await pass_through_request(
-                    request=request,
-                    target=full_target,
-                    custom_headers=headers_dict,
-                    user_api_key_dict=user_api_key_dict,
-                    forward_headers=cast(bool | None, param_forward_headers),
-                    merge_query_params=cast(bool | None, param_merge_query_params),
-                    query_params=final_query_params,
-                    default_query_params=cast(dict | None, param_default_query_params),
-                    stream=is_streaming_request or stream,
-                    custom_body=final_custom_body,
-                    cost_per_request=cast(float | None, param_cost_per_request),
-                    custom_llm_provider=custom_llm_provider,
-                    guardrails_config=cast(dict | None, param_guardrails),
-                    timeout=cast(float | None, param_timeout),
-                )
-            finally:
-                if hasattr(request.state, LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY):
-                    delattr(request.state, LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY)
-                if hasattr(request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY):
-                    delattr(request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY)
+            is_stream: Final = bool(is_streaming_request or stream)
+
+            async def _relay() -> Response:
+                try:
+                    return await pass_through_request(
+                        request=request,
+                        target=full_target,
+                        custom_headers=headers_dict,
+                        user_api_key_dict=user_api_key_dict,
+                        forward_headers=cast(bool | None, param_forward_headers),
+                        merge_query_params=cast(bool | None, param_merge_query_params),
+                        query_params=final_query_params,
+                        default_query_params=cast(dict | None, param_default_query_params),
+                        stream=is_stream,
+                        custom_body=final_custom_body,
+                        cost_per_request=cast(float | None, param_cost_per_request),
+                        custom_llm_provider=custom_llm_provider,
+                        guardrails_config=cast(dict | None, param_guardrails),
+                        timeout=cast(float | None, param_timeout),
+                    )
+                finally:
+                    if hasattr(request.state, LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY):
+                        delattr(request.state, LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY)
+                    if hasattr(request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY):
+                        delattr(request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY)
+
+            # The upstream withholds its response headers until its first token, so
+            # the whole time-to-first-token is spent inside _relay with nothing on
+            # the wire. Off unless an operator sets an interval.
+            return await open_sse_before_first_byte(
+                _relay(),
+                ping_interval_seconds=(litellm.sse_keepalive_ping_interval_seconds if is_stream else None),
+            )
 
     setattr(endpoint_func, LITELLM_PASS_THROUGH_ENDPOINT_MARKER, True)
     return endpoint_func

--- a/tests/test_litellm/proxy/common_utils/test_sse_keepalive.py
+++ b/tests/test_litellm/proxy/common_utils/test_sse_keepalive.py
@@ -8,6 +8,9 @@ from fastapi.responses import StreamingResponse
 from litellm.proxy.common_request_processing import create_response
 from litellm.proxy.common_utils.sse_keepalive import (
     ANTHROPIC_PING_SSE_CHUNK,
+    SSE_COMMENT_PING_BYTES,
+    resolve_ttft_keepalive_interval,
+    wrap_passthrough_sse_bytes_with_keepalive_pings,
     wrap_sse_stream_with_keepalive_pings,
 )
 
@@ -156,3 +159,229 @@ async def test_create_response_streams_ping_first_for_slow_upstream():
     collected: Final = [chunk async for chunk in response.body_iterator]
     assert collected[0] == ANTHROPIC_PING_SSE_CHUNK
     assert collected[-1] == MESSAGE_START_CHUNK
+
+
+SSE_FRAME_BYTES: Final = b'event: content_block_delta\ndata: {"type": "content_block_delta"}\n\n'
+BEDROCK_EVENT_STREAM_CONTENT_TYPE: Final = "application/vnd.amazon.eventstream"
+
+
+@pytest.mark.asyncio
+async def test_passthrough_ping_emitted_while_waiting_for_the_first_upstream_byte():
+    async def slow_start_stream() -> AsyncGenerator[bytes, None]:
+        await asyncio.sleep(0.2)
+        yield SSE_FRAME_BYTES
+
+    wrapped: Final = wrap_passthrough_sse_bytes_with_keepalive_pings(
+        stream=slow_start_stream(),
+        ping_interval_seconds=0.05,
+        upstream_headers={"content-type": "text/event-stream"},
+    )
+    collected: Final = [chunk async for chunk in wrapped]
+
+    assert collected[0] == SSE_COMMENT_PING_BYTES
+    assert collected[-1] == SSE_FRAME_BYTES
+    assert b"".join(c for c in collected if c != SSE_COMMENT_PING_BYTES) == SSE_FRAME_BYTES
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content_type", ["text/event-stream", "text/event-stream; charset=utf-8", "TEXT/Event-Stream"])
+async def test_passthrough_wraps_every_spelling_of_the_sse_content_type(content_type: str):
+    async def slow_start_stream() -> AsyncGenerator[bytes, None]:
+        await asyncio.sleep(0.2)
+        yield SSE_FRAME_BYTES
+
+    wrapped: Final = wrap_passthrough_sse_bytes_with_keepalive_pings(
+        stream=slow_start_stream(),
+        ping_interval_seconds=0.05,
+        upstream_headers={"content-type": content_type},
+    )
+    collected: Final = [chunk async for chunk in wrapped]
+
+    assert SSE_COMMENT_PING_BYTES in collected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content_type",
+    [BEDROCK_EVENT_STREAM_CONTENT_TYPE, "application/json", "application/x-ndjson", None, "text/event-streamish"],
+)
+async def test_passthrough_leaves_a_non_sse_transport_untouched(content_type: str | None):
+    """A comment spliced into a binary transport (e.g. an AWS event stream) corrupts it."""
+
+    async def any_stream() -> AsyncGenerator[bytes, None]:
+        yield SSE_FRAME_BYTES
+
+    stream: Final = any_stream()
+    assert (
+        wrap_passthrough_sse_bytes_with_keepalive_pings(
+            stream=stream,
+            ping_interval_seconds=0.05,
+            upstream_headers={} if content_type is None else {"content-type": content_type},
+        )
+        is stream
+    )
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_passthrough_ping_is_never_spliced_into_a_half_delivered_frame():
+    """Relayed chunks are raw transport reads, so an upstream can stall mid-frame."""
+
+    async def stalls_mid_frame() -> AsyncGenerator[bytes, None]:
+        yield b'event: content_block_delta\ndata: {"partial":'
+        await asyncio.sleep(0.3)
+        yield b"1}\n\n"
+
+    wrapped: Final = wrap_passthrough_sse_bytes_with_keepalive_pings(
+        stream=stalls_mid_frame(),
+        ping_interval_seconds=0.05,
+        upstream_headers={"content-type": "text/event-stream"},
+    )
+    collected: Final = [chunk async for chunk in wrapped]
+
+    assert SSE_COMMENT_PING_BYTES not in collected
+    assert b"".join(collected) == b'event: content_block_delta\ndata: {"partial":1}\n\n'
+
+
+@pytest.mark.asyncio
+async def test_passthrough_ping_resumes_once_the_stalled_frame_completes():
+    async def stalls_mid_frame_then_at_boundary() -> AsyncGenerator[bytes, None]:
+        yield b'event: content_block_delta\ndata: {"partial":'
+        await asyncio.sleep(0.2)
+        yield b"1}\n\n"
+        await asyncio.sleep(0.2)
+        yield SSE_FRAME_BYTES
+
+    wrapped: Final = wrap_passthrough_sse_bytes_with_keepalive_pings(
+        stream=stalls_mid_frame_then_at_boundary(),
+        ping_interval_seconds=0.05,
+        upstream_headers={"content-type": "text/event-stream"},
+    )
+    collected: Final = [chunk async for chunk in wrapped]
+
+    ping_index: Final = collected.index(SSE_COMMENT_PING_BYTES)
+    assert collected[:ping_index] == [b'event: content_block_delta\ndata: {"partial":', b"1}\n\n"]
+    assert collected[-1] == SSE_FRAME_BYTES
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_interval", [None, 0, "abc", float("inf"), float("nan"), "-3"])
+async def test_passthrough_invalid_or_disabled_interval_returns_stream_unwrapped(bad_interval: float | str | None):
+    async def any_stream() -> AsyncGenerator[bytes, None]:
+        yield SSE_FRAME_BYTES
+
+    stream: Final = any_stream()
+    assert (
+        wrap_passthrough_sse_bytes_with_keepalive_pings(
+            stream=stream,
+            ping_interval_seconds=bad_interval,
+            upstream_headers={"content-type": "text/event-stream"},
+        )
+        is stream
+    )
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_passthrough_aclose_mid_silence_cancels_upstream_and_runs_its_cleanup():
+    upstream_cleaned_up: Final = asyncio.Event()
+
+    async def hung_stream() -> AsyncGenerator[bytes, None]:
+        try:
+            yield SSE_FRAME_BYTES
+            await asyncio.Event().wait()
+        finally:
+            upstream_cleaned_up.set()
+
+    wrapped: Final = wrap_passthrough_sse_bytes_with_keepalive_pings(
+        stream=hung_stream(),
+        ping_interval_seconds=0.05,
+        upstream_headers={"content-type": "text/event-stream"},
+    )
+
+    assert await wrapped.__anext__() == SSE_FRAME_BYTES
+    assert await wrapped.__anext__() == SSE_COMMENT_PING_BYTES
+    await wrapped.aclose()
+
+    assert upstream_cleaned_up.is_set()
+
+
+@pytest.mark.asyncio
+async def test_passthrough_upstream_exception_propagates():
+    async def failing_stream() -> AsyncGenerator[bytes, None]:
+        yield SSE_FRAME_BYTES
+        raise ValueError("upstream broke")
+
+    wrapped: Final = wrap_passthrough_sse_bytes_with_keepalive_pings(
+        stream=failing_stream(),
+        ping_interval_seconds=5.0,
+        upstream_headers={"content-type": "text/event-stream"},
+    )
+
+    assert await wrapped.__anext__() == SSE_FRAME_BYTES
+    with pytest.raises(ValueError, match="upstream broke"):
+        await wrapped.__anext__()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "split_frame",
+    [
+        (b'data: {"a": 1}\n', b"\n"),
+        (b'data: {"a": 1}\r\n', b"\r\n"),
+        (b'data: {"a": 1}\r', b"\n\r\n"),
+        (b'data: {"a": 1}\r', b"\r"),
+        (b'data: {"a": 1}\r\r', b""),
+        (b'data: {"a": 1}\n\n', b""),
+    ],
+    ids=["lf-split", "crlf-split", "crlf-mixed-split", "cr-only-split", "cr-only-whole", "not-split"],
+)
+async def test_passthrough_sees_a_frame_delimiter_split_across_transport_chunks(split_frame):
+    """A raw transport read can end mid-delimiter. Testing only the latest chunk
+    would leave the stream looking permanently mid-frame, silently disabling the
+    keepalive the operator configured."""
+
+    async def split_delimiter_stream() -> AsyncGenerator[bytes, None]:
+        for part in split_frame:
+            if part:
+                yield part
+        await asyncio.sleep(0.3)
+        yield SSE_FRAME_BYTES
+
+    wrapped: Final = wrap_passthrough_sse_bytes_with_keepalive_pings(
+        stream=split_delimiter_stream(),
+        ping_interval_seconds=0.05,
+        upstream_headers={"content-type": "text/event-stream"},
+    )
+    collected: Final = [chunk async for chunk in wrapped]
+
+    assert SSE_COMMENT_PING_BYTES in collected
+    assert b"".join(c for c in collected if c != SSE_COMMENT_PING_BYTES) == b"".join(split_frame) + SSE_FRAME_BYTES
+
+
+def _deployment(keepalive_seconds=..., model="openai/gpt-4o"):
+    params = {"model": model}
+    if keepalive_seconds is not ...:
+        params["keepalive_seconds"] = keepalive_seconds
+    return {"model_name": "m", "litellm_params": params}
+
+
+@pytest.mark.parametrize(
+    "deployments, global_interval, expected, why",
+    [
+        ([], 30.0, 30.0, "no deployments known, the global applies"),
+        ([_deployment()], 30.0, 30.0, "nothing configured, the global applies"),
+        ([_deployment(0)], 30.0, None, "an operator's explicit 0 is a hard disable the global cannot lift"),
+        ([_deployment("0")], 30.0, None, "the same, written as a yaml string"),
+        ([_deployment(15)], 30.0, 15.0, "a deployment value wins over the global"),
+        ([_deployment(15), _deployment(15)], 30.0, 15.0, "agreeing deployments are trusted"),
+        ([_deployment(15), _deployment(60)], 30.0, 30.0, "disagreeing deployments fall back to the global"),
+        ([_deployment(0), _deployment(30)], 30.0, 30.0, "a partial disable is not trusted before one is chosen"),
+        ([_deployment(15)], None, 15.0, "a deployment value applies with no global set"),
+        ([_deployment()], None, None, "nothing anywhere leaves it off"),
+    ],
+)
+def test_ttft_interval_resolves_through_the_deployments_it_could_land_on(
+    deployments, global_interval, expected, why
+):
+    assert resolve_ttft_keepalive_interval(deployments, global_interval) == expected, why

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -386,25 +386,30 @@ def test_flush_deferred_async_logging_noop_when_no_closure_stored():
 
 def test_proxy_finally_block_routes_through_flush_helper():
     """
-    Source-level contract: the proxy's `base_process_llm_request` finally
-    block must delegate to `_flush_deferred_async_logging` rather than
-    inlining the gating logic. Inlining is what allowed the duplicate
-    Success+Failure spend log to slip in originally — this guards the
-    refactor.
+    Source-level contract: the proxy's request-processing finally block must
+    delegate to `_flush_deferred_async_logging` rather than inlining the gating
+    logic. Inlining is what allowed the duplicate Success+Failure spend log to
+    slip in originally — this guards the refactor.
+
+    Both halves of the request path are inspected: `base_process_llm_request` is
+    the public entry point and `_process_llm_request` holds the body, so neither
+    may inline the reset regardless of which one carries the finally block.
     """
     import inspect
 
-    src = inspect.getsource(ProxyBaseLLMRequestProcessing.base_process_llm_request)
+    src = inspect.getsource(ProxyBaseLLMRequestProcessing._process_llm_request) + inspect.getsource(
+        ProxyBaseLLMRequestProcessing.base_process_llm_request
+    )
     assert "_flush_deferred_async_logging" in src, (
-        "base_process_llm_request must call _flush_deferred_async_logging "
-        "from its finally block — do not inline the gating logic."
+        "the request path must call _flush_deferred_async_logging from its "
+        "finally block — do not inline the gating logic."
     )
     # Belt-and-braces: the inlined `_enqueue_deferred_logging = None` reset
     # was the symptom of the duplicate-log bug; assert it stays inside the
     # helper, not in the request-processing function.
     assert "_enqueue_deferred_logging = None" not in src, (
         "Reset of _enqueue_deferred_logging must live inside "
-        "_flush_deferred_async_logging, not in base_process_llm_request."
+        "_flush_deferred_async_logging, not in the request path."
     )
 
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -41,6 +41,10 @@ from litellm.proxy.pass_through_endpoints.success_handler import (
     PassThroughEndpointLogging,
 )
 
+import litellm
+
+MESSAGE_START_SSE_FRAME = b'event: message_start\ndata: {"type": "message_start"}\n\n'
+
 
 # Test is_multipart
 def test_is_multipart():
@@ -5104,3 +5108,185 @@ async def test_passthrough_body_cannot_forge_budget_reservation():
 
     increment_spend_counters.assert_awaited_once()
     assert increment_spend_counters.await_args.kwargs["budget_reservation"] is None
+
+
+async def _drive_streaming_pass_through(
+    upstream_content_type, chunk_delay_seconds, client_asked_for_stream=True
+):
+    """Drive pass_through_request against an upstream that stalls before its first byte.
+
+    ``client_asked_for_stream`` picks which of pass_through_request's two streaming
+    dispatch branches runs: the up-front one, and the one that only discovers the
+    response is a stream from its content-type.
+    """
+    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+        PassThroughStreamingHandler,
+    )
+
+    with ExitStack() as stack:
+        mock_proxy_logging = stack.enter_context(
+            patch("litellm.proxy.proxy_server.proxy_logging_obj")
+        )
+        mock_get_client = stack.enter_context(
+            patch(
+                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client"
+            )
+        )
+        mock_chunk_processor = stack.enter_context(
+            patch.object(PassThroughStreamingHandler, "chunk_processor")
+        )
+
+        mock_proxy_logging.pre_call_hook = AsyncMock(
+            return_value={"model": "claude-3", "stream": True}
+            if client_asked_for_stream
+            else {"model": "claude-3"}
+        )
+        mock_proxy_logging.post_call_failure_hook = AsyncMock()
+        mock_proxy_logging.post_call_response_headers_hook = AsyncMock(return_value={})
+
+        upstream_response = MagicMock()
+        upstream_response.status_code = 200
+        upstream_response.headers = {"content-type": upstream_content_type}
+        upstream_response.raise_for_status = MagicMock()
+
+        async_client = MagicMock()
+        async_client.build_request = MagicMock(return_value=MagicMock())
+        async_client.send = AsyncMock(return_value=upstream_response)
+        mock_get_client.return_value = MagicMock(client=async_client)
+
+        async def _slow_first_chunk(*args, **kwargs):
+            await asyncio.sleep(chunk_delay_seconds)
+            yield MESSAGE_START_SSE_FRAME
+
+        mock_chunk_processor.return_value = _slow_first_chunk()
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "POST"
+        mock_request.url = "http://test-proxy.com/v1/messages"
+        mock_request.body = AsyncMock(
+            return_value=b'{"model": "claude-3", "stream": true}'
+            if client_asked_for_stream
+            else b'{"model": "claude-3"}'
+        )
+        mock_request.headers = Headers({})
+        mock_request.query_params = QueryParams({})
+
+        response = await pass_through_request(
+            request=mock_request,
+            target="http://target-api.com/v1/messages",
+            custom_headers={},
+            user_api_key_dict=MagicMock(),
+            stream=client_asked_for_stream,
+        )
+        return [chunk async for chunk in response.body_iterator]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_asked_for_stream", [True, False])
+async def test_pass_through_sse_stream_emits_keepalive_before_the_first_upstream_byte(
+    client_asked_for_stream,
+):
+    """
+    Regression for #34819: a passthrough SSE stream wrote zero bytes during the
+    model's time-to-first-token, so an intermediary with an idle read timeout
+    (ALB, nginx) dropped a healthy connection before any token arrived.
+
+    Both dispatch branches are covered: a request that declared stream=true, and
+    one whose response is only recognised as a stream from its content-type.
+    """
+    with patch.object(litellm, "sse_keepalive_ping_interval_seconds", 0.05):
+        collected = await _drive_streaming_pass_through(
+            upstream_content_type="text/event-stream",
+            chunk_delay_seconds=0.2,
+            client_asked_for_stream=client_asked_for_stream,
+        )
+
+    assert collected[0] == b": ping\n\n"
+    assert collected[-1] == MESSAGE_START_SSE_FRAME
+
+
+@pytest.mark.asyncio
+async def test_pass_through_sse_stream_stays_silent_when_keepalive_is_unconfigured():
+    with patch.object(litellm, "sse_keepalive_ping_interval_seconds", None):
+        collected = await _drive_streaming_pass_through(
+            upstream_content_type="text/event-stream", chunk_delay_seconds=0.2
+        )
+
+    assert collected == [MESSAGE_START_SSE_FRAME]
+
+
+@pytest.mark.asyncio
+async def test_pass_through_binary_event_stream_is_never_given_an_sse_comment():
+    """An AWS event stream is a binary transport: a ": ping" frame would corrupt it."""
+    with patch.object(litellm, "sse_keepalive_ping_interval_seconds", 0.05):
+        collected = await _drive_streaming_pass_through(
+            upstream_content_type="application/vnd.amazon.eventstream",
+            chunk_delay_seconds=0.2,
+        )
+
+    assert collected == [MESSAGE_START_SSE_FRAME]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("configured_interval, expect_ping", [(0.05, True), (None, False)])
+async def test_pass_through_route_pings_while_the_upstream_call_is_still_running(
+    configured_interval, expect_ping
+):
+    """The upstream withholds its response headers until its first token, so the
+    whole time-to-first-token is spent inside pass_through_request with nothing on
+    the wire (issue #34819)."""
+    from fastapi import Response
+    from fastapi.responses import StreamingResponse
+
+    module = "litellm.proxy.pass_through_endpoints.pass_through_endpoints"
+
+    async def _relayed():
+        yield MESSAGE_START_SSE_FRAME
+
+    async def slow_pass_through(**kwargs):
+        await asyncio.sleep(0.25)
+        return StreamingResponse(_relayed(), media_type="text/event-stream")
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                f"{module}.InitPassThroughEndpointHelpers.is_registered_pass_through_route",
+                return_value=True,
+            )
+        )
+        stack.enter_context(
+            patch(
+                f"{module}.InitPassThroughEndpointHelpers.get_registered_pass_through_route",
+                return_value=None,
+            )
+        )
+        stack.enter_context(patch(f"{module}.pass_through_request", slow_pass_through))
+        stack.enter_context(
+            patch.object(litellm, "sse_keepalive_ping_interval_seconds", configured_interval)
+        )
+
+        endpoint_func = create_pass_through_route(
+            endpoint="/v1/messages",
+            target="https://api.anthropic.com/v1/messages",
+            custom_headers={},
+            is_streaming_request=True,
+        )
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "POST"
+        mock_request.url = httpx.URL("http://test-proxy.com/v1/messages")
+        mock_request.scope = {}
+        mock_request.body = AsyncMock(return_value=b'{"model": "claude-3"}')
+        mock_request.headers = Headers({"content-type": "application/json"})
+        mock_request.query_params = QueryParams({})
+        mock_request.state = SimpleNamespace()
+
+        response = await endpoint_func(
+            request=mock_request,
+            fastapi_response=Response(),
+            user_api_key_dict=MagicMock(),
+        )
+        collected = [chunk async for chunk in response.body_iterator]
+
+    assert (collected[0] == b": ping\n\n") is expect_ping
+    assert collected[-1] in (MESSAGE_START_SSE_FRAME, MESSAGE_START_SSE_FRAME.decode())

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -28,6 +28,9 @@ from litellm.proxy.common_request_processing import (
     _get_cost_breakdown_from_logging_obj,
     _has_attribute_error_in_chain,
     _is_azure_model_router_request,
+    _UpstreamClosingStreamingResponse,
+    open_sse_before_first_byte,
+    ttft_keepalive_interval,
     _override_openai_response_model,
     _parse_event_data_for_error,
     _resolve_per_request_model_group_alias,
@@ -6057,3 +6060,525 @@ class TestProcessChunkWithCostInjection:
         )
 
         assert ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(chunk, "gpt-4o-mini") == chunk
+
+
+# ---------------------------------------------------------------------------
+# SSE keepalive during the time-to-first-token (issue #34819)
+# ---------------------------------------------------------------------------
+
+TTFT_PING = b": ping\n\n"
+
+
+async def _drain(response):
+    return [chunk async for chunk in response.body_iterator]
+
+
+def _sse_response(chunks, upstream_generator=None):
+    async def gen():
+        for chunk in chunks:
+            yield chunk
+
+    if upstream_generator is None:
+        return StreamingResponse(gen(), media_type="text/event-stream")
+    return _UpstreamClosingStreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        upstream_generator=upstream_generator,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ttft_keepalive_fills_the_wire_while_the_upstream_is_still_silent():
+    """Regression for #34819. The upstream withholds its headers until the first
+    token, so the whole wait happens before a byte can be written and an
+    idle-timeout hop drops a healthy connection."""
+
+    async def slow_upstream():
+        await asyncio.sleep(0.35)
+        return _sse_response(['data: {"first": true}\n\n'])
+
+    response = await open_sse_before_first_byte(slow_upstream(), ping_interval_seconds=0.05)
+
+    assert isinstance(response, StreamingResponse)
+    assert response.headers["x-accel-buffering"] == "no"
+    collected = await _drain(response)
+    assert collected[0] == TTFT_PING
+    assert collected.count(TTFT_PING) >= 3
+    assert collected[-1] == b'data: {"first": true}\n\n'
+
+
+@pytest.mark.asyncio
+async def test_ttft_keepalive_is_a_no_op_when_the_upstream_answers_in_time():
+    produced = _sse_response(['data: {"fast": true}\n\n'])
+
+    async def fast_upstream():
+        return produced
+
+    response = await open_sse_before_first_byte(fast_upstream(), ping_interval_seconds=5.0)
+
+    assert response is produced
+    assert await _drain(response) == ['data: {"fast": true}\n\n']
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("interval", [None, 0, "", "abc", float("inf"), float("nan"), -1])
+async def test_ttft_keepalive_unconfigured_leaves_the_call_completely_untouched(interval):
+    produced = _sse_response(['data: {"x": 1}\n\n'])
+    started_at = asyncio.get_running_loop().time()
+
+    async def slow_upstream():
+        await asyncio.sleep(0.15)
+        return produced
+
+    response = await open_sse_before_first_byte(slow_upstream(), ping_interval_seconds=interval)
+
+    assert response is produced
+    assert asyncio.get_running_loop().time() - started_at >= 0.15
+
+
+@pytest.mark.asyncio
+async def test_ttft_keepalive_reraises_a_fast_failure_so_it_keeps_its_http_status():
+    async def fast_failure():
+        raise HTTPException(status_code=429, detail="rate limited")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await open_sse_before_first_byte(fast_failure(), ping_interval_seconds=5.0)
+
+    assert excinfo.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_ttft_keepalive_delivers_a_late_failure_as_an_sse_frame():
+    """Once a ping is on the wire the status line is committed, so a failure
+    discovered afterwards can only reach the client as a frame."""
+
+    async def slow_failure():
+        await asyncio.sleep(0.2)
+        raise HTTPException(status_code=429, detail="rate limited")
+
+    response = await open_sse_before_first_byte(slow_failure(), ping_interval_seconds=0.05)
+    collected = await _drain(response)
+
+    assert collected[0] == TTFT_PING
+    assert collected[-1] == b"data: [DONE]\n\n"
+    error_frame = json.loads(collected[-2].decode().removeprefix("data: ").strip())
+    assert error_frame["error"]["code"] == "429"
+    assert error_frame["error"]["message"] == "rate limited"
+
+
+@pytest.mark.asyncio
+async def test_ttft_keepalive_relays_a_late_non_streaming_body_as_an_sse_frame():
+    async def slow_json():
+        await asyncio.sleep(0.2)
+        return JSONResponse(status_code=400, content={"error": {"message": "bad request"}})
+
+    response = await open_sse_before_first_byte(slow_json(), ping_interval_seconds=0.05)
+    collected = await _drain(response)
+
+    assert collected[0] == TTFT_PING
+    assert json.loads(collected[-2].decode().removeprefix("data: ").strip()) == {"error": {"message": "bad request"}}
+    assert collected[-1] == b"data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_ttft_keepalive_closes_the_upstream_stream_it_relayed():
+    """Starlette never calls the produced response, so its own cleanup never runs
+    and the upstream LLM connection would leak."""
+    upstream_closed = asyncio.Event()
+
+    async def upstream():
+        try:
+            yield 'data: {"a": 1}\n\n'
+        finally:
+            upstream_closed.set()
+
+    upstream_gen = upstream()
+    # Started, as create_response leaves it: aclose() on a never-started generator
+    # skips its body, so an unstarted fixture cannot tell cleanup from no cleanup.
+    await upstream_gen.__anext__()
+
+    async def slow_upstream():
+        await asyncio.sleep(0.2)
+        return _sse_response(['data: {"a": 1}\n\n'], upstream_generator=upstream_gen)
+
+    response = await open_sse_before_first_byte(slow_upstream(), ping_interval_seconds=0.05)
+    await _drain(response)
+
+    assert upstream_closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_ttft_keepalive_cancels_the_in_flight_call_when_the_client_gives_up():
+    upstream_cancelled = asyncio.Event()
+
+    async def never_answers():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            upstream_cancelled.set()
+            raise
+
+    response = await open_sse_before_first_byte(never_answers(), ping_interval_seconds=0.05)
+    assert await response.body_iterator.__anext__() == TTFT_PING
+    await response.body_iterator.aclose()
+    await asyncio.sleep(0)
+
+    assert upstream_cancelled.is_set()
+
+
+@pytest.mark.parametrize(
+    "request_data, global_interval, expected",
+    [
+        ({"stream": True}, 30.0, 30.0),
+        ({"stream": True}, None, None),
+        ({"stream": False}, 30.0, None),
+        ({}, 30.0, None),
+        ({"stream": "true"}, 30.0, None),
+    ],
+)
+def test_ttft_keepalive_interval_only_arms_for_a_streaming_request(request_data, global_interval, expected):
+    with patch.object(litellm, "sse_keepalive_ping_interval_seconds", global_interval):
+        assert ttft_keepalive_interval(request_data) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream_requested, expect_ping", [(True, True), (False, False)])
+async def test_base_process_llm_request_pings_while_the_upstream_call_is_still_running(
+    stream_requested, expect_ping
+):
+    """The wiring, not the helper: every route funnels through this method, and the
+    whole time-to-first-token is spent inside the call it wraps."""
+
+    async def slow_inner(self, **kwargs):
+        await asyncio.sleep(0.25)
+        return _sse_response(['data: {"late": true}\n\n'])
+
+    processor = ProxyBaseLLMRequestProcessing(data={"model": "gpt-4o", "stream": stream_requested})
+
+    with patch.object(litellm, "sse_keepalive_ping_interval_seconds", 0.05):
+        with patch.object(ProxyBaseLLMRequestProcessing, "_process_llm_request", slow_inner):
+            response = await processor.base_process_llm_request(
+                request=MagicMock(spec=Request),
+                fastapi_response=Response(),
+                user_api_key_dict=MagicMock(spec=UserAPIKeyAuth),
+                route_type="acompletion",
+                proxy_logging_obj=MagicMock(spec=ProxyLogging),
+                general_settings={},
+                proxy_config=MagicMock(spec=ProxyConfig),
+            )
+
+    collected = await _drain(response)
+    assert (collected[0] == TTFT_PING) is expect_ping
+    assert collected[-1] == (b'data: {"late": true}\n\n' if expect_ping else 'data: {"late": true}\n\n')
+
+
+def _request_disconnecting_after(delay_seconds):
+    """A Request whose ASGI channel delivers one http.disconnect, then goes quiet."""
+    request = MagicMock(spec=Request)
+    delivered = {"done": False}
+
+    async def receive():
+        if delivered["done"]:
+            await asyncio.Event().wait()
+        await asyncio.sleep(delay_seconds)
+        delivered["done"] = True
+        return {"type": "http.disconnect"}
+
+    request.receive = receive
+    return request
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "disconnect_after, expect_full_delivery",
+    [(0.25, False), (999.0, True)],
+)
+async def test_opening_the_response_early_still_closes_the_upstream_on_disconnect(
+    disconnect_after, expect_full_delivery
+):
+    """Once the response is opened early, create_response's own disconnect
+    monitoring runs while Starlette is already serving, so both read the same ASGI
+    channel. Whichever observes the disconnect, the upstream LLM stream must close.
+    """
+    upstream_closed = asyncio.Event()
+    delivered = []
+
+    async def upstream():
+        try:
+            await asyncio.sleep(0.4)
+            for chunk in ('data: {"a": 1}\n\n', "data: [DONE]\n\n"):
+                delivered.append(chunk)
+                yield chunk
+        finally:
+            upstream_closed.set()
+
+    request = _request_disconnecting_after(disconnect_after)
+
+    async def produce():
+        await asyncio.sleep(0.15)
+        return await create_response(
+            generator=upstream(),
+            media_type="text/event-stream",
+            headers={},
+            request=request,
+        )
+
+    response = await open_sse_before_first_byte(produce(), ping_interval_seconds=0.05)
+    collected = await _drain(response)
+    await asyncio.sleep(0.05)
+
+    assert collected[0] == TTFT_PING
+    assert upstream_closed.is_set()
+    # The control has to actually deliver, or "the upstream closed" proves nothing.
+    assert (delivered == ['data: {"a": 1}\n\n', "data: [DONE]\n\n"]) is expect_full_delivery
+
+
+@pytest.mark.asyncio
+async def test_a_disconnect_after_the_upstream_answered_still_closes_the_response():
+    """The upstream can answer while nobody is draining the relay, e.g. the client
+    vanished first. Nothing else holds that response, so only this teardown closes
+    it; cancelling the produce task is not enough because it already finished."""
+    upstream_closed = asyncio.Event()
+    body_closed = asyncio.Event()
+
+    async def upstream():
+        try:
+            yield 'data: {"a": 1}\n\n'
+            await asyncio.Event().wait()
+        finally:
+            upstream_closed.set()
+
+    async def body():
+        try:
+            yield 'data: {"a": 1}\n\n'
+            await asyncio.Event().wait()
+        finally:
+            body_closed.set()
+
+    # Both started, as create_response leaves them: aclose() on a never-started
+    # generator skips its body, so an unstarted fixture cannot tell cleanup apart
+    # from no cleanup at all.
+    upstream_gen, body_gen = upstream(), body()
+    await upstream_gen.__anext__()
+    await body_gen.__anext__()
+
+    async def produce():
+        await asyncio.sleep(0.15)
+        return _UpstreamClosingStreamingResponse(
+            body_gen, media_type="text/event-stream", upstream_generator=upstream_gen
+        )
+
+    response = await open_sse_before_first_byte(produce(), ping_interval_seconds=0.05)
+    assert await response.body_iterator.__anext__() == TTFT_PING
+    await asyncio.sleep(0.25)  # the produce task finishes while nothing is pulling
+    await response.body_iterator.aclose()
+    await asyncio.sleep(0.05)
+
+    assert body_closed.is_set()
+    assert upstream_closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_a_late_failure_is_reported_to_the_failure_hook():
+    """Once a keepalive is on the wire this can no longer raise, so the caller's
+    own `except` never runs and the failure would otherwise go unaudited."""
+    audited = []
+
+    async def slow_failure():
+        await asyncio.sleep(0.2)
+        raise HTTPException(status_code=500, detail="upstream exploded")
+
+    async def record(exc):
+        audited.append(exc)
+
+    response = await open_sse_before_first_byte(
+        slow_failure(), ping_interval_seconds=0.05, on_late_failure=record
+    )
+    collected = await _drain(response)
+
+    assert [type(exc).__name__ for exc in audited] == ["HTTPException"]
+    assert getattr(audited[0], "detail", None) == "upstream exploded"
+    assert collected[-1] == b"data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_audit_hook_never_costs_the_client_its_error_frame():
+    async def slow_failure():
+        await asyncio.sleep(0.2)
+        raise HTTPException(status_code=500, detail="upstream exploded")
+
+    async def broken_hook(exc):
+        raise RuntimeError("the audit backend is down")
+
+    response = await open_sse_before_first_byte(
+        slow_failure(), ping_interval_seconds=0.05, on_late_failure=broken_hook
+    )
+    collected = await _drain(response)
+
+    error_frame = json.loads(collected[-2].decode().removeprefix("data: ").strip())
+    assert error_frame["error"]["message"] == "upstream exploded"
+    assert collected[-1] == b"data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_base_process_llm_request_audits_a_failure_that_lands_after_its_keepalive():
+    """The helper honouring on_late_failure is not enough: this pins that the shared
+    funnel actually passes one, which is where the route's own except would have
+    fired before the response was opened early."""
+
+    async def slow_failure(self, **kwargs):
+        await asyncio.sleep(0.25)
+        raise HTTPException(status_code=503, detail="upstream exploded")
+
+    proxy_logging_obj = MagicMock(spec=ProxyLogging)
+    # None is what a hook that only audits returns; a bare AsyncMock would hand
+    # back a MagicMock, which the code correctly reads as a sanitized replacement.
+    proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+    user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+    processor = ProxyBaseLLMRequestProcessing(data={"model": "gpt-4o", "stream": True})
+
+    with patch.object(litellm, "sse_keepalive_ping_interval_seconds", 0.05):
+        with patch.object(ProxyBaseLLMRequestProcessing, "_process_llm_request", slow_failure):
+            response = await processor.base_process_llm_request(
+                request=MagicMock(spec=Request),
+                fastapi_response=Response(),
+                user_api_key_dict=user_api_key_dict,
+                route_type="acompletion",
+                proxy_logging_obj=proxy_logging_obj,
+                general_settings={},
+                proxy_config=MagicMock(spec=ProxyConfig),
+            )
+        collected = await _drain(response)
+
+    proxy_logging_obj.post_call_failure_hook.assert_awaited_once()
+    call = proxy_logging_obj.post_call_failure_hook.await_args.kwargs
+    assert call["user_api_key_dict"] is user_api_key_dict
+    assert call["request_data"] is processor.data
+    assert getattr(call["original_exception"], "detail", None) == "upstream exploded"
+
+    assert collected[0] == TTFT_PING
+    assert collected[-1] == b"data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "deployment_keepalive, expect_ping",
+    [(0, False), (None, True)],
+    ids=["operator-hard-disabled-this-deployment", "deployment-says-nothing"],
+)
+async def test_base_process_llm_request_honours_a_deployment_hard_disable(
+    deployment_keepalive, expect_ping
+):
+    """`keepalive_seconds: 0` is documented as a disable a request cannot lift. The
+    funnel has to hand its router to the gate for that to hold before the upstream
+    has answered, since no deployment has served the request yet."""
+    params = {"model": "openai/gpt-4o"}
+    if deployment_keepalive is not None:
+        params["keepalive_seconds"] = deployment_keepalive
+
+    llm_router = MagicMock()
+    llm_router.get_model_list = MagicMock(return_value=[{"model_name": "m", "litellm_params": params}])
+
+    async def slow_inner(self, **kwargs):
+        await asyncio.sleep(0.25)
+        return _sse_response(['data: {"late": true}\n\n'])
+
+    processor = ProxyBaseLLMRequestProcessing(data={"model": "m", "stream": True})
+
+    with patch.object(litellm, "sse_keepalive_ping_interval_seconds", 0.05):
+        with patch.object(ProxyBaseLLMRequestProcessing, "_process_llm_request", slow_inner):
+            response = await processor.base_process_llm_request(
+                request=MagicMock(spec=Request),
+                fastapi_response=Response(),
+                user_api_key_dict=MagicMock(spec=UserAPIKeyAuth),
+                route_type="acompletion",
+                proxy_logging_obj=MagicMock(spec=ProxyLogging),
+                general_settings={},
+                proxy_config=MagicMock(spec=ProxyConfig),
+                llm_router=llm_router,
+            )
+
+    collected = await _drain(response)
+    assert (collected[0] == TTFT_PING) is expect_ping
+
+
+@pytest.mark.asyncio
+async def test_a_hook_returning_a_replacement_decides_what_the_client_sees():
+    """post_call_failure_hook exists partly to sanitize client-facing errors.
+    Serializing the original would leak provider detail a deployment configured away."""
+
+    async def slow_failure():
+        await asyncio.sleep(0.2)
+        raise HTTPException(status_code=500, detail="upstream said host=10.0.0.7 key=sk-internal")
+
+    async def sanitize(exc):
+        return HTTPException(status_code=502, detail="upstream unavailable")
+
+    response = await open_sse_before_first_byte(
+        slow_failure(), ping_interval_seconds=0.05, on_late_failure=sanitize
+    )
+    collected = await _drain(response)
+
+    error_frame = json.loads(collected[-2].decode().removeprefix("data: ").strip())
+    assert error_frame["error"]["message"] == "upstream unavailable"
+    assert "sk-internal" not in collected[-2].decode()
+
+
+@pytest.mark.asyncio
+async def test_a_hook_raising_a_replacement_also_decides_what_the_client_sees():
+    """The hook's contract is return *or* raise, and raising is the path a
+    suppress(Exception) around the call would silently discard."""
+
+    async def slow_failure():
+        await asyncio.sleep(0.2)
+        raise HTTPException(status_code=500, detail="upstream said host=10.0.0.7 key=sk-internal")
+
+    async def sanitize_by_raising(exc):
+        raise HTTPException(status_code=403, detail="blocked by policy")
+
+    response = await open_sse_before_first_byte(
+        slow_failure(), ping_interval_seconds=0.05, on_late_failure=sanitize_by_raising
+    )
+    collected = await _drain(response)
+
+    error_frame = json.loads(collected[-2].decode().removeprefix("data: ").strip())
+    assert error_frame["error"]["message"] == "blocked by policy"
+    assert "sk-internal" not in collected[-2].decode()
+
+
+@pytest.mark.asyncio
+async def test_a_hook_that_returns_nothing_leaves_the_real_error_intact():
+    async def slow_failure():
+        await asyncio.sleep(0.2)
+        raise HTTPException(status_code=429, detail="rate limited")
+
+    async def audit_only(exc):
+        return None
+
+    response = await open_sse_before_first_byte(
+        slow_failure(), ping_interval_seconds=0.05, on_late_failure=audit_only
+    )
+    collected = await _drain(response)
+
+    error_frame = json.loads(collected[-2].decode().removeprefix("data: ").strip())
+    assert error_frame["error"]["message"] == "rate limited"
+    assert error_frame["error"]["code"] == "429"
+
+
+@pytest.mark.asyncio
+async def test_a_broken_hook_does_not_replace_the_real_error_with_its_own_bug():
+    async def slow_failure():
+        await asyncio.sleep(0.2)
+        raise HTTPException(status_code=429, detail="rate limited")
+
+    async def broken_hook(exc):
+        raise RuntimeError("the audit backend is down")
+
+    response = await open_sse_before_first_byte(
+        slow_failure(), ping_interval_seconds=0.05, on_late_failure=broken_hook
+    )
+    collected = await _drain(response)
+
+    error_frame = json.loads(collected[-2].decode().removeprefix("data: ").strip())
+    assert error_frame["error"]["message"] == "rate limited"
+    assert "audit backend" not in collected[-2].decode()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming writes zero bytes for the whole time-to-first-token
- ALB and nginx drop those healthy connections at 60s
- LiteLLM's keepalives only start after the upstream answers
- Passthrough streams reach no keepalive at all

How it solves it:

- Race the upstream call against the keepalive interval
- Open the SSE response early, fill it with `: ping`
- One seam per funnel, native and passthrough
- Off until an operator sets an interval

## User Flow

Before: a developer streaming a reasoning model through a gateway behind an AWS ALB sees the request die at 60 seconds, every time, before a single token arrives

1. Their proxy admin sets `litellm_settings.sse_keepalive_ping_interval_seconds: 5` and restarts the proxy
2. They send POST https://litellm-domain/v1/chat/completions with `"stream": true`, `"model": "gpt-5.6"` and `"reasoning_effort": "high"`
3. Nothing is printed for 26 seconds, not one byte, while the model thinks
4. On a slower prompt the ALB hits its 60 second idle timeout first and the connection is reset, so their app reports a truncated stream for a request that was healthy the whole time
5. The same request sent straight to the proxy with no ALB in between completes normally after the same silent gap

After: the same request starts producing output within seconds, so the ALB's idle timer never fires and the tokens arrive when the model is ready

1. Their proxy admin sets `litellm_settings.sse_keepalive_ping_interval_seconds: 5` and restarts the proxy
2. They send the same POST https://litellm-domain/v1/chat/completions with `"stream": true`, `"model": "gpt-5.6"` and `"reasoning_effort": "high"`
3. A `: ping` comment line appears at 5 seconds and every 5 seconds after that, which every conformant SSE client ignores, so nothing changes for their app
4. The real `data:` frames start at 23 seconds and the response completes normally
5. Behind the ALB the connection now survives, because the longest gap the ALB sees is 5 seconds rather than the model's full thinking time

## Relevant issues

Fixes #34819

Companion docs PR: BerriAI/litellm-docs#929, which documents `sse_keepalive_ping_interval_seconds` and what opening the response early costs. Merge that one after this.

## Linear ticket

Resolves LIT-5728

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g. lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup for every case below. `config.yaml`:

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  sse_keepalive_ping_interval_seconds: 5

general_settings:
  master_key: sk-lit34819
```

`body.json` for the chat completions and passthrough cases:

```json
{
  "model": "gpt-5.6",
  "stream": true,
  "reasoning_effort": "high",
  "messages": [{"role": "user", "content": "Think very carefully, step by step, before answering: how many primes below 500 have a digit sum of exactly 10? Show your reasoning."}]
}
```

`body.json` for the responses case is the same prompt as `"input"` with `"reasoning": {"effort": "high"}`.

Every case is one live proxy, real OpenAI calls, no mocks. Each output line is stamped with seconds since the request was sent.

### Before (base e09bbe9a14)

#### /v1/chat/completions

1. `curl -sS -N http://localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-lit34819' -H 'content-type: application/json' -d @body.json`, timestamping each line
2. Output (first 6 non-blank lines, then the summary):

   [ 32s] data: {"id":"chatcmpl-EEJJttteAIEYkKDh5nLOX31CesXZz","object":"chat.completion.chunk","created":1787
   [ 32s] data: {"id":"chatcmpl-EEJJttteAIEYkKDh5nLOX31CesXZz","object":"chat.completion.chunk","created":1787
   [ 32s] data: {"id":"chatcmpl-EEJJttteAIEYkKDh5nLOX31CesXZz","object":"chat.completion.chunk","created":1787
   [ 32s] data: {"id":"chatcmpl-EEJJttteAIEYkKDh5nLOX31CesXZz","object":"chat.completion.chunk","created":1787
   [ 32s] data: {"id":"chatcmpl-EEJJttteAIEYkKDh5nLOX31CesXZz","object":"chat.completion.chunk","created":1787
   [ 32s] data: {"id":"chatcmpl-EEJJttteAIEYkKDh5nLOX31CesXZz","object":"chat.completion.chunk","created":1787
   ...

   first byte to the client: 32s | first upstream frame: 32s | keepalive comments: 0

#### /v1/responses

1. `curl -sS -N http://localhost:4000/v1/responses -H 'Authorization: Bearer sk-lit34819' -H 'content-type: application/json' -d @body.json`, timestamping each line
2. Output (first 6 non-blank lines, then the summary):

   [  1s] data: {"type":"response.created","response":{"id":"resp_atY-4VkTGf9metEFjT7KzVztaiLcEkvmZ0JclGHRI9FD
   [  1s] data: {"type":"response.in_progress","response":{"id":"resp_atY-4VkTGf9metEFjT7KzVztaiLcEkvmZ0JclGHR
   [  2s] data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_069f669ad13c86df006a84a
   [  7s] : ping
   [ 11s] data: {"type":"response.output_item.done","output_index":0,"sequence_number":3,"item":{"id":"rs_069f
   [ 11s] data: {"type":"response.output_item.added","output_index":1,"item":{"id":"rs_069f669ad13c86df006a84a
   ...

   first byte to the client: 1s | first upstream frame: 1s | keepalive comments: 4

#### /openai/v1/chat/completions (passthrough)

1. `curl -sS -N http://localhost:4000/openai/v1/chat/completions -H 'Authorization: Bearer sk-lit34819' -H 'content-type: application/json' -d @body.json`, timestamping each line
2. Output (first 6 non-blank lines, then the summary):

   [ 27s] data: {"id":"chatcmpl-EEJLHuxLrYvqqDV2I07DcVonqysdh","object":"chat.completion.chunk","created":1787
   [ 27s] data: {"id":"chatcmpl-EEJLHuxLrYvqqDV2I07DcVonqysdh","object":"chat.completion.chunk","created":1787
   [ 27s] data: {"id":"chatcmpl-EEJLHuxLrYvqqDV2I07DcVonqysdh","object":"chat.completion.chunk","created":1787
   [ 27s] data: {"id":"chatcmpl-EEJLHuxLrYvqqDV2I07DcVonqysdh","object":"chat.completion.chunk","created":1787
   [ 27s] data: {"id":"chatcmpl-EEJLHuxLrYvqqDV2I07DcVonqysdh","object":"chat.completion.chunk","created":1787
   [ 27s] data: {"id":"chatcmpl-EEJLHuxLrYvqqDV2I07DcVonqysdh","object":"chat.completion.chunk","created":1787
   ...

   first byte to the client: 27s | first upstream frame: 27s | keepalive comments: 0

### After (3ec353c4d8)

Captured at `da8f70133d`. Every delta since is covered in Review notes and none can move these legs: a test-file hunk, a resolution that returns the same global for this config, and a sanitization path reachable only from the relay's except branch.

#### /v1/chat/completions

1. `curl -sS -N http://localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-lit34819' -H 'content-type: application/json' -d @body.json`, timestamping each line
2. Output (first 6 non-blank lines, then the summary):

   [  5s] : ping
   [ 10s] : ping
   [ 15s] : ping
   [ 20s] : ping
   [ 21s] data: {"id":"chatcmpl-EEJLr7A0qIhEYOQusM0hC6PSQ7iMx","object":"chat.completion.chunk","created":1787
   [ 21s] data: {"id":"chatcmpl-EEJLr7A0qIhEYOQusM0hC6PSQ7iMx","object":"chat.completion.chunk","created":1787
   ...

   first byte to the client: 5s | first upstream frame: 21s | keepalive comments: 4

#### /v1/responses

1. `curl -sS -N http://localhost:4000/v1/responses -H 'Authorization: Bearer sk-lit34819' -H 'content-type: application/json' -d @body.json`, timestamping each line
2. Output (first 6 non-blank lines, then the summary):

   [  0s] data: {"type":"response.created","response":{"id":"resp_ztNg7vlMXZH4rllFladWlcP2Pl9spqntqTmQ8bUX5kLt
   [  0s] data: {"type":"response.in_progress","response":{"id":"resp_ztNg7vlMXZH4rllFladWlcP2Pl9spqntqTmQ8bUX
   [  1s] data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_045416c105e60a56006a84a
   [  6s] : ping
   [  9s] data: {"type":"response.output_item.done","output_index":0,"sequence_number":3,"item":{"id":"rs_0454
   [  9s] data: {"type":"response.output_item.added","output_index":1,"item":{"id":"rs_045416c105e60a56006a84a
   ...

   first byte to the client: 0s | first upstream frame: 0s | keepalive comments: 3

#### /openai/v1/chat/completions (passthrough)

1. `curl -sS -N http://localhost:4000/openai/v1/chat/completions -H 'Authorization: Bearer sk-lit34819' -H 'content-type: application/json' -d @body.json`, timestamping each line
2. Output (first 6 non-blank lines, then the summary):

   [  5s] : ping
   [ 10s] : ping
   [ 15s] : ping
   [ 19s] data: {"id":"chatcmpl-EEJMxQL4MCeUA8UJUeOynfxYzyQcD","object":"chat.completion.chunk","created":1787
   [ 19s] data: {"id":"chatcmpl-EEJMxQL4MCeUA8UJUeOynfxYzyQcD","object":"chat.completion.chunk","created":1787
   [ 19s] data: {"id":"chatcmpl-EEJMxQL4MCeUA8UJUeOynfxYzyQcD","object":"chat.completion.chunk","created":1787
   ...

   first byte to the client: 5s | first upstream frame: 19s | keepalive comments: 3

### Control (same fixed build, `sse_keepalive_ping_interval_seconds` unset)

1. `curl -sS -N http://localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-lit34819' -H 'content-type: application/json' -d @body.json`, timestamping each line
2. Output (first 6 non-blank lines, then the summary):

   [ 26s] data: {"id":"chatcmpl-EEJNRWNawIWDVqxDbRN7Tv817Ht4d","object":"chat.completion.chunk","created":1787
   [ 26s] data: {"id":"chatcmpl-EEJNRWNawIWDVqxDbRN7Tv817Ht4d","object":"chat.completion.chunk","created":1787
   [ 26s] data: {"id":"chatcmpl-EEJNRWNawIWDVqxDbRN7Tv817Ht4d","object":"chat.completion.chunk","created":1787
   [ 26s] data: {"id":"chatcmpl-EEJNRWNawIWDVqxDbRN7Tv817Ht4d","object":"chat.completion.chunk","created":1787
   [ 26s] data: {"id":"chatcmpl-EEJNRWNawIWDVqxDbRN7Tv817Ht4d","object":"chat.completion.chunk","created":1787
   [ 26s] data: {"id":"chatcmpl-EEJNRWNawIWDVqxDbRN7Tv817Ht4d","object":"chat.completion.chunk","created":1787
   ...

   first byte to the client: 26s | first upstream frame: 26s | keepalive comments: 0

### Why `/v1/responses` looks different

It is the case the existing engine already covers. OpenAI's Responses API sends `response.created` immediately, so its silence is genuinely mid-stream and `_iter_with_keepalive` was already filling it (4 comments before, 3 after, both correct). Chat completions is the broken one because OpenAI withholds the response headers until the first token, which a direct measurement confirms:

```
$ python probe_headers.py     # httpx client.send(request, stream=True) against api.openai.com
headers returned at    37.90s  status=200
upstream content-type: 'text/event-stream; charset=utf-8'
first body byte at     37.90s  (313 bytes)
```

The whole wait therefore happens inside the router call, before anything the existing engines wrap even exists.

## Review notes

Three review rounds, two bots. The reasoning lives here rather than in comments, per this repo's comment length rule.

### Round 6 from veria: error sanitization bypass, accepted and widened

Checking the premise made the fix bigger than the one proposed. veria said `post_call_failure_hook` can return a sanitized exception and this branch discarded it. True: five call sites capture it as `transformed_exception`, two of them in this same file, so that contract is live rather than theoretical.

The check also turned up a second leak it did not name. The hook's documented contract is return *or raise*, and the `contextlib.suppress(Exception)` around the call swallowed the raise path outright, which is the path a sanitizing callback is most likely to use.

Both are honoured now. A returned replacement wins, a raised `HTTPException` wins, and a callback that fails some other way is logged as a callback bug without costing the client the real error. Four tests cover the matrix, each asserting the internal detail never reaches the wire, and four mutants die one-for-one: ignore the returned replacement, swallow the raised one, surface the callback's own bug, never consult the hook at all.

One fixture correction fell out of this. An earlier wiring test used a bare `AsyncMock()`, whose return value is a `MagicMock`; harmless before, but the new code correctly reads it as a sanitized replacement. A hook that only audits returns `None`, and the fixture now says so. Same shape as the unstarted-generator fixture in round 3: a code change makes a sloppy fixture start mattering.

Not re-captured, and that is structural rather than a judgement call: `_sanitized_late_failure` is reachable only from the relay's `except` branch, which no successful capture leg enters.

### Round 5: a defect neither bot found, caught by reading the docs against the code

While checking that the companion docs PR still matched the code, I found that this PR overrode an operator's documented hard disable. `keepalive_seconds: 0` on a deployment is specified as a disable a request cannot lift, and it exists so heartbeats cannot be used to hold a connection past a load balancer's idle timeout and tie up a `max_parallel_requests` slot. The new time-to-first-token gate read only the global setting, so such a deployment got pinged anyway:

```
deployment keepalive_seconds  = 0   (documented hard disable)
mid-stream engine resolves to = 0.0
TTFT gate resolves to         = 5.0   <- MISMATCH
```

That is the same class of bug `e53f044d20` was written to fix, and the docs PR I had already opened asserted the contract still held, so it would have shipped a document that contradicted its own code.

The gate now resolves through the deployments the request could land on. No deployment has served it yet, so a per-deployment value is trusted only when every candidate under the requested model agrees, mirroring how the mid-stream engine treats its own model_name fallback; an explicit `0` survives coercion and stays a disable. Client-supplied values are deliberately not consulted, since opening the response early is an operator decision.

Pinned by a ten-row resolution table covering agreement, disagreement, a partial disable, a yaml-string zero, and no global at all. Three mutants: replacing the resolution with the global, trusting a disagreeing set, and dropping the router at the call site. The third initially survived, the same plumb-through gap as round 3 at a new seam, so `test_base_process_llm_request_honours_a_deployment_hard_disable` was added; all three die now.

The live capture was not re-run for this round, and that is a measured claim rather than an assumption. The capture's config sets no per-deployment `keepalive_seconds`, and the new resolver returns the global unchanged for it:

```
per-deployment keepalive_seconds: ['<unset>']
global sse_keepalive_ping_interval_seconds: 5
resolver returns                : 5.0
```

### Round 4: a contract test CI caught and my local checks could not

`proxy-endpoints` failed on `test_proxy_finally_block_routes_through_flush_helper`, a source-level contract guarding a past duplicate Success+Failure spend log: the request path's finally block must delegate to `_flush_deferred_async_logging` rather than inline the reset. Splitting `base_process_llm_request` into a thin wrapper plus `_process_llm_request` moved the finally block, so `inspect.getsource` on the public name no longer saw it.

The invariant itself still holds, it just lives in the other half now, so the check now spans both methods. That is strictly stronger than before, since neither half may inline the reset whichever one carries the finally. Confirmed not vacuous:

```
in _process_llm_request:     True
in base_process_llm_request: False
reset string in either:      False
```

Worth naming why this got past me: my regression comparisons were scoped to the three directories the diff touches, and this test lives in `proxy/guardrails/`. Twenty-four test files name `base_process_llm_request`; all of them now run clean against base, 1 pre-existing failure on both sides and zero regressions.

### Round 3 on `386228ab23`: two from veria, both accepted

**Late failures bypassed the failure hook.** Verified rather than assumed: `chat_completion` calls `post_call_failure_hook` from three `except` blocks, all of them outside this wrapper. Once a ping is on the wire the wrapper can no longer raise, so swallowing the exception into an SSE frame meant none of them ran and the failure went unaudited. An injected `on_late_failure` callback now carries it to `post_call_failure_hook`, wired at the native funnel.

Scoped to the native path deliberately: `pass_through_request` already calls `post_call_failure_hook` itself at lines 1507-1544 before it raises, so wiring the callback there too would double-audit every passthrough failure.

**A completed response was not closed on disconnect.** The teardown only cancelled an *unfinished* produce task. When the upstream answered while nobody was draining the relay, which is what a client disconnect looks like from here, nothing ever closed that response and its upstream LLM stream stayed open. Probed before fixing:

```
produced body_iterator closed: False
upstream generator closed:     False
LEAK CONFIRMED: the produced response was never closed
```

and after: `no leak`. The teardown now closes an already-completed response as well, through a `_aclose_late_response` helper shared with the relay's own teardown, since closing an already-closed generator is a no-op.

Worth recording that the first re-probe read `body_iterator closed: False` and looked like a partial fix. The fixture's body generator had never been started, and `aclose()` on an unstarted generator skips its body, which is the exact hazard `_UpstreamClosingStreamingResponse`'s docstring describes and the reason it tracks the upstream separately. Both regression tests start their generators for that reason.

Mutation coverage found a gap here worth naming: dropping the callback *at the call site* initially killed nothing, because the tests exercised the helper honouring a callback rather than the funnel supplying one. `test_base_process_llm_request_audits_a_failure_that_lands_after_its_keepalive` closes that, asserting the hook was awaited with the right key, exception and request data. All three mutants now die.

### Round 2 on `ccc0f97c40`: CR-only SSE boundaries

Accepted, and the premise checked out. SSE terminates a line with CRLF, LF or CR, so a blank line can be `\r\r`, and this repo already knows that: `litellm/proxy/proxy_server.py:7822` defines `_SSE_FRAME_DELIMITERS = ("\r\n\r\n", "\n\n", "\r\r")`. My byte-level copy had only two of the three, so a CR-only upstream would have lost its keepalives exactly as before the fix. The byte tuple now mirrors that set, with a comment pointing at it so the two do not drift apart again.

Test parametrization grew to six cases: LF split, CRLF split, a mixed `\r` + `\n\r\n` split, a CR-only split, a CR-only whole delimiter, and an unsplit control. Dropping `\r\r` back out fails exactly the two CR-only cases and leaves the other four green:

```
FAILED ...[cr-only-split]
FAILED ...[cr-only-whole]
2 failed, 39 passed
```

One incidental trap avoided while doing this: the rolling tail used to be seeded as `_SSE_FRAME_DELIMITERS[0]`, and reordering the tuple to match `proxy_server`'s would have silently changed what it was seeded with. It is now a named `_STREAM_START_TAIL` so the seed cannot move when the set does.

### Round 1 on `da810b81c3`: split delimiters, and the error mapping

**Frame-boundary tracking across chunks: accepted, real, fixed.** The boundary check tested only the latest chunk, so a delimiter split between two transport reads (`...}\n` then `\n...`) left the stream looking permanently mid-frame and silently stopped the keepalive an operator had configured, which is worse than the bug this PR fixes. `_keepalive_ping_byte_stream` now carries a rolling 4-byte tail across chunks, seeded as a delimiter because a stream starts at a frame boundary. Restoring the old one-chunk logic fails the three split cases and leaves the control green.

**The mapping construction in `_sse_error_payload`: kept as it is, on measurement.** The one-shot spread form is the nicer shape and I tried it first, but the conditional spread costs two extra dict constructions and `scripts/type_discipline_gate.py` rejects it:

```
FAIL: LIT002: total 26912 over limit 26893 (this change added 2)
```

The current form costs exactly one construction, which is what the code it was extracted from already cost, so this is net zero against the ceiling. It also is not the pattern that rule targets: nothing seeds an empty dict and mutates it over time, the value is built in one statement and given one optional key. Reverted to it with a comment recording why, and both budget gates pass against the merge base.

## Type

🐛 Bug Fix

## Caveats (if any)

- Off until an operator sets an interval; unset behaves exactly as before
- Once a ping is sent, a later failure arrives as an SSE frame under 200
- Once a ping is sent, `x-litellm-*` response headers are not yet known
- Serving early puts two readers on the ASGI receive channel; see below
- Assistants and A2A SSE routes are still unwrapped, tracked as LIT-5737

On the receive-channel point: once the response is open, Starlette listens for `http.disconnect` while `create_response`'s own first-chunk monitoring reads the same channel, so a disconnect landing in that window is seen by one of them, not both. I probed the orderings and the upstream LLM stream closes either way, which is the property that matters; `test_opening_the_response_early_still_closes_the_upstream_on_disconnect` pins it, with the no-disconnect leg asserting full delivery so the control can actually discriminate. Worth a reviewer's eye all the same.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
