### PR TITLE
fix(proxy): log spend for OpenAI passthrough embeddings with unmapped models

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
@@ -230,6 +230,25 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             return 0.0
 
     @staticmethod
+    def _calculate_embeddings_cost(
+        litellm_model_response: EmbeddingResponse,
+        model: str,
+        custom_llm_provider: str,
+    ) -> float:
+        try:
+            return litellm.completion_cost(
+                completion_response=litellm_model_response,
+                model=model,
+                custom_llm_provider=custom_llm_provider,
+                call_type="aembedding",
+            )
+        except Exception as e:  # noqa: BLE001  # completion_cost raises bare Exception for unmapped models; cost failure must never drop the spend log
+            verbose_proxy_logger.warning(
+                "Error calculating embeddings cost for model %s, logging spend with cost 0: %s", model, e
+            )
+            return 0.0
+
+    @staticmethod
     def _build_responses_api_response_and_cost(
         model: str,
         httpx_response: httpx.Response,
@@ -351,11 +370,10 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
                     model_response_object=EmbeddingResponse(),
                     response_type="embedding",
                 )
-                response_cost = litellm.completion_cost(
-                    completion_response=litellm_model_response,
+                response_cost = OpenAIPassthroughLoggingHandler._calculate_embeddings_cost(
+                    litellm_model_response=litellm_model_response,
                     model=model,
                     custom_llm_provider=custom_llm_provider,
-                    call_type="aembedding",
                 )
                 litellm_model_response._hidden_params["response_cost"] = response_cost
             elif is_image_generation:
@@ -471,6 +489,12 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
 
         except Exception as e:
             verbose_proxy_logger.error("Error in OpenAI passthrough cost tracking: %s", e)
+            if not is_chat_completions:
+                unbilled_result: Final[PassThroughEndpointLoggingTypedDict] = {
+                    "result": None,
+                    "kwargs": kwargs,
+                }
+                return unbilled_result
             # Fall back to base handler without cost tracking
             base_handler = OpenAIPassthroughLoggingHandler()
             return base_handler.passthrough_chat_handler(

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
@@ -1286,6 +1286,75 @@ class TestOpenAIPassthroughIntegration:
         mock_chat_handler.assert_called_once()
         assert result == {"result": None, "kwargs": {}}
 
+    def test_openai_passthrough_handler_embeddings_unmapped_model_logs_zero_cost(self):
+        response_body = {
+            "object": "list",
+            "model": "lit5787-unmapped-embeddings-deployment",
+            "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+            "usage": {"prompt_tokens": 9, "total_tokens": 9},
+        }
+        mock_logging_obj = self._create_mock_logging_obj()
+        result = OpenAIPassthroughLoggingHandler.openai_passthrough_handler(
+            httpx_response=self._create_mock_httpx_response(response_body),
+            response_body=response_body,
+            logging_obj=mock_logging_obj,
+            url_route="https://my-resource.openai.azure.com/openai/v1/embeddings",
+            result="",
+            start_time=self.start_time,
+            end_time=self.end_time,
+            cache_hit=False,
+            request_body={
+                "model": "lit5787-unmapped-embeddings-deployment",
+                "input": "spend probe",
+            },
+            passthrough_logging_payload=PassthroughStandardLoggingPayload(
+                url="https://my-resource.openai.azure.com/openai/v1/embeddings",
+                request_body={
+                    "model": "lit5787-unmapped-embeddings-deployment",
+                    "input": "spend probe",
+                },
+                request_method="POST",
+            ),
+            litellm_params={},
+        )
+
+        assert result["result"] is not None
+        assert result["result"].usage.prompt_tokens == 9
+        assert result["kwargs"]["response_cost"] == 0.0
+        assert result["kwargs"]["model"] == "lit5787-unmapped-embeddings-deployment"
+        assert result["result"]._hidden_params["response_cost"] == 0.0
+        assert mock_logging_obj.model_call_details["response_cost"] == 0.0
+
+    def test_openai_passthrough_handler_embeddings_error_skips_chat_fallback(self):
+        response_body = {
+            "object": "list",
+            "model": "text-embedding-3-small",
+            "usage": {"prompt_tokens": 9, "total_tokens": 9},
+        }
+        kwargs_in = {
+            "passthrough_logging_payload": PassthroughStandardLoggingPayload(
+                url="https://api.openai.com/v1/embeddings",
+                request_body={"model": "text-embedding-3-small", "input": "spend probe"},
+                request_method="POST",
+            ),
+            "litellm_params": {},
+        }
+        result = OpenAIPassthroughLoggingHandler.openai_passthrough_handler(
+            httpx_response=self._create_mock_httpx_response(response_body),
+            response_body=response_body,
+            logging_obj=self._create_mock_logging_obj(),
+            url_route="https://api.openai.com/v1/embeddings",
+            result="",
+            start_time=self.start_time,
+            end_time=self.end_time,
+            cache_hit=False,
+            request_body={"model": "text-embedding-3-small", "input": "spend probe"},
+            **kwargs_in,
+        )
+
+        assert result["result"] is None
+        assert result["kwargs"]["passthrough_logging_payload"] == kwargs_in["passthrough_logging_payload"]
+
     @patch(
         "litellm.proxy.pass_through_endpoints.llm_provider_handlers.openai_passthrough_logging_handler.OpenAIPassthroughLoggingHandler.openai_passthrough_handler"
     )


### PR DESCRIPTION
## TLDR

Problem this solves:

- OpenAI passthrough embeddings with unmapped models return 200 but never get billed
- Cost lookup failure crashed the logging task, dropping the spend log row

How it solves it:

- Embeddings cost failures now log spend at cost 0 instead of crashing
- Errors on non-chat bodies no longer hit the chat-shaped fallback

## User Flow

Before: a developer calls embeddings through the OpenAI passthrough with their Azure deployment name, gets a normal 200, and the proxy admin never sees the request billed

1. The proxy admin exposes the OpenAI passthrough by setting the upstream base URL and key, then hands the developer a virtual key
2. The developer sends `POST https://litellm-domain/openai_passthrough/v1/embeddings` with `{"model": "my-embeddings-deployment", "input": ["hello"]}`, a deployment name LiteLLM has no pricing for
3. They get back 200 with a normal embeddings body: `object: "list"`, the vector in `data`, and real token usage
4. The admin opens https://litellm-domain/ui/?page=logs and the request is nowhere in the list; `GET https://litellm-domain/spend/logs` shows no row for it either
5. The key's spend at `GET https://litellm-domain/key/info` never moves, so the request is served but invisible and unbilled forever

After: the same request shows up in the spend logs with its token counts, priced at $0 until a mapped price exists

1. The proxy admin exposes the OpenAI passthrough by setting the upstream base URL and key, then hands the developer a virtual key
2. The developer sends `POST https://litellm-domain/openai_passthrough/v1/embeddings` with `{"model": "my-embeddings-deployment", "input": ["hello"]}`, a deployment name LiteLLM has no pricing for
3. They get back 200 with a normal embeddings body: `object: "list"`, the vector in `data`, and real token usage
4. The admin opens https://litellm-domain/ui/?page=logs and the request is there; `GET https://litellm-domain/spend/logs?request_id=<id>` returns the row with the deployment name, its real prompt token count, and `"spend": 0.0`
5. Requests with models LiteLLM does have pricing for keep billing at their real cost, exactly as before

## Relevant issues

Embeddings residual of #36646 (the chat completions side was fixed in #36660)

## Linear ticket

Resolves LIT-5787

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: live proxy from the worktree against a real Azure OpenAI upstream (real API calls, real $)

```bash
export OPENAI_API_BASE="https://e2e-claude-foundry.openai.azure.com/openai"
export OPENAI_API_KEY="<azure key>"
.venv/bin/python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --port <port>
```

`lit5787-embed-qa2` is an Azure deployment name with no entry in the pricing map; `text-embedding-3-small` is mapped

### Before (ec6f1c1a56)

#### Unmapped deployment name

1. Request served fine:

   ```bash
   curl -sS http://localhost:43217/openai_passthrough/v1/embeddings \
     -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d '{"model": "lit5787-embed-qa2", "input": ["spend attribution probe LIT-5787"]}'
   ```

   Returns 200 with a normal embeddings body (`object: "list"`, vector in `data`, real `usage`), and the proxy log shows `"POST /openai_passthrough/v1/embeddings HTTP/1.1" 200 OK`

2. The logging task dies before writing anything:

   ```text
   19:27:50 - LiteLLM:ERROR: logging_worker.py:104 - LoggingWorker error: litellm.APIError: LiteLLM: provider returned a response with no 'choices'. Raw keys: ['id', 'object', 'data', 'model', 'usage']
   ...
   ValueError: This model isn't mapped yet. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
   ```

3. The next spend flush has nothing for the request, and no spend log row is ever written:

   ```text
   19:27:51 - spend_update_queue.py:37 - Aggregating updates by entity type: []
   19:27:51 - db_spend_update_writer.py:1225 - User Spend transactions: {}
   19:27:51 - db_spend_update_writer.py:1267 - KEY Spend transactions: {}
   ```

#### Mapped model (control)

1. Same curl with `{"model": "text-embedding-3-small", "input": "spend attribution probe LIT-5787 control"}` returns 200
2. Spend row written as expected: `SpendTable: created payload - request_id: d0d17210-..., model: text-embedding-3-small, spend: 2e-07`

### After (81914ebc31)

#### Unmapped deployment name

1. Same request against the fixed tip:

   ```bash
   curl -sS http://localhost:24886/openai_passthrough/v1/embeddings \
     -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d '{"model": "lit5787-embed-qa2", "input": ["spend attribution probe LIT-5787 tip"]}'
   ```

   Returns the same 200 embeddings body

2. The logging task now survives and writes the spend row (zero LoggingWorker errors in the whole run):

   ```text
   19:48:32 - openai_passthrough_logging_handler.py:246 - Error calculating embeddings cost for model lit5787-embed-qa2, logging spend with cost 0: This model isn't mapped yet. ...
   19:48:32 - spend_tracking_utils.py:441 - SpendTable: created payload - request_id: cacdffd2-40ed-4baa-9fda-4e2fc2686324, model: lit5787-embed-qa2, spend: 0.0
   19:48:32 - db_spend_update_writer.py:816 - Writing spend log to db - request_id: cacdffd2-40ed-4baa-9fda-4e2fc2686324, spend: 0.0
   ```

3. The row is visible where the admin looks:

   ```bash
   curl -sS "http://localhost:24886/spend/logs?request_id=cacdffd2-40ed-4baa-9fda-4e2fc2686324" \
     -H "Authorization: Bearer sk-1234"
   ```

   Returns the row: `request_id: cacdffd2-40ed-4baa-9fda-4e2fc2686324`, `model: lit5787-embed-qa2`, `custom_llm_provider: openai`, `spend: 0.0`, `prompt_tokens: 11`, `completion_tokens: 0`, `call_type: pass_through_endpoint`

#### Mapped model (control)

1. Same curl with `{"model": "text-embedding-3-small", "input": "spend attribution probe LIT-5787 control tip"}` returns 200
2. Real cost still billed: `SpendTable: created payload - request_id: be84855d-014b-4e2f-b972-ea6ed18e627d, model: text-embedding-3-small, spend: 2.2e-07`

## Type

🐛 Bug Fix

## Caveats (if any)

- Unmapped models bill at $0 until pricing is added to the map

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

live-pr-risk CHECKED at 81914ebc31: PASS. Only dispatch site (success_handler) A/B verified on a live proxy at base and tip with real Azure calls; no subclasses, no wire/config/DB/UI surface. Error paths on image and responses routes previously always crashed the chat-shaped fallback (body has no choices), so returning the pre-existing result-None contract removes no working behavior
