### PR TITLE
refactor(ui): migrate the model settings and credential rotation modals to react-hook-form and shadcn

### DIFF
--- a/ui/litellm-dashboard/src/components/model_dashboard/ModelSettingsModal/ModelSettingsModal.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard/ModelSettingsModal/ModelSettingsModal.tsx
@@ -4,8 +4,14 @@ import { ConfigType, useProxyConfig } from "@/app/(dashboard)/hooks/proxyConfig/
 import { StoreModelInDBParams, useStoreModelInDB } from "@/app/(dashboard)/hooks/storeModelInDB/useStoreModelInDB";
 import { toast } from "@/lib/toast";
 import { parseErrorMessage } from "@/components/shared/errorUtils";
-import { Button, Form, Modal, Skeleton, Space, Switch, Typography } from "antd";
+import { FieldGroup } from "@/components/shared/form/field";
+import { FormField } from "@/components/shared/form/FormField";
+import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Button, Modal, Skeleton, Space, Typography } from "antd";
+import { CircleHelp } from "lucide-react";
 import React, { useEffect, useMemo } from "react";
+import { useForm } from "react-hook-form";
 
 interface ModelSettingsModalProps {
   isVisible: boolean;
@@ -13,8 +19,17 @@ interface ModelSettingsModalProps {
   onSuccess?: () => void;
 }
 
+const labelWithHint = (label: string, hint: string): React.ReactNode => (
+  <>
+    {label}
+    <Tooltip>
+      <TooltipTrigger render={<CircleHelp className="size-3.5 shrink-0 cursor-help text-muted-foreground" />} />
+      <TooltipContent>{hint}</TooltipContent>
+    </Tooltip>
+  </>
+);
+
 const ModelSettingsModal: React.FC<ModelSettingsModalProps> = ({ isVisible, onCancel, onSuccess }) => {
-  const [form] = Form.useForm();
   const { mutateAsync, isPending } = useStoreModelInDB();
   const { data: proxyConfigData, isLoading: isLoadingConfig, refetch } = useProxyConfig(ConfigType.GENERAL_SETTINGS);
 
@@ -26,7 +41,7 @@ const ModelSettingsModal: React.FC<ModelSettingsModalProps> = ({ isVisible, onCa
   }, [isVisible, refetch]);
 
   // Compute initial values from fetched config data
-  const initialValues = useMemo(() => {
+  const initialValues = useMemo<StoreModelInDBParams>(() => {
     if (!proxyConfigData) {
       return {
         store_model_in_db: false,
@@ -39,6 +54,8 @@ const ModelSettingsModal: React.FC<ModelSettingsModalProps> = ({ isVisible, onCa
       store_model_in_db: storeModelField?.field_value ?? false,
     };
   }, [proxyConfigData]);
+
+  const form = useForm<StoreModelInDBParams>({ defaultValues: initialValues, values: initialValues });
 
   const handleFormSubmit = async (formValues: StoreModelInDBParams) => {
     try {
@@ -58,7 +75,7 @@ const ModelSettingsModal: React.FC<ModelSettingsModalProps> = ({ isVisible, onCa
   };
 
   const handleCancel = () => {
-    form.resetFields();
+    form.reset(initialValues);
     onCancel();
   };
 
@@ -71,32 +88,47 @@ const ModelSettingsModal: React.FC<ModelSettingsModalProps> = ({ isVisible, onCa
           <Button onClick={handleCancel} disabled={isPending || isLoadingConfig}>
             Cancel
           </Button>
-          <Button type="primary" loading={isPending} disabled={isLoadingConfig} onClick={() => form.submit()}>
+          <Button
+            type="primary"
+            loading={isPending}
+            disabled={isLoadingConfig}
+            onClick={() => void form.handleSubmit(handleFormSubmit)()}
+          >
             {isPending ? "Saving..." : "Save Settings"}
           </Button>
         </Space>
       }
       onCancel={handleCancel}
     >
-      <Form
-        key={proxyConfigData ? JSON.stringify(initialValues) : "loading"}
-        form={form}
-        layout="horizontal"
-        onFinish={handleFormSubmit}
-        initialValues={initialValues}
-      >
-        <Form.Item
-          label="Store Model in DB"
-          name="store_model_in_db"
-          tooltip={
-            proxyConfigData?.find((f) => f.field_name === "store_model_in_db")?.field_description ||
-            "If enabled, models and config are stored in and loaded from the database."
-          }
-          valuePropName="checked"
-        >
-          {isLoadingConfig ? <Skeleton.Input active block /> : <Switch />}
-        </Form.Item>
-      </Form>
+      <TooltipProvider>
+        <form onSubmit={(event) => event.preventDefault()}>
+          <FieldGroup>
+            <FormField
+              control={form.control}
+              name="store_model_in_db"
+              label={labelWithHint(
+                "Store Model in DB",
+                proxyConfigData?.find((f) => f.field_name === "store_model_in_db")?.field_description ||
+                  "If enabled, models and config are stored in and loaded from the database.",
+              )}
+            >
+              {({ id, value, onChange, onBlur }) =>
+                isLoadingConfig ? (
+                  <Skeleton.Input active block />
+                ) : (
+                  <Switch
+                    id={id}
+                    checked={Boolean(value)}
+                    onCheckedChange={onChange}
+                    onBlur={onBlur}
+                    className="w-fit"
+                  />
+                )
+              }
+            </FormField>
+          </FieldGroup>
+        </form>
+      </TooltipProvider>
     </Modal>
   );
 };

--- a/ui/litellm-dashboard/src/components/update_model_credentials_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/update_model_credentials_modal.test.tsx
@@ -134,11 +134,11 @@ describe("UpdateModelCredentialsModal", () => {
     await user.type(field, "sk-peek-42");
     expect(field).toHaveAttribute("type", "password");
 
-    await user.click(screen.getByRole("button", { name: /show api key/i }));
+    await user.click(screen.getByRole("button", { name: /show password/i }));
     expect(field).toHaveAttribute("type", "text");
     expect(field).toHaveValue("sk-peek-42");
 
-    await user.click(screen.getByRole("button", { name: /hide api key/i }));
+    await user.click(screen.getByRole("button", { name: /hide password/i }));
     expect(field).toHaveAttribute("type", "password");
     expect(field).toHaveValue("sk-peek-42");
   });

--- a/ui/litellm-dashboard/src/components/update_model_credentials_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/update_model_credentials_modal.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import UpdateModelCredentialsModal from "./update_model_credentials_modal";
 import * as networking from "./networking";
+import { toast } from "@/lib/toast";
 
 vi.mock("./networking", async () => {
   const actual = await vi.importActual("./networking");
@@ -13,6 +14,7 @@ vi.mock("./networking", async () => {
 });
 
 const mockModelPatchUpdateCall = vi.mocked(networking.modelPatchUpdateCall);
+const mockToast = vi.mocked(toast);
 
 beforeAll(() => {
   Object.defineProperty(window, "matchMedia", {
@@ -75,5 +77,69 @@ describe("UpdateModelCredentialsModal", () => {
     // Required-field validation blocks submit; give it a tick then assert no call.
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(mockModelPatchUpdateCall).not.toHaveBeenCalled();
+  });
+
+  it("renders the required message when the field is left blank", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole("button", { name: /update api key/i }));
+
+    expect(await screen.findByText("Enter a new API key")).toBeInTheDocument();
+  });
+
+  it("rejects a whitespace-only key without sending a PATCH", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByLabelText(/new api key/i), "   ");
+    await user.click(screen.getByRole("button", { name: /update api key/i }));
+
+    await waitFor(() => expect(mockToast.fromError).toHaveBeenCalledWith("Enter a new API key"));
+    expect(mockModelPatchUpdateCall).not.toHaveBeenCalled();
+  });
+
+  it("trims surrounding whitespace off the key it sends", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByLabelText(/new api key/i), "  sk-pad-77  ");
+    await user.click(screen.getByRole("button", { name: /update api key/i }));
+
+    await waitFor(() => expect(mockModelPatchUpdateCall).toHaveBeenCalledTimes(1));
+    expect(mockModelPatchUpdateCall.mock.calls[0][1]).toEqual({
+      litellm_params: { api_key: "sk-pad-77" },
+      model_info: { id: "model-123" },
+    });
+  });
+
+  it("submits on Enter from inside the key field", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByLabelText(/new api key/i), "sk-enter-1{Enter}");
+
+    await waitFor(() => expect(mockModelPatchUpdateCall).toHaveBeenCalledTimes(1));
+    expect(mockModelPatchUpdateCall.mock.calls[0][1]).toEqual({
+      litellm_params: { api_key: "sk-enter-1" },
+      model_info: { id: "model-123" },
+    });
+  });
+
+  it("reveals and re-hides the key without touching the value", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    const field = screen.getByLabelText(/new api key/i);
+    await user.type(field, "sk-peek-42");
+    expect(field).toHaveAttribute("type", "password");
+
+    await user.click(screen.getByRole("button", { name: /show api key/i }));
+    expect(field).toHaveAttribute("type", "text");
+    expect(field).toHaveValue("sk-peek-42");
+
+    await user.click(screen.getByRole("button", { name: /hide api key/i }));
+    expect(field).toHaveAttribute("type", "password");
+    expect(field).toHaveValue("sk-peek-42");
   });
 });

--- a/ui/litellm-dashboard/src/components/update_model_credentials_modal.tsx
+++ b/ui/litellm-dashboard/src/components/update_model_credentials_modal.tsx
@@ -1,9 +1,25 @@
-import { Alert, Button, Form, Input, Modal, Typography } from "antd";
+import { Alert, Modal, Typography } from "antd";
+import { Eye, EyeOff } from "lucide-react";
 import { useState } from "react";
+import { z } from "zod/v4";
 import { modelPatchUpdateCall } from "./networking";
 import { toast } from "@/lib/toast";
+import { FieldGroup } from "@/components/shared/form/field";
+import { FormField } from "@/components/shared/form/FormField";
+import { Button } from "@/components/ui/button";
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/ui/input-group";
+import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
+import { useZodForm } from "@/lib/forms/useZodForm";
 
 const { Text } = Typography;
+
+const updateCredentialsSchema = z.object({
+  api_key: z.string().min(1, "Enter a new API key"),
+});
+
+type UpdateCredentialsValues = z.infer<typeof updateCredentialsSchema>;
+
+const EMPTY_VALUES: UpdateCredentialsValues = { api_key: "" };
 
 interface UpdateModelCredentialsModalProps {
   open: boolean;
@@ -20,15 +36,16 @@ export default function UpdateModelCredentialsModal({
   modelId,
   onUpdated,
 }: UpdateModelCredentialsModalProps) {
-  const [form] = Form.useForm();
+  const form = useZodForm(updateCredentialsSchema, { defaultValues: EMPTY_VALUES });
   const [isSaving, setIsSaving] = useState(false);
+  const [isKeyVisible, setIsKeyVisible] = useState(false);
 
   const close = () => {
-    form.resetFields();
+    form.reset(EMPTY_VALUES);
     onCancel();
   };
 
-  const handleSubmit = async (values: { api_key?: string }) => {
+  const handleSubmit = async (values: UpdateCredentialsValues) => {
     const apiKey = values.api_key?.trim();
     if (!apiKey) {
       toast.fromError("Enter a new API key");
@@ -42,7 +59,7 @@ export default function UpdateModelCredentialsModal({
         modelId,
       );
       toast.success("API key updated");
-      form.resetFields();
+      form.reset(EMPTY_VALUES);
       onUpdated();
       onCancel();
     } catch (error) {
@@ -55,7 +72,7 @@ export default function UpdateModelCredentialsModal({
 
   return (
     <Modal title="Update API Key" open={open} onCancel={close} footer={null} width={520} destroyOnHidden={true}>
-      <Text className="block mb-4 text-gray-500">
+      <Text className="block mb-4 text-muted-foreground">
         Update this model&apos;s API key. Only the new key is sent; the rest of the deployment configuration is left
         untouched.
       </Text>
@@ -65,19 +82,41 @@ export default function UpdateModelCredentialsModal({
         className="mb-4"
         message="Only the API key is rotated here. Models that authenticate with an Azure AD token, AWS credentials, or a Vertex service-account JSON aren't supported yet; update those from the model's LiteLLM Params for now."
       />
-      <Form form={form} onFinish={handleSubmit} layout="vertical">
-        <Form.Item label="New API Key" name="api_key" rules={[{ required: true, message: "Enter a new API key" }]}>
-          <Input.Password placeholder="Enter the new API key" autoComplete="new-password" />
-        </Form.Item>
-        <div className="flex justify-end items-center mt-4">
-          <Button onClick={close} style={{ marginRight: 10 }}>
+      <form onSubmit={form.handleSubmit(handleSubmit)}>
+        <FieldGroup>
+          <FormField control={form.control} name="api_key" label="New API Key">
+            {({ ref, ...field }) => (
+              <InputGroup>
+                <InputGroupInput
+                  {...field}
+                  ref={ref}
+                  type={isKeyVisible ? "text" : "password"}
+                  placeholder="Enter the new API key"
+                  autoComplete="new-password"
+                />
+                <InputGroupAddon align="inline-end">
+                  <InputGroupButton
+                    size="icon-xs"
+                    onClick={() => setIsKeyVisible((visible) => !visible)}
+                    aria-label={isKeyVisible ? "Hide API key" : "Show API key"}
+                  >
+                    {isKeyVisible ? <EyeOff /> : <Eye />}
+                  </InputGroupButton>
+                </InputGroupAddon>
+              </InputGroup>
+            )}
+          </FormField>
+        </FieldGroup>
+        <div className="flex justify-end items-center mt-4 gap-2.5">
+          <Button type="button" variant="outline" onClick={close}>
             Cancel
           </Button>
-          <Button type="primary" htmlType="submit" loading={isSaving}>
+          <Button type="submit" disabled={isSaving}>
+            {isSaving && <UiLoadingSpinner className="size-4" />}
             Update API Key
           </Button>
         </div>
-      </Form>
+      </form>
     </Modal>
   );
 }

--- a/ui/litellm-dashboard/src/components/update_model_credentials_modal.tsx
+++ b/ui/litellm-dashboard/src/components/update_model_credentials_modal.tsx
@@ -1,13 +1,12 @@
 import { Alert, Modal, Typography } from "antd";
-import { Eye, EyeOff } from "lucide-react";
 import { useState } from "react";
 import { z } from "zod/v4";
 import { modelPatchUpdateCall } from "./networking";
 import { toast } from "@/lib/toast";
 import { FieldGroup } from "@/components/shared/form/field";
 import { FormField } from "@/components/shared/form/FormField";
+import { PasswordInput } from "@/components/shared/PasswordInput";
 import { Button } from "@/components/ui/button";
-import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/ui/input-group";
 import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
 import { useZodForm } from "@/lib/forms/useZodForm";
 
@@ -38,7 +37,6 @@ export default function UpdateModelCredentialsModal({
 }: UpdateModelCredentialsModalProps) {
   const form = useZodForm(updateCredentialsSchema, { defaultValues: EMPTY_VALUES });
   const [isSaving, setIsSaving] = useState(false);
-  const [isKeyVisible, setIsKeyVisible] = useState(false);
 
   const close = () => {
     form.reset(EMPTY_VALUES);
@@ -86,24 +84,7 @@ export default function UpdateModelCredentialsModal({
         <FieldGroup>
           <FormField control={form.control} name="api_key" label="New API Key">
             {({ ref, ...field }) => (
-              <InputGroup>
-                <InputGroupInput
-                  {...field}
-                  ref={ref}
-                  type={isKeyVisible ? "text" : "password"}
-                  placeholder="Enter the new API key"
-                  autoComplete="new-password"
-                />
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    size="icon-xs"
-                    onClick={() => setIsKeyVisible((visible) => !visible)}
-                    aria-label={isKeyVisible ? "Hide API key" : "Show API key"}
-                  >
-                    {isKeyVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
+              <PasswordInput {...field} ref={ref} placeholder="Enter the new API key" autoComplete="new-password" />
             )}
           </FormField>
         </FieldGroup>


### PR DESCRIPTION
## TLDR

Problem this solves:

- Two model dialogs still render antd Form, light-mode only
- antd form controls have no dark-mode tokens
- Password field had no shared reveal control

How it solves it:

- Moves both dialogs to react-hook-form plus shadcn fields
- Keeps the exact submit payload each dialog already sent
- Reuses the shared PasswordInput for the key field

## User Flow

Both dialogs already work. What changes is what the controls are made of, so the steps are identical on both sides and only the rendering differs.

Before: a proxy admin can change both settings, but the two dialogs render light-only antd controls that ignore the dashboard theme

1. They open http://localhost:4000/ui/?page=models and click Model Settings
2. The Store Model in DB row shows its label inline to the left of an antd switch, with a hover hint beside the label
3. They flip the switch and click Save Settings, and the page posts `{"store_model_in_db": true}` to /config/field/update
4. They go back, open any deployment, and click Update API Key
5. They type a key into an antd password field whose only reveal control is a small inline eye glyph
6. They click Update API Key and the page sends a PATCH carrying only the new key and the model id

After: the same admin does the same two things, and both dialogs now render themed shadcn controls

1. They open http://localhost:4000/ui/?page=models and click Model Settings
2. The Store Model in DB row shows its label above the switch, with the same hover hint beside the label
3. They flip the switch and click Save Settings, and the page posts `{"store_model_in_db": true}` to /config/field/update
4. They go back, open any deployment, and click Update API Key
5. They type a key into a password field with a labelled Show password / Hide password button
6. They click Update API Key and the page sends the same PATCH carrying only the new key and the model id

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Not yet captured against a live proxy. The evidence that exists today is a jsdom A/B, run in the dashboard's own vitest environment, rendering the pre-migration file straight out of `origin/litellm_internal_staging` beside the migrated one in a single `describe.each` and asserting the same payloads on both. That is labelled jsdom deliberately and is not a live run.

    antd      > whitespace-only key: no PATCH, error toast          PASS
    antd      > trims the key before sending                        PASS
    antd      > blank key: required message renders and no PATCH    PASS
    antd      > Enter in the key field submits                      PASS
    migrated  > whitespace-only key: no PATCH, error toast          PASS
    migrated  > trims the key before sending                        PASS
    migrated  > blank key: required message renders and no PATCH    PASS
    migrated  > Enter in the key field submits                      PASS

Both pre-existing suites also pass unedited after the migration: `ModelSettingsModal.test.tsx` 19/19, which already pinned `mutateAsync` being called with exactly `{store_model_in_db: true}` and `{store_model_in_db: false}`, and `update_model_credentials_modal.test.tsx` 2/2, which already pinned the PATCH body as exactly `{litellm_params: {api_key}, model_info: {id}}`.

Steps below are the live runbook to capture the images and the request bodies, not results I observed. Shared setup, run once:

    python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log

Serve the dashboard from `localhost` on a free port, pointed at that proxy, and open devtools on the Network tab before each case.

### Before (340d30867e)

    git checkout 340d30867e && cd ui/litellm-dashboard && PORT=<free port> npm run dev

#### Model settings

1. Open http://localhost:<port>/?page=models and click Model Settings
2. Screenshot the dialog
3. Turn Store Model in DB on and click Save Settings
4. Copy the request body of the POST to /config/field/update

#### Update API key

1. Open http://localhost:<port>/?page=models, open any deployment, click Update API Key
2. Screenshot the dialog
3. Type a throwaway key and click Update API Key
4. Copy the request body of the PATCH to /model/update

### After (b995c9a641)

    git checkout b995c9a641 && cd ui/litellm-dashboard && PORT=<free port> npm run dev

#### Model settings

1. Open http://localhost:<port>/?page=models and click Model Settings
2. Screenshot the dialog
3. Turn Store Model in DB on and click Save Settings
4. Copy the request body of the POST to /config/field/update, and confirm it matches the Before body byte for byte

#### Update API key

1. Open http://localhost:<port>/?page=models, open any deployment, click Update API Key
2. Screenshot the dialog
3. Type a throwaway key and click Update API Key
4. Copy the request body of the PATCH to /model/update, and confirm it matches the Before body byte for byte

## Type

🧹 Refactoring

## Caveats (if any)

- Model settings labels move from inline to above their control
- antd Modal, Alert and Skeleton stay, so not fully dark-clean
- Enter still submits the key dialog, matching the antd original
- The add_model and model_info_view form graph is untouched

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
