### PR TITLE
fix(guardrails): requeue usage rollup rows dropped after retry exhaustion

### DIFF
--- a/litellm/proxy/guardrails/usage_tracking.py
+++ b/litellm/proxy/guardrails/usage_tracking.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
 
 _UPSERT_RETRY_TIMES: Final = 3
+_MAX_PENDING_ROWS: Final = 10_000
 
 _RowKey = TypeVar("_RowKey")
 _RowValue = TypeVar("_RowValue")
@@ -46,6 +47,58 @@ class _MetricsKey(NamedTuple):
     date: str
 
 
+class PendingRollups:
+    """Rollup rows whose connection-error retries exhausted, held for the next flush."""
+
+    def __init__(self) -> None:
+        self.lock: Final = asyncio.Lock()
+        self.metrics: Mapping[_MetricsKey, Mapping[str, int]] = MappingProxyType({})
+        self.units: Mapping[_UsageUnitKey, int] = MappingProxyType({})
+
+
+_PENDING_ROLLUPS: Final = PendingRollups()
+
+_NO_COUNTERS: Final[Mapping[str, int]] = MappingProxyType({})
+
+
+def _merged_keys(base: Mapping[_RowKey, object], extra: Mapping[_RowKey, object]) -> tuple[_RowKey, ...]:
+    return (*base, *(key for key in extra if key not in base))
+
+
+def _merged_unit_rows(
+    base: Mapping[_UsageUnitKey, int], extra: Mapping[_UsageUnitKey, int]
+) -> Mapping[_UsageUnitKey, int]:
+    return MappingProxyType({key: base.get(key, 0) + extra.get(key, 0) for key in _merged_keys(base, extra)})
+
+
+def _merged_metric_rows(
+    base: Mapping[_MetricsKey, Mapping[str, int]], extra: Mapping[_MetricsKey, Mapping[str, int]]
+) -> Mapping[_MetricsKey, Mapping[str, int]]:
+    def merged_counters(key: _MetricsKey) -> Mapping[str, int]:
+        base_counters: Final = base.get(key, _NO_COUNTERS)
+        extra_counters: Final = extra.get(key, _NO_COUNTERS)
+        return MappingProxyType(
+            {
+                counter: int(base_counters.get(counter, 0)) + int(extra_counters.get(counter, 0))
+                for counter in _merged_keys(base_counters, extra_counters)
+            }
+        )
+
+    return MappingProxyType({key: merged_counters(key) for key in _merged_keys(base, extra)})
+
+
+def _capped(rows: Mapping[_RowKey, _RowValue], label: str) -> Mapping[_RowKey, _RowValue]:
+    if len(rows) <= _MAX_PENDING_ROWS:
+        return rows
+    verbose_proxy_logger.warning(
+        "Guardrail usage tracking: pending %s requeue exceeds %d rows; dropping the %d oldest (non-fatal)",
+        label,
+        _MAX_PENDING_ROWS,
+        len(rows) - _MAX_PENDING_ROWS,
+    )
+    return MappingProxyType(dict(tuple(rows.items())[len(rows) - _MAX_PENDING_ROWS :]))
+
+
 async def _attempt_upsert(
     upsert_row: Callable[[_RowKey, _RowValue], Awaitable[None]], key: _RowKey, value: _RowValue
 ) -> Exception | None:
@@ -62,7 +115,8 @@ async def _upsert_rows_with_retry(
     label: str,
     sleep: Callable[[float], Awaitable[None]],
     retries_left: int = _UPSERT_RETRY_TIMES,
-) -> None:
+) -> Mapping[_RowKey, _RowValue]:
+    """Returns the rows still failing with connection errors once retries exhaust, for requeueing."""
     outcomes: Final = {key: await _attempt_upsert(upsert_row, key, value) for key, value in rows.items()}
     for key, error in outcomes.items():
         if error is not None and not isinstance(error, DB_RETRY_SAFE_ERROR_TYPES):
@@ -76,19 +130,20 @@ async def _upsert_rows_with_retry(
         {key: rows[key] for key, error in outcomes.items() if isinstance(error, DB_RETRY_SAFE_ERROR_TYPES)}
     )
     if not retryable:
