### PR TITLE
fix(router): keep acreate_file fallbacks inside the requested model group

### DIFF
--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -253,6 +253,7 @@ def get_fallback_model_group(fallbacks: list[Any], model_group: str) -> tuple[li
 
 
 PROVIDER_SCOPED_RESOURCE_KEYS: Final = ("input_file_id", "training_file")
+PROVIDER_SCOPED_CREATION_FUNCTION_NAMES: Final = frozenset({"_acreate_file"})
 
 
 def _get_fallback_target_model_group(fallback_entry: str | Mapping[str, object]) -> str | None:
@@ -272,6 +273,18 @@ def references_provider_scoped_resource(kwargs: Mapping[str, object]) -> bool:
     error the caller actually needs to see.
     """
     return any(kwargs.get(key) for key in PROVIDER_SCOPED_RESOURCE_KEYS)
+
+
+def creates_provider_scoped_resource(kwargs: Mapping[str, object]) -> bool:
+    """
+    True when the request creates a resource that will live under one provider's credentials.
+
+    A file uploaded for batches or fine-tuning is stored in the account of the deployment
+    that handled it, and its id is only usable against the model group the caller named.
+    Letting the upload fall back to a different model group silently stores the file with
+    the wrong provider, and every later use of the returned id fails.
+    """
+    return getattr(kwargs.get("original_function"), "__name__", None) in PROVIDER_SCOPED_CREATION_FUNCTION_NAMES
 
 
 async def run_async_fallback(
@@ -322,7 +335,9 @@ async def run_async_fallback(
     metadata_variable_name: Final = _get_router_metadata_variable_name(
         function_name=getattr(kwargs.get("original_function"), "__name__", None)
     )
-    same_model_group_only: Final = references_provider_scoped_resource(kwargs)
+    same_model_group_only: Final = references_provider_scoped_resource(kwargs) or creates_provider_scoped_resource(
+        kwargs
+    )
     # Read out of kwargs and narrowed here rather than declared as a parameter: every caller
     # reaches this function by spreading a loosely-typed kwargs dict, so a declared parameter
     # would carry an annotation that no call site can actually be checked against.

--- a/tests/test_litellm/router_utils/test_fallback_event_handlers.py
+++ b/tests/test_litellm/router_utils/test_fallback_event_handlers.py
@@ -167,6 +167,10 @@ async def _acreate_batch(*args, **kwargs):
     raise AssertionError("only used for its __name__")
 
 
+async def _acreate_file(*args, **kwargs):
+    raise AssertionError("only used for its __name__")
+
+
 @pytest.mark.asyncio
 async def test_run_async_fallback_keeps_uploaded_file_requests_in_their_model_group():
     """An input_file_id only exists under the credentials of the group it was uploaded
@@ -227,6 +231,46 @@ async def test_run_async_fallback_allows_same_model_group_retry_for_uploaded_fil
     )
 
     assert router.attempted_model_groups == ["openai-group"]
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_keeps_file_creation_in_its_model_group():
+    """A file created for batches lands in the account of the deployment that stored it,
+    and its id is only usable against the model group the caller named. A cross-group
+    fallback silently stores the file with the wrong provider."""
+    router = AttemptRecordingRouter()
+
+    with pytest.raises(RuntimeError, match="azure connection error"):
+        await run_async_fallback(
+            litellm_router=router,
+            fallback_model_group=["openai-group"],
+            original_model_group="azure-group",
+            original_exception=RuntimeError("azure connection error"),
+            max_fallbacks=3,
+            fallback_depth=0,
+            model="azure-group",
+            original_function=_acreate_file,
+        )
+
+    assert router.attempted_model_groups == []
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_allows_same_model_group_retry_for_file_creation():
+    router = AttemptRecordingRouter()
+
+    await run_async_fallback(
+        litellm_router=router,
+        fallback_model_group=[{"model": "azure-group", "_target_order": 2}],
+        original_model_group="azure-group",
+        original_exception=RuntimeError("first deployment failed"),
+        max_fallbacks=3,
+        fallback_depth=0,
+        model="azure-group",
+        original_function=_acreate_file,
+    )
+
+    assert router.attempted_model_groups == ["azure-group"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/router_utils/test_fallback_event_handlers.py
+++ b/tests/test_litellm/router_utils/test_fallback_event_handlers.py
@@ -1,4 +1,5 @@
 import json
+from typing import NoReturn
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -167,7 +168,7 @@ async def _acreate_batch(*args, **kwargs):
     raise AssertionError("only used for its __name__")
 
 
-async def _acreate_file(*args, **kwargs):
+async def _acreate_file(*args: object, **kwargs: object) -> NoReturn:
     raise AssertionError("only used for its __name__")
 
 

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -518,7 +518,7 @@ async def test_async_router_acreate_file_does_not_fall_back_across_model_groups(
         fallbacks=[{"azure-gpt": ["openai-gpt"]}],
     )
 
-    def fail_azure(*args, **kwargs):
+    def fail_azure(*args: object, **kwargs: object) -> MagicMock:
         if kwargs.get("model") == "azure/my-azure-deployment":
             raise litellm.APIConnectionError(
                 message="Connection error.",

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -493,6 +493,54 @@ async def test_async_router_acreate_file_with_jsonl():
 
 
 @pytest.mark.asyncio
+async def test_async_router_acreate_file_does_not_fall_back_across_model_groups():
+    """A file created for batches only exists under the credentials of the model group
+    the caller named. A cross-group fallback silently stores it with the wrong provider
+    and the later batch create against the named group permanently fails."""
+    from unittest.mock import MagicMock, patch
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "azure-gpt",
+                "litellm_params": {
+                    "model": "azure/my-azure-deployment",
+                    "api_base": "http://127.0.0.1:9",
+                    "api_key": "dummy-key",
+                    "api_version": "2024-06-01",
+                },
+            },
+            {
+                "model_name": "openai-gpt",
+                "litellm_params": {"model": "gpt-4o-mini"},
+            },
+        ],
+        fallbacks=[{"azure-gpt": ["openai-gpt"]}],
+    )
+
+    def fail_azure(*args, **kwargs):
+        if kwargs.get("model") == "azure/my-azure-deployment":
+            raise litellm.APIConnectionError(
+                message="Connection error.",
+                llm_provider="azure",
+                model="azure/my-azure-deployment",
+            )
+        return MagicMock()
+
+    with patch("litellm.acreate_file", side_effect=fail_azure) as mock_acreate_file:
+        with pytest.raises(litellm.APIConnectionError):
+            await router.acreate_file(
+                model="azure-gpt",
+                purpose="batch",
+                file=MagicMock(),
+            )
+
+        called_models = [call.kwargs.get("model") for call in mock_acreate_file.call_args_list]
+        assert "azure/my-azure-deployment" in called_models
+        assert "gpt-4o-mini" not in called_models
+
+
+@pytest.mark.asyncio
 async def test_async_router_acreate_file_uses_deployment_custom_llm_provider():
     """
     Ensure file routing preserves deployment custom_llm_provider instead of


### PR DESCRIPTION
## TLDR

Problem this solves:

- Files uploaded for one model group could silently land on another provider via router fallbacks
- The returned unified file id then fails every batch create with a permanent 429

How it solves it:

- File creation now reuses the fallback pin that already protects batch and fine-tuning calls
- Cross-group fallbacks are skipped for uploads, so the real provider error surfaces instead

## User Flow

Before: a developer uploading a batch file for their azure model group gets HTTP 200, but every batch create against the returned id fails forever

1. During transient Azure trouble they send POST https://litellm-domain/v1/files with form fields `purpose=batch`, `target_model_names=azure-gpt`, and their JSONL file
2. They get HTTP 200 with `"status": "uploaded"` and a scrambled file id, so they believe the file is ready for azure-gpt
3. They send POST https://litellm-domain/v1/batches with that file id and get HTTP 429 "No deployments available for selected model, Try again in 5 seconds"
4. They wait and retry the batch create, and it returns the same 429 every time, because the file actually landed under the account of the fallback group's provider

After: the upload fails loudly while Azure is down, and a retried upload once Azure is back produces a working batch

1. During the same transient Azure trouble they send the same POST https://litellm-domain/v1/files with `purpose=batch` and `target_model_names=azure-gpt`
2. They get HTTP 500 carrying the real connection error, so they know the upload did not go through and nothing was stored anywhere
3. Once Azure is reachable they retry the upload, get HTTP 200, and POST https://litellm-domain/v1/batches with the returned id succeeds

## Relevant issues

Related to #35371 and #36181, which pinned the batch and fine-tuning side of the same fallback walk

## Linear ticket

Resolves LIT-5788

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)
- [x] b7f4f531b3f88f58ffbed3d3adbcafa4614d5fa0 passes /live-pr-risk

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: proxy booted from the worktree with a fresh Postgres DB and the master key from .env, on random free ports: 30362 for the before leg, then 45817 and (after OpenAI finished the batch) 38571 for the after leg, both boots of the same tip commit. Config has an unreachable azure group, a healthy openai group, and a fallback between them:

```yaml
model_list:
  - model_name: azure-gpt
    litellm_params:
      model: azure/my-azure-deployment
      api_base: http://127.0.0.1:9
      api_key: dummy-key
      api_version: "2024-06-01"
  - model_name: openai-gpt
    litellm_params:
      model: openai/gpt-4.1-mini
      api_key: os.environ/OPENAI_API_KEY

router_settings:
  fallbacks:
    - azure-gpt:
        - openai-gpt
  num_retries: 1

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  database_url: os.environ/LIT5788_DATABASE_URL
```

`batch_input.jsonl`:

```json
{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "azure-gpt", "messages": [{"role": "user", "content": "say hi"}], "max_tokens": 5}}
```

### Before (ec6f1c1a56345350f669377f14ec8586bd43329e)

#### Upload for azure-gpt during the outage, then batch create

1. `curl -sS -i http://localhost:30362/v1/files -H "Authorization: Bearer $MASTER_KEY" -F purpose=batch -F target_model_names="azure-gpt" -F file=@batch_input.jsonl`
2. HTTP 200 with `"status":"uploaded"` and a unified id, even though azure-gpt is unreachable:

```
HTTP/1.1 200 OK

{"id":"bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07dW5pZmllZF9pZCw3YTdiMWEwYy04MjQ2LTQyZTEtYjFiOC1iYzYyZTg2NzFiYWE7dGFyZ2V0X21vZGVsX25hbWVzLGF6dXJlLWdwdDtsbG1fb3V0cHV0X2ZpbGVfaWQsZmlsZS05TFBvNlBqUnJoZ0N0a2hRM00xUnljO2xsbV9vdXRwdXRfZmlsZV9tb2RlbF9pZCw3OTU2ZDM4ZjdmNTY0ZDQxZmQyNTIwYmU2N2QzYTM2M2U3NzgxYjIzZDBmMTk5MzM0ZmE1NGI0NTU0Njc5M2Zm","bytes":176,"created_at":1787106179,"filename":"modified_file.jsonl","object":"file","purpose":"batch","status":"uploaded",...}
```

3. The id base64-decodes to `target_model_names,azure-gpt` next to an OpenAI-format `llm_output_file_id,file-9LPo6PjRrhgCtkhQ3M1Ryc`, and the file physically exists on the provider the caller never named: `curl -sS https://api.openai.com/v1/files/file-9LPo6PjRrhgCtkhQ3M1Ryc -H "Authorization: Bearer $OPENAI_API_KEY"` returns `"status": "processed"`
4. `curl -sS -i http://localhost:30362/v1/batches -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d "{\"input_file_id\": \"$UF\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\", \"model\": \"azure-gpt\"}"`
5. Permanent failure inviting infinite retries (a retry 8 seconds later returned the same thing):

```
HTTP/1.1 429 Too Many Requests

{"error":{"message":"No deployments available for selected model, Try again in 5 seconds. Passed model=azure-gpt. pre-call-checks=False, cooldown_list=[]","type":"internal_server_error","param":"None","code":"429"}}
```

#### Control: upload and batch on the healthy openai-gpt group

1. `curl -sS -i http://localhost:30362/v1/files -H "Authorization: Bearer $MASTER_KEY" -F purpose=batch -F target_model_names="openai-gpt" -F file=@batch_input.jsonl`
2. HTTP 200 and the decoded id consistently pairs `target_model_names,openai-gpt` with the openai deployment, so the harness itself is sound

### After (b7f4f531b3f88f58ffbed3d3adbcafa4614d5fa0)

#### Upload for azure-gpt during the outage

1. `curl -sS -i http://localhost:38571/v1/files -H "Authorization: Bearer $MASTER_KEY" -F purpose=batch -F target_model_names="azure-gpt" -F file=@batch_input.jsonl`
2. The upload now surfaces the real provider error instead of silently succeeding, and there is no unified id to orphan:

```
HTTP/1.1 500 Internal Server Error

{"error":{"message":"Connection error.. Received Model Group=azure-gpt\nAvailable Model Group Fallbacks=['openai-gpt']\nError doing the fallback: Connection error.","type":null,"param":null,"code":"500"}}
```

3. Proxy log shows the pin doing its job: `LiteLLM Router:INFO: fallback_event_handlers.py:354 - Skipping fallback to model_group = openai-gpt: request is pinned to model_group = azure-gpt by its uploaded file`
4. Nothing landed cross-provider: the managed file table holds 5 rows and `select count(*) from "LiteLLM_ManagedFileTable" where model_mappings::text like '%6e195556%'` (the azure deployment id) returns 0

#### Control: upload and batch on the healthy openai-gpt group

1. `curl -sS -i http://localhost:45817/v1/files -H "Authorization: Bearer $MASTER_KEY" -F purpose=batch -F target_model_names="openai-gpt" -F file=@batch_input.jsonl` returns HTTP 200 with `"status":"uploaded"` and a unified id decoding to `litellm_proxy:application/octet-stream;unified_id,aac1a6f4-48f5-45b3-a4cc-ac3ce98ee7f4;target_model_names,openai-gpt;llm_output_file_id,file-U2CAp3DGvD2ACLjahMxQNd;...`
2. `curl -sS -i http://localhost:45817/v1/batches -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d "{\"input_file_id\": \"$UF\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\", \"model\": \"openai-gpt\"}"` is accepted with `"object":"batch","status":"validating"`, creating real OpenAI batch `batch_6a851bc251c08190add73205b555055c`
3. Once OpenAI finished processing, `curl -sS "http://localhost:38571/v1/batches/$UB?provider=openai" -H "Authorization: Bearer $MASTER_KEY"` returns `"status": "completed"` with `"request_counts": {"completed": 1, "failed": 0, "total": 1}` and an output file id decoding to `llm_output_file_id,file-GsDJ474EBaYsHEyRzJqRuT`, a real gpt-4.1-mini batch run costing real money

## Type

🐛 Bug Fix

## Caveats (if any)

- Cross-group fallbacks are now skipped for every router file upload, managed or not

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
