### PR TITLE
fix(mcp): serve token-forwarding servers when oauth discovery fails

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -1341,7 +1341,7 @@ async def _persist_dcr_client_registration(
     ``update_mcp_server`` merges credential blobs: a re-registered public client must not
     inherit the previous client's secret or auth method.
     """
-    if mcp_server.is_true_passthrough or mcp_server.is_oauth_delegate:
+    if mcp_server.is_client_forwarded_token:
         return "skipped"
 
     try:
@@ -2187,7 +2187,7 @@ async def _build_oauth_protected_resource_response(
             )
 
         if upstream_metadata is not None:
-            if mcp_server.is_true_passthrough or mcp_server.is_oauth_delegate:
+            if mcp_server.is_client_forwarded_token:
                 return upstream_metadata
             return {**upstream_metadata, "resource": resource_url}
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1740,12 +1740,14 @@ class MCPServerManager:
             server: The MCP server whose OAuth metadata must be resolved.
 
         Returns:
-            The resolved server, or the registered server when no discovery is
-            pending.
+            The resolved server; the registered server when no discovery is
+            pending, or when discovery failed for a client-forwarded-token
+            server, whose session consumes no discovered endpoint.
 
         Raises:
             HTTPException: Status 503 when discovery times out or returns
-                incomplete metadata.
+                incomplete metadata for a server whose OAuth flow the gateway
+                runs itself.
         """
         acquisition: Final = self._get_or_start_oauth_discovery_task(server)
         if acquisition is None:
@@ -1764,6 +1766,8 @@ class MCPServerManager:
                 return await self.ensure_oauth_metadata_discovered(server)
             case _OAuthDiscoveryFailed(timed_out=timed_out):
                 current: Final = self._registered_server(server)
+                if current.is_client_forwarded_token:
+                    return current
                 server_ref: Final = current.alias or current.server_name or current.name or current.server_id
                 reason: Final = "timed out" if timed_out else "returned incomplete metadata"
                 raise HTTPException(
@@ -5249,7 +5253,7 @@ class MCPServerManager:
                     user_api_key_auth=user_api_key_auth,
                 ):
                     extra_headers = _without_authorization(extra_headers)
-        elif mcp_server.is_true_passthrough or mcp_server.is_oauth_delegate:
+        elif mcp_server.is_client_forwarded_token:
             extra_headers = _client_forwarded_authorization_headers(
                 mcp_server=mcp_server,
                 oauth2_headers=oauth2_headers,
@@ -5356,7 +5360,7 @@ class MCPServerManager:
             # Scoped to the two client-forwarded token modes this stack introduced; legacy
             # oauth2 + delegate_auth_to_upstream (is_oauth_passthrough) is being removed, so it is not
             # added here even though the list path still relays for it.
-            relays_upstream_auth: Final = mcp_server.is_true_passthrough or mcp_server.is_oauth_delegate
+            relays_upstream_auth: Final = mcp_server.is_client_forwarded_token
             server_label: Final = mcp_server.name or mcp_server.server_name or mcp_server.alias or ""
 
             async def _call_tool_via_client(client, params):

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1704,7 +1704,7 @@ if MCP_AVAILABLE:
             )
 
         extra_headers: dict[str, str] | None = None
-        is_client_forwarded_mode: Final = server.is_true_passthrough or server.is_oauth_delegate
+        is_client_forwarded_mode: Final = server.is_client_forwarded_token
         # In a multi-server listing scope the request-wide Authorization can only carry one token,
         # so it is withheld from a client-forwarded server when another server in scope also consumes
         # it (RFC 9700 cross-resource replay); such scopes must bind per-server via

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -225,13 +225,21 @@ class MCPServer(BaseModel):
         return self.auth_type == MCPAuth.oauth_delegate
 
     @property
+    def is_client_forwarded_token(self) -> bool:
+        """True for the two modes whose upstream credential is the caller's own bearer, forwarded
+        unchanged: the gateway mints nothing for them and holds no OAuth client identity, so a
+        discovered ``authorization_url`` / ``token_url`` enriches only the gateway's own OAuth front
+        door and is never a precondition for opening a session."""
+        return self.is_true_passthrough or self.is_oauth_delegate
+
+    @property
     def is_dcr_bridge(self) -> bool:
         """True when this client-forwarded-token server serves the gateway-hosted DCR front door
         (gateway-self protected-resource and authorization-server metadata plus the register,
         authorize, and token relays) instead of relaying the upstream's own OAuth discovery
         verbatim. ``dcr_bridge`` is rejected on every other auth type at create, update, and
         config load, so the mode gate here only defends rows edited outside those paths."""
-        return bool(self.dcr_bridge) and (self.is_true_passthrough or self.is_oauth_delegate)
+        return bool(self.dcr_bridge) and self.is_client_forwarded_token
 
     @property
     def requires_per_user_auth(self) -> bool:
@@ -248,7 +256,7 @@ class MCPServer(BaseModel):
         if self.needs_user_oauth_token:
             return True
 
-        if self.is_true_passthrough or self.is_oauth_delegate:
+        if self.is_client_forwarded_token:
             return True
 
         # PAT passthrough: auth_type is none but extra_headers includes auth headers

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -10457,3 +10457,142 @@ class TestSessionResourceScopeIntersect:
         ):
             fallback = await manager.get_allowed_mcp_servers(auth)
         assert fallback == ["granted-id"]
