### PR TITLE
test(anthropic): pin one content_block_stop per tool_use block on the Responses adapter

### DIFF
--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
@@ -168,7 +168,7 @@ class TestToolUseBlockClosedExactlyOnce:
     """
 
     @staticmethod
-    def _chat_completions_bridge_tool_turn() -> list:
+    def _chat_completions_bridge_tool_turn() -> list[dict[str, object]]:
         return [
             {"type": "response.created"},
             {

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
@@ -148,6 +148,76 @@ class TestReasoningItemWithoutSummaryText:
         assert "".join(c["delta"]["thinking"] for c in chunks[2:4]) == "Weighing options"
 
 
+class TestToolUseBlockClosedExactlyOnce:
+    """Regression for https://github.com/BerriAI/litellm/issues/37273.
+
+    With ``custom_llm_provider: openai`` + ``use_chat_completions_api: true``,
+    ``/v1/messages`` streams through ``LiteLLMCompletionStreamingIterator``,
+    which ends a tool-call turn with two ``response.output_item.done`` events:
+    one for the function_call item (id = call_id) and one for a synthetic
+    message item whose id is the upstream chatcmpl id and was never opened as a
+    content block. Resolving that unknown item id to ``_current_block_index``
+    closed the tool_use block a second time::
+
+        content_block_start[0](tool_use) -> content_block_stop[0]
+        -> content_block_stop[0] -> message_delta(stop_reason=tool_use)
+
+    Anthropic SDK clients (e.g. Claude Code) materialize one tool_use block per
+    ``content_block_stop``, so the tool executed twice. An ``output_item.done``
+    for an item that never opened a block must emit nothing.
+    """
+
+    @staticmethod
+    def _chat_completions_bridge_tool_turn() -> list:
+        return [
+            {"type": "response.created"},
+            {
+                "type": "response.output_item.added",
+                "item": {"type": "function_call", "id": "call_1", "call_id": "call_1", "name": "get_weather"},
+            },
+            {"type": "response.function_call_arguments.delta", "item_id": "call_1", "delta": '{"city": "'},
+            {"type": "response.function_call_arguments.delta", "item_id": "call_1", "delta": 'Tokyo"}'},
+            {
+                "type": "response.function_call_arguments.done",
+                "item_id": "call_1",
+                "arguments": '{"city": "Tokyo"}',
+            },
+            {
+                "type": "response.output_item.done",
+                "item": {"type": "function_call", "id": "call_1", "call_id": "call_1", "status": "completed"},
+            },
+            {
+                "type": "response.output_item.done",
+                "item": {"type": "message", "id": "chatcmpl-123", "status": "completed"},
+            },
+        ]
+
+    def test_one_content_block_stop_per_content_block_start(self):
+        chunks = _drain_async(self._chat_completions_bridge_tool_turn())
+
+        starts = [c["index"] for c in chunks if c["type"] == "content_block_start"]
+        stops = [c["index"] for c in chunks if c["type"] == "content_block_stop"]
+        assert starts == [0]
+        assert stops == [0]
+
+    def test_tool_turn_event_order(self):
+        chunks = _drain_async(self._chat_completions_bridge_tool_turn())
+
+        assert [(c["type"], c.get("index")) for c in chunks] == [
+            ("message_start", None),
+            ("content_block_start", 0),
+            ("content_block_delta", 0),
+            ("content_block_delta", 0),
+            ("content_block_stop", 0),
+        ]
+        assert chunks[1]["content_block"] == {
+            "type": "tool_use",
+            "id": "call_1",
+            "name": "get_weather",
+            "input": {},
+        }
+
+
 class TestProcessEventTextDeltaWithoutOutputItemAdded:
     """Streams that skip response.output_item.added (e.g. LMStudio) must still
     open a text block before any delta and never emit index -1."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- /v1/messages tool streams emitted two content_block_stop for one tool_use block
- Claude Code materializes a block per stop, so tools executed twice
- The emitter fix landed in #36033 with no tool_use regression test

How it solves it:

- Pins the chat-completions bridge tool turn in the Responses adapter tests
- Asserts exactly one content_block_stop per content_block_start
- Fails on pre #36033 code with the exact duplicate stop

## User Flow

Before: a Claude Code user pointed at LiteLLM with an OpenAI-compatible chat-completions model watches every tool run twice

1. The proxy admin configures a model with `custom_llm_provider: openai` and `use_chat_completions_api: true`, and the user points Claude Code at the proxy (`ANTHROPIC_BASE_URL=http://litellm-domain`)
2. The user asks Claude Code to run a command exactly once: `echo ran >> runs.log`
3. Claude Code sends POST http://litellm-domain/v1/messages with `"stream": true` and its tool definitions
4. The SSE stream comes back with one `content_block_start` (tool_use) at index 0 followed by two `content_block_stop` at index 0
5. Claude Code executes the command twice: `runs.log` contains two `ran` lines even though the UI shows one shell command

After: the same request streams one stop per block and the tool runs once

