### PR TITLE
feat(team-callbacks): add DELETE /team/{team_id}/callback/{callback_name}

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1995,6 +1995,18 @@ class AddTeamCallback(LiteLLMPydanticObjectBase):
         return values
 
 
+class TeamCallbackDeleteResponseData(LiteLLMPydanticObjectBase):
+    team_id: str
+    success_callbacks: tuple[str, ...]
+    failure_callbacks: tuple[str, ...]
+
+
+class TeamCallbackDeleteResponse(LiteLLMPydanticObjectBase):
+    status: Literal["success"]
+    message: str
+    data: TeamCallbackDeleteResponseData
+
+
 class TeamCallbackMetadata(LiteLLMPydanticObjectBase):
     success_callback: list[str] | None = []
     failure_callback: list[str] | None = []

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -9,7 +9,7 @@ import copy
 import json
 import traceback
 from datetime import datetime, timezone
-from typing import Any, Final
+from typing import Annotated, Any, Final
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 
@@ -23,6 +23,8 @@ from litellm.proxy._types import (
     LitellmTableNames,
     ProxyErrorTypes,
     ProxyException,
+    TeamCallbackDeleteResponse,
+    TeamCallbackDeleteResponseData,
     TeamCallbackMetadata,
     UserAPIKeyAuth,
 )
