### PR TITLE
feat(bedrock): add a config toggle to disable agent-runtime pass-through

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1299,9 +1299,6 @@ def _is_bedrock_agent_runtime_route(endpoint: str) -> bool:
 
 
 def _is_bedrock_agent_runtime_passthrough_disabled() -> bool:
-    """
-    Return True, if `general_settings.disable_bedrock_agent_runtime_passthrough` is set.
-    """
     from litellm.proxy.proxy_server import general_settings
 
     setting: Final = general_settings.get("disable_bedrock_agent_runtime_passthrough")

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -50,7 +50,7 @@ from litellm.proxy.vector_store_endpoints.utils import (
     get_litellm_managed_vector_store,
     is_allowed_to_call_vector_store_endpoint,
 )
-from litellm.secret_managers.main import get_secret_str
+from litellm.secret_managers.main import get_secret_str, str_to_bool
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
     LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
@@ -1016,15 +1016,21 @@ async def bedrock_proxy_route(
         raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
 
     aws_region_name: Final = litellm.utils.get_secret(secret_name="AWS_REGION_NAME")
-    if _is_bedrock_agent_runtime_route(endpoint=endpoint):  # handle bedrock agents
-        base_target_url: Final = f"https://bedrock-agent-runtime.{aws_region_name}.amazonaws.com"
-    else:
+    if not _is_bedrock_agent_runtime_route(endpoint=endpoint):
         return await bedrock_llm_proxy_route(
             endpoint=endpoint,
             request=request,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
         )
+
+    if _is_bedrock_agent_runtime_passthrough_disabled():
+        raise HTTPException(
+            status_code=403,
+            detail="bedrock-agent-runtime pass-through is disabled on this proxy.",
+        )
+
+    base_target_url: Final = f"https://bedrock-agent-runtime.{aws_region_name}.amazonaws.com"
     encoded_endpoint = httpx.URL(endpoint).path
 
     # Ensure endpoint starts with '/' for proper URL construction
@@ -1290,6 +1296,18 @@ def _is_bedrock_agent_runtime_route(endpoint: str) -> bool:
         if _route in endpoint:
             return True
     return False
+
+
+def _is_bedrock_agent_runtime_passthrough_disabled() -> bool:
+    """
+    Return True, if `general_settings.disable_bedrock_agent_runtime_passthrough` is set.
+    """
+    from litellm.proxy.proxy_server import general_settings
+
+    setting: Final = general_settings.get("disable_bedrock_agent_runtime_passthrough")
+    if isinstance(setting, str):
+        return str_to_bool(setting) is True
+    return setting is True
 
 
 @router.api_route(

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -1735,9 +1735,6 @@ class TestBedrockLLMProxyRoute:
 
 
 class TestBedrockAgentRuntimePassthroughToggle:
-    """`general_settings.disable_bedrock_agent_runtime_passthrough` gates only the
-    bedrock-agent-runtime branch of `/bedrock/{endpoint:path}`."""
-
     AGENT_RUNTIME_ENDPOINT: Final = "knowledgebases/KB1234567/retrieve"
     MODEL_ENDPOINT: Final = "model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/converse"
     DISABLED: Final = MappingProxyType({"disable_bedrock_agent_runtime_passthrough": True})
@@ -1752,7 +1749,6 @@ class TestBedrockAgentRuntimePassthroughToggle:
 
     @contextlib.contextmanager
     def _patched_dispatch(self, general_settings: Mapping[str, object]):
-        """Patch out signing + forwarding so the routing decision is observable."""
         from botocore.credentials import Credentials
 
         bedrock_llm: Final = Mock()
@@ -1776,7 +1772,6 @@ class TestBedrockAgentRuntimePassthroughToggle:
 
     @pytest.mark.asyncio
     async def test_agent_runtime_dispatch_allowed_by_default(self):
-        """Default config must keep forwarding to bedrock-agent-runtime."""
         with self._patched_dispatch(MappingProxyType({})) as (create_route, forwarder):
             result: Final = await bedrock_proxy_route(
                 endpoint=self.AGENT_RUNTIME_ENDPOINT,
@@ -1792,11 +1787,6 @@ class TestBedrockAgentRuntimePassthroughToggle:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("value", (True, "true", "True"))
     async def test_agent_runtime_dispatch_rejected_when_disabled(self, value: bool | str):
-        """With the setting on, the request is rejected before it is signed or sent.
-
-        The string forms matter: /config/field/update persists the raw value, so the
-        setting can reach general_settings as a string rather than a bool.
-        """
         settings: Final = MappingProxyType({"disable_bedrock_agent_runtime_passthrough": value})
 
         with self._patched_dispatch(settings) as (create_route, forwarder):
@@ -1815,7 +1805,6 @@ class TestBedrockAgentRuntimePassthroughToggle:
 
     @pytest.mark.asyncio
     async def test_model_invoke_still_routed_when_agent_runtime_disabled(self):
-        """The setting must not touch plain bedrock-runtime model pass-through."""
         with (
             patch("litellm.proxy.proxy_server.general_settings", self.DISABLED),
             patch("litellm.utils.get_secret", return_value="us-east-1"),
@@ -1841,7 +1830,6 @@ class TestBedrockAgentRuntimePassthroughToggle:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("value", (False, "false", None, "", "yes"))
     async def test_agent_runtime_dispatch_allowed_for_non_true_values(self, value: object):
-        """Anything that is not a recognised true value leaves dispatch untouched."""
         settings: Final = MappingProxyType({"disable_bedrock_agent_runtime_passthrough": value})
 
         with self._patched_dispatch(settings) as (create_route, forwarder):

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -1,7 +1,10 @@
+import contextlib
 import json
 import os
 import sys
 import traceback
+from collections.abc import Mapping
+from types import MappingProxyType, SimpleNamespace
 from typing import Final
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -22,6 +25,7 @@ from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     _join_url_paths,
     azure_proxy_route,
     bedrock_llm_proxy_route,
+    bedrock_proxy_route,
     create_pass_through_route,
     cursor_proxy_route,
     get_azure_ai_search_index_from_endpoint,
@@ -1728,6 +1732,128 @@ class TestBedrockLLMProxyRoute:
 
         assert exc_info.value.status_code == 400
         assert "Blocked by guardrail" in str(exc_info.value.detail)
+
+
+class TestBedrockAgentRuntimePassthroughToggle:
+    """`general_settings.disable_bedrock_agent_runtime_passthrough` gates only the
+    bedrock-agent-runtime branch of `/bedrock/{endpoint:path}`."""
+
+    AGENT_RUNTIME_ENDPOINT: Final = "knowledgebases/KB1234567/retrieve"
+    MODEL_ENDPOINT: Final = "model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/converse"
+    DISABLED: Final = MappingProxyType({"disable_bedrock_agent_runtime_passthrough": True})
+
+    @staticmethod
+    def _mock_request() -> Mock:
+        request: Final = Mock()
+        request.method = "POST"
+        request.state = SimpleNamespace()
+        request.json = AsyncMock(return_value={"retrievalQuery": {"text": "hi"}})  # mutable-ok: must be json.dumps-able
+        return request
+
+    @contextlib.contextmanager
+    def _patched_dispatch(self, general_settings: Mapping[str, object]):
+        """Patch out signing + forwarding so the routing decision is observable."""
+        from botocore.credentials import Credentials
+
+        bedrock_llm: Final = Mock()
+        bedrock_llm.get_credentials = Mock(return_value=Credentials("ak", "sk"))
+        forwarder: Final = AsyncMock(return_value="forwarded")
+
+        with (
+            patch("litellm.proxy.proxy_server.general_settings", general_settings),
+            patch("litellm.utils.get_secret", return_value="us-east-1"),
+            patch("litellm.llms.bedrock.chat.BedrockConverseLLM", return_value=bedrock_llm),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_request_copy",
+                Mock(),
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+                return_value=forwarder,
+            ) as create_route,
+        ):
+            yield create_route, forwarder
+
+    @pytest.mark.asyncio
+    async def test_agent_runtime_dispatch_allowed_by_default(self):
+        """Default config must keep forwarding to bedrock-agent-runtime."""
+        with self._patched_dispatch(MappingProxyType({})) as (create_route, forwarder):
+            result: Final = await bedrock_proxy_route(
+                endpoint=self.AGENT_RUNTIME_ENDPOINT,
+                request=self._mock_request(),
+                fastapi_response=Mock(),
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+        assert result == "forwarded"
+        forwarder.assert_awaited_once()
+        assert "bedrock-agent-runtime.us-east-1.amazonaws.com" in create_route.call_args.kwargs["target"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", (True, "true", "True"))
+    async def test_agent_runtime_dispatch_rejected_when_disabled(self, value: bool | str):
+        """With the setting on, the request is rejected before it is signed or sent.
+
+        The string forms matter: /config/field/update persists the raw value, so the
+        setting can reach general_settings as a string rather than a bool.
+        """
+        settings: Final = MappingProxyType({"disable_bedrock_agent_runtime_passthrough": value})
+
+        with self._patched_dispatch(settings) as (create_route, forwarder):
+            with pytest.raises(HTTPException) as exc_info:
+                await bedrock_proxy_route(
+                    endpoint=self.AGENT_RUNTIME_ENDPOINT,
+                    request=self._mock_request(),
+                    fastapi_response=Mock(),
+                    user_api_key_dict=UserAPIKeyAuth(),
+                )
+
+        assert exc_info.value.status_code == 403
+        assert "bedrock-agent-runtime pass-through is disabled" in str(exc_info.value.detail)
+        create_route.assert_not_called()
+        forwarder.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_model_invoke_still_routed_when_agent_runtime_disabled(self):
+        """The setting must not touch plain bedrock-runtime model pass-through."""
+        with (
+            patch("litellm.proxy.proxy_server.general_settings", self.DISABLED),
+            patch("litellm.utils.get_secret", return_value="us-east-1"),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_request_copy",
+                Mock(),
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.bedrock_llm_proxy_route",
+                new=AsyncMock(return_value="llm-route"),
+            ) as llm_route,
+        ):
+            result: Final = await bedrock_proxy_route(
+                endpoint=self.MODEL_ENDPOINT,
+                request=self._mock_request(),
+                fastapi_response=Mock(),
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+        assert result == "llm-route"
+        llm_route.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", (False, "false", None, "", "yes"))
+    async def test_agent_runtime_dispatch_allowed_for_non_true_values(self, value: object):
+        """Anything that is not a recognised true value leaves dispatch untouched."""
+        settings: Final = MappingProxyType({"disable_bedrock_agent_runtime_passthrough": value})
+
+        with self._patched_dispatch(settings) as (create_route, forwarder):
+            result: Final = await bedrock_proxy_route(
+                endpoint=self.AGENT_RUNTIME_ENDPOINT,
+                request=self._mock_request(),
+                fastapi_response=Mock(),
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+        assert result == "forwarded"
+        create_route.assert_called_once()
 
 
 class TestLLMPassthroughFactoryProxyRoute:


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/bedrock` pass-through always dispatches agent-runtime routes
- Operators cannot narrow the gateway to model invoke/converse

How it solves it:

- Adds `general_settings.disable_bedrock_agent_runtime_passthrough`
- Rejects agent-runtime routes with 403 before any signing
- Plain bedrock-runtime model pass-through is untouched
- Defaults off, so existing deployments do not change

## User Flow

Before: a proxy admin running a shared gateway cannot stop callers from reaching Bedrock agents, knowledge bases and flows through the pass-through

1. They expose https://litellm-domain/bedrock so their teams can call Bedrock models
2. A developer sends POST https://litellm-domain/bedrock/knowledgebases/{knowledgeBaseId}/retrieve with `{"retrievalQuery": {"text": "..."}}`
3. It comes back 200 with a `retrievalResults` array, even though the admin only meant to expose model invocation
4. No proxy setting turns that off, so the admin's only lever is the gateway's AWS IAM policy

After: the same admin can narrow the pass-through to model invocation

1. They set `general_settings.disable_bedrock_agent_runtime_passthrough: true` in config.yaml and restart the proxy
2. The developer sends the same POST https://litellm-domain/bedrock/knowledgebases/{knowledgeBaseId}/retrieve
3. It comes back 403 with `bedrock-agent-runtime pass-through is disabled on this proxy`, and no AWS request id, so nothing reached AWS
4. POST https://litellm-domain/bedrock/model/{modelId}/invoke and .../converse keep returning real completions

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

🆕 New Feature

## Caveats (if any)

- Settable in config.yaml only, not through `/config/field/update`
- Whole-surface toggle, no per-team or per-resource scoping
- Docs page still to follow in the litellm-docs repo

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
