### PR TITLE
fix(logging): close three secret-leak paths in verbose logging

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -265,7 +265,9 @@ class JsonFormatter(Formatter):
         if record.exc_info:
             json_record["stacktrace"] = record.exc_text or self.formatException(record.exc_info)
 
-        return safe_dumps(json_record)
+        # SecretRedactionFilter only scrubs str values; redacting the rendered line means
+        # no `extra=` value shape (dict, list, set, nested) can bypass redaction.
+        return _redact_string(safe_dumps(json_record))
 
 
 class CorrelationPlainFormatter(logging.Formatter):
@@ -276,7 +278,7 @@ class CorrelationPlainFormatter(logging.Formatter):
     """
 
     def format(self, record: logging.LogRecord) -> str:
-        formatted: Final = super().format(record)
+        formatted: Final = _redact_string(super().format(record))
         trace_id: Final = getattr(record, "trace_id", None)
         session_id: Final = getattr(record, "session_id", None)
         if not trace_id and not session_id:

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -10,7 +10,7 @@ from typing import Any, Final
 import litellm
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
-from litellm.litellm_core_utils.secret_redaction import redact_string
+from litellm.litellm_core_utils.secret_redaction import redact_string, redact_structured_value
 
 set_verbose = False
 
@@ -57,6 +57,12 @@ def _redact_string(value: str) -> str:
     if not _ENABLE_SECRET_REDACTION:
         return value
     return redact_string(value)
+
+
+def _redact_structured_value(key: str | None, value: str) -> str:
+    if not _ENABLE_SECRET_REDACTION:
+        return value
+    return redact_structured_value(key, value)
 
 
 def redact_secrets(value: str) -> str:
@@ -265,7 +271,7 @@ class JsonFormatter(Formatter):
         if record.exc_info:
             json_record["stacktrace"] = record.exc_text or self.formatException(record.exc_info)
 
-        return _redact_string(safe_dumps(json_record))
+        return safe_dumps(json_record, value_transform=_redact_structured_value)
 
 
 class CorrelationPlainFormatter(logging.Formatter):

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -265,8 +265,6 @@ class JsonFormatter(Formatter):
         if record.exc_info:
             json_record["stacktrace"] = record.exc_text or self.formatException(record.exc_info)
 
-        # SecretRedactionFilter only scrubs str values; redacting the rendered line means
-        # no `extra=` value shape (dict, list, set, nested) can bypass redaction.
         return _redact_string(safe_dumps(json_record))
 
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1094,10 +1094,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             data=additional_args.get("complete_input_dict", {}),
                         )
 
-                        _metadata["raw_request"] = str(curl_command)
+                        _metadata["raw_request"] = _redact_string(str(curl_command))
                         # split up, so it's easier to parse in the UI
                         self.model_call_details["raw_request_typed_dict"] = RawRequestTypedDict(
-                            raw_request_api_base=str(additional_args.get("api_base") or ""),
+                            raw_request_api_base=self._get_masked_api_base(str(additional_args.get("api_base") or "")),
                             raw_request_body=self._get_raw_request_body(additional_args.get("complete_input_dict", {})),
                             # NOTE: setting ignore_sensitive_headers to True will cause
                             # the Authorization header to be leaked when calls to the health
@@ -1111,8 +1111,10 @@ class Logging(LiteLLMLoggingBaseClass):
                     self.model_call_details["raw_request_typed_dict"] = RawRequestTypedDict(
                         error=str(e),
                     )
-                    _metadata["raw_request"] = f"Unable to Log \
+                    _metadata["raw_request"] = _redact_string(
+                        f"Unable to Log \
                         raw request: {e}"
+                    )
             if getattr(self, "logger_fn", None) and callable(self.logger_fn):
                 try:
                     self.logger_fn(
@@ -1206,15 +1208,16 @@ class Logging(LiteLLMLoggingBaseClass):
         if _is_debugging_on() or self.litellm_request_debug:
             if json_logs:
                 masked_headers: Final = self._get_masked_headers(headers)
+                masked_api_base: Final = self._get_masked_api_base(str(api_base or ""))
                 if self.litellm_request_debug:
                     verbose_logger.warning(  # .warning ensures this shows up in all environments
                         "POST Request Sent from LiteLLM",
-                        extra={"api_base": {api_base}, **masked_headers},
+                        extra={"api_base": {masked_api_base}, **masked_headers},
                     )
                 else:
                     verbose_logger.debug(
                         "POST Request Sent from LiteLLM",
-                        extra={"api_base": {api_base}, **masked_headers},
+                        extra={"api_base": {masked_api_base}, **masked_headers},
                     )
             else:
                 headers = additional_args.get("headers", {})
@@ -1254,8 +1257,6 @@ class Logging(LiteLLMLoggingBaseClass):
             curl_command = "\nRequest Sent from LiteLLM:\n"
             request_str: Final = additional_args.get("request_str", "")
             curl_command += request_str
-        elif api_base == "":
-            curl_command = str(self.model_call_details)
         return curl_command
 
     def _get_masked_headers(self, headers: dict, ignore_sensitive_headers: bool = False) -> dict:

--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Callable
 from typing import Any, Final
 
 from pydantic import BaseModel
@@ -11,20 +12,32 @@ def strip_null_bytes(value: str) -> str:
     return value.replace("\x00", "")
 
 
-def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
+def safe_dumps(
+    data: Any,
+    max_depth: int = DEFAULT_MAX_RECURSE_DEPTH,
+    value_transform: Callable[[str | None, str], str] | None = None,
+) -> str:
     """
     Recursively serialize data while detecting circular references.
     If a circular reference is detected then a marker string is returned.
     NUL bytes are stripped from strings to prevent PostgreSQL 22P05 errors.
+
+    value_transform, when given, is applied to every string leaf (and to the
+    str() fallback for non-serializable objects) with the mapping key the leaf
+    was reached under, so callers can rewrite values without touching structure.
     """
 
-    def _serialize(obj: Any, seen: set, depth: int) -> Any:
+    def _transform(key: str | None, value: str) -> str:
+        return value if value_transform is None else value_transform(key, value)
+
+    def _serialize(obj: Any, seen: set, depth: int, key: str | None = None) -> Any:
         # Check for maximum depth.
         if depth > max_depth:
             return "MaxDepthExceeded"
         # Base-case: if it is a primitive, simply return it.
         if isinstance(obj, str):
-            return obj.replace("\x00", "") if "\x00" in obj else obj
+            cleaned = obj.replace("\x00", "") if "\x00" in obj else obj
+            return _transform(key, cleaned)
         if isinstance(obj, (int, float, bool, type(None))):
             return obj
         # Check for circular reference.
@@ -37,30 +50,30 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
             for k, v in obj.items():
                 if isinstance(k, (str)):
                     clean_k = k.replace("\x00", "") if "\x00" in k else k
-                    result[clean_k] = _serialize(v, seen, depth + 1)
+                    result[clean_k] = _serialize(v, seen, depth + 1, clean_k)
             seen.remove(id(obj))
             return result
         elif isinstance(obj, list):
-            result = [_serialize(item, seen, depth + 1) for item in obj]
+            result = [_serialize(item, seen, depth + 1, key) for item in obj]
             seen.remove(id(obj))
             return result
         elif isinstance(obj, tuple):
-            result = tuple(_serialize(item, seen, depth + 1) for item in obj)
+            result = tuple(_serialize(item, seen, depth + 1, key) for item in obj)
             seen.remove(id(obj))
             return result
         elif isinstance(obj, set):
-            result = sorted([_serialize(item, seen, depth + 1) for item in obj])
+            result = sorted([_serialize(item, seen, depth + 1, key) for item in obj])
             seen.remove(id(obj))
             return result
         elif isinstance(obj, BaseModel):
             dumped: Final = obj.model_dump()
-            result = _serialize(dumped, seen, depth + 1)
+            result = _serialize(dumped, seen, depth + 1, key)
             seen.remove(id(obj))
             return result
         else:
             # Fall back to string conversion for non-serializable objects.
             try:
-                return strip_null_bytes(str(obj))
+                return _transform(key, strip_null_bytes(str(obj)))
             except Exception:
                 return "Unserializable Object"
 

--- a/litellm/litellm_core_utils/secret_redaction.py
+++ b/litellm/litellm_core_utils/secret_redaction.py
@@ -81,3 +81,19 @@ _SECRET_RE: Final = _build_secret_patterns()
 def redact_string(value: str) -> str:
     """Scrub known secret/credential patterns from *value* and return the result."""
     return _SECRET_RE.sub(_REDACTED, value)
+
+
+def redact_structured_value(key: str | None, value: str) -> str:
+    """Scrub *value* as it appeared under *key* inside a structured record.
+
+    redact_string() replaces a whole ``key: value`` span with REDACTED, which is
+    fine inside free text but destroys the surrounding syntax when the span is a
+    JSON member rather than message content. This renders the pair the way a dict
+    repr would, so the key-name patterns still fire, but collapses only the value
+    so the caller's structure survives.
+    """
+    scrubbed: Final = redact_string(value)
+    if scrubbed != value or key is None:
+        return scrubbed
+    rendered: Final = f"'{key}': '{value}'"
+    return _REDACTED if redact_string(rendered) != rendered else value

--- a/litellm/litellm_core_utils/secret_redaction.py
+++ b/litellm/litellm_core_utils/secret_redaction.py
@@ -24,9 +24,6 @@ def _build_secret_patterns() -> "re.Pattern[str]":
         r"(?:client_secret|azure_password|azure_username)\s+[^\s,'\"})\]{}>]+",
         # AWS access key IDs
         r"(?:AKIA|ASIA)[0-9A-Z]{16}",
-        # AWS secrets / session tokens / access key IDs (key=value)
-        r"(?:aws_secret_access_key|aws_session_token|aws_access_key_id)"
-        r"\s*[:=]\s*[A-Za-z0-9/+=]{20,}",
         # Bearer tokens (OAuth, JWT, etc.)
         r"Bearer\s+[A-Za-z0-9\-._~+/]{10,}=*",
         # Basic auth headers
@@ -61,6 +58,7 @@ def _build_secret_patterns() -> "re.Pattern[str]":
         # private_key with PEM-aware value capture
         r"""private_key['\"]?\s*[:=]\s*['\"]?(?:-----BEGIN[A-Z \-]*PRIVATE KEY-----[\s\S]*?-----END[A-Z \-]*PRIVATE KEY-----|[^\s,'\"})\]{}>]+)""",
         r"(?:master_key|xai_key|database_url|db_url|connection_string|"
+        r"aws_secret_access_key|aws_session_token|aws_access_key_id|"
         r"signing_key|encryption_key|"
         r"auth_token|access_token|refresh_token|"
         r"slack_webhook_url|webhook_url|"

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -4910,3 +4910,51 @@ def test_payload_without_guardrail_cost_is_unchanged(logging_obj):
     assert payload is not None
     assert payload["response_cost"] == pytest.approx(0.0000429)
     assert payload["cost_breakdown"] is None
+
+
+_AWS_SECRET = "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY"
+_GEMINI_KEY = "AIzaSyC0000000000000000000000000000000"
+
+
+def test_empty_api_base_does_not_dump_call_state(logging_obj):
+    """Direct (non-HTTP) providers pass api_base='', which used to echo model_call_details."""
+    logging_obj.model_call_details["litellm_params"] = {
+        "api_key": "sk-proj-hunter2hunter2hunter2hunter2",
+        "aws_secret_access_key": _AWS_SECRET,
+    }
+
+    curl_command = logging_obj._get_request_curl_command(
+        api_base="",
+        headers={},
+        additional_args={},
+        data={"model": "some-model"},
+    )
+
+    assert "litellm_call_id" not in curl_command
+    assert _AWS_SECRET not in curl_command
+    assert "hunter2" not in curl_command
+
+
+def test_pre_call_redacts_and_masks_raw_request(logging_obj):
+    """log_raw_request_response echoes the request body and api_base back to loggers/UI."""
+    metadata = {"user_api_key_alias": "qa-key"}
+    logging_obj.model_call_details["litellm_params"] = {"metadata": metadata}
+    logging_obj.log_raw_request_response = True
+
+    logging_obj.pre_call(
+        input="hi",
+        api_key="",
+        additional_args={
+            "api_base": f"https://generativelanguage.googleapis.com/v1beta/models/x:generateContent?key={_GEMINI_KEY}",
+            "headers": {},
+            "complete_input_dict": {"aws_secret_access_key": _AWS_SECRET},
+        },
+    )
+
+    raw_request = metadata["raw_request"]
+    assert _AWS_SECRET not in raw_request
+    assert "REDACTED" in raw_request
+
+    raw_api_base = logging_obj.model_call_details["raw_request_typed_dict"]["raw_request_api_base"]
+    assert _GEMINI_KEY not in raw_api_base
+    assert "key=*****" in raw_api_base

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -177,12 +177,47 @@ def test_json_formatter_parses_embedded_python_dict_repr():
     # Python dict parsed and promoted to first-class properties
     assert obj["model_name"] == "text-embedding-3-large"
     assert "litellm_params" in obj
-    assert obj["litellm_params"]["api_key"] == "sk**********"
+    # Redacted, not passed through: SecretRedactionFilter already collapses this
+    # pair in the plain path before any formatter sees it, so the JSON path matching
+    # it is production parity. The key survives because redaction is per-value here.
+    assert obj["litellm_params"]["api_key"] == "REDACTED"
     assert obj["litellm_params"]["tpm"] == 1000000
     assert obj["litellm_params"]["use_in_pass_through"] is False
     assert "model_info" in obj
     assert obj["model_info"]["id"] == "a624b057aec64ada48311"
     assert obj["model_info"]["db_model"] is False
+
+
+def test_json_formatter_output_stays_parseable_when_a_secret_is_redacted():
+    """Redaction must collapse the value only, never the surrounding JSON member.
+
+    Redacting the serialized document turned '"api_key": "sk-..."' into a bare
+    REDACTED token, so the line stopped being valid JSON entirely.
+    """
+    formatter = JsonFormatter()
+    record = logging.LogRecord(
+        name="LiteLLM",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="calling deployment",
+        args=(),
+        exc_info=None,
+    )
+    record.deployment = {
+        "api_key": "sk-abcdefghijklmnopqrstuvwxyz0123456789",
+        "aws_secret_access_key": "wJalrXUtnFEMIQAfakeKEYbPxRfiCYEXAMPLEKEY",
+        "aws_region_name": "us-east-1",
+        "nested": {"tokens": ["Bearer abcdefghijklmnop", "keep-me"]},
+    }
+
+    obj = json.loads(formatter.format(record))
+
+    assert obj["deployment"]["api_key"] == "REDACTED"
+    assert obj["deployment"]["aws_secret_access_key"] == "REDACTED"
+    # Non-secret siblings stay legible so the logs remain useful
+    assert obj["deployment"]["aws_region_name"] == "us-east-1"
+    assert obj["deployment"]["nested"]["tokens"] == ["REDACTED", "keep-me"]
 
 
 def test_json_formatter_includes_component_field():

--- a/tests/test_litellm/test_secret_redaction.py
+++ b/tests/test_litellm/test_secret_redaction.py
@@ -495,3 +495,54 @@ def test_redaction_survives_uvicorn_logging_reconfiguration():
             lg.handlers[:] = handlers
             lg.setLevel(level)
             lg.propagate = True
+
+
+def test_aws_credential_redaction_catches_quoted_values():
+    """AWS creds appear as quoted dict-repr values, not just bare key=value."""
+    cases = (
+        "{'aws_secret_access_key': 'wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY'}",
+        '{"aws_session_token": "IQoJb3JpZ2luX2VjEaCXVzLWVhc3QtMSJHMEUCIQ"}',
+        "aws_session_token: 'FwoGZXIvYXdzEBYaDHh4eHh4eHh4eHh4eCLLAe'",
+        "aws_secret_access_key=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY",
+        "{'aws_access_key_id': 'not-an-akia-shaped-value'}",
+    )
+    for secret_line in cases:
+        result = redact_string(secret_line)
+        assert "REDACTED" in result, f"AWS redaction missed: {secret_line!r}"
+        assert "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY" not in result
+        assert "IQoJb3JpZ2luX2VjEaCXVzLWVhc3QtMSJHMEUCIQ" not in result
+
+    safe = "'aws_region_name': 'us-east-1'"
+    assert redact_string(safe) == safe
+
+
+@pytest.mark.parametrize(
+    "extra",
+    (
+        {"api_base": {f"https://host/v1?key={SECRET}"}},
+        {"blob": {"authorization": f"Bearer {SECRET}"}},
+        {"blob": [f"Bearer {SECRET}"]},
+        {"blob": ({"nested": {"deep": SECRET}},)},
+    ),
+    ids=("set", "dict", "list", "nested"),
+)
+def test_json_formatter_redacts_non_string_extra_values(extra):
+    """SecretRedactionFilter only scrubs str attrs, so containers must be caught on render."""
+    buf = StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(JsonFormatter())
+    handler.addFilter(_secret_filter)
+
+    logger = logging.getLogger("test_json_extra_redaction")
+    logger.handlers = [handler]
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    try:
+        logger.warning("request sent", extra=extra)
+    finally:
+        logger.handlers = []
+
+    output = buf.getvalue()
+    assert output.strip(), "no record captured"
+    assert SECRET not in output, f"non-string extra leaked a secret: {output}"
+    assert "REDACTED" in output


### PR DESCRIPTION
## TLDR

Problem this solves:

- Quoted AWS secrets escaped log redaction entirely
- Non-string `extra={}` log values bypassed the redaction filter
- `log_raw_request_response` wrote unredacted curl commands and api_base
- An empty api_base dumped the whole internal call state

How it solves it:

- Fold AWS key names into the quote-tolerant matcher
- Redact at the formatter, after rendering, so value shape stops mattering
- Redact `raw_request` and mask `raw_request_api_base`
- Drop the call-state dump fallback

## User Flow

Before: a proxy admin who ships proxy logs to a shared aggregator finds live provider credentials sitting there in plaintext

1. They configure a Bedrock deployment holding AWS credentials, plus a model whose `api_base` carries a key in its query string, and start the proxy with verbose logging on
2. They send POST http://litellm-domain/v1/chat/completions for the Bedrock model and get back a normal response
3. They search the log sink for their AWS secret and find it, so the secret is readable by anyone with log access
4. They send a request to the gateway model and find its api_base logged with the key still in the URL
5. They send one request with an invalid virtual key, get the expected 401, and the rejection also writes a large log line holding internal call state including the end user's prompt
6. Anyone with read access to that log sink can lift the AWS secret and the gateway key and use both directly against the upstream providers

After: the same admin sees the same requests logged with every credential replaced by `REDACTED`

1. They configure the same two deployments and start the proxy with verbose logging on
2. They send POST http://litellm-domain/v1/chat/completions for the Bedrock model and get back the same normal response
3. They search the log sink for their AWS secret and find nothing; the surrounding line reads `'litellm_params': {'REDACTED', 'REDACTED', 'aws_region_name': 'us-east-1', ...}`, so the non-secret region stays legible
4. They send the same request to the gateway model and the api_base is logged as `https://api.groq.com/openai/v1?REDACTED`, host and path still readable
5. They send the same request with an invalid virtual key, get the same 401, and no call-state line is written at all
6. A reader of the log sink now has nothing usable: no AWS secret, no gateway key, and no end user prompt from the rejected request

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This one touches credential handling in logs, so the public write-up below is deliberately light on the exact trigger conditions. Maintainers: ping me on Slack and I will walk through the full four-phase capture, including the reproduction config, the per-path hit counts, and the raw before-logs.

Shared setup, identical on both sides. Three deployments, each carrying throwaway fake credentials: a working Groq model, a "gateway" model whose `api_base` holds a key in the query string, and a Bedrock model with credentials in the config. `log_raw_request_response: true` in `litellm_settings`. The proxy runs on port 4082 with verbose logging, captured under both the plain and the JSON formatter, since they take different code paths.

The same four requests hit it in each capture: one Groq chat completion, one to the gateway model, one to Bedrock, and one with an invalid virtual key. All four hit real provider APIs and cost real money. Groq answers 200 with `"content":"redaction QA ok"` and 154 tokens billed, the gateway URL 404s at Groq because of the malformed path, and AWS returns a real 403 "The security token included in the request is invalid" for the fake credentials. The status codes are 200, 404, 403, 401 and come back identical before and after, which is the check that none of this changed behavior.

Each case below greps the captured logs for one planted credential.

### Before (6c4059aacc)

#### AWS secret in verbose deployment logs

1. Grep the plain-formatter capture for the planted AWS secret: found, under both formatters
2. The sibling `aws_access_key_id` on the very same line is correctly redacted, so the leak is specific to the secret rather than a wholesale redaction failure

#### Gateway key inside api_base

1. Grep the JSON-formatter capture for the planted gateway key: found
2. On that line the api_base has been rendered as a parsed tuple rather than a string, which is why it never reaches the redaction filter

#### Call-state dump on a rejected request

1. The invalid-key request returns 401 as expected, and additionally emits one call-state log line
2. That line is roughly 2.6 KB and carries the end user's prompt along with the internal parameter block

### After (ea88d9e77f)

#### AWS secret in verbose deployment logs

1. Same requests, same greps, under both formatters: zero hits on the planted secret
2. The non-secret `aws_region_name` is deliberately left readable so the logs stay useful:

```
'litellm_params': {'REDACTED', 'REDACTED', 'aws_region_name': 'us-east-1', 'allow_client...
```

#### Gateway key inside api_base

1. Same grep on the JSON-formatter capture: zero hits on the planted gateway key
2. The line is now masked, with the rest of the URL intact for debugging:

```
"api_base": ["https://api.groq.com/openai/v1?REDACTED"], "Authorization": "Be****vG"
```

3. A request whose api_base holds no key is untouched, so ordinary debugging still reads normally:

```
"api_base": ["https://api.groq.com/openai/v1/chat/completions"], "Authorization": "Be****vG"
```

#### Call-state dump on a rejected request

1. The invalid-key request still returns 401, and the call-state line is gone
2. Zero such lines under either formatter

## Type

🐛 Bug Fix

## Caveats (if any)

- `raw_request_api_base` is now masked, matching sibling api_base fields
- Redaction moved to formatters; the existing opt-out is unchanged
- `raw_request_body` stays unredacted, since that is the feature's point

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
