### PR TITLE
fix(team_callback_endpoints): omit credential callback_vars instead of masking them

### DIFF
--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -125,7 +125,7 @@ def _resolve_team_callbacks(team_metadata: object) -> TeamCallbackMetadata:
     entry as active for a team whose requests never fire it.
 
     Credential ``callback_vars`` are stored encrypted, so they are decrypted
-    before being masked by key; a value encrypted under a key that is no longer
+    before being dropped by key; a value encrypted under a key that is no longer
     classified as sensitive would otherwise come back as raw ciphertext.
     """
     if not isinstance(team_metadata, dict):

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -76,21 +76,28 @@ def _redact_callback_secrets(metadata: Any) -> Any:
     return redacted
 
 
-def _mask_sensitive_callback_vars(callbacks: TeamCallbackMetadata) -> None:
-    """Mask credential-bearing callback vars in place, keeping the rest readable.
+def _drop_sensitive_callback_vars(callbacks: TeamCallbackMetadata) -> None:
+    """Remove credential-bearing callback vars in place, keeping the rest readable.
 
     ``callback_vars`` mixes credentials (``langsmith_api_key``,
     ``langfuse_secret_key``, ``gcs_path_service_account``) with plain
     configuration (project names, bucket names, hosts). The configuration is
     what makes a read of this endpoint useful, so only the sensitive keys are
-    replaced, using the same marker as the audit-log redaction above.
+    dropped.
 
     A value that still carries the encrypted prefix here failed to decrypt, so
-    it is masked too. Handing back a ciphertext blob under a key that is not
+    it is dropped too. Handing back a ciphertext blob under a key that is not
     classified as sensitive would give the caller something it cannot use and
     cannot tell apart from a real value.
 
-    Masking in place rather than rebuilding the mapping keeps this under the
+    Keys are omitted rather than replaced with the ``***REDACTED***`` marker
+    used for audit logs, because a marker survives a read-modify-write and is
+    then stored as the credential itself. Omitting does not make the response a
+    safe round trip: the metadata write paths replace ``logging`` wholesale, so
+    echoing this payload back still drops the stored credential. It only stops
+    a fabricated one being stored in its place.
+
+    Deleting in place rather than rebuilding the mapping keeps this under the
     LIT002 mutable-collection-construction budget. It is safe because the only
     caller passes an object it just built from a decrypted deep copy of the
     row, so nothing here is reachable from the team's stored metadata.
@@ -100,7 +107,7 @@ def _mask_sensitive_callback_vars(callbacks: TeamCallbackMetadata) -> None:
     for key in tuple(callbacks.callback_vars):
         value = callbacks.callback_vars[key]
         if is_sensitive_callback_key(key) or str(value).startswith(_CALLBACK_VAR_ENCRYPTED_PREFIX):
-            callbacks.callback_vars[key] = _CALLBACK_VARS_REDACTED
+            del callbacks.callback_vars[key]
 
 
 def _resolve_team_callbacks(team_metadata: object) -> TeamCallbackMetadata:
@@ -142,7 +149,7 @@ def _resolve_team_callbacks(team_metadata: object) -> TeamCallbackMetadata:
             TeamCallbackMetadata(**callback_settings) if isinstance(callback_settings, dict) else TeamCallbackMetadata()
         )
 
-    _mask_sensitive_callback_vars(resolved)
+    _drop_sensitive_callback_vars(resolved)
     return resolved
 
 
@@ -530,8 +537,10 @@ async def get_team_callbacks(
     Covers callbacks registered through POST /team/{team_id}/callback and the Admin UI as well as
     teams still on the deprecated callback_settings shape, resolved from the team's stored metadata
     with the same precedence used at request time. A key-level logging config overrides the team's
-    at request time and is not reflected here. Credential-bearing callback_vars are returned masked
-    as `***REDACTED***`
+    at request time and is not reflected here. Credential-bearing callback_vars are omitted from the
+    response rather than masked, so a marker can never be posted back and stored as a credential. The
+    response is therefore a partial config; credentials must be supplied again before it is written
+    anywhere, and a team left without one falls back to the proxy-level credential for that callback
 
     Returns {
             "status": "success",

--- a/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
@@ -19,6 +19,10 @@ from litellm.proxy._types import (
     LitellmUserRoles,
     UserAPIKeyAuth,
 )
+from litellm.proxy.common_utils.callback_utils import (
+    decrypt_callback_vars,
+    encrypt_callback_vars,
+)
 from litellm.proxy.management_endpoints.team_callback_endpoints import (
     add_team_callbacks,
     disable_team_logging,
@@ -526,12 +530,85 @@ async def test_get_team_callbacks_returns_callbacks_registered_via_post(monkeypa
 
     assert response["data"]["success_callbacks"] == ["langsmith"]
     assert response["data"]["failure_callbacks"] == []
-    # Non-secret vars come back usable, the credential is masked, and the
+    # Non-secret vars come back usable, the credential key is absent, and the
     # ciphertext that is stored on the row never reaches the response.
     assert response["data"]["callback_vars"]["langsmith_project"] == "tenant-project"
-    assert response["data"]["callback_vars"]["langsmith_api_key"] == "***REDACTED***"
+    assert "langsmith_api_key" not in response["data"]["callback_vars"]
     assert "lsv2-real-secret" not in json.dumps(response)
     assert "litellm_enc::" not in json.dumps(response)
+
+
+@pytest.mark.asyncio
+async def test_get_team_callbacks_response_does_not_write_a_marker_as_a_credential_when_cloned(monkeypatch):
+    """The read response must be safe to post back into a write path.
+
+    Cloning one team's logging config onto another is the obvious use of this
+    endpoint. When the response carried a ``***REDACTED***`` marker in place of
+    the credential, that replay stored the marker itself as the credential:
+    it is encrypted at rest like any real secret, so the row looks legitimate
+    while the target team's logging silently does nothing. Omitting the key
+    instead means the replay writes no credential at all, which is a visibly
+    incomplete config rather than a plausible broken one.
+    """
+    monkeypatch.setenv("LITELLM_SALT_KEY", "test-salt-32-bytes-aaaaaaaaaaaaaa")
+    source_metadata = {
+        "logging": [
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success",
+                "callback_vars": {
+                    "langsmith_api_key": "lsv2-source-secret",
+                    "langsmith_project": "source-project",
+                },
+            }
+        ]
+    }
+    source_row = _team_row(team_id="team-source", metadata=encrypt_callback_vars(source_metadata))
+    source_prisma = _patch_prisma(source_row)
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", source_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        read = await get_team_callbacks(
+            http_request=MagicMock(spec=Request),
+            team_id="team-source",
+            user_api_key_dict=_admin_auth(),
+        )
+
+    # Nothing a caller could echo into any write path is a marker, so this
+    # holds whichever of the metadata write routes the clone goes through.
+    assert "***REDACTED***" not in json.dumps(read)
+
+    target_row = _team_row(team_id="team-target", metadata={})
+    target_prisma = _patch_prisma(target_row)
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", target_prisma),
+        patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        await add_team_callbacks(
+            data=AddTeamCallback(
+                callback_name="langsmith",
+                callback_type="success",
+                callback_vars=read["data"]["callback_vars"],
+            ),
+            http_request=MagicMock(spec=Request),
+            team_id="team-target",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    persisted = decrypt_callback_vars(
+        json.loads(target_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+    )
+    cloned_vars = persisted["logging"][0]["callback_vars"]
+    # The non-secret config clones, the credential does not follow, and no
+    # marker is ever stored where a credential belongs.
+    assert cloned_vars["langsmith_project"] == "source-project"
+    assert "langsmith_api_key" not in cloned_vars
+    assert "***REDACTED***" not in json.dumps(persisted)
 
 
 @pytest.mark.asyncio
@@ -646,7 +723,7 @@ async def test_get_team_callbacks_decrypts_vars_stored_under_non_sensitive_keys(
 
 
 @pytest.mark.asyncio
-async def test_get_team_callbacks_masks_values_that_fail_to_decrypt(monkeypatch):
+async def test_get_team_callbacks_drops_values_that_fail_to_decrypt(monkeypatch):
     """A value that cannot be decrypted must never leave as ciphertext.
 
     After a salt-key rotation an existing value no longer decrypts, and the
