### PR TITLE
test: move the remaining live groq call sites off the retired llama models

### DIFF
--- a/tests/local_testing/test_model_alias_map.py
+++ b/tests/local_testing/test_model_alias_map.py
@@ -15,7 +15,7 @@ from litellm import completion, embedding
 
 litellm.set_verbose = True
 
-model_alias_map = {"good-model": "groq/llama-3.1-8b-instant"}
+model_alias_map = {"good-model": "groq/openai/gpt-oss-120b"}
 
 
 def test_model_alias_map(caplog):
@@ -34,7 +34,7 @@ def test_model_alias_map(caplog):
             if rec.levelname == "ERROR" and rec.name.startswith("LiteLLM"):
                 pytest.fail(f"Unexpected litellm ERROR log: {rec.getMessage()}")
 
-        assert "llama-3.1-8b-instant" in response.model
+        assert "gpt-oss-120b" in response.model
     except litellm.ServiceUnavailableError:
         pass
     except Exception as e:

--- a/tests/local_testing/test_router.py
+++ b/tests/local_testing/test_router.py
@@ -120,7 +120,7 @@ async def test_router_provider_wildcard_routing():
     print("response 2 = ", response2)
 
     response3 = await router.acompletion(
-        model="groq/llama-3.1-8b-instant",
+        model="groq/openai/gpt-oss-120b",
         messages=[{"role": "user", "content": "hello"}],
     )
 

--- a/tests/local_testing/test_router_batch_completion.py
+++ b/tests/local_testing/test_router_batch_completion.py
@@ -44,7 +44,7 @@ async def test_batch_completion_multiple_models(mode):
             {
                 "model_name": "groq-llama",
                 "litellm_params": {
-                    "model": "groq/llama-3.1-8b-instant",
+                    "model": "groq/openai/gpt-oss-120b",
                 },
             },
         ]
@@ -143,7 +143,7 @@ async def test_batch_completion_fastest_response_streaming():
             {
                 "model_name": "groq-llama",
                 "litellm_params": {
-                    "model": "groq/llama-3.1-8b-instant",
+                    "model": "groq/openai/gpt-oss-120b",
                 },
             },
         ]
@@ -179,7 +179,7 @@ async def test_batch_completion_multiple_models_multiple_messages():
             {
                 "model_name": "groq-llama",
                 "litellm_params": {
-                    "model": "groq/llama-3.1-8b-instant",
+                    "model": "groq/openai/gpt-oss-120b",
                 },
             },
         ]

--- a/tests/local_testing/test_stream_chunk_builder.py
+++ b/tests/local_testing/test_stream_chunk_builder.py
@@ -871,7 +871,7 @@ def load_env():
     }
     LLAMA3_3 = {
         "messages": messages,
-        "model": "groq/llama-3.3-70b-versatile",
+        "model": "groq/openai/gpt-oss-120b",
         "api_base": "https://api.groq.com/openai/v1",
         "temperature": 0.0,
         "tools": tools,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Groq retired `llama-3.1-8b-instant` too, not just the 70b
- Four live tests still call them, so three CI jobs 404

How it solves it:

- Point those four call sites at `groq/openai/gpt-oss-120b`
- Leave the offline fixtures on the old ids

## User Flow

Before: a developer copying our router examples wires up a Groq model that no longer answers

1. They copy the `groq/*` wildcard router setup from `test_router_provider_wildcard_routing`
2. They send POST https://litellm-domain/v1/chat/completions with `"model": "groq/llama-3.1-8b-instant"`
3. They get back 404 "The model `llama-3.1-8b-instant` does not exist or you do not have access to it"

After: the same copy-paste reaches a model Groq still serves

1. They copy the same router setup, now naming `groq/openai/gpt-oss-120b`
2. They send POST https://litellm-domain/v1/chat/completions with that model
3. They get back 200 with a completion

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

✅ Test

## Caveats

- Not live-verified locally: no Groq key on hand
- `test_model_alias_map` asserts the new id, so it moves too
- Cost and routing tests keep the old ids deliberately

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
