### PR TITLE
fix: accept bool thinking param instead of crashing with AttributeError

### DIFF
--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -5,7 +5,7 @@ Common base config for all LLM providers
 import types
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterator
-from typing import TYPE_CHECKING, Any, Final, Union, cast
+from typing import TYPE_CHECKING, Any, Final, Union
 
 import httpx
 from pydantic import BaseModel
@@ -90,9 +90,9 @@ class BaseConfig(ABC):
         return type_to_response_format_param(response_format=response_format)
 
     def is_thinking_enabled(self, non_default_params: dict) -> bool:
-        return (non_default_params.get("thinking") or {}).get("type") == "enabled" or non_default_params.get(
-            "reasoning_effort"
-        ) is not None
+        thinking: Final = non_default_params.get("thinking")
+        thinking_type: Final = thinking.get("type") if isinstance(thinking, dict) else None
+        return thinking is True or thinking_type == "enabled" or non_default_params.get("reasoning_effort") is not None
 
     def is_max_tokens_in_request(self, non_default_params: dict) -> bool:
         """
@@ -112,7 +112,10 @@ class BaseConfig(ABC):
         if is_thinking_enabled and (
             "max_tokens" not in non_default_params and "max_completion_tokens" not in non_default_params
         ):
-            thinking_token_budget: Final = cast(dict, optional_params["thinking"]).get("budget_tokens", None)
+            thinking_value: Final = optional_params.get("thinking")
+            thinking_token_budget: Final = (
+                thinking_value.get("budget_tokens") if isinstance(thinking_value, dict) else None
+            )
             if thinking_token_budget is not None:
                 optional_params["max_tokens"] = thinking_token_budget + DEFAULT_MAX_TOKENS
 

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1090,7 +1090,10 @@ class AmazonConverseConfig(BaseConfig):
         is_thinking_enabled: Final = self.is_thinking_enabled(optional_params)
         is_max_tokens_in_request: Final = self.is_max_tokens_in_request(non_default_params)
         if is_thinking_enabled and not is_max_tokens_in_request:
-            thinking_token_budget: Final = cast(dict, optional_params["thinking"]).get("budget_tokens", None)
+            thinking_value: Final = optional_params.get("thinking")
+            thinking_token_budget: Final = (
+                thinking_value.get("budget_tokens") if isinstance(thinking_value, dict) else None
+            )
             if thinking_token_budget is not None:
                 optional_params["maxTokens"] = thinking_token_budget + DEFAULT_MAX_TOKENS
 

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -131,9 +131,11 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
           - model supports reasoning (capability check)
           - user explicitly passed thinking={"type": "enabled"} (opt-in check)
         """
