### PR TITLE
fix(ui): stop alerting settings writing unusable values into stored config

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -2017,9 +2017,6 @@
   "src/components/alerting/alerting_settings.tsx": {
     "local/filename-pascal-case": {
       "count": 1
-    },
-    "prefer-const": {
-      "count": 1
     }
   },
   "src/components/alerting/dynamic_form.tsx": {

--- a/ui/litellm-dashboard/src/components/alerting/alerting_settings.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/alerting/alerting_settings.integration.test.tsx
@@ -1,0 +1,218 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const toastMock = vi.hoisted(() => ({
+  success: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+  fromError: vi.fn(),
+  dismiss: vi.fn(),
+}));
+vi.mock("@/lib/toast", () => ({ toast: toastMock }));
+
+import AlertingSettings from "./alerting_settings";
+
+const PROXY_SETTINGS = [
+  {
+    field_name: "slack_alerting",
+    field_type: "Boolean",
+    field_value: false,
+    field_default_value: null,
+    field_description: "Enable slack alerting",
+    stored_in_db: false,
+    premium_field: false,
+  },
+  {
+    field_name: "daily_report_frequency",
+    field_type: "Integer",
+    field_value: 43200,
+    field_default_value: 43200,
+    field_description: "Frequency of deployment reports",
+    stored_in_db: false,
+    premium_field: false,
+  },
+  {
+    field_name: "budget_alert_ttl",
+    field_type: "Integer",
+    field_value: 86400,
+    field_default_value: 86400,
+    field_description: "Cache ttl for budget alerts",
+    stored_in_db: false,
+    premium_field: false,
+  },
+];
+
+interface Captured {
+  readonly url: string;
+  readonly body: string | undefined;
+}
+
+const installProxy = (settings: unknown, updateStatus = 200): Captured[] => {
+  const calls: Captured[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: unknown, init?: RequestInit) => {
+      calls.push({ url: String(url), body: init?.body as string | undefined });
+      if (!init?.method || init.method === "GET") {
+        return new Response(JSON.stringify(settings), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify(updateStatus === 200 ? { status: "success" } : { detail: { error: "rejected by proxy" } }),
+        { status: updateStatus, headers: { "Content-Type": "application/json" } },
+      );
+    }),
+  );
+  return calls;
+};
+
+const alertingArgsBody = (calls: readonly Captured[]): Record<string, unknown> | undefined => {
+  const write = calls
+    .filter((call) => call.url.includes("/config/field/update"))
+    .map((call) => JSON.parse(call.body ?? "{}") as { field_name?: string; field_value?: Record<string, unknown> })
+    .find((payload) => payload.field_name === "alerting_args");
+  return write?.field_value;
+};
+
+const renderPage = async (settings: unknown, updateStatus = 200) => {
+  const calls = installProxy(settings, updateStatus);
+  const user = userEvent.setup();
+  render(<AlertingSettings accessToken="sk-test" premiumUser={true} />);
+  await screen.findByText("daily_report_frequency");
+  return { calls, user };
+};
+
+const save = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole("button", { name: "Update Settings" }));
+  await waitFor(() =>
+    expect(toastMock.success.mock.calls.length + toastMock.fromError.mock.calls.length).toBeGreaterThan(0),
+  );
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AlertingSettings alerting_args payload", () => {
+  it("omits an Integer field the user cleared instead of writing null into stored config", async () => {
+    const { calls, user } = await renderPage(PROXY_SETTINGS);
+
+    await user.clear(screen.getByDisplayValue("43200"));
+    await user.click(screen.getByRole("switch"));
+    await save(user);
+
+    const args = alertingArgsBody(calls);
+    expect(args).toBeDefined();
+    expect(args).not.toHaveProperty("daily_report_frequency");
+  });
+
+  it("still sends the Integer fields the user did not clear", async () => {
+    const { calls, user } = await renderPage(PROXY_SETTINGS);
+
+    await user.clear(screen.getByDisplayValue("43200"));
+    await user.click(screen.getByRole("switch"));
+    await save(user);
+
+    expect(alertingArgsBody(calls)).toEqual({ budget_alert_ttl: 86400 });
+  });
+
+  it("sends an edited Integer field as a number", async () => {
+    const { calls, user } = await renderPage(PROXY_SETTINGS);
+
+    await user.clear(screen.getByDisplayValue("43200"));
+    await user.type(screen.getByDisplayValue(""), "600");
+    await save(user);
+
+    expect(alertingArgsBody(calls)).toEqual({ daily_report_frequency: 600, budget_alert_ttl: 86400 });
+  });
+
+  it("sends an Integer field the user set to zero", async () => {
+    const { calls, user } = await renderPage(PROXY_SETTINGS);
+
+    await user.clear(screen.getByDisplayValue("43200"));
+    await user.type(screen.getByDisplayValue(""), "0");
+    await save(user);
+
+    expect(alertingArgsBody(calls)).toEqual({ daily_report_frequency: 0, budget_alert_ttl: 86400 });
+  });
+
+  it("sends a String field's text rather than the change event", async () => {
+    const withStringField = [
+      ...PROXY_SETTINGS,
+      {
+        field_name: "region_name",
+        field_type: "String",
+        field_value: "us-east",
+        field_default_value: "us-east",
+        field_description: "Region to watch",
+        stored_in_db: false,
+        premium_field: false,
+      },
+    ];
+    const { calls, user } = await renderPage(withStringField);
+
+    await user.type(screen.getByDisplayValue("us-east"), "-2");
+    await save(user);
+
+    expect(alertingArgsBody(calls)).toEqual({
+      daily_report_frequency: 43200,
+      budget_alert_ttl: 86400,
+      region_name: "us-east-2",
+    });
+  });
+
+  it("keeps the edited text visible instead of replacing it with the stringified event", async () => {
+    const withStringField = [
+      ...PROXY_SETTINGS,
+      {
+        field_name: "region_name",
+        field_type: "String",
+        field_value: "us-east",
+        field_default_value: "us-east",
+        field_description: "Region to watch",
+        stored_in_db: false,
+        premium_field: false,
+      },
+    ];
+    const { user } = await renderPage(withStringField);
+
+    await user.type(screen.getByDisplayValue("us-east"), "-2");
+
+    expect(screen.getByDisplayValue("us-east-2")).toBeInTheDocument();
+  });
+});
+
+describe("AlertingSettings save feedback", () => {
+  it("reports the failure and claims no success when the proxy rejects the write", async () => {
+    const { user } = await renderPage(PROXY_SETTINGS, 400);
+
+    await user.click(screen.getByRole("switch"));
+    await save(user);
+
+    expect(toastMock.fromError).toHaveBeenCalledTimes(1);
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+
+  it("confirms success when the proxy accepts the write", async () => {
+    const { user } = await renderPage(PROXY_SETTINGS);
+
+    await user.click(screen.getByRole("switch"));
+    await save(user);
+
+    expect(toastMock.success).toHaveBeenCalledWith("Wait 10s for proxy to update.");
+    expect(toastMock.fromError).not.toHaveBeenCalled();
+  });
+
+  it("does not write anything when no field was changed", async () => {
+    const { calls, user } = await renderPage(PROXY_SETTINGS);
+
+    await user.click(screen.getByRole("button", { name: "Update Settings" }));
+
+    expect(calls.filter((call) => call.url.includes("/config/field/update"))).toHaveLength(0);
+  });
+});

--- a/ui/litellm-dashboard/src/components/alerting/alerting_settings.tsx
+++ b/ui/litellm-dashboard/src/components/alerting/alerting_settings.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect } from "react";
 
 import { alertingSettingsCall, updateConfigFieldSetting } from "../networking";
-import DynamicForm, { type AlertingFieldValue } from "./dynamic_form";
+import DynamicForm, { type AlertingFieldValue, type AlertingFormValues } from "./dynamic_form";
 import { toast } from "@/lib/toast";
 interface alertingSettingsItem {
   field_name: string;
@@ -43,7 +43,7 @@ const AlertingSettings: React.FC<AlertingSettingsProps> = ({ accessToken, premiu
     setAlertingSettings(updatedSettings);
   };
 
-  const handleSubmit = async (formValues: Record<string, any>) => {
+  const handleSubmit = async (formValues: AlertingFormValues) => {
     if (!accessToken) {
       return;
     }

--- a/ui/litellm-dashboard/src/components/alerting/alerting_settings.tsx
+++ b/ui/litellm-dashboard/src/components/alerting/alerting_settings.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect } from "react";
 
 import { alertingSettingsCall, updateConfigFieldSetting } from "../networking";
-import DynamicForm from "./dynamic_form";
+import DynamicForm, { type AlertingFieldValue } from "./dynamic_form";
 import { toast } from "@/lib/toast";
 interface alertingSettingsItem {
   field_name: string;
@@ -34,7 +34,7 @@ const AlertingSettings: React.FC<AlertingSettingsProps> = ({ accessToken, premiu
     });
   }, [accessToken]);
 
-  const handleInputChange = (fieldName: string, newValue: any) => {
+  const handleInputChange = (fieldName: string, newValue: AlertingFieldValue) => {
     // Update the value in the state
     const updatedSettings = alertingSettings.map((setting) =>
       setting.field_name === fieldName ? { ...setting, field_value: newValue } : setting,
@@ -43,39 +43,27 @@ const AlertingSettings: React.FC<AlertingSettingsProps> = ({ accessToken, premiu
     setAlertingSettings(updatedSettings);
   };
 
-  const handleSubmit = (formValues: Record<string, any>) => {
+  const handleSubmit = async (formValues: Record<string, any>) => {
     if (!accessToken) {
       return;
     }
 
-    let fieldValue = formValues;
+    const storedValues = Object.fromEntries(
+      alertingSettings.map((setting) => [setting.field_name, setting.field_value]),
+    );
+    const { slack_alerting, ...editedArgs } = { ...formValues, ...storedValues };
+    const alertingArgs = Object.fromEntries(
+      Object.entries(editedArgs).filter(([, value]) => value !== null && value !== undefined && value !== ""),
+    );
 
-    if (fieldValue == null || fieldValue == undefined) {
-      return;
-    }
-
-    const initialFormValues: Record<string, any> = {};
-
-    alertingSettings.forEach((setting) => {
-      initialFormValues[setting.field_name] = setting.field_value;
-    });
-
-    // Merge initialFormValues with actual formValues
-    const mergedFormValues = { ...formValues, ...initialFormValues };
-    const { slack_alerting, ...alertingArgs } = mergedFormValues;
     try {
-      updateConfigFieldSetting(accessToken, "alerting_args", alertingArgs);
+      await updateConfigFieldSetting(accessToken, "alerting_args", alertingArgs);
       if (typeof slack_alerting === "boolean") {
-        if (slack_alerting == true) {
-          updateConfigFieldSetting(accessToken, "alerting", ["slack"]);
-        } else {
-          updateConfigFieldSetting(accessToken, "alerting", []);
-        }
+        await updateConfigFieldSetting(accessToken, "alerting", slack_alerting ? ["slack"] : []);
       }
-      // update value in state
       toast.success("Wait 10s for proxy to update.");
     } catch (error) {
-      // do something
+      toast.fromError(error);
     }
   };
 

--- a/ui/litellm-dashboard/src/components/alerting/dynamic_form.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/alerting/dynamic_form.integration.test.tsx
@@ -170,6 +170,15 @@ describe("DynamicForm change notifications", () => {
     expect(handleInputChange).toHaveBeenCalledWith("daily_report_frequency", 128);
   });
 
+  it("reports a String change to the parent as the typed text, not the change event", async () => {
+    const user = userEvent.setup();
+    const { handleInputChange } = renderForm();
+
+    await user.type(screen.getByDisplayValue("us-east"), "Z");
+
+    expect(handleInputChange).toHaveBeenLastCalledWith("region_name", "us-eastZ");
+  });
+
   it("reports a reset with the field name and its row index", async () => {
     const user = userEvent.setup();
     const { handleResetField } = renderForm();

--- a/ui/litellm-dashboard/src/components/alerting/dynamic_form.tsx
+++ b/ui/litellm-dashboard/src/components/alerting/dynamic_form.tsx
@@ -13,9 +13,11 @@ interface AlertingSetting {
   premium_field: boolean;
 }
 
+export type AlertingFieldValue = string | number | boolean | null;
+
 interface DynamicFormProps {
   alertingSettings: AlertingSetting[];
-  handleInputChange: (fieldName: string, newValue: any) => void;
+  handleInputChange: (fieldName: string, newValue: AlertingFieldValue) => void;
   handleResetField: (fieldName: string, index: number) => void;
   handleSubmit: (formValues: Record<string, any>) => void;
   premiumUser: boolean;
@@ -51,7 +53,7 @@ const DynamicForm: React.FC<DynamicFormProps> = ({
 
   const handleTextChange = (setting: AlertingSetting, event: React.ChangeEvent<HTMLInputElement>) => {
     form.setValue(setting.field_name, event.target.value);
-    handleInputChange(setting.field_name, event);
+    handleInputChange(setting.field_name, event.target.value);
   };
 
   const handleToggle = (setting: AlertingSetting, checked: boolean) => {

--- a/ui/litellm-dashboard/src/components/alerting/dynamic_form.tsx
+++ b/ui/litellm-dashboard/src/components/alerting/dynamic_form.tsx
@@ -22,11 +22,11 @@ interface DynamicFormProps {
   alertingSettings: AlertingSetting[];
   handleInputChange: (fieldName: string, newValue: AlertingFieldValue) => void;
   handleResetField: (fieldName: string, index: number) => void;
-  handleSubmit: (formValues: Record<string, any>) => void;
+  handleSubmit: (formValues: AlertingFormValues) => void;
   premiumUser: boolean;
 }
 
-type AlertingFormValues = Record<string, string | boolean>;
+export type AlertingFormValues = Record<string, string | boolean>;
 
 const DynamicForm: React.FC<DynamicFormProps> = ({
   alertingSettings,


### PR DESCRIPTION
> **Deferred, not ready to merge.** Everything here changes behaviour rather than migrating it, and the current mandate is migration with today's behaviour preserved. Parked as a draft until the behaviour fixes are picked up as their own piece of work. The branch and its tests are complete; see the known-behaviour note below

## Known behaviour this would change, measured at staging `3f15dc3287`

Both of these are shipped today and are longstanding, not recent regressions:

- `dynamic_form.tsx:52` sends `null` when a numeric alerting field is emptied
- `dynamic_form.tsx:57` sends the whole React change event, not the typed text

The `null` is the one with real consequences. `/config/field/update` stores it because `ConfigGeneralSettings` types `alerting_args` as a plain dict and never checks contents, and `SlackAlertingArgs` then rejects the stored value on every config reconcile. Reachable with an ordinary two-field edit, and it survives a reload.

The change event is inert in practice. `renderControl` only reaches that branch for a `field_type` outside `Integer` and `Boolean`, and `/alerting/settings` hard-codes all nine fields to those two, so the branch never renders against a real proxy. Forced open in a test it does not corrupt anything either, because the event's circular fiber reference makes `JSON.stringify` throw before the request is built, so the save is dropped rather than written.

## TLDR

Problem this solves:

- Emptying a numeric alerting field stored an unusable value
- The proxy then rejected its own stored alerting settings on every reload
- The page claimed success even when the save was refused

How it solves it:

- Emptied fields are dropped instead of sent as null
- Both saves are awaited, and a refusal now surfaces as an error
- The text control reports the typed text, not the raw event

## User Flow

Before: an admin who clears a numeric alerting field silently poisons the proxy's saved alerting settings

1. Sign in and open http://localhost:4000/ui/?page=settings, then the Alerting tab
2. Empty the `daily_report_frequency` box and switch `slack_alerting` on
3. Click Update Settings and see "Wait 10s for proxy to update."
4. Reload the page; `daily_report_frequency` shows its old value, so it looks like nothing happened
5. From here on the proxy log reports the saved alerting settings as invalid on every refresh, and later changes on the same page stop taking effect until the saved settings are cleared by hand
6. If the proxy refuses the save outright, the page still shows the same "Wait 10s for proxy to update." and no error

After: the same edit saves cleanly, and a refusal is visible

1. Sign in and open http://localhost:4000/ui/?page=settings, then the Alerting tab
2. Empty the `daily_report_frequency` box and switch `slack_alerting` on
3. Click Update Settings and see "Wait 10s for proxy to update."
4. Reload the page; `daily_report_frequency` shows the proxy default, which is what emptying it asks for
5. The proxy log stays quiet and later changes on the same page keep taking effect
6. If the proxy refuses the save, the page shows the refusal instead of claiming success

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

🐛 Bug Fix

## Caveats

- Deferred; behaviour change, and the mandate is migration only
- Backend still accepts any `alerting_args` shape; API callers can reproduce it
- The text control never renders today; that part is hygiene
- Saving still requires changing at least one field, unchanged

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
