### PR TITLE
fix: use resolved credentials in health checks

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8385,29 +8385,36 @@ async def ahealth_check(
         api_base_from_params: Final = model_params.get("api_base", None)
         api_key_from_params: Final = model_params.get("api_key", None)
 
-        model, custom_llm_provider, _, _ = get_llm_provider(
+        model, custom_llm_provider, dynamic_api_key, dynamic_api_base = get_llm_provider(
             model=model,
             custom_llm_provider=custom_llm_provider_from_params,
             api_base=api_base_from_params,
             api_key=api_key_from_params,
         )
+        resolved_model_params: Final = dict(  # mutable-ok: health-check handlers require mutable request parameters
+            model_params
+        )
+        if dynamic_api_base is not None:
+            resolved_model_params["api_base"] = dynamic_api_base
+        if dynamic_api_key is not None:
+            resolved_model_params["api_key"] = dynamic_api_key
+        resolved_model_params["cache"] = {"no-cache": True}
         if model in litellm.model_cost and mode is None:
             mode = litellm.model_cost[model].get("mode")
 
-        model_params["cache"] = {"no-cache": True}  # don't used cached responses for making health check calls
         mode = mode or "chat"
         if "*" in model:
             return await HealthCheckHelpers.ahealth_check_wildcard_models(
                 model=model,
                 custom_llm_provider=custom_llm_provider,
-                model_params=model_params,
+                model_params=resolved_model_params,
                 litellm_logging_obj=litellm_logging_obj,
             )
 
         mode_handlers: Final = HealthCheckHelpers.get_mode_handlers(
             model=model,
             custom_llm_provider=custom_llm_provider,
-            model_params=model_params,
+            model_params=resolved_model_params,
             prompt=prompt,
             input=input,
         )

--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -16,6 +16,38 @@ import litellm
 
 
 @pytest.mark.asyncio
+async def test_hosted_vllm_health_check_uses_resolved_provider_credentials(
+    monkeypatch,
+):
+    monkeypatch.setenv("HOSTED_VLLM_API_BASE", "https://env.example/v1")
+    monkeypatch.setenv("HOSTED_VLLM_API_KEY", "env-key")
+
+    mock_response = litellm.ModelResponse(
+        choices=[{"message": {"role": "assistant", "content": "ok"}}]
+    )
+    with (
+        patch(
+            "litellm.litellm_core_utils.health_check_helpers.HealthCheckHelpers."
+            "_update_model_params_with_health_check_tracking_information",
+            side_effect=lambda model_params: model_params,
+        ),
+        patch(
+            "litellm.acompletion",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_acompletion,
+    ):
+        response = await litellm.ahealth_check(
+            model_params={"model": "hosted_vllm/org/model"},
+            mode="chat",
+        )
+
+    assert "error" not in response
+    assert mock_acompletion.await_args.kwargs["api_base"] == "https://env.example/v1"
+    assert mock_acompletion.await_args.kwargs["api_key"] == "env-key"
+
+
+@pytest.mark.asyncio
 async def test_azure_health_check():
     response = await litellm.ahealth_check(
         model_params={


### PR DESCRIPTION
## TLDR

Problem this solves:

- Hosted vLLM health checks discard resolved credentials
- Healthy deployments can be reported as unavailable

How it solves it:

- Propagates the resolved API base into health checks
- Propagates the resolved API key into health checks
- Adds focused regression coverage for both values

## User Flow

Before: a proxy admin health-checks a hosted vLLM deployment, but the check does not use the provider-resolved endpoint and credentials

1. The admin configures a `hosted_vllm/` model with its endpoint and API key
2. They send `GET http://localhost:4000/health` with the proxy master key
3. The deployment appears in `unhealthy_endpoints` with an authentication error
4. A normal completion request to the same deployment still succeeds

After: the same health check uses the resolved endpoint and credentials

1. The admin configures the same `hosted_vllm/` model with its endpoint and API key
2. They send `GET http://localhost:4000/health` with the proxy master key
3. The health check sends the provider-resolved API base and API key upstream
4. The operational deployment appears in `healthy_endpoints`

## Relevant issues

Fixes #37321

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

An end-to-end run against a live hosted vLLM endpoint has not been completed yet

### Before (aa90828)

1. Pending live proxy reproduction against a hosted vLLM endpoint

### After (cc45d3b)

1. Pending the same live proxy health-check run at the PR tip

## Type

🐛 Bug Fix

## Caveats (if any)

- Live hosted vLLM end-to-end proof is still pending
- Regression coverage validates provider-resolved credential propagation

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR