### PR TITLE
test(ui): repoint the e2e locators at the post-antd form controls

### DIFF
--- a/tests/e2e/ui/tests/mcp/mcpTools.spec.ts
+++ b/tests/e2e/ui/tests/mcp/mcpTools.spec.ts
@@ -63,7 +63,7 @@ test.describe("MCP Tools", () => {
 
     // The form is generated from the tool's inputSchema, so `repoName` proves the schema
     // round-tripped through the proxy instead of the panel falling back to a generic field.
-    const repoInput = page.locator('input[id="repoName"]');
+    const repoInput = page.getByLabel(/repoName/);
     await expect(repoInput).toBeVisible();
     await repoInput.fill(TOOL_ARG_REPO);
 

--- a/tests/e2e/ui/tests/modelsPage/addModel.spec.ts
+++ b/tests/e2e/ui/tests/modelsPage/addModel.spec.ts
@@ -338,8 +338,8 @@ test.describe("Add Model", () => {
 
       await page.getByRole("button", { name: "Add Model" }).last().click();
 
-      // Scope to antd's notification container so a stale toast can't satisfy this.
-      await expect(page.locator(".ant-notification").getByText("created successfully").last()).toBeVisible({
+      // Scope to the toast container so a stale toast can't satisfy this.
+      await expect(page.locator("[data-sonner-toast]").getByText("created successfully").last()).toBeVisible({
         timeout: 15_000,
       });
 

--- a/tests/e2e/ui/tests/modelsPage/clearCustomPricing.spec.ts
+++ b/tests/e2e/ui/tests/modelsPage/clearCustomPricing.spec.ts
@@ -85,9 +85,9 @@ test.describe("Clear custom pricing on a deployment", () => {
     const inputCost = page.getByPlaceholder("Enter input cost");
     const outputCost = page.getByPlaceholder("Enter output cost");
     // Both cache fields share the same placeholder ("Defaults to Input Cost if blank"),
-    // so disambiguate via the Form.Item id (AntD assigns the `name` prop as input id).
-    const cacheReadCost = page.locator("#cache_read_cost");
-    const cacheWriteCost = page.locator("#cache_write_cost");
+    // so disambiguate via their labels.
+    const cacheReadCost = page.getByLabel(/Cache Read Cost/);
+    const cacheWriteCost = page.getByLabel(/Cache Write Cost/);
     await inputCost.waitFor({ timeout: 15_000 });
     for (const field of [inputCost, outputCost, cacheReadCost, cacheWriteCost]) {
       await field.click({ clickCount: 3 });

--- a/tests/e2e/ui/tests/proxy-admin/keys.spec.ts
+++ b/tests/e2e/ui/tests/proxy-admin/keys.spec.ts
@@ -36,9 +36,8 @@ test.describe("Proxy Admin - Keys", () => {
     // Wait for the key creation modal
     await expect(page.getByText("Key Ownership")).toBeVisible({ timeout: 10_000 });
 
-    // Fill key name (has data-testid="base-input" in the built UI)
     const keyName = `e2e-admin-key-${Date.now()}`;
-    await page.getByTestId("base-input").fill(keyName);
+    await page.getByLabel(/Key Name/).fill(keyName);
 
     // Select team
     const teamSelect = page.getByTestId("team-dropdown").getByRole("combobox");
@@ -192,7 +191,7 @@ test.describe("Proxy Admin - Keys", () => {
     await expect(page.getByText("Key Ownership")).toBeVisible({ timeout: 10_000 });
 
     const keyName = `e2e-admin-allproxy-${Date.now()}`;
-    await page.getByTestId("base-input").fill(keyName);
+    await page.getByLabel(/Key Name/).fill(keyName);
 
     // No team selection — leave team dropdown empty so the key is owned by the admin user
 
@@ -220,7 +219,7 @@ test.describe("Proxy Admin - Keys", () => {
     await expect(page.getByText("Key Ownership")).toBeVisible({ timeout: 10_000 });
 
     const keyName = `e2e-admin-specific-${Date.now()}`;
-    await page.getByTestId("base-input").fill(keyName);
+    await page.getByLabel(/Key Name/).fill(keyName);
 
     // Open the model multi-select and pick a single specific model. Use
     // getByRole("option", ...) to avoid the strict-mode collision between

--- a/tests/e2e/ui/tests/proxy-admin/teams.spec.ts
+++ b/tests/e2e/ui/tests/proxy-admin/teams.spec.ts
@@ -79,7 +79,7 @@ test.describe("Proxy Admin - Teams", () => {
     await expect(modal).toBeVisible({ timeout: 5_000 });
 
     // The email field is a Select — type to search, then select from dropdown
-    await modal.locator(".ant-select").first().click();
+    await modal.getByRole("combobox").first().click();
     await page.keyboard.type("invitable@test.local");
 
     // Wait for the option to appear, then select via keyboard (avoids viewport issues)

--- a/tests/e2e/ui/tests/team-admin/teamAdmin.spec.ts
+++ b/tests/e2e/ui/tests/team-admin/teamAdmin.spec.ts
@@ -66,7 +66,7 @@ test.describe("Team Admin", () => {
 
     // Use a dedicated invitee user so this doesn't race with the proxy-admin
     // "Invite a user" test that adds invitable@test.local to the same team.
-    await modal.locator(".ant-select").first().click();
+    await modal.getByRole("combobox").first().click();
     await page.keyboard.type("invitable-team@test.local");
 
     const emailOption = page.getByRole("option", { name: "invitable-team@test.local" }).first();
@@ -136,7 +136,7 @@ test.describe("Team Admin", () => {
     await expect(page.getByText("Key Ownership")).toBeVisible({ timeout: 10_000 });
 
     const keyName = `e2e-team-admin-key-${Date.now()}`;
-    await page.getByTestId("base-input").fill(keyName);
+    await page.getByLabel(/Key Name/).fill(keyName);
 
     // Team selector — same locator pattern as the proxy-admin keys test.
     const teamSelect = page.getByTestId("team-dropdown").getByRole("combobox");

--- a/ui/litellm-dashboard/src/components/ModelInfoEditForm.tsx
+++ b/ui/litellm-dashboard/src/components/ModelInfoEditForm.tsx
@@ -403,29 +403,27 @@ const ModelInfoEditForm: React.FC<ModelInfoEditFormProps> = ({
     </div>
   );
 
-  const pricingField = (name: TouchedPricingField, label: string, placeholder: string, description?: string) => (
-    <div>
-      <FieldLabel htmlFor={name}>{label}</FieldLabel>
-      {isEditing ? (
-        <FormField control={form.control} name={name} description={description}>
-          {({ value, onChange, ...control }) => (
-            <NumericalInput
-              {...control}
-              id={name}
-              value={value ?? ""}
-              placeholder={placeholder}
-              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                markTouched(name);
-                onChange(event);
-              }}
-            />
-          )}
-        </FormField>
-      ) : (
+  const pricingField = (name: TouchedPricingField, label: string, placeholder: string, description?: string) =>
+    isEditing ? (
+      <FormField control={form.control} name={name} label={label} description={description}>
+        {({ value, onChange, ...control }) => (
+          <NumericalInput
+            {...control}
+            value={value ?? ""}
+            placeholder={placeholder}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              markTouched(name);
+              onChange(event);
+            }}
+          />
+        )}
+      </FormField>
+    ) : (
+      <div>
+        <FieldLabel>{label}</FieldLabel>
         <Display>{displayCost(localModelData, name)}</Display>
-      )}
-    </div>
-  );
+      </div>
+    );
 
   const tagsField = (
     name: "model_access_group" | "guardrails" | "tags",

--- a/ui/litellm-dashboard/src/components/ModelInfoEditForm.tsx
+++ b/ui/litellm-dashboard/src/components/ModelInfoEditForm.tsx
@@ -405,12 +405,13 @@ const ModelInfoEditForm: React.FC<ModelInfoEditFormProps> = ({
 
   const pricingField = (name: TouchedPricingField, label: string, placeholder: string, description?: string) => (
     <div>
-      <FieldLabel>{label}</FieldLabel>
+      <FieldLabel htmlFor={name}>{label}</FieldLabel>
       {isEditing ? (
         <FormField control={form.control} name={name} description={description}>
           {({ value, onChange, ...control }) => (
             <NumericalInput
               {...control}
+              id={name}
               value={value ?? ""}
               placeholder={placeholder}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Nine e2e specs went red after the tremor and antd removals
- They selected on markup those libraries owned, not ours
- Both cache pricing inputs lost their accessible name entirely

How it solves it:

- Repoint each locator onto a user-facing label or role
- Pin the pricing input id back and tie its label to it

## User Flow

Before: an operator editing a deployment's cache pricing meets two fields that screen readers and keyboards cannot tell apart

1. They open https://litellm-domain/ui/?page=models, pick a deployment, and press Edit Settings
2. They tab to Cache Read Cost and Cache Write Cost; neither announces a name, because the only text near them is a label wired to nothing
3. Both fields show the same placeholder, "Defaults to Input Cost if blank", so nothing distinguishes them but position

After: the same two fields are named and individually addressable

1. They open https://litellm-domain/ui/?page=models, pick a deployment, and press Edit Settings
2. They tab to Cache Read Cost and Cache Write Cost; each announces its own label
3. Clearing either one and saving sends that field alone as null, unchanged from before

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

## Type

✅ Test
🐛 Bug Fix

## Caveats (if any)

- I did not run the Playwright suite locally; the e2e job is the gate
- Key name locator verified by running the existing vitest integration suite
- Remaining locators derived from source, not from a live run

## QA runbook

- tests/e2e/ui/tests/proxy-admin/keys.spec.ts - a proxy admin can name and create a key
  - [ ] Open http://localhost:4000/ui/?page=api-keys and press Create New Key
  - [ ] Expect the Key Name field to be focusable by its label text alone
  - [ ] Fill it, pick a team, submit, and expect the Save your Key dialog
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/ui/tests/modelsPage/clearCustomPricing.spec.ts - clearing cache pricing sends explicit nulls
  - [ ] Open http://localhost:4000/ui/?page=models, pick a deployment with custom pricing, press Edit Settings
  - [ ] Expect Cache Read Cost and Cache Write Cost to be separately reachable by label
  - [ ] Clear all four pricing fields and save
  - [ ] Expect the outgoing PATCH /model/{id}/update to carry null for each cleared field
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/ui/tests/mcp/mcpTools.spec.ts - the tool test panel builds its form from the tool schema
  - [ ] Open http://localhost:4000/ui/?page=mcp-servers, pick a server, select a tool taking a repoName argument
  - [ ] Expect a field labelled repoName rather than a generic fallback input
  - [ ] Call the tool and expect Tool executed successfully plus the repo named in the result
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/ui/tests/proxy-admin/teams.spec.ts and tests/e2e/ui/tests/team-admin/teamAdmin.spec.ts - a member can be added by email search
  - [ ] Open http://localhost:4000/ui/?page=teams, open a team, Members tab, press Add Member
  - [ ] Expect the email field to be a searchable combobox; type a known user's email
  - [ ] Pick the option, submit, and expect the member to appear on the team
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/ui/tests/modelsPage/addModel.spec.ts - a team-only model creation toasts success
  - [ ] Open http://localhost:4000/ui/?page=models, add a model with the Team-BYOK toggle on
  - [ ] Expect a success toast naming the model as created
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
