### PR TITLE
fix(vector_stores): stop leaking stored credentials in direct search debug logs

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -9404,6 +9404,27 @@ class BaseLLMHTTPHandler:
             )
 
     ###### VECTOR STORE HANDLER ######
+    @staticmethod
+    def _pre_call_direct_vector_store_search(
+        logging_obj: LiteLLMLoggingObj,
+        custom_llm_provider: str,
+        vector_store_id: str,
+        query: str | list[str],
+    ) -> None:
+        """Direct providers have no HTTP request to echo, and an empty api_base makes the debug
+        logger fall back to dumping model_call_details, which holds stored provider credentials."""
+        endpoint: Final = f"{custom_llm_provider}://{vector_store_id}"
+        logging_obj.pre_call(
+            input="",
+            api_key="",
+            additional_args={  # mutable-ok: pre_call's additional_args contract is a dict
+                "query": query,
+                "vector_store_id": vector_store_id,
+                "api_base": endpoint,
+                "request_str": f"direct vector store search: {endpoint}",
+            },
+        )
+
     async def async_vector_store_search_handler(
         self,
         vector_store_id: str,
@@ -9420,13 +9441,11 @@ class BaseLLMHTTPHandler:
         _is_async: bool = False,
     ) -> VectorStoreSearchResponse:
         if isinstance(vector_store_provider_config, BaseDirectVectorStoreConfig):
