### PR TITLE
feat(proxy): turn audit logging on by default

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -221,7 +221,7 @@ overwrite_user_with_key_hash: bool = (
 bedrock_request_metadata_fields: Optional[Sequence[str]] = (
     None  # allow-list of `user_api_key_*` fields (+ `spend_logs_metadata`) sent as Bedrock `requestMetadata`
 )
-store_audit_logs = False  # Enterprise feature, allow users to see audit logs
+store_audit_logs: bool = True  # Enterprise feature, allow users to see audit logs
 skip_system_message_in_guardrail: bool = False
 skip_tool_message_in_guardrail: bool = False
 ### end of callbacks #############

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1816,7 +1816,6 @@ async def bulk_user_update(
                         litellm_changed_by=litellm_changed_by or user_api_key_dict.user_id,
                         user_api_key_dict=user_api_key_dict,
                         litellm_proxy_admin_name=litellm_proxy_admin_name,
-                        before_value=f"Updated {len(all_users_in_db)} users",
                         after_value=json.dumps(non_default_values),
                     )
                 )

--- a/litellm/proxy/management_helpers/audit_logs.py
+++ b/litellm/proxy/management_helpers/audit_logs.py
@@ -18,10 +18,26 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.repositories.table_repositories import AuditLogRepository
+from litellm.secret_managers.main import get_secret_bool
 from litellm.types.utils import StandardAuditLogPayload
 
 _audit_log_callback_cache: Final[dict[str, CustomLogger]] = {}
 ALLOW_LITELLM_CHANGED_BY_HEADER_METADATA_KEY: Final = "allow_litellm_changed_by_header"
+
+
+def store_audit_logs_enabled(*, config_override: bool | None = None) -> bool:
+    """Resolve whether audit logging is on.
+
+    `LITELLM_STORE_AUDIT_LOGS` wins when it holds "true" or "false", then `config_override`
+    for callers that hold the raw config value before it reaches `litellm.store_audit_logs`,
+    then `litellm.store_audit_logs` itself.
+    """
+    env_value: Final = get_secret_bool("LITELLM_STORE_AUDIT_LOGS")
+    if env_value is not None:
+        return env_value
+    if config_override is not None:
+        return config_override is True
+    return litellm.store_audit_logs is True
 
 
 def _allows_litellm_changed_by_header(user_api_key_dict: UserAPIKeyAuth) -> bool:
