### PR TITLE
fix(proxy): stop leaking the client_side_timeout marker to providers

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3476,6 +3476,7 @@ all_litellm_params = (
         "bos_token",
         "eos_token",
         "request_timeout",
+        "client_side_timeout",
         "complete_response",
         "self",
         "client",

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -1038,6 +1038,65 @@ async def test_add_litellm_data_to_request_ignores_forged_client_side_timeout():
 
 
 @pytest.mark.asyncio
+async def test_client_side_timeout_marker_never_reaches_the_provider():
+    """A proxy request with a caller-supplied timeout gets kwargs["client_side_timeout"]
+    stamped for the router's cooldown logic. That router-only marker must not ride
+    into the provider payload: unregistered kwargs are swept into extra_body /
+    additionalModelRequestFields, so Bedrock rejects the whole call with
+    `client_side_timeout: Extra inputs are not permitted`."""
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+    request_mock = MagicMock(spec=Request)
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url = MagicMock()
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {"Content-Type": "application/json"}
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+
+    updated = await add_litellm_data_to_request(
+        data={
+            "model": "bedrock/us.anthropic.claude-sonnet-5",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 10,
+            "timeout": 30,
+        },
+        request=request_mock,
+        user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key"),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+    assert updated["client_side_timeout"] is True
+
+    converse_response = MagicMock()
+    converse_response.status_code = 200
+    converse_response.headers = {}
+    converse_response.json.return_value = {
+        "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+    }
+    converse_response.text = json.dumps(converse_response.json.return_value)
+    client = AsyncHTTPHandler()
+    with patch.object(client, "post", return_value=converse_response) as mock_post:
+        await litellm.acompletion(
+            **updated,
+            aws_access_key_id="fake-access-key",
+            aws_secret_access_key="fake-secret-key",
+            aws_region_name="us-east-1",
+            client=client,
+        )
+
+    mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs["url"].endswith("/converse")
+    provider_body = json.loads(mock_post.call_args.kwargs["data"])
+    assert "client_side_timeout" not in json.dumps(provider_body), provider_body
+
+
+@pytest.mark.asyncio
 async def test_add_litellm_data_to_request_allows_client_mock_response_with_admin_opt_in():
     request_mock = MagicMock(spec=Request)
     request_mock.url.path = "/v1/chat/completions"

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4797,6 +4797,24 @@ def test_bedrock_batch_params_never_reach_the_provider():
     )
 
 
+def test_client_side_timeout_marker_never_reaches_the_provider():
+    """The proxy stamps kwargs["client_side_timeout"] = True whenever a request carries
+    a caller-supplied timeout (body timeout / request_timeout / stream_timeout or the
+    x-litellm-timeout headers) so the router can skip cooldowns on the resulting 408s.
+    The marker is only meaningful to the router, so it must be filtered out of the
+    provider params: swept into extra_body / additionalModelRequestFields it turns every
+    timed-out request into a provider 400 (`client_side_timeout: Extra inputs are not
+    permitted`)."""
+    kwargs = {"a_real_provider_specific_param": 1, "client_side_timeout": True}
+
+    non_default = get_non_default_completion_params(kwargs)
+
+    assert non_default == {"a_real_provider_specific_param": 1}, (
+        "client_side_timeout leaked into the provider params: "
+        f"{sorted(set(non_default) - {'a_real_provider_specific_param'})}"
+    )
+
+
 def test_rust_flag_not_forwarded_as_provider_param():
     forwarded = get_non_default_completion_params({"rust": True, "temperature": 0.5})
     assert "rust" not in forwarded


### PR DESCRIPTION
## TLDR

Problem this solves:

- Setting any request timeout through the proxy broke strict providers
- Bedrock returned 400 `client_side_timeout: Extra inputs are not permitted`
- Body `timeout`/`request_timeout`/`stream_timeout` and `x-litellm-timeout` headers all triggered it

How it solves it:

- Registers `client_side_timeout` in the LiteLLM-only param list
- The marker is now stripped before the provider payload is built
- Router cooldown logic still sees it and keeps skipping caller-caused 408s

## User Flow

Before: a developer who sets a request timeout gets a 400 from Bedrock instead of a completion

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "claude-sonnet-5", "timeout": 30` against a Bedrock deployment
2. The response is HTTP 400 with `BedrockException - {"message":"The model returned the following errors: client_side_timeout: Extra inputs are not permitted"}`
3. Sending the same request without a body timeout but with an `x-litellm-timeout: 30` header fails with the identical 400
4. Only requests with no timeout at all return 200

After: the same timeout-carrying requests complete normally

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "claude-sonnet-5", "timeout": 30` against a Bedrock deployment
2. The response is HTTP 200 with the model's completion
3. The same request with the `x-litellm-timeout: 30` header also returns 200
4. The timeout still applies: a deliberately tiny `x-litellm-timeout` still returns the usual 408 timeout error

## Relevant issues

## Linear ticket

Resolves LIT-5755

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: proxy booted with this config against real Bedrock (bearer token auth), `curl` as the client

```yaml
model_list:
  - model_name: claude-sonnet-5
    litellm_params:
      model: bedrock/us.anthropic.claude-sonnet-5
      aws_region_name: us-east-1
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

### Before (6d32d4081d)

#### /v1/chat/completions with body `"timeout": 30`

1. `curl -s http://127.0.0.1:31700/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"model":"claude-sonnet-5","messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":10,"timeout":30}'`
2. HTTP 400: `{"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: client_side_timeout: Extra inputs are not permitted\"}. Received Model Group=claude-sonnet-5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}`

#### /v1/chat/completions with header `x-litellm-timeout: 30`

1. `curl -s http://127.0.0.1:31700/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "x-litellm-timeout: 30" -H "Content-Type: application/json" -d '{"model":"claude-sonnet-5","messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":10}'`
2. HTTP 400 with the same `client_side_timeout: Extra inputs are not permitted` BedrockException

#### /v1/responses with header `x-litellm-timeout: 30`

1. `curl -s http://127.0.0.1:31700/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "x-litellm-timeout: 30" -H "Content-Type: application/json" -d '{"model":"claude-sonnet-5","input":"Say hi in one word","max_output_tokens":16}'`
2. HTTP 400 with the same `client_side_timeout: Extra inputs are not permitted` BedrockException

#### /v1/messages with header `x-litellm-timeout: 30`

1. `curl -s http://127.0.0.1:31700/v1/messages -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "x-litellm-timeout: 30" -H "Content-Type: application/json" -d '{"model":"claude-sonnet-5","messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":10}'`
2. HTTP 200 (this endpoint already filtered the marker; included for coverage): `{"model":"claude-sonnet-5","id":"msg_bdrk_hqnd...","type":"message","role":"assistant","content":[{"type":"text","text":"Hi!"}],"stop_reason":"end_turn",...}`

### After (e3a93c40be)

#### /v1/chat/completions with body `"timeout": 30`

1. `curl -s http://127.0.0.1:23011/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"model":"claude-sonnet-5","messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":10,"timeout":30}'`
2. HTTP 200: `{"id":"chatcmpl-...","model":"claude-sonnet-5","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"**Hi!**","role":"assistant"}}],"usage":{"completion_tokens":8,"prompt_tokens":13,"total_tokens":21,...}}`

#### /v1/chat/completions with header `x-litellm-timeout: 30`

1. `curl -s http://127.0.0.1:23011/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "x-litellm-timeout: 30" -H "Content-Type: application/json" -d '{"model":"claude-sonnet-5","messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":10}'`
2. HTTP 200 with the model's completion
3. The timeout still applies: repeating with `x-litellm-timeout: 0.001` returns HTTP 408 `{"error":{"message":"litellm.Timeout: Connection timed out. Timeout passed=Timeout(timeout=0.001), time taken=0.009 seconds\n\nDeployment Info: request_timeout: None\ntimeout: None. Received Model Group=claude-sonnet-5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"408"}}`

#### /v1/responses with header `x-litellm-timeout: 30`

1. `curl -s http://127.0.0.1:23011/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "x-litellm-timeout: 30" -H "Content-Type: application/json" -d '{"model":"claude-sonnet-5","input":"Say hi in one word","max_output_tokens":16}'`
2. HTTP 200: `{"id":"resp_s6ZC...","object":"response",...}` with the model's output

#### /v1/messages with header `x-litellm-timeout: 30`

1. `curl -s http://127.0.0.1:23011/v1/messages -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "x-litellm-timeout: 30" -H "Content-Type: application/json" -d '{"model":"claude-sonnet-5","messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":10}'`
2. HTTP 200: `{"model":"claude-sonnet-5","id":"msg_bdrk_t7us...","type":"message","role":"assistant",...}`

Observations from the run:

- /v1/messages never leaked the marker; this PR leaves it alone
- Before-leg /v1/responses failed too: symptom broader than ticket narrated

## Type

🐛 Bug Fix

## Caveats (if any)

- With `enable_caching_on_provider_specific_optional_params` on, the marker no longer fragments cache keys (intended)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e3a93c40be34ef06ab8c8099afd967f337e63f5d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] e3a93c40be34ef06ab8c8099afd967f337e63f5d passes /live-pr-risk


