### PR TITLE
feat(guardrails): count bedrock guardrail cost against spend and budgets

### DIFF
--- a/ci_cd/generate_model_prices_schema.py
+++ b/ci_cd/generate_model_prices_schema.py
@@ -41,6 +41,11 @@ OBJECT_KEYS: dict[str, JsonSchema] = {
         },
         "additionalProperties": False,
     },
+    "guardrail_cost_per_unit": {
+        "type": "object",
+        "description": "USD cost per billable guardrail unit, keyed by the provider's usage counter name (e.g. Bedrock's contentPolicyUnits).",
+        "additionalProperties": NONNEG_NUMBER,
+    },
     "metadata": {
         "type": "object",
         "description": "Free-form notes about the entry (e.g. pricing derivation).",

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -792,6 +792,8 @@ def _populate_provider_model_sets(model_cost_map: Dict) -> None:
             nlp_cloud_models.add(key)
         elif value.get("litellm_provider") == "aleph_alpha":
             aleph_alpha_models.add(key)
+        elif value.get("litellm_provider") == "bedrock" and value.get("mode") == "guardrail":
+            pass
         elif value.get("litellm_provider") == "bedrock" and not is_bedrock_pricing_only_model(key):
             bedrock_models.add(key)
         elif value.get("litellm_provider") == "bedrock_converse":

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -64,6 +64,10 @@ from litellm.integrations.mlflow import MlflowLogger
 from litellm.integrations.sqs import SQSLogger
 from litellm.litellm_core_utils.core_helpers import reconstruct_model_name
 from litellm.litellm_core_utils.get_litellm_params import get_litellm_params
+from litellm.litellm_core_utils.llm_cost_calc.guardrail_cost import (
+    cost_breakdown_with_guardrail,
+    guardrail_information_cost,
+)
 from litellm.litellm_core_utils.llm_cost_calc.tool_call_cost_tracking import (
     StandardBuiltInToolCostTracking,
 )
@@ -5650,12 +5654,14 @@ def get_standard_logging_object_payload(
             base_model = metadata.get("deployment")
         custom_pricing: Final = use_custom_pricing_for_model(litellm_params=litellm_params)
         raw_response_cost: Final = kwargs.get("response_cost")
-        response_cost: Final[float] = raw_response_cost or 0.0
+        llm_response_cost: Final[float] = raw_response_cost or 0.0
+        guardrail_cost: Final = guardrail_information_cost(metadata.get("standard_logging_guardrail_information"))
+        response_cost: Final[float] = llm_response_cost + guardrail_cost
 
         # clean up litellm hidden params
         clean_hidden_params: Final = StandardLoggingPayloadSetup.get_hidden_params(hidden_params)
         if clean_hidden_params["response_cost"] is None and raw_response_cost is not None:
-            clean_hidden_params["response_cost"] = response_cost
+            clean_hidden_params["response_cost"] = llm_response_cost
 
         model_cost_information: Final = StandardLoggingPayloadSetup.get_model_cost_information(
             base_model=base_model,
@@ -5735,7 +5741,7 @@ def get_standard_logging_object_payload(
             metadata=clean_metadata,
             cache_key=clean_hidden_params["cache_key"],
             response_cost=response_cost,
-            cost_breakdown=logging_obj.cost_breakdown,
+            cost_breakdown=cost_breakdown_with_guardrail(logging_obj.cost_breakdown, guardrail_cost),
             total_tokens=usage_dict.get("total_tokens", 0),
             prompt_tokens=usage_dict.get("prompt_tokens", 0),
             completion_tokens=usage_dict.get("completion_tokens", 0),

--- a/litellm/litellm_core_utils/llm_cost_calc/guardrail_cost.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/guardrail_cost.py
@@ -1,0 +1,70 @@
+from collections.abc import Mapping
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
+
+import litellm
+from litellm._logging import verbose_logger
+from litellm.types.utils import CostBreakdown
+
+BEDROCK_GUARDRAIL_PRICING_KEY: Final = "bedrock/guardrails"
+
+
+class GuardrailPricing(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    guardrail_cost_per_unit: Mapping[str, float]
+
+
+class GuardrailCostEntry(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    guardrail_cost: float | None = None
+
+
+GuardrailInformationShape = tuple[GuardrailCostEntry, ...] | GuardrailCostEntry | None
+
+_GUARDRAIL_INFORMATION_ADAPTER: Final[TypeAdapter[GuardrailInformationShape]] = TypeAdapter(GuardrailInformationShape)
+
+
+def _bedrock_guardrail_pricing(aws_region_name: str | None) -> GuardrailPricing | None:
+    regional_key: Final = f"bedrock/{aws_region_name}/guardrails" if aws_region_name else None
+    for key in (regional_key, BEDROCK_GUARDRAIL_PRICING_KEY):
+        if key is None or key not in litellm.model_cost:
+            continue
+        try:
+            return GuardrailPricing.model_validate(litellm.model_cost[key])
+        except ValidationError as e:
+            verbose_logger.warning("Ignoring malformed guardrail pricing entry %s: %s", key, e)
+    return None
+
+
+def bedrock_guardrail_cost(usage_units: Mapping[str, int], aws_region_name: str | None) -> float:
+    pricing: Final = _bedrock_guardrail_pricing(aws_region_name)
+    if pricing is None:
+        return 0.0
+    return sum(units * pricing.guardrail_cost_per_unit.get(counter, 0.0) for counter, units in usage_units.items())
+
+
+def guardrail_information_cost(guardrail_information: object) -> float:
+    try:
+        parsed: Final = _GUARDRAIL_INFORMATION_ADAPTER.validate_python(guardrail_information)
+    except ValidationError:
+        return 0.0
+    if parsed is None:
+        return 0.0
+    if isinstance(parsed, GuardrailCostEntry):
+        return parsed.guardrail_cost or 0.0
+    return sum(entry.guardrail_cost or 0.0 for entry in parsed)
+
+
+def cost_breakdown_with_guardrail(cost_breakdown: CostBreakdown | None, guardrail_cost: float) -> CostBreakdown | None:
+    if guardrail_cost <= 0.0:
+        return cost_breakdown
+    existing: Final[CostBreakdown] = cost_breakdown if cost_breakdown is not None else CostBreakdown()
+    merged: Final[CostBreakdown] = {
+        **existing,
+        "guardrail_cost": guardrail_cost,
+        "total_cost": existing.get("total_cost", 0.0) + guardrail_cost,
+    }
+    return merged

--- a/litellm/litellm_core_utils/llm_cost_calc/guardrail_cost.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/guardrail_cost.py
@@ -1,3 +1,4 @@
+import math
 from collections.abc import Mapping
 from typing import Final
 
@@ -46,6 +47,13 @@ def bedrock_guardrail_cost(usage_units: Mapping[str, int], aws_region_name: str 
     return sum(units * pricing.guardrail_cost_per_unit.get(counter, 0.0) for counter, units in usage_units.items())
 
 
+def _billable_entry_cost(entry: GuardrailCostEntry) -> float:
+    cost: Final = entry.guardrail_cost
+    if cost is None or not math.isfinite(cost) or cost <= 0.0:
+        return 0.0
+    return cost
+
+
 def guardrail_information_cost(guardrail_information: object) -> float:
     try:
         parsed: Final = _GUARDRAIL_INFORMATION_ADAPTER.validate_python(guardrail_information)
@@ -54,8 +62,8 @@ def guardrail_information_cost(guardrail_information: object) -> float:
     if parsed is None:
         return 0.0
     if isinstance(parsed, GuardrailCostEntry):
-        return parsed.guardrail_cost or 0.0
-    return sum(entry.guardrail_cost or 0.0 for entry in parsed)
+        return _billable_entry_cost(parsed)
+    return sum(_billable_entry_cost(entry) for entry in parsed)
 
 
 def cost_breakdown_with_guardrail(cost_breakdown: CostBreakdown | None, guardrail_cost: float) -> CostBreakdown | None:

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10052,6 +10052,21 @@
         "output_cost_per_second": 0.0066027,
         "supports_tool_choice": true
     },
+    "bedrock/guardrails": {
+        "guardrail_cost_per_unit": {
+            "automatedReasoningPolicyUnits": 0.00017,
+            "contentPolicyImageUnits": 0.00075,
+            "contentPolicyUnits": 0.00015,
+            "contextualGroundingPolicyUnits": 0.0001,
+            "sensitiveInformationPolicyFreeUnits": 0.0,
+            "sensitiveInformationPolicyUnits": 0.0001,
+            "topicPolicyUnits": 0.00015,
+            "wordPolicyUnits": 0.0
+        },
+        "litellm_provider": "bedrock",
+        "mode": "guardrail",
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "bedrock/ap-northeast-1/1-month-commitment/anthropic.claude-instant-v1": {
         "input_cost_per_second": 0.01475,
         "litellm_provider": "bedrock",

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -31,11 +31,13 @@ from litellm.constants import (
     UNSAFE_PROXY_RESPONSE_HEADERS,
 )
 from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.litellm_core_utils.core_helpers import get_or_create_metadata_bucket
 from litellm.litellm_core_utils.dd_tracing import NullTracer, tracer
 from litellm.litellm_core_utils.get_supported_openai_params import (
     get_supported_openai_params,
 )
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.litellm_core_utils.llm_cost_calc.guardrail_cost import guardrail_information_cost
 from litellm.litellm_core_utils.llm_response_utils.get_headers import (
     get_response_headers,
 )
@@ -2197,10 +2199,20 @@ class ProxyBaseLLMRequestProcessing:
         additional_headers = hidden_params.get("additional_headers", {}) or {}
 
         recover_response_cost: Final = not response_cost and hidden_params.get("response_cost") is None
-        response_cost_for_headers: Final = (
+        llm_cost_for_headers: Final = (
             self._response_cost_from_logging_obj(response=response, logging_obj=logging_obj) or ""
             if recover_response_cost
             else response_cost
+        )
+        _, request_metadata_bucket = get_or_create_metadata_bucket(self.data)
+        guardrail_cost_for_headers: Final = guardrail_information_cost(
+            request_metadata_bucket.get("standard_logging_guardrail_information")
+        )
+        response_cost_for_headers: Final = (
+            (llm_cost_for_headers if isinstance(llm_cost_for_headers, (int, float)) else 0.0)
+            + guardrail_cost_for_headers
+            if guardrail_cost_for_headers > 0
+            else llm_cost_for_headers
         )
 
         fastapi_response.headers.update(

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -31,6 +31,7 @@ from litellm.constants import BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS
 from litellm.exceptions import ModifyResponseException
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.litellm_core_utils.core_helpers import redact_nested_match_and_regex_keys
+from litellm.litellm_core_utils.llm_cost_calc.guardrail_cost import bedrock_guardrail_cost
 from litellm.llms.anthropic.chat.guardrail_translation.handler import AnthropicMessagesHandler
 from litellm.llms.base_llm.guardrail_translation.utils import (
     effective_scan_only_tool_results_for_guardrail,
@@ -899,6 +900,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             request_data=request_data,
             event_type=event_type,
             start_time=start_time,
+            aws_region_name=aws_region_name,
         )
         return merged_response
 
@@ -1151,6 +1153,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     request_data=request_data,
                     event_type=event_type,
                     start_time=start_time,
+                    aws_region_name=aws_region_name,
                 )
                 raise self._get_http_exception_for_blocked_guardrail(
                     bedrock_guardrail_response, request_data=request_data
@@ -1172,11 +1175,14 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         request_data: dict | None,  # mutable-ok: proxy request body dict, mutated by the logging helper
         event_type: GuardrailEventHooks,
         start_time: "datetime",
+        aws_region_name: str | None,
     ) -> None:
         """Log a single ApplyGuardrail HTTP attempt as-is (its own status,
         derived from its own response). Used only for the blocked-content
         case, which ends the whole chunking flow immediately."""
-        tracing_detail: Final = self._build_tracing_detail(BedrockGuardrailResponse(**json_response))
+        tracing_detail: Final = self._build_tracing_detail(
+            BedrockGuardrailResponse(**json_response), aws_region_name=aws_region_name
+        )
         self.add_standard_logging_guardrail_information_to_request_data(
             guardrail_provider=self.guardrail_provider,
             guardrail_json_response=json_response,
@@ -1195,6 +1201,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         request_data: dict | None,  # mutable-ok: proxy request body dict, mutated by the logging helper
         event_type: GuardrailEventHooks,
         start_time: "datetime",
+        aws_region_name: str | None,
     ) -> None:
         """Log one logical ApplyGuardrail call -- possibly several chunk calls
         under the hood -- using its final merged response, so a chunked
@@ -1205,7 +1212,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         ``Output.__type`` with an exception marker. That marker survives the merge,
         so the status is derived from the merged response rather than assumed to be
         a success, which is what the pre-chunking code reported for that shape."""
-        tracing_detail: Final = self._build_tracing_detail(merged_response)
+        tracing_detail: Final = self._build_tracing_detail(merged_response, aws_region_name=aws_region_name)
         self.add_standard_logging_guardrail_information_to_request_data(
             guardrail_provider=self.guardrail_provider,
             guardrail_json_response=dict(merged_response),  # mutable-ok: logging helper requires a dict
@@ -2036,7 +2043,9 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 return (status_code, err)
         return (status_code, message)
 
-    def _build_tracing_detail(self, response: BedrockGuardrailResponse) -> GuardrailTracingDetail:
+    def _build_tracing_detail(
+        self, response: BedrockGuardrailResponse, aws_region_name: str | None
+    ) -> GuardrailTracingDetail:
         """
         Build the tracing detail from the raw Bedrock response, before
         redaction, so downstream loggers (OTEL, Langfuse, ...) get the
@@ -2060,6 +2069,9 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             }
             if usage_units:
                 tracing_detail["guardrail_usage"] = usage_units
+                tracing_detail["guardrail_cost"] = bedrock_guardrail_cost(
+                    usage_units=usage_units, aws_region_name=aws_region_name
+                )
         return tracing_detail
 
     def _extract_violation_category_names(self, response: BedrockGuardrailResponse) -> list[str]:

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -894,6 +894,8 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     request_data=request_data,
                     event_type=event_type,
                     start_time=start_time,
+                    aws_region_name=aws_region_name,
+                    completed_chunk_usages=completed_chunk_usages,
                 )
             raise
         merged_response: Final = self._merge_bedrock_guardrail_responses(responses)
@@ -1268,20 +1270,36 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         request_data: dict | None,  # mutable-ok: proxy request body dict, mutated by the logging helper
         event_type: GuardrailEventHooks,
         start_time: "datetime",
+        aws_region_name: str | None,
+        completed_chunk_usages: Sequence[BedrockGuardrailUsage],
     ) -> None:
         """Log one logical ApplyGuardrail call that failed end-to-end (an
         unrecoverable too-large error, a non-size validation error, or
         exhausted throttle retries) as a single failure, rather than logging
-        every failed attempt chunking made along the way."""
+        every failed attempt chunking made along the way. Chunk calls AWS
+        billed before the failure still carry their usage and cost."""
+        billed_usage: Final = self._sum_usage_counters(completed_chunk_usages) if completed_chunk_usages else None
+        error_payload: Final = {"error": str(detail)}  # mutable-ok: logging helper requires a dict
+        json_response: Final = (
+            {**error_payload, "usage": billed_usage}  # mutable-ok: logging helper requires a dict
+            if billed_usage is not None
+            else error_payload
+        )
+        tracing_detail: Final = (
+            self._build_tracing_detail(BedrockGuardrailResponse(usage=billed_usage), aws_region_name=aws_region_name)
+            if billed_usage is not None
+            else None
+        )
         self.add_standard_logging_guardrail_information_to_request_data(
             guardrail_provider=self.guardrail_provider,
-            guardrail_json_response={"error": str(detail)},  # mutable-ok: logging helper requires a dict
+            guardrail_json_response=json_response,
             request_data=request_data or {},  # mutable-ok: logging helper requires a dict
             guardrail_status="guardrail_failed_to_respond",
             start_time=start_time.timestamp(),
             end_time=datetime.now(timezone.utc).timestamp(),
             duration=(datetime.now(timezone.utc) - start_time).total_seconds(),
             event_type=event_type,
+            tracing_detail=tracing_detail or None,
         )
 
     @staticmethod

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -873,6 +873,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         credentials, aws_region_name = self._load_credentials()
         allow_chunking: Final = not self._content_uses_contextual_grounding(content)
 
+        completed_chunk_usages: Final[list[BedrockGuardrailUsage]] = []  # mutable-ok: billed-chunk usage accumulator
         try:
             responses: Final = await self._apply_guardrail_content_with_chunking(
                 content=content,
@@ -884,6 +885,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 event_type=event_type,
                 start_time=start_time,
                 allow_chunking=allow_chunking,
+                completed_chunk_usages=completed_chunk_usages,
             )
         except HTTPException as exc:
             if not isinstance(exc.detail, dict):
@@ -915,6 +917,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         event_type: GuardrailEventHooks,
         start_time: "datetime",
         allow_chunking: bool,
+        completed_chunk_usages: list[BedrockGuardrailUsage],  # mutable-ok: billed-chunk usage accumulator
     ) -> tuple[BedrockContentChunkResult, ...]:
         """Post `content` to ApplyGuardrail, chunking only if AWS rejects it as too large.
 
@@ -961,6 +964,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 request_data=request_data,
                 event_type=event_type,
                 start_time=start_time,
+                completed_chunk_usages=completed_chunk_usages,
             )
             return (
                 BedrockContentChunkResult(
@@ -991,6 +995,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                             event_type=event_type,
                             start_time=start_time,
                             allow_chunking=allow_chunking,
+                            completed_chunk_usages=completed_chunk_usages,
                         )
                         for batch in batches
                     ]
@@ -1017,6 +1022,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     event_type=event_type,
                     start_time=start_time,
                     allow_chunking=allow_chunking,
+                    completed_chunk_usages=completed_chunk_usages,
                 )
                 second_results: Final = await self._apply_guardrail_content_with_chunking(
                     content=second_half,
@@ -1028,6 +1034,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     event_type=event_type,
                     start_time=start_time,
                     allow_chunking=allow_chunking,
+                    completed_chunk_usages=completed_chunk_usages,
                 )
                 combined_results: Final = tuple(first_results) + tuple(second_results)
                 if is_single_item_text_split:
@@ -1047,6 +1054,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         request_data: dict | None,  # mutable-ok: proxy request body dict, mutated by the logging helper
         event_type: GuardrailEventHooks,
         start_time: "datetime",
+        completed_chunk_usages: list[BedrockGuardrailUsage],  # mutable-ok: passed through to the single-call layer
     ) -> BedrockGuardrailResponse:
         """Post one ApplyGuardrail call for `content`, retrying with exponential
         backoff on AWS ThrottlingException (HTTP 429).
@@ -1074,6 +1082,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     request_data=request_data,
                     event_type=event_type,
                     start_time=start_time,
+                    completed_chunk_usages=completed_chunk_usages,
                 )
             except HTTPException as exc:
                 if (
@@ -1095,6 +1104,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         request_data: dict | None,  # mutable-ok: proxy request body dict, mutated by the logging helper
         event_type: GuardrailEventHooks,
         start_time: "datetime",
+        completed_chunk_usages: list[BedrockGuardrailUsage],  # mutable-ok: billed-chunk usage accumulator
     ) -> BedrockGuardrailResponse:
         """Make exactly one signed ApplyGuardrail HTTP call for `content` and
         parse the result. Raises HTTPException on a guardrail block or any
@@ -1110,7 +1120,10 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
         A block is logged here rather than by the caller: it ends the whole chunking
         flow immediately, with no further chunks attempted, so there is no later
-        merged response for the caller to log instead.
+        merged response for the caller to log instead. The logged usage still spans
+        the whole logical request: chunks that passed before the block appended what
+        AWS billed them to ``completed_chunk_usages``, and the attempt log sums those
+        with the blocking call's own usage.
         """
         bedrock_request_data: Final = {  # mutable-ok: outbound JSON request body
             **base_request_data,
@@ -1154,10 +1167,16 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     event_type=event_type,
                     start_time=start_time,
                     aws_region_name=aws_region_name,
+                    completed_chunk_usages=completed_chunk_usages,
                 )
                 raise self._get_http_exception_for_blocked_guardrail(
                     bedrock_guardrail_response, request_data=request_data
                 )
+            response_usage: Final = bedrock_guardrail_response.get("usage")
+            if isinstance(response_usage, dict):
+                completed_chunk_usages.append(
+                    response_usage
+                )  # rebind-ok: accumulator threaded from make_bedrock_api_request, recording this billed call
             return bedrock_guardrail_response
 
         status_code, detail_message = self._parse_bedrock_guardrail_error_response(httpx_response)
@@ -1176,16 +1195,30 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         event_type: GuardrailEventHooks,
         start_time: "datetime",
         aws_region_name: str | None,
+        completed_chunk_usages: Sequence[BedrockGuardrailUsage],
     ) -> None:
-        """Log a single ApplyGuardrail HTTP attempt as-is (its own status,
-        derived from its own response). Used only for the blocked-content
-        case, which ends the whole chunking flow immediately."""
+        """Log the blocking ApplyGuardrail attempt, which ends the whole chunking
+        flow immediately. Its status derives from its own response, but its usage
+        (and so its cost) spans every billed call of the logical request: the
+        chunks that passed before the block plus the blocking call itself."""
+        blocking_usage: Final = json_response.get("usage")
+        billed_usages: Final[tuple[BedrockGuardrailUsage, ...]] = tuple(completed_chunk_usages) + (
+            (blocking_usage,) if isinstance(blocking_usage, dict) else ()
+        )
+        logged_json_response: Final = (
+            {  # mutable-ok: raw AWS JSON payload carrying the total billed usage
+                **json_response,
+                "usage": self._sum_usage_counters(billed_usages),
+            }
+            if completed_chunk_usages
+            else json_response
+        )
         tracing_detail: Final = self._build_tracing_detail(
-            BedrockGuardrailResponse(**json_response), aws_region_name=aws_region_name
+            BedrockGuardrailResponse(**logged_json_response), aws_region_name=aws_region_name
         )
         self.add_standard_logging_guardrail_information_to_request_data(
             guardrail_provider=self.guardrail_provider,
-            guardrail_json_response=json_response,
+            guardrail_json_response=logged_json_response,
             request_data=request_data or {},  # mutable-ok: logging helper requires a dict
             guardrail_status=self._get_bedrock_guardrail_response_status(response=httpx_response),
             start_time=start_time.timestamp(),
@@ -1511,15 +1544,20 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         Keys are taken from the responses rather than from a fixed list, so a counter
         this code does not know about (AWS has added several) is still summed and
         reported instead of being silently dropped to zero."""
-        chunk_usages: Final = tuple(
-            chunk_result.response.get("usage") or {}  # mutable-ok: read-only empty fallback
-            for chunk_result in chunk_results
+        return BedrockGuardrail._sum_usage_counters(
+            tuple(
+                chunk_result.response.get("usage") or {}  # mutable-ok: read-only empty fallback
+                for chunk_result in chunk_results
+            )
         )
+
+    @staticmethod
+    def _sum_usage_counters(usages: Sequence[BedrockGuardrailUsage]) -> BedrockGuardrailUsage:
         return cast(  # cast-ok: TypedDict assembled from a comprehension
             BedrockGuardrailUsage,
             {  # mutable-ok: builds the TypedDict payload
-                key: sum(usage.get(key) or 0 for usage in chunk_usages)
-                for key in dict.fromkeys(key for usage in chunk_usages for key in usage)
+                key: sum(usage.get(key) or 0 for usage in usages)
+                for key in dict.fromkeys(key for usage in usages for key in usage)
             },
         )
 

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -11,6 +11,7 @@ from litellm.litellm_core_utils.core_helpers import (
     get_litellm_metadata_from_kwargs,
 )
 from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+from litellm.litellm_core_utils.llm_cost_calc.guardrail_cost import guardrail_information_cost
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.auth_checks import (
     get_key_object,
@@ -184,9 +185,14 @@ class _ProxyDBLogger(CustomLogger):
         # recovered cost onto request_data (the usage rides along in
         # ``combined_usage_object`` for the token columns), so attribute the
         # real partial spend to this failure row instead of zero.
-        recovered_response_cost = 0.0
-        if isinstance(request_data.get("combined_usage_object"), litellm.Usage):
-            recovered_response_cost = max(float(request_data.get("response_cost") or 0.0), 0.0)
+        recovered_stream_cost: Final = (
+            max(float(request_data.get("response_cost") or 0.0), 0.0)
+            if isinstance(request_data.get("combined_usage_object"), litellm.Usage)
+            else 0.0
+        )
+        recovered_response_cost: Final = recovered_stream_cost + guardrail_information_cost(
+            existing_metadata.get("standard_logging_guardrail_information")
+        )
 
         await proxy_logging_obj.db_spend_update_writer.update_database(
             token=user_api_key_dict.api_key,

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -296,7 +296,10 @@ _ALLOW_CLIENT_MESSAGE_REDACTION_OPT_OUT_METADATA_KEY: Final = "allow_client_mess
 _CLIENT_PRICING_CONTROL_FIELDS: Final = frozenset(CustomPricingLiteLLMParams.model_fields.keys())
 # ``model_info`` carries the same pricing fields when read by
 # ``use_custom_pricing_for_model``; strip from metadata for the same reason.
-_CLIENT_PRICING_METADATA_FIELDS: Final = frozenset({"model_info"})
+# ``standard_logging_guardrail_information`` is proxy-written telemetry summed
+# into response_cost and spend; a client seeding it forges (even negative)
+# guardrail cost.
+_CLIENT_PRICING_METADATA_FIELDS: Final = frozenset({"model_info", "standard_logging_guardrail_information"})
 _ALLOW_CLIENT_PRICING_OVERRIDE_METADATA_KEY: Final = "allow_client_pricing_override"
 
 # Request fields whose value, when URL-valued, becomes the outbound destination

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3020,6 +3020,11 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     provider's counter name (e.g. Bedrock's ``contentPolicyUnits``). Kept as a
     sibling of guardrail_response so spend-log prompt redaction never drops it."""
 
+    guardrail_cost: ReadOnly[float | None]
+    """USD cost of this guardrail invocation, priced from ``guardrail_usage`` by the
+    provider hook. Summed into the request's ``response_cost`` so it counts against
+    spend and budgets like token cost."""
+
 
 class EvalVerdict(TypedDict, total=False):
     criterion_name: str
@@ -3064,6 +3069,7 @@ class GuardrailTracingDetail(TypedDict, total=False):
     violation_categories: list[str] | None
     guardrail_action: str | None
     guardrail_usage: ReadOnly[Mapping[str, int] | None]
+    guardrail_cost: ReadOnly[float | None]
 
 
 StandardLoggingPayloadStatus = Literal["success", "failure"]
@@ -3103,8 +3109,9 @@ class CostBreakdown(TypedDict, total=False):
     cache_creation_cost: float  # Cost of cache-write tokens (premium rate)
     output_cost: float  # Cost of output/completion tokens (includes reasoning if applicable)
     reasoning_cost: float  # Cost of reasoning tokens (subset of output_cost)
-    total_cost: float  # Total cost (input + output + tool usage)
+    total_cost: ReadOnly[float]  # Total cost (input + output + tool usage + guardrail)
     tool_usage_cost: float  # Cost of usage of built-in tools
+    guardrail_cost: ReadOnly[float]  # Cost of guardrail invocations billed by the guardrail provider
     additional_costs: dict[str, float]  # Free-form additional costs (e.g., {"azure_model_router_flat_cost": 0.00014})
     original_cost: float  # Cost before discount (optional)
     discount_percent: float  # Discount percentage applied (e.g., 0.05 = 5%) (optional)

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10052,6 +10052,21 @@
         "output_cost_per_second": 0.0066027,
         "supports_tool_choice": true
     },
+    "bedrock/guardrails": {
+        "guardrail_cost_per_unit": {
+            "automatedReasoningPolicyUnits": 0.00017,
+            "contentPolicyImageUnits": 0.00075,
+            "contentPolicyUnits": 0.00015,
+            "contextualGroundingPolicyUnits": 0.0001,
+            "sensitiveInformationPolicyFreeUnits": 0.0,
+            "sensitiveInformationPolicyUnits": 0.0001,
+            "topicPolicyUnits": 0.00015,
+            "wordPolicyUnits": 0.0
+        },
+        "litellm_provider": "bedrock",
+        "mode": "guardrail",
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "bedrock/ap-northeast-1/1-month-commitment/anthropic.claude-instant-v1": {
         "input_cost_per_second": 0.01475,
         "litellm_provider": "bedrock",

--- a/model_prices_and_context_window.schema.json
+++ b/model_prices_and_context_window.schema.json
@@ -186,6 +186,14 @@
         "gemini_native_audio": {
           "type": "boolean"
         },
+        "guardrail_cost_per_unit": {
+          "type": "object",
+          "description": "USD cost per billable guardrail unit, keyed by the provider's usage counter name (e.g. Bedrock's contentPolicyUnits).",
+          "additionalProperties": {
+            "type": "number",
+            "minimum": 0
+          }
+        },
         "input_cost_per_audio_per_second": {
           "type": "number",
           "minimum": 0
@@ -361,6 +369,7 @@
             "chat",
             "completion",
             "embedding",
+            "guardrail",
             "image_edit",
             "image_generation",
             "moderation",

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_guardrail_cost.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_guardrail_cost.py
@@ -89,6 +89,17 @@ def test_guardrail_information_cost_single_entry_and_garbage():
     assert guardrail_information_cost([{"guardrail_cost": "bad"}]) == 0.0
 
 
+def test_guardrail_information_cost_ignores_negative_and_non_finite():
+    entries = [
+        {"guardrail_name": "forged-negative", "guardrail_cost": -0.005},
+        {"guardrail_name": "forged-nan", "guardrail_cost": float("nan")},
+        {"guardrail_name": "forged-inf", "guardrail_cost": float("inf")},
+        {"guardrail_name": "real", "guardrail_cost": 0.0003},
+    ]
+    assert guardrail_information_cost(entries) == pytest.approx(0.0003)
+    assert guardrail_information_cost({"guardrail_cost": -1.0}) == 0.0
+
+
 def test_cost_breakdown_with_guardrail_merges_and_creates():
     assert cost_breakdown_with_guardrail(None, 0.0) is None
     untouched = {"input_cost": 0.1, "total_cost": 0.4}

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_guardrail_cost.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_guardrail_cost.py
@@ -1,0 +1,102 @@
+import os
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.llm_cost_calc.guardrail_cost import (
+    bedrock_guardrail_cost,
+    cost_breakdown_with_guardrail,
+    guardrail_information_cost,
+)
+
+
+@pytest.fixture
+def synthetic_cost_map(monkeypatch):
+    monkeypatch.setattr(
+        litellm,
+        "model_cost",
+        {
+            "bedrock/guardrails": {
+                "guardrail_cost_per_unit": {
+                    "contentPolicyUnits": 0.00015,
+                    "topicPolicyUnits": 0.00015,
+                    "wordPolicyUnits": 0.0,
+                }
+            },
+            "bedrock/eu-west-1/guardrails": {"guardrail_cost_per_unit": {"contentPolicyUnits": 0.0002}},
+            "bedrock/us-west-2/guardrails": {"guardrail_cost_per_unit": "malformed"},
+        },
+    )
+
+
+def test_bedrock_guardrail_cost_prices_each_counter(synthetic_cost_map):
+    cost = bedrock_guardrail_cost(
+        usage_units={"contentPolicyUnits": 2, "topicPolicyUnits": 1, "wordPolicyUnits": 5},
+        aws_region_name="us-east-1",
+    )
+    assert cost == pytest.approx(0.00045)
+
+
+def test_bedrock_guardrail_cost_prefers_regional_entry(synthetic_cost_map):
+    cost = bedrock_guardrail_cost(usage_units={"contentPolicyUnits": 1}, aws_region_name="eu-west-1")
+    assert cost == pytest.approx(0.0002)
+
+
+def test_bedrock_guardrail_cost_unknown_counter_is_free(synthetic_cost_map):
+    assert bedrock_guardrail_cost(usage_units={"someFutureCounter": 3}, aws_region_name="us-east-1") == 0.0
+
+
+def test_bedrock_guardrail_cost_malformed_regional_entry_falls_back(synthetic_cost_map):
+    cost = bedrock_guardrail_cost(usage_units={"contentPolicyUnits": 1}, aws_region_name="us-west-2")
+    assert cost == pytest.approx(0.00015)
+
+
+def test_bedrock_guardrail_cost_no_pricing_entry(monkeypatch):
+    monkeypatch.setattr(litellm, "model_cost", {})
+    assert bedrock_guardrail_cost(usage_units={"contentPolicyUnits": 1}, aws_region_name="us-east-1") == 0.0
+
+
+def test_shipped_bedrock_guardrail_prices_match_aws_pricing_page():
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    assert litellm.model_cost["bedrock/guardrails"]["guardrail_cost_per_unit"] == {
+        "automatedReasoningPolicyUnits": 0.00017,
+        "contentPolicyImageUnits": 0.00075,
+        "contentPolicyUnits": 0.00015,
+        "contextualGroundingPolicyUnits": 0.0001,
+        "sensitiveInformationPolicyFreeUnits": 0.0,
+        "sensitiveInformationPolicyUnits": 0.0001,
+        "topicPolicyUnits": 0.00015,
+        "wordPolicyUnits": 0.0,
+    }
+    assert "bedrock/guardrails" not in litellm.bedrock_models
+
+
+def test_guardrail_information_cost_sums_entries():
+    entries = [
+        {"guardrail_name": "a", "guardrail_cost": 0.0003},
+        {"guardrail_name": "b", "guardrail_cost": None},
+        {"guardrail_name": "c"},
+        {"guardrail_name": "d", "guardrail_cost": 0.0001},
+    ]
+    assert guardrail_information_cost(entries) == pytest.approx(0.0004)
+
+
+def test_guardrail_information_cost_single_entry_and_garbage():
+    assert guardrail_information_cost({"guardrail_cost": 0.0001}) == pytest.approx(0.0001)
+    assert guardrail_information_cost(None) == 0.0
+    assert guardrail_information_cost("not-guardrail-info") == 0.0
+    assert guardrail_information_cost([{"guardrail_cost": "bad"}]) == 0.0
+
+
+def test_cost_breakdown_with_guardrail_merges_and_creates():
+    assert cost_breakdown_with_guardrail(None, 0.0) is None
+    untouched = {"input_cost": 0.1, "total_cost": 0.4}
+    assert cost_breakdown_with_guardrail(untouched, 0.0) is untouched
+    merged = cost_breakdown_with_guardrail({"input_cost": 0.1, "total_cost": 0.4}, 0.0003)
+    assert merged is not None
+    assert merged["guardrail_cost"] == pytest.approx(0.0003)
+    assert merged["total_cost"] == pytest.approx(0.4003)
+    assert merged["input_cost"] == pytest.approx(0.1)
+    created = cost_breakdown_with_guardrail(None, 0.0003)
+    assert created == {"guardrail_cost": 0.0003, "total_cost": 0.0003}

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -4869,8 +4869,7 @@ def _guardrail_kwargs(response_cost):
 
 
 def test_payload_response_cost_includes_guardrail_cost(logging_obj):
-    """LIT-5651: guardrail invocations billed by the provider must count in
-    response_cost so spend and budget enforcement see them like token cost."""
+    """LIT-5651: provider-billed guardrail cost must count in response_cost."""
     payload = _build_success_payload(logging_obj, _guardrail_kwargs(response_cost=0.0000429))
 
     assert payload is not None

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -4826,3 +4826,88 @@ async def test_restore_correlation_context_works_across_asyncio_task_boundary():
     finally:
         trace_id_var.set("")
         session_id_var.set("")
+
+
+def _build_success_payload(logging_obj, kwargs):
+    import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        get_standard_logging_object_payload,
+    )
+
+    now = datetime.datetime.now()
+    return get_standard_logging_object_payload(
+        kwargs=kwargs,
+        init_response_obj={},
+        start_time=now,
+        end_time=now,
+        logging_obj=logging_obj,
+        status="success",
+    )
+
+
+def _guardrail_kwargs(response_cost):
+    return {
+        "litellm_call_id": "guardrail-cost-call",
+        "model": "gpt-4o",
+        "messages": [],
+        "response_cost": response_cost,
+        "litellm_params": {
+            "metadata": {
+                "standard_logging_guardrail_information": [
+                    {
+                        "guardrail_name": "bedrock-pre",
+                        "guardrail_status": "success",
+                        "guardrail_usage": {"topicPolicyUnits": 1, "contentPolicyUnits": 1},
+                        "guardrail_cost": 0.0003,
+                    },
+                    {"guardrail_name": "no-usage-guardrail", "guardrail_status": "success"},
+                ]
+            }
+        },
+    }
+
+
+def test_payload_response_cost_includes_guardrail_cost(logging_obj):
+    """LIT-5651: guardrail invocations billed by the provider must count in
+    response_cost so spend and budget enforcement see them like token cost."""
+    payload = _build_success_payload(logging_obj, _guardrail_kwargs(response_cost=0.0000429))
+
+    assert payload is not None
+    assert payload["response_cost"] == pytest.approx(0.0003429)
+    assert payload["cost_breakdown"] is not None
+    assert payload["cost_breakdown"]["guardrail_cost"] == pytest.approx(0.0003)
+    assert payload["cost_breakdown"]["total_cost"] == pytest.approx(0.0003)
+    assert payload["hidden_params"]["response_cost"] == pytest.approx(0.0000429)
+
+
+def test_payload_guardrail_cost_merges_into_existing_cost_breakdown(logging_obj):
+    logging_obj.set_cost_breakdown(
+        input_cost=0.00003,
+        output_cost=0.0000129,
+        total_cost=0.0000429,
+        cost_for_built_in_tools_cost_usd_dollar=0.0,
+    )
+    payload = _build_success_payload(logging_obj, _guardrail_kwargs(response_cost=0.0000429))
+
+    assert payload is not None
+    assert payload["response_cost"] == pytest.approx(0.0003429)
+    assert payload["cost_breakdown"]["guardrail_cost"] == pytest.approx(0.0003)
+    assert payload["cost_breakdown"]["total_cost"] == pytest.approx(0.0003429)
+    assert payload["cost_breakdown"]["input_cost"] == pytest.approx(0.00003)
+    assert logging_obj.cost_breakdown["total_cost"] == pytest.approx(0.0000429)
+
+
+def test_payload_without_guardrail_cost_is_unchanged(logging_obj):
+    kwargs = {
+        "litellm_call_id": "no-guardrail-call",
+        "model": "gpt-4o",
+        "messages": [],
+        "response_cost": 0.0000429,
+        "litellm_params": {"metadata": {}},
+    }
+    payload = _build_success_payload(logging_obj, kwargs)
+
+    assert payload is not None
+    assert payload["response_cost"] == pytest.approx(0.0000429)
+    assert payload["cost_breakdown"] is None

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -5080,9 +5080,7 @@ async def test_apply_guardrail_failure_logs_a_dict_not_a_bare_string():
 
 
 def test_build_tracing_detail_surfaces_usage_counters_and_cost(monkeypatch):
-    """LIT-5650/LIT-5651: the billable usage block Bedrock returns per ApplyGuardrail
-    call must land on the tracing detail as guardrail_usage, priced into
-    guardrail_cost, so spend logs and budgets see what AWS bills."""
+    """LIT-5650/LIT-5651: AWS-billed usage must land as guardrail_usage priced into guardrail_cost."""
     monkeypatch.setattr(
         litellm,
         "model_cost",
@@ -5119,3 +5117,84 @@ def test_build_tracing_detail_omits_guardrail_usage_when_bedrock_reports_none():
     ):
         assert "guardrail_usage" not in detail
         assert "guardrail_cost" not in detail
+
+
+@pytest.mark.asyncio
+async def test_blocked_chunk_logs_usage_and_cost_of_prior_passed_chunks(monkeypatch):
+    """LIT-5651 regression: a block on a later chunk must still bill the chunks AWS already processed."""
+    monkeypatch.setattr(
+        litellm,
+        "model_cost",
+        {
+            "bedrock/guardrails": {
+                "guardrail_cost_per_unit": {
+                    "contentPolicyUnits": 0.00015,
+                    "wordPolicyUnits": 0.0,
+                }
+            }
+        },
+    )
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="test-guardrail",
+        guardrailVersion="DRAFT",
+        chunk_budget_chars=40,
+    )
+
+    too_large_response = MagicMock()
+    too_large_response.status_code = 429
+    too_large_response.json.return_value = {
+        "message": "Input text size (60 text units) exceeds the maximum allowed (1 text units) for the content filter policy"
+    }
+
+    passed_chunk_response = MagicMock()
+    passed_chunk_response.status_code = 200
+    passed_chunk_response.json.return_value = {
+        "action": "NONE",
+        "outputs": [],
+        "assessments": [],
+        "usage": {"contentPolicyUnits": 2, "wordPolicyUnits": 1},
+    }
+
+    blocked_chunk_response = MagicMock()
+    blocked_chunk_response.status_code = 200
+    blocked_chunk_response.json.return_value = {
+        "action": "GUARDRAIL_INTERVENED",
+        "assessments": [{"contentPolicy": {"filters": [{"type": "HATE", "confidence": "HIGH", "action": "BLOCKED"}]}}],
+        "outputs": [{"text": "Content blocked"}],
+        "usage": {"contentPolicyUnits": 3},
+    }
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "test-access-key"
+    mock_credentials.secret_key = "test-secret-key"
+    mock_credentials.token = None
+
+    request_data = {
+        "model": "gpt-4o",
+        "messages": [
+            {"role": "user", "content": "a" * 30},
+            {"role": "user", "content": "b" * 30},
+        ],
+    }
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.side_effect = [too_large_response, passed_chunk_response, blocked_chunk_response]
+
+        with pytest.raises(HTTPException):
+            await guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=request_data["messages"],
+                request_data=request_data,
+            )
+
+    assert mock_post.call_count == 3
+    logged_entries = request_data["metadata"]["standard_logging_guardrail_information"]
+    assert len(logged_entries) == 1
+    logged = logged_entries[0]
+    assert logged["guardrail_usage"] == {"contentPolicyUnits": 5, "wordPolicyUnits": 1}
+    assert logged["guardrail_cost"] == pytest.approx(0.00075)
+    assert logged["guardrail_response"]["usage"] == {"contentPolicyUnits": 5, "wordPolicyUnits": 1}

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -5079,24 +5079,43 @@ async def test_apply_guardrail_failure_logs_a_dict_not_a_bare_string():
     assert "error" in logged
 
 
-def test_build_tracing_detail_surfaces_usage_counters():
-    """LIT-5650: the billable usage block Bedrock returns per ApplyGuardrail call must
-    land on the tracing detail as guardrail_usage so it reaches spend logs as a
-    sibling of guardrail_response (which default redaction replaces wholesale)."""
+def test_build_tracing_detail_surfaces_usage_counters_and_cost(monkeypatch):
+    """LIT-5650/LIT-5651: the billable usage block Bedrock returns per ApplyGuardrail
+    call must land on the tracing detail as guardrail_usage, priced into
+    guardrail_cost, so spend logs and budgets see what AWS bills."""
+    monkeypatch.setattr(
+        litellm,
+        "model_cost",
+        {
+            "bedrock/guardrails": {
+                "guardrail_cost_per_unit": {
+                    "topicPolicyUnits": 0.00015,
+                    "contentPolicyUnits": 0.00015,
+                    "wordPolicyUnits": 0.0,
+                }
+            }
+        },
+    )
     guardrail = BedrockGuardrail(guardrailIdentifier="test-guardrail", guardrailVersion="DRAFT")
 
     detail = guardrail._build_tracing_detail(
         {
             "action": "GUARDRAIL_INTERVENED",
             "usage": {"topicPolicyUnits": 1, "contentPolicyUnits": 2, "wordPolicyUnits": 0, "oddball": "not-an-int"},
-        }
+        },
+        aws_region_name="us-east-1",
     )
 
     assert detail["guardrail_usage"] == {"topicPolicyUnits": 1, "contentPolicyUnits": 2, "wordPolicyUnits": 0}
+    assert detail["guardrail_cost"] == pytest.approx(0.00045)
 
 
 def test_build_tracing_detail_omits_guardrail_usage_when_bedrock_reports_none():
     guardrail = BedrockGuardrail(guardrailIdentifier="test-guardrail", guardrailVersion="DRAFT")
 
-    assert "guardrail_usage" not in guardrail._build_tracing_detail({"action": "NONE"})
-    assert "guardrail_usage" not in guardrail._build_tracing_detail({"action": "NONE", "usage": {}})
+    for detail in (
+        guardrail._build_tracing_detail({"action": "NONE"}, aws_region_name="us-east-1"),
+        guardrail._build_tracing_detail({"action": "NONE", "usage": {}}, aws_region_name="us-east-1"),
+    ):
+        assert "guardrail_usage" not in detail
+        assert "guardrail_cost" not in detail

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -5198,3 +5198,81 @@ async def test_blocked_chunk_logs_usage_and_cost_of_prior_passed_chunks(monkeypa
     assert logged["guardrail_usage"] == {"contentPolicyUnits": 5, "wordPolicyUnits": 1}
     assert logged["guardrail_cost"] == pytest.approx(0.00075)
     assert logged["guardrail_response"]["usage"] == {"contentPolicyUnits": 5, "wordPolicyUnits": 1}
+
+
+@pytest.mark.asyncio
+async def test_terminal_failure_logs_usage_and_cost_of_prior_passed_chunks(monkeypatch):
+    """LIT-5651 regression: a terminal failure on a later chunk must still bill the chunks AWS already processed."""
+    monkeypatch.setattr(
+        litellm,
+        "model_cost",
+        {
+            "bedrock/guardrails": {
+                "guardrail_cost_per_unit": {
+                    "contentPolicyUnits": 0.00015,
+                    "wordPolicyUnits": 0.0,
+                }
+            }
+        },
+    )
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="test-guardrail",
+        guardrailVersion="DRAFT",
+        chunk_budget_chars=40,
+    )
+
+    too_large_response = MagicMock()
+    too_large_response.status_code = 429
+    too_large_response.json.return_value = {
+        "message": "Input text size (60 text units) exceeds the maximum allowed (1 text units) for the content filter policy"
+    }
+
+    passed_chunk_response = MagicMock()
+    passed_chunk_response.status_code = 200
+    passed_chunk_response.json.return_value = {
+        "action": "NONE",
+        "outputs": [],
+        "assessments": [],
+        "usage": {"contentPolicyUnits": 2, "wordPolicyUnits": 1},
+    }
+
+    failed_chunk_response = MagicMock()
+    failed_chunk_response.status_code = 400
+    failed_chunk_response.json.return_value = {"message": "ValidationException: guardrail is in a failed state"}
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "test-access-key"
+    mock_credentials.secret_key = "test-secret-key"
+    mock_credentials.token = None
+
+    request_data = {
+        "model": "gpt-4o",
+        "messages": [
+            {"role": "user", "content": "a" * 30},
+            {"role": "user", "content": "b" * 30},
+        ],
+    }
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.side_effect = [too_large_response, passed_chunk_response, failed_chunk_response]
+
+        with pytest.raises(HTTPException):
+            await guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=request_data["messages"],
+                request_data=request_data,
+            )
+
+    assert mock_post.call_count == 3
+    logged_entries = request_data["metadata"]["standard_logging_guardrail_information"]
+    assert len(logged_entries) == 1
+    logged = logged_entries[0]
+    assert logged["guardrail_status"] == "guardrail_failed_to_respond"
+    assert logged["guardrail_usage"] == {"contentPolicyUnits": 2, "wordPolicyUnits": 1}
+    assert logged["guardrail_cost"] == pytest.approx(0.0003)
+    assert logged["guardrail_response"]["usage"] == {"contentPolicyUnits": 2, "wordPolicyUnits": 1}
+    assert "error" in logged["guardrail_response"]

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -17,7 +17,7 @@ from litellm.proxy.hooks.proxy_track_cost_callback import (
     _should_track_cost_callback,
     _update_database_and_spend_counters,
 )
-from litellm.types.utils import CallTypes
+from litellm.types.utils import CallTypes, Usage
 
 
 @pytest.mark.asyncio
@@ -150,6 +150,70 @@ async def test_async_post_call_failure_hook_does_not_clobber_guardrail_info_in_m
 
         metadata = mock_update_database.call_args[1]["kwargs"]["litellm_params"]["metadata"]
         assert metadata["standard_logging_guardrail_information"] == metadata_bucket_info
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_hook_bills_guardrail_cost_on_blocked_request():
+    """LIT-5651: a request blocked by a guardrail never reaches the LLM, but the
+    guardrail invocation itself is billed by the provider. The failure row must
+    charge that cost against the key instead of recording zero spend."""
+    logger = _ProxyDBLogger()
+    request_data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "metadata": {
+            "standard_logging_guardrail_information": [
+                {
+                    "guardrail_name": "bedrock-guard",
+                    "guardrail_status": "guardrail_intervened",
+                    "guardrail_usage": {"topicPolicyUnits": 1, "contentPolicyUnits": 1},
+                    "guardrail_cost": 0.0003,
+                }
+            ]
+        },
+        "proxy_server_request": {"request_id": "test_request_id"},
+    }
+
+    with patch(
+        "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter.update_database",
+        new_callable=AsyncMock,
+    ) as mock_update_database:
+        await logger.async_post_call_failure_hook(
+            request_data=request_data,
+            original_exception=Exception("Violated guardrail policy"),
+            user_api_key_dict=UserAPIKeyAuth(api_key="test_api_key"),
+        )
+
+        assert mock_update_database.call_args[1]["response_cost"] == pytest.approx(0.0003)
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_hook_adds_guardrail_cost_to_recovered_stream_cost():
+    logger = _ProxyDBLogger()
+    request_data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "metadata": {
+            "standard_logging_guardrail_information": [
+                {"guardrail_name": "bedrock-guard", "guardrail_status": "success", "guardrail_cost": 0.0003}
+            ]
+        },
+        "proxy_server_request": {"request_id": "test_request_id"},
+        "combined_usage_object": Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        "response_cost": 0.001,
+    }
+
+    with patch(
+        "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter.update_database",
+        new_callable=AsyncMock,
+    ) as mock_update_database:
+        await logger.async_post_call_failure_hook(
+            request_data=request_data,
+            original_exception=Exception("stream broke mid-flight"),
+            user_api_key_dict=UserAPIKeyAuth(api_key="test_api_key"),
+        )
+
+        assert mock_update_database.call_args[1]["response_cost"] == pytest.approx(0.0013)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_pricing_field_strip.py
+++ b/tests/test_litellm/proxy/test_pricing_field_strip.py
@@ -102,6 +102,30 @@ class TestStripClientPricingOverrides:
         assert data["metadata"] == {"user_session": "keep-me"}
         assert data["litellm_metadata"] == {}
 
+    def test_metadata_guardrail_information_dropped(self):
+        # Client-seeded guardrail entries would otherwise be summed into
+        # response_cost and spend, letting a caller forge (even negative)
+        # guardrail cost against their own budget.
+        data = {
+            "model": "gpt-4",
+            "metadata": {
+                "user_session": "keep-me",
+                "standard_logging_guardrail_information": [
+                    {
+                        "guardrail_name": "forged",
+                        "guardrail_status": "success",
+                        "guardrail_cost": -0.005,
+                    }
+                ],
+            },
+            "litellm_metadata": {
+                "standard_logging_guardrail_information": [{"guardrail_cost": 5.0}],
+            },
+        }
+        _strip_client_pricing_overrides(data)
+        assert data["metadata"] == {"user_session": "keep-me"}
+        assert data["litellm_metadata"] == {}
+
     def test_non_pricing_fields_untouched(self):
         data = {
             "model": "gpt-4",
@@ -129,6 +153,7 @@ class TestStripClientPricingOverrides:
 
     def test_metadata_field_set_contains_model_info(self):
         assert "model_info" in _CLIENT_PRICING_METADATA_FIELDS
+        assert "standard_logging_guardrail_information" in _CLIENT_PRICING_METADATA_FIELDS
 
     def test_strip_emits_debug_log_listing_dropped_fields(self, caplog):
         # Operators need a paper trail so they can diagnose why a previously

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -869,6 +869,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                         "container",
                         "image_edit",
                         "embedding",
+                        "guardrail",
                         "image_generation",
                         "video_generation",
                         "moderation",
@@ -975,6 +976,10 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                     "items": {
                         "type": "string",
                     },
+                },
+                "guardrail_cost_per_unit": {
+                    "type": "object",
+                    "additionalProperties": {"type": "number"},
                 },
                 "search_context_cost_per_query": {
                     "type": "object",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock guardrail invocations bill AWS units LiteLLM never priced
- Spend, budgets, and cost headers ignored those charges
- Blocked requests recorded $0 despite a billed ApplyGuardrail call

How it solves it:

- Ships Bedrock guardrail per-unit prices in the cost map
- Prices each invocation's usage units into a guardrail_cost field
- Adds guardrail cost to response_cost, cost headers, and cost_breakdown
- Bills guardrail cost on guardrail-blocked requests too
- A block or terminal failure mid-chunking bills every ApplyGuardrail call AWS already made, not just the final chunk
- Strips client-supplied `metadata.standard_logging_guardrail_information` at the proxy boundary and ignores negative or non-finite guardrail costs, so callers cannot forge spend

## User Flow

Before: a proxy admin fronting Bedrock with a Bedrock guardrail sees guardrail charges on the AWS bill that LiteLLM never counts, so keys outlive their budgets

1. The admin attaches a Bedrock guardrail (topic + content policy) to the proxy and mints a key with POST http://localhost:4000/key/generate and `{"max_budget": 0.0005}`
2. A user sends POST http://localhost:4000/v1/chat/completions with that key and gets `x-litellm-response-cost: 4.29e-05`, though AWS also billed $0.0003 of guardrail units for the call
3. http://localhost:4000/ui/?page=logs shows the request at $0.0000429 with the guardrail's unit counts listed but no cost attached to them
4. After two such requests the key has spent 8.58e-05 of its 0.0005 budget, so a third request sails through, and every one of them keeps adding unbilled guardrail units to the AWS invoice
5. A request the guardrail blocks returns 400 and records $0 spend even though AWS billed that ApplyGuardrail call

After: the same requests bill the guardrail units, so spend and budgets match the AWS bill

1. The admin attaches a Bedrock guardrail (topic + content policy) to the proxy and mints a key with POST http://localhost:4000/key/generate and `{"max_budget": 0.0005}`
2. A user sends POST http://localhost:4000/v1/chat/completions with that key and gets `x-litellm-response-cost: 0.0003429`, the token cost plus the $0.0003 the guardrail units cost
3. http://localhost:4000/ui/?page=logs shows the request at $0.0003429 with `guardrail_cost: 0.0003` in its cost breakdown next to the unit counts
4. After two such requests the key has spent 0.0006858, so the third request is refused with 429 "Budget has been exceeded"
5. The blocked request still bills its $0.0003 guardrail invocation to the key, and a long request blocked partway through its guardrail scan bills every scan call AWS already made

## Relevant issues

## Linear ticket

Resolves LIT-5651

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: local proxy with a Postgres DB, one Bedrock model, and a default-on pre_call Bedrock guardrail (topic policy denying "coffee" plus a content policy, so every apply bills 1 topicPolicyUnit + 1 contentPolicyUnit = $0.0003 at AWS list prices). Real AWS Bedrock calls in us-east-1

```yaml
model_list:
  - model_name: bedrock-haiku
    litellm_params:
      model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: us-east-1

guardrails:
  - guardrail_name: bedrock-topic-content-pre
    litellm_params:
      guardrail: bedrock
      mode: pre_call
      guardrailIdentifier: gf3sc1mzinjw
      guardrailVersion: DRAFT
      aws_region_name: us-east-1
      default_on: true
```

### Before (6d32d4081d)

#### /v1/chat/completions: cost header and spend log

1. `curl -sS -D - http://127.0.0.1:30764/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"bedrock-haiku","messages":[{"role":"user","content":"What is the capital of France? Answer in one word."}]}'`
2. `HTTP/1.1 200 OK`, `x-litellm-response-cost: 4.29e-05`, `x-litellm-applied-guardrails: bedrock-topic-content-pre`, body id `chatcmpl-a33e3d84-59bc-40da-ac16-85ea437cc1bf`
3. `curl -sS "http://127.0.0.1:30764/spend/logs?request_id=chatcmpl-a33e3d84-59bc-40da-ac16-85ea437cc1bf" -H "Authorization: Bearer sk-1234"`
4. Row: `spend 4.29e-05`; `cost_breakdown {"input_cost": 2.09e-05, "output_cost": 2.2e-05, "total_cost": 4.29e-05, ...}` with no guardrail component; `guardrail_information[0].guardrail_usage {"topicPolicyUnits": 1, "contentPolicyUnits": 1}` and no `guardrail_cost` key

#### /v1/chat/completions: budget enforcement

1. `KEY=$(curl -sS http://127.0.0.1:30764/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"key_alias":"lit5651-before2-budget","max_budget":0.0005}' | python3 -c 'import json,sys;print(json.load(sys.stdin)["key"])')`
2. Two guarded requests with `$KEY`: both `HTTP/1.1 200 OK` with `x-litellm-response-cost: 4.29e-05`
3. `curl -sS http://127.0.0.1:30764/key/info -H "Authorization: Bearer $KEY"`: `key spend after 2 requests: 8.58e-05` (zero guardrail contribution; AWS billed $0.0006 of guardrail units)
4. Third identical request: `HTTP 200`, budget never trips

#### /v1/chat/completions: blocked request billing

1. `curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:30764/v1/chat/completions -H "Authorization: Bearer $KEY2" -H "Content-Type: application/json" -d '{"model":"bedrock-haiku","messages":[{"role":"user","content":"Tell me about the best coffee brewing methods"}]}'`
2. `400` (topic policy DENY), then `curl -sS http://127.0.0.1:30764/key/info -H "Authorization: Bearer $KEY2"`: `blocked-request key spend: 0.0` despite the billed ApplyGuardrail call

#### /v1/messages: cost header

1. `curl -sS -D - http://127.0.0.1:30764/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"bedrock-haiku","max_tokens":50,"messages":[{"role":"user","content":"What is the capital of Japan? One word."}]}'`
2. `HTTP/1.1 200 OK`, `x-litellm-response-cost: 4.07e-05` (token cost only)

#### /v1/responses: cost header

1. `curl -sS -D - http://127.0.0.1:30764/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"bedrock-haiku","input":"What is the capital of Italy? One word."}'`
2. `HTTP/1.1 200 OK`, `x-litellm-response-cost: 4.07e-05` (token cost only)

### After (be594f5984)

#### /v1/chat/completions: cost header and spend log

1. `curl -sS -D - http://127.0.0.1:43998/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"bedrock-haiku","messages":[{"role":"user","content":"What is the capital of France? Answer in one word."}]}'`
2. `HTTP/1.1 200 OK`, `x-litellm-response-cost: 0.0003429` (= 4.29e-05 tokens + $0.0003 guardrail units), `x-litellm-applied-guardrails: bedrock-topic-content-pre`, body id `chatcmpl-bb9a6812-b360-4071-bf7f-5ae4eb5991f1`
3. `curl -sS "http://127.0.0.1:43998/spend/logs?request_id=chatcmpl-bb9a6812-b360-4071-bf7f-5ae4eb5991f1" -H "Authorization: Bearer sk-1234"`
4. Row: `spend 0.0003429`; `cost_breakdown {"input_cost": 2.09e-05, "output_cost": 2.2e-05, "guardrail_cost": 0.0003, "total_cost": 0.0003429, ...}`; `guardrail_information[0]` carries both `guardrail_usage {"topicPolicyUnits": 1, "contentPolicyUnits": 1}` and `guardrail_cost: 0.0003`

#### /v1/chat/completions: budget enforcement

1. `KEY=$(curl -sS http://127.0.0.1:43998/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"key_alias":"lit5651-after-budget","max_budget":0.0005}' | python3 -c 'import json,sys;print(json.load(sys.stdin)["key"])')`
2. Two guarded requests with `$KEY`: both `HTTP/1.1 200 OK` with `x-litellm-response-cost: 0.0003429`
3. `curl -sS http://127.0.0.1:43998/key/info -H "Authorization: Bearer $KEY"`: `key spend: 0.0006858 max_budget: 0.0005`
4. Third identical request: `HTTP 429`, `"Budget has been exceeded! Key=lit5651-after-budget (sk-...J1dQ) Current cost: 0.0006858000000000075, Max budget: 0.0005"`

#### /v1/chat/completions: blocked request billing

1. `curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:43998/v1/chat/completions -H "Authorization: Bearer $KEY2" -H "Content-Type: application/json" -d '{"model":"bedrock-haiku","messages":[{"role":"user","content":"Tell me about the best coffee brewing methods"}]}'`
2. `400` (topic policy DENY), then `curl -sS http://127.0.0.1:43998/key/info -H "Authorization: Bearer $KEY2"`: `blocked-request key spend: 0.0003`, and the spend log records a failure row at `0.0003`

#### /v1/messages: cost header

1. `curl -sS -D - http://127.0.0.1:43998/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"bedrock-haiku","max_tokens":50,"messages":[{"role":"user","content":"What is the capital of Japan? One word."}]}'`
2. `HTTP/1.1 200 OK`, `x-litellm-response-cost: 0.0003407` (= 4.07e-05 tokens + $0.0003 guardrail units); its spend row shows `0.0003407` with `cost_breakdown.guardrail_cost 0.0003`

#### /v1/responses: cost header

1. `curl -sS -D - http://127.0.0.1:43998/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"bedrock-haiku","input":"What is the capital of Italy? One word."}'`
2. `HTTP/1.1 200 OK`, `x-litellm-response-cost: 0.0003407` (= 4.07e-05 tokens + $0.0003 guardrail units); its spend row shows `0.0003407` with `cost_breakdown.guardrail_cost 0.0003`

### Re-confirmed at tip (354b0c3a45, smoke re-run at b849d073e0)

All legs re-run at 354b0c3a45 on port 34914, real AWS us-east-1; the follow-up commit b849d073e0 only changes the terminal-failure logging path (unit-tested), and legs 1 and 3 were re-run at it unchanged (0.0003429 and the 0.0093 failure row)

1. Guarded request: `x-litellm-response-cost: 0.0003429`; spend row `0.0003473` for `chatcmpl-b8ae3c09-cc9e-4f46-9546-1ecfaf79090f` carries `guardrail_information[0].guardrail_cost 0.0003`
2. Budget: key `lit5651-tip2-budget` with `max_budget 0.0005`; two requests at `0.0003429` pass, the third gets `HTTP 429 "Budget has been exceeded! ... Current cost: 0.0006858..., Max budget: 0.0005"`
3. Block mid-chunking bills every call: a 30k-char message plus a coffee message makes AWS reject the single scan as too large, so the guardrail splits it into three billed ApplyGuardrail calls and the last one blocks. `HTTP 400`, and the single failure spend row is `0.0093` with `guardrail_usage {"topicPolicyUnits": 31, "contentPolicyUnits": 31}` summed across all three calls. Before this commit that row only carried the blocking chunk's `1 + 1` units at `0.0003`
4. Forged client metadata: `curl ... /v1/chat/completions -d '{"model":"bedrock-haiku","messages":[...],"metadata":{"standard_logging_guardrail_information":[{"guardrail_name":"forged","guardrail_status":"success","guardrail_cost":-0.005}]}}'`. Before this commit the spend row came out **negative** (`-0.0049681` for `chatcmpl-b74e5c5e`) with only the forged entry logged. At the tip the same request logs `+0.0003583` (`chatcmpl-2b3ec357`) and its `guardrail_information` holds only the real `bedrock-topic-content-pre` entry at `0.0003`
5. Unified endpoints: `/v1/messages` and `/v1/responses` both return `x-litellm-response-cost: 0.0003407` and write spend rows carrying `guardrail_cost 0.0003`

## Type

🆕 New Feature

## Caveats (if any)

- automatedReasoningPolicyUnits priced flat, not multiplied by automatedReasoningPolicies
- InvokeGuardrailChecks responses carry no usage block, so nothing billed
- Regional overrides via `bedrock/<region>/guardrails` keys; AWS prices currently uniform

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] b849d073e0 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b849d073e043339616df1cfd154a373baccb6df2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
