### PR TITLE
fix(health_endpoints): log full error details in test_model_connection (#37401)

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1975,6 +1975,13 @@ async def test_model_connection(
         # Clean the result for display
         cleaned_result: Final = _clean_endpoint_data({**litellm_params, **result}, details=True)
 
+        if "error" in result:
+            verbose_proxy_logger.error(
+                "test_model_connection failure for model '%s': %s",
+                litellm_params.get("model", "unknown"),
+                result["error"],
+            )
+
         return {
             "status": "error" if "error" in result else "success",
             "result": cleaned_result,


### PR DESCRIPTION
# Title
fix(health_endpoints): log full error details in test_model_connection (#37401)

## Description
- Emits detailed error logs in `verbose_proxy_logger.error` during `test_model_connection` failures.
- Ensures backend log files capture the complete underlying exception string (including provider authentication and permission failure payloads) to diagnose issues when frontend UI toast notifications truncate long JSON errors.

Closes #37401
