### PR TITLE
fix(proxy): record estimated input tokens in spend logs for failed dispatched requests

### DIFF
--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -179,7 +179,7 @@ async def anthropic_response(
             await proxy_logging_obj.post_call_failure_hook(
                 user_api_key_dict=user_api_key_dict,
                 original_exception=e,
-                request_data=data,
+                request_data=base_llm_response_processor.data,
             )
         body: Final = AnthropicExceptionMapping.transform_to_anthropic_error(
             status_code=e.status_code,
@@ -189,7 +189,7 @@ async def anthropic_response(
         return JSONResponse(status_code=e.status_code, content=body)
     except Exception as e:
         await proxy_logging_obj.post_call_failure_hook(
-            user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
+            user_api_key_dict=user_api_key_dict, original_exception=e, request_data=base_llm_response_processor.data
         )
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.anthropic_response(): Exception occured - %s", e)
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10197,11 +10197,9 @@ async def embeddings(
 
 """
     global proxy_logging_obj
-    data: Any = {}
+    data: Final = await _read_request_body(request=request)
+    base_llm_response_processor: Final = ProxyBaseLLMRequestProcessing(data=data)
     try:
-        # Use shared request body reading helper (same as chat/completions)
-        data = await _read_request_body(request=request)
-
         ### HANDLE TOKEN ARRAY INPUT DECODING ###
         # This must happen BEFORE base_process_llm_request() since it modifies the input
         router_model_names: Final = llm_router.model_names if llm_router is not None else []
@@ -10245,10 +10243,6 @@ async def embeddings(
             if hasattr(user_api_key_dict, "agent_id") and user_api_key_dict.agent_id is not None:
                 data["metadata"]["agent_id"] = user_api_key_dict.agent_id
 
-        # Use unified request processor (same as chat/completions and responses)
-        base_llm_response_processor = ProxyBaseLLMRequestProcessing(data=data)
-
-        # Process the request with all optimizations (shared sessions, network tuning, etc.)
         response: Final = await base_llm_response_processor.base_process_llm_request(
             request=request,
             fastapi_response=fastapi_response,
@@ -10270,8 +10264,6 @@ async def embeddings(
 
         return response
     except Exception as e:
-        # Use unified error handler
-        base_llm_response_processor = ProxyBaseLLMRequestProcessing(data=data)
         raise await base_llm_response_processor._handle_llm_api_exception(
             e=e,
             user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -480,12 +480,18 @@ _INPUT_ESTIMABLE_CALL_TYPES: Final = frozenset(
 )
 
 
-def _failure_usage_to_lift(model_call_details: Mapping[str, object], dispatched: bool) -> tuple[object, object] | None:
+def _failure_usage_to_lift(
+    model_call_details: Mapping[str, object],
+    request_body: Mapping[str, object],
+    dispatched: bool,
+) -> tuple[object, object] | None:
     """A stream that broke mid-flight still billed the provider for the chunks
     already delivered; the streaming handler stashes that recovered usage and
     cost in model_call_details, so prefer it. Otherwise a request that was
     dispatched to a provider and failed without upstream usage gets an
-    estimated input-side Usage with zero cost. Returns the
+    estimated input-side Usage with zero cost. The raw request body backfills
+    the system prompt when the SDK bridges an endpoint (e.g. /v1/messages on a
+    chat-completions provider) without filling optional_params. Returns the
     (combined_usage_object, response_cost) pair to lift, or None."""
     recovered_usage: Final = model_call_details.get("combined_usage_object")
     if recovered_usage is not None:
@@ -495,11 +501,12 @@ def _failure_usage_to_lift(model_call_details: Mapping[str, object], dispatched:
     if str(model_call_details.get("call_type")) not in _INPUT_ESTIMABLE_CALL_TYPES:
         return None
     optional_params: Final = model_call_details.get("optional_params")
-    system_input: Final = (
+    dispatched_system: Final = (
         (optional_params.get("system") or optional_params.get("instructions"))
         if isinstance(optional_params, dict)
         else None
     )
+    system_input: Final = dispatched_system or request_body.get("system") or request_body.get("instructions")
     estimated_usage: Final = _estimate_dispatched_failure_usage(
         model=str(model_call_details.get("model") or ""),
         request_input=model_call_details.get("messages"),
@@ -2303,6 +2310,7 @@ class ProxyLogging:
             # is popped) record real token counts instead of zero.
             _usage_to_lift: Final = _failure_usage_to_lift(
                 model_call_details=_model_call_details,
+                request_body=request_data,
                 dispatched=_first_handoff is not None,
             )
             if _usage_to_lift is not None:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -430,7 +430,9 @@ def _count_request_input_tokens(model: str, request_input: object, system_input:
     text_entries: Final = tuple(entry for entry in request_input if isinstance(entry, str))
     if len(text_entries) == len(request_input):
         return system_tokens + litellm.token_counter(model=model, text="".join(text_entries))
-    return system_tokens + litellm.token_counter(model=model, messages=request_input)
+    return system_tokens + litellm.token_counter(
+        model=model, messages=request_input, use_default_image_token_count=True
+    )
 
 
 def _estimate_dispatched_failure_usage(model: str, request_input: object, system_input: object) -> Usage | None:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -403,24 +403,45 @@ def _exception_changes_request_flow(exc: BaseException) -> bool:
     return isinstance(exc, (SensitiveDataRouteException, ModifyResponseException))
 
 
-def _count_request_input_tokens(model: str, request_input: object) -> int:
+def _prompt_block_text(block: object) -> str:
+    if isinstance(block, str):
+        return block
+    if not isinstance(block, dict):
+        return ""
+    block_text: Final = block.get("text")
+    return block_text if isinstance(block_text, str) else ""
+
+
+def _system_prompt_text(system_input: object) -> str:
+    if isinstance(system_input, str):
+        return system_input
+    if not isinstance(system_input, list):
+        return ""
+    return "".join(_prompt_block_text(block) for block in system_input)
+
+
+def _count_request_input_tokens(model: str, request_input: object, system_input: object) -> int:
+    system_text: Final = _system_prompt_text(system_input)
+    system_tokens: Final = litellm.token_counter(model=model, text=system_text) if system_text else 0
     if isinstance(request_input, str):
-        return litellm.token_counter(model=model, text=request_input)
+        return system_tokens + litellm.token_counter(model=model, text=request_input)
     if not isinstance(request_input, list) or not request_input:
-        return 0
+        return system_tokens
     text_entries: Final = tuple(entry for entry in request_input if isinstance(entry, str))
     if len(text_entries) == len(request_input):
-        return litellm.token_counter(model=model, text="".join(text_entries))
-    return litellm.token_counter(model=model, messages=request_input)
+        return system_tokens + litellm.token_counter(model=model, text="".join(text_entries))
+    return system_tokens + litellm.token_counter(model=model, messages=request_input)
 
 
-def _estimate_dispatched_failure_usage(model: str, request_input: object) -> Usage | None:
+def _estimate_dispatched_failure_usage(model: str, request_input: object, system_input: object) -> Usage | None:
     """A request that failed after dispatch consumed provider-billed input
     tokens, but no provider usage ever came back. Estimate the input side with
     the same tokenizer fallback interrupted streams use, so the spend log's
     failure row records what was sent instead of zero."""
     try:
-        input_tokens: Final = _count_request_input_tokens(model=model, request_input=request_input)
+        input_tokens: Final = _count_request_input_tokens(
+            model=model, request_input=request_input, system_input=system_input
+        )
     except Exception:
         return None
     if input_tokens <= 0:
@@ -440,9 +461,16 @@ def _failure_usage_to_lift(model_call_details: Mapping[str, object], dispatched:
         return recovered_usage, model_call_details.get("response_cost")
     if not dispatched or model_call_details.get(LITELLM_LOGGING_NO_UPSTREAM_LLM_CALL):
         return None
+    optional_params: Final = model_call_details.get("optional_params")
+    system_input: Final = (
+        (optional_params.get("system") or optional_params.get("instructions"))
+        if isinstance(optional_params, dict)
+        else None
+    )
     estimated_usage: Final = _estimate_dispatched_failure_usage(
         model=str(model_call_details.get("model") or ""),
         request_input=model_call_details.get("messages"),
+        system_input=system_input,
     )
     if estimated_usage is None:
         return None

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -40,7 +40,7 @@ from litellm.proxy._types import (
 from litellm.proxy.spend_tracking.spend_log_error_logger import spend_log_error
 from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.proxy.model_listing import ModelInfoResponse
-from litellm.types.utils import CallTypes, CallTypesLiteral, ModelInfo
+from litellm.types.utils import CallTypes, CallTypesLiteral, ModelInfo, Usage
 
 try:
     from litellm_enterprise.enterprise_callbacks.send_emails.base_email import (
@@ -401,6 +401,52 @@ def _exception_changes_request_flow(exc: BaseException) -> bool:
     generic pipeline block instead of being re-raised verbatim.
     """
     return isinstance(exc, (SensitiveDataRouteException, ModifyResponseException))
+
+
+def _count_request_input_tokens(model: str, request_input: object) -> int:
+    if isinstance(request_input, str):
+        return litellm.token_counter(model=model, text=request_input)
+    if not isinstance(request_input, list) or not request_input:
+        return 0
+    text_entries: Final = tuple(entry for entry in request_input if isinstance(entry, str))
+    if len(text_entries) == len(request_input):
+        return litellm.token_counter(model=model, text="".join(text_entries))
+    return litellm.token_counter(model=model, messages=request_input)
+
+
+def _estimate_dispatched_failure_usage(model: str, request_input: object) -> Usage | None:
+    """A request that failed after dispatch consumed provider-billed input
+    tokens, but no provider usage ever came back. Estimate the input side with
+    the same tokenizer fallback interrupted streams use, so the spend log's
+    failure row records what was sent instead of zero."""
+    try:
+        input_tokens: Final = _count_request_input_tokens(model=model, request_input=request_input)
+    except Exception:
+        return None
+    if input_tokens <= 0:
+        return None
+    return Usage(prompt_tokens=input_tokens, completion_tokens=0, total_tokens=input_tokens)
+
+
+def _failure_usage_to_lift(model_call_details: Mapping[str, object], dispatched: bool) -> tuple[object, object] | None:
+    """A stream that broke mid-flight still billed the provider for the chunks
+    already delivered; the streaming handler stashes that recovered usage and
+    cost in model_call_details, so prefer it. Otherwise a request that was
+    dispatched to a provider and failed without upstream usage gets an
+    estimated input-side Usage with zero cost. Returns the
+    (combined_usage_object, response_cost) pair to lift, or None."""
+    recovered_usage: Final = model_call_details.get("combined_usage_object")
+    if recovered_usage is not None:
+        return recovered_usage, model_call_details.get("response_cost")
+    if not dispatched or model_call_details.get(LITELLM_LOGGING_NO_UPSTREAM_LLM_CALL):
+        return None
+    estimated_usage: Final = _estimate_dispatched_failure_usage(
+        model=str(model_call_details.get("model") or ""),
+        request_input=model_call_details.get("messages"),
+    )
+    if estimated_usage is None:
+        return None
+    return estimated_usage, 0.0
 
 
 @dataclass(frozen=True)
@@ -2190,15 +2236,18 @@ class ProxyLogging:
             if _first_handoff is not None:
                 request_data["first_api_call_start_time"] = _first_handoff
 
-            # A stream that broke mid-flight still billed the provider for the
-            # chunks already delivered; the streaming handler stashes that
-            # recovered usage and cost here. Lift them onto request_data so the
+            # Lift recovered partial-stream usage, or an estimated input-side
+            # usage for a dispatched failure, onto request_data so the
             # failure-path spend callbacks (which run after the logging object
-            # is popped) record the real partial spend instead of zero.
-            _recovered_usage: Final = _model_call_details.get("combined_usage_object")
-            if _recovered_usage is not None:
-                request_data["combined_usage_object"] = _recovered_usage
-                request_data["response_cost"] = _model_call_details.get("response_cost")
+            # is popped) record real token counts instead of zero.
+            _usage_to_lift: Final = _failure_usage_to_lift(
+                model_call_details=_model_call_details,
+                dispatched=_first_handoff is not None,
+            )
+            if _usage_to_lift is not None:
+                _lifted_usage, _lifted_cost = _usage_to_lift
+                request_data["combined_usage_object"] = _lifted_usage
+                request_data["response_cost"] = _lifted_cost
 
         # Remove before callbacks iterate — not serialisable
         request_data.pop("litellm_logging_obj", None)

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -449,6 +449,35 @@ def _estimate_dispatched_failure_usage(model: str, request_input: object, system
     return Usage(prompt_tokens=input_tokens, completion_tokens=0, total_tokens=input_tokens)
 
 
+_INPUT_ESTIMABLE_CALL_TYPES: Final = frozenset(
+    call_type.value
+    for call_type in (
+        CallTypes.completion,
+        CallTypes.acompletion,
+        CallTypes.text_completion,
+        CallTypes.atext_completion,
+        CallTypes.anthropic_messages,
+        CallTypes.aanthropic_messages,
+        CallTypes.responses,
+        CallTypes.aresponses,
+        CallTypes.embedding,
+        CallTypes.aembedding,
+        CallTypes.moderation,
+        CallTypes.amoderation,
+        CallTypes.image_generation,
+        CallTypes.aimage_generation,
+        CallTypes.speech,
+        CallTypes.aspeech,
+        CallTypes.rerank,
+        CallTypes.arerank,
+        CallTypes.generate_content,
+        CallTypes.agenerate_content,
+        CallTypes.generate_content_stream,
+        CallTypes.agenerate_content_stream,
+    )
+)
+
+
 def _failure_usage_to_lift(model_call_details: Mapping[str, object], dispatched: bool) -> tuple[object, object] | None:
     """A stream that broke mid-flight still billed the provider for the chunks
     already delivered; the streaming handler stashes that recovered usage and
@@ -460,6 +489,8 @@ def _failure_usage_to_lift(model_call_details: Mapping[str, object], dispatched:
     if recovered_usage is not None:
         return recovered_usage, model_call_details.get("response_cost")
     if not dispatched or model_call_details.get(LITELLM_LOGGING_NO_UPSTREAM_LLM_CALL):
+        return None
+    if str(model_call_details.get("call_type")) not in _INPUT_ESTIMABLE_CALL_TYPES:
         return None
     optional_params: Final = model_call_details.get("optional_params")
     system_input: Final = (

--- a/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
@@ -164,6 +164,41 @@ class TestProxyExceptionPassthrough:
         mock_logging.post_call_failure_hook.assert_awaited_once()
 
 
+class TestFailureHookRequestData:
+    @pytest.mark.asyncio
+    async def test_failure_hook_gets_post_setup_data_with_logging_obj(self):
+        """Request setup replaces the processor's data dict (adding the logging
+        object the failure hook needs to lift token usage from); the exception
+        handler must pass that replaced dict, not the raw request body dict."""
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+        import litellm.proxy.proxy_server as proxy_server
+        from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+
+        captured = {}
+
+        async def fake_process(self, **kwargs):
+            self.data = {**self.data, "litellm_logging_obj": "logging-obj-sentinel"}
+            captured["processor_data"] = self.data
+            raise RuntimeError("provider timeout")
+
+        with (
+            patch.object(ep, "_read_request_body", new=AsyncMock(return_value={"model": "claude-sonnet"})),
+            patch.object(ep.ProxyBaseLLMRequestProcessing, "base_process_llm_request", new=fake_process),
+            patch.object(proxy_server, "proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock()
+            with pytest.raises(ProxyException):
+                await ep.anthropic_response(
+                    fastapi_response=MagicMock(),
+                    request=MagicMock(),
+                    user_api_key_dict=UserAPIKeyAuth(),
+                )
+
+        hook_request_data = mock_logging.post_call_failure_hook.await_args.kwargs["request_data"]
+        assert hook_request_data is captured["processor_data"]
+        assert hook_request_data["litellm_logging_obj"] == "logging-obj-sentinel"
+
+
 class TestEventLoggingBatchEndpoint:
     """Test the stubbed event logging batch endpoint"""
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -11098,3 +11098,46 @@ async def test_moderations_reraises_proxy_exception_unwrapped():
     assert exc_info.value.code == "400"
     assert exc_info.value.param == "metadata"
     mock_logging.post_call_failure_hook.assert_awaited_once()
+
+
+class TestEmbeddingsFailureHookRequestData:
+    @pytest.mark.asyncio
+    async def test_failure_hook_gets_post_setup_data_with_logging_obj(self):
+        """Request setup replaces the processor's data dict (adding the logging
+        object the failure hook needs to lift token usage from); the embeddings
+        exception handler must pass that replaced dict, not the raw request body
+        dict it was rebuilt from."""
+        from litellm.proxy._types import ProxyException
+
+        captured = {}
+        logging_obj_sentinel = MagicMock()
+
+        async def fake_process(self, **kwargs):
+            self.data = {**self.data, "litellm_logging_obj": logging_obj_sentinel}
+            captured["processor_data"] = self.data
+            raise RuntimeError("provider timeout")
+
+        with (
+            patch.object(
+                proxy_server_module,
+                "_read_request_body",
+                new=AsyncMock(return_value={"model": "my-embed", "input": "hello"}),
+            ),
+            patch.object(
+                proxy_server_module.ProxyBaseLLMRequestProcessing,
+                "base_process_llm_request",
+                new=fake_process,
+            ),
+            patch.object(proxy_server_module, "proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock(return_value=None)
+            with pytest.raises(ProxyException):
+                await proxy_server_module.embeddings(
+                    request=MagicMock(),
+                    fastapi_response=MagicMock(),
+                    user_api_key_dict=UserAPIKeyAuth(),
+                )
+
+        hook_request_data = mock_logging.post_call_failure_hook.await_args.kwargs["request_data"]
+        assert hook_request_data is captured["processor_data"]
+        assert hook_request_data["litellm_logging_obj"] is logging_obj_sentinel

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -517,6 +517,7 @@ class TestPostCallFailureHookEstimatesDispatchedInputTokens:
                     "first_api_call_start_time": datetime.now(),
                     "model": "gpt-3.5-turbo",
                     "messages": [{"role": "user", "content": "count these input tokens please"}],
+                    "call_type": "acompletion",
                 }
             ),
             "metadata": {},
@@ -582,6 +583,7 @@ class TestPostCallFailureHookEstimatesDispatchedInputTokens:
                     "first_api_call_start_time": datetime.now(),
                     "model": "gpt-3.5-turbo",
                     "messages": [{"role": "user", "content": "mid-stream failure"}],
+                    "call_type": "acompletion",
                     "combined_usage_object": recovered_usage,
                     "response_cost": 3.5e-05,
                 }
@@ -605,6 +607,7 @@ class TestPostCallFailureHookEstimatesDispatchedInputTokens:
                     "first_api_call_start_time": datetime.now(),
                     "model": "gpt-3.5-turbo",
                     "messages": "a plain text-completion prompt string",
+                    "call_type": "atext_completion",
                 }
             ),
             "metadata": {},
@@ -616,7 +619,7 @@ class TestPostCallFailureHookEstimatesDispatchedInputTokens:
         assert estimated.prompt_tokens > 0
         assert estimated.completion_tokens == 0
 
-    def _dispatched_request_data(self, messages, optional_params):
+    def _dispatched_request_data(self, messages, optional_params, call_type="acompletion"):
         from datetime import datetime
 
         return {
@@ -626,10 +629,33 @@ class TestPostCallFailureHookEstimatesDispatchedInputTokens:
                     "model": "gpt-3.5-turbo",
                     "messages": messages,
                     "optional_params": optional_params,
+                    "call_type": call_type,
                 }
             ),
             "metadata": {},
         }
+
+    @pytest.mark.asyncio
+    async def test_embedding_string_list_input_counted_in_estimate(self):
+        import litellm as litellm_module
+        from litellm.types.utils import Usage
+
+        embedding_input = ["first embedding text", "second embedding text"]
+        request_data = self._dispatched_request_data(embedding_input, {}, call_type="aembedding")
+        await self._run(request_data)
+
+        estimated = request_data["combined_usage_object"]
+        assert isinstance(estimated, Usage)
+        expected = litellm_module.token_counter(model="gpt-3.5-turbo", text="".join(embedding_input))
+        assert estimated.prompt_tokens == expected
+
+    @pytest.mark.asyncio
+    async def test_transcription_checksum_not_estimated(self):
+        request_data = self._dispatched_request_data("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6", {}, call_type="atranscription")
+        await self._run(request_data)
+
+        assert "combined_usage_object" not in request_data
+        assert "response_cost" not in request_data
 
     @pytest.mark.asyncio
     async def test_anthropic_system_prompt_counted_in_estimate(self):

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -636,6 +636,34 @@ class TestPostCallFailureHookEstimatesDispatchedInputTokens:
         }
 
     @pytest.mark.asyncio
+    async def test_image_message_estimated_without_fetching_image(self):
+        import litellm as litellm_module
+        from litellm.types.utils import Usage
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this image"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "http://127.0.0.1:1/unreachable.png", "detail": "high"},
+                    },
+                ],
+            }
+        ]
+        request_data = self._dispatched_request_data(messages, {})
+        await self._run(request_data)
+
+        estimated = request_data["combined_usage_object"]
+        assert isinstance(estimated, Usage)
+        expected = litellm_module.token_counter(
+            model="gpt-3.5-turbo", messages=messages, use_default_image_token_count=True
+        )
+        assert estimated.prompt_tokens == expected
+        assert estimated.prompt_tokens > 0
+
+    @pytest.mark.asyncio
     async def test_embedding_string_list_input_counted_in_estimate(self):
         import litellm as litellm_module
         from litellm.types.utils import Usage

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -478,6 +478,145 @@ class TestPostCallFailureHookLiftsRecoveredPartialSpend:
         assert "response_cost" not in request_data
 
 
+class TestPostCallFailureHookEstimatesDispatchedInputTokens:
+    """A non-stream request that failed after dispatch (timeout, provider
+    error) consumed provider-billed input tokens but recovered no usage.
+    post_call_failure_hook must estimate the input side onto request_data so
+    the spend log's failure row records what was sent instead of zero, while
+    never charging spend for the failure (LIT-5690).
+    """
+
+    async def _run(self, request_data):
+        from unittest.mock import AsyncMock, patch
+
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
+        proxy_logging_obj.alert_types = []
+        with patch.object(proxy_logging_obj, "update_request_status", new=AsyncMock()):
+            await proxy_logging_obj.post_call_failure_hook(
+                request_data=request_data,
+                original_exception=Exception("boom"),
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+    def _logging_obj(self, model_call_details):
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = model_call_details
+        return logging_obj
+
+    @pytest.mark.asyncio
+    async def test_dispatched_failure_estimates_input_tokens_with_zero_cost(self):
+        from datetime import datetime
+
+        from litellm.types.utils import Usage
+
+        request_data = {
+            "litellm_logging_obj": self._logging_obj(
+                {
+                    "first_api_call_start_time": datetime.now(),
+                    "model": "gpt-3.5-turbo",
+                    "messages": [{"role": "user", "content": "count these input tokens please"}],
+                }
+            ),
+            "metadata": {},
+            "response_cost": 123.0,
+        }
+        await self._run(request_data)
+
+        estimated = request_data["combined_usage_object"]
+        assert isinstance(estimated, Usage)
+        assert estimated.prompt_tokens > 0
+        assert estimated.completion_tokens == 0
+        assert estimated.total_tokens == estimated.prompt_tokens
+        assert request_data["response_cost"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_failure_before_dispatch_stays_zero(self):
+        request_data = {
+            "litellm_logging_obj": self._logging_obj(
+                {
+                    "model": "gpt-3.5-turbo",
+                    "messages": [{"role": "user", "content": "never dispatched"}],
+                }
+            ),
+            "metadata": {},
+        }
+        await self._run(request_data)
+
+        assert "combined_usage_object" not in request_data
+        assert "response_cost" not in request_data
+
+    @pytest.mark.asyncio
+    async def test_proxy_only_error_never_dispatched_stays_zero(self):
+        from datetime import datetime
+
+        from litellm.constants import LITELLM_LOGGING_NO_UPSTREAM_LLM_CALL
+
+        request_data = {
+            "litellm_logging_obj": self._logging_obj(
+                {
+                    "first_api_call_start_time": datetime.now(),
+                    "model": "no-such-model",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    LITELLM_LOGGING_NO_UPSTREAM_LLM_CALL: True,
+                }
+            ),
+            "metadata": {},
+        }
+        await self._run(request_data)
+
+        assert "combined_usage_object" not in request_data
+        assert "response_cost" not in request_data
+
+    @pytest.mark.asyncio
+    async def test_recovered_partial_usage_wins_over_estimate(self):
+        from datetime import datetime
+
+        from litellm.types.utils import Usage
+
+        recovered_usage = Usage(prompt_tokens=30, completion_tokens=7, total_tokens=37)
+        request_data = {
+            "litellm_logging_obj": self._logging_obj(
+                {
+                    "first_api_call_start_time": datetime.now(),
+                    "model": "gpt-3.5-turbo",
+                    "messages": [{"role": "user", "content": "mid-stream failure"}],
+                    "combined_usage_object": recovered_usage,
+                    "response_cost": 3.5e-05,
+                }
+            ),
+            "metadata": {},
+        }
+        await self._run(request_data)
+
+        assert request_data["combined_usage_object"] is recovered_usage
+        assert request_data["response_cost"] == 3.5e-05
+
+    @pytest.mark.asyncio
+    async def test_dispatched_failure_with_text_completion_prompt(self):
+        from datetime import datetime
+
+        from litellm.types.utils import Usage
+
+        request_data = {
+            "litellm_logging_obj": self._logging_obj(
+                {
+                    "first_api_call_start_time": datetime.now(),
+                    "model": "gpt-3.5-turbo",
+                    "messages": "a plain text-completion prompt string",
+                }
+            ),
+            "metadata": {},
+        }
+        await self._run(request_data)
+
+        estimated = request_data["combined_usage_object"]
+        assert isinstance(estimated, Usage)
+        assert estimated.prompt_tokens > 0
+        assert estimated.completion_tokens == 0
+
+
 from typing import cast
 
 import litellm

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -738,6 +738,46 @@ class TestPostCallFailureHookEstimatesDispatchedInputTokens:
         ) + litellm_module.token_counter(model="gpt-3.5-turbo", text=instructions)
         assert estimated.prompt_tokens == expected
 
+    @pytest.mark.asyncio
+    async def test_request_body_system_counted_when_optional_params_empty(self):
+        import litellm as litellm_module
+        from litellm.types.utils import Usage
+
+        system_prompt = "You are a meticulous cartographer who labels every landmark."
+        messages = [{"role": "user", "content": "draw me a map"}]
+        request_data = {
+            **self._dispatched_request_data(messages, {}, call_type="aanthropic_messages"),
+            "system": system_prompt,
+        }
+        await self._run(request_data)
+
+        estimated = request_data["combined_usage_object"]
+        assert isinstance(estimated, Usage)
+        expected = litellm_module.token_counter(model="gpt-3.5-turbo", messages=messages) + litellm_module.token_counter(
+            model="gpt-3.5-turbo", text=system_prompt
+        )
+        assert estimated.prompt_tokens == expected
+
+    @pytest.mark.asyncio
+    async def test_optional_params_system_wins_over_request_body_system(self):
+        import litellm as litellm_module
+        from litellm.types.utils import Usage
+
+        dispatched_system = "short dispatched system prompt"
+        messages = [{"role": "user", "content": "hello"}]
+        request_data = {
+            **self._dispatched_request_data(messages, {"system": dispatched_system}),
+            "system": "a much longer request body system prompt that must not be double counted here",
+        }
+        await self._run(request_data)
+
+        estimated = request_data["combined_usage_object"]
+        assert isinstance(estimated, Usage)
+        expected = litellm_module.token_counter(model="gpt-3.5-turbo", messages=messages) + litellm_module.token_counter(
+            model="gpt-3.5-turbo", text=dispatched_system
+        )
+        assert estimated.prompt_tokens == expected
+
 
 from typing import cast
 

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -616,6 +616,74 @@ class TestPostCallFailureHookEstimatesDispatchedInputTokens:
         assert estimated.prompt_tokens > 0
         assert estimated.completion_tokens == 0
 
+    def _dispatched_request_data(self, messages, optional_params):
+        from datetime import datetime
+
+        return {
+            "litellm_logging_obj": self._logging_obj(
+                {
+                    "first_api_call_start_time": datetime.now(),
+                    "model": "gpt-3.5-turbo",
+                    "messages": messages,
+                    "optional_params": optional_params,
+                }
+            ),
+            "metadata": {},
+        }
+
+    @pytest.mark.asyncio
+    async def test_anthropic_system_prompt_counted_in_estimate(self):
+        import litellm as litellm_module
+        from litellm.types.utils import Usage
+
+        system_prompt = "You are a verbose historian who narrates every fact in exhaustive detail."
+        messages = [{"role": "user", "content": "write a short essay"}]
+        request_data = self._dispatched_request_data(messages, {"system": system_prompt, "max_tokens": 100})
+        await self._run(request_data)
+
+        estimated = request_data["combined_usage_object"]
+        assert isinstance(estimated, Usage)
+        expected = litellm_module.token_counter(model="gpt-3.5-turbo", messages=messages) + litellm_module.token_counter(
+            model="gpt-3.5-turbo", text=system_prompt
+        )
+        assert estimated.prompt_tokens == expected
+
+    @pytest.mark.asyncio
+    async def test_anthropic_system_text_blocks_counted_in_estimate(self):
+        import litellm as litellm_module
+        from litellm.types.utils import Usage
+
+        system_blocks = [
+            {"type": "text", "text": "part one of the system prompt. "},
+            {"type": "text", "text": "part two of the system prompt."},
+        ]
+        messages = [{"role": "user", "content": "write a short essay"}]
+        request_data = self._dispatched_request_data(messages, {"system": system_blocks})
+        await self._run(request_data)
+
+        estimated = request_data["combined_usage_object"]
+        assert isinstance(estimated, Usage)
+        expected = litellm_module.token_counter(model="gpt-3.5-turbo", messages=messages) + litellm_module.token_counter(
+            model="gpt-3.5-turbo", text="part one of the system prompt. part two of the system prompt."
+        )
+        assert estimated.prompt_tokens == expected
+
+    @pytest.mark.asyncio
+    async def test_responses_instructions_counted_in_estimate(self):
+        import litellm as litellm_module
+        from litellm.types.utils import Usage
+
+        instructions = "Answer every question as a meticulous archivist."
+        request_data = self._dispatched_request_data("summarize the archive", {"instructions": instructions})
+        await self._run(request_data)
+
+        estimated = request_data["combined_usage_object"]
+        assert isinstance(estimated, Usage)
+        expected = litellm_module.token_counter(
+            model="gpt-3.5-turbo", text="summarize the archive"
+        ) + litellm_module.token_counter(model="gpt-3.5-turbo", text=instructions)
+        assert estimated.prompt_tokens == expected
+
 
 from typing import cast
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Requests that fail after reaching the provider log 0 tokens
- The provider bills the input anyway, so spend cannot be reconciled

How it solves it:

- Failure rows now carry tokenizer-estimated input token counts at $0 spend
- Only dispatched call types with countable text input get estimates
- Image inputs count at the default per-image token estimate; the image is never fetched
- Recovered mid-stream usage keeps priority over the estimate
- /v1/messages and /v1/embeddings failure rows now see the request's usage data at all
- The raw request body backfills the top-level `system` / `instructions` prompt when a bridged endpoint (e.g. /v1/messages served by a chat-completions provider) never fills it in internally

## User Flow

Before: a platform admin reconciling their AWS Bedrock bill against the gateway's spend logs finds every failed request logged at zero tokens, even though the provider billed the input

1. A developer sends POST https://litellm-domain/v1/chat/completions with a ~2900 token prompt for a Bedrock model and it times out, returning 408 "litellm.Timeout: Connection timed out"
2. Another request comes back 400 "BedrockException: The maximum tokens you requested exceeds the model limit of 128000"
3. The same timeout happens on POST https://litellm-domain/v1/messages and POST https://litellm-domain/v1/responses after the provider has already started reading the prompt
4. A POST https://litellm-domain/v1/messages call with a large top-level `system` prompt for a Gemini model (which the gateway serves by translating to the provider's chat API) times out the same way with a 408
5. A POST https://litellm-domain/v1/embeddings call for a Bedrock embedding model times out the same way with a 408
6. A chat request carrying an image attachment (an `image_url` content block) also times out with a 408
7. The admin opens https://litellm-domain/ui/?page=logs and every one of those failure rows shows 0 input, 0 output, and 0 total tokens
8. The provider's console shows billed input processing for those same calls, so the two reports cannot be reconciled

After: the same failed requests log an estimated input token count, so the spend logs line up with what the provider billed

1. A developer sends POST https://litellm-domain/v1/chat/completions with a ~2900 token prompt for a Bedrock model and it times out, returning 408 "litellm.Timeout: Connection timed out"
2. Another request comes back 400 "BedrockException: The maximum tokens you requested exceeds the model limit of 128000"
3. The same timeout happens on POST https://litellm-domain/v1/messages and POST https://litellm-domain/v1/responses after the provider has already started reading the prompt
4. A POST https://litellm-domain/v1/messages call with a large top-level `system` prompt for a Gemini model (which the gateway serves by translating to the provider's chat API) times out the same way with a 408
5. A POST https://litellm-domain/v1/embeddings call for a Bedrock embedding model times out the same way with a 408
6. A chat request carrying an image attachment (an `image_url` content block) also times out with a 408, and the proxy never downloads the image while logging it
7. The admin opens https://litellm-domain/ui/?page=logs and each of those failure rows now shows the input tokens that were sent (2917 on the chat and responses calls, 2913 on the messages call, 728 on the translated Gemini messages call with its 720 token system prompt included, 263 on the image call as text plus a default per-image allowance, 21 on the embeddings call) with 0 output tokens at $0 spend
8. A request that never reached a provider, like an unknown model name, still logs 0 tokens, so only provider-dispatched failures carry counts

## Relevant issues

## Linear ticket

Resolves LIT-5690

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, identical for both runs: a live proxy against real AWS Bedrock and OpenAI (us-east-1, real $$$), fresh Postgres, `router_settings: {num_retries: 0}`, deployments `bedrock-sonnet-5` (`bedrock/us.anthropic.claude-sonnet-5`, no timeout), `bedrock-sonnet-5-timeout-2s` (same model, `litellm_params.timeout: 2`, so the call is cut off after Bedrock starts reading the prompt), `bedrock-sonnet-5-timeout-50ms` (same model, `timeout: 0.05`), `bedrock-embed-timeout-50ms` (`bedrock/amazon.titan-embed-text-v2:0`, `timeout: 0.05`), `gemini-timeout-50ms` (`gemini/gemini-3.7-flash`, `timeout: 0.05`), and `gpt-timeout-50ms` (`openai/gpt-5.6`, `timeout: 0.05`); the last two exercise the /v1/messages bridges (Gemini goes through the chat-completions bridge, OpenAI through the responses bridge). probe_gemini.json and probe_gpt.json are Anthropic messages bodies with a ~720 token top-level `system` string and a one-word user message. Payloads legA/legD/legG/legH share the same ~2.9k token prompt (a long system prompt plus a 1500 word essay ask); legA and legD are chat completions bodies (legD on `bedrock-sonnet-5` with `max_tokens: 999999`), legG is an Anthropic messages body with the system prompt top-level, legH is a responses body with the prompt as `input` role messages. legI is a chat completions body on `bedrock-sonnet-5-timeout-50ms` pairing a short text block with an `image_url` block (`detail: "high"`, a public PNG URL). Spend rows are read with

```
psql -d lit5690_qa -tA -F' | ' -c "select to_char(\"startTime\",'HH24:MI:SS'), model, prompt_tokens, completion_tokens, total_tokens, spend, metadata::jsonb->>'status', metadata::jsonb->'error_information'->>'error_class', metadata::jsonb->'error_information'->>'error_code' from \"LiteLLM_SpendLogs\" where \"startTime\" >= '<sweep start>' order by \"startTime\";"
```

### Before (852368d72f33)

#### /v1/chat/completions timeout after dispatch

1. `curl -s http://localhost:34225/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d @legA.json` returns HTTP 408, `litellm.Timeout: Connection timed out. Timeout passed=Timeout(timeout=2.0), time taken=2.146 seconds`
2. Spend row: `23:20:32 | bedrock/us.anthropic.claude-sonnet-5 | 0 | 0 | 0 | 0 | failure | Timeout | 408`

#### /v1/chat/completions provider rejection

1. `curl -s http://localhost:34225/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d @legD.json` returns HTTP 400, `BedrockException - The maximum tokens you requested exceeds the model limit of 128000`
2. Spend row: `23:20:32 | bedrock/us.anthropic.claude-sonnet-5 | 0 | 0 | 0 | 0 | failure | BadRequestError | 400`

#### /v1/messages timeout after dispatch

1. `curl -s http://localhost:34225/v1/messages -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d @legG.json` returns HTTP 408, `litellm.Timeout: Connection timed out. Timeout passed=2.0, time taken=2.168 seconds`
2. Spend row: `23:20:34 | bedrock-sonnet-5-timeout-2s | 0 | 0 | 0 | 0 | failure | BaseLLMException | 408`

#### /v1/responses timeout after dispatch

1. `curl -s http://localhost:34225/v1/responses -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d @legH.json` returns HTTP 408, `litellm.Timeout: Connection timed out. Timeout passed=Timeout(timeout=2.0), time taken=2.144 seconds`
2. Spend row: `23:20:37 | bedrock-sonnet-5-timeout-2s | 0 | 0 | 0 | 0 | failure | Timeout | 408`

#### /v1/chat/completions with an image attachment, timeout after dispatch

1. `curl -s http://localhost:34225/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d @legI.json` returns HTTP 408, `litellm.Timeout: Connection timed out. Timeout passed=Timeout(timeout=0.05), time taken=0.051 seconds`
2. Spend row: `23:20:37 | bedrock/us.anthropic.claude-sonnet-5 | 0 | 0 | 0 | 0 | failure | Timeout | 408`

#### /v1/embeddings timeout after dispatch

1. `curl -s http://localhost:34225/v1/embeddings -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model": "bedrock-embed-timeout-50ms", "input": ["first embedding text to count", "second embedding text to count"]}'` returns HTTP 408, `litellm.Timeout: Connection timed out. Timeout passed=Timeout(timeout=0.05), time taken=0.052 seconds`
2. Spend row: `23:20:39 | bedrock/amazon.titan-embed-text-v2:0 | 0 | 0 | 0 | 0 | failure | Timeout | 408`

#### Success request logs real provider usage

1. `curl -s http://localhost:34225/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model": "bedrock-sonnet-5", "messages": [{"role": "user", "content": "Reply with the word ok"}], "max_tokens": 10}'` returns HTTP 200
2. Spend row: `23:20:37 | bedrock/us.anthropic.claude-sonnet-5 | 14 | 4 | 18 | 7.48e-05 | | |`

#### Never-dispatched request stays at zero

1. `curl -s http://localhost:34225/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model": "no-such-model", "messages": [{"role": "user", "content": "hi"}]}'` returns HTTP 400, model not found
2. Spend row: `23:20:39 | no-such-model | 0 | 0 | 0 | 0 | failure | ProxyModelNotFoundError | 400`

#### Bridged /v1/messages with a top-level system prompt (both bridges)

1. `curl -s http://localhost:34225/v1/messages -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d @probe_gemini.json` and the same with `probe_gpt.json` both return HTTP 408 timeouts after dispatch
2. Spend rows (probes run against the same base commit): `02:57:29 | gemini-timeout-50ms | 0 | 0 | 0 | 0 | failure | 408` and `02:57:29 | gpt-timeout-50ms | 0 | 0 | 0 | 0 | failure | 408`

### After (f8c8b41bf5)

#### /v1/chat/completions timeout after dispatch

1. `curl -s http://localhost:34225/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d @legA.json` returns HTTP 408, `litellm.Timeout: Connection timed out. Timeout passed=Timeout(timeout=2.0), time taken=2.161 seconds`
2. Spend row: `02:54:11 | bedrock/us.anthropic.claude-sonnet-5 | 2917 | 0 | 2917 | 0 | failure | Timeout | 408`

#### /v1/chat/completions provider rejection

1. `curl -s http://localhost:34225/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d @legD.json` returns HTTP 400, `BedrockException - The maximum tokens you requested exceeds the model limit of 128000`
2. Spend row: `02:54:11 | bedrock/us.anthropic.claude-sonnet-5 | 2917 | 0 | 2917 | 0 | failure | BadRequestError | 400`

#### /v1/messages timeout after dispatch

1. `curl -s http://localhost:34225/v1/messages -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d @legG.json` returns HTTP 408, `litellm.Timeout: Connection timed out. Timeout passed=2.0, time taken=2.148 seconds`
2. Spend row: `02:54:14 | bedrock-sonnet-5-timeout-2s | 2913 | 0 | 2913 | 0 | failure | BaseLLMException | 408`

#### /v1/responses timeout after dispatch

1. `curl -s http://localhost:34225/v1/responses -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d @legH.json` returns HTTP 408, `litellm.Timeout: Connection timed out. Timeout passed=Timeout(timeout=2.0), time taken=2.145 seconds`
2. Spend row: `02:54:16 | bedrock-sonnet-5-timeout-2s | 2917 | 0 | 2917 | 0 | failure | Timeout | 408`

#### /v1/chat/completions with an image attachment, timeout after dispatch

1. `curl -s http://localhost:34225/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d @legI.json` returns HTTP 408, `litellm.Timeout: Connection timed out. Timeout passed=Timeout(timeout=0.05), time taken=0.052 seconds`
2. Spend row: `02:54:18 | bedrock/us.anthropic.claude-sonnet-5 | 263 | 0 | 263 | 0 | failure | Timeout | 408` (the text blocks plus the default per-image token count; failure logging never fetched the image URL)

#### Bridged /v1/messages with a top-level system prompt (both bridges)

1. `curl -s http://localhost:34225/v1/messages -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d @probe_gemini.json` and the same with `probe_gpt.json` both return HTTP 408 timeouts after dispatch
2. Spend rows: `02:54:16 | gemini-timeout-50ms | 728 | 0 | 728 | 0 | failure | Timeout | 408` and `02:54:16 | gpt-timeout-50ms | 728 | 0 | 728 | 0 | failure | Timeout | 408`, each 8 message tokens plus the 720 token system prompt
3. At the intermediate tip 42ddc5c535, before the request-body backfill commit, the same probes logged `728` for the OpenAI probe but only `8` for the Gemini one: the chat-completions bridge never fills the internal params the estimate read the system prompt from, so it silently dropped. Caught by review, fixed and re-proven in f8c8b41bf5

#### /v1/embeddings timeout after dispatch

1. `curl -s http://localhost:34225/v1/embeddings -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model": "bedrock-embed-timeout-50ms", "input": ["first embedding text to count", "second embedding text to count"]}'` returns HTTP 408, `litellm.Timeout: Connection timed out. Timeout passed=Timeout(timeout=0.05), time taken=0.051 seconds`
2. Spend row: `02:54:20 | bedrock/amazon.titan-embed-text-v2:0 | 21 | 0 | 21 | 0 | failure | Timeout | 408`

#### Success request logs real provider usage

1. `curl -s http://localhost:34225/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model": "bedrock-sonnet-5", "messages": [{"role": "user", "content": "Reply with the word ok"}], "max_tokens": 10}'` returns HTTP 200
2. Spend row: `02:54:18 | bedrock/us.anthropic.claude-sonnet-5 | 14 | 4 | 18 | 7.48e-05 | | |` (identical to Before, success path untouched)

#### Never-dispatched request stays at zero

1. `curl -s http://localhost:34225/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model": "no-such-model", "messages": [{"role": "user", "content": "hi"}]}'` returns HTTP 400, model not found
2. Spend row: `02:54:20 | no-such-model | 0 | 0 | 0 | 0 | failure | ProxyModelNotFoundError | 400`

## Type

🐛 Bug Fix

## Caveats (if any)

- Estimates cover the input side only and log $0 spend
- Cache read and write counts stay 0 unless provider-reported
- Call types without countable text input (transcription, realtime) get no estimate
- Image inputs are estimated with the default per-image token count; failure logging never fetches the image URL
- Transcription failures write no spend row at all today, pre-existing gap

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] f8c8b41bf5c3 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f8c8b41bf5c30cb3aebf7030c028820d97c5265b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->