### PR TITLE
fix(pass_through): don't override client-forwarded Anthropic OAuth with server x-api-key

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -54,8 +54,10 @@ def is_anthropic_oauth_key(value: str | None) -> bool:
     """Check if a value contains an Anthropic OAuth token (sk-ant-oat*)."""
     if value is None:
         return False
-    # Handle both raw token and "Bearer <token>" format
-    value = value.removeprefix("Bearer ")
+    # Handle both raw token and "Bearer <token>" format, case-insensitive scheme
+    scheme, _, token = value.partition(" ")
+    if scheme.lower() == "bearer":
+        value = token
     return value.startswith(ANTHROPIC_OAUTH_TOKEN_PREFIX)
 
 

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -24,7 +24,7 @@ from litellm.constants import (
     ALLOWED_VERTEX_AI_PASSTHROUGH_HEADERS,
     BEDROCK_AGENT_RUNTIME_PASS_THROUGH_ROUTES,
 )
-from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+from litellm.llms.anthropic.common_utils import AnthropicModelInfo, is_anthropic_oauth_key
 from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
 from litellm.proxy._types import *
 from litellm.proxy.auth.route_checks import RouteChecks
@@ -601,7 +601,13 @@ async def anthropic_proxy_route(
     is_streaming_request: Final = await is_streaming_request_fn(request)
 
     ## CREATE PASS-THROUGH
-    auth_header: Final = AnthropicModelInfo.get_auth_header(anthropic_api_key or None)
+    # A client-forwarded Anthropic OAuth token (e.g. Claude Code Max subscription auth)
+    # must not be sent alongside a server-configured x-api-key: Anthropic authenticates
+    # off x-api-key when both are present, silently discarding the client's own identity.
+    client_forwards_own_oauth: Final = is_anthropic_oauth_key(request.headers.get("authorization"))
+    auth_header: Final = (
+        None if client_forwards_own_oauth else AnthropicModelInfo.get_auth_header(anthropic_api_key or None)
+    )
     endpoint_func: Final = create_pass_through_route(
         endpoint=endpoint,
         target=str(updated_url),

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -601,9 +601,6 @@ async def anthropic_proxy_route(
     is_streaming_request: Final = await is_streaming_request_fn(request)
 
     ## CREATE PASS-THROUGH
-    # A client-forwarded Anthropic OAuth token (e.g. Claude Code Max subscription auth)
-    # must not be sent alongside a server-configured x-api-key: Anthropic authenticates
-    # off x-api-key when both are present, silently discarding the client's own identity.
     client_forwards_own_oauth: Final = is_anthropic_oauth_key(request.headers.get("authorization"))
     auth_header: Final = (
         None if client_forwards_own_oauth else AnthropicModelInfo.get_auth_header(anthropic_api_key or None)

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -23,6 +23,7 @@ from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     BaseOpenAIPassThroughHandler,
     RouteChecks,
     _join_url_paths,
+    anthropic_proxy_route,
     azure_proxy_route,
     bedrock_llm_proxy_route,
     bedrock_proxy_route,
@@ -2931,6 +2932,76 @@ class TestOpenAIPassthroughRoute:
 
             # Verify result
             assert result == {"id": "asst_123", "object": "assistant"}
+
+
+class TestAnthropicProxyRoute:
+    """Regression (issue #37344): a client forwarding its own Anthropic OAuth token
+    (e.g. a Claude Code Max subscription) must not also get the server-configured
+    ANTHROPIC_API_KEY injected as x-api-key. Anthropic authenticates off x-api-key
+    when both are present, silently discarding the client's forwarded identity.
+    """
+
+    @pytest.mark.asyncio
+    async def test_anthropic_passthrough_omits_server_api_key_when_client_forwards_oauth(self):
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "POST"
+        mock_request.headers = {"authorization": "Bearer sk-ant-oat01-canary"}
+        mock_request.query_params = {}
+        mock_response = MagicMock(spec=Response)
+        mock_user_api_key_dict = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+                return_value="sk-ant-server-configured-key",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route"
+            ) as mock_create_route,
+        ):
+            mock_endpoint_func = AsyncMock(return_value={"id": "msg_123"})
+            mock_create_route.return_value = mock_endpoint_func
+
+            await anthropic_proxy_route(
+                endpoint="v1/messages",
+                request=mock_request,
+                fastapi_response=mock_response,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+            call_args = mock_create_route.call_args[1]
+            assert call_args["custom_headers"] == {}
+
+    @pytest.mark.asyncio
+    async def test_anthropic_passthrough_uses_server_api_key_without_client_oauth(self):
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "POST"
+        mock_request.headers = {}
+        mock_request.query_params = {}
+        mock_response = MagicMock(spec=Response)
+        mock_user_api_key_dict = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+                return_value="sk-ant-server-configured-key",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route"
+            ) as mock_create_route,
+        ):
+            mock_endpoint_func = AsyncMock(return_value={"id": "msg_123"})
+            mock_create_route.return_value = mock_endpoint_func
+
+            await anthropic_proxy_route(
+                endpoint="v1/messages",
+                request=mock_request,
+                fastapi_response=mock_response,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+            call_args = mock_create_route.call_args[1]
+            assert call_args["custom_headers"] == {"x-api-key": "sk-ant-server-configured-key"}
 
 
 def _resolve_route_name(method: str, path: str) -> str | None:

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -2935,11 +2935,7 @@ class TestOpenAIPassthroughRoute:
 
 
 class TestAnthropicProxyRoute:
-    """Regression (issue #37344): a client forwarding its own Anthropic OAuth token
-    (e.g. a Claude Code Max subscription) must not also get the server-configured
-    ANTHROPIC_API_KEY injected as x-api-key. Anthropic authenticates off x-api-key
-    when both are present, silently discarding the client's forwarded identity.
-    """
+    """Regression test for issue #37344."""
 
     @pytest.mark.asyncio
     async def test_anthropic_passthrough_omits_server_api_key_when_client_forwards_oauth(self):
@@ -3002,6 +2998,37 @@ class TestAnthropicProxyRoute:
 
             call_args = mock_create_route.call_args[1]
             assert call_args["custom_headers"] == {"x-api-key": "sk-ant-server-configured-key"}
+
+    @pytest.mark.asyncio
+    async def test_anthropic_passthrough_omits_server_api_key_for_lowercase_bearer_scheme(self):
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "POST"
+        mock_request.headers = {"authorization": "bearer sk-ant-oat01-canary"}
+        mock_request.query_params = {}
+        mock_response = MagicMock(spec=Response)
+        mock_user_api_key_dict = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+                return_value="sk-ant-server-configured-key",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route"
+            ) as mock_create_route,
+        ):
+            mock_endpoint_func = AsyncMock(return_value={"id": "msg_123"})
+            mock_create_route.return_value = mock_endpoint_func
+
+            await anthropic_proxy_route(
+                endpoint="v1/messages",
+                request=mock_request,
+                fastapi_response=mock_response,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+            call_args = mock_create_route.call_args[1]
+            assert call_args["custom_headers"] == {}
 
 
 def _resolve_route_name(method: str, path: str) -> str | None:


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/anthropic` passthrough always sent the server's ANTHROPIC_API_KEY as `x-api-key`
- Anthropic authenticates off `x-api-key` when both it and `Authorization` are present
- A client forwarding its own OAuth token (e.g. Claude Code Max) got silently ignored

How it solves it:

- Skip injecting the server `x-api-key` when the request already carries a client OAuth token
- The client's own `Authorization` header then reaches Anthropic unmodified

## User Flow

Before: a developer routing a Claude Code Max subscription through the `/anthropic` passthrough gets authenticated as the proxy's own configured key instead of their subscription

1. They set `ANTHROPIC_BASE_URL=http://localhost:4000/anthropic` and run Claude Code with their Max subscription OAuth token
2. Claude Code sends `POST http://localhost:4000/anthropic/v1/messages` with `Authorization: Bearer sk-ant-oat...`
3. The proxy also attaches `x-api-key: <the operator's configured ANTHROPIC_API_KEY>` to the upstream request
4. Anthropic authenticates off `x-api-key`, so every request runs as the proxy's own key, not the developer's Max subscription (probing with a deliberately invalid client token still returns "API key is invalid" instead of an OAuth-token error, proving the client's identity never reached Anthropic)

After: the same flow authenticates as the developer's own subscription

1. They set `ANTHROPIC_BASE_URL=http://localhost:4000/anthropic` and run Claude Code with their Max subscription OAuth token
2. Claude Code sends `POST http://localhost:4000/anthropic/v1/messages` with `Authorization: Bearer sk-ant-oat...`
3. The proxy forwards only that `Authorization` header; it no longer attaches its own `x-api-key`
4. Anthropic authenticates the request as the developer's own Max subscription

## Relevant issues

Relates to #37344 (the `/anthropic` passthrough auth-substitution finding in that report; the report's separate 429 rate-limit observation on the router/provider path is not reproduced or explained by this change and remains open)

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Ran the real proxy (`litellm/proxy/proxy_cli.py`) with `ANTHROPIC_API_BASE` pointed at a local echo listener standing in for `api.anthropic.com`, so the actual outbound headers can be inspected directly, the same technique the issue reporter used to diagnose this. `ANTHROPIC_API_KEY=sk-ant-server-configured-fakekey` simulates the operator's configured key; the request carries a fake Claude Code Max OAuth token (`sk-ant-oat01-...`) as the client's own `Authorization` header.

```bash
curl -s -X POST http://127.0.0.1:4111/anthropic/v1/messages \
  -H "x-litellm-api-key: Bearer sk-test-master-key-1234" \
  -H "authorization: Bearer sk-ant-oat01-fake-claude-code-max-oauth-token" \
  -H "content-type: application/json" \
  -d '{"model":"claude-sonnet-4-5","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}'
```

### Before (41de13aa0c)

1. Ran the command above against the proxy on the merge-base commit
2. The echo listener recorded both headers on the outbound request:
   ```json
   {
     "authorization": "Bearer sk-ant-oat01-fake-claude-code-max-oauth-token",
     "x-api-key": "sk-ant-server-configured-fakekey"
   }
   ```
3. Anthropic would authenticate this request off `x-api-key`, i.e. as the proxy operator, not the client

### After (abf911ec19)

1. Ran the identical command against the proxy rebuilt from this branch's tip
2. The echo listener recorded only the client's own header:
   ```json
   {
     "authorization": "Bearer sk-ant-oat01-fake-claude-code-max-oauth-token"
   }
   ```
3. `x-api-key` is no longer sent, so Anthropic has only the client's own credential to authenticate with

## Type

🐛 Bug Fix

## Caveats (if any)

- Does not address the report's separate 429 rate-limit observation on the router/provider `/v1/messages` path; that needs reproduction against a real Claude Max subscription, which wasn't available here
- Testing used a local echo listener instead of the live Anthropic API since no Anthropic OAuth subscription or API key was available in this environment

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