+
+
+class TestClientForwardedDiscoveryFailureIsNotFatal:
+    """A failed OAuth metadata discovery may only brick the flows the gateway runs itself.
+
+    ``true_passthrough`` / ``oauth_delegate`` forward the caller's own bearer and mint nothing, so an
+    upstream that publishes no RFC 9728 metadata (an internal API, or any IdP unreachable from the
+    pod) must still serve sessions instead of 503-ing before the upstream is ever contacted.
+    """
+
+    @staticmethod
+    def _config(auth_type: MCPAuthType, dcr_bridge: bool | None) -> dict[str, dict[str, object]]:
+        entry: Final[dict[str, object]] = {
+            "url": "https://up.example.com/mcp",
+            "transport": MCPTransport.http,
+            "auth_type": auth_type,
+            **({"oauth2_flow": "authorization_code"} if auth_type == MCPAuth.oauth2 else {}),
+            **({"dcr_bridge": dcr_bridge} if dcr_bridge is not None else {}),
+        }
+        return {"upstream": entry}
+
+    async def _registered(self, manager: MCPServerManager, auth_type: MCPAuthType, dcr_bridge: bool | None):
+        with (
+            patch.object(manager, "_discover_oauth_metadata_for_server", new=AsyncMock(return_value=None)),
+            patch.object(manager, "initialize_tool_name_to_mcp_server_name_mapping"),
+        ):
+            await manager.load_servers_from_config(self._config(auth_type, dcr_bridge))
+        return next(iter(manager.config_mcp_servers.values()))
+
+    @pytest.mark.parametrize(
+        "auth_type, dcr_bridge, serves_without_endpoints",
+        [
+            (MCPAuth.true_passthrough, None, True),
+            (MCPAuth.true_passthrough, True, True),
+            (MCPAuth.oauth_delegate, None, True),
+            (MCPAuth.oauth_delegate, True, True),
+            (MCPAuth.oauth2, None, False),
+            (MCPAuth.oauth2_token_exchange, None, False),
+        ],
+    )
+    @pytest.mark.parametrize("failure", ["incomplete", "timed_out"])
+    @pytest.mark.asyncio
+    async def test_discovery_failure_blocks_only_gateway_run_flows(
+        self,
+        auth_type: MCPAuthType,
+        dcr_bridge: bool | None,
+        serves_without_endpoints: bool,
+        failure: str,
+    ):
+        manager = MCPServerManager()
+        server = await self._registered(manager, auth_type, dcr_bridge)
+        manager._set_oauth_discovery_deferred(server.server_id, True)
+
+        async def never_returns(_server):
+            await asyncio.Future()
+
+        discovery_patch: Final = (
+            {"new": AsyncMock(return_value=None)} if failure == "incomplete" else {"side_effect": never_returns}
+        )
+        with (
+            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.MCP_METADATA_TIMEOUT", 0.01),
+            patch.object(manager, "_discover_oauth_metadata_for_server", **discovery_patch),
+        ):
+            if not serves_without_endpoints:
+                with pytest.raises(HTTPException) as exc:
+                    await manager.ensure_oauth_metadata_discovered(server)
+                assert exc.value.status_code == 503
+                return
+
+            resolved = await manager.ensure_oauth_metadata_discovered(server)
+
+        assert resolved is manager.config_mcp_servers[server.server_id]
+        assert resolved.authorization_url is None
+        assert resolved.token_url is None
+        assert manager._oauth_discovery_slot(server.server_id) is not None
+
+    @pytest.mark.parametrize(
+        "auth_type, serves_the_listing",
+        [(MCPAuth.true_passthrough, True), (MCPAuth.oauth_delegate, True), (MCPAuth.oauth2, False)],
+    )
+    @pytest.mark.asyncio
+    async def test_listing_leg_serves_a_forwarding_server_whose_discovery_failed(
+        self, auth_type: MCPAuthType, serves_the_listing: bool
+    ):
+        """The listing leg is where the 503 became an empty tool list, so pin the fix there too.
+
+        ``_get_tools_from_server`` is the per-server leg the aggregate absorbs: a failure here is what
+        the fan-out turns into HTTP 200 with ``tools: []``, which is why the outage carried no
+        diagnostic. A forwarding server must now reach its upstream, and a gateway-run flow must still
+        surface the fault rather than be silently listed as empty.
+        """
+        manager = MCPServerManager()
+        server = await self._registered(manager, auth_type, None)
+        manager._set_oauth_discovery_deferred(server.server_id, True)
+        manager._fetch_tools_with_timeout = AsyncMock(
+            return_value=[MCPTool(name="list_reports", description="d", inputSchema={"type": "object"})]
+        )
+
+        with patch.object(manager, "_discover_oauth_metadata_for_server", new=AsyncMock(return_value=None)):
+            if not serves_the_listing:
+                with pytest.raises(MCPServerListError):
+                    await manager._get_tools_from_server(server=server)
+                return
+            tools = await manager._get_tools_from_server(server=server)
+
+        assert [tool.name for tool in tools] == ["upstream-list_reports"]
+        manager._fetch_tools_with_timeout.assert_awaited_once()
+
+    @pytest.mark.parametrize("auth_type", [MCPAuth.true_passthrough, MCPAuth.oauth_delegate])
+    @pytest.mark.asyncio
+    async def test_client_forwarded_servers_keep_discovering_their_front_door_endpoints(
+        self, auth_type: MCPAuthType
+    ):
+        """Exempting these modes from the FAILURE must not exempt them from discovery itself.
+
+        ``/authorize``, ``/token`` and ``/register`` read the discovered endpoints for these servers
+        (``_resolve_ephemeral_dcr_client`` mints for ``true_passthrough`` whatever ``dcr_bridge``
+        says), so an exemption written into the unresolved-endpoints predicate would disarm the slot
+        and silently drop a working front door.
+        """
+        manager = MCPServerManager()
+        metadata: Final = MCPOAuthMetadata(
+            authorization_url="https://idp.example.com/authorize",
+            token_url="https://idp.example.com/token",
+            registration_url="https://idp.example.com/register",
+        )
+        with (
+            patch.object(manager, "_discover_oauth_metadata_for_server", new=AsyncMock(return_value=metadata)),
+            patch.object(manager, "initialize_tool_name_to_mcp_server_name_mapping"),
+        ):
+            await manager.load_servers_from_config(self._config(auth_type, None))
+            server = next(iter(manager.config_mcp_servers.values()))
+            resolved = await manager.ensure_oauth_metadata_discovered(server)
+
+        assert resolved.authorization_url == "https://idp.example.com/authorize"
+        assert resolved.token_url == "https://idp.example.com/token"
+        assert resolved.registration_url == "https://idp.example.com/register"
+        assert manager.config_mcp_servers[server.server_id].authorization_url == "https://idp.example.com/authorize"
+        assert manager._oauth_discovery_slot(server.server_id) is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Token forwarding MCP servers 503 when upstream OAuth discovery fails
- Clients get HTTP 200 with an empty tool list, no error
- Internal APIs publish no OAuth metadata, so they never work

