### PR TITLE
fix(guardrails): cap the date window accepted by /guardrails/usage endpoints

### DIFF
--- a/litellm/proxy/guardrails/usage_endpoints.py
+++ b/litellm/proxy/guardrails/usage_endpoints.py
@@ -5,7 +5,7 @@ GET /guardrails/usage/overview, /guardrails/usage/detail/:id, /guardrails/usage/
 
 import json
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from itertools import groupby
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal, overload
@@ -47,6 +47,35 @@ if TYPE_CHECKING:
 router: Final = APIRouter()
 
 _EMPTY_UNITS: Final[Mapping[str, int]] = MappingProxyType({})
+
+_USAGE_MAX_RANGE_DAYS: Final = 366
+
+
+def _resolve_usage_window(start_date: str | None, end_date: str | None) -> tuple[str, str]:
+    from fastapi import HTTPException, status
+
+    now: Final = datetime.now(timezone.utc)
+    end: Final = end_date or now.strftime("%Y-%m-%d")
+    start: Final = start_date or (now - timedelta(days=7)).strftime("%Y-%m-%d")
+    try:
+        parsed: Final = (date.fromisoformat(start), date.fromisoformat(end))
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="start_date and end_date must be in YYYY-MM-DD format",
+        )
+    start_obj, end_obj = parsed
+    if end_obj < start_obj:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="start_date must be on or before end_date",
+        )
+    if end_obj - start_obj > timedelta(days=_USAGE_MAX_RANGE_DAYS):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Date range too large; maximum is {_USAGE_MAX_RANGE_DAYS} days",
+        )
+    return start, end
 
 
 def _guardrails_table(
@@ -457,9 +486,7 @@ async def guardrails_usage_overview(
             rows=[], chart=[], totalRequests=0, totalBlocked=0, passRate=100.0, totalUsageUnits=_EMPTY_UNITS
         )
 
-    now: Final = datetime.now(timezone.utc)
-    end: Final = end_date or now.strftime("%Y-%m-%d")
-    start: Final = start_date or (now - timedelta(days=7)).strftime("%Y-%m-%d")
+    start, end = _resolve_usage_window(start_date, end_date)
 
     from litellm.proxy.guardrails.guardrail_registry import IN_MEMORY_GUARDRAIL_HANDLER
 
@@ -477,7 +504,7 @@ async def guardrails_usage_overview(
         )
 
         # Previous period for trend
-        start_prev: Final = (datetime.strptime(start, "%Y-%m-%d") - timedelta(days=7)).strftime("%Y-%m-%d")
+        start_prev: Final = (date.fromisoformat(start) - timedelta(days=7)).isoformat()
         metrics_prev: Sequence[prisma_models.LiteLLM_DailyGuardrailMetrics] = await _find_daily_guardrail_metrics(
             prisma_client, where={"date": {"gte": start_prev, "lt": start}}
         )
@@ -531,9 +558,7 @@ async def guardrails_usage_detail(
 
         raise HTTPException(status_code=500, detail="Prisma client not initialized")
 
-    now: Final = datetime.now(timezone.utc)
-    end: Final = end_date or now.strftime("%Y-%m-%d")
-    start: Final = start_date or (now - timedelta(days=7)).strftime("%Y-%m-%d")
+    start, end = _resolve_usage_window(start_date, end_date)
 
     from litellm.proxy.guardrails.guardrail_registry import IN_MEMORY_GUARDRAIL_HANDLER
 
@@ -556,11 +581,12 @@ async def guardrails_usage_detail(
             "date": {"gte": start, "lte": end},
         },
     )
+    start_prev: Final = (date.fromisoformat(start) - timedelta(days=7)).isoformat()
     metrics_prev: Final[Sequence[prisma_models.LiteLLM_DailyGuardrailMetrics]] = await _find_daily_guardrail_metrics(
         prisma_client,
         where={
             "guardrail_id": {"in": metric_ids},
-            "date": {"lt": start},
+            "date": {"gte": start_prev, "lt": start},
         },
     )
     units_where: Final[prisma_types.LiteLLM_DailyGuardrailUsageUnitsWhereInput] = {
@@ -838,9 +864,7 @@ async def policies_usage_overview(
             rows=[], chart=[], totalRequests=0, totalBlocked=0, passRate=100.0, totalUsageUnits=_EMPTY_UNITS
         )
 
-    now: Final = datetime.now(timezone.utc)
-    end: Final = end_date or now.strftime("%Y-%m-%d")
-    start: Final = start_date or (now - timedelta(days=7)).strftime("%Y-%m-%d")
+    start, end = _resolve_usage_window(start_date, end_date)
 
     try:
         policies: Final = await _policies_table(prisma_client).find_many()
@@ -851,7 +875,7 @@ async def policies_usage_overview(
             prisma_client,
             where={
                 "date": {
-                    "gte": (datetime.strptime(start, "%Y-%m-%d") - timedelta(days=7)).strftime("%Y-%m-%d"),
+                    "gte": (date.fromisoformat(start) - timedelta(days=7)).isoformat(),
                     "lt": start,
                 }
             },

--- a/litellm/proxy/guardrails/usage_endpoints.py
+++ b/litellm/proxy/guardrails/usage_endpoints.py
@@ -65,6 +65,11 @@ def _resolve_usage_window(start_date: str | None, end_date: str | None) -> tuple
             detail="start_date and end_date must be in YYYY-MM-DD format",
         )
     start_obj, end_obj = parsed
+    if (start_obj.isoformat(), end_obj.isoformat()) != (start, end):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="start_date and end_date must be in YYYY-MM-DD format",
+        )
     if end_obj < start_obj:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/ruff-strict-budget.json
+++ b/ruff-strict-budget.json
@@ -96,7 +96,7 @@
     "limit": 10
   },
   "DTZ007": {
-    "limit": 19
+    "limit": 17
   },
   "DTZ011": {
     "limit": 3

--- a/tests/test_litellm/proxy/guardrails/test_usage_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_usage_endpoints.py
@@ -27,6 +27,7 @@ from litellm.proxy.guardrails.usage_endpoints import (
     guardrails_usage_detail,
     guardrails_usage_logs,
     guardrails_usage_overview,
+    policies_usage_overview,
 )
 from litellm.types.guardrails import Guardrail, LitellmParams
 
@@ -356,3 +357,71 @@ async def test_logs_resolves_config_guardrail_logical_name():
         )
     where = prisma.db.litellm_spendlogguardrailindex.find_many.call_args.kwargs["where"]
     assert where["guardrail_id"] == {"in": ["yaml-uuid", "yaml-pii"]}
