### PR TITLE
fix(mcp): bind tool existence check to the selected server

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2321,22 +2321,29 @@ class MCPServerManager:
             openapi_key_prefix: Final = prefix_root + MCP_TOOL_PREFIX_SEPARATOR
             global_mcp_tool_registry.unregister_tools_with_prefix(openapi_key_prefix)
 
-        owned_raw: Final[set[str]] = set()
-        for p in iter_known_server_prefixes(server):
-            if p:
-                owned_raw.add(p)
-        if server.name:
-            owned_raw.add(server.name)
+        owned_normalized: Final = self._owned_mapping_values(server)
 
-        owned_normalized: Final = {normalize_server_name(x) for x in owned_raw}
-
-        stale_mapping_keys: Final[list[str]] = []
-        for tool_name, mapped_server in list(self.tool_name_to_mcp_server_name_mapping.items()):
-            if mapped_server in owned_raw or normalize_server_name(str(mapped_server)) in owned_normalized:
-                stale_mapping_keys.append(tool_name)
+        stale_mapping_keys: Final = tuple(
+            tool_name
+            for tool_name, mapped_server in self.tool_name_to_mcp_server_name_mapping.items()
+            if normalize_server_name(str(mapped_server)) in owned_normalized
+        )
 
         for key in stale_mapping_keys:
             del self.tool_name_to_mcp_server_name_mapping[key]
