### PR TITLE
test(ocr): update Azure DI supported-params assertion for req_format

### DIFF
--- a/tests/ocr_tests/test_ocr_azure_document_intelligence.py
+++ b/tests/ocr_tests/test_ocr_azure_document_intelligence.py
@@ -62,7 +62,7 @@ class TestAzureDocumentIntelligencePagesParam:
         return AzureDocumentIntelligenceOCRConfig()
 
     def test_get_supported_ocr_params_includes_pages_and_features(self, cfg):
-        assert cfg.get_supported_ocr_params("prebuilt-layout") == ["pages", "features"]
+        assert cfg.get_supported_ocr_params("prebuilt-layout") == ["pages", "features", "req_format"]
 
     def test_map_ocr_params_mistral_zero_based_int_list(self, cfg):
         mapped = cfg.map_ocr_params({"pages": [0, 1, 2]}, {}, "prebuilt-layout")


### PR DESCRIPTION
## TLDR

Problem this solves:

- ocr_testing CI job is red on litellm_internal_staging
- 57d739b433 added `req_format` but missed one duplicate test assertion

How it solves it:

- Updates the stale assertion to the new three-param list

## User Flow

Before: a maintainer watching CI on litellm_internal_staging sees the ocr_testing job fail on every run

1. They push any commit to litellm_internal_staging or open a PR against it
2. The ocr_testing CI job runs and fails with `AssertionError: assert ['pages', 'features', 'req_format'] == ['pages', 'features']` in test_get_supported_ocr_params_includes_pages_and_features
3. They see a red check on their PR that has nothing to do with their change

After: the same CI run comes back green

1. They push any commit to litellm_internal_staging or open a PR against it
2. The ocr_testing CI job runs and all Azure Document Intelligence tests pass
3. The check is green and only their own changes decide the PR's fate

## Relevant issues

## Linear ticket

Resolves LIT-5790

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR only updates a test assertion, no product behavior changes, so there is no proxy curl to show: the end-user observable is the ocr_testing suite itself, run against real Azure Document Intelligence (the live tests in the same file hit the real API and cost real $$$)

### Before (ec6f1c1a56)

1. `uv run pytest tests/ocr_tests/test_ocr_azure_document_intelligence.py -q`
2. Observed: `FAILED tests/ocr_tests/test_ocr_azure_document_intelligence.py::TestAzureDocumentIntelligencePagesParam::test_get_supported_ocr_params_includes_pages_and_features` with `AssertionError: assert ['pages', 'fe... 'req_format'] == ['pages', 'features']`, summary `1 failed, 17 passed in 24.77s`

### After (05e32e9fee)

1. `uv run pytest tests/ocr_tests/test_ocr_azure_document_intelligence.py -q`
2. Observed: `18 passed in 17.74s`

## Type

✅ Test

## Caveats (if any)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

CHECKED with /live-pr-risk at 05e32e9fee: test-only diff, product code byte-identical to base, so no runtime path can change. The sole consumer of the changed symbol is the ocr_testing CI job, and its suite ran live against real Azure Document Intelligence at both base (1 failed, 17 passed) and head (18 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 05e32e9fee57cb20f4ff62c44916c61193670f71. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->