+
+
+# ---- date window cap (LIT-5762) ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_overview_rejects_range_over_max_days():
+    prisma = _prisma()
+    handler = _config_handler()
+    p1, p2 = _patches(prisma, handler)
+    with p1, p2, pytest.raises(HTTPException) as exc:
+        await guardrails_usage_overview(start_date="2020-01-01", end_date=END, user_api_key_dict=ADMIN)
+    assert exc.value.status_code == 400
+    assert "366" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_overview_accepts_range_at_exactly_max_days():
+    prisma = _prisma()
+    handler = _config_handler()
+    p1, p2 = _patches(prisma, handler)
+    with p1, p2:
+        resp = await guardrails_usage_overview(start_date="2025-04-26", end_date="2026-04-27", user_api_key_dict=ADMIN)
+    assert resp.totalRequests == 0
+
+
+@pytest.mark.asyncio
+async def test_overview_rejects_malformed_dates():
+    prisma = _prisma()
+    handler = _config_handler()
+    p1, p2 = _patches(prisma, handler)
+    with p1, p2, pytest.raises(HTTPException) as exc:
+        await guardrails_usage_overview(start_date="not-a-date", end_date=END, user_api_key_dict=ADMIN)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_detail_rejects_reversed_dates():
+    prisma = _prisma(find_unique=_db_row())
+    handler = _config_handler()
+    p1, p2 = _patches(prisma, handler)
+    with p1, p2, pytest.raises(HTTPException) as exc:
+        await guardrails_usage_detail(guardrail_id="db-1", start_date=END, end_date=START, user_api_key_dict=ADMIN)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_policies_overview_rejects_range_over_max_days():
+    prisma = _prisma()
+    handler = _config_handler()
+    p1, p2 = _patches(prisma, handler)
+    with p1, p2, pytest.raises(HTTPException) as exc:
+        await policies_usage_overview(start_date="2020-01-01", end_date=END, user_api_key_dict=ADMIN)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_detail_prev_trend_query_is_bounded():
+    """Regression: the trend query scanned every metrics row before start_date."""
+    prisma = _prisma(find_unique=_db_row())
+    handler = _config_handler()
+    p1, p2 = _patches(prisma, handler)
+    with p1, p2:
+        await guardrails_usage_detail(guardrail_id="db-1", start_date=START, end_date=END, user_api_key_dict=ADMIN)
+    wheres = [c.kwargs["where"] for c in prisma.db.litellm_dailyguardrailmetrics.find_many.await_args_list]
+    prev_wheres = [w for w in wheres if "lt" in w.get("date", {})]
+    assert prev_wheres
+    assert all("gte" in w["date"] for w in prev_wheres)

