### PR TITLE
fix(proxy): return no rows when the aggregated activity entity filter is empty

### DIFF
--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -594,13 +594,16 @@ def _build_aggregated_where_clause(
     sql_params.append(adjusted_end)
     p += 1
 
-    # Optional entity filter
+    # Optional entity filter; an empty list must match nothing, not everything
     if entity_id is not None:
         if isinstance(entity_id, list):
-            placeholders = ", ".join(f"${p + i}" for i in range(len(entity_id)))
-            sql_conditions.append(f'"{entity_id_field}" IN ({placeholders})')
-            sql_params.extend(entity_id)
-            p += len(entity_id)
+            if entity_id:
+                placeholders = ", ".join(f"${p + i}" for i in range(len(entity_id)))
+                sql_conditions.append(f'"{entity_id_field}" IN ({placeholders})')
+                sql_params.extend(entity_id)
+                p += len(entity_id)
+            else:
+                sql_conditions.append("FALSE")
         else:
             sql_conditions.append(f'"{entity_id_field}" = ${p}')
             sql_params.append(entity_id)

--- a/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.path.abspath("../../../.."))  # Adds the parent directory 
 from litellm.proxy.management_endpoints.common_daily_activity import (
     _adjust_dates_for_timezone,
     _build_aggregated_sql_query,
+    _build_entity_rollup_sql_query,
     _is_user_agent_tag,
     _record_to_spend_metrics,
     get_api_key_metadata,
@@ -980,6 +981,58 @@ class TestBuildAggregatedSqlQuery:
         assert f"(date, {fallback}), (date, {fallback}, api_key)," in normalized
         assert "(date, model_group)" not in normalized
         assert "COALESCE(model_group, model)" not in normalized
+
+
+class TestAggregatedEmptyEntityFilter:
+    _BUILDERS: Final = (_build_aggregated_sql_query, _build_entity_rollup_sql_query)
+
+    @pytest.mark.parametrize("build", _BUILDERS)
+    def test_empty_entity_list_emits_no_degenerate_in_clause(self, build):
+        sql, params = build(
+            table_name="litellm_dailyteamspend",
+            entity_id_field="team_id",
+            entity_id=[],
+            start_date="2026-08-01",
+            end_date="2026-08-19",
+            model=None,
+            api_key=None,
+        )
+
+        normalized = " ".join(sql.split())
+        assert "IN ()" not in normalized
+        assert '"team_id" IN' not in normalized
+        assert params == ["2026-08-01", "2026-08-19"]
+
+    @pytest.mark.parametrize("build", _BUILDERS)
+    def test_empty_entity_list_matches_nothing_rather_than_everything(self, build):
+        sql, _ = build(
+            table_name="litellm_dailyteamspend",
+            entity_id_field="team_id",
+            entity_id=[],
+            start_date="2026-08-01",
+            end_date="2026-08-19",
+            model=None,
+            api_key=None,
+        )
+
+        assert "FALSE" in " ".join(sql.split())
+
+    @pytest.mark.parametrize("build", _BUILDERS)
+    def test_populated_entity_list_still_filters_on_its_ids(self, build):
+        sql, params = build(
+            table_name="litellm_dailyteamspend",
+            entity_id_field="team_id",
+            entity_id=["team-alpha", "team-beta"],
+            start_date="2026-08-01",
+            end_date="2026-08-19",
+            model=None,
+            api_key=None,
+        )
+
+        normalized = " ".join(sql.split())
+        assert '"team_id" IN ($3, $4)' in normalized
+        assert "FALSE" not in normalized
+        assert params == ["2026-08-01", "2026-08-19", "team-alpha", "team-beta"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Org admins get a 500 opening the Usage page team tab
- An empty team filter renders invalid SQL, `IN ()`
- Only the aggregated endpoints break; the paginated one is fine

How it solves it:

- An empty entity list now matches nothing instead of erroring
- Both aggregated queries share the one fixed clause builder

## User Flow

Before: an org admin who belongs to no team cannot open the team usage view at all

1. They sign in at https://litellm-domain/ui/ with an org admin key
2. They open https://litellm-domain/ui/?page=usage and pick the Team tab
3. The tab fails to render, and `GET /team/daily/activity/aggregated?start_date=2026-08-01&end_date=2026-08-19` comes back 500 with `{"error":"Failed to fetch analytics: ERROR: syntax error at or near \")\""}`
4. Adding an explicit `&team_ids=<some-team>` makes the same call return 200, so the view only works if they narrow it by hand

After: the same tab loads and simply shows nothing to report

1. They sign in at https://litellm-domain/ui/ with an org admin key
2. They open https://litellm-domain/ui/?page=usage and pick the Team tab
3. The tab renders with zero spend and no team rows, and the same call returns 200 with an empty `results` list
4. Adding `&team_ids=<some-team>` still returns 200 with that team's rows, unchanged

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

## Type

🐛 Bug Fix

## Caveats (if any)

- Empty filter now returns an empty view, not org-wide usage
- Whether org admins should instead see every team in their org is a separate question

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
