### PR TITLE
test: point the live gemini and groq conformance suites at models that still exist

### DIFF
--- a/tests/image_gen_tests/test_image_generation.py
+++ b/tests/image_gen_tests/test_image_generation.py
@@ -269,7 +269,7 @@ class TestAimlImageGeneration(BaseImageGenTest):
 
 class TestGoogleImageGen(BaseImageGenTest):
     def get_base_image_generation_call_args(self) -> dict:
-        return {"model": "gemini/imagen-4.0-generate-001"}
+        return {"model": "gemini/gemini-3.1-flash-image"}
 
 
 @pytest.mark.skip(reason="Runwayml image generation API only tested locally")

--- a/tests/llm_translation/test_groq.py
+++ b/tests/llm_translation/test_groq.py
@@ -20,7 +20,7 @@ from litellm.llms.groq.chat.transformation import (
 class TestGroq(BaseLLMChatTest):
     def get_base_completion_call_args(self) -> dict:
         return {
-            "model": "groq/llama-3.3-70b-versatile",
+            "model": "groq/openai/gpt-oss-120b",
         }
 
     def test_tool_call_no_arguments(self, tool_call_no_arguments):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Two live test suites call models the providers retired
- CI has been red since the retirement dates passed

How it solves it:

- Point the Gemini image suite at the replacement Google named
- Point the Groq chat suite at a current production model

## User Flow

Before: a developer following our test suite for a working Gemini image model copies one that 404s

1. They read `TestGoogleImageGen` and copy `gemini/imagen-4.0-generate-001`
2. They send POST https://litellm-domain/v1/images/generations with that model
3. They get back 404 "This model models/imagen-4.0-generate-001 is no longer available. Please update your code to use models/gemini-3.1-flash-image"
4. They repeat the same with `groq/llama-3.3-70b-versatile` from `TestGroq` and get a model-decommissioned error from Groq

After: the same copy-paste reaches models that are actually served

1. They read `TestGoogleImageGen` and copy `gemini/gemini-3.1-flash-image`
2. They send POST https://litellm-domain/v1/images/generations with that model
3. They get back 200 with image data
4. They repeat with `groq/openai/gpt-oss-120b` from `TestGroq` and get a 200 chat completion

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

✅ Test

## Caveats

- Groq replacement not live-verified: no Groq key locally
- `gpt-oss-120b` is a reasoning model, unlike the old Llama
- Offline transformation tests keep the retired ids deliberately

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