How it solves it:

- Discovery failure now blocks only gateway run OAuth flows
- Forwarded token servers open sessions with no discovered endpoints
- Discovery still runs, so the OAuth front door keeps its endpoints

## User Flow

Before: a developer reaching a corporate MCP server through the gateway, sending their own upstream token, gets an empty tool list and no reason for it

1. Their admin registers the corporate server on the gateway in token forwarding mode, so the caller's own bearer is what that server sees
2. The developer sends POST https://litellm-domain/mcp/ with `x-litellm-api-key` for admission and `Authorization: Bearer <their own upstream token>`, asking for the tool list
3. The response is HTTP 200 with `"tools": []`, and the corporate server's own request log shows it was never contacted
4. Narrowing the same request to that one server with `x-mcp-servers` returns HTTP 503 `OAuth metadata discovery returned incomplete metadata for MCP server '<name>'`
5. Every retry repeats it, because the gateway's network cannot reach the identity provider's discovery documents, and an internal API publishes none at all
6. Opening https://litellm-domain/<server>/authorize returns that same 503, so nothing says which setting is missing

After: the same request returns the server's tools, and the tool call reaches that server carrying the developer's own token

1. Same registration
2. Same POST with the same two headers
3. The tool list now names the corporate server's tools
4. A tool call returns real data, and the corporate server's request log shows the developer's own bearer on the request
5. A wrong or missing token still fails: the corporate server rejects it and the developer sees the upstream 401
6. https://litellm-domain/<server>/authorize now answers HTTP 400 naming the missing authorization url and how to set it