+        thinking: Final = optional_params.get("thinking")
         return (
             supports_reasoning(model=model, custom_llm_provider="deepseek")
-            and (optional_params.get("thinking") or {}).get("type") == "enabled"
+            and isinstance(thinking, dict)
+            and thinking.get("type") == "enabled"
         )
 
     @staticmethod

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5007,7 +5007,6 @@ def completion(
     tool_choice = validate_chat_completion_tool_choice(tool_choice=tool_choice)
     # validate optional params
     stop = validate_openai_optional_params(stop=stop)
-    # normalize camelCase thinking keys (e.g. budgetTokens -> budget_tokens)
     thinking = validate_and_fix_thinking_param(thinking=thinking)
 
     ######### unpacking kwargs #####################

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -65,6 +65,7 @@ from litellm.constants import (
     DEFAULT_EMBEDDING_PARAM_VALUES,
     DEFAULT_MAX_LRU_CACHE_SIZE,
     DEFAULT_MINIMUM_PROMPT_CACHE_TOKEN_COUNT,
+    DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
     DEFAULT_TRIM_RATIO,
     FUNCTION_DEFINITION_TOKEN_COUNT,
     INITIAL_RETRY_DELAY,
@@ -7638,12 +7639,20 @@ def validate_and_fix_openai_tools(tools: list | None) -> list[dict] | None:
 
 
 def validate_and_fix_thinking_param(
-    thinking: AnthropicThinkingParam | None,
+    thinking: AnthropicThinkingParam | bool | None,
 ) -> AnthropicThinkingParam | None:
     """
-    Normalizes camelCase keys in the thinking param to snake_case.
+    Coerces bool thinking values (True becomes enabled with the default medium budget, False becomes None)
+    and normalizes camelCase keys in the thinking param to snake_case.
     Handles clients that send budgetTokens instead of budget_tokens.
     """
+    if thinking is True:
+        return cast(
+            "AnthropicThinkingParam",
+            {"type": "enabled", "budget_tokens": DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET},
+        )
+    if thinking is False:
+        return None
     if thinking is None or not isinstance(thinking, dict):
         return thinking
     normalized: Final = dict(thinking)

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -6043,3 +6043,10 @@ def test_streaming_usage_chunk_is_transformed():
     assert chunk.usage.prompt_tokens == 11
     assert chunk.usage.completion_tokens == 4
     assert chunk.usage.total_tokens == 15
+
+
+def test_update_optional_params_with_thinking_tokens_bool_thinking_does_not_crash():
+    config = AmazonConverseConfig()
+    optional_params = {"thinking": True}
+    config.update_optional_params_with_thinking_tokens(non_default_params={"thinking": True}, optional_params=optional_params)
+    assert "maxTokens" not in optional_params

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -6048,5 +6048,7 @@ def test_streaming_usage_chunk_is_transformed():
 def test_update_optional_params_with_thinking_tokens_bool_thinking_does_not_crash():
     config = AmazonConverseConfig()
     optional_params = {"thinking": True}
-    config.update_optional_params_with_thinking_tokens(non_default_params={"thinking": True}, optional_params=optional_params)
+    config.update_optional_params_with_thinking_tokens(
+        non_default_params={"thinking": True}, optional_params=optional_params
+    )
     assert "maxTokens" not in optional_params

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -101,3 +101,8 @@ async def test_async_transform_request_strips_unsupported_tools_from_body():
 
     assert [tool["type"] for tool in body["tools"]] == ["function"]
     assert body["tools"][0]["function"]["name"] == "shell"
+
+
+def test_thinking_mode_active_bool_thinking_returns_false_without_crashing():
+    config = DeepSeekChatConfig()
+    assert config._thinking_mode_active(model="deepseek-reasoner", optional_params={"thinking": True}) is False

--- a/tests/test_litellm/test_thinking_enabled.py
+++ b/tests/test_litellm/test_thinking_enabled.py
@@ -60,6 +60,8 @@ class TestIsThinkingEnabled:
             ({"reasoning_effort": "medium"}, True),
             # both thinking enabled and reasoning_effort returns True
             ({"thinking": {"type": "enabled"}, "reasoning_effort": "high"}, True),
+            # thinking=True (bool) should not crash, returns True
+            ({"thinking": True}, True),
             # falsy thinking values should not crash
             ({"thinking": False}, False),
             ({"thinking": 0}, False),

--- a/tests/test_litellm/test_thinking_enabled.py
+++ b/tests/test_litellm/test_thinking_enabled.py
@@ -60,7 +60,6 @@ class TestIsThinkingEnabled:
             ({"reasoning_effort": "medium"}, True),
             # both thinking enabled and reasoning_effort returns True
             ({"thinking": {"type": "enabled"}, "reasoning_effort": "high"}, True),
-            # thinking=True (bool) should not crash, returns True
             ({"thinking": True}, True),
             # falsy thinking values should not crash
             ({"thinking": False}, False),

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -3766,6 +3766,20 @@ class TestValidateAndFixThinkingParam:
         assert "budgetTokens" in thinking
         assert "budget_tokens" not in thinking
 
+    def test_bool_true_maps_to_enabled_with_default_budget(self):
+        from litellm.constants import DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET
+        from litellm.utils import validate_and_fix_thinking_param
+
+        assert validate_and_fix_thinking_param(thinking=True) == {
+            "type": "enabled",
+            "budget_tokens": DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
+        }
+
+    def test_bool_false_returns_none(self):
+        from litellm.utils import validate_and_fix_thinking_param
+
+        assert validate_and_fix_thinking_param(thinking=False) is None
+
 
 def test_deepseek_v4_models_in_cost_map():
     """


### PR DESCRIPTION
## TLDR

Problem this solves:

- `thinking: true` (bool) crashed pre-network with `AttributeError: 'bool' object has no attribute 'get'`
- The crash surfaced as a retryable `APIConnectionError`, so the router burned 2 retries on it
- Proxy clients got a 400 leaking the full server-side Python traceback
- `thinking: false` was forwarded verbatim and Anthropic rejected it with a 400

How it solves it:

- `thinking: true` now coerces to `{"type": "enabled", "budget_tokens": 2048}` at request validation
- `thinking: false` is dropped, so the request runs as a normal non-thinking completion
- The dict-assuming thinking accessors (base config, bedrock converse, deepseek) now guard with `isinstance`

## User Flow

Before: a developer whose Anthropic-style client sends `"thinking": true` gets a Python traceback and silent retries instead of a completion

1. They send POST http://litellm-domain/v1/chat/completions with `{"model": "anthropic-haiku-4-5", "messages": [...], "thinking": true}`
2. The gateway silently re-runs the same failure twice, then returns HTTP 400 whose message is a raw server-side Python traceback ending in `AttributeError: 'bool' object has no attribute 'get'`, labeled `litellm.APIConnectionError` and `LiteLLM Retried: 2 times`
3. They try `"thinking": false` instead and still get HTTP 400, this time Anthropic's own `thinking: Input should be an object`

After: the same request returns a real completion with thinking content

1. They send the same POST http://litellm-domain/v1/chat/completions with `{"model": "anthropic-haiku-4-5", "messages": [...], "thinking": true}`
2. HTTP 200 comes back with the answer plus `reasoning_content` and `thinking_blocks`, exactly as if they had sent `{"type": "enabled", "budget_tokens": 2048}`, and no retries fire
3. They try `"thinking": false` and get HTTP 200 with a normal non-thinking completion
4. On a model that has dropped the legacy enabled shape (e.g. `claude-sonnet-5`), `"thinking": true` returns Anthropic's own clean HTTP 400 telling them to switch to `thinking.type.adaptive`, with no traceback and no retries

## Relevant issues

## Linear ticket

Resolves LIT-5786

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: proxy started from the worktree with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port <port> --detailed_debug --use_v2_migration_resolver` (port 47163 for Before, 52741 for After, both confirmed free with `lsof` first), master key `sk-1234`, real Anthropic API calls

### Before (ec6f1c1a56)

#### thinking: true via /v1/chat/completions (claude-haiku-4-5)

1. `curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:47163/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"What is 2+2? Answer in one word."}],"thinking":true}'`
2. HTTP 400 with the full server traceback in the body: `"Invalid request format: litellm.APIConnectionError: 'bool' object has no attribute 'get'\nTraceback (most recent call last): ... AttributeError: 'bool' object has no attribute 'get'\n. Received Model Group=anthropic-haiku-4-5\nAvailable Model Group Fallbacks=None LiteLLM Retried: 2 times, LiteLLM Max Retries: 2"`

#### thinking: false via /v1/chat/completions (claude-haiku-4-5)

1. `curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:47163/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"What is 2+2? Answer in one word."}],"max_tokens":2048,"thinking":false}'`
2. HTTP 400: `"litellm.BadRequestError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"thinking: Input should be an object\"},\"request_id\":\"req_011CeBLkP97HvQ5Pwg84FBde\"}"`

#### thinking=True via the Python SDK

1. `python -c "import litellm; litellm.completion(model='anthropic/claude-haiku-4-5', messages=[{'role':'user','content':'What is 2+2? Answer in one word.'}], thinking=True)"`
2. Raises `APIConnectionError: litellm.APIConnectionError: 'bool' object has no attribute 'get'` with the full traceback, a 500-class error that retry and fallback layers treat as a provider outage

#### thinking: true on claude-sonnet-5 (legacy shape unsupported)

1. `curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:47163/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"anthropic-sonnet-5","messages":[{"role":"user","content":"What is 2+2? Answer in one word."}],"max_tokens":2048,"thinking":true}'`
2. HTTP 400 with the same `AttributeError` traceback and `LiteLLM Retried: 2 times, LiteLLM Max Retries: 2`

### After (138c77023a)

#### thinking: true via /v1/chat/completions (claude-haiku-4-5)

1. `curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:52741/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"What is 2+2? Answer in one word."}],"thinking":true}'`
2. HTTP 200: `{"id":"chatcmpl-62d81655-d880-424b-96bf-113d1ad2d144", ..., "message":{"content":"Four.","role":"assistant","reasoning_content":"2+2 = 4\n\nThe user wants me to answer in one word. ...","thinking_blocks":[{"type":"thinking", ...}]}}` and the proxy log shows zero router retries

#### thinking: false via /v1/chat/completions (claude-haiku-4-5)

1. `curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:52741/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"What is 2+2? Answer in one word."}],"max_tokens":2048,"thinking":false}'`
2. HTTP 200: `{"id":"chatcmpl-57065fd3-1815-4e17-947d-bef322fbfa49", ..., "message":{"content":"Four.","role":"assistant", ...}, "usage":{"completion_tokens":5,"prompt_tokens":19, ..., "completion_tokens_details":{"reasoning_tokens":0, ...}}}`

#### thinking=True via the Python SDK

1. `python -c "import litellm; r = litellm.completion(model='anthropic/claude-haiku-4-5', messages=[{'role':'user','content':'What is 2+2? Answer in one word.'}], thinking=True); print(r.choices[0].message.content, r.choices[0].message.reasoning_content[:70])"`
2. Prints `Four.` and `The user is asking what 2+2 equals and wants me to answer in one word.` with no exception

#### thinking: true on claude-sonnet-5 (legacy shape unsupported)

1. `curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:52741/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"anthropic-sonnet-5","messages":[{"role":"user","content":"What is 2+2? Answer in one word."}],"max_tokens":2048,"thinking":true}'`
2. HTTP 400 with Anthropic's own actionable message and no traceback or retries: `"litellm.BadRequestError: AnthropicException - ... \"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."`

`/v1/messages` with `"thinking": true` was probed at both hashes and is unaffected: the bool passes through to Anthropic, which returns its clean 400 `thinking: Input should be an object` before and after

### Tip re-verification (54cc988a9e)

The tip differs from 138c77023a only in two test files (`git diff 138c77023a..54cc988a9e -- litellm/` is empty), and the headline case was re-run live at the tip:

1. `curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:32429/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"What is 2+2? Answer in one word."}],"thinking":true}'`
2. HTTP 200: `{"id":"chatcmpl-34bb90a8-0440-4d8b-9ce2-38b6a1d06411", ..., "message":{"content":"Four.","role":"assistant","reasoning_content":"The user is asking what 2+2 is ...","thinking_blocks":[{"type":"thinking", ...}]}}`

## Type

🐛 Bug Fix

## Caveats (if any)

- Adaptive-only models (sonnet-5+) reject the coerced legacy shape with Anthropic's clean 400
- User-supplied `max_tokens` <= 2048 collides with the default budget; Anthropic's 400 explains it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

CHECKED by /live-pr-risk at 138c77023a (tip 54cc988a9e is test-file-only on top, runtime tree identical, headline case re-run live at tip): every dependent of the changed thinking accessors (anthropic, bedrock converse, deepseek, Python SDK) was driven live A/B at ec6f1c1a56 vs 138c77023a with real provider calls; dict thinking, reasoning_effort, and /v1/messages behave identically on both sides, bool thinking goes from AttributeError plus 2 retries to working responses, and only the databricks path (same inherited base methods, dict path unchanged and unit-covered) was not driven live
