### PR TITLE
fix(ui): keep keyword tier rules that target operator-defined tiers when hydrating the edit modal

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/KeywordTierRules.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/KeywordTierRules.tsx
@@ -14,7 +14,8 @@ export type ComplexityTier = "SIMPLE" | "MEDIUM" | "COMPLEX" | "REASONING";
 export interface KeywordTierRule {
   id: string;
   keywords: string[];
-  tier: ComplexityTier;
+  /** A built-in tier name, or with a custom tier set, one of the defined tier names. */
+  tier: string;
 }
 
 interface KeywordTierRulesProps {
@@ -99,7 +100,7 @@ const KeywordTierRules: React.FC<KeywordTierRulesProps> = ({ rules, onChange, ti
                     <Select
                       items={tierOptions(tierLabels)}
                       value={rule.tier}
-                      onValueChange={(tier: ComplexityTier | null) => tier && updateRule(rule.id, { tier })}
+                      onValueChange={(tier: string | null) => tier && updateRule(rule.id, { tier })}
                     >
                       <SelectTrigger aria-label={`Route keyword rule ${index + 1} to tier`} className="w-full">
                         <SelectValue />

--- a/ui/litellm-dashboard/src/components/add_model/complexity_router_keywords.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/complexity_router_keywords.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { hydrateKeywordTierRules, serializeKeywordTierRules } from "./complexity_router_keywords";
+
+describe("hydrateKeywordTierRules", () => {
+  it("keeps a rule whose tier is operator-defined instead of silently deleting it on edit", () => {
+    const stored = [
+      { keywords: ["invoice"], tier: "MEDIUM" },
+      { keywords: ["pentest", "vulnerability"], tier: "SECURITY_REVIEW" },
+    ];
+    expect(hydrateKeywordTierRules(stored)).toEqual([
+      { id: "stored-0", keywords: ["invoice"], tier: "MEDIUM" },
+      { id: "stored-1", keywords: ["pentest", "vulnerability"], tier: "SECURITY_REVIEW" },
+    ]);
+  });
+
+  it("round-trips through serialize without loss", () => {
+    const stored = [{ keywords: ["pentest"], tier: "SECURITY_REVIEW" }];
+    expect(serializeKeywordTierRules(hydrateKeywordTierRules(stored))).toEqual(stored);
+  });
+
+  it("still drops rows that are not rules at all", () => {
+    expect(hydrateKeywordTierRules([{ keywords: [], tier: "MEDIUM" }, { keywords: ["x"] }, "junk", null])).toEqual([]);
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/complexity_router_keywords.ts
+++ b/ui/litellm-dashboard/src/components/add_model/complexity_router_keywords.ts
@@ -1,17 +1,17 @@
-import { ComplexityTier, KeywordTierRule } from "./KeywordTierRules";
+import { KeywordTierRule } from "./KeywordTierRules";
 
 /**
  * Stored shape of a keyword tier rule inside `complexity_router_config`. The UI's
  * KeywordTierRule carries an extra `id` used only as a React key, so it is stripped on the
  * way out and synthesized on the way back in. Both the create form and the edit modal go
- * through here so the two directions cannot drift.
+ * through here so the two directions cannot drift. The tier is any active tier name: a
+ * built-in one, or with tier_definitions, an operator-defined one, so hydration must not
+ * filter on the built-in set or an edit would silently delete a custom tier's rules.
  */
 export interface StoredKeywordTierRule {
   keywords: string[];
-  tier: ComplexityTier;
+  tier: string;
 }
-
-const TIERS: ReadonlySet<string> = new Set<ComplexityTier>(["SIMPLE", "MEDIUM", "COMPLEX", "REASONING"]);
 
 const asKeywords = (value: unknown): string[] =>
   Array.isArray(value)
@@ -40,7 +40,7 @@ export const hydrateKeywordTierRules = (value: unknown): KeywordTierRule[] => {
     const record = entry as Record<string, unknown>;
     const keywords = asKeywords(record.keywords).filter(Boolean);
     const tier = record.tier;
-    if (keywords.length === 0 || typeof tier !== "string" || !TIERS.has(tier)) return [];
-    return [{ id: `stored-${index}`, keywords, tier: tier as ComplexityTier }];
+    if (keywords.length === 0 || typeof tier !== "string" || !tier.trim()) return [];
+    return [{ id: `stored-${index}`, keywords, tier }];
   });
 };


### PR DESCRIPTION
## TLDR

Problem this solves:

- The backend accepts keyword rules targeting operator-defined tiers
- The edit modal's hydration only keeps built-in tier names
- Opening and saving a router silently deletes those rules

How it solves it:

- Hydration keeps any rule with a non-empty string tier
- The rule type widens from the built-in union to string
- A round-trip unit test pins hydrate then serialize losslessly

## User Flow

Before: an operator whose custom-tier router routes pentest prompts by keyword loses that rule by touching the edit form

1. They run a router whose config defines a SECURITY_REVIEW tier and a keyword rule sending "pentest" prompts to it
2. They open http://localhost:4000/ui/?page=models-and-endpoints and open that router's Edit Auto Router modal
3. The keyword rules section shows their MEDIUM rule but not the SECURITY_REVIEW one
4. They press Save without changing anything, and the stored config now has the SECURITY_REVIEW rule deleted
5. "pentest" prompts quietly stop routing to the security tier, with nothing telling them why

After: the same modal shows and preserves every rule

1. They run the same router and open the same Edit Auto Router modal
2. The keyword rules section lists both rules, the SECURITY_REVIEW one included
3. They press Save without changing anything, and the stored config still carries both rules
4. "pentest" prompts keep routing to the security tier

## Relevant issues

Extracted from #37246; the data loss is reachable on staging today because #37226 (merged) already accepts these configs

## Linear ticket

Part of LIT-5214

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

UI change; screenshots to be posted from the steps below

1. Create a router whose complexity_router_config defines a custom tier and a keyword rule targeting it, via POST http://localhost:4000/model/new with tier_definitions including SECURITY_REVIEW and keyword_tier_rules [{"keywords": ["pentest"], "tier": "SECURITY_REVIEW"}]
2. Open http://localhost:4000/ui/?page=models-and-endpoints, find the router, open Edit Auto Router
3. Before this change the SECURITY_REVIEW rule is missing from the keyword rules list and a no-op Save deletes it from the stored config; after, it is listed and survives the save
4. Confirm via GET http://localhost:4000/v1/model/info that keyword_tier_rules still contains the SECURITY_REVIEW rule after saving

## Type

🐛 Bug Fix

## Caveats (if any)

- The rule editor's tier dropdown still offers only built-in tiers; offering defined tier names is part of the tier editor UI in #37246

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI hydration/type change that prevents data loss on save; routing logic and auth are untouched. The dropdown still cannot pick custom tiers, so operators can preserve but not newly select them here.
> 
> **Overview**
> Stops the Auto Router edit modal from silently dropping keyword-tier rules that target operator-defined tiers.
> 
> `hydrateKeywordTierRules` no longer filters against the built-in `SIMPLE`/`MEDIUM`/`COMPLEX`/`REASONING` set. Any rule with keywords and a non-empty string `tier` is kept, so a no-op save no longer deletes custom-tier routing. The `KeywordTierRule` type is widened to `string` to match.
> 
> Tests pin hydrate/serialize round-trip for names like `SECURITY_REVIEW`. The dropdown still only lists built-in tiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a4ebb7e9baba7583d7a1367fc3d846c086df1f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->