@@ -164,11 +180,7 @@ async def create_object_audit_log(
     - user_api_key_dict: UserAPIKeyAuth - The user api key dictionary.
     - litellm_proxy_admin_name: Optional[str] - The name of the proxy admin.
     """
-    from litellm.secret_managers.main import get_secret_bool
-
-    _store_audit_logs: Final[bool | None] = litellm.store_audit_logs or get_secret_bool("LITELLM_STORE_AUDIT_LOGS")
-
-    if _store_audit_logs is not True:
+    if not store_audit_logs_enabled():
         return
 
     _changed_by: Final = get_audit_log_changed_by(
@@ -196,10 +208,7 @@ async def create_audit_log_for_update(request_data: LiteLLM_AuditLogs):
     """
     Create an audit log for an object.
     """
-    from litellm.secret_managers.main import get_secret_bool
-
-    _store_audit_logs: Final[bool | None] = litellm.store_audit_logs or get_secret_bool("LITELLM_STORE_AUDIT_LOGS")
-    if _store_audit_logs is not True:
+    if not store_audit_logs_enabled():
         return
 
     from litellm.proxy.proxy_server import premium_user, prisma_client

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -510,6 +510,7 @@ from litellm.proxy.management_endpoints.workflow_management_endpoints import (
 from litellm.proxy.management_helpers.audit_logs import (
     create_audit_log_for_update,
     create_object_audit_log,
+    store_audit_logs_enabled,
 )
 from litellm.proxy.management_helpers.team_metadata_validation import (
     TEAM_METADATA_SCHEMA_REGISTRY,
@@ -4969,15 +4970,15 @@ class ProxyConfig:
                         else:
                             litellm.audit_log_callbacks.append(callback)
 
-                    _store_audit_logs = litellm_settings.get("store_audit_logs", litellm.store_audit_logs)
-                    if _store_audit_logs:
+                    if store_audit_logs_enabled(config_override=litellm_settings.get("store_audit_logs")):
                         print(  # noqa: T201
                             f"{blue_color_code} Initialized Audit Log Callbacks - {litellm.audit_log_callbacks} {reset_color_code}"
                         )
                     else:
                         verbose_proxy_logger.warning(
-                            "'audit_log_callbacks' is configured but 'store_audit_logs' is not enabled. "
-                            "Audit log callbacks will not fire until 'store_audit_logs: true' is added to litellm_settings."
+                            "'audit_log_callbacks' is configured but audit logging is disabled. "
+                            "Audit log callbacks will not fire while litellm_settings.store_audit_logs "
+                            "or LITELLM_STORE_AUDIT_LOGS is false."
                         )
                 elif key == "cache_params":
                     # this is set in the cache branch

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import sys
@@ -4145,3 +4146,52 @@ async def test_user_info_v2_returns_the_mcp_entitlement(mocker):
     assert response.object_permission.mcp_tool_permissions == {
         "github": ["list_issues"]
     }
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_all_users_writes_a_valid_audit_log(monkeypatch):
+    """`before_value` is a pydantic Json field, so the sentence the all-users path used to pass there could never validate and the row was never written."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.types.proxy.management_endpoints.internal_user_endpoints import (
+        BulkUpdateUserRequest,
+        UpdateUserRequestNoUserIDorEmail,
+    )
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        bulk_user_update,
+    )
+
+    monkeypatch.setattr("litellm.store_audit_logs", True)
+
+    existing_users = [
+        SimpleNamespace(user_id=f"u-{i}", user_email=f"u-{i}@example.com") for i in range(3)
+    ]
+    prisma_client = MagicMock()
+    prisma_client.db = MagicMock()
+    prisma_client.db.litellm_usertable = MagicMock()
+    prisma_client.db.litellm_usertable.find_many = AsyncMock(return_value=existing_users)
+    prisma_client.db.litellm_usertable.update_many = AsyncMock()
+    audit_create = AsyncMock()
+    prisma_client.db.litellm_auditlog = MagicMock()
+    prisma_client.db.litellm_auditlog.create = audit_create
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", prisma_client),
+        patch("litellm.proxy.proxy_server.premium_user", True),
+    ):
+        response = await bulk_user_update(
+            data=BulkUpdateUserRequest(
+                all_users=True,
+                user_updates=UpdateUserRequestNoUserIDorEmail(max_budget=42.0),
+            ),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin-1"
+            ),
+        )
+        await asyncio.sleep(0.1)
+
+    assert response.successful_updates == 3
+    audit_create.assert_called_once()
+    audit_row = audit_create.call_args.kwargs["data"]
+    assert "before_value" not in audit_row
+    assert json.loads(audit_row["updated_values"]) == {"max_budget": 42.0}

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -93,6 +93,15 @@ mock_prisma_client.db.litellm_teamtable = MagicMock()
 mock_prisma_client.db.litellm_teamtable.update = AsyncMock()
 
 
+@pytest.fixture(autouse=True)
+def disable_audit_logs(monkeypatch):
+    """These tests pass MagicMock team rows that cannot serialize into an audit payload.
+
+    Audit behavior on a realistic row is covered by test_update_team_writes_an_audit_log below.
+    """
+    monkeypatch.setattr("litellm.store_audit_logs", False)
+
+
 # Fixture to provide the mock prisma client
 @pytest.fixture(autouse=True)
 def mock_db_client():
@@ -8573,6 +8582,57 @@ async def test_update_team_with_router_settings(mock_db_client, mock_admin_auth)
     # Verify router_settings can be deserialized and matches input
     deserialized_settings = json.loads(team_data["router_settings"])
     assert deserialized_settings == router_settings_data