+
+    def _owned_mapping_values(self, server: MCPServer) -> frozenset[str]:
+        return frozenset(
+            normalize_server_name(value) for value in (*iter_known_server_prefixes(server), server.name) if value
+        )
+
+    def _server_exposes_tool(self, server: MCPServer, tool_name: str) -> bool:
+        owned: Final = self._owned_mapping_values(server)
+        mapped_owners: Final = (
+            self.tool_name_to_mcp_server_name_mapping.get(spelling)
+            for spelling in iter_known_tool_name_spellings(tool_name, server)
+        )
+        return any(owner is not None and normalize_server_name(owner) in owned for owner in mapped_owners)
 
     def remove_server(self, mcp_server: LiteLLM_MCPServerTable):
         """
@@ -5463,13 +5470,8 @@ class MCPServerManager:
         if mcp_server is None:
             raise ValueError(f"Tool {name} not found")
 
-        if resolved_by_server_name_only:
-            tool_known: Final = (
-                name in self.tool_name_to_mcp_server_name_mapping
-                or prefixed_tool_name in self.tool_name_to_mcp_server_name_mapping
-            )
-            if not tool_known:
-                raise ValueError(f"Tool {name} not found")
+        if resolved_by_server_name_only and not self._server_exposes_tool(mcp_server, name):
+            raise ValueError(f"Tool {name} not found")
 
         return mcp_server
 
@@ -5847,10 +5849,7 @@ class MCPServerManager:
         if matched is not None:
             matched_prefix, original_tool_name = matched
             matched_server: Final = prefix_to_server.get(matched_prefix)
-            if matched_server is not None and (
-                original_tool_name in self.tool_name_to_mcp_server_name_mapping
-                or tool_name in self.tool_name_to_mcp_server_name_mapping
-            ):
+            if matched_server is not None and self._server_exposes_tool(matched_server, original_tool_name):
                 return matched_server
 
         return None

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -6406,7 +6406,7 @@ async def test_execute_mcp_tool_rest_server_id_injects_requested_server_credenti
     with (
         patch.dict(
             mcp_module.global_mcp_server_manager.tool_name_to_mcp_server_name_mapping,
-            {"echo": collision_server.name},
+            {"echo": collision_server.name, "echo_requested-echo": requested_server.name},
         ),
         patch.object(
             mcp_module.global_mcp_server_manager,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -4841,14 +4841,12 @@ class TestMCPServerManager:
             server_id="huggingface-id", name="huggingface", server_name="huggingface", transport=MCPTransport.http
         )
         manager.registry = {"deepwiki-id": deepwiki, "huggingface-id": huggingface}
-        manager.tool_name_to_mcp_server_name_mapping.update(
-            {
-                "read_wiki_structure": "deepwiki",
-                "deepwiki-read_wiki_structure": "deepwiki",
-                "hub_repo_search": "huggingface",
-                "huggingface-hub_repo_search": "huggingface",
-            }
-        )
+        manager.tool_name_to_mcp_server_name_mapping = {
+            "read_wiki_structure": "deepwiki",
+            "deepwiki-read_wiki_structure": "deepwiki",
+            "hub_repo_search": "huggingface",
+            "huggingface-hub_repo_search": "huggingface",
+        }
         return manager
 
     def test_resolve_mcp_server_for_tool_call_rejects_tool_exposed_only_by_another_server(self):
@@ -4875,13 +4873,11 @@ class TestMCPServerManager:
         zapier = MCPServer(server_id="zapier-id", name="zapier", alias="zapier-alias", transport=MCPTransport.http)
         other = MCPServer(server_id="other-id", name="other", server_name="other", transport=MCPTransport.http)
         manager.registry = {"zapier-id": zapier, "other-id": other}
-        manager.tool_name_to_mcp_server_name_mapping.update(
-            {
-                "create_zap": "other",
-                "other-create_zap": "other",
-                "zapier-alias-create_zap": "zapier-alias",
-            }
-        )
+        manager.tool_name_to_mcp_server_name_mapping = {
+            "create_zap": "other",
+            "other-create_zap": "other",
+            "zapier-alias-create_zap": "zapier-alias",
+        }
 
         assert manager._resolve_mcp_server_for_tool_call("zapier", "create_zap") is zapier
         assert manager._resolve_mcp_server_for_tool_call("other", "create_zap") is other

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -4833,6 +4833,78 @@ class TestMCPServerManager:
         with pytest.raises(ValueError, match="Tool missing_tool not found"):
             manager._resolve_mcp_server_for_tool_call("github", "missing_tool")
 
+    @staticmethod
+    def _manager_with_deepwiki_and_huggingface() -> MCPServerManager:
+        manager = MCPServerManager()
+        deepwiki = MCPServer(server_id="deepwiki-id", name="deepwiki", server_name="deepwiki", transport=MCPTransport.http)
+        huggingface = MCPServer(
+            server_id="huggingface-id", name="huggingface", server_name="huggingface", transport=MCPTransport.http
+        )
+        manager.registry = {"deepwiki-id": deepwiki, "huggingface-id": huggingface}
+        manager.tool_name_to_mcp_server_name_mapping.update(
+            {
+                "read_wiki_structure": "deepwiki",
+                "deepwiki-read_wiki_structure": "deepwiki",
+                "hub_repo_search": "huggingface",
+                "huggingface-hub_repo_search": "huggingface",
+            }
+        )
+        return manager
+
+    def test_resolve_mcp_server_for_tool_call_rejects_tool_exposed_only_by_another_server(self):
+        manager = self._manager_with_deepwiki_and_huggingface()
+
+        with pytest.raises(ValueError, match="Tool read_wiki_structure not found"):
+            manager._resolve_mcp_server_for_tool_call("huggingface", "read_wiki_structure")
+        with pytest.raises(ValueError, match="Tool hub_repo_search not found"):
+            manager._resolve_mcp_server_for_tool_call("deepwiki", "hub_repo_search")
+
+        assert manager._resolve_mcp_server_for_tool_call("deepwiki", "read_wiki_structure") is manager.registry["deepwiki-id"]
+        assert manager._resolve_mcp_server_for_tool_call("huggingface", "hub_repo_search") is manager.registry["huggingface-id"]
+
+    def test_get_mcp_server_from_tool_name_rejects_other_servers_prefix(self):
+        manager = self._manager_with_deepwiki_and_huggingface()
+
+        assert manager._get_mcp_server_from_tool_name("huggingface-read_wiki_structure") is None
+        assert manager._get_mcp_server_from_tool_name("deepwiki-hub_repo_search") is None
+        assert manager._get_mcp_server_from_tool_name("deepwiki-read_wiki_structure") is manager.registry["deepwiki-id"]
+        assert manager._get_mcp_server_from_tool_name("huggingface-hub_repo_search") is manager.registry["huggingface-id"]
+
+    def test_resolve_mcp_server_for_tool_call_shared_bare_name_resolves_via_own_prefixed_spelling(self):
+        manager = MCPServerManager()
+        zapier = MCPServer(server_id="zapier-id", name="zapier", alias="zapier-alias", transport=MCPTransport.http)
+        other = MCPServer(server_id="other-id", name="other", server_name="other", transport=MCPTransport.http)
+        manager.registry = {"zapier-id": zapier, "other-id": other}
+        manager.tool_name_to_mcp_server_name_mapping.update(
+            {
+                "create_zap": "other",
+                "other-create_zap": "other",
+                "zapier-alias-create_zap": "zapier-alias",
+            }
+        )
+
+        assert manager._resolve_mcp_server_for_tool_call("zapier", "create_zap") is zapier
+        assert manager._resolve_mcp_server_for_tool_call("other", "create_zap") is other
+
+    def test_remove_server_drops_only_its_own_tool_mapping_rows(self):
+        manager = self._manager_with_deepwiki_and_huggingface()
+
+        manager.remove_server(
+            LiteLLM_MCPServerTable(
+                server_id="huggingface-id",
+                alias="huggingface",
+                url="https://huggingface.co/mcp",
+                transport=MCPTransport.http,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            )
+        )
+
+        assert manager.tool_name_to_mcp_server_name_mapping == {
+            "read_wiki_structure": "deepwiki",
+            "deepwiki-read_wiki_structure": "deepwiki",
+        }
+
     @pytest.mark.asyncio
     async def test_resolve_oauth2_headers_skipped_when_not_user_oauth(self):
         """Returns input headers unchanged when server does not need user OAuth."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Tool calls naming server B but a tool only server A has were forwarded to B
- Wrong-server calls leaked to upstream MCP servers instead of failing fast

How it solves it:

- Tool existence is now checked against the selected server's own tool list
- Same request now gets the gateway's own 404 "Tool not found", no upstream call

## User Flow

Before: a developer with two MCP servers on their gateway calls a tool under the wrong server's name, and the request leaves the gateway and hits the wrong upstream

1. The gateway admin configures two MCP servers, `deepwiki` (https://mcp.deepwiki.com/mcp) and `huggingface` (https://huggingface.co/mcp)
2. The developer connects an MCP client to POST https://litellm-domain/mcp and `tools/list` shows `deepwiki-read_wiki_structure`, `huggingface-hub_repo_search`, etc.
3. They send `tools/call` for `huggingface-read_wiki_structure`, a tool only deepwiki has
4. The call is forwarded to huggingface.co and comes back with the upstream's own error, `McpError: Tool read_wiki_structure not found`
5. The same happens on POST https://litellm-domain/mcp-rest/tools/call with `server_id` set to the huggingface server and `name` `read_wiki_structure`, returning 200 with the upstream's `isError` result
6. The mistaken request reached an unrelated upstream server, with the gateway's logging and rate-limit hooks recorded against that server

After: the same call is rejected inside the gateway with its usual not-found error, identical to any other unknown tool name

1. The gateway admin configures the same two MCP servers
2. The developer connects an MCP client to POST https://litellm-domain/mcp and `tools/list` shows the same tools
3. They send `tools/call` for `huggingface-read_wiki_structure`
4. The gateway itself answers `Error: Tool 'read_wiki_structure' not found`, exactly like it answers `huggingface-not_a_real_tool`, and nothing is sent to huggingface.co
5. POST https://litellm-domain/mcp-rest/tools/call with the huggingface `server_id` and `name` `read_wiki_structure` is rejected the same way
6. Calls that name the right server, like `deepwiki-read_wiki_structure`, keep working unchanged

## Relevant issues

## Linear ticket

Resolves LIT-5718

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup, both legs: proxy from this branch's worktree with two real public MCP servers and no DB, master key `sk-1234`, config:

```yaml
mcp_servers:
  deepwiki:
    transport: "http"
    url: "https://mcp.deepwiki.com/mcp"
  huggingface:
    transport: "http"
    url: "https://huggingface.co/mcp"
```

Client is the official `mcp` Python SDK streamable-http client pointed at the proxy's `/mcp` with header `x-litellm-api-key: Bearer sk-1234`; `tools/list` on both legs returns `['deepwiki-ask_question', 'deepwiki-read_wiki_contents', 'deepwiki-read_wiki_structure', 'huggingface-hf_whoami', 'huggingface-hub_repo_search', 'huggingface-hub_repo_details', 'huggingface-hf_fs']`

### Before (6d32d4081d)

#### JSON-RPC tools/call naming the wrong server's prefix

1. `tools/call` name `huggingface-read_wiki_structure` (a deepwiki-only tool), arguments `{"repoName":"BerriAI/litellm"}`
2. Result `isError: true`, text `McpError: Tool read_wiki_structure not found`: that error text is huggingface.co's, and the proxy log confirms the egress: `MCP client call_tool failed - Error Type: McpError, Error: Tool read_wiki_structure not found, Tool: read_wiki_structure, Server: https://huggingface.co/mcp, Transport: MCPTransport.http`

#### JSON-RPC tools/call with a nonexistent tool

1. `tools/call` name `huggingface-not_a_real_tool`, same arguments
2. Result `isError: true`, text `Error: Tool 'not_a_real_tool' not found`; proxy log shows the gateway's own rejection, `HTTPException in MCP tool call: 404: Tool 'not_a_real_tool' not found`, and no upstream call

#### REST tools/call with server_id selecting the wrong server

1. `curl -X POST http://localhost:57626/mcp-rest/tools/call -H 'Authorization: Bearer sk-1234' -d '{"server_id":"<huggingface id>","name":"read_wiki_structure","arguments":{"repoName":"BerriAI/litellm"}}'`
2. HTTP 200 with `"isError": true` and the upstream's `McpError: Tool read_wiki_structure not found`; proxy log again shows the call leaving for https://huggingface.co/mcp

#### Correct-server calls

1. `tools/call` name `deepwiki-read_wiki_structure`, same arguments
2. Result is the real DeepWiki page list for BerriAI/litellm

### After (a30e1f6e3d)

#### JSON-RPC tools/call naming the wrong server's prefix

1. Same `tools/call` name `huggingface-read_wiki_structure`, same arguments
2. Result `isError: true`, text `Error: Tool 'read_wiki_structure' not found`: now the gateway's own rejection, proxy log shows `HTTPException in MCP tool call: 404: Tool 'read_wiki_structure' not found` and no request to huggingface.co

#### JSON-RPC tools/call with a nonexistent tool

1. Same `tools/call` name `huggingface-not_a_real_tool`
2. Same in-gateway rejection as before, `Error: Tool 'not_a_real_tool' not found`

#### REST tools/call with server_id selecting the wrong server

1. Same curl with the huggingface `server_id` and `name` `read_wiki_structure`
2. Rejected in-gateway with `Tool read_wiki_structure not found`; proxy log shows no upstream call

#### Correct-server calls

1. `tools/call` name `deepwiki-read_wiki_structure` returns the real DeepWiki page list, and `tools/call` name `huggingface-hub_repo_search` with `{"query":"litellm","limit":2}` returns real Hub results

## Type

🐛 Bug Fix

## Caveats (if any)

- A server not yet tool-listed rejects calls even for names other servers expose
- One existing URL-collision credential test updated to a post-listing mapping state

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a30e1f6e3d718f2b20fd6f62073fd9c9a6b4ab7d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] a30e1f6e3d passes /live-pr-risk

- [x] 9018a95037 passes /live-pr-risk