@@ -683,7 +760,7 @@ async def test_get_team_callbacks_masks_values_that_fail_to_decrypt(monkeypatch)
         )
 
     assert response["data"]["success_callbacks"] == ["langsmith"]
-    assert response["data"]["callback_vars"]["langsmith_project"] == "***REDACTED***"
+    assert "langsmith_project" not in response["data"]["callback_vars"]
     assert _CALLBACK_VAR_ENCRYPTED_PREFIX not in json.dumps(response)
 
 
@@ -716,7 +793,7 @@ async def test_get_team_callbacks_falls_back_to_deprecated_callback_settings():
     assert response["data"]["callback_vars"]["gcs_bucket_name"] == "legacy-bucket"
     # Legacy rows predate encryption at rest, so this endpoint is where the
     # plaintext secret would otherwise escape.
-    assert response["data"]["callback_vars"]["langfuse_secret_key"] == "***REDACTED***"
+    assert "langfuse_secret_key" not in response["data"]["callback_vars"]
     assert "sk-lf-legacy-plaintext" not in json.dumps(response)
 
 

--- a/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
@@ -687,14 +687,14 @@ async def test_get_team_callbacks_decrypts_vars_stored_under_non_sensitive_keys(
     """Stored ciphertext must be decrypted, not handed back raw.
 
     Which keys count as sensitive is a moving classification, so a value can be
-    encrypted at rest under a key that later stops being masked on read. Without
+    encrypted at rest under a key that later stops being dropped on read. Without
     the decrypt step that value comes back as an unusable litellm_enc:: blob.
     """
     from litellm.proxy.common_utils.callback_utils import _CALLBACK_VAR_ENCRYPTED_PREFIX, is_sensitive_callback_key
     from litellm.proxy.common_utils.encrypt_decrypt_utils import encrypt_value_helper
 
     monkeypatch.setenv("LITELLM_SALT_KEY", "test-salt-32-bytes-aaaaaaaaaaaaaa")
-    assert not is_sensitive_callback_key("langsmith_project"), "test needs a key that is not masked on read"
+    assert not is_sensitive_callback_key("langsmith_project"), "test needs a key that is not dropped on read"
 
     metadata = {
         "logging": [

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -14750,8 +14750,10 @@ export interface paths {
          *     Covers callbacks registered through POST /team/{team_id}/callback and the Admin UI as well as
          *     teams still on the deprecated callback_settings shape, resolved from the team's stored metadata
          *     with the same precedence used at request time. A key-level logging config overrides the team's
-         *     at request time and is not reflected here. Credential-bearing callback_vars are returned masked
-         *     as `***REDACTED***`
+         *     at request time and is not reflected here. Credential-bearing callback_vars are omitted from the
+         *     response rather than masked, so a marker can never be posted back and stored as a credential. The
+         *     response is therefore a partial config; credentials must be supplied again before it is written
+         *     anywhere, and a team left without one falls back to the proxy-level credential for that callback
          *
          *     Returns {
          *             "status": "success",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Reading a team's callbacks handed back a `***REDACTED***` marker
- Posting that payload back stored the marker as the real credential
- The row encrypts and looks legitimate; team logging silently stops working

How it solves it:

- Credential callback_vars are omitted from the read response, not masked
- An absent key cannot be written over a stored credential
- No write path needs to learn about a marker

## User Flow

Before: a proxy admin cloning one team's logging config onto another team silently gives the second team a dead credential

1. They call GET https://litellm-domain/team/TEAM_A/callback and get back `{"langsmith_api_key": "***REDACTED***", "langsmith_project": "prod"}`
2. They post that same `callback_vars` object to POST https://litellm-domain/team/TEAM_B/callback and get HTTP 200
3. Nothing warns them, and team B's stored Langsmith key is now the literal text `***REDACTED***`
4. Team B's requests log nothing to Langsmith, and every read of the config keeps showing a credential that looks configured

After: the same clone carries the shared configuration and visibly leaves the credential to be filled in

1. They call GET https://litellm-domain/team/TEAM_A/callback and get back `{"langsmith_project": "prod"}` with no credential field at all
2. They post that same `callback_vars` object to POST https://litellm-domain/team/TEAM_B/callback and get HTTP 200
3. Team B is stored with the project name and no Langsmith key, so the missing credential is visible on the next read
4. Team A's real credential is untouched, and no request can turn a read of this endpoint into an overwrite of a stored secret

## Relevant issues

## Linear ticket

Resolves LIT-5110

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy on a real Postgres. Values are read back out of the database and decrypted, so the evidence is the stored row, not the API echo.

Shared setup

```
docker run -d --name litfix-pg-5110 -p 15110:5432 -e POSTGRES_DB=litellm \
  -e POSTGRES_USER=llmproxy -e POSTGRES_PASSWORD=dbpassword9090 postgres:16
export DATABASE_URL="postgresql://llmproxy:dbpassword9090@localhost:15110/litellm"
export LITELLM_MASTER_KEY=sk-1234
export LITELLM_SALT_KEY=lit5110-salt-key-32-bytes-aaaaaa
python -m litellm.proxy.proxy_cli --config config.yaml --port 20110 --use_prisma_db_push
```

Team A is seeded once with a real credential:

```
curl -X POST localhost:20110/team/$A/callback -H "Authorization: Bearer sk-1234" \
  -d '{"callback_name":"langsmith","callback_type":"success",
       "callback_vars":{"langsmith_api_key":"lsv2-REAL-WORKING-KEY","langsmith_project":"prod"}}'
```

### Before (8159f240c4, the merge base at capture time)

#### Cloning team A's callback config onto team B

1. Read team A's config

```
$ curl -s localhost:20110/team/$A/callback -H "Authorization: Bearer sk-1234"
{"status":"success","data":{"team_id":"8ef61fb6...","success_callbacks":["langsmith"],
 "failure_callbacks":[],
 "callback_vars":{"langsmith_api_key":"***REDACTED***","langsmith_project":"prod"}}}
```

2. Post that exact `callback_vars` payload to team B

```
$ curl -s -o /dev/null -w "HTTP %{http_code}\n" -X POST localhost:20110/team/$B/callback \
    -H "Authorization: Bearer sk-1234" \
    -d '{"callback_name":"langsmith","callback_type":"success",
         "callback_vars":{"langsmith_api_key":"***REDACTED***","langsmith_project":"prod"}}'
HTTP 200
```

3. Decrypt both rows straight out of Postgres

```
8ef61fb6  langsmith_api_key = 'lsv2-REAL-WORKING-KEY'
40903df7  langsmith_api_key = '***REDACTED***'
```

Team B now holds the marker as an encrypted credential, with no validation error at any point.

#### Overwriting a team's own credential through POST /team/update

1. Seed team D with a real key, then send the marker back through the team update route

```
$ curl -s -o /dev/null -w "HTTP %{http_code}\n" -X POST localhost:20110/team/update \
    -H "Authorization: Bearer sk-1234" \
    -d '{"team_id":"'$D'","metadata":{"logging":[{"callback_name":"langsmith",
         "callback_type":"success","callback_vars":{"langsmith_api_key":"***REDACTED***",
         "langsmith_project":"prod"}}]}}'
HTTP 200
```

2. Decrypt team D out of Postgres

```
team D at rest: {'langsmith_api_key': '***REDACTED***', 'langsmith_project': 'prod'}
```

The real key is gone, replaced in place by the marker. This second case is why the fix is on the read side; every write path would otherwise need its own marker rule, and missing one destroys credentials silently.

### After (433aef58e5)

#### Cloning team A's callback config onto team E

1. Read team A's config; the credential key is absent rather than masked

```
$ curl -s localhost:20110/team/$A/callback -H "Authorization: Bearer sk-1234"
{"status":"success","data":{"team_id":"8ef61fb6...","success_callbacks":["langsmith"],
 "failure_callbacks":[],"callback_vars":{"langsmith_project":"prod"}}}
```

2. Post that exact `callback_vars` payload to a fresh team E

```
HTTP 200
```

3. Decrypt both rows straight out of Postgres

```
8ef61fb6  callback_vars at rest = {'langsmith_api_key': 'lsv2-REAL-WORKING-KEY', 'langsmith_project': 'prod'}
ac130867  callback_vars at rest = {'langsmith_project': 'prod'}
```

Team A's credential is untouched and team E carries the shared configuration with no fabricated secret.

#### Legacy teams still on the deprecated callback_settings shape

1. A team whose row predates encryption at rest, holding a plaintext secret

```
$ curl -s localhost:20110/team/$L/callback -H "Authorization: Bearer sk-1234"
{"team_id":"6448d8ab...","success_callbacks":["gcs_bucket"],"failure_callbacks":[],
 "callback_vars":{"gcs_bucket_name":"legacy-bucket"}}
```

The plaintext secret does not escape, and the bucket name is still readable.

#### A team whose callback_vars are all credentials

```
$ curl -s localhost:20110/team/$S/callback -H "Authorization: Bearer sk-1234"
{"team_id":"24f19d4b...","success_callbacks":["langfuse"],"failure_callbacks":[],
 "callback_vars":{}}
```

`success_callbacks` still reports langfuse as active, so an empty `callback_vars` is not mistaken for an unconfigured team.

## Type

🐛 Bug Fix

## Behavior changes

Credential-bearing `callback_vars` keys are absent from this response rather than present with a marker. The response is a partial config, not a safe round trip: the metadata write paths replace `logging` wholesale, so echoing the payload back still drops the stored credential. What it can no longer do is store a fabricated one in its place.

That changes the failure mode of a cloned config, and the direction depends on whether a destination field survives the drop. This was measured on a base-vs-head A/B with real Gemini calls exported to a real Langfuse project, cloning a config and then reading the traces back through the Langfuse API:

| cloned team config | base 00e1f25e9b | head 16b1e6e7f6 |
| --- | --- | --- |
| keys plus `langfuse_host` | marker sent as basic auth to the team host, no trace | credentials absent and host present, so `allow_env_credentials` blocks the proxy credential and the callback no-ops, no trace |
| keys only, no host | marker rejected as credentials, no trace | no dynamic credentials, so the global logger exports the team's request into the proxy-level Langfuse project |

Only the fourth cell changed to something a reader would not expect, and it was observed rather than reasoned: the target team's prompt and completion land in the proxy operator's own project. The state itself is not new, since any team registering a callback with only non-secret vars reaches it today, and the endpoint is admin-gated so the actor could already point that team anywhere. It is quieter than the old failure, so a caller cloning a config has to re-supply the credential.

`gcs_path_service_account` and `posthog_api_key` have no equivalent `allow_env_credentials` guard, so the same shape applies to them. Datadog fails closed. The Langfuse passthrough route improves: it now returns a 400 naming the missing dynamic credentials instead of forwarding the marker as basic auth.

A value that fails to decrypt after a salt-key rotation is likewise omitted rather than marked. It was already non-functional at request time, so nothing working is hidden, but the response no longer distinguishes "not configured" from "configured but undecryptable".

## Caveats (if any)

- `***REDACTED***` stays defined here for audit-log redaction
- Write paths still accept the marker as an ordinary string
- `/team/info` still returns these credentials unmasked, tracked in LIT-5102
- The marker constant was not consolidated; see below

## Why this endpoint diverges from the in-repo precedent

Two endpoints already implement the alternative, teaching the write path to read the marker as "keep the saved value" (`_merge_over_saved` in `coordination_redis_endpoints.py` and `cache_settings_endpoints.py`). That was not reused here for two reasons. Team callback config has four write paths rather than one, and missing any of them destroys credentials silently. And `logging` is a list, so a restore needs stable per-entry identity rather than a flat key match.

For the same reason the marker constant was not consolidated into `litellm/constants.py`. In those two cache endpoints the marker is a round-trippable sentinel the write path honours; here it is a display string with no write meaning. One shared constant would conflate the two and invite exactly the "the write path must know about the marker" assumption that produced this bug.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