+
+
+@pytest.mark.asyncio
+async def test_update_team_writes_an_audit_log(mock_db_client, mock_admin_auth, monkeypatch):
+    """/team/update awaits its audit payload build on the request path, so a realistic row must return normally and produce exactly one audit row."""
+    monkeypatch.setattr("litellm.store_audit_logs", True)
+
+    from fastapi import Request
+
+    from litellm.proxy._types import LitellmTableNames, UpdateTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import update_team
+
+    team_id = "team-audit-on-1"
+    existing_team_row = LiteLLM_TeamTable(
+        team_id=team_id,
+        team_alias="audit demo",
+        models=[],
+        members_with_roles=[],
+        metadata={"nested": {"a": 1}},
+        created_at=datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    mock_db_client.jsonify_team_object = lambda db_data: db_data
+    mock_db_client.db = MagicMock()
+    updated_team_result = MagicMock(team_id=team_id)
+    updated_team_result.model_dump.return_value = {"team_id": team_id}
+    mock_db_client.db.litellm_teamtable = MagicMock()
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team_row)
+    mock_db_client.db.litellm_teamtable.update = AsyncMock(return_value=updated_team_result)
+    audit_create = AsyncMock()
+    mock_db_client.db.litellm_auditlog = MagicMock()
+    mock_db_client.db.litellm_auditlog.create = audit_create
+
+    with (
+        patch("litellm.proxy.proxy_server.premium_user", True),
+        patch("litellm.proxy.proxy_server.prisma_client", mock_db_client),
+    ):
+        response = await update_team(
+            data=UpdateTeamRequest(team_id=team_id, team_alias="audit demo renamed"),
+            http_request=MagicMock(spec=Request),
+            user_api_key_dict=mock_admin_auth,
+        )
+        await asyncio.sleep(0.1)
+
+    assert response["team_id"] == team_id
+    audit_create.assert_called_once()
+    audit_row = audit_create.call_args.kwargs["data"]
+    assert audit_row["table_name"] == LitellmTableNames.TEAM_TABLE_NAME
+    assert audit_row["object_id"] == team_id
+    assert audit_row["action"] == "updated"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_helpers/test_audit_log_callbacks.py
+++ b/tests/test_litellm/proxy/management_helpers/test_audit_log_callbacks.py
@@ -13,12 +13,14 @@ import pytest
 
 import litellm
 from litellm.integrations.custom_logger import CustomLogger
-from litellm.proxy._types import LiteLLM_AuditLogs, LitellmTableNames
+from litellm.proxy._types import LiteLLM_AuditLogs, LitellmTableNames, UserAPIKeyAuth
 from litellm.proxy.management_helpers.audit_logs import (
     _audit_log_task_done_callback,
     _build_audit_log_payload,
     _dispatch_audit_log_to_callbacks,
     create_audit_log_for_update,
+    create_object_audit_log,
+    store_audit_logs_enabled,
 )
 from litellm.types.utils import StandardAuditLogPayload
 
@@ -469,3 +471,115 @@ class TestS3AuditCallbackParamsDecoupling:
             assert second is not None
             assert id(second) != id(first)
             assert second.s3_bucket_name == "second"
