### PR TITLE
feat(ui): pick the auto router's custom classifier from a config-declared registry

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -358,6 +358,11 @@ blocked_user_list: Optional[Union[str, List]] = None
 banned_keywords_list: Optional[Union[str, List]] = None
 llm_guard_mode: Literal["all", "key-specific", "request-specific"] = "all"
 guardrail_name_config_map: Dict[str, GuardrailItem] = {}
+# Complexity-router classifier plugins declared under the proxy config's top-level
+# `classifier_plugins` key, keyed by the name the Admin UI selects and saved models
+# reference. Populated at proxy startup; ComplexityRouterConfig resolves string
+# classifier_plugin values through it.
+classifier_plugin_registry: Dict[str, "ClassifierPlugin"] = {}  # mutable-ok: populated at proxy startup
 include_cost_in_streaming_usage: bool = False
 reasoning_auto_summary: bool = False
 ### PROMPTS ####
@@ -488,6 +493,8 @@ priority_reservation: Optional[Dict[str, Union[float, "PriorityReservationDict"]
 # priority_reservation_settings is lazy-loaded via __getattr__
 # Only declare for type checking - at runtime __getattr__ handles it
 if TYPE_CHECKING:
+    from litellm.types.router import ClassifierPlugin
+
     priority_reservation_settings: Optional["PriorityReservationSettings"] = None
 
 

--- a/litellm/proxy/management_endpoints/auto_router_endpoints.py
+++ b/litellm/proxy/management_endpoints/auto_router_endpoints.py
@@ -39,6 +39,7 @@ from litellm.types.management_endpoints.auto_router_endpoints import (
     AutoRouterCacheStats,
     AutoRouterRoutingTestRequest,
     AutoRouterRoutingTestResponse,
+    ClassifierPluginsListResponse,
     RequestComplexityRouterConfig,
     ShadowEvalJobResponse,
     ShadowEvalResult,
@@ -367,6 +368,22 @@ def _summed_agg_row(rows: Sequence[_SessionAggRow]) -> _SessionAggRow:
         saved_spend=sum(row.saved_spend for row in rows),
         session_seconds=sum(row.session_seconds for row in rows),
     )
+
+
+@router.get(
+    "/auto_router/classifier_plugins",
+    tags=("auto router",),
+    dependencies=(Depends(user_api_key_auth),),
+    response_model=ClassifierPluginsListResponse,
+)
+async def list_classifier_plugins(
+    user_api_key_dict: Annotated[UserAPIKeyAuth, Depends(user_api_key_auth)],
+) -> ClassifierPluginsListResponse:
+    """Registered classifier plugin names, for the Admin UI's custom classifier picker."""
+    import litellm
+
+    _require_admin_viewer(user_api_key_dict, "list classifier plugins")
+    return ClassifierPluginsListResponse(classifier_plugins=tuple(sorted(litellm.classifier_plugin_registry)))
 
 
 @router.get(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4089,6 +4089,9 @@ def resolve_classifier_plugin(
     sync `def classify` passes the runtime_checkable isinstance and would only fail on the
     first classified request, so reject it here where the error names the config key.
     """
+    registered: Final = litellm.classifier_plugin_registry.get(plugin_path)
+    if registered is not None:
+        return registered
     resolved: Final = get_instance_fn(value=plugin_path, config_file_path=config_file_path)
     if not isinstance(resolved, ClassifierPlugin) or not inspect.iscoroutinefunction(
         getattr(resolved, "classify", None)
@@ -5488,6 +5491,20 @@ class ProxyConfig:
 
             # Load vector stores from config
             litellm.vector_store_registry.load_vector_stores_from_config(vector_store_registry_config)
+
+        ## CLASSIFIER PLUGINS (complexity-router custom classifiers, picked by name in the Admin UI)
+        classifier_plugins_config: Final = config.get("classifier_plugins", None)
+        if classifier_plugins_config:
+            if not isinstance(classifier_plugins_config, dict):
+                raise TypeError("classifier_plugins must map plugin names to dotted paths")
+            for plugin_name, plugin_path in classifier_plugins_config.items():
+                if not isinstance(plugin_path, str):
+                    raise TypeError(f"classifier_plugins.{plugin_name} must be a dotted-path string")
+                litellm.classifier_plugin_registry[str(plugin_name)] = resolve_classifier_plugin(
+                    plugin_path=plugin_path,
+                    config_file_path=config_file_path,
+                    source_label=f"classifier_plugins.{plugin_name}",
+                )
 
         ## WORKER REGISTRY (Global Control Plane)
         worker_registry_config: Final = config.get("worker_registry", None)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5500,11 +5500,22 @@ class ProxyConfig:
             for plugin_name, plugin_path in classifier_plugins_config.items():
                 if not isinstance(plugin_path, str):
                     raise TypeError(f"classifier_plugins.{plugin_name} must be a dotted-path string")
-                litellm.classifier_plugin_registry[str(plugin_name)] = resolve_classifier_plugin(
-                    plugin_path=plugin_path,
-                    config_file_path=config_file_path,
-                    source_label=f"classifier_plugins.{plugin_name}",
+            resolved_entries: Final = tuple(
+                (
+                    str(plugin_name),
+                    resolve_classifier_plugin(
+                        plugin_path=plugin_path,
+                        config_file_path=config_file_path,
+                        source_label=f"classifier_plugins.{plugin_name}",
+                    ),
                 )
+                for plugin_name, plugin_path in classifier_plugins_config.items()
+            )
+            # Replace, never merge: a config reload that drops a name must evict it, or a
+            # deleted plugin stays selectable until the next restart. Resolution runs before
+            # the clear, so a module broken at reload time keeps the old registry intact.
+            litellm.classifier_plugin_registry.clear()
+            litellm.classifier_plugin_registry.update(resolved_entries)
 
         ## WORKER REGISTRY (Global Control Plane)
         worker_registry_config: Final = config.get("worker_registry", None)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5311,6 +5311,32 @@ class ProxyConfig:
             router_params["health_check_staleness_threshold"] = _hc_staleness
         if _hc_ignore_transient:
             router_params["health_check_ignore_transient_errors"] = True
+        ## CLASSIFIER PLUGINS (complexity-router custom classifiers, picked by name in the Admin UI).
+        ## Registered before the model list resolves, so config-file routers can reference names.
+        classifier_plugins_config: Final = config.get("classifier_plugins", None)
+        if classifier_plugins_config is not None and not isinstance(classifier_plugins_config, dict):
+            raise TypeError("classifier_plugins must map plugin names to dotted paths")
+        for plugin_name, plugin_path in (classifier_plugins_config or _EMPTY_MAPPING).items():
+            if not isinstance(plugin_path, str):
+                raise TypeError(f"classifier_plugins.{plugin_name} must be a dotted-path string")
+        resolved_classifier_entries: Final = tuple(
+            (
+                str(plugin_name),
+                resolve_classifier_plugin(
+                    plugin_path=plugin_path,
+                    config_file_path=config_file_path,
+                    source_label=f"classifier_plugins.{plugin_name}",
+                ),
+            )
+            for plugin_name, plugin_path in (classifier_plugins_config or _EMPTY_MAPPING).items()
+        )
+        # Replace, never merge: a reload that drops a name, empties the block, or removes it
+        # entirely must evict the stale entries, or a deleted plugin stays selectable until
+        # the next restart. Resolution runs before the clear, so a module broken at reload
+        # time keeps the old registry intact.
+        litellm.classifier_plugin_registry.clear()
+        litellm.classifier_plugin_registry.update(resolved_classifier_entries)
+
         ## MODEL LIST
         model_list: Final = config.get("model_list", None)
         if model_list:
@@ -5491,31 +5517,6 @@ class ProxyConfig:
 
             # Load vector stores from config
             litellm.vector_store_registry.load_vector_stores_from_config(vector_store_registry_config)
-
-        ## CLASSIFIER PLUGINS (complexity-router custom classifiers, picked by name in the Admin UI)
-        classifier_plugins_config: Final = config.get("classifier_plugins", None)
-        if classifier_plugins_config:
-            if not isinstance(classifier_plugins_config, dict):
-                raise TypeError("classifier_plugins must map plugin names to dotted paths")
-            for plugin_name, plugin_path in classifier_plugins_config.items():
-                if not isinstance(plugin_path, str):
-                    raise TypeError(f"classifier_plugins.{plugin_name} must be a dotted-path string")
-            resolved_entries: Final = tuple(
-                (
-                    str(plugin_name),
-                    resolve_classifier_plugin(
-                        plugin_path=plugin_path,
-                        config_file_path=config_file_path,
-                        source_label=f"classifier_plugins.{plugin_name}",
-                    ),
-                )
-                for plugin_name, plugin_path in classifier_plugins_config.items()
-            )
-            # Replace, never merge: a config reload that drops a name must evict it, or a
-            # deleted plugin stays selectable until the next restart. Resolution runs before
-            # the clear, so a module broken at reload time keeps the old registry intact.
-            litellm.classifier_plugin_registry.clear()
-            litellm.classifier_plugin_registry.update(resolved_entries)
 
         ## WORKER REGISTRY (Global Control Plane)
         worker_registry_config: Final = config.get("worker_registry", None)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4049,7 +4049,7 @@ def resolve_complexity_router_plugins(
     classifier_plugin_path: Final = complexity_router_config.get("classifier_plugin")
     if isinstance(classifier_plugin_path, str):
         resolved_classifier: Final = resolve_classifier_plugin(
-            plugin_path=classifier_plugin_path,
+            plugin_reference=classifier_plugin_path,
             config_file_path=config_file_path,
             source_label=f"complexity_router_config.classifier_plugin on model {model_name!r}",
         )
@@ -4079,7 +4079,7 @@ def pin_complexity_router_model_id(model: dict) -> None:  # mutable-ok: out-para
 
 
 def resolve_classifier_plugin(
-    plugin_path: str,
+    plugin_reference: str,
     config_file_path: str | None,
     source_label: str,
 ) -> ClassifierPlugin:
@@ -4089,15 +4089,15 @@ def resolve_classifier_plugin(
     sync `def classify` passes the runtime_checkable isinstance and would only fail on the
     first classified request, so reject it here where the error names the config key.
     """
-    registered: Final = litellm.classifier_plugin_registry.get(plugin_path)
+    registered: Final = litellm.classifier_plugin_registry.get(plugin_reference)
     if registered is not None:
         return registered
-    resolved: Final = get_instance_fn(value=plugin_path, config_file_path=config_file_path)
+    resolved: Final = get_instance_fn(value=plugin_reference, config_file_path=config_file_path)
     if not isinstance(resolved, ClassifierPlugin) or not inspect.iscoroutinefunction(
         getattr(resolved, "classify", None)
     ):
         raise ValueError(
-            f"{source_label} entry {plugin_path!r} resolved to {resolved!r}, which does not "
+            f"{source_label} entry {plugin_reference!r} resolved to {resolved!r}, which does not "
             "implement the ClassifierPlugin interface (an async `classify(context)` method). Fix "
             "the referenced module before starting the proxy."
         )
@@ -5323,7 +5323,7 @@ class ProxyConfig:
             (
                 str(plugin_name),
                 resolve_classifier_plugin(
-                    plugin_path=plugin_path,
+                    plugin_reference=plugin_path,
                     config_file_path=config_file_path,
                     source_label=f"classifier_plugins.{plugin_name}",
                 ),
@@ -5332,10 +5332,10 @@ class ProxyConfig:
         )
         # Replace, never merge: a reload that drops a name, empties the block, or removes it
         # entirely must evict the stale entries, or a deleted plugin stays selectable until
-        # the next restart. Resolution runs before the clear, so a module broken at reload
-        # time keeps the old registry intact.
-        litellm.classifier_plugin_registry.clear()
-        litellm.classifier_plugin_registry.update(resolved_classifier_entries)
+        # the next restart. Rebinding swaps the mapping atomically, so an in-flight request
+        # validating mid-reload sees the old set or the new one, never an empty window, and
+        # a module broken at reload time keeps the old registry intact.
+        litellm.classifier_plugin_registry = dict(resolved_classifier_entries)  # mutable-ok: the registry global's type
 
         ## MODEL LIST
         model_list: Final = config.get("model_list", None)

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -546,12 +546,29 @@ class ComplexityRouterConfig(BaseModel):
     classifier_plugin: ClassifierPlugin | None = Field(
         default=None,
         description=(
-            "Custom classifier deciding the tier; required when classifier_type is 'custom'. In the proxy "
-            "config, a dotted path to a ClassifierPlugin instance (resolved at startup, like plugins). Its "
-            "classify(context) receives the request messages and metadata (caller identity included) and "
+            "Custom classifier deciding the tier; required when classifier_type is 'custom'. A name from "
+            "the proxy config's top-level classifier_plugins registry (what the Admin UI saves), or in the "
+            "proxy config a dotted path to a ClassifierPlugin instance (resolved at startup, like plugins). "
+            "Its classify(context) receives the request messages and metadata (caller identity included) and "
             "returns the name of the tier to route to, or None to decline and let classifier_fallback decide."
         ),
     )
+
+    @field_validator("classifier_plugin", mode="before")
+    @classmethod
+    def _resolve_registered_classifier_plugin(cls, value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        import litellm
+
+        registered: Final = litellm.classifier_plugin_registry.get(value)
+        if registered is None:
+            raise ValueError(
+                f"{value!r} is not a registered classifier plugin; declare it under "
+                "classifier_plugins in the proxy config"
+            )
+        return registered
+
     classifier_plugin_timeout_ms: int = Field(
         default=3000,
         gt=0,

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -565,7 +565,7 @@ class ComplexityRouterConfig(BaseModel):
         if registered is None:
             raise ValueError(
                 f"{value!r} is not a registered classifier plugin; declare it under "
-                "classifier_plugins in the proxy config"
+                "classifier_plugins in the proxy config (the registry loads at startup and config reload)"
             )
         return registered
 

--- a/litellm/types/management_endpoints/auto_router_endpoints.py
+++ b/litellm/types/management_endpoints/auto_router_endpoints.py
@@ -27,6 +27,14 @@ class RequestComplexityRouterConfig(ComplexityRouterConfig):
     )
 
 
+class ClassifierPluginsListResponse(BaseModel):
+    """Names from the proxy config's classifier_plugins registry, for the custom classifier picker."""
+
+    classifier_plugins: tuple[str, ...] = Field(
+        description="Registered classifier plugin names an auto-router's classifier_plugin may reference",
+    )
+
+
 class AutoRouterRoutingTestRequest(BaseModel):
     """A single prompt to classify against a complexity-router config that need not be saved yet."""
 

--- a/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
@@ -293,6 +293,21 @@ def test_classifier_plugin_is_not_settable_over_http():
         _request("what is 2+2", classifier_type="custom", classifier_plugin="my_module.instance")
 
 
+@pytest.mark.asyncio
+async def test_list_classifier_plugins_returns_sorted_registry_names(monkeypatch):
+    import litellm
+    from litellm.proxy.management_endpoints.auto_router_endpoints import list_classifier_plugins
+
+    class _Classifier:
+        async def classify(self, context):
+            return "SIMPLE"
+
+    monkeypatch.setitem(litellm.classifier_plugin_registry, "tier-by-team", _Classifier())
+    monkeypatch.setitem(litellm.classifier_plugin_registry, "spend-aware", _Classifier())
+    response = await list_classifier_plugins(user_api_key_dict=ADMIN)
+    assert response.classifier_plugins == ("spend-aware", "tier-by-team")
+
+
 class TestAutoRouterBenchmarks:
     from litellm.proxy.management_endpoints.auto_router_endpoints import _SessionAggRow
 

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -297,6 +297,63 @@ def test_classifier_plugins_config_key_replaces_the_registry_on_reload(monkeypat
     assert set(litellm.classifier_plugin_registry) == {"fresh-name"}
 
 
+def test_config_file_router_can_reference_a_registry_name(monkeypatch, tmp_path):
+    """The registry registers before the model list resolves, so a config.yaml router may
+    set classifier_plugin to a registry name; regression for the ordering bug where the
+    registry filled after plugin resolution and names failed as dotted imports."""
+    import asyncio
+
+    import litellm
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    (tmp_path / "reg_classifier.py").write_text(
+        "class _Classifier:\n"
+        "    async def classify(self, context):\n"
+        "        return 'SIMPLE'\n"
+        "\n"
+        "instance = _Classifier()\n"
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "classifier_plugins:\n"
+        "  tier-by-team: reg_classifier.instance\n"
+        "model_list:\n"
+        "  - model_name: smart-router\n"
+        "    litellm_params:\n"
+        "      model: auto_router/complexity_router\n"
+        "      complexity_router_default_model: gpt-4o-mini\n"
+        "      complexity_router_config:\n"
+        "        classifier_type: custom\n"
+        "        classifier_plugin: tier-by-team\n"
+        "        tiers:\n"
+        "          SIMPLE: gpt-4o-mini\n"
+    )
+    monkeypatch.setattr(litellm, "classifier_plugin_registry", {}, raising=True)
+    proxy_config = ProxyConfig()
+    router, _, _ = asyncio.run(proxy_config.load_config(router=None, config_file_path=str(config_path)))
+    assert "smart-router" in router.model_names
+    assert list(router.complexity_routers) == ["smart-router"]
+
+
+def test_registry_clears_when_the_config_key_is_removed(monkeypatch, tmp_path):
+    """Removing the classifier_plugins block on reload must evict every stale entry."""
+    import asyncio
+
+    import litellm
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    class _Classifier:
+        async def classify(self, context):
+            return "SIMPLE"
+
+    monkeypatch.setattr(litellm, "classifier_plugin_registry", {"stale-name": _Classifier()}, raising=True)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model_list:\n  - model_name: gpt-4o-mini\n    litellm_params:\n      model: gpt-4o-mini\n")
+    proxy_config = ProxyConfig()
+    asyncio.run(proxy_config.load_config(router=None, config_file_path=str(config_path)))
+    assert litellm.classifier_plugin_registry == {}
+
+
 def test_resolve_complexity_router_plugins_leaves_live_classifier_instance_alone():
     class _Classifier:
         async def classify(self, context):

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -246,6 +246,22 @@ def test_resolve_complexity_router_plugins_rejects_synchronous_classify_method(t
         )
 
 
+def test_resolve_classifier_plugin_prefers_the_registry_over_dotted_import(monkeypatch):
+    import litellm
+    from litellm.proxy.proxy_server import resolve_classifier_plugin
+
+    class _Classifier:
+        async def classify(self, context):
+            return "SIMPLE"
+
+    instance = _Classifier()
+    monkeypatch.setitem(litellm.classifier_plugin_registry, "tier-by-team", instance)
+    resolved = resolve_classifier_plugin(
+        plugin_path="tier-by-team", config_file_path=None, source_label="classifier_plugins.tier-by-team"
+    )
+    assert resolved is instance
+
+
 def test_resolve_complexity_router_plugins_leaves_live_classifier_instance_alone():
     class _Classifier:
         async def classify(self, context):

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -123,20 +123,14 @@ def test__scrub_db_overlay_remote_module_loads_invalid_non_dict_returns_input():
 
 def test_resolve_complexity_router_plugins_no_plugins_key_is_a_noop():
     config: Dict[str, Any] = {"tiers": {"SIMPLE": "gpt-4o-mini"}}
-    resolve_complexity_router_plugins(
-        model_name="smart-router", complexity_router_config=config, config_file_path=None
-    )
+    resolve_complexity_router_plugins(model_name="smart-router", complexity_router_config=config, config_file_path=None)
     assert config == {"tiers": {"SIMPLE": "gpt-4o-mini"}}
 
 
 def test_resolve_complexity_router_plugins_resolves_dotted_path_to_live_instance(tmp_path):
     plugin_file = tmp_path / "my_plugin.py"
     plugin_file.write_text(
-        "class _Plugin:\n"
-        "    async def run(self, context):\n"
-        "        return context\n"
-        "\n"
-        "my_plugin_instance = _Plugin()\n"
+        "class _Plugin:\n    async def run(self, context):\n        return context\n\nmy_plugin_instance = _Plugin()\n"
     )
     config: Dict[str, Any] = {"plugins": ["my_plugin.my_plugin_instance"]}
 
@@ -262,6 +256,47 @@ def test_resolve_classifier_plugin_prefers_the_registry_over_dotted_import(monke
     assert resolved is instance
 
 
+def test_classifier_plugins_config_key_replaces_the_registry_on_reload(monkeypatch, tmp_path):
+    """A reload that drops a name must evict it, or a deleted plugin stays selectable."""
+    import asyncio
+
+    import litellm
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    (tmp_path / "reg_classifier.py").write_text(
+        "class _Classifier:\n"
+        "    async def classify(self, context):\n"
+        "        return 'SIMPLE'\n"
+        "\n"
+        "instance = _Classifier()\n"
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "model_list:\n"
+        "  - model_name: gpt-4o-mini\n"
+        "    litellm_params:\n"
+        "      model: gpt-4o-mini\n"
+        "classifier_plugins:\n"
+        "  stale-name: reg_classifier.instance\n"
+    )
+    monkeypatch.setattr(litellm, "classifier_plugin_registry", {}, raising=True)
+    asyncio.get_event_loop_policy()
+    proxy_config = ProxyConfig()
+    asyncio.run(proxy_config.load_config(router=None, config_file_path=str(config_path)))
+    assert set(litellm.classifier_plugin_registry) == {"stale-name"}
+
+    config_path.write_text(
+        "model_list:\n"
+        "  - model_name: gpt-4o-mini\n"
+        "    litellm_params:\n"
+        "      model: gpt-4o-mini\n"
+        "classifier_plugins:\n"
+        "  fresh-name: reg_classifier.instance\n"
+    )
+    asyncio.run(proxy_config.load_config(router=None, config_file_path=str(config_path)))
+    assert set(litellm.classifier_plugin_registry) == {"fresh-name"}
+
+
 def test_resolve_complexity_router_plugins_leaves_live_classifier_instance_alone():
     class _Classifier:
         async def classify(self, context):
@@ -269,9 +304,7 @@ def test_resolve_complexity_router_plugins_leaves_live_classifier_instance_alone
 
     instance = _Classifier()
     config: dict[str, Any] = {"classifier_plugin": instance}
-    resolve_complexity_router_plugins(
-        model_name="smart-router", complexity_router_config=config, config_file_path=None
-    )
+    resolve_complexity_router_plugins(model_name="smart-router", complexity_router_config=config, config_file_path=None)
     assert config["classifier_plugin"] is instance
 
 
@@ -283,11 +316,7 @@ def test_resolve_complexity_router_plugins_leaves_live_classifier_instance_alone
 def test_resolve_routing_plugins_resolves_dotted_paths(tmp_path):
     plugin_file = tmp_path / "rs_plugin.py"
     plugin_file.write_text(
-        "class _Plugin:\n"
-        "    async def run(self, context):\n"
-        "        return context\n"
-        "\n"
-        "rs_plugin_instance = _Plugin()\n"
+        "class _Plugin:\n    async def run(self, context):\n        return context\n\nrs_plugin_instance = _Plugin()\n"
     )
 
     resolved = resolve_routing_plugins(
@@ -1078,11 +1107,7 @@ async def test_ProxyConfig_load_config_resolves_router_settings_plugins(tmp_path
     to `await "some.string".run(context)`."""
     plugin_file = tmp_path / "rs_plugin.py"
     plugin_file.write_text(
-        "class _Plugin:\n"
-        "    async def run(self, context):\n"
-        "        return context\n"
-        "\n"
-        "rs_plugin_instance = _Plugin()\n"
+        "class _Plugin:\n    async def run(self, context):\n        return context\n\nrs_plugin_instance = _Plugin()\n"
     )
     f = tmp_path / "c.yaml"
     f.write_text(
@@ -1097,9 +1122,7 @@ async def test_ProxyConfig_load_config_resolves_router_settings_plugins(tmp_path
     monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", False)
     monkeypatch.delenv("LITELLM_CONFIG_BUCKET_NAME", raising=False)
 
-    router, _model_list, _general_settings = await ProxyConfig().load_config(
-        router=None, config_file_path=str(f)
-    )
+    router, _model_list, _general_settings = await ProxyConfig().load_config(router=None, config_file_path=str(f))
 
     assert len(router.routing_plugins) == 1
     assert type(router.routing_plugins[0]).__name__ == "_Plugin"
@@ -1166,10 +1189,7 @@ async def test_ProxyConfig_load_config_wires_config_reload_interval(tmp_path, mo
 
     f = tmp_path / "c.yaml"
     f.write_text(
-        "model_list: []\n"
-        "general_settings:\n"
-        "  proxy_config_reload_interval_seconds: 47\n"
-        "litellm_settings: {}\n"
+        "model_list: []\ngeneral_settings:\n  proxy_config_reload_interval_seconds: 47\nlitellm_settings: {}\n"
     )
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
     monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", False)
@@ -1313,11 +1333,7 @@ async def test_ProxyConfig__init_non_llm_configs_worker_registry_requires_premiu
     pc = ProxyConfig()
     with pytest.raises(ValueError) as exc_info:
         await pc._init_non_llm_configs(
-            config={
-                "worker_registry": [
-                    {"worker_id": "worker-a", "name": "Worker A", "url": "http://localhost:4001"}
-                ]
-            },
+            config={"worker_registry": [{"worker_id": "worker-a", "name": "Worker A", "url": "http://localhost:4001"}]},
             config_file_path=None,
         )
     message = str(exc_info.value)
@@ -1547,9 +1563,7 @@ def test_ProxyConfig__warn_on_misplaced_jwt_keys_warns_even_when_also_under_gene
 
 def test_ProxyConfig__warn_on_misplaced_jwt_keys_silent_when_correctly_placed():
     """Keys living only under general_settings are valid, so no warning fires."""
-    result, warnings = _capture_proxy_warnings(
-        {"general_settings": {"enable_jwt_auth": True, "litellm_jwtauth": {}}}
-    )
+    result, warnings = _capture_proxy_warnings({"general_settings": {"enable_jwt_auth": True, "litellm_jwtauth": {}}})
 
     assert result == ()
     assert warnings == []

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -251,7 +251,7 @@ def test_resolve_classifier_plugin_prefers_the_registry_over_dotted_import(monke
     instance = _Classifier()
     monkeypatch.setitem(litellm.classifier_plugin_registry, "tier-by-team", instance)
     resolved = resolve_classifier_plugin(
-        plugin_path="tier-by-team", config_file_path=None, source_label="classifier_plugins.tier-by-team"
+        plugin_reference="tier-by-team", config_file_path=None, source_label="classifier_plugins.tier-by-team"
     )
     assert resolved is instance
 
@@ -280,7 +280,6 @@ def test_classifier_plugins_config_key_replaces_the_registry_on_reload(monkeypat
         "  stale-name: reg_classifier.instance\n"
     )
     monkeypatch.setattr(litellm, "classifier_plugin_registry", {}, raising=True)
-    asyncio.get_event_loop_policy()
     proxy_config = ProxyConfig()
     asyncio.run(proxy_config.load_config(router=None, config_file_path=str(config_path)))
     assert set(litellm.classifier_plugin_registry) == {"stale-name"}

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -4233,6 +4233,52 @@ class TestClassifierPluginConfig:
             )
 
 
+class _RegistryClassifier:
+    async def classify(self, context):
+        return "COMPLEX"
+
+
+class TestClassifierPluginRegistry:
+    """String classifier_plugin values resolve through litellm.classifier_plugin_registry."""
+
+    def test_registered_name_resolves_to_the_instance(self, monkeypatch):
+        instance = _RegistryClassifier()
+        monkeypatch.setitem(litellm.classifier_plugin_registry, "tier-by-team", instance)
+        config = ComplexityRouterConfig(
+            tiers={"SIMPLE": "gpt-4o-mini"}, classifier_type="custom", classifier_plugin="tier-by-team"
+        )
+        assert config.classifier_plugin is instance
+
+    def test_unknown_name_is_rejected_at_validation(self):
+        with pytest.raises(ValidationError, match="not a registered classifier plugin"):
+            ComplexityRouterConfig(
+                tiers={"SIMPLE": "gpt-4o-mini"}, classifier_type="custom", classifier_plugin="no-such-plugin"
+            )
+
+    def test_live_instance_passes_through_untouched(self):
+        instance = _RegistryClassifier()
+        config = ComplexityRouterConfig(
+            tiers={"SIMPLE": "gpt-4o-mini"}, classifier_type="custom", classifier_plugin=instance
+        )
+        assert config.classifier_plugin is instance
+
+    @pytest.mark.asyncio
+    async def test_registry_named_plugin_classifies_end_to_end(self, mock_router_instance, monkeypatch):
+        monkeypatch.setitem(litellm.classifier_plugin_registry, "tier-by-team", _RegistryClassifier())
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": "gpt-4o-mini", "COMPLEX": "claude-sonnet-4-20250514"},
+                "classifier_type": "custom",
+                "classifier_plugin": "tier-by-team",
+            },
+        )
+        outcome = await router.aclassify("hello")
+        assert outcome.cause == "classifier_plugin"
+        assert outcome.tier == ComplexityTier.COMPLEX
+
+
 class TestClassifierPlugin:
     """classifier_type='custom': an operator hook decides the tier."""
 

--- a/tests/test_litellm/router_utils/test_auto_router_model_naming.py
+++ b/tests/test_litellm/router_utils/test_auto_router_model_naming.py
@@ -138,6 +138,38 @@ def test_validate_rejects_ambiguous_tier_labels(tier_labels, expected_fragment):
     assert expected_fragment in violation
 
 
+def test_validate_rejects_an_unregistered_classifier_plugin_name():
+    """A stored name the registry does not hold must be refused at write time, not at load."""
+    violation = validate_complexity_router_config_write(
+        complexity_router_config={
+            "tiers": VALID_TIERS,
+            "classifier_type": "custom",
+            "classifier_plugin": "no-such-plugin",
+        }
+    )
+    assert violation is not None
+    assert "complexity_router_config is invalid" in violation
+    assert "not a registered classifier plugin" in violation
+
+
+def test_validate_accepts_a_registered_classifier_plugin_name(monkeypatch):
+    import litellm
+
+    class _Classifier:
+        async def classify(self, context):
+            return "SIMPLE"
+
+    monkeypatch.setitem(litellm.classifier_plugin_registry, "tier-by-team", _Classifier())
+    violation = validate_complexity_router_config_write(
+        complexity_router_config={
+            "tiers": VALID_TIERS,
+            "classifier_type": "custom",
+            "classifier_plugin": "tier-by-team",
+        }
+    )
+    assert violation is None
+
+
 @pytest.mark.parametrize(
     "complexity_router_config",
     [

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/autoRouter/useClassifierPlugins.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/autoRouter/useClassifierPlugins.ts
@@ -1,0 +1,13 @@
+import { $api } from "@/lib/http/api";
+
+export const useClassifierPlugins = () =>
+  $api.useQuery(
+    "get",
+    "/auto_router/classifier_plugins",
+    {},
+    {
+      // Registration is config-file-only, so the list changes only on a proxy reload.
+      staleTime: 5 * 60 * 1000,
+      select: (data) => data.classifier_plugins,
+    },
+  );

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.test.ts
@@ -99,6 +99,23 @@ describe("autoRouterRows", () => {
     expect(row.typeLabel).toBe("LLM Classifier");
   });
 
+  it("labels a router using a custom classifier plugin", () => {
+    const row = toAutoRouterRow(
+      {
+        ...complexityDeployment,
+        litellm_params: {
+          ...complexityDeployment.litellm_params,
+          complexity_router_config: { tiers: {}, classifier_type: "custom", classifier_plugin: "tier-by-team" },
+        },
+      },
+      0,
+      ADMIN,
+      null,
+    );
+
+    expect(row.typeLabel).toBe("Custom classifier");
+  });
+
   it("treats a deployment carrying complexity_router_config as complexity even off the canonical model string", () => {
     expect(isComplexityRouter({ model: "auto_router/legacy", complexity_router_config: { tiers: {} } })).toBe(true);
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.ts
@@ -54,8 +54,11 @@ const asStringArray = (value: unknown): string[] =>
 
 const dedupe = (models: string[]): string[] => Array.from(new Set(models));
 
-export const complexityTypeLabel = (config: Record<string, unknown>): string =>
-  config.classifier_type === "llm" ? "LLM Classifier" : "Heuristic";
+export const complexityTypeLabel = (config: Record<string, unknown>): string => {
+  if (config.classifier_type === "llm") return "LLM Classifier";
+  if (config.classifier_type === "custom") return "Custom classifier";
+  return "Heuristic";
+};
 
 interface Presentation {
   typeLabel: string;

--- a/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.test.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, renderWithProviders, screen } from "../../../tests/test-utils";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useClassifierPlugins } from "@/app/(dashboard)/hooks/autoRouter/useClassifierPlugins";
+import ClassificationMethodConfig from "./ClassificationMethodConfig";
+import { ComplexityRouterConfigValue } from "./ComplexityRouterConfig";
+import { LOADED_CLASSIFIER_PLUGINS_QUERY } from "../../../tests/mocks/classifierPlugins";
+
+vi.mock(
+  "@/app/(dashboard)/hooks/autoRouter/useComplexityScorerDefaults",
+  async () => await import("../../../tests/mocks/complexityScorerDefaults"),
+);
+
+vi.mock(
+  "@/app/(dashboard)/hooks/autoRouter/useClassifierPlugins",
+  async () => await import("../../../tests/mocks/classifierPlugins"),
+);
+
+const BASE: ComplexityRouterConfigValue = {
+  tiers: { SIMPLE: ["gpt-4o-mini"], MEDIUM: ["gpt-4o"], COMPLEX: ["o3"], REASONING: ["o3"] },
+  classifier_type: "heuristic",
+};
+
+const CUSTOM: ComplexityRouterConfigValue = {
+  ...BASE,
+  classifier_type: "custom",
+  classifier_plugin: "tier-by-team",
+  classifier_plugin_timeout_ms: 3000,
+};
+
+const MODEL_OPTIONS = [{ value: "gpt-4o-mini", label: "gpt-4o-mini" }];
+
+const render = (value: ComplexityRouterConfigValue, onChange = vi.fn()) => {
+  renderWithProviders(
+    <ClassificationMethodConfig value={value} onChange={onChange} modelOptions={MODEL_OPTIONS} defaultModel="gpt-4o" />,
+  );
+  return onChange;
+};
+
+const lastValue = (onChange: ReturnType<typeof vi.fn>) =>
+  onChange.mock.calls.at(-1)?.[0] as ComplexityRouterConfigValue | undefined;
+
+describe("ClassificationMethodConfig classification method radios", () => {
+  it("offers the custom classifier alongside the heuristic and the LLM classifier", () => {
+    render(BASE);
+
+    expect(screen.getByRole("radio", { name: /Heuristic/ })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /LLM Classifier/ })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Custom classifier/ })).toBeEnabled();
+  });
+
+  // Only the custom branch may carry a plugin: leaving one behind would have the backend reject the
+  // save outright (classifier_plugin set with a non-custom classifier_type).
+  it("clears the plugin when the operator switches back to the heuristic", async () => {
+    const onChange = render(CUSTOM);
+
+    await userEvent.click(screen.getByRole("radio", { name: /Heuristic/ }));
+
+    expect(lastValue(onChange)).toMatchObject({
+      classifier_type: "heuristic",
+      classifier_plugin: undefined,
+      classifier_plugin_timeout_ms: undefined,
+      classifier_fallback: undefined,
+    });
+  });
+
+  it("stamps the default plugin timeout when custom is selected", async () => {
+    const onChange = render(BASE);
+
+    await userEvent.click(screen.getByRole("radio", { name: /Custom classifier/ }));
+
+    expect(lastValue(onChange)).toMatchObject({ classifier_type: "custom", classifier_plugin_timeout_ms: 3000 });
+  });
+});
+
+describe("ClassificationMethodConfig custom classifier controls", () => {
+  it("does not show the plugin controls until custom is the selected method", () => {
+    render(BASE);
+
+    expect(screen.queryByRole("combobox", { name: "Classifier Plugin" })).not.toBeInTheDocument();
+  });
+
+  it("offers the names the proxy registered", async () => {
+    render({ ...CUSTOM, classifier_plugin: undefined });
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Classifier Plugin" }));
+
+    expect(await screen.findByTitle("tier-by-team")).toBeInTheDocument();
+    expect(screen.getByTitle("spend-aware")).toBeInTheDocument();
+  });
+
+  it("records the plugin the operator picks", async () => {
+    const onChange = render({ ...CUSTOM, classifier_plugin: undefined });
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Classifier Plugin" }));
+    await userEvent.click(await screen.findByTitle("spend-aware"));
+
+    expect(lastValue(onChange)).toMatchObject({ classifier_plugin: "spend-aware", classifier_plugin_timeout_ms: 3000 });
+  });
+
+  it("emits an edited plugin timeout", () => {
+    const onChange = render(CUSTOM);
+
+    fireEvent.change(screen.getByRole("spinbutton", { name: "Plugin Timeout (ms)" }), { target: { value: "750" } });
+
+    expect(lastValue(onChange)).toMatchObject({ classifier_plugin_timeout_ms: 750 });
+  });
+
+  // The backend applies classifier_fallback to a plugin exactly as it does to an LLM classifier, so
+  // gating this picker on the LLM branch would leave the plugin's failure path unconfigurable.
+  it("offers the fallback picker, which is not LLM-only", () => {
+    render(CUSTOM);
+
+    expect(screen.getByRole("radio", { name: /Score with the heuristic/ })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Route to the default model/ })).toBeInTheDocument();
+  });
+
+  it("says the score no longer decides the tier under a plugin", () => {
+    render(CUSTOM);
+
+    expect(screen.getByText(/classifies with your own classifier plugin/)).toBeInTheDocument();
+  });
+
+  it("reports a missing plugin once the form has been submitted", () => {
+    renderWithProviders(
+      <ClassificationMethodConfig
+        value={{ ...CUSTOM, classifier_plugin: undefined }}
+        onChange={vi.fn()}
+        modelOptions={MODEL_OPTIONS}
+        showValidationErrors
+      />,
+    );
+
+    expect(screen.getByText("A classifier plugin is required")).toBeInTheDocument();
+  });
+});
+
+describe("ClassificationMethodConfig when the proxy registered no plugins", () => {
+  const empty = { data: [], isPending: false, isError: false, refetch: vi.fn() };
+  const failing = { data: undefined, isPending: false, isError: true, refetch: vi.fn() };
+
+  afterEach(() => vi.mocked(useClassifierPlugins).mockReturnValue(LOADED_CLASSIFIER_PLUGINS_QUERY));
+
+  it("disables the custom radio and says how to enable it", () => {
+    vi.mocked(useClassifierPlugins).mockReturnValue(empty as never);
+    render(BASE);
+
+    expect(screen.getByRole("radio", { name: /Custom classifier/ })).toBeDisabled();
+    expect(
+      screen.getByText("Declare classifier_plugins in the proxy config to enable custom classifiers"),
+    ).toBeInTheDocument();
+  });
+
+  // A fetch that never landed leaves the registry unknown, not empty. Blanking the select or greying
+  // out the radio here would clear an already-configured plugin on the operator's next save.
+  it("keeps a stored plugin name selectable when the fetch failed", () => {
+    vi.mocked(useClassifierPlugins).mockReturnValue(failing as never);
+    render(CUSTOM);
+
+    expect(screen.getByRole("radio", { name: /Custom classifier/ })).toBeEnabled();
+    expect(screen.getByRole("combobox", { name: "Classifier Plugin" })).toBeInTheDocument();
+    expect(screen.getByTitle("tier-by-team")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Declare classifier_plugins in the proxy config to enable custom classifiers"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
@@ -3,6 +3,7 @@ import { Select as AntdSelect, Card, InputNumber, Radio, Space, Switch, Tooltip,
 import React from "react";
 import ClassifierPromptEditor from "./ClassifierPromptEditor";
 import HeuristicScoringConfig from "./HeuristicScoringConfig";
+import { useClassifierPlugins } from "@/app/(dashboard)/hooks/autoRouter/useClassifierPlugins";
 import { useComplexityScorerDefaults } from "@/app/(dashboard)/hooks/autoRouter/useComplexityScorerDefaults";
 import {
   ClassifierFallback,
@@ -11,6 +12,7 @@ import {
   DEFAULT_CLASSIFIER_CONTEXT_PER_TURN_CHARS,
   DEFAULT_CLASSIFIER_CONTEXT_WINDOW_SIZE,
   DEFAULT_CLASSIFIER_FALLBACK,
+  DEFAULT_CLASSIFIER_PLUGIN_TIMEOUT_MS,
   DEFAULT_CLASSIFIER_TIMEOUT_MS,
   DEFAULT_CLASSIFICATION_RUBRIC,
   NEW_CLASSIFIER_CLASSIFICATION_RUBRIC,
@@ -35,18 +37,29 @@ const CUSTOM_PROMPT_WITH_DEFAULT_MODEL_FALLBACK =
   "names stay fixed. The scoring below no longer runs at all, since a failed classifier routes to the default " +
   "model instead:";
 
+const PLUGIN_WITH_HEURISTIC_FALLBACK =
+  "This router classifies with your own classifier plugin, so the tier comes from whatever the plugin decides. The " +
+  "four tier names stay fixed. The scoring below is the heuristic, which now runs only when the plugin fails:";
+
+const PLUGIN_WITH_DEFAULT_MODEL_FALLBACK =
+  "This router classifies with your own classifier plugin, so the tier comes from whatever the plugin decides. The " +
+  "four tier names stay fixed. The scoring below no longer runs at all, since a failed plugin routes to the default " +
+  "model instead:";
+
 /**
- * What the scoring breakdown below it actually describes. A custom prompt means the score no longer
- * decides the tier, and pairing one with the default-model fallback means the heuristic never runs
- * at all, so the panel must not keep implying a score is involved on either router.
+ * What the scoring breakdown below it actually describes. A custom prompt or a classifier plugin means
+ * the score no longer decides the tier, and pairing either with the default-model fallback means the
+ * heuristic never runs at all, so the panel must not keep implying a score is involved.
  */
 const scoringExplanation = (value: ComplexityRouterConfigValue): string => {
+  const fallsBackToDefaultModel = value.classifier_fallback === "default_model";
+  if (value.classifier_type === "custom") {
+    return fallsBackToDefaultModel ? PLUGIN_WITH_DEFAULT_MODEL_FALLBACK : PLUGIN_WITH_HEURISTIC_FALLBACK;
+  }
   const usesCustomPrompt =
     value.classifier_type === "llm" && Boolean(value.classifier_llm_config?.system_prompt?.trim());
   if (!usesCustomPrompt) return DEFAULT_SCORING_EXPLANATION;
-  return value.classifier_fallback === "default_model"
-    ? CUSTOM_PROMPT_WITH_DEFAULT_MODEL_FALLBACK
-    : CUSTOM_PROMPT_WITH_HEURISTIC_FALLBACK;
+  return fallsBackToDefaultModel ? CUSTOM_PROMPT_WITH_DEFAULT_MODEL_FALLBACK : CUSTOM_PROMPT_WITH_HEURISTIC_FALLBACK;
 };
 
 /**
@@ -105,6 +118,43 @@ const HowClassificationWorks: React.FC<{ value: ComplexityRouterConfigValue }> =
   );
 };
 
+const ClassifierFallbackPicker: React.FC<{
+  fallback: ClassifierFallback | undefined;
+  onChange: (fallback: ClassifierFallback) => void;
+  defaultModel: string | undefined;
+}> = ({ fallback, onChange, defaultModel }) => (
+  <div>
+    <Text strong style={{ display: "block", marginBottom: 4 }}>
+      If the classifier fails
+    </Text>
+    <Radio.Group value={fallback ?? DEFAULT_CLASSIFIER_FALLBACK} onChange={(e) => onChange(e.target.value)}>
+      <Space direction="vertical">
+        <Radio value="heuristic">
+          <Text>Score with the heuristic</Text>{" "}
+          <Text type="secondary">— right when the classifier grades complexity too</Text>
+        </Radio>
+        <Radio value="default_model" disabled={!defaultModel}>
+          <Tooltip
+            title={
+              defaultModel
+                ? "Change it from the Default Model select."
+                : "Set a default model on this router to use this option"
+            }
+          >
+            <span>
+              <Text>Route to the default model{defaultModel ? ` (${defaultModel})` : ""}</Text>{" "}
+              <Text type="secondary">— right when your classifier grades something other than complexity</Text>
+            </span>
+          </Tooltip>
+        </Radio>
+      </Space>
+    </Radio.Group>
+    <Text type="secondary" style={{ display: "block", fontSize: 12 }}>
+      Applies when the classifier call errors, times out, or returns an unparseable response.
+    </Text>
+  </div>
+);
+
 interface ClassificationMethodConfigProps {
   value: ComplexityRouterConfigValue;
   onChange: (value: ComplexityRouterConfigValue) => void;
@@ -125,11 +175,20 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
   showValidationErrors = false,
   defaultModel,
 }) => {
-  const hasDefaultModel = Boolean(defaultModel);
   const classifierModelMissing =
     showValidationErrors && value.classifier_type === "llm" && !value.classifier_llm_config?.model;
+  const classifierPluginMissing =
+    showValidationErrors && value.classifier_type === "custom" && !value.classifier_plugin;
   const usesCustomPrompt = Boolean(value.classifier_llm_config?.system_prompt?.trim());
   const classificationRubric = value.classifier_llm_config?.classification_rubric ?? DEFAULT_CLASSIFICATION_RUBRIC;
+
+  const { data: registeredPlugins, isError: pluginsError } = useClassifierPlugins();
+  // A failed fetch leaves the registry unknown, not empty: offering the stored name anyway is what keeps
+  // opening this form on an existing custom router from silently clearing its plugin on the next save.
+  const registryIsEmpty = !pluginsError && registeredPlugins !== undefined && registeredPlugins.length === 0;
+  const pluginOptions = Array.from(
+    new Set([...(registeredPlugins ?? []), ...(value.classifier_plugin ? [value.classifier_plugin] : [])]),
+  ).map((name) => ({ value: name, label: name }));
 
   const handleClassifierTypeChange = (classifierType: ClassifierType) => {
     const nextValue: ComplexityRouterConfigValue = {
@@ -153,7 +212,12 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
           : undefined,
       classifier_context_include_assistant_turns:
         classifierType === "llm" ? value.classifier_context_include_assistant_turns : undefined,
-      classifier_fallback: classifierType === "llm" ? value.classifier_fallback : undefined,
+      classifier_fallback: classifierType === "heuristic" ? undefined : value.classifier_fallback,
+      classifier_plugin: classifierType === "custom" ? value.classifier_plugin : undefined,
+      classifier_plugin_timeout_ms:
+        classifierType === "custom"
+          ? value.classifier_plugin_timeout_ms ?? DEFAULT_CLASSIFIER_PLUGIN_TIMEOUT_MS
+          : undefined,
     };
     onChange(nextValue);
   };
@@ -178,6 +242,18 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
         timeout_ms: timeoutMs ?? DEFAULT_CLASSIFIER_TIMEOUT_MS,
       },
     });
+  };
+
+  const handleClassifierPluginChange = (classifierPlugin: string) => {
+    onChange({
+      ...value,
+      classifier_plugin: classifierPlugin,
+      classifier_plugin_timeout_ms: value.classifier_plugin_timeout_ms ?? DEFAULT_CLASSIFIER_PLUGIN_TIMEOUT_MS,
+    });
+  };
+
+  const handleClassifierPluginTimeoutChange = (timeoutMs: number | null) => {
+    onChange({ ...value, classifier_plugin_timeout_ms: timeoutMs ?? DEFAULT_CLASSIFIER_PLUGIN_TIMEOUT_MS });
   };
 
   const handleClassificationRubricChange = (classificationRubric: ClassificationRubric) => {
@@ -245,6 +321,15 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
             <Text strong>LLM Classifier</Text>{" "}
             <Text type="secondary">— use a model to decide the tier (e.g. a small/fast model)</Text>
           </Radio>
+          <Radio value="custom" disabled={registryIsEmpty && value.classifier_type !== "custom"}>
+            <Text strong>Custom classifier</Text>{" "}
+            <Text type="secondary">— let a classifier plugin registered in the proxy config decide the tier</Text>
+          </Radio>
+          {registryIsEmpty && (
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              Declare classifier_plugins in the proxy config to enable custom classifiers
+            </Text>
+          )}
         </Space>
       </Radio.Group>
 
@@ -321,39 +406,11 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
               classificationRubric={classificationRubric}
             />
           </div>
-          <div>
-            <Text strong style={{ display: "block", marginBottom: 4 }}>
-              If the classifier fails
-            </Text>
-            <Radio.Group
-              value={value.classifier_fallback ?? DEFAULT_CLASSIFIER_FALLBACK}
-              onChange={(e) => handleClassifierFallbackChange(e.target.value)}
-            >
-              <Space direction="vertical">
-                <Radio value="heuristic">
-                  <Text>Score with the heuristic</Text>{" "}
-                  <Text type="secondary">— right when the classifier grades complexity too</Text>
-                </Radio>
-                <Radio value="default_model" disabled={!hasDefaultModel}>
-                  <Tooltip
-                    title={
-                      hasDefaultModel
-                        ? "Change it from the Default Model select."
-                        : "Set a default model on this router to use this option"
-                    }
-                  >
-                    <span>
-                      <Text>Route to the default model{defaultModel ? ` (${defaultModel})` : ""}</Text>{" "}
-                      <Text type="secondary">— right when your prompt grades something other than complexity</Text>
-                    </span>
-                  </Tooltip>
-                </Radio>
-              </Space>
-            </Radio.Group>
-            <Text type="secondary" style={{ display: "block", fontSize: 12 }}>
-              Applies when the classifier call errors, times out, or returns an unparseable response.
-            </Text>
-          </div>
+          <ClassifierFallbackPicker
+            fallback={value.classifier_fallback}
+            onChange={handleClassifierFallbackChange}
+            defaultModel={defaultModel}
+          />
           <div>
             <Text strong style={{ display: "block", marginBottom: 4 }}>
               Context Window Size
@@ -404,6 +461,56 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
               last N user turns.
             </Text>
           </div>
+        </div>
+      )}
+
+      {value.classifier_type === "custom" && (
+        <div className="mt-4 space-y-3">
+          <div>
+            <Text strong style={{ display: "block", marginBottom: 4 }}>
+              Classifier Plugin
+            </Text>
+            <AntdSelect
+              value={value.classifier_plugin || undefined}
+              onChange={handleClassifierPluginChange}
+              placeholder="Select a classifier plugin registered in the proxy config"
+              showSearch
+              style={{ width: "100%" }}
+              options={pluginOptions}
+              status={classifierPluginMissing ? "error" : undefined}
+              aria-label="Classifier Plugin"
+            />
+            {classifierPluginMissing && (
+              <Text type="danger" style={{ fontSize: 12 }}>
+                A classifier plugin is required
+              </Text>
+            )}
+            {pluginsError && (
+              <Text type="secondary" style={{ display: "block", fontSize: 12 }}>
+                The registered plugin names could not be loaded from the proxy.
+              </Text>
+            )}
+          </div>
+          <div>
+            <Text strong style={{ display: "block", marginBottom: 4 }}>
+              Plugin Timeout (ms)
+            </Text>
+            <InputNumber
+              value={value.classifier_plugin_timeout_ms ?? DEFAULT_CLASSIFIER_PLUGIN_TIMEOUT_MS}
+              onChange={handleClassifierPluginTimeoutChange}
+              min={1}
+              style={{ width: "100%" }}
+              aria-label="Plugin Timeout (ms)"
+            />
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              How long the plugin has to classify before it fails and the fallback below takes over.
+            </Text>
+          </div>
+          <ClassifierFallbackPicker
+            fallback={value.classifier_fallback}
+            onChange={handleClassifierFallbackChange}
+            defaultModel={defaultModel}
+          />
         </div>
       )}
 

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -15,6 +15,7 @@ export type { DimensionWeights, TierBoundaries, TokenThresholds };
 const { Text } = Typography;
 
 export const DEFAULT_CLASSIFIER_TIMEOUT_MS = 3000;
+export const DEFAULT_CLASSIFIER_PLUGIN_TIMEOUT_MS = 3000;
 export const DEFAULT_TIER_DISTANCE_PENALTY = 0.5;
 export const DEFAULT_CLASSIFIER_CONTEXT_WINDOW_SIZE = 3;
 export const DEFAULT_CLASSIFIER_CONTEXT_PER_TURN_CHARS = 200;
@@ -73,7 +74,7 @@ export interface ClassifierLLMConfig {
   system_prompt?: string;
 }
 
-export type ClassifierType = "heuristic" | "llm";
+export type ClassifierType = "heuristic" | "llm" | "custom";
 
 export type ClassifierFallback = "heuristic" | "default_model";
 
@@ -90,8 +91,8 @@ export type HeuristicScoringRole = "decides" | "fallback_only" | "never";
 
 /**
  * Whether the heuristic scorer runs on this router at all, which is what gates its knobs. An LLM
- * classifier still falls back to the scorer unless the fallback is the default model, so the gate cannot be
- * a plain classifier_type check.
+ * classifier or a classifier plugin still falls back to the scorer unless the fallback is the default
+ * model, so the gate cannot be a plain classifier_type check.
  */
 export const heuristicScoringRoleFor = (
   classifierType: ClassifierType,
@@ -115,6 +116,9 @@ export interface ComplexityRouterConfigValue {
   default_model?: string;
   classifier_type: ClassifierType;
   classifier_llm_config?: ClassifierLLMConfig;
+  /** A name from the proxy config's classifier_plugins registry. Required when classifier_type is "custom". */
+  classifier_plugin?: string;
+  classifier_plugin_timeout_ms?: number;
   classifier_context_window_size?: number;
   classifier_context_per_turn_chars?: number;
   classifier_context_include_assistant_turns?: boolean;

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -13,6 +13,11 @@ vi.mock(
   async () => await import("../../../tests/mocks/complexityScorerDefaults"),
 );
 
+vi.mock(
+  "@/app/(dashboard)/hooks/autoRouter/useClassifierPlugins",
+  async () => await import("../../../tests/mocks/classifierPlugins"),
+);
+
 const ANTHROPIC_PRESET = getPresetByKey("anthropic_family")!;
 const ANTHROPIC_TIERS = ANTHROPIC_PRESET.complexity_router_config.tiers;
 
@@ -283,6 +288,50 @@ describe("AddAutoRouterTab", () => {
     expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
       session_affinity: false,
     });
+  });
+
+  it("carries a selected classifier plugin and its timeout through to the create payload", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(<Harness />);
+
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "plugin-router");
+    expandDetailedConfiguration();
+    await user.click(screen.getByText("Advanced: Classification Method"));
+    await user.click(await screen.findByRole("radio", { name: /Custom classifier/ }));
+    fireEvent.mouseDown(await screen.findByRole("combobox", { name: "Classifier Plugin" }));
+    await user.click(await screen.findByTitle("tier-by-team"));
+
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+    expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
+      classifier_type: "custom",
+      classifier_plugin: "tier-by-team",
+      classifier_plugin_timeout_ms: 3000,
+    });
+  });
+
+  // The backend rejects classifier_type "custom" with no classifier_plugin, so the form has to say
+  // what is missing rather than let the save come back as a raw 400.
+  it("blocks a submit that selects the custom classifier without a plugin", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(<Harness />);
+
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "plugin-router");
+    expandDetailedConfiguration();
+    await user.click(screen.getByText("Advanced: Classification Method"));
+    await user.click(await screen.findByRole("radio", { name: /Custom classifier/ }));
+
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    await waitFor(() =>
+      expect(toast.fromError).toHaveBeenCalledWith("Please select a classifier plugin, or switch back to Heuristic"),
+    );
+    expect(handleAddAutoRouterSubmit).not.toHaveBeenCalled();
   });
 
   it("carries session affinity turned on through to the create payload", async () => {

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -341,6 +341,8 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     tierLabels: complexityRouterConfig.tier_labels,
     classifierType: complexityRouterConfig.classifier_type,
     classifierLlmConfig: complexityRouterConfig.classifier_llm_config,
+    classifierPlugin: complexityRouterConfig.classifier_plugin,
+    classifierPluginTimeoutMs: complexityRouterConfig.classifier_plugin_timeout_ms,
     classifierContextWindowSize: complexityRouterConfig.classifier_context_window_size,
     classifierContextPerTurnChars: complexityRouterConfig.classifier_context_per_turn_chars,
     classifierContextIncludeAssistantTurns: complexityRouterConfig.classifier_context_include_assistant_turns,
@@ -364,7 +366,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   };
 
   const submitRecommendedRouter = async (name: string) => {
-    const { tiers, tierLabels, classifierType, classifierLlmConfig } = complexityRouterConfigParams;
+    const { tiers, tierLabels, classifierType, classifierLlmConfig, classifierPlugin } = complexityRouterConfigParams;
 
     const missingTiersError = getMissingTiersError(tiers);
     if (missingTiersError) {
@@ -383,6 +385,12 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     if (classifierType === "llm" && !classifierLlmConfig?.model) {
       setShowValidationErrors(true);
       toast.fromError("Please select a classifier model, or switch back to Heuristic");
+      return;
+    }
+
+    if (classifierType === "custom" && !classifierPlugin) {
+      setShowValidationErrors(true);
+      toast.fromError("Please select a classifier plugin, or switch back to Heuristic");
       return;
     }
 

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
@@ -22,6 +22,8 @@ const baseParams: BuildComplexityRouterConfigParams = {
   tierLabels: undefined,
   classifierType: "heuristic",
   classifierLlmConfig: undefined,
+  classifierPlugin: undefined,
+  classifierPluginTimeoutMs: undefined,
   classifierContextWindowSize: undefined,
   classifierContextPerTurnChars: undefined,
   classifierContextIncludeAssistantTurns: undefined,
@@ -91,6 +93,86 @@ describe("buildComplexityRouterConfig", () => {
       classifierLlmConfig: { model: "gpt-4o-mini", timeout_ms: 3000 },
     });
     expect(config.classifier_llm_config).toBeUndefined();
+  });
+
+  it("includes the plugin and its timeout only when classifier_type is custom", () => {
+    const config = buildComplexityRouterConfig({
+      ...baseParams,
+      classifierType: "custom",
+      classifierPlugin: "tier-by-team",
+      classifierPluginTimeoutMs: 1500,
+    });
+
+    expect(config.classifier_type).toBe("custom");
+    expect(config.classifier_plugin).toBe("tier-by-team");
+    expect(config.classifier_plugin_timeout_ms).toBe(1500);
+    expect(config.classifier_llm_config).toBeUndefined();
+  });
+
+  // The backend rejects classifier_plugin alongside a non-custom classifier_type, so a selection
+  // left on the form after the operator switched away must never reach the wire.
+  it("omits the plugin and its timeout when classifier_type is heuristic even if they linger in state", () => {
+    const config = buildComplexityRouterConfig({
+      ...baseParams,
+      classifierPlugin: "tier-by-team",
+      classifierPluginTimeoutMs: 1500,
+    });
+
+    expect(config.classifier_plugin).toBeUndefined();
+    expect(config.classifier_plugin_timeout_ms).toBeUndefined();
+  });
+
+  it("omits the plugin and its timeout when classifier_type is llm even if they linger in state", () => {
+    const config = buildComplexityRouterConfig({
+      ...baseParams,
+      classifierType: "llm",
+      classifierLlmConfig: { model: "gpt-4o-mini", timeout_ms: 3000 },
+      classifierPlugin: "tier-by-team",
+      classifierPluginTimeoutMs: 1500,
+    });
+
+    expect(config.classifier_plugin).toBeUndefined();
+    expect(config.classifier_plugin_timeout_ms).toBeUndefined();
+  });
+
+  // The plugin's failure path is configurable exactly like the LLM classifier's, so the fallback
+  // gate is "not the heuristic" rather than "llm".
+  it("emits classifier_fallback for a custom classifier as well as an llm one", () => {
+    const custom = buildComplexityRouterConfig({
+      ...baseParams,
+      classifierType: "custom",
+      classifierPlugin: "tier-by-team",
+      classifierFallback: "default_model",
+    });
+    const llm = buildComplexityRouterConfig({
+      ...baseParams,
+      classifierType: "llm",
+      classifierLlmConfig: { model: "gpt-4o-mini", timeout_ms: 3000 },
+      classifierFallback: "default_model",
+    });
+
+    expect(custom.classifier_fallback).toBe("default_model");
+    expect(llm.classifier_fallback).toBe("default_model");
+  });
+
+  it("omits classifier_fallback for the heuristic, which has nothing to fall back from", () => {
+    const config = buildComplexityRouterConfig({ ...baseParams, classifierFallback: "default_model" });
+
+    expect(config.classifier_fallback).toBeUndefined();
+  });
+
+  // heuristicScoringRoleFor keys off the fallback, not the classifier type, so a plugin routing its
+  // failures to the default model must drop the scorer knobs the same way an LLM classifier does.
+  it("drops the scorer knobs on a custom classifier that never scores", () => {
+    const config = buildComplexityRouterConfig({
+      ...baseParams,
+      classifierType: "custom",
+      classifierPlugin: "tier-by-team",
+      classifierFallback: "default_model",
+      tokenThresholds: { simple: 25, complex: 900 },
+    });
+
+    expect(config.token_thresholds).toBeUndefined();
   });
 
   it("includes classifier_context_window_size and classifier_context_per_turn_chars only when classifier_type is llm", () => {

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
@@ -75,6 +75,8 @@ export interface BuildComplexityRouterConfigParams {
   tierLabels: ComplexityTierLabels | undefined;
   classifierType: ClassifierType;
   classifierLlmConfig: ClassifierLLMConfig | undefined;
+  classifierPlugin: string | undefined;
+  classifierPluginTimeoutMs: number | undefined;
   classifierContextWindowSize: number | undefined;
   classifierContextPerTurnChars: number | undefined;
   classifierContextIncludeAssistantTurns: boolean | undefined;
@@ -104,6 +106,8 @@ export interface ComplexityRouterConfigPayload {
   tier_labels?: ComplexityTierLabels;
   classifier_type: ClassifierType;
   classifier_llm_config?: ClassifierLLMConfig;
+  classifier_plugin?: string;
+  classifier_plugin_timeout_ms?: number;
   classifier_context_window_size?: number;
   classifier_context_per_turn_chars?: number;
   classifier_context_include_assistant_turns?: boolean;
@@ -210,6 +214,8 @@ export const buildComplexityRouterConfig = ({
   tierLabels,
   classifierType,
   classifierLlmConfig,
+  classifierPlugin,
+  classifierPluginTimeoutMs,
   classifierContextWindowSize,
   classifierContextPerTurnChars,
   classifierContextIncludeAssistantTurns,
@@ -245,7 +251,11 @@ export const buildComplexityRouterConfig = ({
     classifier_type: classifierType,
     ...(classifierType === "llm" &&
       classifierLlmConfig && { classifier_llm_config: normalizeClassifierLlmConfig(classifierLlmConfig) }),
-    ...(classifierType === "llm" && classifierFallback !== undefined && { classifier_fallback: classifierFallback }),
+    ...(classifierType === "custom" && classifierPlugin && { classifier_plugin: classifierPlugin }),
+    ...(classifierType === "custom" &&
+      classifierPluginTimeoutMs !== undefined && { classifier_plugin_timeout_ms: classifierPluginTimeoutMs }),
+    ...(classifierType !== "heuristic" &&
+      classifierFallback !== undefined && { classifier_fallback: classifierFallback }),
     ...(classifierType === "llm" &&
       classifierContextWindowSize !== undefined && {
         classifier_context_window_size: classifierContextWindowSize,

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.ts
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.ts
@@ -106,6 +106,40 @@ describe("buildUpdatedComplexityRouterConfig", () => {
     expect(updatedConfig.custom_technical_keywords).toBeUndefined();
   });
 
+  it("writes the plugin and its timeout for a custom classifier", () => {
+    const updatedConfig = buildUpdatedComplexityRouterConfig(storedConfig, {
+      tiers,
+      classifier_type: "custom" as const,
+      classifier_plugin: "tier-by-team",
+      classifier_plugin_timeout_ms: 1500,
+      classifier_fallback: "default_model" as const,
+    });
+
+    expect(updatedConfig).toMatchObject({
+      classifier_type: "custom",
+      classifier_plugin: "tier-by-team",
+      classifier_plugin_timeout_ms: 1500,
+      classifier_fallback: "default_model",
+    });
+    expect(updatedConfig.classifier_llm_config).toBeUndefined();
+  });
+
+  // Both keys are managed, so switching off custom has to remove them: the backend rejects a stored
+  // classifier_plugin sitting next to a non-custom classifier_type.
+  it("removes a stored plugin and its timeout when the classifier is no longer custom", () => {
+    const storedCustom = JSON.stringify({
+      ...storedConfigValue,
+      classifier_type: "custom",
+      classifier_plugin: "tier-by-team",
+      classifier_plugin_timeout_ms: 1500,
+    });
+
+    const updatedConfig = buildUpdatedComplexityRouterConfig(storedCustom, classifiedTierValue);
+
+    expect(updatedConfig.classifier_plugin).toBeUndefined();
+    expect(updatedConfig.classifier_plugin_timeout_ms).toBeUndefined();
+  });
+
   it("preserves a tier configured with more than one model as a pool", () => {
     const multiModelValue = {
       ...classifiedTierValue,

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
@@ -10,6 +10,11 @@ vi.mock(
   async () => await import("../../../tests/mocks/complexityScorerDefaults"),
 );
 
+vi.mock(
+  "@/app/(dashboard)/hooks/autoRouter/useClassifierPlugins",
+  async () => await import("../../../tests/mocks/classifierPlugins"),
+);
+
 const { modelPatchUpdateCall, modelAvailableCall, getAutoRouterClassifierDefaultPromptCall } = vi.hoisted(() => ({
   modelPatchUpdateCall: vi.fn().mockResolvedValue({}),
   modelAvailableCall: vi.fn().mockResolvedValue({ data: [] }),
@@ -481,6 +486,93 @@ describe("EditAutoRouterModal deployment affinity", () => {
 
     await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
     expect(savedConfig().deployment_affinity).toBe(false);
+  });
+});
+
+describe("EditAutoRouterModal custom classifier plugin", () => {
+  beforeEach(() => {
+    modelPatchUpdateCall.mockClear();
+  });
+
+  const STORED_PLUGIN_CONFIG = {
+    tiers: { SIMPLE: ["gpt-4o-mini"], MEDIUM: ["gpt-4o-mini"], COMPLEX: ["gpt-4o-mini"], REASONING: ["gpt-4o-mini"] },
+    classifier_type: "custom",
+    classifier_plugin: "tier-by-team",
+    classifier_plugin_timeout_ms: 1500,
+    classifier_fallback: "heuristic",
+  };
+
+  const renderPluginModal = () =>
+    renderWithProviders(
+      <EditAutoRouterModal
+        isVisible
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        modelData={{
+          ...MODEL_DATA,
+          litellm_params: { ...MODEL_DATA.litellm_params, complexity_router_config: STORED_PLUGIN_CONFIG },
+        }}
+        accessToken="token"
+        userRole="Admin"
+      />,
+    );
+
+  // Every one of these keys is rewritten from form state on save, so a missing hydration line would
+  // silently wipe the operator's plugin the first time they opened this modal for anything else.
+  it("preserves a stored plugin, its timeout, and its fallback through an untouched open-and-save", async () => {
+    const user = userEvent.setup();
+    renderPluginModal();
+
+    await user.click(await screen.findByText("Advanced: Classification Method"));
+    expect(await screen.findByRole("combobox", { name: "Classifier Plugin" })).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton", { name: "Plugin Timeout (ms)" })).toHaveValue("1500");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    const config = savedConfig();
+    expect(config.classifier_type).toBe("custom");
+    expect(config.classifier_plugin).toBe("tier-by-team");
+    expect(config.classifier_plugin_timeout_ms).toBe(1500);
+    expect(config.classifier_fallback).toBe("heuristic");
+  });
+
+  it("persists a switch to another registered plugin", async () => {
+    const user = userEvent.setup();
+    renderPluginModal();
+
+    await user.click(await screen.findByText("Advanced: Classification Method"));
+    fireEvent.mouseDown(await screen.findByRole("combobox", { name: "Classifier Plugin" }));
+    await user.click(await screen.findByTitle("spend-aware"));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().classifier_plugin).toBe("spend-aware");
+  });
+
+  it("blocks a save that leaves the custom classifier with no plugin", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <EditAutoRouterModal
+        isVisible
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        modelData={{
+          ...MODEL_DATA,
+          litellm_params: {
+            ...MODEL_DATA.litellm_params,
+            complexity_router_config: { ...STORED_PLUGIN_CONFIG, classifier_plugin: undefined },
+          },
+        }}
+        accessToken="token"
+        userRole="Admin"
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(toast.fromError).toHaveBeenCalled());
+    expect(modelPatchUpdateCall).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -70,6 +70,8 @@ const MANAGED_COMPLEXITY_ROUTER_KEYS = new Set([
   "tier_labels",
   "classifier_type",
   "classifier_llm_config",
+  "classifier_plugin",
+  "classifier_plugin_timeout_ms",
   "classifier_context_window_size",
   "classifier_context_per_turn_chars",
   "classifier_context_include_assistant_turns",
@@ -157,7 +159,14 @@ export const buildUpdatedComplexityRouterConfig = (
     ...(value.classifier_type === "llm" && value.classifier_llm_config
       ? { classifier_llm_config: normalizeClassifierLlmConfig(value.classifier_llm_config) }
       : {}),
-    ...(value.classifier_type === "llm" &&
+    ...(value.classifier_type === "custom" && value.classifier_plugin
+      ? { classifier_plugin: value.classifier_plugin }
+      : {}),
+    ...(value.classifier_type === "custom" &&
+      value.classifier_plugin_timeout_ms !== undefined && {
+        classifier_plugin_timeout_ms: value.classifier_plugin_timeout_ms,
+      }),
+    ...(value.classifier_type !== "heuristic" &&
       value.classifier_fallback !== undefined && { classifier_fallback: value.classifier_fallback }),
     ...(value.classifier_type === "llm" &&
       value.classifier_context_window_size !== undefined && {
@@ -348,6 +357,12 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
           tier_labels: hydrateTierLabels(parsedConfig.tier_labels),
           classifier_type: parsedConfig.classifier_type || "heuristic",
           classifier_llm_config: parsedConfig.classifier_llm_config,
+          classifier_plugin:
+            typeof parsedConfig.classifier_plugin === "string" ? parsedConfig.classifier_plugin : undefined,
+          classifier_plugin_timeout_ms:
+            typeof parsedConfig.classifier_plugin_timeout_ms === "number"
+              ? parsedConfig.classifier_plugin_timeout_ms
+              : undefined,
           classifier_context_window_size:
             typeof parsedConfig.classifier_context_window_size === "number"
               ? parsedConfig.classifier_context_window_size
@@ -435,7 +450,7 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
 
   const saveValues = async (values: EditAutoRouterFormValues) => {
     if (isComplexityRouterModel) {
-      const { tiers, classifier_type, classifier_llm_config } = complexityRouterConfig;
+      const { tiers, classifier_type, classifier_llm_config, classifier_plugin } = complexityRouterConfig;
       if (Object.values(tiers).every((models) => models.length === 0)) {
         setShowValidationErrors(true);
         toast.fromError("Please select at least one model for a complexity tier");
@@ -444,6 +459,11 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
       if (classifier_type === "llm" && !classifier_llm_config?.model) {
         setShowValidationErrors(true);
         toast.fromError("Please select a classifier model, or switch back to Heuristic");
+        return;
+      }
+      if (classifier_type === "custom" && !classifier_plugin) {
+        setShowValidationErrors(true);
+        toast.fromError("Please select a classifier plugin, or switch back to Heuristic");
         return;
       }
       // Same guards the create form applies (add_auto_router_tab.tsx). The backend rejects a

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.test.tsx
@@ -85,6 +85,31 @@ describe("RoutingDecisionCard", () => {
     expect(screen.queryByText("Score")).not.toBeInTheDocument();
   });
 
+  it("names the custom classifier plugin instead of rendering its raw cause string", () => {
+    render(
+      <RoutingDecisionCard
+        decision={{
+          router_model_name: "plugin-router",
+          router_type: "complexity",
+          routed_model: "claude-sonnet",
+          cause: "classifier_plugin",
+          tier: "COMPLEX",
+          signals: ["classifier-plugin:COMPLEX"],
+        }}
+      />,
+    );
+    expect(screen.getByText("Custom classifier plugin")).toBeInTheDocument();
+    expect(screen.queryByText("classifier_plugin")).not.toBeInTheDocument();
+  });
+
+  // The plugin chose the tier, so pairing a score with a boundary band would claim the heuristic did.
+  it("does not claim the score chose the tier on a plugin-decided row", () => {
+    render(<RoutingDecisionCard decision={{ ...heuristic, cause: "classifier_plugin", score: 0.2 }} />);
+
+    expect(screen.getByText("0.20")).toBeInTheDocument();
+    expect(screen.queryByText(/SIMPLE|MEDIUM|COMPLEX|at or above/)).not.toBeInTheDocument();
+  });
+
   it("explains a route that fell back to the default model after the classifier failed", () => {
     // No tier is recorded on this path, so the card must not show a Tier row: nothing
     // about the request produced one, the classifier never answered.
@@ -99,7 +124,7 @@ describe("RoutingDecisionCard", () => {
         }}
       />,
     );
-    expect(screen.getByText("Default model, LLM classifier failed")).toBeInTheDocument();
+    expect(screen.getByText("Default model, the classifier failed")).toBeInTheDocument();
     expect(screen.queryByText("Tier")).not.toBeInTheDocument();
   });
 
@@ -116,7 +141,7 @@ describe("RoutingDecisionCard", () => {
         }}
       />,
     );
-    expect(screen.getByText("Fallback tier, LLM classifier failed")).toBeInTheDocument();
+    expect(screen.getByText("Fallback tier, the classifier failed")).toBeInTheDocument();
     expect(screen.getByText("SECURITY_REVIEW")).toBeInTheDocument();
   });
 

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.tsx
@@ -75,6 +75,8 @@ function describeCause(decision: RoutingDecision): string {
       return `Heuristic, ${tierLabel ?? "REASONING"} override (2 or more reasoning markers)`;
     case "llm_classifier":
       return classifierModel ? `LLM classifier (${classifierModel})` : "LLM classifier";
+    case "classifier_plugin":
+      return "Custom classifier plugin";
     case "literal_keyword_match":
       return matchedKeyword ? `Keyword match: "${matchedKeyword}"` : "Keyword match";
     case "semantic_keyword_match":
@@ -94,9 +96,9 @@ function describeCause(decision: RoutingDecision): string {
     case "default_fallback":
       return "Default model, no route matched";
     case "classifier_fallback":
-      return "Fallback tier, LLM classifier failed";
+      return "Fallback tier, the classifier failed";
     case "default_model_fallback":
-      return "Default model, LLM classifier failed";
+      return "Default model, the classifier failed";
     default:
       return cause ?? "Unknown";
   }
@@ -145,11 +147,14 @@ export function RoutingDecisionCard({
     tier_boundaries: tierBoundaries,
   } = decision;
 
-  // On an override row the score did not decide the tier, so showing it against a
-  // boundary would claim something untrue. Keyed off the cause rather than a marker
+  // On an override row, or one a plugin decided, the score did not choose the tier, so showing
+  // it against a boundary would claim something untrue. Keyed off the cause rather than a marker
   // inside `signals`, which redaction can remove.
   const scoreExplanation =
-    score !== undefined && decision.cause !== "reasoning_override" && decision.cause !== "plan_mode"
+    score !== undefined &&
+    decision.cause !== "reasoning_override" &&
+    decision.cause !== "plan_mode" &&
+    decision.cause !== "classifier_plugin"
       ? describeScoreAgainstBoundaries(score, tierBoundaries, tierLabel !== undefined)
       : null;
 

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -807,6 +807,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auto_router/classifier_plugins": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Classifier Plugins
+         * @description Registered classifier plugin names, for the Admin UI's custom classifier picker.
+         */
+        get: operations["list_classifier_plugins_auto_router_classifier_plugins_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auto_router/shadow_eval": {
         parameters: {
             query?: never;
@@ -23593,6 +23613,17 @@ export interface components {
             timeout_ms: number;
         };
         /**
+         * ClassifierPluginsListResponse
+         * @description Names from the proxy config's classifier_plugins registry, for the custom classifier picker.
+         */
+        ClassifierPluginsListResponse: {
+            /**
+             * Classifier Plugins
+             * @description Registered classifier plugin names an auto-router's classifier_plugin may reference
+             */
+            classifier_plugins: string[];
+        };
+        /**
          * CloudZeroExportRequest
          * @description Request model for CloudZero export operations
          */
@@ -37802,6 +37833,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_classifier_plugins_auto_router_classifier_plugins_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ClassifierPluginsListResponse"];
                 };
             };
         };

--- a/ui/litellm-dashboard/tests/mocks/classifierPlugins.ts
+++ b/ui/litellm-dashboard/tests/mocks/classifierPlugins.ts
@@ -1,0 +1,17 @@
+import { vi } from "vitest";
+
+/**
+ * Stubs the proxy's registered classifier plugin names for any test that renders the auto-router tree.
+ * Exported as a vi.fn so a test can override the query state, which is how the empty-registry and
+ * failed-fetch paths are covered.
+ */
+export const REGISTERED_CLASSIFIER_PLUGINS = ["spend-aware", "tier-by-team"];
+
+export const LOADED_CLASSIFIER_PLUGINS_QUERY = {
+  data: REGISTERED_CLASSIFIER_PLUGINS,
+  isPending: false,
+  isError: false,
+  refetch: vi.fn(),
+};
+
+export const useClassifierPlugins = vi.fn(() => LOADED_CLASSIFIER_PLUGINS_QUERY);


### PR DESCRIPTION
## TLDR

Problem this solves:

- Custom classifiers (classifier_type "custom", from the earlier backend PR) are config-file-only
- The dashboard cannot create or edit a custom-classifier auto-router at all
- The models table mislabels custom routers "Heuristic"

How it solves it:

- New top-level `classifier_plugins` config key: names mapped to dotted paths
- Names resolve through a registry at save, load, and deployment init
- Dashboard picker gains a Custom classifier option with a plugin dropdown
- Decision card and models table now name the plugin cause correctly

## User Flow

Before: a platform admin who wants a team-aware auto-router cannot build one in the dashboard

1. They open http://localhost:4000/ui/?page=llm-playground → Models and Endpoints → Add Model → Auto Router
2. The Classification method picker offers only Heuristic and LLM Classifier
3. They try POST /model/new with `"classifier_plugin": "tier-by-team"` and get back 400 `complexity_router_config is invalid at classifier_plugin: Input should be an instance of ClassifierPlugin`
4. Their only path is editing config.yaml on the proxy host and restarting

After: the same admin declares plugins once in config and builds routers in the dashboard

1. The operator adds a top-level `classifier_plugins:` block naming `tier-by-team` and restarts the proxy once
2. The admin opens Add Model → Auto Router; the picker now shows Custom classifier
3. Selecting it reveals a dropdown listing `spend-aware` and `tier-by-team`, a plugin timeout field, and the classifier fallback picker
4. Saving sends the name; the same POST from step 3 above now returns the created model
5. A saved router with an unknown name is rejected at save with `'no-such-plugin' is not a registered classifier plugin; declare it under classifier_plugins in the proxy config`
6. In the logs page each routed request shows cause "Custom classifier plugin" with the tier, and the models table labels the router "Custom classifier"

## Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs/my-website)
- [x] I have read the [Contributing Guidelines](https://github.com/BerriAI/litellm/blob/main/CONTRIBUTING.md)
- [x] I have added a screenshot or proof of the fix working locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR passes all tests

## Type

🆕 New Feature

## Changes

Backend: top-level `classifier_plugins` config key (name to dotted path), resolved at startup through the existing `resolve_classifier_plugin` load-time checks into `litellm.classifier_plugin_registry` (module global beside `guardrail_name_config_map`, since the consumer is router code that must not import proxy_server). A `mode="before"` validator on `ComplexityRouterConfig.classifier_plugin` resolves string values through the registry, so one seam covers the save-time write gate, router deployment init, and direct construction: registered names resolve, unknown names fail with a clean error naming the fix. DB-stored auto-routers therefore carry plain names and no proxy read path changes at all. `resolve_classifier_plugin` checks the registry before dotted-path import, so config files may use either form. `GET /auto_router/classifier_plugins` lists the names (admin viewer auth, names only; dotted paths stay operator-private).

Dashboard: the classification method picker gains Custom classifier with a plugin dropdown fed by a `useClassifierPlugins` hook over the new endpoint, a plugin timeout field, and the fallback picker shown for both non-heuristic modes (the backend has always applied `classifier_fallback` to custom). Create and edit serialize and validate identically, including an edit-time guard cloning the create-time one so edit cannot save what create blocks. The empty-registry state disables the radio with a hint but never locks out a router already in custom mode, and a failed registry fetch never blanks a stored plugin name. The models table gains a three-way classifier label, and the routing decision card names the `classifier_plugin` cause, suppresses the meaningless score display for it, and stops claiming the LLM classifier failed on plugin fallbacks.

Considered and rejected: letting the dashboard submit dotted paths directly. A register-by-path form would make the proxy import any module a dashboard admin names, which is arbitrary code execution handed to a role that cannot touch the filesystem today. The registry keeps code declaration on the operator side, matching how custom guardrail and callback code is declared.

## Feature Demo

```yaml
classifier_plugins:
  tier-by-team: custom_classifiers.tier_by_team
  spend-aware: custom_classifiers.spend_aware
```

Dashboard flow for screenshots (dev server on :3000 against the rig proxy on :4474, or any proxy with the block above):

1. Go to http://localhost:3000/ui?page=models-and-endpoints, open the Add Model tab, pick Auto Router
2. Under Classification method choose Custom classifier; the dropdown lists spend-aware and tier-by-team
3. Pick tier-by-team, leave timeout at 3000, choose the fallback, fill tiers, save
4. The Auto Routers table row shows Classifier: Custom classifier
5. Send traffic, open http://localhost:3000/ui?page=logs, click a request: the routing decision card reads Custom classifier plugin with the tier

## Proof it works: live proxy

Same rig pattern as the backend PR (all provider credentials on this box are still dead, so tier models point at a local recording upstream returning distinct model names; auth, save validation, registry resolution, deployment init, routing, and spend logging are the real path end to end).

### Before (merged backend only): dashboard-shaped writes are impossible

```
$ curl -s -o /dev/null -w "%{http_code}" $PROXY/auto_router/classifier_plugins -H "Authorization: Bearer $MASTER"
404

$ curl -s $PROXY/model/new ... -d '{..."classifier_type": "custom", "classifier_plugin": "tier-by-team"...}'
{"error":{"message":"complexity_router_config is invalid at classifier_plugin: Input should be an instance of ClassifierPlugin. ..."}}
```

### After: names list, save, resolve, route, attribute

```
$ curl -s $PROXY/auto_router/classifier_plugins -H "Authorization: Bearer $MASTER"
{"classifier_plugins":["spend-aware","tier-by-team"]}

$ curl -s $PROXY/model/new ... -d '{..."classifier_plugin": "no-such-plugin"...}'
{"error":{"message":"complexity_router_config is invalid at classifier_plugin: Value error, 'no-such-plugin' is not a registered classifier plugin; declare it under classifier_plugins in the proxy config. The router would drop this deployment at load time, so the write is rejected instead."}}

$ curl -s $PROXY/model/new ... -d '{..."classifier_plugin": "tier-by-team"...}'
created: smart-router

$ curl -s $PROXY/v1/chat/completions -H "Authorization: Bearer $RESEARCH_TEAM_KEY" -d '{"model": "smart-router", "messages": [{"role": "user", "content": "What is the capital of France?"}]}'
served by claude-sonnet-5

$ curl -s $PROXY/v1/chat/completions -H "Authorization: Bearer $SUPPORT_TEAM_KEY" -d '<same body>'
served by claude-haiku-4-5
```

Spend log attribution for those two requests:

```
classifier_plugin|REASONING|claude-sonnet
classifier_plugin|SIMPLE|claude-haiku
```

### After: restart with a name missing from the registry fails loudly

Removing tier-by-team from `classifier_plugins` and restarting logs
`'tier-by-team' is not a registered classifier plugin; declare it under classifier_plugins in the proxy config`, the DB-stored router is dropped, and requests to it 400 instead of silently misrouting. Restoring the entry recovers it without touching the model

## Linear ticket

## Tests

- Python (725 pass in the touched files): registry name resolution, unknown-name rejection, and instance passthrough on ComplexityRouterConfig; end-to-end aclassify through a registry name; write-gate accept and reject cases; registry-first resolve_classifier_plugin; the list endpoint
- Vitest (full dashboard suite: 7877 pass): new ClassificationMethodConfig suite (radio, dropdown from mocked hook, disabled-when-empty, timeout field), build and edit serialization gates including an untouched-open-and-save preservation test for classifier_plugin, submit-payload assertion, three-way row label, decision card cause and score suppression
- `make check` passes (ruff, budgets, basedpyright, prettier, eslint, npm run build, API type sync)

## Caveats / follow-ups

- Registration stays config-file-only by design (see Changes); the docs-site page goes to the litellm-docs repository
- The routing-test endpoint keeps classifier_plugin closed off; custom-mode routing tests are a follow-up
- Provider legs of the proof ran against a local recording upstream because every provider credential on this box is out of credits; the curls rerun unchanged against real providers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 72671282dfb60d2f2757b9570e4ac26c07e98d79. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->