### PR TITLE
fix(responses): strip the responses/ routing prefix on the Responses API path

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -640,6 +640,15 @@ def _pop_use_chat_completions_api_kw(kwargs: dict[str, object]) -> bool:
     return bool(use_cc)
 
 
+_RESPONSES_ROUTING_PREFIX: Final = "responses/"
+
+
+def _strip_responses_routing_prefix(model: str) -> str:
+    if not model.startswith(_RESPONSES_ROUTING_PREFIX):
+        return model
+    return model[len(_RESPONSES_ROUTING_PREFIX) :]
+
+
 def _resolve_model_provider_for_responses(
     model: str,
     custom_llm_provider: str | None,
@@ -649,20 +658,20 @@ def _resolve_model_provider_for_responses(
     if custom_llm_provider is not None and not litellm_params.custom_llm_provider:
         litellm_params.custom_llm_provider = custom_llm_provider
     (
-        model,
-        custom_llm_provider,
+        provider_model,
+        resolved_provider,
         dynamic_api_key,
         dynamic_api_base,
     ) = litellm.get_llm_provider(
         model=model,
         litellm_params=litellm_params,
     )
-    local_vars["custom_llm_provider"] = custom_llm_provider
+    local_vars["custom_llm_provider"] = resolved_provider
     if dynamic_api_key is not None:
         litellm_params.api_key = dynamic_api_key
     if dynamic_api_base is not None:
         litellm_params.api_base = dynamic_api_base
-    return model, custom_llm_provider
+    return _strip_responses_routing_prefix(provider_model), resolved_provider
 
 
 def _apply_managed_file_id_mapping(
@@ -1997,7 +2006,7 @@ async def _aresponses_websocket(
     litellm_params_dict: Final = get_litellm_params(**kwargs)
 
     (
-        model,
+        provider_model,
         _custom_llm_provider,
         dynamic_api_key,
         dynamic_api_base,
@@ -2006,6 +2015,7 @@ async def _aresponses_websocket(
         api_base=api_base,
         api_key=api_key,
     )
+    resolved_model: Final = _strip_responses_routing_prefix(provider_model)
 
     litellm_params_dict["data_residency"] = infer_openai_data_residency(
         _custom_llm_provider,
@@ -2014,7 +2024,7 @@ async def _aresponses_websocket(
 
     litellm_logging_obj.update_from_kwargs(
         kwargs=kwargs,
-        model=model,
+        model=resolved_model,
         user=user,
         optional_params={},
         litellm_params=litellm_params_dict,
@@ -2024,7 +2034,7 @@ async def _aresponses_websocket(
     responses_api_provider_config: BaseResponsesAPIConfig | None = None
     if _custom_llm_provider is not None:
         responses_api_provider_config = ProviderConfigManager.get_provider_responses_api_config(
-            model=model,
+            model=resolved_model,
             provider=litellm.LlmProviders(_custom_llm_provider),
         )
 
@@ -2052,7 +2062,7 @@ async def _aresponses_websocket(
     remaining_kwargs: Final = {k: v for k, v in kwargs.items() if k not in _explicit_keys}
 
     await base_llm_http_handler.async_responses_websocket(
-        model=model,
+        model=resolved_model,
         websocket=websocket,
         logging_obj=litellm_logging_obj,
         responses_api_provider_config=responses_api_provider_config,

--- a/tests/test_litellm/responses/test_responses_api_request_body.py
+++ b/tests/test_litellm/responses/test_responses_api_request_body.py
@@ -12,6 +12,7 @@ import httpx
 import pytest
 
 import litellm
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
 
 def _expected_dir() -> Path:
@@ -384,22 +385,21 @@ async def test_aresponses_strips_responses_routing_prefix_from_openai_model(mode
     /v1/responses and via the /v1/messages adapter (which passes responses/<model>
     with custom_llm_provider="openai"), so both shapes must hit OpenAI as <model>.
     """
-    with patch(
-        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
-        new_callable=AsyncMock,
-    ) as mock_post:
-        mock_post.return_value = MockResponse(_minimal_responses_api_payload("resp_prefix_test", "gpt-5.6"), 200)
+    injected_client = AsyncHTTPHandler()
+    mock_post = AsyncMock(return_value=MockResponse(_minimal_responses_api_payload("resp_prefix_test", "gpt-5.6"), 200))
+    injected_client.post = mock_post
 
-        await litellm.aresponses(
-            model=model,
-            custom_llm_provider=custom_llm_provider,
-            input="ping",
-            api_key="sk-test",
-        )
+    await litellm.aresponses(
+        model=model,
+        custom_llm_provider=custom_llm_provider,
+        input="ping",
+        api_key="sk-test",
+        client=injected_client,
+    )
 
-        mock_post.assert_called_once()
-        assert mock_post.call_args.kwargs["url"].endswith("/responses")
-        assert mock_post.call_args.kwargs["json"]["model"] == "gpt-5.6"
+    mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs["url"].endswith("/responses")
+    assert mock_post.call_args.kwargs["json"]["model"] == "gpt-5.6"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/responses/test_responses_api_request_body.py
+++ b/tests/test_litellm/responses/test_responses_api_request_body.py
@@ -367,3 +367,58 @@ async def test_aresponses_client_header_conflict_is_case_insensitive():
 
     assert [name for name in request_headers if name.lower() == "x-shared"] == ["x-shared"]
     assert request_headers["x-shared"] == "from-caller"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "custom_llm_provider"),
+    [
+        ("openai/responses/gpt-5.6", None),
+        ("responses/gpt-5.6", "openai"),
+    ],
+)
+async def test_aresponses_strips_responses_routing_prefix_from_openai_model(model, custom_llm_provider):
+    """
+    `responses/` is LiteLLM routing sugar, never part of the provider model id.
+    Deployments configured as openai/responses/<model> reach this path directly via
+    /v1/responses and via the /v1/messages adapter (which passes responses/<model>
+    with custom_llm_provider="openai"), so both shapes must hit OpenAI as <model>.
+    """
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        mock_post.return_value = MockResponse(_minimal_responses_api_payload("resp_prefix_test", "gpt-5.6"), 200)
+
+        await litellm.aresponses(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            input="ping",
+            api_key="sk-test",
+        )
+
+        mock_post.assert_called_once()
+        assert mock_post.call_args.kwargs["url"].endswith("/responses")
+        assert mock_post.call_args.kwargs["json"]["model"] == "gpt-5.6"
+
+
+@pytest.mark.asyncio
+async def test_aresponses_websocket_strips_responses_routing_prefix_from_openai_model():
+    from unittest.mock import MagicMock
+
+    from litellm.responses.main import _aresponses_websocket
+
+    with patch(
+        "litellm.responses.main.base_llm_http_handler.async_responses_websocket",
+        new_callable=AsyncMock,
+    ) as mock_ws:
+        await _aresponses_websocket(
+            model="openai/responses/gpt-5.6",
+            websocket=MagicMock(),
+            api_key="sk-test",
+            litellm_logging_obj=MagicMock(),
+        )
+
+        mock_ws.assert_awaited_once()
+        assert mock_ws.call_args.kwargs["model"] == "gpt-5.6"
+        assert mock_ws.call_args.kwargs["custom_llm_provider"] == "openai"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `openai/responses/<model>` deployments 400 on `/v1/messages` and `/v1/responses`
- OpenAI receives the literal model id `responses/gpt-5.6` and says model_not_found
- Only `/v1/chat/completions` strips the `responses/` routing prefix today

How it solves it:

- Strip a leading `responses/` right after provider resolution on the Responses API path
- Covers `/v1/responses`, its websocket mode, compaction, and the `/v1/messages` adapter
- Regression tests assert the wire model is `gpt-5.6` for both call shapes

## User Flow

Before: a developer whose gateway lists a model as `openai/responses/gpt-5.6` can chat with it, but the same model 400s on the Anthropic-style and Responses routes

1. The proxy admin adds `model_name: gpt-5.6-responses` with `litellm_params.model: openai/responses/gpt-5.6` and boots the proxy
2. The developer sends POST https://litellm-domain/v1/chat/completions with `{"model":"gpt-5.6-responses","messages":[{"role":"user","content":"Reply with exactly: pong"}]}` and gets HTTP 200 with `pong`
3. They send POST https://litellm-domain/v1/messages with `{"model":"gpt-5.6-responses","max_tokens":50,"messages":[...]}` and get HTTP 400 `The requested model 'responses/gpt-5.6' does not exist ... model_not_found`
4. They send POST https://litellm-domain/v1/responses with `{"model":"gpt-5.6-responses","input":"Reply with exactly: pong"}` and get the same HTTP 400 model_not_found

After: the same model answers on all three routes

1. The proxy admin adds `model_name: gpt-5.6-responses` with `litellm_params.model: openai/responses/gpt-5.6` and boots the proxy
2. The developer sends POST https://litellm-domain/v1/chat/completions with `{"model":"gpt-5.6-responses","messages":[{"role":"user","content":"Reply with exactly: pong"}]}` and gets HTTP 200 with `pong`
3. They send POST https://litellm-domain/v1/messages with `{"model":"gpt-5.6-responses","max_tokens":50,"messages":[...]}` and get HTTP 200 with an Anthropic-shaped `content` block reading `pong`
4. They send POST https://litellm-domain/v1/responses with `{"model":"gpt-5.6-responses","input":"Reply with exactly: pong"}` and get HTTP 200 with a `resp_...` id and `output_text` `pong`

## Relevant issues

## Linear ticket

Resolves LIT-5720

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: no-DB proxy on a random port with this config, real OpenAI key, plain curl on each route

```yaml
model_list:
  - model_name: gpt-5.6-responses
    litellm_params:
      model: openai/responses/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234
```

### Before (6d32d4081d)

#### /v1/chat/completions

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:52731/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"gpt-5.6-responses","messages":[{"role":"user","content":"Reply with exactly: pong"}],"max_tokens":50}'`
2. HTTP 200, `choices[0].message.content` = `pong`

#### /v1/messages

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:52731/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"gpt-5.6-responses","max_tokens":50,"messages":[{"role":"user","content":"Reply with exactly: pong"}]}'`
2. HTTP 400, `{"error":{"message":"litellm.NotFoundError: OpenAIException - {\"error\": {\"message\": \"The requested model 'responses/gpt-5.6' does not exist.\", \"type\": \"invalid_request_error\", \"param\": \"model\", \"code\": \"model_not_found\"}}. Received Model Group=gpt-5.6-responses ...","code":"400"}}`

#### /v1/responses

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:52731/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"gpt-5.6-responses","input":"Reply with exactly: pong","max_output_tokens":50}'`
2. HTTP 400, same `model_not_found` error for `responses/gpt-5.6`

### After (61625723a7)

#### /v1/chat/completions

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:52732/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"gpt-5.6-responses","messages":[{"role":"user","content":"Reply with exactly: pong"}],"max_tokens":50}'`
2. HTTP 200, `choices[0].message.content` = `pong`, `x-litellm-response-cost: 0.000205`

#### /v1/messages

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:52732/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"gpt-5.6-responses","max_tokens":50,"messages":[{"role":"user","content":"Reply with exactly: pong"}]}'`
2. HTTP 200, `content` = `[{"type":"text","text":"pong"}]`, `stop_reason` = `end_turn`, `x-litellm-response-cost: 0.000205`

#### /v1/responses

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:52732/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"gpt-5.6-responses","input":"Reply with exactly: pong","max_output_tokens":50}'`
2. HTTP 200, `id` = `resp_N5DTZuTYJq8lLJLyvt3as1RD...`, `status` = `completed`, `output_text` = `pong`, `x-litellm-response-cost: 0.000205`

## Type

🐛 Bug Fix

## Caveats (if any)

- Azure keeps its own `responses/` strip in its Responses transformation; now a harmless duplicate on the regular responses path. That strip never covered /v1/responses/compact, so `azure/responses/<deployment>` on the compact route went from 404 DeploymentNotFound to 200 with this PR (verified live on a real Azure deployment)
- `azure/responses/<o-series>` models now select the O-series Azure Responses config (the stripped name makes `supports_reasoning` return True), whose only effect is dropping `temperature` under drop_params; analysis-only, no o-series deployment was available to drive live

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 39c5ccaed4f67d67c4452d2d818c2b5df1508722 passes /live-pr-risk (test-only delta over 61625723a7; runtime tree identical, live A/B ran at 61625723a7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 61625723a7b692f40d462001b83f560daca6d00a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
