### PR TITLE
test: allow protocol-constrained pass-through routes to declare fewer methods

### DIFF
--- a/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
+++ b/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
@@ -413,33 +413,52 @@ async def test_pass_through_request_logging_failure_with_stream(
             assert response.body == b'{"mock": "response"}'
 
 
+PROTOCOL_CONSTRAINED_PASS_THROUGH_ROUTES = {
+    "/comprehendmedical": {"POST"},
+    "/comprehendmedical/{operation}": {"POST"},
+}
+
+
 def test_pass_through_routes_support_all_methods():
     """
-    Test that all pass-through routes support GET, POST, PUT, DELETE, PATCH methods
+    A pass-through route fronts a whole provider API, so narrowing its method
+    set turns a request the upstream would have accepted into a 405. The
+    exceptions are providers whose wire protocol admits only one method: Amazon
+    Comprehend Medical speaks AWS JSON 1.1, which is POST-only, so there is no
+    other method to forward.
     """
-    # Import the routers
     from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
         router as llm_router,
     )
 
-    # Expected HTTP methods
     expected_methods = {"GET", "POST", "PUT", "DELETE", "PATCH"}
 
-    # Function to check routes in a router
     def check_router_methods(router):
         for route in router.routes:
             if isinstance(route, APIRoute):
-                # Get path and methods for this route
                 path = route.path
                 methods = set(route.methods)
-                print("supported methods for route", path, "are", methods)
-                # Assert all expected methods are supported
+                allowed = PROTOCOL_CONSTRAINED_PASS_THROUGH_ROUTES.get(path, expected_methods)
                 assert (
-                    methods == expected_methods
-                ), f"Route {path} does not support all methods. Supported: {methods}, Expected: {expected_methods}"
+                    methods == allowed
+                ), f"Route {path} does not support all methods. Supported: {methods}, Expected: {allowed}"
 
-    # Check both routers
     check_router_methods(llm_router)
+
+
+def test_protocol_constrained_pass_through_exemptions_are_not_stale():
+    """
+    The exemption list above weakens the method contract, so it must not
+    outlive the routes it covers: a renamed or deleted route has to fail here
+    rather than sit in the list silently exempting nothing.
+    """
+    from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+        router as llm_router,
+    )
+
+    registered_paths = {route.path for route in llm_router.routes if isinstance(route, APIRoute)}
+    unmatched = set(PROTOCOL_CONSTRAINED_PASS_THROUGH_ROUTES) - registered_paths
+    assert not unmatched, f"Exempted pass-through routes no longer exist: {sorted(unmatched)}"
 
 
 def test_is_bedrock_agent_runtime_route():


### PR DESCRIPTION
## TLDR

Problem this solves:

- The pass-through method contract fails on Comprehend Medical
- That route is POST-only on purpose: AWS JSON 1.1 has no other verb
- A blanket all-verbs rule cannot describe a single-verb protocol

How it solves it:

- Exempt protocol-constrained routes, pinned to an exact method set
- A companion test stops the exemption outliving its routes

## User Flow

Before: a developer calling Comprehend Medical through the gateway is served correctly, but the suite that guards every other pass-through route is red

1. They send `POST https://litellm-domain/comprehendmedical/DetectEntitiesV2` with an AWS JSON 1.1 body and get their entities back
2. They send `GET https://litellm-domain/comprehendmedical/DetectEntitiesV2` and get 405, which is the right answer since AWS offers no GET form of this API
3. The repository's pass-through method check fails anyway, so nobody can tell that red apart from a route that really did lose a verb

After: the same calls behave identically and the check describes reality

1. They send `POST https://litellm-domain/comprehendmedical/DetectEntitiesV2` with an AWS JSON 1.1 body and get their entities back
2. They send `GET https://litellm-domain/comprehendmedical/DetectEntitiesV2` and still get 405
3. The check passes, and if any other pass-through route silently drops a verb it goes red again

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

## Type

✅ Test

## Caveats (if any)

- No runtime behaviour changes; the route keeps serving POST only
- Every future exemption weakens the contract, so keep the list short

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