+
+
+class TestStoreAuditLogsEnabled:
+    """Precedence for the audit-log toggle: env var, then config, then the litellm default."""
+
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("LITELLM_STORE_AUDIT_LOGS", raising=False)
+        assert litellm.store_audit_logs is True
+        assert store_audit_logs_enabled() is True
+
+    def test_env_false_disables_despite_module_setting(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_STORE_AUDIT_LOGS", "false")
+        with patch("litellm.store_audit_logs", True):
+            assert store_audit_logs_enabled() is False
+
+    def test_env_true_enables_when_module_setting_off(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_STORE_AUDIT_LOGS", "true")
+        with patch("litellm.store_audit_logs", False):
+            assert store_audit_logs_enabled() is True
+
+    def test_config_false_disables(self, monkeypatch):
+        monkeypatch.delenv("LITELLM_STORE_AUDIT_LOGS", raising=False)
+        with patch("litellm.store_audit_logs", False):
+            assert store_audit_logs_enabled() is False
+
+    def test_unrecognized_env_value_falls_back_to_module_setting(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_STORE_AUDIT_LOGS", "yes")
+        with patch("litellm.store_audit_logs", False):
+            assert store_audit_logs_enabled() is False
+
+    def test_config_override_beats_module_setting(self, monkeypatch):
+        monkeypatch.delenv("LITELLM_STORE_AUDIT_LOGS", raising=False)
+        with patch("litellm.store_audit_logs", True):
+            assert store_audit_logs_enabled(config_override=False) is False
+
+    def test_env_beats_config_override(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_STORE_AUDIT_LOGS", "false")
+        assert store_audit_logs_enabled(config_override=True) is False
+
+
+class TestAuditLoggingOnByDefault:
+    @pytest.mark.asyncio
+    async def test_writes_audit_log_with_no_store_audit_logs_configured(self, monkeypatch):
+        monkeypatch.delenv("LITELLM_STORE_AUDIT_LOGS", raising=False)
+
+        with (
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma,
+        ):
+            mock_prisma.db.litellm_auditlog.create = AsyncMock()
+
+            await create_audit_log_for_update(_make_audit_log())
+
+            mock_prisma.db.litellm_auditlog.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_object_audit_log_writes_with_no_store_audit_logs_configured(self, monkeypatch):
+        monkeypatch.delenv("LITELLM_STORE_AUDIT_LOGS", raising=False)
+
+        with (
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma,
+        ):
+            mock_prisma.db.litellm_auditlog.create = AsyncMock()
+
+            await create_object_audit_log(
+                object_id="team-456",
+                action="created",
+                litellm_changed_by=None,
+                user_api_key_dict=UserAPIKeyAuth(user_id="user-123"),
+                litellm_proxy_admin_name="default_user_id",
+                table_name=LitellmTableNames.TEAM_TABLE_NAME,
+                after_value=json.dumps({"name": "new-team"}),
+            )
+
+            mock_prisma.db.litellm_auditlog.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_env_opt_out_blocks_the_db_write(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_STORE_AUDIT_LOGS", "false")
+
+        with (
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma,
+        ):
+            mock_prisma.db.litellm_auditlog.create = AsyncMock()
+
+            await create_audit_log_for_update(_make_audit_log())
+
+            mock_prisma.db.litellm_auditlog.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_env_opt_out_blocks_create_object_audit_log(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_STORE_AUDIT_LOGS", "false")
+
+        with (
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma,
+        ):
+            mock_prisma.db.litellm_auditlog.create = AsyncMock()
+
+            await create_object_audit_log(
+                object_id="team-456",
+                action="created",
+                litellm_changed_by=None,
+                user_api_key_dict=UserAPIKeyAuth(user_id="user-123"),
+                litellm_proxy_admin_name="default_user_id",
+                table_name=LitellmTableNames.TEAM_TABLE_NAME,
+                after_value=json.dumps({"name": "new-team"}),
+            )
+
+            mock_prisma.db.litellm_auditlog.create.assert_not_called()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Audit logging was off unless an admin opted in, so a fresh proxy recorded nothing about who created keys, changed teams, or edited proxy settings, which is exactly the trail people go looking for after an incident
- `LITELLM_STORE_AUDIT_LOGS` was folded in with `litellm.store_audit_logs or get_secret_bool(...)`, an expression that can only ever enable. Flipping the default would have short-circuited it into a dead no-op

How it solves it:

- `litellm.store_audit_logs` now defaults to `True`, so audit rows are written out of the box with no config
- `store_audit_logs_enabled()` replaces the duplicated `or` at both gates in `management_helpers/audit_logs.py` and gives the setting a real precedence chain: `LITELLM_STORE_AUDIT_LOGS` when it parses as a boolean, then an explicitly supplied config value, then the module attribute
- The `audit_log_callbacks` startup warning now reads through the same resolver, so it stops claiming callbacks are initialized when the env var has turned auditing off
- `/user/bulk_update` with `all_users` passed a plain sentence into `before_value`, which is a pydantic `Json` field, so its audit payload could never validate and the row was never written. Turning the feature on by default would have made that broken emitter fire on every licensed proxy, so it is fixed here

## Relevant issues

## Linear ticket

Resolves LIT-5764

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two proxies on the same Postgres, one at the merge base and one at this branch, both on a config with no `store_audit_logs` key at all. Each tree was verified before launch:

```
BASE   litellm /Users/.../lit5764_base/litellm/__init__.py   DEFAULT_store_audit_logs False   HAS_FIX False
HEAD   litellm /Users/.../lit5764/litellm/__init__.py        DEFAULT_store_audit_logs True    HAS_FIX True
```

### Before, on the merge base

```shell
curl -sS -X POST http://127.0.0.1:20765/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"key_alias":"audit-demo-base","models":["gemini-flash"]}'
```
```
{'key_alias': 'audit-demo-base', 'token_id': 'cf5c20240ee73689b83880bcb16931df21c2d67a5ae24c6d1125441d90d03d61'}
```
```shell
curl -sS http://127.0.0.1:20765/audit -H "Authorization: Bearer sk-1234"
```
```json
{"audit_logs": [], "total": 0, "page": 1, "page_size": 10, "total_pages": 0}
```

### After, on this branch, same config

```shell
curl -sS -X POST http://127.0.0.1:20764/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"key_alias":"audit-demo-head","models":["gemini-flash"]}'

curl -sS http://127.0.0.1:20764/audit -H "Authorization: Bearer sk-1234"
```
```json
{
    "audit_logs": [
        {
            "id": "9f48cb2b-3bb3-4f49-b2c7-6f847b3fe32c",
            "updated_at": "2026-08-18T22:59:56.044000Z",
            "changed_by": "default_user_id",
            "changed_by_api_key": "litellm_proxy_master_key",
            "action": "created",
            "table_name": "LiteLLM_VerificationToken",
            "object_id": "b583ad766ac6de41c87d76a6499e4a81bbb9b420615e9572dfffdfe0ea118e17",
            "before_value": null,
            "updated_values": {
                "key": "sk-q*****************NpOg",
                "models": ["gemini-flash"],
                "key_alias": "audi*******head",
                "created_by": "default_user_id"
            }
        }
    ],
    "total": 1
}
```

### Opt-out via config

`litellm_settings: {store_audit_logs: false}`, then create a key:

```
audit rows before: 113
created key_alias = optout-config-demo
audit rows after:  113   (delta 0)
```

### Opt-out via env var

`LITELLM_STORE_AUDIT_LOGS=false` with no `litellm_settings` block, then create a key and a user:

```
audit rows before: 113
created key_alias = optout-env-demo
created user = edcec723
audit rows after:  113   (delta 0)
```

### The env var now wins over the config file

Same config on both sides (`store_audit_logs: true`) with `LITELLM_STORE_AUDIT_LOGS=false`:

```
BASE   rows 0 -> 1     env false is ignored, the row is still written
HEAD   rows 113 -> 113 env opt-out wins
```

### Admin UI, Logs -> Audit Logs

Same flow driven end to end against both trees on their own empty database, with a real Gemini call through the proxy first to show it is live. Team create, user create, key create on that team, team update, key delete, in that order, on a config with no `store_audit_logs` key.

Merge base, five mutations, nothing recorded:

![Audit Logs on the merge base](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr37396/before-audit-logs-base.png)

This branch, same five mutations, one row per audited object. The two extra `Users updated` rows above them are the dashboard logins themselves, which are also management mutations:

![Audit Logs on this branch](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr37396/after-audit-logs-head.png)

```
BASE   GET /audit  total = 0
HEAD   GET /audit  total = 5
  LiteLLM_TeamTable                created  x1
  LiteLLM_TeamTable                updated  x1
  LiteLLM_UserTable                created  x1
  LiteLLM_VerificationToken        created  x1
  LiteLLM_VerificationToken        deleted  x1
```

The `LiteLLM_TeamTable updated` row is the one that goes through `update_team`'s inline await, and that request returned 200

## Behavior changes

Audit rows are written with no configuration on any proxy carrying an enterprise license. `create_audit_log_for_update` still returns early on `premium_user is not True` and every write funnels through it, so nothing changes for a proxy without a license.

`LITELLM_STORE_AUDIT_LOGS=false` now disables audit logging even when `litellm_settings.store_audit_logs` is `true`. Previously the two were OR'd, so the config value won and the env var could only ever enable. This is the one backward incompatible case, shown in the last evidence block above, and it is the price of the env var being an opt-out at all once the default is on. An unrecognized value such as `1` or `yes` still parses to `None` and falls through to the config value, unchanged from before.

The startup warning for `audit_log_callbacks` now fires when audit logging is disabled by either source rather than only when the config key is missing or false. Its wording changed to match.

This alters an existing default, so it wants a breaking-change entry in the release note it ships in.

## Cost of turning it on

Measured on a live proxy against real Postgres with `log_statement='all'`. An identical workload of five `POST /user/new` plus five `POST /key/generate` produced 103 statements at the base and 114 on this branch, of which exactly 10 are `INSERT INTO "LiteLLM_AuditLog"`, so the change is one extra INSERT per audited management mutation and nothing else. With `log_min_duration_statement=0` that INSERT costs a median of 0.08ms and a mean of 0.35ms of Postgres time over 31 samples, with a 6.57ms worst case.

That is one INSERT per audited object rather than per request, so a batch endpoint emits one per object: `/team/member_add` writes one for the membership change plus one per user row it creates, and the delete endpoints write one per object in the batch.

All but two of the audit call sites dispatch through `asyncio.create_task`, so the write sits off the HTTP response path, though the task still shares the request's event loop and is not free. The two that await inline are `POST /team/update`, which awaits the payload build, and `POST /team/member_add`, which awaits the INSERTs themselves. End to end request latency is below the measurement floor of a dev machine: an A/A null control of two base proxies interleaved with rotating start order spread 2 to 5 percent, against an effect of roughly 0.1ms on a request that takes 55 to 350ms, so no latency figure is quoted here.

The rig had no secret manager configured. `store_audit_logs_enabled()` reads `LITELLM_STORE_AUDIT_LOGS` through `get_secret_bool`, so a deployment that points `_key_management_system` at Vault or AWS Secrets Manager pays a lookup there instead of an env read. That is unchanged from before: the previous expression was `litellm.store_audit_logs or get_secret_bool(...)`, which for the default-off case that everyone was on already evaluated the right-hand side on every management mutation.

The cost that does accumulate is storage. Audit rows run about 1.9 KB each including index overhead, `LiteLLM_AuditLog` has no retention or pruning, and its only index is the `id` primary key while `GET /audit` filters and sorts on `changed_by`, `changed_by_api_key`, `action`, `table_name`, `object_id` and `updated_at`. So the table grows monotonically with management-API traffic and the Audit Logs page degrades to sequential scans as it does. Operators who do not want that can opt out with `store_audit_logs: false` or the env var; indexes and a retention story are worth a follow-up.

## Type

🆕 New Feature

## Changes

`litellm/__init__.py` flips the default and annotates it `bool`.

`litellm/proxy/management_helpers/audit_logs.py` gains `store_audit_logs_enabled()` and both gates call it instead of repeating `litellm.store_audit_logs or get_secret_bool("LITELLM_STORE_AUDIT_LOGS")`. The `get_secret_bool` import moves to module scope since it is no longer conditional. The optional `config_override` argument exists because the startup path has to read the raw `litellm_settings` dict: `store_audit_logs` is applied by the generic `setattr` tail of that loop, so when `audit_log_callbacks` sorts first in the YAML the module attribute has not been assigned yet.

`litellm/proxy/proxy_server.py` routes the `audit_log_callbacks` warning through the resolver.

`tests/test_litellm/proxy/management_helpers/test_audit_log_callbacks.py` adds seven precedence cases and four end-to-end cases covering the default-on write and the env opt-out through both `create_audit_log_for_update` and `create_object_audit_log`.

`tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py` pins the setting off for that file. Those tests drive the endpoints with `MagicMock` team rows whose `.json()` is a mock, which cannot be serialized into a `LiteLLM_AuditLogs` payload; with the default on, 28 of them started failing on payload construction rather than on anything they assert. Audit behavior itself is covered by the mapped test file above.

`litellm/proxy/management_endpoints/internal_user_endpoints.py` drops the `before_value` argument from the `/user/bulk_update` all-users audit entry. The all-users path never captures prior state, and the sentence it passed instead could not validate as `Json`, so the entry raised inside its own task and no row was ever written. `tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py` covers it.

Docs ride in [litellm-docs](https://github.com/BerriAI/litellm-docs) and can merge in either order, since `LITELLM_STORE_AUDIT_LOGS` already had a `config_settings.md` row.

## Known gaps, not addressed here

Around fifteen call sites still read `litellm.store_audit_logs` directly as an early exit before building a payload, rather than going through the resolver. The config opt-out sets that attribute, so `store_audit_logs: false` skips the work as well as the write. The env opt-out does not, so with `LITELLM_STORE_AUDIT_LOGS=false` those sites still build payloads that the authoritative gate then discards, and `/team/delete` still issues one extra `find_unique` per team. No row is written either way, so this is wasted work rather than a behavior difference.

`LiteLLM_AuditLogs.mask_api_keys` builds its masker with `sensitive_patterns={"key"}`, which overrides the default set that also covers `password`, `secret`, `token`, `credential` and `auth`. Audit rows persist full before and after row snapshots, so fields such as `client_secret` and `aws_session_token` land in `LiteLLM_AuditLog` unmasked. That is pre-existing for anyone who had the feature on, and `/audit` is reachable only from the admin viewer routes, but this PR makes it the out-of-the-box behavior and it deserves its own fix.

`update_team` awaits its audit payload build inside the `try` that converts any exception into a 500, so a payload that fails to serialize would fail a team update that has already committed. Driving the helper with a realistic `LiteLLM_TeamTable` including nested metadata, callback vars and datetimes did not reproduce it, because `json.dumps(..., default=str)` absorbs every non-JSON leaf, so it is left alone here and covered by a test that asserts the realistic path returns normally and writes exactly one row.

## QA runbook

Start a proxy with a license and a config containing no `store_audit_logs` key, create a key, and confirm `GET /audit` returns the row. Restart with `litellm_settings.store_audit_logs: false` and confirm a key create adds nothing. Restart with `LITELLM_STORE_AUDIT_LOGS=false` and no `litellm_settings` block and confirm the same. Set both `store_audit_logs: true` and `LITELLM_STORE_AUDIT_LOGS=false` and confirm nothing is written.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