## Relevant issues

- MCP servers that forward the caller's own bearer no longer 503 when upstream OAuth discovery comes back empty
- Discovery still runs for those servers, so the gateway's own authorize, token, and register endpoints keep resolving their endpoints
- Interactive `oauth2` and token exchange servers are untouched and still fail closed

`true_passthrough` and `oauth_delegate` mint nothing; the credential they send upstream is the caller's own bearer, and the adapter maps both onto a `PassthroughConfig` that carries no endpoint at all. The completeness gate still treated them like interactive `oauth2`, so a server stayed unresolved until discovery produced both an `authorization_url` and a `token_url`, and `ensure_oauth_metadata_discovered` raised 503 from the first statement of every client build, before the upstream was ever contacted. The single server route surfaced that 503 while the fan out swallowed it into HTTP 200 with an empty list, which is why this reads as "the tool list is just empty" with nothing in between

The endpoints are not useless for these modes, which is why the exemption is not written into the unresolved check itself. The gateway's own `/authorize`, `/token` and `/register` read them, and `_resolve_ephemeral_dcr_client` mints for `true_passthrough` whatever `dcr_bridge` says. Marking these servers resolved would disarm the discovery slot and silently drop a front door that works today, so the split is by consequence instead: discovery keeps running and a failure is fatal only where the gateway runs the flow itself. Every front door site already had its own `is None` check and returns a 400 that names the missing setting, which is a better error than the 503 it replaces

`MCPServer.is_client_forwarded_token` now owns the mode pair. Five call sites spelled `is_true_passthrough or is_oauth_delegate` inline, one of them already calling the result `is_client_forwarded_mode`

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical on both legs. One proxy on `:4611` against real Postgres, plus two real streamable HTTP MCP upstreams that each require `Authorization: Bearer upstream-ok`. Port 9101 publishes no OAuth metadata at all, every `/.well-known/` path 404s, which is what an internal API or an egress blocked endpoint looks like from the gateway. Port 9102 publishes proper RFC 9728 and RFC 8414 documents, and is there to prove discovery still enriches a forwarding server when it can reach one

```yaml
mcp_servers:
  pbi_pass:     { url: http://127.0.0.1:9101/mcp, transport: http, auth_type: true_passthrough }
  pbi_delegate: { url: http://127.0.0.1:9101/mcp, transport: http, auth_type: oauth_delegate }
  pbi_bridge:   { url: http://127.0.0.1:9101/mcp, transport: http, auth_type: true_passthrough, dcr_bridge: true }
  pbi_oauth2:   { url: http://127.0.0.1:9101/mcp, transport: http, auth_type: oauth2, oauth2_flow: authorization_code, client_id: rig-client, client_secret: rig-secret }
  pbi_meta:     { url: http://127.0.0.1:9102/mcp, transport: http, auth_type: true_passthrough }
```

Both legs run the same script, `evidence.sh`, whose six numbered steps are the six numbered blocks below. Every request carries `x-litellm-api-key: Bearer sk-1234` for admission and `Authorization: Bearer upstream-ok` as the forwarded upstream token

### Before (55777d0e80)

