### PR TITLE
feat(images): support ChatGPT OAuth image APIs

### DIFF
--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -376,6 +376,7 @@ def image_generation(
         # Providers using llm_http_handler
         #########################################################
         elif custom_llm_provider in (
+            litellm.LlmProviders.CHATGPT,
             litellm.LlmProviders.RECRAFT,
             litellm.LlmProviders.AIML,
             litellm.LlmProviders.GEMINI,

--- a/litellm/llms/chatgpt/image_edit/__init__.py
+++ b/litellm/llms/chatgpt/image_edit/__init__.py
@@ -1,0 +1,9 @@
+from litellm.llms.base_llm.image_edit.transformation import BaseImageEditConfig
+
+from .transformation import ChatGPTImageEditConfig
+
+__all__ = ["ChatGPTImageEditConfig", "get_chatgpt_image_edit_config"]
+
+
+def get_chatgpt_image_edit_config(model: str) -> BaseImageEditConfig:
+    return ChatGPTImageEditConfig()

--- a/litellm/llms/chatgpt/image_edit/transformation.py
+++ b/litellm/llms/chatgpt/image_edit/transformation.py
@@ -1,0 +1,143 @@
+import base64
+from typing import Any, Final
+
+from litellm.exceptions import AuthenticationError
+from litellm.images.utils import ImageEditRequestUtils
+from litellm.llms.openai.image_edit.transformation import OpenAIImageEditConfig
+from litellm.types.images.main import ImageEditOptionalRequestParams
+from litellm.types.llms.openai import FileTypes
+from litellm.types.router import GenericLiteLLMParams
+
+from ..authenticator import Authenticator
+from ..common_utils import (
+    CHATGPT_API_BASE,
+    GetAccessTokenError,
+    ensure_chatgpt_session_id,
+    get_chatgpt_default_headers,
+)
+
+
+class ChatGPTImageEditConfig(OpenAIImageEditConfig):
+    """Codex Images edit API configuration backed by ChatGPT OAuth."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.authenticator = Authenticator()
+
+    def get_supported_openai_params(self, model: str) -> list:
+        return [
+            "image",
+            "prompt",
+            "background",
+            "model",
+            "n",
+            "quality",
+            "size",
+            "extra_headers",
+            "extra_query",
+            "extra_body",
+            "timeout",
+        ]
+
+    def map_openai_params(
+        self,
+        image_edit_optional_params: ImageEditOptionalRequestParams,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        supported: Final = self.get_supported_openai_params(model)
+        return {
+            key: value
+            for key, value in image_edit_optional_params.items()
+            if key in supported
+        }
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        api_key: str | None = None,
+        litellm_params: dict | None = None,
+        api_base: str | None = None,
+    ) -> dict:
+        try:
+            access_token: Final = self.authenticator.get_access_token()
+        except GetAccessTokenError as e:
+            raise AuthenticationError(
+                model=model,
+                llm_provider="chatgpt",
+                message=str(e),
+            )
+
+        account_id: Final = self.authenticator.get_account_id()
+        turn_id: Final = ensure_chatgpt_session_id(litellm_params)
+        default_headers: Final = get_chatgpt_default_headers(
+            access_token, account_id, turn_id
+        )
+        default_headers["accept"] = "application/json"
+        default_headers["x-codex-image-turn-id"] = turn_id
+        return {**default_headers, **headers}
+
+    def get_complete_url(
+        self,
+        model: str,
+        api_base: str | None,
+        litellm_params: dict,
+    ) -> str:
+        resolved_api_base: Final = (
+            api_base or self.authenticator.get_api_base() or CHATGPT_API_BASE
+        )
+        return f"{resolved_api_base.rstrip('/')}/images/edits"
+
+    def transform_image_edit_request(
+        self,
+        model: str,
+        prompt: str | None,
+        image: FileTypes | None,
+        image_edit_optional_request_params: dict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> tuple[dict, dict]:
+        image_list: Final = image if isinstance(image, list) else [image]
+        images: Final = [
+            {"image_url": self._to_data_url(item)}
+            for item in image_list
+            if item is not None
+        ]
+        optional_params: Final = {
+            key: value
+            for key, value in image_edit_optional_request_params.items()
+            if key in {"background", "n", "quality", "size"}
+        }
+        return {
+            "images": images,
+            "prompt": prompt or "",
+            "model": model,
+            **optional_params,
+        }, {}
+
+    def use_multipart_form_data(self) -> bool:
+        return False
+
+    @staticmethod
+    def _to_data_url(image: Any) -> str:
+        if isinstance(image, str) and (
+            image.startswith("data:")
+            or image.startswith("https://")
+            or image.startswith("http://")
+        ):
+            return image
+
+        content_type: Final = ImageEditRequestUtils.get_image_content_type(image)
+        if isinstance(image, (bytes, bytearray)):
+            image_bytes = bytes(image)
+        elif hasattr(image, "read"):
+            position = image.tell() if hasattr(image, "tell") else None
+            image_bytes = image.read()
+            if position is not None and hasattr(image, "seek"):
+                image.seek(position)
+        else:
+            raise ValueError("ChatGPT image edits require image bytes or a URL")
+
+        encoded: Final = base64.b64encode(image_bytes).decode("ascii")
+        return f"data:{content_type};base64,{encoded}"

--- a/litellm/llms/chatgpt/image_generation/__init__.py
+++ b/litellm/llms/chatgpt/image_generation/__init__.py
@@ -1,0 +1,14 @@
+from litellm.llms.base_llm.image_generation.transformation import (
+    BaseImageGenerationConfig,
+)
+
+from .transformation import ChatGPTImageGenerationConfig
+
+__all__ = [
+    "ChatGPTImageGenerationConfig",
+    "get_chatgpt_image_generation_config",
+]
+
+
+def get_chatgpt_image_generation_config(model: str) -> BaseImageGenerationConfig:
+    return ChatGPTImageGenerationConfig()

--- a/litellm/llms/chatgpt/image_generation/transformation.py
+++ b/litellm/llms/chatgpt/image_generation/transformation.py
@@ -1,0 +1,78 @@
+from typing import Final
+
+from litellm.exceptions import AuthenticationError
+from litellm.llms.openai.image_generation.gpt_transformation import (
+    GPTImageGenerationConfig,
+)
+from litellm.types.llms.openai import AllMessageValues
+
+from ..authenticator import Authenticator
+from ..common_utils import (
+    CHATGPT_API_BASE,
+    GetAccessTokenError,
+    ensure_chatgpt_session_id,
+    get_chatgpt_default_headers,
+)
+
+
+class ChatGPTImageGenerationConfig(GPTImageGenerationConfig):
+    """Codex Images API configuration backed by ChatGPT subscription OAuth."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.authenticator = Authenticator()
+
+    def get_supported_openai_params(self, model: str) -> list:
+        return ["background", "n", "quality", "size"]
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: list[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> dict:
+        try:
+            access_token: Final = self.authenticator.get_access_token()
+        except GetAccessTokenError as e:
+            raise AuthenticationError(
+                model=model,
+                llm_provider="chatgpt",
+                message=str(e),
+            )
+
+        account_id: Final = self.authenticator.get_account_id()
+        turn_id: Final = ensure_chatgpt_session_id(litellm_params)
+        default_headers: Final = get_chatgpt_default_headers(
+            access_token, account_id, turn_id
+        )
+        default_headers["accept"] = "application/json"
+        default_headers["x-codex-image-turn-id"] = turn_id
+        return {**default_headers, **headers}
+
+    def get_complete_url(
+        self,
+        api_base: str | None,
+        api_key: str | None,
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: bool | None = None,
+    ) -> str:
+        resolved_api_base: Final = (
+            api_base or self.authenticator.get_api_base() or CHATGPT_API_BASE
+        )
+        return f"{resolved_api_base.rstrip('/')}/images/generations"
+
+    def transform_image_generation_request(
+        self,
+        model: str,
+        prompt: str,
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        return {"prompt": prompt, "model": model, **optional_params}

--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -1,7 +1,11 @@
 import asyncio
+import base64
+import binascii
 import io
+import os
+import re
 import traceback
-from typing import Final
+from typing import Any, Final
 
 import orjson
 from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, UploadFile, status
@@ -19,6 +23,90 @@ from litellm.proxy.route_llm_request import route_request
 from litellm.types.llms.openai import ChatCompletionUserMessage
 
 router: Final = APIRouter()
+
+_IMAGE_DATA_URL_PATTERN: Final = re.compile(
+    r"^data:(?P<mime>image/[a-zA-Z0-9.+-]+);base64,(?P<data>.*)$",
+    re.DOTALL,
+)
+_IMAGE_MIME_EXTENSIONS: Final = {
+    "image/gif": "gif",
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+}
+_DEFAULT_IMAGE_EDIT_MAX_IMAGES: Final = 10
+_DEFAULT_IMAGE_EDIT_MAX_TOTAL_BYTES: Final = 50 * 1024 * 1024
+
+
+def _positive_env_int(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise RuntimeError(f"{name} must be an integer") from exc
+    if value <= 0:
+        raise RuntimeError(f"{name} must be greater than zero")
+    return value
+
+
+def decode_json_image_edit_images(images: Any) -> list[io.BytesIO]:
+    """Decode JSON image-edit data URLs into the file objects LiteLLM expects."""
+    if not isinstance(images, list) or not images:
+        raise ValueError("'images' must be a non-empty array")
+
+    max_images = _positive_env_int(
+        "IMAGE_EDIT_MAX_IMAGES", _DEFAULT_IMAGE_EDIT_MAX_IMAGES
+    )
+    max_total_bytes = _positive_env_int(
+        "IMAGE_EDIT_MAX_TOTAL_BYTES", _DEFAULT_IMAGE_EDIT_MAX_TOTAL_BYTES
+    )
+    if len(images) > max_images:
+        raise ValueError(f"'images' contains more than {max_images} items")
+
+    decoded_images: list[io.BytesIO] = []
+    total_bytes = 0
+    for index, item in enumerate(images):
+        image_url = item.get("image_url") if isinstance(item, dict) else item
+        if not isinstance(image_url, str):
+            raise ValueError(
+                f"images[{index}].image_url must be a data URL string"
+            )
+
+        match = _IMAGE_DATA_URL_PATTERN.fullmatch(image_url)
+        if match is None:
+            raise ValueError(
+                f"images[{index}].image_url must be a base64 image data URL"
+            )
+
+        mime_type = match.group("mime").lower()
+        try:
+            payload = base64.b64decode(match.group("data"), validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError(
+                f"images[{index}].image_url contains invalid base64 data"
+            ) from exc
+        if not payload:
+            raise ValueError(
+                f"images[{index}].image_url contains an empty image"
+            )
+
+        total_bytes += len(payload)
+        if total_bytes > max_total_bytes:
+            raise ValueError(
+                "decoded images exceed IMAGE_EDIT_MAX_TOTAL_BYTES "
+                f"({max_total_bytes})"
+            )
+
+        image_buffer = io.BytesIO(payload)
+        extension = _IMAGE_MIME_EXTENSIONS.get(
+            mime_type, mime_type.split("/", 1)[1]
+        )
+        image_buffer.name = f"image-{index + 1}.{extension}"
+        decoded_images.append(image_buffer)
+
+    return decoded_images
 
 
 async def uploadfile_to_bytesio(upload: UploadFile) -> io.BytesIO:
@@ -279,8 +367,26 @@ async def image_edit_api(
     # Read request body and convert UploadFiles to BytesIO
     #########################################################
     data: Final = await _read_request_body(request=request)
-    image_files: Final = await batch_to_bytesio(image)
+    multipart_image_files: Final = await batch_to_bytesio(image)
     mask_files: Final = await batch_to_bytesio(mask)
+
+    # OpenClaw/Codex can send JSON
+    # {"images": [{"image_url": "data:image/...;base64,..."}]} instead of
+    # multipart image/image[]. Convert it to the BytesIO values aimage_edit uses.
+    json_images = data.pop("images", None)
+    if json_images is not None:
+        if multipart_image_files:
+            raise HTTPException(
+                status_code=422,
+                detail="Cannot specify both multipart 'image' and JSON 'images'",
+            )
+        try:
+            image_files = decode_json_image_edit_images(json_images)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+    else:
+        image_files = multipart_image_files
+
     if image_files:
         data["image"] = image_files
     if mask_files:

--- a/litellm/proxy/route_llm_request.py
+++ b/litellm/proxy/route_llm_request.py
@@ -55,6 +55,26 @@ def _is_a2a_agent_model(model_name: Any) -> bool:
     return isinstance(model_name, str) and model_name.startswith("a2a/")
 
 
+def _should_auto_route_chatgpt_image_model(
+    data: Mapping[str, Any],
+    route_type: str,
+    llm_router: LitellmRouter | None,
+) -> bool:
+    """Use ChatGPT OAuth for unconfigured, provider-less GPT Image models."""
+    if route_type not in {"aimage_generation", "aimage_edit"}:
+        return False
+    model: Final = data.get("model")
+    if (
+        not isinstance(model, str)
+        or not model.startswith("gpt-image-")
+        or "/" in model
+    ):
+        return False
+    if llm_router is None:
+        return True
+    return not bool(llm_router.get_model_list(model_name=model))
+
+
 def _raise_if_model_fully_blocked(llm_router: LitellmRouter, model_name: Any, team_id: str | None) -> None:
     if not isinstance(model_name, str) or not model_name:
         return
@@ -448,6 +468,16 @@ async def route_request(
             return getattr(llm_router, f"{route_type}")(**data)
         else:
             return getattr(litellm, f"{route_type}")(**data)
+
+    elif _should_auto_route_chatgpt_image_model(
+        data=data,
+        route_type=route_type,
+        llm_router=llm_router,
+    ):
+        requested_model: Final = data["model"]
+        data.setdefault("_litellm_client_requested_model", requested_model)
+        data["model"] = f"chatgpt/{requested_model}"
+        return getattr(litellm, f"{route_type}")(**data)
 
     elif (
         route_type == "acompletion"

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8771,6 +8771,12 @@ class ProviderConfigManager:
             )
 
             return get_openai_image_generation_config(model)
+        elif LlmProviders.CHATGPT == provider:
+            from litellm.llms.chatgpt.image_generation import (
+                get_chatgpt_image_generation_config,
+            )
+
+            return get_chatgpt_image_generation_config(model)
         elif LlmProviders.AZURE == provider:
             from litellm.llms.azure.image_generation import (
                 get_azure_image_generation_config,
@@ -8958,6 +8964,12 @@ class ProviderConfigManager:
             from litellm.llms.openai.image_edit import get_openai_image_edit_config
 
             return get_openai_image_edit_config(model=model)
+        elif LlmProviders.CHATGPT == provider:
+            from litellm.llms.chatgpt.image_edit import (
+                get_chatgpt_image_edit_config,
+            )
+
+            return get_chatgpt_image_edit_config(model=model)
         elif LlmProviders.AZURE == provider:
             from litellm.llms.azure.image_edit.transformation import (
                 AzureImageEditConfig,

--- a/tests/test_litellm/llms/chatgpt/test_chatgpt_images_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/test_chatgpt_images_transformation.py
@@ -1,0 +1,122 @@
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import litellm
+from litellm.llms.chatgpt.image_edit.transformation import ChatGPTImageEditConfig
+from litellm.llms.chatgpt.image_generation.transformation import (
+    ChatGPTImageGenerationConfig,
+)
+from litellm.types.router import GenericLiteLLMParams
+from litellm.types.utils import LlmProviders
+from litellm.utils import ProviderConfigManager
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_type"),
+    [
+        (
+            ProviderConfigManager.get_provider_image_generation_config,
+            ChatGPTImageGenerationConfig,
+        ),
+        (
+            ProviderConfigManager.get_provider_image_edit_config,
+            ChatGPTImageEditConfig,
+        ),
+    ],
+)
+def test_chatgpt_image_provider_configs_are_registered(factory, expected_type):
+    config = factory(model="gpt-image-2", provider=LlmProviders.CHATGPT)
+    assert isinstance(config, expected_type)
+
+
+@patch("litellm.llms.chatgpt.image_generation.transformation.Authenticator")
+def test_chatgpt_image_generation_request(mock_authenticator_class):
+    authenticator = MagicMock()
+    authenticator.get_access_token.return_value = "oauth-token"
+    authenticator.get_account_id.return_value = "account-id"
+    authenticator.get_api_base.return_value = "https://chatgpt.example/backend-api/codex"
+    mock_authenticator_class.return_value = authenticator
+    config = ChatGPTImageGenerationConfig()
+
+    headers = config.validate_environment(
+        headers={},
+        model="gpt-image-2",
+        messages=[],
+        optional_params={},
+        litellm_params={"litellm_session_id": "turn-id"},
+    )
+    request = config.transform_image_generation_request(
+        model="gpt-image-2",
+        prompt="draw a fox",
+        optional_params={"quality": "high", "size": "1024x1024"},
+        litellm_params={},
+        headers=headers,
+    )
+
+    assert headers["Authorization"] == "Bearer oauth-token"
+    assert headers["ChatGPT-Account-Id"] == "account-id"
+    assert headers["x-codex-image-turn-id"] == "turn-id"
+    assert config.get_complete_url(None, None, "gpt-image-2", {}, {}) == (
+        "https://chatgpt.example/backend-api/codex/images/generations"
+    )
+    assert request == {
+        "prompt": "draw a fox",
+        "model": "gpt-image-2",
+        "quality": "high",
+        "size": "1024x1024",
+    }
+
+
+@patch("litellm.llms.chatgpt.image_edit.transformation.Authenticator")
+def test_chatgpt_image_edit_uses_json_data_urls(mock_authenticator_class):
+    authenticator = MagicMock()
+    authenticator.get_api_base.return_value = "https://chatgpt.example/backend-api/codex/"
+    mock_authenticator_class.return_value = authenticator
+    config = ChatGPTImageEditConfig()
+    image = BytesIO(b"\x89PNG\r\n\x1a\nimage-data")
+
+    request, files = config.transform_image_edit_request(
+        model="gpt-image-2",
+        prompt="add a hat",
+        image=[image],
+        image_edit_optional_request_params={"quality": "medium"},
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert config.use_multipart_form_data() is False
+    assert files == {}
+    assert request["images"] == [
+        {"image_url": "data:image/png;base64,iVBORw0KGgppbWFnZS1kYXRh"}
+    ]
+    assert request["prompt"] == "add a hat"
+    assert request["model"] == "gpt-image-2"
+    assert request["quality"] == "medium"
+    assert image.tell() == 0
+    assert config.get_complete_url("gpt-image-2", None, {}) == (
+        "https://chatgpt.example/backend-api/codex/images/edits"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route_type", ["aimage_generation", "aimage_edit"])
+async def test_unconfigured_gpt_image_model_auto_routes_to_chatgpt(route_type):
+    from litellm.proxy.route_llm_request import route_request
+
+    async def fake_image_call(**kwargs):
+        return kwargs
+
+    with patch.object(litellm, route_type, side_effect=fake_image_call) as image_call:
+        pending = await route_request(
+            data={"model": "gpt-image-2", "prompt": "draw a fox"},
+            llm_router=None,
+            user_model=None,
+            route_type=route_type,
+        )
+        result = await pending
+
+    assert result["model"] == "chatgpt/gpt-image-2"
+    assert result["_litellm_client_requested_model"] == "gpt-image-2"
+    image_call.assert_called_once()

--- a/tests/test_litellm/proxy/image_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/image_endpoints/test_endpoints.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import copy
 from types import SimpleNamespace
 from typing import Any, Dict
@@ -10,6 +11,52 @@ from starlette.responses import Response
 
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.image_endpoints import endpoints
+
+
+def _image_data_url(payload: bytes, mime_type: str = "image/png") -> str:
+    encoded = base64.b64encode(payload).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
+def test_decode_json_image_edit_images_openclaw_shape():
+    images = endpoints.decode_json_image_edit_images(
+        [{"image_url": _image_data_url(b"png-data")}]
+    )
+
+    assert images[0].read() == b"png-data"
+    assert images[0].name == "image-1.png"
+
+
+def test_decode_json_image_edit_images_supports_strings_and_multiple_formats():
+    images = endpoints.decode_json_image_edit_images(
+        [
+            _image_data_url(b"one", "image/jpeg"),
+            _image_data_url(b"two", "image/webp"),
+        ]
+    )
+
+    assert [image.name for image in images] == ["image-1.jpg", "image-2.webp"]
+    assert [image.read() for image in images] == [b"one", b"two"]
+
+
+@pytest.mark.parametrize(
+    "images, error",
+    [
+        ([{"image_url": "https://example.com/image.png"}], "base64 image data URL"),
+        ([{"image_url": "data:image/png;base64,%%%"}], "invalid base64"),
+        ([], "non-empty array"),
+    ],
+)
+def test_decode_json_image_edit_images_rejects_invalid_input(images, error):
+    with pytest.raises(ValueError, match=error):
+        endpoints.decode_json_image_edit_images(images)
+
+
+def test_decode_json_image_edit_images_enforces_total_size_limit(monkeypatch):
+    monkeypatch.setenv("IMAGE_EDIT_MAX_TOTAL_BYTES", "2")
+
+    with pytest.raises(ValueError, match="IMAGE_EDIT_MAX_TOTAL_BYTES"):
+        endpoints.decode_json_image_edit_images([_image_data_url(b"123")])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- ChatGPT OAuth could not call GPT Image endpoints
- JSON data URL image edits failed at the proxy

How it solves it:

- Add ChatGPT image generation and edit transformations
- Decode JSON image edit inputs with configurable limits
- Auto-route unconfigured GPT Image models through ChatGPT

## User Flow

Before: a developer using ChatGPT OAuth cannot generate or edit GPT images through the proxy

1. They send POST https://litellm-domain/v1/images/generations with `"model": "gpt-image-2"`
2. The request cannot resolve a configured image provider, so no image is returned
3. They send POST https://litellm-domain/v1/images/edits with base64 data URLs in `images`
4. The proxy does not accept the JSON image payload, so the edit fails

After: the same requests use ChatGPT OAuth and return image responses

1. They send POST https://litellm-domain/v1/images/generations with `"model": "gpt-image-2"`
2. The request uses their ChatGPT OAuth session and returns a generated image
3. They send POST https://litellm-domain/v1/images/edits with base64 data URLs in `images`
4. The proxy decodes the images and returns the edited image response

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

## Type

🆕 New Feature

## Caveats (if any)

- Requires an existing ChatGPT OAuth session

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