-        return
+        return MappingProxyType({})
     if retries_left == 0:
         for key in retryable:
             verbose_proxy_logger.warning(
-                "Guardrail usage tracking: %s upsert failed for %s after %d retries (non-fatal): %s",
+                "Guardrail usage tracking: %s upsert failed for %s after %d retries; requeued for the next flush "
+                "(non-fatal): %s",
                 label,
                 key,
                 _UPSERT_RETRY_TIMES,
                 outcomes[key],
             )
-        return
+        return retryable
     await sleep(2 ** (_UPSERT_RETRY_TIMES - retries_left))
-    await _upsert_rows_with_retry(retryable, upsert_row, label, sleep, retries_left - 1)
+    return await _upsert_rows_with_retry(retryable, upsert_row, label, sleep, retries_left - 1)
 
 
 def _guardrail_status_to_action(status: str | None) -> str:
@@ -217,6 +272,7 @@ async def process_spend_logs_guardrail_usage(
     prisma_client: PrismaClient,
     logs_to_process: list[dict[str, Any]],
     sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    pending: PendingRollups = _PENDING_ROLLUPS,
 ) -> None:
     """
     After spend logs are written: update DailyGuardrailMetrics and insert
@@ -265,9 +321,20 @@ async def process_spend_logs_guardrail_usage(
                 }
             )
 
-    usage_unit_totals: Final = _sum_usage_unit_increments(logs_to_process)
+    async with pending.lock:
+        pending_metrics: Final = pending.metrics
+        pending_units: Final = pending.units
+        pending.metrics = MappingProxyType({})
+        pending.units = MappingProxyType({})
 
-    if not daily_guardrail and not index_rows and not usage_unit_totals:
+    # Upsert daily guardrail metrics (counts only; latency/score dropped)
+    evaluated_metrics: Final = MappingProxyType(
+        {key: agg for key, agg in daily_guardrail.items() if int(agg["requests_evaluated"]) > 0}
+    )
+    metrics_rows: Final = _merged_metric_rows(pending_metrics, evaluated_metrics)
+    unit_rows: Final = _merged_unit_rows(pending_units, _sum_usage_unit_increments(logs_to_process))
+
+    if not metrics_rows and not index_rows and not unit_rows:
         return
 
     try:
@@ -281,13 +348,15 @@ async def process_spend_logs_guardrail_usage(
             except Exception as e:
                 verbose_proxy_logger.debug("Guardrail usage tracking: index create_many skipped: %s", e)
 
-        # Upsert daily guardrail metrics (counts only; latency/score dropped)
-        metrics_rows: Final = MappingProxyType(
-            {key: agg for key, agg in daily_guardrail.items() if int(agg["requests_evaluated"]) > 0}
+        failed_metrics: Final = await _upsert_rows_with_retry(
+            metrics_rows, partial(_upsert_metrics_row, prisma_client), "daily metrics", sleep
         )
-        await _upsert_rows_with_retry(metrics_rows, partial(_upsert_metrics_row, prisma_client), "daily metrics", sleep)
-        await _upsert_rows_with_retry(
-            usage_unit_totals, partial(_upsert_usage_unit_row, prisma_client), "usage unit", sleep
+        failed_units: Final = await _upsert_rows_with_retry(
+            unit_rows, partial(_upsert_usage_unit_row, prisma_client), "usage unit", sleep
         )
+        if failed_metrics or failed_units:
+            async with pending.lock:
+                pending.metrics = _capped(_merged_metric_rows(pending.metrics, failed_metrics), "daily metrics")
+                pending.units = _capped(_merged_unit_rows(pending.units, failed_units), "usage unit")
     except Exception as e:
         verbose_proxy_logger.warning("Guardrail usage tracking failed (non-fatal): %s", e)

--- a/tests/test_litellm/proxy/guardrails/test_usage_tracking.py
+++ b/tests/test_litellm/proxy/guardrails/test_usage_tracking.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from litellm.proxy.guardrails.usage_tracking import process_spend_logs_guardrail_usage
+from litellm.proxy.guardrails.usage_tracking import (
+    _MAX_PENDING_ROWS,
+    PendingRollups,
+    _capped,
+    process_spend_logs_guardrail_usage,
+)
 
 
 def _prisma() -> MagicMock:
@@ -103,7 +108,7 @@ async def test_one_failing_upsert_does_not_drop_remaining_writes():
         _payload("r2", team_id=None, api_key="hashed-key-2", usage={"topicPolicyUnits": 1}),
     ]
 
-    await process_spend_logs_guardrail_usage(prisma, logs, sleep=sleep)
+    await process_spend_logs_guardrail_usage(prisma, logs, sleep=sleep, pending=PendingRollups())
 
     assert _units_upserts(prisma) == {
         ("bedrock-guard", "2026-08-17", "team-a", "hashed-key-1", "topicPolicyUnits"): 1,
@@ -140,12 +145,86 @@ async def test_persistent_upsert_failure_stops_after_three_retries():
     prisma = _prisma()
     prisma.db.litellm_dailyguardrailmetrics.upsert.side_effect = httpx.ConnectError("db down")
     sleep, delays = _fake_sleep()
+    pending = PendingRollups()
 
-    await process_spend_logs_guardrail_usage(prisma, [_payload("r1", usage={"topicPolicyUnits": 1})], sleep=sleep)
+    await process_spend_logs_guardrail_usage(
+        prisma, [_payload("r1", usage={"topicPolicyUnits": 1})], sleep=sleep, pending=pending
+    )
 
     assert prisma.db.litellm_dailyguardrailmetrics.upsert.call_count == 4
     assert delays == [1, 2, 4]
     assert prisma.db.litellm_dailyguardrailusageunits.upsert.call_count == 1
+    assert dict(pending.metrics) == {
+        ("bedrock-guard", "2026-08-17"): {
+            "requests_evaluated": 1,
+            "passed_count": 1,
+            "blocked_count": 0,
+            "flagged_count": 0,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_retry_exhausted_rows_are_requeued_and_land_on_the_next_flush():
+    """
+    LIT-5761: rollup rows whose connection-error retries exhaust must not be
+    silently lost. They are requeued and merged into the next flushed batch,
+    so the aggregates catch up once the database is reachable again.
+    """
+    pending = PendingRollups()
+    down = _prisma()
+    down.db.litellm_dailyguardrailmetrics.upsert.side_effect = httpx.ConnectError("db down")
+    down.db.litellm_dailyguardrailusageunits.upsert.side_effect = httpx.ConnectError("db down")
+    sleep, _ = _fake_sleep()
+
+    await process_spend_logs_guardrail_usage(
+        down, [_payload("r1", usage={"topicPolicyUnits": 2})], sleep=sleep, pending=pending
+    )
+
+    assert dict(pending.units) == {("bedrock-guard", "2026-08-17", "team-a", "hashed-key-1", "topicPolicyUnits"): 2}
+
+    recovered = _prisma()
+    await process_spend_logs_guardrail_usage(
+        recovered, [_payload("r2", usage={"topicPolicyUnits": 3})], sleep=sleep, pending=pending
+    )
+
+    assert _units_upserts(recovered) == {
+        ("bedrock-guard", "2026-08-17", "team-a", "hashed-key-1", "topicPolicyUnits"): 5,
+    }
+    metrics_create = recovered.db.litellm_dailyguardrailmetrics.upsert.call_args.kwargs["data"]["create"]
+    assert metrics_create["requests_evaluated"] == 2
+    assert not pending.units
+    assert not pending.metrics
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_failures_are_never_requeued():
+    """
+    A post-send failure (the increment may have committed) must stay dropped:
+    requeueing it would re-send a possibly applied increment and double-count.
+    """
+    pending = PendingRollups()
+    prisma = _prisma()
+    prisma.db.litellm_dailyguardrailusageunits.upsert.side_effect = httpx.ReadTimeout("maybe committed")
+    sleep, delays = _fake_sleep()
+
+    await process_spend_logs_guardrail_usage(
+        prisma, [_payload("r1", usage={"topicPolicyUnits": 1})], sleep=sleep, pending=pending
+    )
+
+    assert delays == []
+    assert not pending.units
+    assert not pending.metrics
+
+
+def test_pending_requeue_is_capped_dropping_oldest_rows():
+    rows = {index: index for index in range(_MAX_PENDING_ROWS + 5)}
+
+    capped = _capped(rows, "usage unit")
+
+    assert len(capped) == _MAX_PENDING_ROWS
+    assert 4 not in capped
+    assert _MAX_PENDING_ROWS + 4 in capped
 
 
 def _units_upsert_wheres(prisma: MagicMock) -> list[tuple]:


### PR DESCRIPTION
## TLDR

Problem this solves:

- A DB blip during a flush permanently drops guardrail usage rollup rows
- Dashboard usage then undercounts what AWS actually billed, forever

How it solves it:

- Rows whose connection-error retries exhaust are now held in memory
- The next flush merges the held rows into its own upsert batch
- Ambiguous in-flight failures still drop, so nothing double counts

## User Flow

Before: an admin whose database blips for a few seconds during a flush loses guardrail usage units for good, so the dashboard undercounts the AWS bill forever

1. Developers send 100 POST http://localhost:47804/v1/chat/completions requests through a Bedrock-guarded model; all 100 return 200
2. The proxy's database becomes unreachable for about 15 seconds right as the batch is being written
3. The proxy log prints a warning per usage row saying the write "failed ... after 3 retries (non-fatal)" and the rows are gone
4. The database comes back and traffic continues normally
5. GET http://localhost:47804/guardrails/usage/overview now reports `requestsEvaluated: 141` but only 42 `topicPolicyUnits` and 42 `contentPolicyUnits`, and the roughly 99-unit gap against the AWS bill never heals, no matter how long the admin waits

After: the same outage only delays those rows; the next flush lands them and the totals catch up

1. Developers send 100 POST http://localhost:49219/v1/chat/completions requests through a Bedrock-guarded model; all 100 return 200
2. The proxy's database becomes unreachable for about 15 seconds right as the batch is being written
3. The proxy log prints a warning per usage row saying the write failed after 3 retries and was "requeued for the next flush (non-fatal)"
4. The database comes back and traffic continues normally
5. GET http://localhost:49219/guardrails/usage/overview shows the held rows landed with the next flush: `requestsEvaluated: 241` with 239 units per policy, and the only writes still uncounted are the 4 that were already in flight at the instant of the outage, each one named in a log warning because replaying an in-flight write risks counting it twice

## Relevant issues

Follow-up to #37225

## Linear ticket

Resolves LIT-5761

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Both legs run a live proxy against a real AWS Bedrock guardrail (`gf3sc1mzinjw`, us-east-1, topic + content policies) and `bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0`, real AWS calls, no mocks. Config:

```yaml
model_list:
  - model_name: bedrock-claude-haiku-4-5
    litellm_params:
      model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: us-east-1
guardrails:
  - guardrail_name: bedrock-lit5761
    litellm_params:
      guardrail: bedrock
      mode: pre_call
      guardrailIdentifier: gf3sc1mzinjw
      guardrailVersion: DRAFT
      aws_region_name: us-east-1
      default_on: true
general_settings:
  master_key: sk-1234
```

Boot (fresh Postgres DB per leg, random free port per leg):

```bash
AWS_BEARER_TOKEN_BEDROCK=$TOKEN DATABASE_URL=postgresql://mateo@localhost:5432/$DB \
  python litellm/proxy/proxy_cli.py --config lit5761_qa_config.yaml --port $PORT --detailed_debug
```

The outage is injected deterministically, in two parts. An `ACCESS EXCLUSIVE` lock pins the flush at the exact vulnerable instant, after the spend logs commit but before the rollup upserts, and a 15-second kill loop on the proxy's own Prisma query engine then makes every DB round trip fail with connection refused, exactly what a momentary DB outage produces (the engine respawns by itself, so a single kill heals in under a second):

```bash
psql -d $DB -c 'BEGIN; LOCK TABLE "LiteLLM_DailyGuardrailUsageUnits" IN ACCESS EXCLUSIVE MODE; SELECT pg_sleep(600);' &
# wait for "Flushed 100 logs to the DB." in the proxy log, then:
end=$((SECONDS+15)); while ((SECONDS<end)); do for p in $(pgrep -P $PROXY_PID -f query-engine); do kill -9 $p; done; sleep 0.1; done &
sleep 1 && psql -d $DB -c "SELECT pg_terminate_backend(l.pid) FROM pg_locks l JOIN pg_class c ON c.oid = l.relation WHERE c.relname = 'LiteLLM_DailyGuardrailUsageUnits' AND l.mode = 'AccessExclusiveLock';"
```

### Before (6d32d4081d)

This commit sits 72 commits behind the branch's merge base e75b4b1c2a, but every file on the affected write path (usage_tracking.py, proxy utils, and the retry-safe error tuple) is byte-identical between the two; the only guardrail-adjacent commits in the gap change streaming-chunk cost billing, which this non-streaming flow never hits

#### Happy-path baseline

1. Generate 40 keys, then `xargs -P 40 ... curl -s -o /dev/null -w "%{http_code}\n" http://localhost:47804/v1/chat/completions -d '{"model":"bedrock-claude-haiku-4-5","messages":[{"role":"user","content":"Reply with the single word ok."}],"max_tokens":5}'` across them: `40 200`
2. `curl -s http://localhost:47804/guardrails/usage/overview -H "Authorization: Bearer sk-1234"`: `evaluated: 40 units: {'contentPolicyUnits': 40, 'topicPolicyUnits': 40}`

#### DB outage during a flush

1. Hold the table lock, then fire 100 completions across 100 keys: `100 200`
2. Proxy log: `Flushed 40 logs to the DB.` then `Flushed 59 logs to the DB.`; start the kill loop, release the lock
3. Proxy log, 8 seconds later: 188 warnings like `Guardrail usage tracking: usage unit upsert failed for _UsageUnitKey(guardrail_id='bedrock-lit5761', date='2026-08-18', team_id='', REDACTED', usage_unit='contentPolicyUnits') after 3 retries (non-fatal): All connection attempts failed`, plus 10 `not safe to retry` warnings for the writes that were mid-flight; nothing is requeued

#### Traffic resumes after the outage

1. One more completion returns 200; proxy log: `Flushed 1 logs to the DB.`
2. `curl -s http://localhost:47804/guardrails/usage/overview ...`: `evaluated: 141 units: {'contentPolicyUnits': 42, 'topicPolicyUnits': 42}`
3. The same curl 30 seconds later: still `42 / 42`; about 99 units per policy are gone for good while AWS billed all 141 requests

### After (5513fd032d)

#### Happy-path baseline

1. Generate 100 keys and run three happy-path batches (40 + 100 + lock-free re-run) through `http://localhost:49219/v1/chat/completions`; every request returns 200
2. `curl -s http://localhost:49219/guardrails/usage/overview -H "Authorization: Bearer sk-1234"`: `evaluated: 140 units: {'contentPolicyUnits': 140, 'topicPolicyUnits': 140}`

#### DB outage during a flush

1. Hold the table lock, then fire 100 completions across the same 100 keys: `100 200`
2. Proxy log: `Flushed 100 logs to the DB.`; start the kill loop, release the lock
3. Proxy log, 8 seconds later: 196 warnings like `Guardrail usage tracking: usage unit upsert failed for _UsageUnitKey(guardrail_id='bedrock-lit5761', date='2026-08-18', team_id='', REDACTED', usage_unit='topicPolicyUnits') after 3 retries; requeued for the next flush (non-fatal): All connection attempts failed`, plus 4 `not safe to retry` warnings (2 content, 2 topic) for the mid-flight writes, which drop by design
4. `curl -s http://localhost:49219/guardrails/usage/overview ...` after the engine self-heals: `evaluated: 240 units: {'contentPolicyUnits': 140, 'topicPolicyUnits': 140}`, the vulnerable partial state, with 196 rows held in memory

#### Traffic resumes after the outage

1. One more completion returns 200; proxy log: `Flushed 1 logs to the DB.` and no new upsert failures
2. `curl -s http://localhost:49219/guardrails/usage/overview ...`: `evaluated: 241 units: {'contentPolicyUnits': 239, 'topicPolicyUnits': 239}`; all 196 held rows landed with that flush
3. The ledger closes exactly: 241 expected per policy, minus the 2 per policy that were mid-flight at the kill and are individually named in `not safe to retry` warnings

QA observations:

- Mid-flight writes can commit despite client errors; PR leaves alone
- Overview can briefly show more requests than units; PR heals

## Type

🐛 Bug Fix

## Caveats (if any)

- Pending rows live in process memory; a restart loses them
- Only connection-refused failures requeue; mid-flight failures still drop by design
- Held rows land with the next non-empty flush, so they need follow-on traffic
- Pending buffer caps at 10k rows per kind, dropping oldest beyond that

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] 5513fd032d passes /live-pr-risk