1. The proxy admin configures the same model and the user points Claude Code at the proxy the same way
2. The user asks Claude Code to run the same command exactly once
3. Claude Code sends the same POST http://litellm-domain/v1/messages with `"stream": true`
4. The SSE stream comes back with exactly one `content_block_stop` per `content_block_start`
5. The command runs once: `runs.log` contains a single `ran` line

## Relevant issues

Fixes #37273

## Linear ticket

Resolves LIT-5751

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

The duplicate stop reproduces at the reporter's pinned v1.97.0 but not at this PR's merge base: the emitter fix landed on litellm_internal_staging in #36033 (merged after the issue was filed, unreleased, rides v1.98.0). Before is therefore captured at v1.97.0, where the regression this test pins is live; After is the PR tip. Both runs use a live proxy against real api.openai.com and a real Claude Code session, no mocks

Shared setup: proxy config with `gpt-5.6-luna`, `custom_llm_provider: openai`, `use_chat_completions_api: true`, `api_base: https://api.openai.com/v1`, `reasoning_effort: none` (real OpenAI rejects function tools on chat completions for this model otherwise); streaming request `messages_tool_request_auto.json` = `{"model": "gpt-5.6-luna", "max_tokens": 512, "stream": true, "tools": [get_weather], "messages": [asking for Tokyo weather via the tool]}`

### Before (ef84494d52, tag v1.97.0)

#### Raw SSE: two content_block_stop for one tool_use block

1. `curl -sN http://localhost:47911/v1/messages -H "Authorization: Bearer sk-repro-37273" -H "content-type: application/json" -H "anthropic-version: 2023-06-01" -d @messages_tool_request_auto.json > v1970_auto_tool.sse`
2. Event order observed: `content_block_start[0](tool_use) -> content_block_stop[0] -> content_block_stop[0] -> message_delta(stop_reason=tool_use)`
3. Counting per index: `index 0: content_block_start=1 content_block_stop=2` (MISMATCH)

#### Claude Code executes the tool twice

1. `env -u ANTHROPIC_API_KEY ANTHROPIC_BASE_URL=http://localhost:47911 ANTHROPIC_AUTH_TOKEN=sk-repro-37273 claude --model gpt-5.6-luna`, prompt: "Use the Bash tool to run this command exactly once: echo ran >> runs.log . Then say done."
2. TUI shows "Ran 1 shell command" then "done"
3. `cat runs.log` prints `ran` twice (`wc -l` = 2): the single requested command executed twice

#### Upstream control: chat completions itself is well formed

1. `curl -sN http://localhost:47911/v1/chat/completions` with the same tool and prompt
2. Exactly one tool_call id, one `get_weather` name, `finish_reasons=['tool_calls']`, so the duplication happens in the translation layer

### After (9b837fccde)

#### Raw SSE: two content_block_stop for one tool_use block

1. `curl -sN http://localhost:46322/v1/messages -H "Authorization: Bearer sk-repro-37273" -H "content-type: application/json" -H "anthropic-version: 2023-06-01" -d @messages_tool_request_auto.json > head_auto_tool.sse`
2. Event order observed: `content_block_start[0](tool_use) -> content_block_stop[0] -> message_delta(stop_reason=tool_use)`
3. Counting per index: `index 0: content_block_start=1 content_block_stop=1` (1:1 OK)

#### Claude Code executes the tool twice

1. Same Claude Code launch against port 46322, same prompt
2. TUI shows "Ran 1 shell command" then "done"
3. `cat runs.log` prints `ran` once (`wc -l` = 1)

#### Upstream control: chat completions itself is well formed

1. Same `/v1/chat/completions` curl against port 46322
2. Exactly one tool_call id, one `get_weather` name, `finish_reasons=['tool_calls']`

The new test replays the bridge's exact event sequence (function_call output_item.done followed by the synthetic message item output_item.done whose id never opened a block) and fails on pre #36033 code with the extra `('content_block_stop', 0)` while passing at this tip

## Type

✅ Test

## Caveats (if any)

- Behavioral fix shipped in #36033, unreleased; v1.97.x users need v1.98.0 or a backport
- `tool_choice: {"type": "tool", ...}` crashes this bridge on both versions, separate pre-existing bug

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 9b837fccde passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths modified.
> 
> **Overview**
> Adds **`TestToolUseBlockClosedExactlyOnce`** to the Anthropic Responses adapter streaming iterator tests, locking in behavior for [#37273](https://github.com/BerriAI/litellm/issues/37273).
> 
> The tests replay the **chat-completions bridge** tool-turn sequence: a `function_call` stream followed by two `response.output_item.done` events (the real tool item plus a synthetic `message` item whose id never opened a block). They assert **one `content_block_stop` per `content_block_start`** and the expected Anthropic event order for a single `tool_use` block. Pre-#36033 adapter code would fail with a duplicate stop at index 0; this PR does not change production code—only prevents that regression from returning unnoticed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b837fccde6bf20142e97e734dcc44595f555e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->