### PR TITLE
fix(mcp): forward the per-server auth header on OpenAPI tool calls

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -123,6 +123,7 @@ from litellm.proxy._experimental.mcp_server.utils import (
     iter_known_server_prefixes,
     iter_known_tool_name_spellings,
     logging_safe_mcp_headers,
+    lookup_mcp_server_auth_in_headers,
     match_known_server_prefix,
     match_known_tool_name,
     merge_mcp_headers,
@@ -871,6 +872,53 @@ def _openapi_forwarded_extra_headers(
         if value is not None:
             forwarded[header_name] = value
     return forwarded or None
+
+
+def _resolve_openapi_tool_auth(
+    mcp_server: MCPServer,
+    mcp_auth_header: str | None,
+    mcp_server_auth_headers: Mapping[str, str | dict[str, str]] | None,  # mutable-ok: sink shape
+    raw_headers: dict[str, str] | None,  # mutable-ok: sink takes a concrete dict
+    user_api_key_auth: UserAPIKeyAuth | None,
+) -> tuple[str | None, dict[str, str] | None, str | dict[str, str] | None]:  # mutable-ok: sink shapes
+    """The caller's upstream credential for one ``spec_path`` server, for both OpenAPI dispatch arms.
+
+    A per-server ``x-mcp-{alias}-authorization`` wins over the deprecated global / BYOK
+    ``mcp_auth_header``, the same precedence ``_call_regular_mcp_tool`` applies, so the OpenAPI and
+    managed paths cannot disagree about which credential is authoritative. The two kinds are not
+    interchangeable: a per-server value is already a complete header value and is forwarded verbatim,
+    while a BYOK credential is a raw secret that takes the server's auth-type prefix. Formatting the
+    former would ship ``Bearer Bearer <token>``.
+
+    Returns the ``Authorization`` value to inject, the extra headers to forward, and the credential to
+    hand ``resolve_openapi_upstream_auth``, whose passthrough arm reads it via
+    ``_passthrough_token_from_mcp_auth_header``. The per-server Authorization travels only in the
+    credential, never also in the forwarded headers, because the resolver pops Authorization out of
+    those and would otherwise have two sources to reconcile.
+    """
+    forwarded: Final = _openapi_forwarded_extra_headers(mcp_server, raw_headers, user_api_key_auth)
+    per_server: Final = (
+        lookup_mcp_server_auth_in_headers(
+            mcp_server_auth_headers,
+            alias=mcp_server.alias,
+            server_name=mcp_server.server_name,
+        )
+        if mcp_server_auth_headers
+        else None
+    )
+
+    if isinstance(per_server, dict):
+        authorization: Final = next((v for k, v in per_server.items() if k.lower() == "authorization"), None)
+        merged: Final = merge_mcp_headers(extra_headers=forwarded, static_headers=_without_authorization(per_server))
+        if authorization is None:
+            byok: Final = _format_byok_openapi_auth_header(mcp_server, mcp_auth_header) if mcp_auth_header else None
+            return byok, merged, mcp_auth_header
+        return authorization, merged, per_server
+    if isinstance(per_server, str) and per_server:
+        return per_server, forwarded, per_server
+    if mcp_auth_header:
+        return _format_byok_openapi_auth_header(mcp_server, mcp_auth_header), forwarded, mcp_auth_header
+    return None, forwarded, None
 
 
 async def _resolve_byok_mcp_auth_header(
@@ -3193,10 +3241,6 @@ class MCPServerManager:
             # Get server-specific auth header if available
             server_auth_header: str | dict[str, str] | None = None
             if mcp_server_auth_headers:
-                from litellm.proxy._experimental.mcp_server.utils import (
-                    lookup_mcp_server_auth_in_headers,
-                )
-
                 server_auth_header = lookup_mcp_server_auth_in_headers(
                     mcp_server_auth_headers,
                     alias=server.alias,
@@ -5221,11 +5265,6 @@ class MCPServerManager:
         # the exact case of server alias/name (e.g., '1litellmagcgateway' vs '1LiteLLMAGCGateway')
         server_auth_header: dict[str, str] | str | None = None
         if mcp_server_auth_headers:
-            # Normalize keys for case-insensitive lookup
-            from litellm.proxy._experimental.mcp_server.utils import (
-                lookup_mcp_server_auth_in_headers,
-            )
-
             server_auth_header = lookup_mcp_server_auth_in_headers(
                 mcp_server_auth_headers,
                 alias=mcp_server.alias,
@@ -5718,16 +5757,20 @@ class MCPServerManager:
                     server_name,
                 )
 
-            auth_header_value: Final = (
-                _format_byok_openapi_auth_header(mcp_server, mcp_auth_header) if mcp_auth_header else None
+            auth_header_value, openapi_forwarded_headers, upstream_credential = _resolve_openapi_tool_auth(
+                mcp_server=mcp_server,
+                mcp_auth_header=mcp_auth_header,
+                mcp_server_auth_headers=mcp_server_auth_headers,
+                raw_headers=raw_headers,
+                user_api_key_auth=user_api_key_auth,
             )
             resolved_auth_headers, forwarded_headers = await self.resolve_openapi_upstream_auth(
                 mcp_server=mcp_server,
                 oauth2_headers=caller_oauth2_headers,
                 raw_headers=raw_headers,
-                mcp_auth_header=mcp_auth_header,
+                mcp_auth_header=upstream_credential,
                 user_api_key_auth=user_api_key_auth,
-                forwarded_headers=_openapi_forwarded_extra_headers(mcp_server, raw_headers, user_api_key_auth),
+                forwarded_headers=openapi_forwarded_headers,
             )
 
             async def _call_openapi_via_handler():

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -430,6 +430,7 @@ if MCP_AVAILABLE:
         MCPServerManager,
         _caller_authorization_fans_out,
         _client_forwarded_authorization_headers,
+        _resolve_openapi_tool_auth,
         _should_strip_caller_authorization,
         _without_authorization,
         global_mcp_server_manager,
@@ -2835,58 +2836,26 @@ if MCP_AVAILABLE:
                 arguments = hook_result["arguments"]
 
             verbose_logger.debug("Executing local registry tool: %s", name)
-            # For BYOK servers the credential must be injected via a ContextVar
-            # because the tool function has headers baked into its closure.
-            # Pre-format the full Authorization header value using the server's
-            # configured auth_type so the generator doesn't need to know the prefix.
-            auth_header_value: str | None = None
-            if mcp_auth_header:
-                server_auth_type: Final = getattr(mcp_server, "auth_type", None) if mcp_server else None
-                if server_auth_type == MCPAuth.api_key:
-                    auth_header_value = f"ApiKey {mcp_auth_header}"
-                elif server_auth_type == MCPAuth.basic:
-                    auth_header_value = f"Basic {mcp_auth_header}"
-                else:
-                    auth_header_value = f"Bearer {mcp_auth_header}"
-
-            # Forward named client headers to OpenAPI tool upstream requests.
-            # MCPServer.extra_headers lists header names to copy from raw_headers.
-            # The strip decision is centralized in _should_strip_caller_authorization so this
-            # OpenAPI/local path agrees with the managed paths: M2M and the resolver-owned modes
-            # (token_exchange's raw subject token, authorization_code's stored token) must never
-            # have the caller's Authorization forwarded verbatim upstream.
-            forwarded_headers: dict[str, str] | None = None
-            if mcp_server and mcp_server.extra_headers and raw_headers:
-                normalized_raw: Final = {str(k).lower(): v for k, v in raw_headers.items() if isinstance(k, str)}
-                skip_caller_authorization: Final = _should_strip_caller_authorization(
-                    mcp_server=mcp_server,
-                    raw_headers=raw_headers,
-                    user_api_key_auth=user_api_key_auth,
-                )
-                for header_name in mcp_server.extra_headers:
-                    if not isinstance(header_name, str):
-                        continue
-                    if skip_caller_authorization and header_name.lower() == "authorization":
-                        continue
-                    value = normalized_raw.get(header_name.lower())
-                    if value is not None:
-                        if forwarded_headers is None:
-                            forwarded_headers = {}
-                        forwarded_headers[header_name] = value
-
-            resolved_auth_headers: dict[str, str] | None = None
-            if mcp_server:
-                (
-                    resolved_auth_headers,
-                    forwarded_headers,
-                ) = await global_mcp_server_manager.resolve_openapi_upstream_auth(
-                    mcp_server=mcp_server,
-                    oauth2_headers=oauth2_headers,
-                    raw_headers=raw_headers,
-                    mcp_auth_header=mcp_auth_header,
-                    user_api_key_auth=user_api_key_auth,
-                    forwarded_headers=forwarded_headers,
-                )
+            # The credential rides ContextVars because the tool function has its
+            # headers baked into the closure at registration time.
+            auth_header_value, openapi_forwarded_headers, upstream_credential = _resolve_openapi_tool_auth(
+                mcp_server=mcp_server,
+                mcp_auth_header=mcp_auth_header,
+                mcp_server_auth_headers=mcp_server_auth_headers,
+                raw_headers=raw_headers,
+                user_api_key_auth=user_api_key_auth,
+            )
+            (
+                resolved_auth_headers,
+                forwarded_headers,
+            ) = await global_mcp_server_manager.resolve_openapi_upstream_auth(
+                mcp_server=mcp_server,
+                oauth2_headers=oauth2_headers,
+                raw_headers=raw_headers,
+                mcp_auth_header=upstream_credential,
+                user_api_key_auth=user_api_key_auth,
+                forwarded_headers=openapi_forwarded_headers,
+            )
 
             _auth_token: Final = _request_auth_header.set(auth_header_value)
             _extra_token: Final = _request_extra_headers.set(forwarded_headers)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -42,6 +42,7 @@ from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
     _deserialize_json_list,
     _normalize_mcp_server_cost_info,
     _obo_retry_applies,
+    _resolve_openapi_tool_auth,
     _should_strip_caller_authorization,
     _without_authorization,
 )
@@ -10664,3 +10665,103 @@ class TestClientForwardedDiscoveryFailureIsNotFatal:
         assert resolved.registration_url == "https://idp.example.com/register"
         assert manager.config_mcp_servers[server.server_id].authorization_url == "https://idp.example.com/authorize"
         assert manager._oauth_discovery_slot(server.server_id) is None
+
+
+class TestResolveOpenapiToolAuth:
+    """The credential matrix for a ``spec_path`` server's two OpenAPI dispatch arms.
+
+    A per-server ``x-mcp-{alias}-authorization`` is already a complete header value and is forwarded
+    verbatim; a BYOK credential is a raw secret that takes the auth-type prefix. Conflating them
+    ships ``Bearer Bearer <token>``, so every cell pins which of the two a value came from.
+    """
+
+    @staticmethod
+    def _server(auth_type: MCPAuthType = MCPAuth.oauth_delegate) -> MCPServer:
+        return MCPServer(
+            server_id="srv-openapi",
+            name="report_api",
+            server_name="report_api",
+            alias="report_api",
+            url="https://api.internal.example.com",
+            transport=MCPTransport.http,
+            auth_type=auth_type,
+            spec_path="https://api.internal.example.com/openapi.json",
+            extra_headers=["X-Tenant"],
+        )
+
+    @pytest.mark.parametrize(
+        "per_server, byok, expected_auth, expected_extra_keys, expected_credential",
+        [
+            (
+                {"report_api": "Bearer caller-token"},
+                None,
+                "Bearer caller-token",
+                {"X-Tenant"},
+                "Bearer caller-token",
+            ),
+            (
+                {"report_api": {"Authorization": "Bearer caller-token", "X-Trace": "abc"}},
+                None,
+                "Bearer caller-token",
+                {"X-Tenant", "X-Trace"},
+                {"Authorization": "Bearer caller-token", "X-Trace": "abc"},
+            ),
+            (
+                {"report_api": {"X-Api-Key": "k1"}},
+                "byok-secret",
+                "Bearer byok-secret",
+                {"X-Tenant", "X-Api-Key"},
+                "byok-secret",
+            ),
+            ({"report_api": {"X-Api-Key": "k1"}}, None, None, {"X-Tenant", "X-Api-Key"}, None),
+            (None, "byok-secret", "Bearer byok-secret", {"X-Tenant"}, "byok-secret"),
+            (None, None, None, {"X-Tenant"}, None),
+            ({"other_server": "Bearer wrong"}, None, None, {"X-Tenant"}, None),
+        ],
+    )
+    def test_credential_matrix(
+        self,
+        per_server: dict | None,
+        byok: str | None,
+        expected_auth: str | None,
+        expected_extra_keys: set,
+        expected_credential: object,
+    ):
+        auth_value, forwarded, credential = _resolve_openapi_tool_auth(
+            mcp_server=self._server(),
+            mcp_auth_header=byok,
+            mcp_server_auth_headers=per_server,
+            raw_headers={"x-tenant": "acme", "authorization": "Bearer admission-key"},
+            user_api_key_auth=None,
+        )
+
+        assert auth_value == expected_auth
+        assert set(forwarded or {}) == expected_extra_keys
+        assert credential == expected_credential
+
+    def test_per_server_value_is_never_re_prefixed(self):
+        """The regression that a naive wiring produces: the caller already sent ``Bearer <token>``."""
+        auth_value, _, credential = _resolve_openapi_tool_auth(
+            mcp_server=self._server(auth_type=MCPAuth.api_key),
+            mcp_auth_header="byok-secret",
+            mcp_server_auth_headers={"report_api": "Bearer caller-token"},
+            raw_headers=None,
+            user_api_key_auth=None,
+        )
+
+        assert auth_value == "Bearer caller-token"
+        assert credential == "Bearer caller-token"
+        assert not auth_value.startswith("ApiKey ")
+
+    def test_per_server_authorization_is_not_also_left_in_forwarded_headers(self):
+        """``resolve_openapi_upstream_auth`` pops Authorization out of the forwarded headers, so a
+        second copy there would give the passthrough arm two sources to reconcile."""
+        _, forwarded, _ = _resolve_openapi_tool_auth(
+            mcp_server=self._server(),
+            mcp_auth_header=None,
+            mcp_server_auth_headers={"report_api": {"Authorization": "Bearer caller-token"}},
+            raw_headers={"x-tenant": "acme"},
+            user_api_key_auth=None,
+        )
+
+        assert "Authorization" not in (forwarded or {})

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_tool_auth.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_tool_auth.py
@@ -189,9 +189,11 @@ async def test_openapi_local_tool_denied_when_server_not_resolvable():
 
     pre_call = AsyncMock(return_value={})
     handle_local = AsyncMock(return_value=[])
+    resolve_auth = MagicMock()
 
     # `_get_mcp_server_from_tool_name` returns None — no server context.
     with (
+        patch.object(mcp_module, "_resolve_openapi_tool_auth", new=resolve_auth),
         patch.object(
             mcp_module.global_mcp_server_manager,
             "_get_mcp_server_from_tool_name",
@@ -228,6 +230,9 @@ async def test_openapi_local_tool_denied_when_server_not_resolvable():
     assert exc.value.status_code == 503
     pre_call.assert_not_awaited()
     handle_local.assert_not_awaited()
+    # The credential resolver takes a non-optional server, so the 503 guard above it is what keeps
+    # a missing server from ever reaching it. Pinned here so moving the guard reds this test.
+    resolve_auth.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -549,3 +554,101 @@ async def test_unknown_tool_name_still_reports_not_found():
 
     assert exc.value.status_code == 404
     assert "not found" in str(exc.value.detail)
+
+
+OPENAPI_PER_SERVER_TOKEN = "Bearer per-server-upstream-token"
+
+
+def _spec_path_server() -> MCPServer:
+    return MCPServer(
+        server_id="srv-reports",
+        name="report_api",
+        server_name="report_api",
+        alias="report_api",
+        url="https://api.internal.example.com",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth_delegate,
+        spec_path="https://api.internal.example.com/openapi.json",
+    )
+
+
+@pytest.mark.parametrize("dispatch_arm", ["local_registry", "call_tool"])
+@pytest.mark.asyncio
+async def test_per_server_auth_header_reaches_both_openapi_dispatch_arms(dispatch_arm: str):
+    """`x-mcp-{alias}-authorization` must survive on BOTH OpenAPI dispatch arms.
+
+    OpenAPI tools live in the local tool registry, so `execute_mcp_tool` serves MCP-protocol and REST
+    tool calls while `MCPServerManager.call_tool` serves the responses-API handler. Both arms sourced
+    the upstream credential only from the deprecated global / BYOK `mcp_auth_header`, so the
+    per-server header was dropped and the upstream API saw no Authorization at all.
+
+    Asserting on the resolver kwarg as well as the ContextVar is deliberate: for the client-forwarded
+    modes the credential has to reach `resolve_openapi_upstream_auth`, whose passthrough arm outranks
+    the ContextVar when it materializes a header.
+    """
+    from litellm.proxy._experimental.mcp_server import server as mcp_module
+    from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+        _request_auth_header,
+    )
+
+    server = _spec_path_server()
+    auth_headers = {"report_api": {"Authorization": OPENAPI_PER_SERVER_TOKEN}}
+    user = UserAPIKeyAuth(api_key="sk-user", user_id="alice", user_role=LitellmUserRoles.INTERNAL_USER.value)
+    captured: dict = {}
+
+    async def fake_resolver(**kwargs):
+        captured["resolver_credential"] = kwargs["mcp_auth_header"]
+        return None, kwargs["forwarded_headers"]
+
+    async def capture_local(_name, _arguments):
+        captured["injected"] = _request_auth_header.get()
+        return []
+
+    async def capture_openapi_handler(_server, _name, _arguments):
+        captured["injected"] = _request_auth_header.get()
+        return []
+
+    manager = mcp_module.global_mcp_server_manager
+    with (
+        patch.object(manager, "resolve_openapi_upstream_auth", new=fake_resolver),
+        patch.object(manager, "pre_call_tool_check", new=AsyncMock(return_value={})),
+    ):
+        if dispatch_arm == "local_registry":
+            fake_tool = MagicMock()
+            fake_tool.name = "list_reports"
+            with (
+                patch.object(manager, "_get_mcp_server_from_tool_name", return_value=server),
+                patch.object(mcp_module.global_mcp_tool_registry, "get_tool", return_value=fake_tool),
+                patch(
+                    "litellm.proxy._experimental.mcp_server.server._handle_local_mcp_tool",
+                    new=capture_local,
+                ),
+                patch(
+                    "litellm.proxy._experimental.mcp_server.server.MCPRequestHandler.is_tool_allowed",
+                    return_value=True,
+                ),
+            ):
+                await mcp_module.execute_mcp_tool(
+                    name="list_reports",
+                    arguments={},
+                    allowed_mcp_servers=[server],
+                    start_time=datetime.now(timezone.utc),
+                    user_api_key_auth=user,
+                    mcp_server_auth_headers=auth_headers,
+                )
+        else:
+            with (
+                patch.object(manager, "_resolve_mcp_server_for_tool_call", return_value=server),
+                patch.object(manager, "_call_openapi_tool_handler", new=capture_openapi_handler),
+            ):
+                await manager.call_tool(
+                    server_name="report_api",
+                    name="list_reports",
+                    arguments={},
+                    user_api_key_auth=user,
+                    mcp_server_auth_headers=auth_headers,
+                )
+
+    assert captured["resolver_credential"] == {"Authorization": OPENAPI_PER_SERVER_TOKEN}
+    assert captured["injected"] == OPENAPI_PER_SERVER_TOKEN
+    assert _request_auth_header.get() is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- `x-mcp-{alias}-authorization` is dropped on OpenAPI-backed MCP servers
- The internal API receives no Authorization header at all
- The managed MCP path resolves that header correctly, so the two drifted

How it solves it:

- One owner resolves the credential for both OpenAPI dispatch arms
- Per-server values forward verbatim, BYOK values keep their prefix
- The credential now reaches the passthrough resolver, not just a ContextVar

## User Flow

Before: a developer whose internal REST API is exposed through the gateway as an MCP server sends their own API token per server, and every call comes back unauthorized

1. Their admin registers the internal API as an MCP server from its OpenAPI spec, in a token forwarding mode
2. The developer calls a tool through POST https://litellm-domain/mcp/ with `x-litellm-api-key` for admission and `x-mcp-{alias}-authorization: Bearer <their API token>`
3. The call returns HTTP 200 and the tool output is the internal API's own rejection, `{"error":"invalid_token"}`
4. The internal API's access log shows the request arrived with no Authorization header at all, so the token never left the gateway
5. Sending the token as a top-level `Authorization` does work, but that is one token for the whole request, so it cannot address two forwarding servers in one scope

After: the same call reaches the internal API carrying the developer's own token

1. Same registration
2. The developer sends the same call with the same `x-mcp-{alias}-authorization` header
3. The tool returns the real payload from the internal API
4. The internal API's access log shows the request arrived with exactly the token the developer bound to that server, unchanged
5. A wrong token still fails at the internal API, and several forwarding servers can now be addressed in one request, one token each

## Relevant issues

- Per-server `x-mcp-{alias}-authorization` now reaches the upstream on `spec_path` MCP servers
- Both OpenAPI dispatch arms are fixed, and one owner replaces the logic each carried separately
- Top-level `Authorization` and BYOK credentials behave exactly as before

Closes #33344

Supersedes #33349, whose analysis and approach this borrows from, credit to its author. That PR predates `resolve_openapi_upstream_auth` so it no longer applies, and it fixes only the `_request_auth_header` ContextVar. That is not enough on current staging: `_merge_openapi_tool_request_headers` lets `_request_resolved_auth_headers` outrank the ContextVar, so for the client-forwarded modes the credential also has to reach the resolver's passthrough arm. `_passthrough_token_from_mcp_auth_header` already accepts the `str | dict` shape and documents itself as sourced from `x-mcp-{alias}-authorization`; that dict branch was simply dead because no OpenAPI caller passed it

Worth knowing for review: OpenAPI tools register into the local tool registry, so `execute_mcp_tool` serves MCP-protocol and REST tool calls while `MCPServerManager.call_tool` serves the responses-API handler. The proof below records which arm ran and it is the local-registry one; the other arm is covered by a parametrized symmetry test rather than by assumption

The two kinds of credential are deliberately kept apart. A per-server header is already a complete header value and is forwarded unchanged, while a BYOK credential is a raw secret that takes the server's auth-type prefix, so conflating them would ship `Bearer Bearer <token>`. A test pins that

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical on both legs. One proxy on `:4612` against real Postgres, plus a real internal REST API on `:9201` that publishes an OpenAPI spec, requires `Authorization: Bearer upstream-ok`, and logs the auth header of every request it receives. Like a real internal API it publishes no OAuth metadata

```yaml
mcp_servers:
  api_spec:
    url: http://127.0.0.1:9201
    spec_path: http://127.0.0.1:9201/openapi.json
    auth_type: oauth_delegate
    authorization_url: http://127.0.0.1:9299/authorize
    token_url: http://127.0.0.1:9299/token
    extra_headers: ["Authorization"]
```

Both legs run the same script. Every call carries `x-litellm-api-key: Bearer sk-1234` for admission and `x-mcp-servers: api_spec` for scope; only the credential header differs across the three cases

### Before (41de13aa0c)

```
1. tools/call against the OpenAPI-backed server, by header shape
   top-level Authorization      {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{\"workspace\":\"finance\",\"reports\":[\"Sales\",\"Ops\"]}"}],"isError":false}}  [HTTP 200]
   x-mcp-api_spec-authorization {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{\"error\":\"invalid_token\"}"}],"isError":false}}  [HTTP 200]
   per-server, WRONG token      {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{\"error\":\"invalid_token\"}"}],"isError":false}}  [HTTP 200]

2. what the internal API actually received, in order
   {"path": "/reports", "method": "GET", "got_authorization": "Bearer upstream-ok"}
   {"path": "/reports", "method": "GET", "got_authorization": null}
   {"path": "/reports", "method": "GET", "got_authorization": null}

3. which dispatch arm served the calls
   execute_mcp_tool local-registry arm: 3
   MCPServerManager.call_tool arm:      0
```

### After (1e54ddce28)

```
1. tools/call against the OpenAPI-backed server, by header shape
   top-level Authorization      {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{\"workspace\":\"finance\",\"reports\":[\"Sales\",\"Ops\"]}"}],"isError":false}}  [HTTP 200]
   x-mcp-api_spec-authorization {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{\"workspace\":\"finance\",\"reports\":[\"Sales\",\"Ops\"]}"}],"isError":false}}  [HTTP 200]
   per-server, WRONG token      {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{\"error\":\"invalid_token\"}"}],"isError":false}}  [HTTP 200]

2. what the internal API actually received, in order
   {"path": "/reports", "method": "GET", "got_authorization": "Bearer upstream-ok"}
   {"path": "/reports", "method": "GET", "got_authorization": "Bearer upstream-ok"}
   {"path": "/reports", "method": "GET", "got_authorization": "Bearer wrong-token"}

3. which dispatch arm served the calls
   execute_mcp_tool local-registry arm: 3
   MCPServerManager.call_tool arm:      0
```

The After leg was captured at 37cf5a8927; 1e54ddce28 amends it with one extra test assertion and leaves the production diff byte identical, so the run above still describes the tip

Step 2 is the whole change: the second request went from no Authorization header to the caller's own token, forwarded unchanged. The third case shows a wrong token still reaching the API and still being rejected, which also proves the value is not re-prefixed. Step 3 records which dispatch arm served the calls, identical on both legs

## Type

🐛 Bug Fix

## Caveats (if any)

- An upstream 401 still surfaces as `isError: false` on OpenAPI tools
- Only the OpenAPI arms change; managed MCP servers already resolved this header

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1e54ddce280dfcd729f1b1a4156f2d9942fcb7f2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->