### PR TITLE
chore: bump litellm-enterprise 0.1.56 -> 0.1.57, litellm-proxy-extras 0.4.86 -> 0.4.87, litellm 1.98.0 -> 1.99.0

### DIFF
--- a/enterprise/pyproject.toml
+++ b/enterprise/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-enterprise"
-version = "0.1.56"
+version = "0.1.57"
 description = "Package for LiteLLM Enterprise features"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.1.56"
+version = "0.1.57"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-enterprise==",

--- a/litellm-proxy-extras/pyproject.toml
+++ b/litellm-proxy-extras/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-proxy-extras"
-version = "0.4.86"
+version = "0.4.87"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.4.86"
+version = "0.4.87"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-proxy-extras==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.98.0"
+version = "1.99.0"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.15"
@@ -67,8 +67,8 @@ proxy = [
     "azure-identity>=1.25.2,<2.0",
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.28.1,<2.0",
-    "litellm-proxy-extras==0.4.86",
-    "litellm-enterprise==0.1.56",
+    "litellm-proxy-extras==0.4.87",
+    "litellm-enterprise==0.1.57",
     "RestrictedPython>=8.1,<9.0",
     "rich>=13.9.4,<14.0",
     "InquirerPy>=0.3.4,<1.0",
@@ -306,7 +306,7 @@ members = ["enterprise", "litellm-proxy-extras"]
 profile = "black"
 
 [tool.commitizen]
-version = "1.98.0"
+version = "1.99.0"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-14T18:59:56.524034Z"
+exclude-newer = "2026-08-16T00:41:08.185444Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4194,7 +4194,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.98.0"
+version = "1.99.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -4585,12 +4585,12 @@ proxy-dev = [
 
 [[package]]
 name = "litellm-enterprise"
-version = "0.1.56"
+version = "0.1.57"
 source = { editable = "enterprise" }
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.86"
+version = "0.4.87"
 source = { editable = "litellm-proxy-extras" }
 
 [[package]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Both subpackages changed since main but kept their versions
- The 1.98.0 line already graduated, so litellm is due
- Publishing unchanged versions would misrepresent package contents

How it solves it:

- PATCH bump for litellm-enterprise and litellm-proxy-extras
- MINOR bump for litellm, opening the 1.99.0 line
- uv.lock re-resolved against the three new versions

## User Flow

Not applicable: this changes no runtime behavior. Nothing an end user does against the proxy or the Admin UI differs before and after, and the only observable effect is the version string the next release publishes

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

There is no meaningful proof of fix for a version bump. The change is three version strings plus the lock entries that mirror them, and no code path behaves differently, so there is nothing to run against a live proxy

The bump decision itself is reproducible from git. `enterprise/` and `litellm-proxy-extras/` both differ between `origin/main` and `origin/litellm_internal_staging` while still carrying main's version, which is what makes each PATCH bump due. The `v1.98.0-rc.1` tag means the 1.98.0 line has graduated, so this promotion opens 1.99.0 and litellm takes its MINOR bump

`uv lock` reported only the three editable packages as updated, so the sole extra line in the lock diff is the `exclude-newer` timestamp moving forward under the rolling `exclude-newer-span = "P3D"` window. No third-party dependency version moved

## Type

🚄 Infrastructure

## Caveats (if any)

- Touches pyproject.toml, so it needs more than one reviewer

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