```
1. tools/list, scoped to one server with x-mcp-servers
   pbi_pass      HTTP 503  {"detail": "OAuth metadata discovery returned incomplete metadata for MCP server 'pbi_pass'"}
   pbi_delegate  HTTP 503  {"detail": "OAuth metadata discovery returned incomplete metadata for MCP server 'pbi_delegate'"}
   pbi_bridge    HTTP 503  {"detail": "OAuth metadata discovery returned incomplete metadata for MCP server 'pbi_bridge'"}
   pbi_oauth2    HTTP 503  {"detail": "OAuth metadata discovery returned incomplete metadata for MCP server 'pbi_oauth2'"}
   pbi_meta      HTTP 200  {"pbi_meta": {"status": "ok", "tool_count": 1}}  tools=['pbi_meta-list_dashboards']

2. tools/call on the passthrough server, carrying the caller's own upstream token
{"detail":"OAuth metadata discovery returned incomplete metadata for MCP server 'pbi_pass'"}  [HTTP 503]

3. same tool call with a WRONG upstream token, which must not return data
{"detail":"OAuth metadata discovery returned incomplete metadata for MCP server 'pbi_pass'"}  [HTTP 503]

4. OAuth endpoints the gateway resolved for each server
   pbi_pass      auth_type=true_passthrough  dcr_bridge=None  authorization_url=None
   pbi_delegate  auth_type=oauth_delegate    dcr_bridge=None  authorization_url=None
   pbi_bridge    auth_type=true_passthrough  dcr_bridge=True  authorization_url=None
   pbi_oauth2    auth_type=oauth2            dcr_bridge=None  authorization_url=None
   pbi_meta      auth_type=true_passthrough  dcr_bridge=None  authorization_url=http://127.0.0.1:9102/oauth/authorize

5. gateway OAuth front door for a passthrough server whose upstream publishes nothing
   {"detail":"OAuth metadata discovery returned incomplete metadata for MCP server 'pbi_pass'"}  [HTTP 503]

6. what the upstream on :9101 actually received during this leg
```

Step 6 printed nothing because the upstream received zero requests during the whole leg: the gateway never got as far as contacting it

### After (951265c18d)

```
1. tools/list, scoped to one server with x-mcp-servers
   pbi_pass      HTTP 200  {"pbi_pass": {"status": "ok", "tool_count": 1}}  tools=['pbi_pass-list_reports']
   pbi_delegate  HTTP 200  {"pbi_delegate": {"status": "ok", "tool_count": 1}}  tools=['pbi_delegate-list_reports']
   pbi_bridge    HTTP 200  {"pbi_bridge": {"status": "ok", "tool_count": 1}}  tools=['pbi_bridge-list_reports']
   pbi_oauth2    HTTP 503  {"detail": "OAuth metadata discovery returned incomplete metadata for MCP server 'pbi_oauth2'"}
   pbi_meta      HTTP 200  {"pbi_meta": {"status": "ok", "tool_count": 1}}  tools=['pbi_meta-list_dashboards']

2. tools/call on the passthrough server, carrying the caller's own upstream token
   {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"reports for finance: [Sales, Ops]"}],"structuredContent":{"result":"reports for finance: [Sales, Ops]"},"isError":false}}  [HTTP 200]

3. same tool call with a WRONG upstream token, which must not return data
   {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"Error: upstream authentication required (HTTP 401)"}],"isError":true}}  [HTTP 200]

4. OAuth endpoints the gateway resolved for each server
   pbi_pass      auth_type=true_passthrough  dcr_bridge=None  authorization_url=None
   pbi_delegate  auth_type=oauth_delegate    dcr_bridge=None  authorization_url=None
   pbi_bridge    auth_type=true_passthrough  dcr_bridge=True  authorization_url=None
   pbi_oauth2    auth_type=oauth2            dcr_bridge=None  authorization_url=None
   pbi_meta      auth_type=true_passthrough  dcr_bridge=None  authorization_url=http://127.0.0.1:9102/oauth/authorize

5. gateway OAuth front door for a passthrough server whose upstream publishes nothing
   {"detail":"MCP server authorization url is not configured. OAuth endpoint discovery against the configured server url did not resolve it; the url may be misconfigured. Check the proxy logs for 'MCP OAuth' warnings from server load, verify the server url, or set Authorization URL and Token URL manual


6. what the upstream on :9101 actually received during this leg
    13 {"path": "/mcp", "method": "POST", "authorization": "Bearer upstream-ok"}
     1 {"path": "/mcp", "method": "POST", "authorization": "Bearer wrong-token"}
```

A regression test drives the listing leg itself, `_get_tools_from_server`, since that is where the 503 became an empty list: a forwarding server now returns its tools from there while a gateway-run flow still raises rather than being listed as empty

`pbi_oauth2` still 503s in step 1, which is the gate staying closed for a flow the gateway runs itself. `pbi_meta` keeps its discovered `authorization_url` in step 4, which is the enrichment that would have been lost had the exemption gone into the unresolved check. Step 3 shows a wrong token still failing against the upstream, so nothing fails open

## Type

🐛 Bug Fix

## Caveats (if any)

- Unresolved endpoints now surface as 400 at `/authorize`, replacing the 503
- A listing spanning two forwarding servers still withholds their shared `Authorization`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 951265c18de9a9b5b3529ad8aab1e047baf83c40. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->