### PR TITLE
feat(ui): add success, warning and info status tokens

### DIFF
--- a/ui/litellm-dashboard/src/app/globals.css
+++ b/ui/litellm-dashboard/src/app/globals.css
@@ -95,6 +95,9 @@
   --accent: oklch(0.967 0.003 264.542);
   --accent-foreground: oklch(0.21 0.034 264.665);
   --destructive: oklch(0.577 0.245 27.325);
+  --success: oklch(0.527 0.154 150.069);
+  --warning: oklch(0.555 0.163 48.998);
+  --info: oklch(0.546 0.245 262.881);
   --border: oklch(0.928 0.006 264.531);
   --input: oklch(0.928 0.006 264.531);
   --ring: oklch(0.707 0.022 261.325);
@@ -130,6 +133,9 @@
   --accent: oklch(0.278 0.033 256.848);
   --accent-foreground: oklch(0.985 0.002 247.839);
   --destructive: oklch(0.704 0.191 22.216);
+  --success: oklch(0.792 0.209 151.711);
+  --warning: oklch(0.828 0.189 84.429);
+  --info: oklch(0.707 0.165 254.624);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.551 0.027 264.364);
@@ -168,6 +174,9 @@
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-info: var(--info);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);

--- a/ui/litellm-dashboard/src/components/shared/Alert.tsx
+++ b/ui/litellm-dashboard/src/components/shared/Alert.tsx
@@ -9,9 +9,8 @@ const alertVariants = cva({
     variant: {
       default: "bg-card text-card-foreground",
       destructive: "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
-      info: "border-blue-200 bg-blue-50 text-blue-900 *:data-[slot=alert-description]:text-blue-800 *:[svg]:text-blue-600",
-      warning:
-        "border-amber-200 bg-amber-50 text-amber-900 *:data-[slot=alert-description]:text-amber-800 *:[svg]:text-amber-600",
+      info: "border-info/20 bg-info/5 text-info *:[svg]:text-current",
+      warning: "border-warning/20 bg-warning/5 text-warning *:[svg]:text-current",
       error: "border-red-200 bg-red-50 text-red-900 *:data-[slot=alert-description]:text-red-800 *:[svg]:text-red-600",
     },
   },


### PR DESCRIPTION
## TLDR

Problem this solves:

- No shared tokens for success, warning or info colours
- Components hardcode raw Tailwind shades instead
- Token lanes are blocked until these exist

How it solves it:

- Adds three tokens next to the existing `--destructive`
- Light values chosen to clear WCAG AA as text
- Moves Alert's info and warning variants onto them

## User Flow

Before: an admin reading a warning callout sees it, but every component needing a status colour hardcodes its own shade, so the shades drift apart across pages

1. They open http://localhost:4000/ui/?page=mcp-servers and see a warning callout in one set of amber shades
2. They open http://localhost:4000/ui/?page=policies and see a warning callout built from a different set
3. Any new component needing a warning colour has to pick shades by hand, so the drift keeps growing

After: status colours come from one place, so the same warning reads the same everywhere

1. They open http://localhost:4000/ui/?page=mcp-servers and see the warning callout rendered from the shared warning colour
2. They open http://localhost:4000/ui/?page=policies and see the same warning colour, not a near miss
3. Everything else is unchanged, and the app still presents its light appearance

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

No unit test is included, and that is deliberate rather than an omission. What this PR needs to be true is that the tokens survive the Tailwind build and that the utilities Alert consumes are actually emitted. The unit suite runs in jsdom, which never runs the Tailwind pipeline, so a test there could only assert the literal class strings back to itself and would keep passing if the tokens were deleted. The verification that does have teeth runs against the compiled stylesheet and is below, including negative controls on both sides.

## Screenshots / Proof of Fix

The change is a build-time one, so the verification below reads the compiled stylesheet. UI screenshots to follow.

### Before (3f15dc3287)

#### tokens and utilities absent

1. `npm run build && find .next -name '*.css' | xargs cat > /tmp/built.css`
2. `grep -c -- '--success:' /tmp/built.css` returns `0`, same for `--warning:` and `--info:`
3. `grep -c '\.text-warning' /tmp/built.css` returns `0`, same for `.text-info`
4. Control, so the greps are known to work here: `grep -o -- '--destructive:#[0-9a-f]*' /tmp/built.css` returns `--destructive:#e40014` and `--destructive:#ff6568`

### After (6176b76cdd)

#### tokens emit in both appearances

1. `npm run build && find .next -name '*.css' | xargs cat > /tmp/built.css`
2. `grep -o -- '--warning:#[0-9a-f]*' /tmp/built.css` returns `--warning:#b75000` and `--warning:#fcbb00`
3. Same for `--success` (`#008138`, `#05df72`) and `--info` (`#155dfc`, `#54a2ff`)

#### the dark values land in the `.dark` rule, not in `:root`

1. Parse the compiled `.dark{...}` rule and read the tokens out of it
2. It carries `--success:#05df72`, `--warning:#fcbb00`, `--info:#54a2ff`, alongside the existing `--destructive:#ff6568`

#### utilities Alert consumes are emitted

1. `for u in text-warning 'bg-warning\\/5' 'border-warning\\/20' text-info 'bg-info\\/5' 'border-info\\/20'; do grep -c "\.$u" /tmp/built.css; done`
2. Every one returns `1`

#### negative control, so the check above can fail

1. `grep -c '\.text-success' /tmp/built.css` returns `0`
2. Correct: `--success` is defined but nothing consumes it yet, so Tailwind emits no utility. The greps above therefore mean something.

#### contrast, measured from the sRGB conversion of each token

1. Light as text on white: success 4.94, warning 5.05, info 5.26, all clearing the 4.50 AA threshold
2. Dark as text on the dark card: success 10.00, warning 10.33, info 6.73

## Type

🆕 New Feature

## Caveats

- Alert warning and info change appearance across 15 sites
- Light shades are `-700`/`-600`, not `-600` uniformly; see below
- `meter.tsx` keeps `bg-amber-500`; it is CLI managed
- `--neutral-border` still has no `.dark` pairing
- Nothing can apply `.dark` yet; the switch is separate work

On the shade choice: `--destructive` light is exactly `red-600`, so `-600` looks like the rule. It is not. Tailwind's ramps are not perceptually aligned across hues, so `amber-600` measures 3.19:1 on plain white and `green-600` 3.22:1, both failing AA as text before any tint is applied. What `--destructive` actually is, is a colour at 57.7% lightness. The tokens here match that band, `green-700` at 52.7%, `amber-700` at 55.5%, `blue-600` at 54.6%, and clear AA. Dark mode uses the `-400` shades throughout, matching `--destructive`.

Alert's tint is `/5` rather than `/10` for the same reason: at `/10` warning measures 4.39 and info 4.55, so warning would ship below AA. The `error` variant is deliberately left on its raw shades, because it involves no new token and its present 9.21:1 beats anything the token form would give it. No `success` variant was added to Alert, since it never had one and has no callers; the token is there for whoever needs it first.

The `.dark` values are populated even though nothing can activate them yet. They are the artifact the later theme switch turns on, which is the point of landing tokens first.

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Left unchecked on purpose, to match the tests checkbox. This PR adds no tests, so there is nothing here I can honestly attest to. The compiled-CSS checks above are what guards the change, and they run by hand rather than in CI.
