### PR TITLE
fix(redis): avoid duplicate Azure AD credentials

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -456,6 +456,8 @@ def _get_redis_client_logic(**env_overrides):
         # are intentionally NOT exposed on the function to avoid leaking
         # credentials via inspection or logging.
         redis_kwargs["redis_connect_func"]._azure_redis_ad_token = True
+        redis_kwargs.pop("username", None)
+        redis_kwargs.pop("password", None)
 
     # Always remove Azure-specific kwargs that shouldn't be passed to Redis client
     redis_kwargs.pop("azure_redis_ad_token", None)

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -12,11 +12,12 @@ from litellm._redis import (
     get_redis_connection_pool,
     get_redis_url_from_environment,
 )
-from litellm.constants import REDIS_CLUSTER_HEALTH_CHECK_INTERVAL
 from litellm._redis_credential_provider import (
+    AzureADCredentialProvider,
     GCPIAMCredentialProvider,
     _token_cache,
 )
+from litellm.constants import REDIS_CLUSTER_HEALTH_CHECK_INTERVAL
 
 
 @pytest.fixture(autouse=True)
@@ -257,6 +258,31 @@ def test_get_redis_async_client_without_connection_pool():
         assert (
             "connection_pool" not in call_kwargs
         ), "connection_pool should not be in kwargs when not provided"
+
+
+def test_azure_ad_connection_pool_does_not_duplicate_credentials(monkeypatch):
+    credential = MagicMock()
+    credential.get_token.return_value.token = "azure-token"
+    monkeypatch.setenv("REDIS_USERNAME", "entra-user")
+    monkeypatch.setenv("REDIS_PASSWORD", "static-password")
+
+    with patch("litellm._redis._build_azure_credential", return_value=credential):
+        pool = get_redis_connection_pool(
+            host="cache.redis.azure.net",
+            port=10000,
+            ssl=True,
+            azure_redis_ad_token="true",
+        )
+
+    assert pool is not None
+    connection = pool.make_connection()
+    assert isinstance(connection.credential_provider, AzureADCredentialProvider)
+    assert connection.username is None
+    assert connection.password is None
+    assert connection.credential_provider.get_credentials() == (
+        "entra-user",
+        "azure-token",
+    )
 
 
 def test_gcp_iam_credential_provider_get_credentials():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure AD Redis fails before establishing connections
- Cache health checks report conflicting authentication methods

How it solves it:

- Remove direct credentials when Azure AD authentication is enabled
- Let the credential provider supply the username and token
- Add regression coverage for both conflicting credential fields

## User Flow

Before: a proxy operator cannot connect LiteLLM to Azure Managed Redis using Entra authentication

1. They configure Azure Managed Redis, `REDIS_AZURE_AD_TOKEN=true`, `REDIS_USERNAME`, TLS, and service principal credentials
2. They send `GET http://localhost:4000/cache/ping`
3. The endpoint returns HTTP 500 with `'username' and 'password' cannot be passed along with 'credential_provider'`
4. They observe that Redis remains unavailable for shared caching

After: the same configuration passes LiteLLM's complete Redis health check

1. They configure Azure Managed Redis, `REDIS_AZURE_AD_TOKEN=true`, `REDIS_USERNAME`, TLS, and service principal credentials
2. They send `GET http://localhost:4000/cache/ping`
3. The endpoint returns HTTP 200 with `"status": "healthy"`
4. They observe `"ping_response": true` and `"set_cache_response": "success"`

## Relevant issues

Fixes #37335

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup:

- Azure Managed Redis with Entra authentication enabled
- TLS connection using the service principal object ID
- No static Redis password configured

### Before (6d32d4081dc5696d6be9307195afac3612d80de2)

1. Build and run the proxy from this commit
2. Run `curl -i http://localhost:4000/cache/ping`
3. TODO: paste the observed HTTP 500 response and credential conflict

### After (129534305f1411581f8272a3bb8139a7c4b3c8c6)

1. Build and run the proxy from this commit
2. Run `curl -i http://localhost:4000/cache/ping`
3. TODO: paste the observed HTTP 200 response showing `"status": "healthy"`, `"ping_response": true`, and `"set_cache_response": "success"`

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

- Azure Redis usernames must use the documented `REDIS_USERNAME` variable

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR