### PR TITLE
fix(mcp): complete DCR bridge OAuth challenges

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import Sequence
 from datetime import datetime, timezone
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Final, cast
 
 from fastapi import HTTPException
@@ -13,6 +14,7 @@ import litellm
 from litellm._logging import verbose_logger
 from litellm.proxy._experimental.mcp_server.oauth_utils import (
     get_passthrough_resource_metadata_url,
+    get_passthrough_www_authenticate,
     get_request_base_url,
     well_known_root_suffix,
 )
@@ -437,24 +439,23 @@ class MCPRequestHandler:
             path=request_route,
             mcp_servers=mcp_servers,
             client_ip=IPAddressUtils.get_mcp_client_ip(request),
+        ) or (
+            MCPRequestHandler._single_dcr_bridge_delegate_target(
+                path=request_route,
+                mcp_servers=mcp_servers,
+                client_ip=IPAddressUtils.get_mcp_client_ip(request),
+            )
+            is not None
+            and not oauth2_headers
         ):
             validated_user_api_key_auth = UserAPIKeyAuth()
         elif (
-            (
-                bridge_delegate_target := MCPRequestHandler._single_dcr_bridge_delegate_target(
-                    path=request_route,
-                    mcp_servers=mcp_servers,
-                    client_ip=IPAddressUtils.get_mcp_client_ip(request),
-                )
+            bridge_delegate_target := MCPRequestHandler._single_dcr_bridge_delegate_target(
+                path=request_route,
+                mcp_servers=mcp_servers,
+                client_ip=IPAddressUtils.get_mcp_client_ip(request),
             )
-            is not None
-            and oauth2_headers
-            and is_bridge_envelope_shaped(oauth2_headers["Authorization"])
-        ):
-            # A single DCR-bridge oauth_delegate target carrying an envelope-shaped
-            # Authorization: open the envelope, admit under its recovered identity, and
-            # inject the inner upstream token for egress. A non-envelope bearer on the same
-            # server is NOT admitted here — it falls through to the oauth2 arm, which 401s.
+        ) is not None and oauth2_headers:
             validated_user_api_key_auth, mcp_server_auth_headers = await MCPRequestHandler._admit_dcr_bridge_delegate(
                 server=bridge_delegate_target,
                 authorization_value=oauth2_headers["Authorization"],
@@ -740,7 +741,10 @@ class MCPRequestHandler:
         if len(target_names) != 1:
             return None
         server: Final = global_mcp_server_manager.get_mcp_server_by_name(target_names[0], client_ip=client_ip)
-        if server is None or not server.is_oauth_delegate or not server.is_dcr_bridge:
+        # Both flags are security-sensitive opt-ins. Require literal booleans so
+        # partially populated objects and truthy proxy values cannot enable bridge
+        # admission accidentally.
+        if server is None or server.is_oauth_delegate is not True or server.is_dcr_bridge is not True:
             return None
         # Egress resolves the injected per-server token only by alias / server_name; a server with
         # neither cannot receive the forwarded token, so fail closed rather than admit-and-drop.
@@ -798,7 +802,25 @@ class MCPRequestHandler:
                 new_headers: Final = {**(mcp_server_auth_headers or {}), **injected}
                 return admitted, new_headers
             case BridgeEnvelopeInvalid() | NotBridgeEnvelope():
-                raise HTTPException(status_code=401, detail="Invalid or expired credential")
+                resource_name: Final = server.alias or server.server_name
+                if resource_name is None:
+                    raise HTTPException(
+                        status_code=500,
+                        detail="Server misconfigured: MCP server has no routable name",
+                    )
+                raise HTTPException(
+                    status_code=401,
+                    detail="Invalid or expired credential",
+                    headers=MappingProxyType(
+                        {
+                            "www-authenticate": get_passthrough_www_authenticate(
+                                scope=request.scope,
+                                server_name=resource_name,
+                                invalid_token=True,
+                            )
+                        }
+                    ),
+                )
             case _:
                 assert_never(result)
 

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -447,6 +447,8 @@ class MCPRequestHandler:
             )
             is not None
             and not oauth2_headers
+            and not mcp_server_auth_headers
+            and not mcp_auth_header
         ):
             validated_user_api_key_auth = UserAPIKeyAuth()
         elif (
@@ -456,9 +458,13 @@ class MCPRequestHandler:
                 client_ip=IPAddressUtils.get_mcp_client_ip(request),
             )
         ) is not None and oauth2_headers:
-            validated_user_api_key_auth, mcp_server_auth_headers = await MCPRequestHandler._admit_dcr_bridge_delegate(
+            (
+                validated_user_api_key_auth,
+                mcp_server_auth_headers,
+            ) = await MCPRequestHandler._admit_dcr_bridge_authorization(
                 server=bridge_delegate_target,
                 authorization_value=oauth2_headers["Authorization"],
+                litellm_api_key=litellm_api_key,
                 mcp_server_auth_headers=mcp_server_auth_headers,
                 request=request,
                 route=request_route,
@@ -802,27 +808,56 @@ class MCPRequestHandler:
                 new_headers: Final = {**(mcp_server_auth_headers or {}), **injected}
                 return admitted, new_headers
             case BridgeEnvelopeInvalid() | NotBridgeEnvelope():
-                resource_name: Final = server.alias or server.server_name
-                if resource_name is None:
-                    raise HTTPException(
-                        status_code=500,
-                        detail="Server misconfigured: MCP server has no routable name",
-                    )
-                raise HTTPException(
-                    status_code=401,
-                    detail="Invalid or expired credential",
-                    headers=MappingProxyType(
-                        {
-                            "www-authenticate": get_passthrough_www_authenticate(
-                                scope=request.scope,
-                                server_name=resource_name,
-                                invalid_token=True,
-                            )
-                        }
-                    ),
-                )
+                raise MCPRequestHandler._dcr_bridge_invalid_token_challenge(server=server, request=request)
             case _:
                 assert_never(result)
+
+    @staticmethod
+    async def _admit_dcr_bridge_authorization(
+        server: MCPServer,
+        authorization_value: str,
+        litellm_api_key: str,
+        mcp_server_auth_headers: dict[str, dict[str, str]] | None,
+        request: Request,
+        route: str,
+    ) -> tuple[UserAPIKeyAuth, dict[str, dict[str, str]] | None]:
+        if is_bridge_envelope_shaped(authorization_value):
+            return await MCPRequestHandler._admit_dcr_bridge_delegate(
+                server=server,
+                authorization_value=authorization_value,
+                mcp_server_auth_headers=mcp_server_auth_headers,
+                request=request,
+                route=route,
+            )
+        try:
+            admitted: Final = await user_api_key_auth(api_key=litellm_api_key, request=request)
+        except (HTTPException, ProxyException) as exc:
+            if not _is_litellm_auth_admission_error(exc):
+                raise
+            raise MCPRequestHandler._dcr_bridge_invalid_token_challenge(server=server, request=request) from exc
+        return admitted, mcp_server_auth_headers
+
+    @staticmethod
+    def _dcr_bridge_invalid_token_challenge(server: MCPServer, request: Request) -> HTTPException:
+        resource_name: Final = server.alias or server.server_name
+        if resource_name is None:
+            raise HTTPException(
+                status_code=500,
+                detail="Server misconfigured: MCP server has no routable name",
+            )
+        return HTTPException(
+            status_code=401,
+            detail="Invalid or expired credential",
+            headers=MappingProxyType(
+                {
+                    "www-authenticate": get_passthrough_www_authenticate(
+                        scope=request.scope,
+                        server_name=resource_name,
+                        invalid_token=True,
+                    )
+                }
+            ),
+        )
 
     @staticmethod
     async def _admit_gateway_session(

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -1,5 +1,6 @@
 import re
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Final, cast
@@ -300,6 +301,16 @@ def _admission_failure_fallback(
     raise exc
 
 
+@dataclass(frozen=True, slots=True)
+class DcrBridgeTarget:
+    """The single DCR-bridge server a request targets, paired with the exact name the caller
+    used to reach it (alias or server_name, whichever they typed), which is the spelling an
+    ``invalid_token`` challenge must echo back."""
+
+    requested_name: str
+    server: MCPServer
+
+
 class MCPRequestHandler:
     """
     Class to handle MCP request processing, including:
@@ -462,7 +473,8 @@ class MCPRequestHandler:
                 validated_user_api_key_auth,
                 mcp_server_auth_headers,
             ) = await MCPRequestHandler._admit_dcr_bridge_authorization(
-                server=bridge_delegate_target,
+                server=bridge_delegate_target.server,
+                requested_name=bridge_delegate_target.requested_name,
                 authorization_value=oauth2_headers["Authorization"],
                 litellm_api_key=litellm_api_key,
                 mcp_server_auth_headers=mcp_server_auth_headers,
@@ -730,10 +742,10 @@ class MCPRequestHandler:
     @staticmethod
     def _single_dcr_bridge_delegate_target(
         path: str, mcp_servers: list[str] | None, client_ip: str | None
-    ) -> MCPServer | None:
+    ) -> DcrBridgeTarget | None:
         """The one DCR-bridge ``oauth_delegate`` server this request targets, or ``None``.
 
-        Returns the server only when EXACTLY ONE target resolves and it is both
+        Returns the target only when EXACTLY ONE name resolves and its server is both
         ``is_oauth_delegate`` and ``is_dcr_bridge``. Fails closed (``None``) on a
         multi-target request, an unresolved target, or a non-matching server, so the
         envelope admission arm never fires for an aggregate scope or a server that did not
@@ -756,11 +768,12 @@ class MCPRequestHandler:
         # neither cannot receive the forwarded token, so fail closed rather than admit-and-drop.
         if not (server.server_name or server.alias):
             return None
-        return server
+        return DcrBridgeTarget(requested_name=target_names[0], server=server)
 
     @staticmethod
     async def _admit_dcr_bridge_delegate(
         server: MCPServer,
+        requested_name: str,
         authorization_value: str,
         mcp_server_auth_headers: dict[str, dict[str, str]] | None,
         request: Request,
@@ -808,13 +821,16 @@ class MCPRequestHandler:
                 new_headers: Final = {**(mcp_server_auth_headers or {}), **injected}
                 return admitted, new_headers
             case BridgeEnvelopeInvalid() | NotBridgeEnvelope():
-                raise MCPRequestHandler._dcr_bridge_invalid_token_challenge(server=server, request=request)
+                raise MCPRequestHandler._dcr_bridge_invalid_token_challenge(
+                    requested_name=requested_name, request=request
+                )
             case _:
                 assert_never(result)
 
     @staticmethod
     async def _admit_dcr_bridge_authorization(
         server: MCPServer,
+        requested_name: str,
         authorization_value: str,
         litellm_api_key: str,
         mcp_server_auth_headers: dict[str, dict[str, str]] | None,  # mutable-ok: existing MCP sink shape
@@ -824,6 +840,7 @@ class MCPRequestHandler:
         if is_bridge_envelope_shaped(authorization_value):
             return await MCPRequestHandler._admit_dcr_bridge_delegate(
                 server=server,
+                requested_name=requested_name,
                 authorization_value=authorization_value,
                 mcp_server_auth_headers=mcp_server_auth_headers,
                 request=request,
@@ -834,17 +851,18 @@ class MCPRequestHandler:
         except (HTTPException, ProxyException) as exc:
             if not _is_litellm_auth_admission_error(exc):
                 raise
-            raise MCPRequestHandler._dcr_bridge_invalid_token_challenge(server=server, request=request) from exc
+            raise MCPRequestHandler._dcr_bridge_invalid_token_challenge(
+                requested_name=requested_name, request=request
+            ) from exc
         return admitted, mcp_server_auth_headers
 
     @staticmethod
-    def _dcr_bridge_invalid_token_challenge(server: MCPServer, request: Request) -> HTTPException:
-        resource_name: Final = server.alias or server.server_name
-        if resource_name is None:
-            raise HTTPException(
-                status_code=500,
-                detail="Server misconfigured: MCP server has no routable name",
-            )
+    def _dcr_bridge_invalid_token_challenge(requested_name: str, request: Request) -> HTTPException:
+        """The RFC 6750 ``invalid_token`` challenge for a failed bridge admission.
+
+        Named by the exact spelling the caller requested, matching the per-server well-known
+        document and the other challenge emitters, so ``resource_metadata`` always points at the
+        resource the client actually asked for even when alias and server_name differ."""
         return HTTPException(
             status_code=401,
             detail="Invalid or expired credential",
@@ -852,7 +870,7 @@ class MCPRequestHandler:
                 {
                     "www-authenticate": get_passthrough_www_authenticate(
                         scope=request.scope,
-                        server_name=resource_name,
+                        server_name=requested_name,
                         invalid_token=True,
                     )
                 }

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -817,10 +817,10 @@ class MCPRequestHandler:
         server: MCPServer,
         authorization_value: str,
         litellm_api_key: str,
-        mcp_server_auth_headers: dict[str, dict[str, str]] | None,
+        mcp_server_auth_headers: dict[str, dict[str, str]] | None,  # mutable-ok: existing MCP sink shape
         request: Request,
         route: str,
-    ) -> tuple[UserAPIKeyAuth, dict[str, dict[str, str]] | None]:
+    ) -> tuple[UserAPIKeyAuth, dict[str, dict[str, str]] | None]:  # mutable-ok: existing MCP sink shape
         if is_bridge_envelope_shaped(authorization_value):
             return await MCPRequestHandler._admit_dcr_bridge_delegate(
                 server=server,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -5320,6 +5320,37 @@ class TestMCPDcrBridgeDelegateAdmission:
         assert auth_result == UserAPIKeyAuth()
         assert mcp_server_auth_headers == {}
 
+    @pytest.mark.parametrize(
+        "headers",
+        (
+            [(b"x-mcp-auth", b"Bearer upstream-token")],
+            [(b"x-mcp-bridge_delegate_server-authorization", b"Bearer upstream-token")],
+        ),
+        ids=("deprecated-mcp-auth", "per-server-auth"),
+    )
+    async def test_client_mcp_credentials_do_not_receive_keyless_bridge_admission(self, headers):
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/bridge_delegate_server",
+            "headers": headers,
+        }
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+                side_effect=HTTPException(status_code=401, detail="Invalid key"),
+            ) as mock_auth,
+            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
+        ):
+            mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
+            with pytest.raises(HTTPException) as exc_info:
+                await MCPRequestHandler.process_mcp_request(scope)
+
+        assert exc_info.value.status_code == 401
+        mock_auth.assert_awaited_once()
+
     async def test_valid_envelope_reloads_live_key_and_admits_its_authorization_context(self):
         """A valid envelope admits under the LIVE key record the sealed key_hash references, not a
         blank identity: the reload is keyed by that exact hash, and the admitted auth carries the
@@ -6058,6 +6089,7 @@ class TestMCPDcrBridgeDelegateAdmission:
             patch(
                 "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
                 new_callable=AsyncMock,
+                side_effect=HTTPException(status_code=401, detail="Invalid key"),
             ) as mock_auth,
             patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
             patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
@@ -6067,13 +6099,69 @@ class TestMCPDcrBridgeDelegateAdmission:
                 await MCPRequestHandler.process_mcp_request(scope)
 
         assert exc_info.value.status_code == 401
-        mock_auth.assert_not_called()
+        mock_auth.assert_awaited_once()
         assert exc_info.value.headers == {
             "www-authenticate": (
                 'Bearer error="invalid_token", '
                 'resource_metadata="http://testserver/.well-known/oauth-protected-resource/mcp/bridge_delegate_server"'
             )
         }
+
+    async def test_valid_litellm_authorization_key_uses_standard_admission(self):
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/bridge_delegate_server",
+            "headers": [(b"authorization", b"Bearer sk-valid-litellm-key")],
+        }
+        admitted = UserAPIKeyAuth(api_key="hashed-key", user_id="litellm-key-user")
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+                return_value=admitted,
+            ) as mock_auth,
+            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+        ):
+            mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
+            (
+                auth_result,
+                _mcp_auth,
+                _servers,
+                mcp_server_auth_headers,
+                _oauth,
+                _raw,
+            ) = await MCPRequestHandler.process_mcp_request(scope)
+
+        assert auth_result is admitted
+        assert mcp_server_auth_headers == {}
+        assert mock_auth.await_args.kwargs["api_key"] == "Bearer sk-valid-litellm-key"
+
+    async def test_non_401_litellm_key_failure_is_not_converted_to_oauth_challenge(self):
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/bridge_delegate_server",
+            "headers": [(b"authorization", b"Bearer sk-blocked-litellm-key")],
+        }
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+                side_effect=HTTPException(status_code=403, detail="Key blocked"),
+            ),
+            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+        ):
+            mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
+            with pytest.raises(HTTPException) as exc_info:
+                await MCPRequestHandler.process_mcp_request(scope)
+
+        assert exc_info.value.status_code == 403
+        assert not exc_info.value.headers
 
     async def test_explicit_litellm_key_wins_over_envelope_arm(self):
         """An explicit x-litellm-api-key is always a LiteLLM credential and its arm precedes the

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -5891,6 +5891,7 @@ class TestMCPDcrBridgeDelegateAdmission:
         ):
             _auth, new_headers = await MCPRequestHandler._admit_dcr_bridge_delegate(
                 server=self._bridge_delegate_server(server_name="bridge_name", alias="bridge_alias"),
+                requested_name="bridge_name",
                 authorization_value=f"Bearer {envelope}",
                 mcp_server_auth_headers=attacker_forwarded,
                 request=self._mcp_request(),
@@ -5927,6 +5928,7 @@ class TestMCPDcrBridgeDelegateAdmission:
         ):
             _auth, new_headers = await MCPRequestHandler._admit_dcr_bridge_delegate(
                 server=server,
+                requested_name="bridge_delegate_server",
                 authorization_value=f"Bearer {envelope}",
                 mcp_server_auth_headers=None,
                 request=self._mcp_request(),
@@ -6073,6 +6075,47 @@ class TestMCPDcrBridgeDelegateAdmission:
             "www-authenticate": (
                 'Bearer error="invalid_token", '
                 'resource_metadata="http://testserver/.well-known/oauth-protected-resource/mcp/bridge_delegate_server"'
+            )
+        }
+
+    @pytest.mark.parametrize("requested_name", ["bridge_name", "bridge_alias"])
+    async def test_invalid_envelope_challenge_names_the_requested_spelling(self, requested_name):
+        """A server reachable under both its server_name and a distinct alias must challenge with
+        metadata for the exact spelling the caller used, matching the per-server well-known
+        document, so the client rediscovers against the resource it actually asked for."""
+        foreign = self._mint_bridge_envelope(master_key="a-different-master-key-entirely")
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": f"/mcp/{requested_name}",
+            "headers": [
+                (b"host", b"testserver"),
+                (b"authorization", f"Bearer {foreign}".encode("latin-1")),
+            ],
+        }
+
+        with (
+            patch(  # test-quality-ok: prove standard admission is never consulted for an envelope bearer
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+            ) as mock_auth,
+            patch(  # test-quality-ok: isolate the MCP registry, same seam as the sibling challenge tests
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+            ) as mock_mgr,
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),  # test-quality-ok: envelope keys derive from the proxy master_key module global
+        ):
+            mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server(
+                server_name="bridge_name", alias="bridge_alias"
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                await MCPRequestHandler.process_mcp_request(scope)
+
+        assert exc_info.value.status_code == 401
+        mock_auth.assert_not_called()
+        assert exc_info.value.headers == {
+            "www-authenticate": (
+                'Bearer error="invalid_token", '
+                f'resource_metadata="http://testserver/.well-known/oauth-protected-resource/mcp/{requested_name}"'
             )
         }
 
@@ -6301,6 +6344,7 @@ class TestMCPDcrBridgeDelegateAdmission:
         ):
             auth_result, new_headers = await MCPRequestHandler._admit_dcr_bridge_delegate(
                 server=self._bridge_delegate_server(),
+                requested_name="bridge_delegate_server",
                 authorization_value=f"Bearer {envelope}",
                 mcp_server_auth_headers=existing,
                 request=self._mcp_request(),
@@ -6325,6 +6369,7 @@ class TestMCPDcrBridgeDelegateAdmission:
             with pytest.raises(HTTPException) as exc_info:
                 await MCPRequestHandler._admit_dcr_bridge_delegate(
                     server=self._bridge_delegate_server(),
+                    requested_name="bridge_delegate_server",
                     authorization_value=f"Bearer {envelope}",
                     mcp_server_auth_headers=None,
                     request=self._mcp_request(),
@@ -6343,6 +6388,7 @@ class TestMCPDcrBridgeDelegateAdmission:
             with pytest.raises(HTTPException) as exc_info:
                 await MCPRequestHandler._admit_dcr_bridge_delegate(
                     server=self._bridge_delegate_server(),
+                    requested_name="bridge_delegate_server",
                     authorization_value=f"Bearer {envelope}",
                     mcp_server_auth_headers=None,
                     request=self._mcp_request(),

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -5097,13 +5097,10 @@ class TestMCPDcrBridgeDelegateAdmission:
     """Admission-side arm for a DCR-bridge ``oauth_delegate`` client that authenticates with
     a single envelope bearer (LIT-4338).
 
-    The arm fires only for a single ``is_dcr_bridge`` ``is_oauth_delegate`` target carrying an
-    envelope-shaped Authorization. It opens the litellm-signed envelope, reloads the live key
-    record the sealed ``key_hash`` references so the caller is admitted under the key's current
-    authorization context (team/org/object-permission) and revocation state, and injects the inner
-    upstream token under the server's per-server auth-header key so egress forwards it. A key that
-    is missing, blocked, or expired fails closed with a 401. Everything else must stay on its
-    existing admission path.
+    A credential-free request reaches the named MCP handler so it can issue the initial OAuth
+    challenge. Every bearer on that same route enters envelope resolution. A valid envelope opens
+    under its live authorization context, while invalid envelopes and non-envelope bearers receive
+    a named ``invalid_token`` challenge. Everything else stays on its existing admission path.
     """
 
     _MASTER_KEY = "sk-bridge-master-key-for-envelope-derivation"
@@ -5271,6 +5268,57 @@ class TestMCPDcrBridgeDelegateAdmission:
 
         request.body = mock_body
         return request
+
+    async def test_bridge_target_requires_literal_boolean_opt_ins(self):
+        """Truthy proxy values must not opt an unresolved server into bridge admission."""
+        for delegate_value, bridge_value in ((MagicMock(), True), (True, MagicMock())):
+            server = MagicMock()
+            server.is_oauth_delegate = delegate_value
+            server.is_dcr_bridge = bridge_value
+            server.server_name = "bridge_delegate_server"
+            server.alias = None
+
+            with patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+            ) as mock_mgr:
+                mock_mgr.get_mcp_server_by_name.return_value = server
+                assert (
+                    MCPRequestHandler._single_dcr_bridge_delegate_target(
+                        path="/mcp/bridge_delegate_server",
+                        mcp_servers=None,
+                        client_ip=None,
+                    )
+                    is None
+                )
+
+    async def test_credential_free_named_bridge_request_reaches_mcp_handler(self):
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/bridge_delegate_server",
+            "headers": [],
+        }
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+            ) as mock_auth,
+            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
+        ):
+            mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
+            (
+                auth_result,
+                _mcp_auth_header,
+                _mcp_servers,
+                mcp_server_auth_headers,
+                _oauth2_headers,
+                _raw_headers,
+            ) = await MCPRequestHandler.process_mcp_request(scope)
+
+        mock_auth.assert_not_called()
+        assert auth_result == UserAPIKeyAuth()
+        assert mcp_server_auth_headers == {}
 
     async def test_valid_envelope_reloads_live_key_and_admits_its_authorization_context(self):
         """A valid envelope admits under the LIVE key record the sealed key_hash references, not a
@@ -5887,8 +5935,7 @@ class TestMCPDcrBridgeDelegateAdmission:
         mock_auth.assert_called_once()
 
     async def test_expired_envelope_fails_closed_401(self):
-        """An envelope whose exp is in the past must fail closed with a 401, never fall through to
-        anonymous admission."""
+        """An expired envelope fails closed and tells the client where to reauthorize."""
         expired = self._mint_bridge_envelope(
             expires_in=60,
             minted_at=datetime.now(timezone.utc) - timedelta(hours=2),
@@ -5897,7 +5944,10 @@ class TestMCPDcrBridgeDelegateAdmission:
             "type": "http",
             "method": "POST",
             "path": "/mcp/bridge_delegate_server",
-            "headers": [(b"authorization", f"Bearer {expired}".encode("latin-1"))],
+            "headers": [
+                (b"host", b"testserver"),
+                (b"authorization", f"Bearer {expired}".encode("latin-1")),
+            ],
         }
 
         with (
@@ -5914,6 +5964,12 @@ class TestMCPDcrBridgeDelegateAdmission:
 
         assert exc_info.value.status_code == 401
         mock_auth.assert_not_called()
+        assert exc_info.value.headers == {
+            "www-authenticate": (
+                'Bearer error="invalid_token", '
+                'resource_metadata="http://testserver/.well-known/oauth-protected-resource/mcp/bridge_delegate_server"'
+            )
+        }
 
     async def test_envelope_minted_for_a_different_server_fails_closed_401(self):
         """An envelope sealed for another server_id must be rejected when presented to this server,
@@ -5924,7 +5980,10 @@ class TestMCPDcrBridgeDelegateAdmission:
             "type": "http",
             "method": "POST",
             "path": "/mcp/bridge_delegate_server",
-            "headers": [(b"authorization", f"Bearer {wrong_server}".encode("latin-1"))],
+            "headers": [
+                (b"host", b"testserver"),
+                (b"authorization", f"Bearer {wrong_server}".encode("latin-1")),
+            ],
         }
 
         with (
@@ -5941,6 +6000,12 @@ class TestMCPDcrBridgeDelegateAdmission:
 
         assert exc_info.value.status_code == 401
         mock_auth.assert_not_called()
+        assert exc_info.value.headers == {
+            "www-authenticate": (
+                'Bearer error="invalid_token", '
+                'resource_metadata="http://testserver/.well-known/oauth-protected-resource/mcp/bridge_delegate_server"'
+            )
+        }
 
     async def test_envelope_under_wrong_master_key_fails_closed_401(self):
         """An envelope-shaped bearer whose signature does not verify under the proxy's derived keys
@@ -5950,7 +6015,10 @@ class TestMCPDcrBridgeDelegateAdmission:
             "type": "http",
             "method": "POST",
             "path": "/mcp/bridge_delegate_server",
-            "headers": [(b"authorization", f"Bearer {foreign}".encode("latin-1"))],
+            "headers": [
+                (b"host", b"testserver"),
+                (b"authorization", f"Bearer {foreign}".encode("latin-1")),
+            ],
         }
 
         with (
@@ -5967,26 +6035,29 @@ class TestMCPDcrBridgeDelegateAdmission:
 
         assert exc_info.value.status_code == 401
         mock_auth.assert_not_called()
+        assert exc_info.value.headers == {
+            "www-authenticate": (
+                'Bearer error="invalid_token", '
+                'resource_metadata="http://testserver/.well-known/oauth-protected-resource/mcp/bridge_delegate_server"'
+            )
+        }
 
-    async def test_non_envelope_bearer_on_bridge_server_falls_through_to_oauth2_arm(self):
-        """A plain (non-envelope) bearer on the same bridge server must NOT be admitted by the
-        envelope arm: it falls through to the oauth2 arm, which validates it as a LiteLLM key and
-        401s here. Proves the arm is gated on envelope shape, not merely on the target being a
-        bridge server."""
+    async def test_non_envelope_bearer_on_bridge_server_returns_named_challenge(self):
+        """A raw provider bearer cannot authorize a bridge route and triggers reauthorization."""
         scope = {
             "type": "http",
             "method": "POST",
             "path": "/mcp/bridge_delegate_server",
-            "headers": [(b"authorization", b"Bearer plain-upstream-bearer-not-an-envelope")],
+            "headers": [
+                (b"host", b"testserver"),
+                (b"authorization", b"Bearer plain-upstream-bearer-not-an-envelope"),
+            ],
         }
-
-        async def mock_user_api_key_auth_fails(api_key, request):
-            raise HTTPException(status_code=401, detail="Invalid API key")
 
         with (
             patch(
                 "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
-                side_effect=mock_user_api_key_auth_fails,
+                new_callable=AsyncMock,
             ) as mock_auth,
             patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
             patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
@@ -5996,8 +6067,13 @@ class TestMCPDcrBridgeDelegateAdmission:
                 await MCPRequestHandler.process_mcp_request(scope)
 
         assert exc_info.value.status_code == 401
-        # The envelope arm was skipped, so the oauth2 arm ran and validated the bearer.
-        mock_auth.assert_called_once()
+        mock_auth.assert_not_called()
+        assert exc_info.value.headers == {
+            "www-authenticate": (
+                'Bearer error="invalid_token", '
+                'resource_metadata="http://testserver/.well-known/oauth-protected-resource/mcp/bridge_delegate_server"'
+            )
+        }
 
     async def test_explicit_litellm_key_wins_over_envelope_arm(self):
         """An explicit x-litellm-api-key is always a LiteLLM credential and its arm precedes the

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -7,8 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
-
-
 from starlette.datastructures import Headers
 
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
@@ -5135,6 +5133,8 @@ class TestMCPDcrBridgeDelegateAdmission:
         minted_at=None,
         master_key=None,
     ):
+        from pydantic import SecretStr
+
         from litellm.proxy._experimental.mcp_server.outbound_credentials.bridge_credentials import (
             envelope_keys_from_master_key,
         )
@@ -5145,7 +5145,6 @@ class TestMCPDcrBridgeDelegateAdmission:
             mint_envelope,
             user_identity,
         )
-        from pydantic import SecretStr
 
         identity = (
             user_identity(server_id=server_id, user_id=user_id)
@@ -5278,7 +5277,7 @@ class TestMCPDcrBridgeDelegateAdmission:
             server.server_name = "bridge_delegate_server"
             server.alias = None
 
-            with patch(
+            with patch(  # test-quality-ok: isolate the MCP registry when testing target selection
                 "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
             ) as mock_mgr:
                 mock_mgr.get_mcp_server_by_name.return_value = server
@@ -5300,11 +5299,13 @@ class TestMCPDcrBridgeDelegateAdmission:
         }
 
         with (
-            patch(
+            patch(  # test-quality-ok: observe the auth boundary while testing admission orchestration
                 "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
                 new_callable=AsyncMock,
             ) as mock_auth,
-            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
+            patch(  # test-quality-ok: isolate the MCP registry used by request admission
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+            ) as mock_mgr,
         ):
             mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
             (
@@ -5337,12 +5338,14 @@ class TestMCPDcrBridgeDelegateAdmission:
         }
 
         with (
-            patch(
+            patch(  # test-quality-ok: force credential rejection through request admission
                 "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
                 new_callable=AsyncMock,
                 side_effect=HTTPException(status_code=401, detail="Invalid key"),
             ) as mock_auth,
-            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
+            patch(  # test-quality-ok: isolate the MCP registry used by request admission
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+            ) as mock_mgr,
         ):
             mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
             with pytest.raises(HTTPException) as exc_info:
@@ -6117,13 +6120,17 @@ class TestMCPDcrBridgeDelegateAdmission:
         admitted = UserAPIKeyAuth(api_key="hashed-key", user_id="litellm-key-user")
 
         with (
-            patch(
+            patch(  # test-quality-ok: supply standard key admission through the auth boundary
                 "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
                 new_callable=AsyncMock,
                 return_value=admitted,
             ) as mock_auth,
-            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
-            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+            patch(  # test-quality-ok: isolate the MCP registry used by request admission
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+            ) as mock_mgr,
+            patch(  # test-quality-ok: configure key classification for the orchestration test
+                "litellm.proxy.proxy_server.master_key", self._MASTER_KEY
+            ),
         ):
             mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
             (
@@ -6148,13 +6155,17 @@ class TestMCPDcrBridgeDelegateAdmission:
         }
 
         with (
-            patch(
+            patch(  # test-quality-ok: force a non-401 auth result through request admission
                 "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
                 new_callable=AsyncMock,
                 side_effect=HTTPException(status_code=403, detail="Key blocked"),
             ),
-            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
-            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+            patch(  # test-quality-ok: isolate the MCP registry used by request admission
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+            ) as mock_mgr,
+            patch(  # test-quality-ok: configure key classification for the orchestration test
+                "litellm.proxy.proxy_server.master_key", self._MASTER_KEY
+            ),
         ):
             mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
             with pytest.raises(HTTPException) as exc_info:
@@ -6644,8 +6655,8 @@ class TestGatewaySessionAdmission:
         )
         from litellm.proxy._experimental.mcp_server.outbound_credentials.session_token import (
             SessionPrincipal,
-            mint_session_token,
             mint_session_refresh_token,
+            mint_session_token,
         )
 
         keys = session_keys_from_master_key(self._MASTER_KEY)
@@ -7111,8 +7122,8 @@ class TestUserSubjectTeamUnion:
 
     def _manager_with(self, server_ids, allow_all=()):
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerManager
-        from litellm.types.mcp_server.mcp_server_manager import MCPServer
         from litellm.types.mcp import MCPTransport
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
         manager = MCPServerManager()
         for sid in server_ids:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bridge clients cannot discover OAuth on their first request
- Invalid bridge credentials do not trigger reauthorization
- Bridge admission must preserve valid LiteLLM keys and reject client-supplied MCP credentials

How it solves it:

- Admit credential-free requests only for one named bridge and only when no top-level, deprecated MCP, or per-server MCP credential is present
- Preserve normal LiteLLM validation for a key supplied through `Authorization`
- Challenge bridge envelopes and non-envelope bearers that fail LiteLLM authentication with named metadata
- Name the challenge by the exact server name the client requested
- Translate only authentication 401s; preserve other key-policy failures
- Require literal bridge/delegate opt-ins so truthy proxy values cannot enable admission

## User Flow

Before: a desktop MCP client connecting to one DCR bridge server cannot reliably start or restart OAuth

1. The client sends `POST http://localhost:4000/mcp/bridge_test_server` without an Authorization header
2. The proxy returns 401 with `Malformed API Key` and no `WWW-Authenticate` header, so the client cannot discover OAuth
3. If the client sends a cached raw provider bearer instead, the proxy returns the same bare 401 with no named OAuth challenge

After: the same client receives the named challenge needed to authenticate or reconnect

1. A fully credential-free request receives `WWW-Authenticate: Bearer resource_metadata=".../mcp/bridge_test_server"` and can start OAuth
2. A cached raw provider bearer that fails LiteLLM authentication receives `error="invalid_token"` and the same named metadata, so the client can reauthorize
3. A valid LiteLLM key in `Authorization` retains standard admission and policy checks
4. A request that also carries a deprecated or per-server MCP credential header is never admitted anonymously

## Relevant issues

Fixes #37210

## Linear ticket

Resolves LIT-6170

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs run the identical rig and differ only in the checked-out commit. Config is the exact server shape from #37210:

```yaml
mcp_servers:
  bridge_test_server:
    url: https://mcp.linear.app/mcp
    transport: http
    auth_type: oauth_delegate
    dcr_bridge: true
```

Each proxy boots with `--num_workers 2`, a real Postgres, and master key `sk-lit6170-qa-master` (throwaway, torn down after the run). Before leg is the merge base d16c4dad4b on port 54804; after leg is the PR tip 764048750e on port 52780. Every case runs this loop, differing only in the Authorization header:

```zsh
BODY='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"qa-client","version":"1.0"}}}'
run() {
  echo "===== CASE: $1 ====="
  shift
  curl -sS -D - -o /tmp/case_body.json -m 20 "$@" \
    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
    -X POST "http://localhost:${PORT}/mcp/bridge_test_server" --data "$BODY" | grep -i 'HTTP/1.1\|www-authenticate'
  echo "--- body ---"
  cat /tmp/case_body.json; echo
}
run "credential-free initialize"
run "tampered envelope bearer" -H 'Authorization: Bearer llm_env_dGFtcGVyZWQtZW52ZWxvcGU'
run "raw provider bearer" -H 'Authorization: Bearer lin_api_cachedProviderToken123'
run "valid LiteLLM master key" -H 'Authorization: Bearer sk-lit6170-qa-master'
run "bogus LiteLLM sk- key" -H 'Authorization: Bearer sk-bogus-key-123'
curl -sS -D - -m 20 -X GET "http://localhost:${PORT}/mcp/bridge_test_server" -H 'Accept: text/event-stream'

### Before (d16c4dad4b, port 54804)

No case carries a `WWW-Authenticate` challenge except the valid master key, so a bridge client that has no credential yet, or holds a stale one, gets a bare 401 it cannot recover from:

```
===== CASE: credential-free initialize =====
HTTP/1.1 401 Unauthorized
--- body ---
{"detail":"Authentication Error, Malformed API Key passed in. Ensure Key has `Bearer ` prefix."}

===== CASE: tampered envelope bearer =====
HTTP/1.1 401 Unauthorized
--- body ---
{"detail":"Invalid or expired credential"}

===== CASE: raw provider bearer =====
HTTP/1.1 401 Unauthorized
--- body ---
{"detail":"LiteLLM Virtual Key expected. Received=lin_****n123, expected to start with 'sk-'."}

===== CASE: valid LiteLLM master key =====
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="http://localhost:54804/.well-known/oauth-protected-resource/mcp/bridge_test_server"
--- body ---
{"detail":"Unauthorized"}

===== CASE: bogus LiteLLM sk- key =====
HTTP/1.1 401 Unauthorized
--- body ---
{"detail":"Authentication Error, Invalid proxy server token passed. Received API Key = sk-...-123, Key Hash (Token) =4c82ea7f315ac3d051805cd642ecf5c2fef60ef13bbb686e40f3c48777f23c20. Unable to find token in cache or `LiteLLM_VerificationTokenTable`"}

===== CASE: SSE GET credential-free =====
HTTP/1.1 401 Unauthorized
--- body ---
{"detail":"Authentication Error, Malformed API Key passed in. Ensure Key has `Bearer ` prefix."}
```

### After (764048750e, port 52780)

Every 401 now names the challenge, and the invalid-credential cases add `error="invalid_token"` per RFC 6750, so a client can discover OAuth on first contact and knows to reauthorize on a stale credential:

```
===== CASE: credential-free initialize =====
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="http://localhost:52780/.well-known/oauth-protected-resource/mcp/bridge_test_server"
--- body ---
{"detail":"Unauthorized"}

===== CASE: tampered envelope bearer =====
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer error="invalid_token", resource_metadata="http://localhost:52780/.well-known/oauth-protected-resource/mcp/bridge_test_server"
--- body ---
{"detail":"Invalid or expired credential"}

===== CASE: raw provider bearer =====
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer error="invalid_token", resource_metadata="http://localhost:52780/.well-known/oauth-protected-resource/mcp/bridge_test_server"
--- body ---
{"detail":"Invalid or expired credential"}

===== CASE: valid LiteLLM master key =====
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="http://localhost:52780/.well-known/oauth-protected-resource/mcp/bridge_test_server"
--- body ---
{"detail":"Unauthorized"}

===== CASE: bogus LiteLLM sk- key =====
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer error="invalid_token", resource_metadata="http://localhost:52780/.well-known/oauth-protected-resource/mcp/bridge_test_server"
--- body ---
{"detail":"Invalid or expired credential"}

===== CASE: SSE GET credential-free =====
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="http://localhost:52780/.well-known/oauth-protected-resource/mcp/bridge_test_server"
--- body ---
{"detail":"Unauthorized"}
```

### Regression check: a valid envelope still admits (after leg)

A real `llm_env_` envelope was minted through the live upstream (Linear consent in the browser, scripted DCR client, PKCE, then the token exchange presenting a LiteLLM virtual key), and it admits cleanly through the rewritten admission arm:

```
$ curl -sS -X POST http://localhost:52780/bridge_test_server/token \
    -H "x-litellm-api-key: $VIRTUAL_KEY" \
    --data-urlencode 'grant_type=authorization_code' \
    --data-urlencode "code=$CODE" --data-urlencode "code_verifier=$PKCE_VERIFIER" \
    --data-urlencode 'redirect_uri=http://127.0.0.1:21739/callback' \
    --data-urlencode "client_id=2yN9D_ecX1KHrEBt"
{"access_token":"llm_env_eyJh...(776 chars)","token_type":"Bearer","expires_in":3599,"refresh_token":"llm_refresh_..."}

$ curl -sS -D - -X POST http://localhost:52780/mcp/bridge_test_server \
    -H "Authorization: Bearer llm_env_eyJh..." \
    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
    --data "$BODY"
HTTP/1.1 200 OK
event: message
data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{...},"serverInfo":{"name":"litellm-mcp-server","version":"1.0.0"}}}
```

### Regression check: non-bridge servers are untouched (after leg)

With a second, plain MCP server added to the same config (`plain_test_server: {url: https://mcp.deepwiki.com/mcp, transport: http}`), the rewritten admission region leaves non-bridge behavior alone and keeps the bridge challenge scoped to its own path:

```
===== credential-free plain_test_server =====
HTTP/1.1 401 Unauthorized
--- body ---
{"detail":"Authentication Error, Malformed API Key passed in. Ensure Key has `Bearer ` prefix."}

===== credential-free bridge_test_server (two servers configured) =====
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="http://localhost:52780/.well-known/oauth-protected-resource/mcp/bridge_test_server"
--- body ---
{"detail":"Unauthorized"}

===== valid master key plain_test_server =====
HTTP/1.1 200 OK
--- body ---
event: message
data: {"jsonrpc":"2.0","id":1,"result":{...,"serverInfo":{"name":"plain_test_server","version":"1.0.0"},"instructions":"DeepWiki MCP provides AI-powered documentation for GitHub repositories...
```

The credential-free aggregate `POST /mcp` answer (401 with `resource_metadata=".../mcp"`) is byte-identical on both legs, so it is pre-existing and out of this PR's blast radius

### Real client (codex CLI 0.145.0), both legs

`codex mcp add bridge6170-<leg> --url http://localhost:<port>/mcp/bridge_test_server`, then `codex mcp login bridge6170-<leg>` driven interactively under tmux with the browser completing Linear consent. Both legs behave identically, because codex falls back to `.well-known` discovery when the 401 carries no challenge, and because the relay-mode token exchange predates this PR:

```
$ codex mcp login bridge6170-after
Authorize `bridge6170-after` by opening this URL in your browser:
http://localhost:52780/bridge_test_server/authorize?response_type=code&client_id=cDjgDXkA3fkKytWT&...

Error: failed to handle OAuth callback
Caused by:
    OAuth token exchange failed: Server returned error response: invalid_request: this server issues a gateway-bound credential; complete the interactive sign-in, or send a litellm credential (x-litellm-api-key or Authorization) on the token request
```

The before leg fails with the byte-identical error at the same step

Observations from the run:

- codex discovery fallback hides the missing before-leg challenge; strict clients stay stranded
- relay-mode token mint refuses pure DCR clients; both legs, pre-existing, PR leaves alone
- master key cannot mint an envelope; virtual keys can; pre-existing
- valid master key still 401-challenged on bridge servers; both legs, pre-existing
- challenge URLs honor PROXY_BASE_URL over the request host; pre-existing

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Mid-session serialized tool errors stay as they are: pre-existing egress behavior this diff cannot reach (it touches only the admission module and its tests), and the reconnect path now recovers cleanly through the `invalid_token` challenge
- 401 detail bodies on the bridge path changed shape (`Malformed API Key ...` becomes `Unauthorized` / `Invalid or expired credential`); status codes and every non-bridge path are unchanged
- A pure DCR client still cannot finish the relay-mode token exchange without presenting a LiteLLM credential; pre-existing, verified byte-identical on the merge base

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 764048750ecbddd9e4baefa8483d66d02089d37b passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes MCP proxy authentication and admission ordering for DCR bridge routes, including when requests are admitted without credentials and how 401s are surfaced to OAuth clients; scope is narrow but security-sensitive.
> 
> **Overview**
> **Completes RFC 9728 / RFC 6750 OAuth discovery and reauthorization for single-target DCR bridge MCP servers** (`oauth_delegate` + `dcr_bridge`), without changing non-bridge admission paths.
> 
> Credential-free `POST /mcp/{name}` requests are admitted anonymously **only** when exactly one bridge target resolves, there is no `Authorization`, and no deprecated `x-mcp-auth` or per-server MCP credential headers—so the route layer can emit a named `WWW-Authenticate` challenge instead of a bare “malformed key” 401.
> 
> When `Authorization` is present on that same route, admission goes through **`_admit_dcr_bridge_authorization`**: envelope-shaped bearers still open via **`_admit_dcr_bridge_delegate`** (live key reload + upstream token injection); non-envelope bearers are validated as LiteLLM keys, and **only authentication 401s** are converted to an **`invalid_token`** challenge with **`resource_metadata`** pointing at the spelling the client actually used (`alias` vs `server_name` via new **`DcrBridgeTarget`**). Invalid envelopes and failed key auth share that named challenge; 403 and other policy failures are not rewritten.
> 
> Bridge targeting is tightened: **`_single_dcr_bridge_delegate_target`** requires literal `is_oauth_delegate is True` and `is_dcr_bridge is True` so truthy proxy values cannot enable bridge admission accidentally.
> 
> Tests in **`test_user_api_key_auth_mcp.py`** cover literal opt-ins, credential-free reachability, MCP credential headers blocking keyless admission, challenge header shape, alias vs server_name naming, valid LiteLLM keys, and non-401 key failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 764048750ecbddd9e4baefa8483d66d02089d37b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->