-            logging_obj.pre_call(
-                input="",
-                api_key="",
-                additional_args={  # mutable-ok: pre_call's additional_args contract is a dict
-                    "query": query,
-                    "vector_store_id": vector_store_id,
-                },
+            self._pre_call_direct_vector_store_search(
+                logging_obj=logging_obj,
+                custom_llm_provider=custom_llm_provider,
+                vector_store_id=vector_store_id,
+                query=query,
             )
             return await vector_store_provider_config.aexecute_search_vector_store_request(
                 vector_store_id=vector_store_id,
@@ -9551,13 +9570,11 @@ class BaseLLMHTTPHandler:
             )
 
         if isinstance(vector_store_provider_config, BaseDirectVectorStoreConfig):
-            logging_obj.pre_call(
-                input="",
-                api_key="",
-                additional_args={  # mutable-ok: pre_call's additional_args contract is a dict
-                    "query": query,
-                    "vector_store_id": vector_store_id,
-                },
+            self._pre_call_direct_vector_store_search(
+                logging_obj=logging_obj,
+                custom_llm_provider=custom_llm_provider,
+                vector_store_id=vector_store_id,
+                query=query,
             )
             return vector_store_provider_config.execute_search_vector_store_request(
                 vector_store_id=vector_store_id,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 import ssl
-from collections.abc import AsyncIterator, Coroutine, Iterator, Mapping
+from collections.abc import AsyncIterator, Coroutine, Iterator, Mapping, Sequence
 from contextlib import asynccontextmanager
 from functools import lru_cache
 from types import ModuleType
@@ -9409,7 +9409,7 @@ class BaseLLMHTTPHandler:
         logging_obj: LiteLLMLoggingObj,
         custom_llm_provider: str,
         vector_store_id: str,
-        query: str | list[str],
+        query: str | Sequence[str],
     ) -> None:
         """Direct providers have no HTTP request to echo, and an empty api_base makes the debug
         logger fall back to dumping model_call_details, which holds stored provider credentials."""

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1,7 +1,9 @@
 import asyncio
 import json
+import logging
 import os
 import sys
+import time
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
@@ -9,6 +11,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("../../../.."))  # Adds the parent directory to the system path
 import litellm
+from litellm._logging import verbose_logger
 from litellm.integrations.code_interpreter_interception.handler import (
     CodeInterpreterInterceptionLogger,
     LITELLM_CODE_EXECUTION_TOOL_NAME,
@@ -2158,3 +2161,68 @@ async def test_vector_store_search_handler_direct_config_async_skips_http():
     pre_call_args = logging_obj.pre_call.call_args.kwargs["additional_args"]
     assert pre_call_args["query"] == ["q1", "q2"]
     assert pre_call_args["vector_store_id"] == "vs_direct"
+
+
+def _direct_vector_store_debug_logging_obj():
+    from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
+
+    logging_obj = LitellmLogging(
+        model="valkey",
+        messages=[{"role": "user", "content": "q"}],
+        stream=False,
+        call_type="vector_store_search",
+        start_time=time.time(),
+        litellm_call_id="vs-debug-call-id",
+        function_id="vs-debug-function-id",
+        log_raw_request_response=True,
+    )
+    logging_obj.update_environment_variables(
+        model="valkey",
+        optional_params={"vector_store_id": "vs_direct", "query": "q"},
+        litellm_params={
+            "litellm_call_id": "vs-debug-call-id",
+            "vector_store_id": "vs_direct",
+            "litellm_request_debug": True,
+            "metadata": {"user_api_key_alias": "vs-test-key"},
+            "valkey_host": "valkey.internal",
+            "valkey_password": "sup3r-s3cret-valkey-pw",
+            "litellm_embedding_config": {"api_key": "sk-embedding-s3cret"},
+        },
+    )
+    return logging_obj
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+def test_direct_vector_store_search_debug_log_omits_stored_credentials(caplog, is_async):
+    """Regression: an empty api_base made pre_call dump the whole model_call_details, so every
+    search shipped the stored valkey_password / embedding api_key into the raw_request metadata."""
+    handler = BaseLLMHTTPHandler()
+    stub_response = {"object": "vector_store.search_results.page", "search_query": "q", "data": []}
+    config = _make_stub_direct_vector_store_config(stub_response)
+    logging_obj = _direct_vector_store_debug_logging_obj()
+
+    with caplog.at_level(logging.DEBUG, logger=verbose_logger.name):
+        result = handler.vector_store_search_handler(
+            vector_store_id="vs_direct",
+            query="q",
+            vector_store_search_optional_params={"max_num_results": 4},
+            vector_store_provider_config=config,
+            custom_llm_provider="valkey",
+            litellm_params=GenericLiteLLMParams(
+                valkey_host="valkey.internal",
+                valkey_password="sup3r-s3cret-valkey-pw",
+            ),
+            logging_obj=logging_obj,
+            _is_async=is_async,
+        )
+        if is_async:
+            result = asyncio.run(result)
+
+    assert result is stub_response
+    raw_request = logging_obj.model_call_details["litellm_params"]["metadata"]["raw_request"]
+    assert "sup3r-s3cret-valkey-pw" not in raw_request
+    assert "sk-embedding-s3cret" not in raw_request
+    assert "valkey://vs_direct" in raw_request
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert "sup3r-s3cret-valkey-pw" not in logged
+    assert "sk-embedding-s3cret" not in logged


### PR DESCRIPTION
## TLDR

Problem this solves:

- Valkey vector store searches dumped their whole call state to debug logs
- That dump carries connection settings, auth objects, and request headers
- Any future direct (non-HTTP) vector store provider inherits the same leak

How it solves it:

- Direct searches now pass a synthetic `provider://vector_store_id` endpoint
- Debug logs print a one-line request summary instead of the state dump
- One shared helper covers both sync and async direct search paths

## User Flow

Before: a proxy admin running a Valkey-backed vector store with debug logging on finds their gateway's internal call state written to stdout on every search

1. They register a Valkey store under `vector_store_registry` with `valkey_host`, `valkey_port`, and `valkey_password`, then start the proxy with `--detailed_debug`
2. They send POST http://localhost:4000/v1/vector_stores/litellm-qa-docs/search with `{"query": "what is valkey", "max_num_results": 1}` and get back a normal 200 with scored matches
3. They tail the proxy log and find a single ~10,000 character line holding the store's connection settings, the resolved auth object for the calling key, the inbound request headers, and the full search response
4. Anyone with read access to those logs, including a shipped log aggregator, sees that blob on every search

After: the same search logs a one-line summary and nothing else

1. Same registry entry, same `--detailed_debug` start
2. Same POST http://localhost:4000/v1/vector_stores/litellm-qa-docs/search, same 200 with the same scored matches
3. The proxy log now shows `Request Sent from LiteLLM: direct vector store search: valkey://litellm-qa-docs` and no call-state blob
4. Log readers and aggregators see only the store id and provider, so nothing about the connection or the caller's key travels with the log line

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, run once for both sides. Valkey 8 with valkey-search on port 6390, `requirepass sup3r-s3cret-valkey-pw`, holding a real 3072-dim HNSW/COSINE index `litellm-qa-docs` with 6 documents. Embeddings come from real Vertex AI `gemini-embedding-001` calls, so each search below costs real money.

```yaml
# /tmp/valkey_leak_qa_config.yaml
vector_store_registry:
  - vector_store_name: valkey-qa-docs
    litellm_params:
      vector_store_id: litellm-qa-docs
      custom_llm_provider: valkey
      valkey_host: 127.0.0.1
      valkey_port: 6390
      valkey_password: sup3r-s3cret-valkey-pw
      litellm_embedding_model: vertex_ai/gemini-embedding-001
      litellm_embedding_config:
        vertex_project: vertex-check-481318
        vertex_location: global

litellm_settings:
  log_raw_request_response: true
  callbacks: ["langfuse"]

general_settings:
  master_key: sk-qa-raw-request-leak
```

### Before (2059033352)

1. Start the proxy at the merge base:

```
$ litellm --config /tmp/valkey_leak_qa_config.yaml --port 4077 --detailed_debug > /tmp/proxy_before_dbg.log 2>&1 &
```

2. Run a real search (real Vertex embedding, real Valkey KNN):

```
$ curl -s -X POST http://127.0.0.1:4077/v1/vector_stores/litellm-qa-docs/search \
    -H 'Authorization: Bearer sk-qa-raw-request-leak' \
    -H 'Content-Type: application/json' \
    -d '{"query":"what is valkey","max_num_results":1}'
{"object":"vector_store.search_results.page","search_query":"what is valkey","data":[{"score":0.7358313202860001,"content":[{"text":"Valkey is an open source high-performance key-value datastore, forked from Redis and stewarded by the Linux Foundation.","type":"text"}],"file_id":"kb:valkey","filename":"kb:valkey"}]}
```

3. The debug logger emitted the entire call state as one line:

```
$ grep -c "litellm_logging.py:1232 - .*{'litellm_trace_id'" /tmp/proxy_before_dbg.log
1

$ grep "litellm_logging.py:1232" /tmp/proxy_before_dbg.log | head -1 | wc -c
    9924
```

4. Reading that line shows the store's connection settings, the resolved key auth object, the inbound headers, and the full response payload:

```
$ grep "litellm_logging.py:1232" /tmp/proxy_before_dbg.log | head -1 | cut -c1-260
15:30:54 - LiteLLM:DEBUG: litellm_logging.py:1232 - {'litellm_trace_id': '0ca033dd-3835-4772-acb7-0754e4e4c3a5', 'litellm_call_id': '2f5a003f-f39e-42fb-a59d-014775333217', 'input': '', 'litellm_params': {'acompletion': None, 'allm_passthrough_route': None, 'api_key'
```

```
$ grep "litellm_logging.py:1232" /tmp/proxy_before_dbg.log | head -1 | grep -o "'valkey_host': '[^']*', 'valkey_port': [0-9]*" | head -1
'valkey_host': '127.0.0.1', 'valkey_port': 6390

$ grep "litellm_logging.py:1232" /tmp/proxy_before_dbg.log | head -1 | grep -oc "UserAPIKeyAuth(token="
1
```

### After (f6220e97f2)

1. Start the proxy at the PR tip, same config, same port:

```
$ litellm --config /tmp/valkey_leak_qa_config.yaml --port 4077 --detailed_debug > /tmp/proxy_after_dbg.log 2>&1 &
```

2. Run the identical search, which still returns the identical result:

```
$ curl -s -X POST http://127.0.0.1:4077/v1/vector_stores/litellm-qa-docs/search \
    -H 'Authorization: Bearer sk-qa-raw-request-leak' \
    -H 'Content-Type: application/json' \
    -d '{"query":"what is valkey","max_num_results":1}'
{"object":"vector_store.search_results.page","search_query":"what is valkey","data":[{"score":0.7358313202860001,"content":[{"text":"Valkey is an open source high-performance key-value datastore, forked from Redis and stewarded by the Linux Foundation.","type":"text"}],"file_id":"kb:valkey","filename":"kb:valkey"}]}
```

3. The call-state dump is gone:

```
$ grep -c "litellm_logging.py:1232 - .*{'litellm_trace_id'" /tmp/proxy_after_dbg.log
0

$ grep "litellm_logging.py:1232" /tmp/proxy_after_dbg.log | head -1 | wc -c
      67
```

4. What the debug logger prints instead is a one-line summary naming only the provider and store id:

```
$ grep -A 3 "litellm_logging.py:1232" /tmp/proxy_after_dbg.log | head -3
15:31:43 - LiteLLM:DEBUG: litellm_logging.py:1232 -
Request Sent from LiteLLM:
direct vector store search: valkey://litellm-qa-docs
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Valkey is today's only direct vector store provider
- Debug line format changed for direct searches only

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
