### PR TITLE
fix(router): route Responses API input through the auto-router

### DIFF
--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -128,13 +128,14 @@ class AutoRouter(CustomLogger):
         """
         from semantic_router.routers import SemanticRouter
 
+        from litellm.litellm_core_utils.prompt_templates.factory import resolve_structured_messages
         from litellm.router_strategy.auto_router.litellm_encoder import (
             LiteLLMRouterEncoder,
         )
         from litellm.types.router import PreRoutingHookResponse
 
-        if messages is None:
-            # do nothing, return same inputs
+        resolved_messages: Final = resolve_structured_messages(messages=messages, request_kwargs=request_kwargs)
+        if resolved_messages is None:
             return None
 
         routelayer = self.routelayer
@@ -153,7 +154,7 @@ class AutoRouter(CustomLogger):
             )
             self.routelayer = routelayer
 
-        message_content: Final = self._extract_text_from_messages(messages)
+        message_content: Final = self._extract_text_from_messages(resolved_messages)
         route_name: Final = self._matched_route_name(routelayer, message_content)
 
         return PreRoutingHookResponse(

--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -134,7 +134,11 @@ class AutoRouter(CustomLogger):
         )
         from litellm.types.router import PreRoutingHookResponse
 
-        resolved_messages: Final = resolve_structured_messages(messages=messages, request_kwargs=request_kwargs)
+        resolved_messages: Final = (
+            messages
+            if messages is not None
+            else resolve_structured_messages(messages=None, request_kwargs=request_kwargs)
+        )
         if resolved_messages is None:
             return None
 

--- a/tests/test_litellm/router_strategy/test_auto_router.py
+++ b/tests/test_litellm/router_strategy/test_auto_router.py
@@ -479,3 +479,70 @@ class TestAutoRouterEmbeddingInputCap:
 
         assert auto_router.routelayer is not None
         assert auto_router.routelayer.encoder.max_input_chars == 777
+
+
+class TestAutoRouterRoutesResponsesApiInput:
+    """Responses API requests carry the prompt in `input`, not `messages`, and still have to reach the route layer."""
+
+    @pytest.mark.asyncio
+    async def test_should_route_a_string_input_when_messages_is_none(self):
+        from semantic_router.schema import RouteChoice
+
+        layer: Final = FixedRouteLayer(RouteChoice(name="code-model"))
+        auto_router: Final = _auto_router(layer)
+
+        result: Final = await auto_router.async_pre_routing_hook(
+            model="my-auto-router",
+            request_kwargs={
+                "input": "fix this stack trace",
+                "litellm_metadata": {"user_api_key_request_route": "/v1/responses"},
+            },
+            messages=None,
+        )
+
+        assert result is not None
+        assert result.model == "code-model"
+        assert result.messages is None
+        assert layer.seen_text == "fix this stack trace"
+
+    @pytest.mark.asyncio
+    async def test_should_route_a_list_input_with_instructions_when_messages_is_none(self):
+        from semantic_router.schema import RouteChoice
+
+        layer: Final = FixedRouteLayer(RouteChoice(name="code-model"))
+        auto_router: Final = _auto_router(layer)
+
+        result: Final = await auto_router.async_pre_routing_hook(
+            model="my-auto-router",
+            request_kwargs={
+                "instructions": "You are a coding agent.",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "fix this stack trace"}],
+                    }
+                ],
+                "litellm_metadata": {"user_api_key_request_route": "/v1/responses"},
+            },
+            messages=None,
+        )
+
+        assert result is not None
+        assert result.model == "code-model"
+        assert layer.seen_text is not None
+        assert "fix this stack trace" in layer.seen_text
+
+    @pytest.mark.asyncio
+    async def test_should_skip_routing_when_neither_messages_nor_input_is_present(self):
+        layer: Final = FixedRouteLayer(None)
+        auto_router: Final = _auto_router(layer)
+
+        result: Final = await auto_router.async_pre_routing_hook(
+            model="my-auto-router",
+            request_kwargs={"litellm_metadata": {"user_api_key_request_route": "/v1/responses"}},
+            messages=None,
+        )
+
+        assert result is None
+        assert layer.seen_text is None

--- a/tests/test_litellm/router_strategy/test_auto_router.py
+++ b/tests/test_litellm/router_strategy/test_auto_router.py
@@ -546,3 +546,18 @@ class TestAutoRouterRoutesResponsesApiInput:
 
         assert result is None
         assert layer.seen_text is None
+
+    @pytest.mark.asyncio
+    async def test_should_keep_routing_an_empty_messages_list_to_the_default_model(self):
+        layer: Final = FixedRouteLayer(None)
+        auto_router: Final = _auto_router(layer)
+
+        result: Final = await auto_router.async_pre_routing_hook(
+            model="my-auto-router",
+            request_kwargs={"messages": [], "litellm_metadata": {"user_api_key_request_route": "/v1/chat/completions"}},
+            messages=[],
+        )
+
+        assert result is not None
+        assert result.model == "fallback-model"
+        assert layer.seen_text == ""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Tagged auto-router never routes `/v1/responses` requests (Codex CLI)
- Header tag `x-litellm-tags` selects the auto-router, then routing gives up
- Client sees 401 "Not allowed to access model due to tags configuration"

How it solves it:

- Auto-router now reads Responses API `input` and `instructions`, not only `messages`
- Reuses the shared prompt-template helper the complexity router already uses
- Only resolves `input` when `messages` is absent, so existing chat paths are untouched
- Regression tests for string input, list input with instructions, empty messages, and no input at all

## User Flow

Before: a Codex CLI user whose gateway auto-routes by header tag gets a 401 on every turn

1. The proxy admin defines `smart-model` twice: a plain deployment and an `auto_router/` marker tagged `auto_route`, with `enable_tag_filtering: true` and tier deployments carrying the same tag
2. The user sets `http_headers = { "x-litellm-tags" = "auto_route" }` and `wire_api = "responses"` in their Codex `config.toml` and types "say hello"
3. Codex sends POST http://litellm-domain/v1/responses with `"model": "smart-model"` and the prompt in `input`
4. The proxy replies 401 `Not allowed to access model due to tags configuration. Passed model=smart-model and tags=['auto_route']` and Codex prints `unexpected status 401 Unauthorized`, retrying with "Reconnecting"
5. The same prompt through POST http://litellm-domain/v1/chat/completions or POST http://litellm-domain/v1/messages with the same header returns 200 from the cheap tier, so only the Responses API path is broken

After: the same Codex turn is answered by the tier the auto-router picks

1. The proxy admin defines `smart-model` twice: a plain deployment and an `auto_router/` marker tagged `auto_route`, with `enable_tag_filtering: true` and tier deployments carrying the same tag
2. The user sets `http_headers = { "x-litellm-tags" = "auto_route" }` and `wire_api = "responses"` in their Codex `config.toml` and types "say hello"
3. Codex sends POST http://litellm-domain/v1/responses with `"model": "smart-model"` and the prompt in `input`
4. The proxy replies 200 with the answer from the cheap tier (`x-litellm-model-id` names the haiku deployment); "debug this stack trace" lands on the strong tier (gpt-5.6)
5. Untagged POST http://litellm-domain/v1/responses still goes to the plain deployment, and `/v1/chat/completions` and `/v1/messages` behave as before

## Relevant issues

## Linear ticket

Resolves LIT-5726

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, proxy started with `python litellm/proxy/proxy_cli.py --config config.yaml --port 47231 --detailed_debug`:

```yaml
model_list:
  - model_name: smart-model
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: smart-model
    litellm_params:
      model: auto_router/smart-router
      auto_router_config_path: auto_router_config.json
      auto_router_default_model: tier-cheap
      auto_router_embedding_model: text-embedding
      tags: ["auto_route"]
  - model_name: tier-cheap
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
      tags: ["auto_route"]
  - model_name: tier-strong
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY
      tags: ["auto_route"]
  - model_name: text-embedding
    litellm_params:
      model: openai/text-embedding-3-small
      api_key: os.environ/OPENAI_API_KEY

router_settings:
  enable_tag_filtering: true

general_settings:
  master_key: sk-lit5726-repro
```

`auto_router_config.json` has two routes: `tier-cheap` (utterances such as "say hello", "tell me a joke") and `tier-strong` (utterances such as "debug this stack trace", "refactor this function to be more readable"), `score_threshold` 0.3, encoder `openai/text-embedding-3-small`. Deployment ids from `GET /model/info`: `b27713f28e16...` = tier-cheap (haiku), `9dc2532096ab...` = tier-strong (gpt-5.6), `12030c7d08d5...` = plain sonnet

Codex CLI 0.145.0 `config.toml`:

```toml
model = "smart-model"
model_provider = "litellm"
[model_providers.litellm]
name = "LiteLLM"
base_url = "http://localhost:47231/v1"
wire_api = "responses"
env_key = "LITELLM_KEY"
http_headers = { "x-litellm-tags" = "auto_route" }
```

Claude Code 2.1.234 launched as `env -u ANTHROPIC_API_KEY ANTHROPIC_BASE_URL=http://localhost:47231 ANTHROPIC_AUTH_TOKEN=sk-lit5726-repro ANTHROPIC_MODEL=smart-model ANTHROPIC_DEFAULT_HAIKU_MODEL=smart-model ANTHROPIC_SMALL_FAST_MODEL=smart-model ANTHROPIC_CUSTOM_HEADERS='x-litellm-tags: auto_route' claude`

### Before (9ec0145986)

#### /v1/responses with x-litellm-tags header

1. `curl -s -D - localhost:47231/v1/responses -H "Authorization: Bearer sk-lit5726-repro" -H "Content-Type: application/json" -H "x-litellm-tags: auto_route" -d '{"model":"smart-model","input":"say hello"}'`
2. `HTTP/1.1 401 Unauthorized` with body `{"error":{"message":"Not allowed to access model due to tags configuration. Passed model=smart-model and tags=['auto_route']", ...}}`; same result with `"input":"debug this stack trace"` and with a list `input`

#### /v1/responses with body tags and untagged control

1. `curl -s -D - localhost:47231/v1/responses -H "Authorization: Bearer sk-lit5726-repro" -H "Content-Type: application/json" -d '{"model":"smart-model","input":"say hello","litellm_metadata":{"tags":["auto_route"]}}'`
2. `HTTP/1.1 401 Unauthorized`, same tags error
3. `curl -s -D - localhost:47231/v1/responses -H "Authorization: Bearer sk-lit5726-repro" -H "Content-Type: application/json" -d '{"model":"smart-model","input":"say hello"}'`
4. `HTTP/1.1 200 OK`, `x-litellm-model-id: 12030c7d08d5...` (plain sonnet, no auto-routing)

#### /v1/chat/completions with x-litellm-tags header

1. `curl -s -D - localhost:47231/v1/chat/completions -H "Authorization: Bearer sk-lit5726-repro" -H "Content-Type: application/json" -H "x-litellm-tags: auto_route" -d '{"model":"smart-model","messages":[{"role":"user","content":"say hello"}]}'`
2. `HTTP/1.1 200 OK`, `x-litellm-model-id: b27713f28e16...` (tier-cheap, route_choice tier-cheap 0.561)

#### /v1/messages with x-litellm-tags header

1. `curl -s -D - localhost:47231/v1/messages -H "Authorization: Bearer sk-lit5726-repro" -H "Content-Type: application/json" -H "anthropic-version: 2023-06-01" -H "x-litellm-tags: auto_route" -d '{"model":"smart-model","max_tokens":64,"messages":[{"role":"user","content":"debug this stack trace"}]}'`
2. `HTTP/1.1 200 OK`, `x-litellm-model-id: 9dc2532096ab...` (tier-strong, route_choice tier-strong 0.597)

#### Codex CLI

1. `CODEX_HOME=<dir with the config.toml above> LITELLM_KEY=sk-lit5726-repro codex`, type `say hello`, Enter
2. Pane shows `■ unexpected status 401 Unauthorized: Not allowed to access model due to tags configuration. Passed model=smart-model and tags=['auto_route'], url: http://localhost:47231/v1/responses` and Codex keeps "Reconnecting"

#### Claude Code

1. Launch Claude Code as above, type `say hello`, Enter, then `debug this stack trace`, Enter
2. Both turns answered; proxy log shows route_choice tier-cheap for the first and tier-strong for the second (this path already worked)

### After (791b478d775edc107fe81fa757b20c1f9b9f5911)

#### /v1/responses with x-litellm-tags header

1. `curl -s -D - localhost:47231/v1/responses -H "Authorization: Bearer sk-lit5726-repro" -H "Content-Type: application/json" -H "x-litellm-tags: auto_route" -d '{"model":"smart-model","input":"say hello"}'`
2. `HTTP/1.1 200 OK`, `x-litellm-model-id: b27713f28e16...` (tier-cheap), output text `Hello! How can I help you today?`
3. Same with `"input":"debug this stack trace"`: `HTTP/1.1 200 OK`, `x-litellm-model-id: 9dc2532096ab...` (tier-strong)
4. Same with `"instructions":"You are a coding agent."` and list `input` `[{"type":"message","role":"user","content":[{"type":"input_text","text":"debug this stack trace"}]}]`: `HTTP/1.1 200 OK`, `"status": "completed"`, route_choice tier-strong

#### /v1/responses with body tags and untagged control

1. `curl -s -D - localhost:47231/v1/responses -H "Authorization: Bearer sk-lit5726-repro" -H "Content-Type: application/json" -d '{"model":"smart-model","input":"say hello","litellm_metadata":{"tags":["auto_route"]}}'`
2. `HTTP/1.1 200 OK`, `"status": "completed"`, route_choice tier-cheap
3. `curl -s -D - localhost:47231/v1/responses -H "Authorization: Bearer sk-lit5726-repro" -H "Content-Type: application/json" -d '{"model":"smart-model","input":"say hello"}'`
4. `HTTP/1.1 200 OK`, `x-litellm-model-id: 12030c7d08d5...` (plain sonnet, unchanged)

#### /v1/chat/completions with x-litellm-tags header

1. Same curl as Before
2. `HTTP/1.1 200 OK`, route_choice tier-cheap 0.561 (unchanged)

#### /v1/messages with x-litellm-tags header

1. Same curl as Before
2. `HTTP/1.1 200 OK`, route_choice tier-strong 0.597 (unchanged)

#### Codex CLI

1. `CODEX_HOME=<dir with the config.toml above> LITELLM_KEY=sk-lit5726-repro codex`, type `say hello`, Enter, then `debug this stack trace: reply with just the word ok`, Enter
2. Pane shows `• Hello! I'm your Codex CLI coding assistant. I'm ready to help you with coding tasks, debugging, file modifications, running commands, and more. What would you like to work on?` then `• ok`; proxy log shows route_choice tier-cheap (0.561) for the first turn and tier-strong (0.443) for the second

#### Claude Code

1. Launch Claude Code as above, type `say hello`, Enter, then `debug this stack trace: reply with just the word ok`, Enter
2. Both turns answered (`Hello! I'm Claude Code, ready to help with your software engineering tasks. What can I work on?` and `ok`) through the tagged auto-router, no 401

## Type

🐛 Bug Fix

## Caveats (if any)

- Route quality for agent clients depends on the configured utterances, since the whole prompt (system text included) is embedded
- The v1.94.3 shape of this failure (400 "Unmapped LLM provider ... custom_llm_provider=auto_router") predates the current router and is not what this PR touches

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 791b478d775edc107fe81fa757b20c1f9b9f5911 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 791b478d775edc107fe81fa757b20c1f9b9f5911. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->