### PR TITLE
fix(vertex): bill Live API output cost when input_cost_per_token is zero

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_ai_live_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_ai_live_passthrough_logging_handler.py
@@ -151,7 +151,9 @@ class VertexAILivePassthroughLoggingHandler(BasePassthroughLoggingHandler):
             verbose_proxy_logger.debug("Vertex AI Live API model info for '%s': %s", model, model_info)
 
             # Check if pricing info is available
-            if not model_info or not model_info.get("input_cost_per_token"):
+            if not model_info or (
+                not model_info.get("input_cost_per_token") and not model_info.get("output_cost_per_token")
+            ):
                 verbose_proxy_logger.error("No pricing info found for %s in local model pricing database", model)
                 return 0.0
 

--- a/tests/pass_through_unit_tests/test_vertex_ai_live_passthrough.py
+++ b/tests/pass_through_unit_tests/test_vertex_ai_live_passthrough.py
@@ -230,6 +230,27 @@ class TestVertexAILivePassthroughLoggingHandler:
     @patch(
         "litellm.proxy.pass_through_endpoints.llm_provider_handlers.vertex_ai_live_passthrough_logging_handler.get_model_info"
     )
+    def test_calculate_cost_input_free_output_priced(self, mock_get_model_info, handler):
+        """A model free on input but priced on output must still bill output, not return 0."""
+        mock_get_model_info.return_value = {
+            "input_cost_per_token": 0.0,
+            "output_cost_per_token": 0.000005,
+        }
+
+        usage_metadata = {
+            "promptTokenCount": 1000,
+            "candidatesTokenCount": 200,
+            "totalTokenCount": 1200,
+        }
+
+        cost = handler._calculate_live_api_cost("gemini-live-x", usage_metadata)
+
+        assert cost == pytest.approx(200 * 0.000005)
+        assert cost > 0
+
+    @patch(
+        "litellm.proxy.pass_through_endpoints.llm_provider_handlers.vertex_ai_live_passthrough_logging_handler.get_model_info"
+    )
     def test_calculate_cost_with_audio(self, mock_get_model_info, handler):
         """Test cost calculation with audio tokens"""
         mock_get_model_info.return_value = {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex AI Live API calls bill $0 whenever the model's input rate is zero
- a model that is free on input but priced on output (or by modality) loses all its cost

How it solves it:

- only treat a model as unpriced when both input and output token costs are absent, not when input alone is zero

## Relevant issues

## Type

🐛 Bug Fix

## Changes

`VertexAILivePassthroughLoggingHandler._calculate_live_api_cost` guarded with `if not model_info or not model_info.get("input_cost_per_token"): return 0.0`, so any model whose `input_cost_per_token` is zero short-circuited to $0 before output and per-modality costs were ever computed. Models that are free on input but charge on output (and modality-priced Live models) were logged at zero. This widens the guard to return early only when both `input_cost_per_token` and `output_cost_per_token` are absent, so a genuinely unpriced model still logs $0 while an output-priced one is billed correctly.

## Screenshots / Proof of Fix

With a model mocked as `input_cost_per_token=0`, `output_cost_per_token=5e-6`, a call with 200 output tokens now returns `0.001` where it previously returned `0.0`.

Regression test `tests/pass_through_unit_tests/test_vertex_ai_live_passthrough.py::TestVertexAILivePassthroughLoggingHandler::test_calculate_cost_input_free_output_priced` (passes; fails if the guard reverts to checking input alone).

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
