### PR TITLE
fix(ui): stop truncating the test connection error toast

### DIFF
--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -302,7 +302,28 @@ describe("ModelInfoView", () => {
     await user.click(testButton);
 
     await waitFor(() => {
-      expect(mockToast.error).toHaveBeenCalled();
+      expect(mockToast.fromError).toHaveBeenCalled();
+    });
+  });
+
+  it("should not truncate the connection test error message", async () => {
+    // Regression test: the error toast used to cut the message to 100 chars
+    // via truncateString, hiding the actual provider error from the user.
+    const user = userEvent.setup();
+    const longMessage = "Bedrock_mantleException - " + "x".repeat(150);
+    mockTestConnectionRequest.mockRejectedValue(new Error(longMessage));
+
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Model Settings")).toBeInTheDocument();
+    });
+
+    const testButton = screen.getByRole("button", { name: /test connection/i });
+    await user.click(testButton);
+
+    await waitFor(() => {
+      expect(mockToast.fromError).toHaveBeenCalledWith(expect.stringContaining(longMessage));
     });
   });
 

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -14,7 +14,6 @@ import { ArrowLeft, CheckIcon, CopyIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { copyToClipboard as utilCopyToClipboard } from "../utils/dataUtils";
 import { stripMaskedSecrets } from "../utils/maskedSecretUtils";
-import { truncateString } from "../utils/textUtils";
 import AutoRouterConnectionTest from "./add_model/auto_router_connection_test";
 import { AutoRouterTestTarget, buildAutoRouterTestTargets } from "./add_model/build_auto_router_test_targets";
 import { normalizeTierModels, resolveComplexityDefaultModel } from "./add_model/complexity_router_tiers";
@@ -530,11 +529,7 @@ export default function ModelInfoView({
         throw new Error(response?.result?.error || response?.message || "Unknown error");
       }
     } catch (error) {
-      if (error instanceof Error) {
-        toast.error("Error testing connection: " + truncateString(error.message, 100));
-      } else {
-        toast.error("Error testing connection: " + String(error));
-      }
+      toast.fromError("Error testing connection: " + (error instanceof Error ? error.message : String(error)));
     }
   };
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Test Connection error toast on the model settings page cut errors to 100 characters
- A provider error like Bedrock's access_denied payload showed only its first two words

How it solves it:

- Route the caught error through `toast.fromError`, the app's existing helper for full error text with a derived title, instead of a manual `truncateString(..., 100)` call

## User Flow

Before: an admin configuring a Bedrock model can't tell why the connection test failed because the error is cut off

1. They open http://localhost:4000/ui/?page=models, click a model row to open its settings, and click "Test Connection"
2. The connection fails and a toast appears reading `Error testing connection: Bedrock_mantleException - {"error":{"code":"access_denied","message":"Yo...` with no way to see the rest
3. Nothing more legible is written to the LiteLLM log either, so they have no way to diagnose the failure

After: the same admin sees the whole error and can act on it

1. They open http://localhost:4000/ui/?page=models, click the same model row, and click "Test Connection"
2. The connection fails and the toast now shows the full provider error message and code, not just the first 100 characters

## Relevant issues

Fixes #37401

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a two-line UI toast change (the diff is a single `catch` block), so the proof here is the regression test plus the manual repro steps above; a maintainer or reviewer can confirm visually by following the User Flow steps against a real Bedrock deployment with a bad credential.

### Before (f6eaca906926827975dec95e1474769758865c46)

1. Reverted just the source fix (`git checkout f6eaca906926827975dec95e1474769758865c46 -- ui/litellm-dashboard/src/components/model_info_view.tsx`) and ran:
   `npx vitest run src/components/model_info_view.test.tsx -t "should not truncate the connection test error message"`
2. Output:
   ```
   AssertionError: expected "spy" to be called with arguments: [ StringContaining{…} ]
   Number of calls: 0
   Tests  1 failed | 89 skipped (90)
   ```
   (the old code calls `toast.error`, never `toast.fromError`, and truncates the message to 100 chars)

### After (2de065929ccc2c9c76e2910d0d5da06453a9cdbb)

1. Restored the fix and ran the full file:
   `npx vitest run src/components/model_info_view.test.tsx`
2. Output:
   ```
   Test Files  1 passed (1)
   Tests  90 passed (90)
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

- Manual visual confirmation against a real Bedrock deployment (per the User Flow above) is still worth doing before merge; automated coverage is the vitest regression test only

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
