### PR TITLE
fix(proxy): stop /{provider}/v1/files from capturing /anthropic passthrough

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -63,6 +63,7 @@ from .passthrough_endpoint_router import PassthroughEndpointRouter
 vertex_llm_base: Final = VertexBase()
 router: Final = APIRouter()
 openai_passthrough_router: Final = APIRouter()
+anthropic_passthrough_router: Final = APIRouter()
 default_vertex_config: Final = None
 
 passthrough_endpoint_router: Final = PassthroughEndpointRouter()
@@ -563,7 +564,7 @@ async def is_streaming_request_fn(request: Request) -> bool:
     return False
 
 
-@router.api_route(
+@anthropic_passthrough_router.api_route(
     "/anthropic/{endpoint:path}",
     methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
     tags=["Anthropic Pass-through", "pass-through"],

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -560,6 +560,7 @@ from litellm.proxy.openai_files_endpoints.files_endpoints import (
     set_files_config,
 )
 from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+    anthropic_passthrough_router,
     openai_passthrough_router,
     passthrough_endpoint_router,
     vertex_ai_live_websocket_passthrough,
@@ -17280,6 +17281,7 @@ app.include_router(image_router)
 app.include_router(fine_tuning_router)
 app.include_router(credential_router)
 app.include_router(openai_passthrough_router)
+app.include_router(anthropic_passthrough_router)
 app.include_router(batches_router)
 app.include_router(openai_files_router)
 app.include_router(llm_passthrough_router)

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -2990,6 +2990,26 @@ def test_native_provider_routes_are_unchanged(method, path, expected_name):
     assert _resolve_route_name(method, path) == expected_name
 
 
+@pytest.mark.parametrize(
+    "method, path",
+    [
+        ("POST", "/anthropic/v1/files"),
+        ("GET", "/anthropic/v1/files"),
+        ("GET", "/anthropic/v1/files/file-abc123"),
+        ("DELETE", "/anthropic/v1/files/file-abc123"),
+        ("POST", "/anthropic/v1/batches"),
+        ("POST", "/anthropic/v1/messages"),
+    ],
+)
+def test_anthropic_passthrough_prefix_wins_over_native_provider_routes(method, path):
+    """
+    Anthropic's Files API has no `purpose` field and no `files_settings` config,
+    so the native /{provider}/v1/files and /{provider}/v1/batches routes must never
+    capture /anthropic/... with provider="anthropic".
+    """
+    assert _resolve_route_name(method, path) == "anthropic_proxy_route"
+
+
 class TestCursorProxyRoute:
     """Tests for the Cursor Cloud Agents pass-through route."""
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/anthropic/v1/files` 422s on OpenAI-only `purpose` instead of forwarding to Anthropic
- Same route-shadowing bug #36092 fixed for `/openai_passthrough`, now on `/anthropic`

How it solves it:

- give `/anthropic` its own router, mounted ahead of the batches and files routers
- every other provider prefix keeps today's behavior

## User Flow

Before: a developer using the Anthropic SDK against the gateway cannot upload a document at all, so the model never sees their PDF

1. They set base URL `https://litellm-domain/anthropic` and send `POST https://litellm-domain/anthropic/v1/files` with `file=@plan.pdf`, what `client.beta.files.upload({ file })` emits
2. They get `422 {"detail":[{"type":"missing","loc":["body","purpose"],"msg":"Field required"}]}`, no file id, and nothing in their Anthropic account
3. With no file id they cannot reference the document in `POST https://litellm-domain/anthropic/v1/messages`, so the answer ignores their PDF

After: the same upload reaches Anthropic instead of being intercepted locally

1. They set base URL `https://litellm-domain/anthropic` and send the same `POST https://litellm-domain/anthropic/v1/files` with `file=@plan.pdf`, no extra fields
2. The request reaches `api.anthropic.com`, so with a valid key they get back Anthropic's own file object and can reference its `file_id` in a later `/anthropic/v1/messages` call

## Relevant issues

Fixes #37289

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Config used for both runs:

```yaml
model_list:
  - model_name: claude-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

general_settings:
  master_key: sk-local-repro-master
```

Run with `ANTHROPIC_API_KEY=sk-ant-invalid-key-for-local-repro` on purpose, same technique as the issue: a request LiteLLM answers itself fails 422 on `purpose`, a request that is forwarded to Anthropic fails 401 there instead.

### Before (41de13aa0c)

1. `POST /anthropic/v1/files`:

```
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:4000/anthropic/v1/files \
    -H "x-api-key: sk-local-repro-master" -H "anthropic-version: 2023-06-01" \
    -H "anthropic-beta: files-api-2025-04-14" -F "file=@repro.pdf;type=application/pdf"

{"detail":[{"type":"missing","loc":["body","purpose"],"msg":"Field required","input":null}]}
HTTP 422
```

### After (75fbc4b481)

1. `POST /anthropic/v1/files`, now forwarded, 401 from Anthropic as expected with an invalid key:

```
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:4000/anthropic/v1/files \
    -H "x-api-key: sk-local-repro-master" -H "anthropic-version: 2023-06-01" \
    -H "anthropic-beta: files-api-2025-04-14" -F "file=@repro.pdf;type=application/pdf"

{"type":"error","error":{"type":"authentication_error","message":"API key is invalid."},"request_id":null}
HTTP 401
```

2. Control, `/anthropic/v1/messages` still forwards normally, same 401:

```
$ curl -s -X POST http://127.0.0.1:4000/anthropic/v1/messages \
    -H "x-api-key: sk-local-repro-master" -H "anthropic-version: 2023-06-01" \
    -H "content-type: application/json" \
    -d '{"model":"claude-haiku-4-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'

{"type":"error","error":{"type":"authentication_error","message":"API key is invalid."},"request_id":null}
HTTP 401
```

Unit test proof, `git checkout HEAD~1 -- litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py litellm/proxy/proxy_server.py` then running the new test:

```
$ uv run pytest tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py -k test_anthropic_passthrough_prefix_wins_over_native_provider_routes -q
...
FAILED ...[DELETE-/anthropic/v1/files/file-abc123] - AssertionError: assert 'delete_file' == 'anthropic_proxy_route'
FAILED ...[GET-/anthropic/v1/files/file-abc123] - AssertionError: assert 'get_file' == 'anthropic_proxy_route'
FAILED ...[GET-/anthropic/v1/files] - AssertionError: assert 'list_files' == 'anthropic_proxy_route'
FAILED ...[POST-/anthropic/v1/batches] - AssertionError: assert 'create_batch' == 'anthropic_proxy_route'
FAILED ...[POST-/anthropic/v1/files] - AssertionError: assert 'create_file' == 'anthropic_proxy_route'
5 failed, 1 passed, 132 deselected, 1 warning in 5.39s
```

Restoring the fix and re-running the full file:

```
$ uv run pytest tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py -q
...
138 passed, 3 warnings in 5.64s
```

## Type

🐛 Bug Fix

## Caveats (if any)

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