--- a/tests/test_litellm/proxy/guardrails/test_usage_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_usage_endpoints.py
@@ -394,6 +394,17 @@ async def test_overview_rejects_malformed_dates():
 
 
 @pytest.mark.asyncio
+async def test_overview_rejects_non_canonical_date_format():
+    prisma = _prisma()
+    handler = _config_handler()
+    p1, p2 = _patches(prisma, handler)
+    with p1, p2, pytest.raises(HTTPException) as exc:
+        await guardrails_usage_overview(start_date="20260420", end_date=END, user_api_key_dict=ADMIN)
+    assert exc.value.status_code == 400
+    assert "YYYY-MM-DD" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_detail_rejects_reversed_dates():
     prisma = _prisma(find_unique=_db_row())
     handler = _config_handler()


### PR DESCRIPTION
## TLDR

Problem this solves:

- /guardrails/usage accepted unbounded date windows, aggregating all history
- Malformed dates surfaced as raw 500 internal errors
- Reversed dates silently returned empty 200s
- The guardrail detail trend query scanned every row before start_date

How it solves it:

- One shared validator caps usage windows at 366 days
- Malformed, non-canonical, or reversed dates now return clear 400s
- The detail trend comparison is bounded to the prior week

## User Flow

Before: a proxy admin checking guardrail usage can request any date span, so a typo'd date comes back as a raw 500 and a multi-year span makes the gateway grind through its entire history

1. The admin sends GET https://litellm-domain/guardrails/usage/overview?start_date=2020-01-01&end_date=2026-08-18 with their admin key
2. The response is HTTP 200 aggregating every guardrail's usage across the whole six-and-a-half-year span, however long that takes
3. They mistype the date: GET https://litellm-domain/guardrails/usage/overview?start_date=not-a-date&end_date=2026-08-18
4. Back comes HTTP 500 with `"time data 'not-a-date' does not match format '%Y-%m-%d'"`, an internal error for a bad input
5. They swap the dates by accident (start after end) and get HTTP 200 with empty rows instead of being told the range is backwards
6. The same unbounded span against GET https://litellm-domain/policies/usage/overview also returns HTTP 200 over all history

After: the same requests get clear 400s up front, and anything up to a year still works

1. The admin sends GET https://litellm-domain/guardrails/usage/overview?start_date=2020-01-01&end_date=2026-08-18 with their admin key
2. The response is HTTP 400 `"Date range too large; maximum is 366 days"`
3. They mistype the date: GET https://litellm-domain/guardrails/usage/overview?start_date=not-a-date&end_date=2026-08-18
4. Back comes HTTP 400 `"start_date and end_date must be in YYYY-MM-DD format"`
5. They swap the dates by accident and get HTTP 400 `"start_date must be on or before end_date"`
6. The unbounded span against GET https://litellm-domain/policies/usage/overview is also refused with the same HTTP 400 cap message
7. A normal request, GET https://litellm-domain/guardrails/usage/overview?start_date=2026-08-11&end_date=2026-08-18, still returns HTTP 200 with the usual rows

## Relevant issues

## Linear ticket

Resolves LIT-5762

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: proxy started with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port <port> --use_v2_migration_resolver` against a live Postgres, admin key `sk-1234`. Before runs the merge base on port 25729, After runs this branch on port 21861

### Before (e75b4b1c2a)

#### Oversized window on /guardrails/usage/overview

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:25729/guardrails/usage/overview?start_date=2020-01-01&end_date=2026-08-18" -H "Authorization: Bearer sk-1234"`
2. `{"rows":[{"id":"e0e5cf44-3f7f-44d2-9431-3a8b442a473d",...,"requestsEvaluated":3,...}, ...]}` then `HTTP 200`: the 6.5-year span is aggregated in full

#### Malformed start_date

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:25729/guardrails/usage/overview?start_date=not-a-date&end_date=2026-08-18" -H "Authorization: Bearer sk-1234"`
2. `{"error":{"message":"time data 'not-a-date' does not match format '%Y-%m-%d'","type":"internal_server_error","param":"None","code":"500"}}` then `HTTP 500`

