### PR TITLE
fix(proxy/redis): pop username and password when using credential_provider for azure ad and gcp iam

### DIFF
--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -1478,3 +1478,60 @@ def test_async_sentinel_keeps_the_credential_provider_off_the_monitors(markers, 
     master_kwargs = mock_sentinel_cls.return_value.master_for.call_args[1]
     assert isinstance(master_kwargs["credential_provider"], provider_cls)
     assert "password" not in master_kwargs
+
+
+@pytest.mark.parametrize("client_mode", ["cluster", "client", "pool"])
+@pytest.mark.parametrize(
+    ("credential_attribute", "credential_value", "provider_type"),
+    [
+        ("_azure_credential", object(), AzureADCredentialProvider),
+        (
+            "_gcp_service_account",
+            "projects/-/serviceAccounts/sa@project.iam.gserviceaccount.com",
+            GCPIAMCredentialProvider,
+        ),
+    ],
+)
+def test_credential_provider_excludes_explicit_credentials(
+    client_mode: str,
+    credential_attribute: str,
+    credential_value: object,
+    provider_type: type[object],
+) -> None:
+    connect_func = SimpleNamespace(**{credential_attribute: credential_value})
+    redis_kwargs = {
+        **(
+            {"startup_nodes": [{"host": "redis.example.com", "port": 6379}]}
+            if client_mode == "cluster"
+            else {"host": "redis.example.com", "port": 6379}
+        ),
+        "username": "configured-user",
+        "password": "configured-password",
+        "redis_connect_func": connect_func,
+    }
+    builder, constructor_path = (
+        (get_redis_async_client, "litellm._redis.async_redis.RedisCluster")
+        if client_mode == "cluster"
+        else (
+            (get_redis_async_client, "litellm._redis.async_redis.Redis")
+            if client_mode == "client"
+            else (
+                get_redis_connection_pool,
+                "litellm._redis.async_redis.BlockingConnectionPool",
+            )
+        )
+    )
+
+    with (
+        patch(constructor_path) as constructor,
+        patch(
+            "litellm._redis._get_redis_client_logic",
+            return_value=redis_kwargs,
+        ),
+    ):
+        builder()
+
+    call_kwargs = constructor.call_args.kwargs
+    assert isinstance(call_kwargs["credential_provider"], provider_type)
+    assert "username" not in call_kwargs
+    assert "password" not in call_kwargs


### PR DESCRIPTION
## TLDR

Problem this solves:

- Entra-authenticated Redis receives two competing credential mechanisms.
- Redis rejects connections before opening the network socket.

How it solves it:

- Build a credential-safe copy of the Redis kwargs when a credential provider is selected.
- Remove explicit username/password credentials from that copy without mutating the caller's dictionary.
- Cover Azure and GCP across client, cluster, and pool paths.

## User Flow

Before: a proxy operator enables Azure Managed Redis with Entra authentication, but LiteLLM cannot use Redis.

1. The operator starts LiteLLM with Azure Redis and service-principal settings.
2. The operator sends `GET http://localhost:4000/cache/ping`.
3. The endpoint returns HTTP 500 with a credential-exclusivity error.
4. Azure Managed Redis records no connection.

After: the same configuration can use the credential provider without conflicting explicit credentials.

1. The operator starts LiteLLM with the same Redis settings.
2. The operator sends `GET http://localhost:4000/cache/ping`.
3. LiteLLM constructs the Redis client with only the credential provider.
4. A configured Azure environment can complete its normal Redis health check.

## Relevant issues

Fixes #37335

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### Before (340d308 + test-only patch)

1. Run the credential-provider regression test with the removal lines reverted.
2. Five cases fail because `username` remains alongside `credential_provider`.

### After (0474fc3)

1. Run `python -m pytest tests/test_litellm/test_redis.py::test_get_redis_async_client_gcp_cluster_uses_credential_provider tests/test_litellm/test_redis.py::test_credential_provider_excludes_explicit_credentials -q`.
2. The suite reports `7 passed`.
3. Run `ruff check tests/test_litellm/test_redis.py`.
4. Ruff reports no errors.
5. The byte-identical code tree passed the full GitHub CI matrix before the metadata-only author correction, including unit tests, lint, security analysis, and 100% patch coverage; the current-head rerun is in progress.
6. Greptile reviewed the current head (`0474fc3`) with a 5/5 confidence score and reported no blocking issue.

## Type

🐛 Bug Fix

✅ Test

## Caveats (if any)

- Live Azure Managed Redis verification requires external Azure credentials.

## QA runbook

- `tests/test_litellm/test_redis.py::test_credential_provider_excludes_explicit_credentials` - explicit credentials never accompany a provider
  - [x] Run the parameterized test for all six cases
  - [x] Confirm Azure and GCP provider objects are passed
  - [x] Confirm `username` and `password` are absent
  - [x] Sanity check: each client construction path is covered

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