@@ -209,6 +211,14 @@ async def _emit_team_callback_audit_log(
     task.add_done_callback(_log_audit_task_exception)
 
 
+def _callback_error(status_code: int, message: str) -> HTTPException:
+    """Build the ``{"error": ...}`` failure body the team callback endpoints return."""
+    return HTTPException(
+        status_code=status_code,
+        detail={"error": message},  # mutable-ok: the error response body is a JSON object
+    )
+
+
 @router.post(
     "/team/{team_id:path}/callback",
     tags=["team management"],
@@ -361,6 +371,151 @@ async def add_team_callbacks(
             param=getattr(e, "param", "None"),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
+
+
+@router.delete(
+    "/team/{team_id:path}/callback/{callback_name}",
+    tags=["team management"],  # mutable-ok: FastAPI's route decorator takes a list of tags
+    dependencies=[Depends(user_api_key_auth)],  # mutable-ok: FastAPI's route decorator takes a list of dependencies
+    response_model=TeamCallbackDeleteResponse,
+)
+@management_endpoint_wrapper
+async def delete_team_callback(
+    http_request: Request,
+    team_id: str,
+    callback_name: str,
+    user_api_key_dict: Annotated[UserAPIKeyAuth, Depends(user_api_key_auth)],
+    litellm_changed_by: Annotated[
+        str | None,
+        Header(
+            description="The litellm-changed-by header enables tracking of actions performed by authorized users on behalf of other users, providing an audit trail for accountability"
+        ),
+    ] = None,
+):
+    """
+    Remove a single callback from a team
+
+    The team's other callbacks stay registered and keep firing. Use this instead of
+    POST /team/{team_id}/disable_logging, which clears every callback on the team at once.
+
+    Every entry registered under this callback_name is removed, across callback types, so a
+    callback registered for both "success" and "failure" is deregistered by one call.
+
+    Parameters:
+    - team_id (str, required): The unique identifier for the team
+    - callback_name (str, required): The name of the callback to remove, matched exactly as it was
+      registered with POST /team/{team_id}/callback (e.g. "langfuse", "langsmith", "gcs")
+
+    Example curl:
+    ```
+    curl -X DELETE 'http://localhost:4000/team/dbe2f686-a686-4896-864a-4c3924458709/callback/langsmith' \
+        -H 'Authorization: Bearer sk-1234'
+    ```
+
+    Covers callbacks registered through POST /team/{team_id}/callback and the Admin UI. Teams still
+    on the deprecated callback_settings metadata shape hold no such entries, so this returns 404 for
+    them; POST /team/{team_id}/disable_logging remains the way to clear those.
+
+    Returns 404 if the team does not exist, or if callback_name is not registered for the team.
+    """
+    try:
+        from litellm.proxy._types import CommonProxyErrors
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        if prisma_client is None:
+            raise _callback_error(500, CommonProxyErrors.db_not_connected_error.value)
+
+        _existing_team: Final = await prisma_client.get_data(
+            team_id=team_id, table_name="team", query_type="find_unique"
+        )
+        if _existing_team is None:
+            raise _callback_error(404, f"Team id = {team_id} does not exist.")
+
+        # IDOR guard: only proxy admins / org admins / team admins of THIS team may
+        # deregister its callbacks, otherwise any authenticated key holder could
+        # silence another team's observability integration.
+        await _verify_team_access(
+            team_obj=LiteLLM_TeamTable(**_existing_team.model_dump()),
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        team_metadata: Final = _existing_team.metadata
+        registered_callbacks: Final = team_metadata.get("logging")
+        entries: Final = registered_callbacks if isinstance(registered_callbacks, list) else ()
+
+        remaining_callbacks: Final = [  # mutable-ok: metadata["logging"] is isinstance-checked for list downstream
+            entry for entry in entries if not (isinstance(entry, dict) and entry.get("callback_name") == callback_name)
+        ]
+        if len(remaining_callbacks) == len(entries):
+            raise _callback_error(404, f"callback_name = {callback_name} is not registered for team_id = {team_id}.")
+
+        updated_metadata: Final = {**team_metadata, "logging": remaining_callbacks}  # mutable-ok: persisted as JSON
+        encrypted_metadata: Final = encrypt_callback_vars(updated_metadata)
+        team_metadata_json: Final = json.dumps(encrypted_metadata)
+
+        updated_team: Final = await TeamRepository(prisma_client).table.update(
+            where={"team_id": team_id},  # mutable-ok: prisma where takes a dict literal
+            data={"metadata": team_metadata_json},  # mutable-ok: prisma data takes a dict literal
+            # `object_permission` is included so `_refresh_cached_team` doesn't write a
+            # cached team with the relation nulled out, see team_model_add for the rationale.
+            include={"object_permission": True},  # mutable-ok: prisma include takes a dict literal
+        )
+
+        if updated_team is None:
+            raise _callback_error(404, f"Team id = {team_id} does not exist. Error removing team callback")
+
+        # Request-time callback resolution reads the cached team, so without this
+        # the removed callback keeps firing for live keys until the cache expires.
+        await _refresh_cached_team(
+            team_row=updated_team,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
+        await _emit_team_callback_audit_log(
+            team_id=team_id,
+            before_metadata=team_metadata,
+            after_metadata=encrypted_metadata,
+            user_api_key_dict=user_api_key_dict,
+            litellm_changed_by=litellm_changed_by,
+        )
+
+        # Report what survives with the same resolution the GET endpoint uses, so a
+        # caller can confirm in one round trip that its other callbacks are intact.
+        surviving: Final = _resolve_team_callbacks(encrypted_metadata)
+
+        response: Final = TeamCallbackDeleteResponse(
+            status="success",
+            message=f"Callback {callback_name} removed for team {team_id}",
+            data=TeamCallbackDeleteResponseData(
+                team_id=team_id,
+                success_callbacks=tuple(surviving.success_callback or ()),
+                failure_callbacks=tuple(surviving.failure_callback or ()),
+            ),
+        )
+
+    except HTTPException:
+        # Legitimate 4xx (403 from the access guard, 404 for an unknown team or
+        # an unregistered callback). Re-raise without the error-level log noise
+        # the catch-all below would produce.
+        raise
+    except ProxyException:
+        raise
+    except Exception as e:
+        verbose_proxy_logger.error("litellm.proxy.proxy_server.delete_team_callback(): Exception occurred - %s", e)
+        verbose_proxy_logger.debug(traceback.format_exc())
+        raise ProxyException(
+            message="Internal Server Error, " + str(e),
+            type=ProxyErrorTypes.internal_server_error.value,
+            param=getattr(e, "param", "None"),
+            code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+    else:
+        return response
 
 
 @router.post(

--- a/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
@@ -21,6 +21,7 @@ from litellm.proxy._types import (
 )
 from litellm.proxy.management_endpoints.team_callback_endpoints import (
     add_team_callbacks,
+    delete_team_callback,
     disable_team_logging,
     get_team_callbacks,
 )
@@ -942,3 +943,465 @@ async def test_disable_team_logging_leaves_team_re_enablable():
 
     written = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
     assert [entry["callback_name"] for entry in written["logging"]] == ["langfuse"]
+
+
+def _two_callback_metadata() -> dict:
+    """A team with two tenants' integrations registered, the LIT-5161 shape."""
+    return {
+        "logging": [
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success",
+                "callback_vars": {
+                    "langsmith_api_key": "ls-demo",
+                    "langsmith_project": "demo",
+                },
+            },
+            {
+                "callback_name": "langfuse",
+                "callback_type": "success",
+                "callback_vars": {
+                    "langfuse_public_key": "pk-demo",
+                    "langfuse_secret_key": "sk-demo",
+                },
+            },
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_rejects_unauthorized_caller(patched_prisma, unauthorized_caller):
+    with pytest.raises(HTTPException) as exc:
+        await delete_team_callback(
+            http_request=Mock(spec=Request),
+            team_id="team-victim",
+            callback_name="langsmith",
+            user_api_key_dict=unauthorized_caller,
+        )
+    assert exc.value.status_code == 403
+    patched_prisma.db.litellm_teamtable.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_removes_only_the_named_callback():
+    """The ticket's scenario: one tenant deregisters without touching the others.
+
+    disable_logging is the only other removal route and it drops every callback
+    on the team, so the surviving entry has to come through this write intact,
+    credentials included.
+    """
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=_two_callback_metadata()))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        response = await delete_team_callback(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            callback_name="langsmith",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    written = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+    assert [entry["callback_name"] for entry in written["logging"]] == ["langfuse"]
+    assert written["logging"][0]["callback_vars"].keys() == {
+        "langfuse_public_key",
+        "langfuse_secret_key",
+    }
+    assert response.status == "success"
+    assert response.data.team_id == "team-1"
+    assert response.data.success_callbacks == ("langfuse",)
+    assert response.data.failure_callbacks == ()
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_leaves_the_other_callback_firing():
+    """The survivor has to still be live, not merely still stored.
+
+    Asks the real request-time resolver what the written row would do, the same
+    way the disable_logging regression test does.
+    """
+    from litellm.proxy.litellm_pre_call_utils import _get_dynamic_logging_metadata
+
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=_two_callback_metadata()))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        await delete_team_callback(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            callback_name="langsmith",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    written = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+    resolved = _get_dynamic_logging_metadata(
+        UserAPIKeyAuth(api_key="hashed", team_id="team-1", team_metadata=written),
+        proxy_config=MagicMock(**{"load_team_config.return_value": {}}),
+    )
+    assert resolved is not None
+    assert resolved.success_callback == ["langfuse"]
+    assert "langsmith" not in resolved.success_callback
+    assert resolved.callback_vars.get("langfuse_public_key") == "pk-demo"
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_removes_every_type_under_that_name():
+    """A callback registered for both events is deregistered by one call.
+
+    add_team_callbacks keys its duplicate check on (callback_name, callback_type),
+    so the same destination can hold a success entry and a failure entry. Removing
+    only one of them would leave the team still sending to it.
+    """
+    metadata = {
+        "logging": [
+            {
+                "callback_name": "langfuse",
+                "callback_type": "success",
+                "callback_vars": {"langfuse_public_key": "pk-demo"},
+            },
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success",
+                "callback_vars": {"langsmith_project": "demo"},
+            },
+            {
+                "callback_name": "langfuse",
+                "callback_type": "failure",
+                "callback_vars": {"langfuse_public_key": "pk-demo"},
+            },
+        ]
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=metadata))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        response = await delete_team_callback(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            callback_name="langfuse",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    written = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+    assert [entry["callback_name"] for entry in written["logging"]] == ["langsmith"]
+    assert response.data.success_callbacks == ("langsmith",)
+    assert response.data.failure_callbacks == ()
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_404s_for_unregistered_callback():
+    """An unregistered name must not rewrite the team's metadata."""
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=_two_callback_metadata()))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await delete_team_callback(
+                http_request=MagicMock(spec=Request),
+                team_id="team-1",
+                callback_name="gcs",
+                user_api_key_dict=_admin_auth(),
+                litellm_changed_by=None,
+            )
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == {"error": "callback_name = gcs is not registered for team_id = team-1."}
+    mock_prisma.db.litellm_teamtable.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_404s_when_team_has_no_logging_slot():
+    """A team on the deprecated callback_settings shape holds no logging entries."""
+    metadata = {
+        "callback_settings": {
+            "success_callback": ["langfuse"],
+            "failure_callback": [],
+            "callback_vars": {"langfuse_public_key": "pk-demo"},
+        }
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=metadata))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await delete_team_callback(
+                http_request=MagicMock(spec=Request),
+                team_id="team-1",
+                callback_name="langfuse",
+                user_api_key_dict=_admin_auth(),
+                litellm_changed_by=None,
+            )
+
+    assert exc.value.status_code == 404
+    mock_prisma.db.litellm_teamtable.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_404s_for_unknown_team():
+    mock_prisma = MagicMock()
+    mock_prisma.get_data = AsyncMock(return_value=None)
+    mock_prisma.db.litellm_teamtable.update = AsyncMock()
+
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+        with pytest.raises(HTTPException) as exc:
+            await delete_team_callback(
+                http_request=MagicMock(spec=Request),
+                team_id="team-missing",
+                callback_name="langfuse",
+                user_api_key_dict=_admin_auth(),
+                litellm_changed_by=None,
+            )
+
+    assert exc.value.status_code == 404
+    mock_prisma.db.litellm_teamtable.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_keeps_last_removal_from_reviving_legacy_shape():
+    """Removing the last entry must leave metadata["logging"] present and empty.
+
+    Request-time resolution selects the logging branch on key presence, so
+    dropping the key would fall through to a legacy callback_settings block and
+    silently re-enable a destination the caller just removed.
+    """
+    from litellm.proxy.litellm_pre_call_utils import _get_dynamic_logging_metadata
+
+    metadata = {
+        "logging": [
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success",
+                "callback_vars": {"langsmith_project": "demo"},
+            }
+        ],
+        "callback_settings": {
+            "success_callback": ["langfuse"],
+            "failure_callback": [],
+            "callback_vars": {"langfuse_public_key": "pk-legacy"},
+        },
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=metadata))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        response = await delete_team_callback(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            callback_name="langsmith",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    written = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+    assert written["logging"] == []
+    assert response.data.success_callbacks == ()
+
+    resolved = _get_dynamic_logging_metadata(
+        UserAPIKeyAuth(api_key="hashed", team_id="team-1", team_metadata=written),
+        proxy_config=MagicMock(**{"load_team_config.return_value": {}}),
+    )
+    assert not (resolved.success_callback if resolved else None)
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_refreshes_cached_team(stub_team_cache_refresh):
+    """The DB write alone leaves the removed callback firing.
+
+    Auth serves a cached team object and request-time callback resolution reads
+    the metadata off it, so a key already in flight keeps sending to the removed
+    destination until the cache entry expires.
+    """
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=_two_callback_metadata()))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        await delete_team_callback(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            callback_name="langsmith",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    stub_team_cache_refresh.assert_awaited_once()
+    refreshed = stub_team_cache_refresh.await_args.kwargs["team_row"]
+    assert refreshed is mock_prisma.db.litellm_teamtable.update.return_value
+    # The row fed to the cache has to carry object_permission, or the refresh
+    # publishes a team whose tool allowlists look empty, which reads as
+    # unrestricted on the search-tool and MCP-tool checks.
+    update_kwargs = mock_prisma.db.litellm_teamtable.update.await_args.kwargs
+    assert update_kwargs["include"]["object_permission"] is True
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_emits_redacted_audit_log(monkeypatch):
+    """The audit row records the removal without becoming a credential sink."""
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=_two_callback_metadata()))
+
+    audit_calls = []
+
+    async def capture(request_data):
+        audit_calls.append(request_data)
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"),
+        patch("litellm.proxy.proxy_server.master_key", None),
+        patch(
+            "litellm.proxy.management_helpers.audit_logs.create_audit_log_for_update",
+            new=capture,
+        ),
+    ):
+        await delete_team_callback(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            callback_name="langsmith",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+        import asyncio
+
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+    assert len(audit_calls) == 1
+    log = audit_calls[0]
+    assert log.table_name == LitellmTableNames.TEAM_TABLE_NAME
+    assert log.object_id == "team-1"
+    assert log.action == "updated"
+
+    before = json.loads(log.before_value)
+    after = json.loads(log.updated_values)
+    assert [entry["callback_name"] for entry in before["metadata"]["logging"]] == [
+        "langsmith",
+        "langfuse",
+    ]
+    assert [entry["callback_name"] for entry in after["metadata"]["logging"]] == ["langfuse"]
+    assert "ls-demo" not in log.before_value
+    assert "sk-demo" not in log.updated_values
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_encrypts_surviving_callback_vars(monkeypatch):
+    """The write must not downgrade the survivors' stored credentials to plaintext."""
+    from litellm.proxy.common_utils.callback_utils import decrypt_callback_vars
+
+    monkeypatch.setenv("LITELLM_SALT_KEY", "test-salt-32-bytes-aaaaaaaaaaaaaa")
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=_two_callback_metadata()))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        await delete_team_callback(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            callback_name="langsmith",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    written = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+    stored = written["logging"][0]["callback_vars"]
+    assert stored["langfuse_secret_key"] != "sk-demo"
+    assert decrypt_callback_vars(written)["logging"][0]["callback_vars"]["langfuse_secret_key"] == "sk-demo"
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_keeps_entries_it_cannot_parse():
+    """A malformed entry is left alone rather than crashing the removal.
+
+    metadata["logging"] is free-form JSON that /team/update will persist as given,
+    so the filter has to tolerate an entry that is not a callback dict.
+    """
+    metadata = {
+        "logging": [
+            "not-a-callback-entry",
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success",
+                "callback_vars": {"langsmith_project": "demo"},
+            },
+        ]
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=metadata))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        await delete_team_callback(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            callback_name="langsmith",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    written = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+    assert written["logging"] == ["not-a-callback-entry"]
+
+
+@pytest.mark.asyncio
+async def test_delete_team_callback_route_accepts_team_ids_containing_slashes():
+    """The route has to reach the same team ids POST and GET /team/{team_id}/callback do.
+
+    Those siblings declare team_id with the path converter, so a team registered under an
+    id with a slash can add and list callbacks. Without the same converter here the delete
+    404s at the routing layer for exactly those teams.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+    from litellm.proxy.management_endpoints.team_callback_endpoints import router
+
+    team_id = "tenant/eu-west"
+    metadata = {
+        "logging": [
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success",
+                "callback_vars": {"langsmith_project": "demo"},
+            },
+            {
+                "callback_name": "langfuse",
+                "callback_type": "success",
+                "callback_vars": {"langfuse_public_key": "pk-demo"},
+            },
+        ]
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id=team_id, metadata=metadata))
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[user_api_key_auth] = _admin_auth
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        response = TestClient(app).delete(f"/team/{team_id}/callback/langfuse")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["success_callbacks"] == ["langsmith"]
+    written = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+    assert [entry["callback_name"] for entry in written["logging"]] == ["langsmith"]

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -14807,6 +14807,48 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/team/{team_id}/callback/{callback_name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Team Callback
+         * @description Remove a single callback from a team
+         *
+         *     The team's other callbacks stay registered and keep firing. Use this instead of
+         *     POST /team/{team_id}/disable_logging, which clears every callback on the team at once.
+         *
+         *     Every entry registered under this callback_name is removed, across callback types, so a
+         *     callback registered for both "success" and "failure" is deregistered by one call.
+         *
+         *     Parameters:
+         *     - team_id (str, required): The unique identifier for the team
+         *     - callback_name (str, required): The name of the callback to remove, matched exactly as it was
+         *       registered with POST /team/{team_id}/callback (e.g. "langfuse", "langsmith", "gcs")
+         *
+         *     Example curl:
+         *     ```
+         *     curl -X DELETE 'http://localhost:4000/team/dbe2f686-a686-4896-864a-4c3924458709/callback/langsmith'         -H 'Authorization: Bearer sk-1234'
+         *     ```
+         *
+         *     Covers callbacks registered through POST /team/{team_id}/callback and the Admin UI. Teams still
+         *     on the deprecated callback_settings metadata shape hold no such entries, so this returns 404 for
+         *     them; POST /team/{team_id}/disable_logging remains the way to clear those.
+         *
+         *     Returns 404 if the team does not exist, or if callback_name is not registered for the team.
+         */
+        delete: operations["delete_team_callback_team__team_id__callback__callback_name__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/team/{team_id}/disable_logging": {
         parameters: {
             query?: never;
@@ -33727,6 +33769,26 @@ export interface components {
             updated_team_memberships: components["schemas"]["LiteLLM_TeamMembership"][];
             /** Updated Users */
             updated_users: components["schemas"]["LiteLLM_UserTable"][];
+        };
+        /** TeamCallbackDeleteResponse */
+        TeamCallbackDeleteResponse: {
+            data: components["schemas"]["TeamCallbackDeleteResponseData"];
+            /** Message */
+            message: string;
+            /**
+             * Status
+             * @constant
+             */
+            status: "success";
+        };
+        /** TeamCallbackDeleteResponseData */
+        TeamCallbackDeleteResponseData: {
+            /** Failure Callbacks */
+            failure_callbacks: string[];
+            /** Success Callbacks */
+            success_callbacks: string[];
+            /** Team Id */
+            team_id: string;
         };
         /**
          * TeamListItem
@@ -54548,6 +54610,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_team_callback_team__team_id__callback__callback_name__delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The litellm-changed-by header enables tracking of actions performed by authorized users on behalf of other users, providing an audit trail for accountability */
+                "litellm-changed-by"?: string | null;
+            };
+            path: {
+                team_id: string;
+                callback_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TeamCallbackDeleteResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## TLDR

Problem this solves:

- A team callback could be added and listed, never removed
- The only removal route wipes every callback on the team
- Tenants sharing a team could not deregister their own integration

How it solves it:

- Adds `DELETE /team/{team_id}/callback/{callback_name}`
- Removes just that callback; the others stay registered and firing
- Same access guard, cache refresh and audit row as the add route

## User Flow

Before: a platform team wraps the team callback routes in a self-service page; a tenant can register an integration there but can never take it off

1. The tenant registers their integration with POST https://litellm-domain/team/TEAM_ID/callback and gets `200`
2. A second tenant on the same team registers theirs the same way and gets `200`
3. GET https://litellm-domain/team/TEAM_ID/callback lists both
4. The first tenant asks to be removed; the page sends DELETE https://litellm-domain/team/TEAM_ID/callback/langsmith and gets `404 {"detail":"Not Found"}` because no such route exists
5. The only removal route, POST https://litellm-domain/team/TEAM_ID/disable_logging, returns `200` and empties the whole list, so the second tenant's traces stop arriving too

After: the same page removes one integration and leaves the other one delivering

1. The tenant registers their integration with POST https://litellm-domain/team/TEAM_ID/callback and gets `200`
2. A second tenant on the same team registers theirs the same way and gets `200`
3. GET https://litellm-domain/team/TEAM_ID/callback lists both
4. The first tenant asks to be removed; the page sends DELETE https://litellm-domain/team/TEAM_ID/callback/langsmith and gets `200` with `"success_callbacks": ["langfuse"]`
5. GET https://litellm-domain/team/TEAM_ID/callback now lists only `langfuse`, and the next chat completion on a key that was already live keeps arriving at the second tenant's destination
6. A repeat DELETE of the same name returns `404`, and a name that was never registered returns `404`, neither of which rewrites the team

## Relevant issues

## Linear ticket

Resolves LIT-5161

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, a live proxy with a real Postgres and a real provider, plus two local HTTP endpoints
standing in for the two observability destinations so it is visible which one a request reaches

```bash
export TEAM_ID=$(curl -s -X POST "$PROXY/team/new" -H "$AUTH" -H 'Content-Type: application/json' \
  -d '{"team_alias":"callback-delete-gap"}' | jq -r .team_id)

curl -s -X POST "$PROXY/team/$TEAM_ID/callback" -H "$AUTH" -H 'Content-Type: application/json' \
  -d '{"callback_name":"langsmith","callback_type":"success","callback_vars":{"langsmith_api_key":"ls-demo","langsmith_project":"demo","langsmith_base_url":"http://127.0.0.1:8561/langsmith"}}'

curl -s -X POST "$PROXY/team/$TEAM_ID/callback" -H "$AUTH" -H 'Content-Type: application/json' \
  -d '{"callback_name":"langfuse","callback_type":"success","callback_vars":{"langfuse_public_key":"pk-demo","langfuse_secret_key":"sk-demo","langfuse_host":"http://127.0.0.1:8561"}}'

export KEY=$(curl -s -X POST "$PROXY/key/generate" -H "$AUTH" -H 'Content-Type: application/json' \
  -d "{\"team_id\":\"$TEAM_ID\",\"models\":[\"test-model\"]}" | jq -r .key)
```

### Before (aa90828811)

#### Removing one callback

1. `curl -s -X DELETE "$PROXY/team/$TEAM_ID/callback/langsmith" -H "$AUTH"`

```
{"detail":"Not Found"}
HTTP 404
```

2. The only removal route takes out the other tenant's integration too

```
$ curl -s -X POST "$PROXY/team/$TEAM_ID/disable_logging" -H "$AUTH"
{"status":"success","message":"Logging disabled for team ...","data":{"team_id":"...","success_callbacks":[],"failure_callbacks":[]}}
HTTP 200

$ curl -s "$PROXY/team/$TEAM_ID/callback" -H "$AUTH"
{"status":"success","data":{"team_id":"...","success_callbacks":[],"failure_callbacks":[],"callback_vars":{}}}
```

3. A live completion on that team's key now reaches neither destination

```
$ curl -s -X POST "$PROXY/v1/chat/completions" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d '{"model":"test-model","messages":[{"role":"user","content":"reply with the single word collateral"}]}'
LLM: collateral
destinations that received the request: NONE
```

#### A team whose id contains a slash

1. Not applicable, the route does not exist

### After (ab925b781e)

#### Removing one callback

1. Both integrations are registered and both receive a live completion

```
$ curl -s -X POST "$PROXY/v1/chat/completions" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d '{"model":"test-model","messages":[{"role":"user","content":"reply with the single word primed"}]}'
LLM: primed
destinations that received the request: {'langsmith': 1, 'langfuse': 1}
```

2. `curl -s -X DELETE "$PROXY/team/$TEAM_ID/callback/langsmith" -H "$AUTH"`

```
{"status":"success","message":"Callback langsmith removed for team ae215436-9384-425a-be6c-7cda0a95db0d","data":{"team_id":"ae215436-9384-425a-be6c-7cda0a95db0d","success_callbacks":["langfuse"],"failure_callbacks":[]}}
HTTP 200
```

3. The next completion, on the same key that was already live, still reaches the surviving destination and no longer reaches the removed one

```
$ curl -s -X POST "$PROXY/v1/chat/completions" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d '{"model":"test-model","messages":[{"role":"user","content":"reply with the single word survivor"}]}'
LLM: survivor
destinations that received the request: {'langfuse': 1}
```

4. Repeating the delete, naming a callback that was never registered, and naming an unknown team all return 404 without rewriting the team

```
$ curl -s -X DELETE "$PROXY/team/$TEAM_ID/callback/langsmith" -H "$AUTH"
{"detail":{"error":"callback_name = langsmith is not registered for team_id = ae215436-9384-425a-be6c-7cda0a95db0d."}}   HTTP 404

$ curl -s -X DELETE "$PROXY/team/$TEAM_ID/callback/gcs" -H "$AUTH"
{"detail":{"error":"callback_name = gcs is not registered for team_id = ae215436-9384-425a-be6c-7cda0a95db0d."}}   HTTP 404

$ curl -s -X DELETE "$PROXY/team/nope-5161/callback/langfuse" -H "$AUTH"
{"detail":{"error":"Team id = nope-5161 does not exist."}}   HTTP 404
```

5. A name registered for both success and failure is deregistered by one call

```
$ curl -s "$PROXY/team/$TEAM_ID/callback" -H "$AUTH"
  success: ['langfuse', 'langsmith']  failure: ['langfuse']

$ curl -s -X DELETE "$PROXY/team/$TEAM_ID/callback/langfuse" -H "$AUTH"
{"status":"success","message":"Callback langfuse removed for team ...","data":{"team_id":"...","success_callbacks":["langsmith"],"failure_callbacks":[]}}   HTTP 200
```

6. Removing the last callback leaves the slot empty rather than dropping it, so a team still carrying the deprecated callback_settings shape cannot silently come back on

```
$ curl -s -X DELETE "$PROXY/team/$TEAM_ID/callback/langfuse" -H "$AUTH"
{"status":"success","message":"Callback langfuse removed for team ...","data":{"team_id":"...","success_callbacks":[],"failure_callbacks":[]}}   HTTP 200

$ psql -tAc "select metadata->'logging' from \"LiteLLM_TeamTable\" where team_id='$TEAM_ID'"
[]
```

7. An audit row records the removal with the credentials redacted

```
$ psql -tAc "select action||' | '||table_name||' | '||left(updated_values::text, 300) from \"LiteLLM_AuditLog\" where object_id='$TEAM_ID' order by updated_at desc limit 1"
updated | LiteLLM_TeamTable | {"metadata": {"logging": [{"callback_name": "langsmith", "callback_type": "success", "callback_vars": {"langsmith_api_key": "***REDACTED***", ...}}]}}

$ psql -tAc "select count(*) from \"LiteLLM_AuditLog\" where updated_values::text like '%<the raw secret>%'"
0
```

#### A team whose id contains a slash

1. The route uses the same path converter as POST and GET `/team/{team_id}/callback`, so a team registered under an id with a slash can deregister too

```
$ curl -s -X DELETE "$PROXY/team/tenant/eu-west-5161/callback/langsmith" -H "$AUTH"
{"status":"success","message":"Callback langsmith removed for team tenant/eu-west-5161","data":{"team_id":"tenant/eu-west-5161","success_callbacks":["langfuse"],"failure_callbacks":[]}}   HTTP 200

$ curl -s "$PROXY/team/tenant/eu-west-5161/callback" -H "$AUTH"
  GET: ['langfuse']
```

#### Admin UI

The team's Settings tab reflects the removal, Logging Integrations goes from 2 to 1 at
`$PROXY/ui/?page=teams` after the DELETE above

Before the delete, the team's Settings tab shows two integrations

![Logging integrations before the delete](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr37331/assets-pr37331/team-logging-before-delete.png)

After the delete, only the surviving integration is listed

![Logging integrations after the delete](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr37331/assets-pr37331/team-logging-after-delete.png)

## Type

🆕 New Feature

## Caveats (if any)

- Removal covers `metadata.logging`; legacy `callback_settings` teams get `404`
- Deleting a name drops every callback_type registered under it
- Read-modify-write on team metadata, same race window as the add route
- Proxy-admin only over HTTP, same as the add and list routes
- Supersedes the closed #34974, which skipped the team-cache refresh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ab925b781ed8562cf82fb3ca5b38b12cddc4e5e1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->