#### Basic-format start_date (20200101)

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:25729/guardrails/usage/overview?start_date=20200101&end_date=2026-08-18" -H "Authorization: Bearer sk-1234"`
2. `{"error":{"message":"time data '20200101' does not match format '%Y-%m-%d'","type":"internal_server_error","param":"None","code":"500"}}` then `HTTP 500`

#### Reversed dates on /guardrails/usage/overview

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:25729/guardrails/usage/overview?start_date=2026-08-18&end_date=2026-08-11" -H "Authorization: Bearer sk-1234"`
2. `{"rows":[],"chart":[],"totalRequests":0,"totalBlocked":0,"passRate":100.0,"totalUsageUnits":{}}` then `HTTP 200`: silently empty instead of an error

#### Reversed dates on /guardrails/usage/detail/{id}

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:25729/guardrails/usage/detail/e0e5cf44-3f7f-44d2-9431-3a8b442a473d?start_date=2026-08-18&end_date=2026-08-11" -H "Authorization: Bearer sk-1234"`
2. `{"detail":"Guardrail not found"}` then `HTTP 404`: the lookup runs before the window is ever checked

#### Oversized window on /policies/usage/overview

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:25729/policies/usage/overview?start_date=2020-01-01&end_date=2026-08-18" -H "Authorization: Bearer sk-1234"`
2. `{"rows":[],"chart":[],"totalRequests":0,"totalBlocked":0,"passRate":100.0,"totalUsageUnits":{}}` then `HTTP 200`

#### Valid 7-day window still works

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:25729/guardrails/usage/overview?start_date=2026-08-11&end_date=2026-08-18" -H "Authorization: Bearer sk-1234"`
2. `{"rows":[],"chart":[],"totalRequests":0,"totalBlocked":0,"passRate":100.0,"totalUsageUnits":{}}` then `HTTP 200`

### After (eb3ed6cf39)

#### Oversized window on /guardrails/usage/overview

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:21861/guardrails/usage/overview?start_date=2020-01-01&end_date=2026-08-18" -H "Authorization: Bearer sk-1234"`
2. `{"detail":"Date range too large; maximum is 366 days"}` then `HTTP 400`

#### Malformed start_date

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:21861/guardrails/usage/overview?start_date=not-a-date&end_date=2026-08-18" -H "Authorization: Bearer sk-1234"`
2. `{"detail":"start_date and end_date must be in YYYY-MM-DD format"}` then `HTTP 400`

#### Basic-format start_date (20200101)

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:21861/guardrails/usage/overview?start_date=20200101&end_date=2026-08-18" -H "Authorization: Bearer sk-1234"`
2. `{"detail":"start_date and end_date must be in YYYY-MM-DD format"}` then `HTTP 400`: rejected instead of silently misfiltering the string-typed date column

#### Reversed dates on /guardrails/usage/overview

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:21861/guardrails/usage/overview?start_date=2026-08-18&end_date=2026-08-11" -H "Authorization: Bearer sk-1234"`
2. `{"detail":"start_date must be on or before end_date"}` then `HTTP 400`

#### Reversed dates on /guardrails/usage/detail/{id}

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:21861/guardrails/usage/detail/e0e5cf44-3f7f-44d2-9431-3a8b442a473d?start_date=2026-08-18&end_date=2026-08-11" -H "Authorization: Bearer sk-1234"`
2. `{"detail":"start_date must be on or before end_date"}` then `HTTP 400`: the window is validated before any lookup

#### Oversized window on /policies/usage/overview

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:21861/policies/usage/overview?start_date=2020-01-01&end_date=2026-08-18" -H "Authorization: Bearer sk-1234"`
2. `{"detail":"Date range too large; maximum is 366 days"}` then `HTTP 400`

#### Valid 7-day window still works

1. `curl -s -w "\nHTTP %{http_code}\n" "http://localhost:21861/guardrails/usage/overview?start_date=2026-08-11&end_date=2026-08-18" -H "Authorization: Bearer sk-1234"`
2. `{"rows":[],"chart":[],"totalRequests":0,"totalBlocked":0,"passRate":100.0,"totalUsageUnits":{}}` then `HTTP 200`

## Type

🐛 Bug Fix

## Caveats (if any)

- The 366-day cap matches the /global/spend/report limit
- /guardrails/usage/logs stays uncapped; it is paginated, not aggregated
- The detail trend now compares against the prior week only
- Dashboard presets stay under the cap; custom ranges over it show the error banner

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] eb3ed6cf39 passes /live-pr-risk
