### PR TITLE
test(ui): cover the edit project modal's required-field validation

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectModals/EditProjectModal.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectModals/EditProjectModal.integration.test.tsx
@@ -154,6 +154,17 @@ describe("EditProjectModal submit payload", () => {
     expect(variables().params.metadata).toStrictEqual({ owner: "platform" });
   });
 
+  it("blocks the save when the project name is cleared", async () => {
+    const user = setup();
+    renderModal();
+
+    await user.clear(screen.getByLabelText("Project Name"));
+    await save(user);
+
+    expect(await screen.findByText("Please enter a project name")).toBeInTheDocument();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
   it("sends an edited project name", async () => {
     const user = setup();
     renderModal();


### PR DESCRIPTION
## TLDR

Problem this solves:

- Edit project modal's required-field validation had no test
- Seven payload tests all started from a valid project
- Skipping validation entirely left all seven green

How it solves it:

- Adds the one case that clears a required field
- Passes on current code, so no behaviour changed
- Fails when validation is bypassed, so it has teeth

## User Flow

Before: an admin who clears the project name is correctly stopped, but nothing proves it stays that way

1. They open http://localhost:4000/ui/?page=projects, click a project, then click "Edit"
2. They clear the Project Name box and click "Save Changes"
3. The save is blocked and "Please enter a project name" appears under the box
4. This still works, but a future change that skipped validation would ship without any test failing

After: the same behaviour, now guarded

1. They open http://localhost:4000/ui/?page=projects, click a project, then click "Edit"
2. They clear the Project Name box and click "Save Changes"
3. The save is blocked and "Please enter a project name" appears under the box
4. A change that skipped validation now fails a test before it can ship

## Relevant issues

Follow-up to #37354

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: a proxy on http://localhost:4000 with the Admin UI, signed in as a proxy admin, and at least one project created

Test-only change, so the proof is that the guarded behaviour is unchanged in the browser, captured on the same commit

### Before (d9e9270574)

1. Go to http://localhost:4000/ui/?page=projects, click a project, then click "Edit"
2. Clear the Project Name box and click "Save Changes"
3. Observe the save blocked and "Please enter a project name" shown under the box

### After (c0e573cd1f)

1. Go to http://localhost:4000/ui/?page=projects, click a project, then click "Edit"
2. Clear the Project Name box and click "Save Changes"
3. Observe the save blocked and "Please enter a project name" shown under the box, unchanged

## Type

✅ Test

## Caveats (if any)

- Test only, no production code touched
- Sibling submit paths were checked and already covered

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
