### PR TITLE
fix(ui): highlight the first member search match so Enter picks it

### DIFF
--- a/ui/litellm-dashboard/src/components/common_components/user_search_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/user_search_modal.test.tsx
@@ -161,6 +161,26 @@ describe("UserSearchModal submit payload", () => {
     });
   });
 
+  it("commits the first match when the typed search is confirmed with Enter", async () => {
+    const { user, onSubmit } = setup();
+
+    const input = getEmailSearchInput();
+    await user.click(input);
+    await user.type(input, "pick");
+    await waitFor(() => expect(userFilterUICall).toHaveBeenCalled(), { timeout: 3000 });
+    await screen.findByRole("option", { name: "picked@example.com" });
+
+    await user.keyboard("{Enter}");
+    await user.click(save());
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).toStrictEqual({
+      user_email: "picked@example.com",
+      user_id: "u-1",
+      role: "user",
+    });
+  });
+
   it("does not submit on Enter in any field, while the button still does", async () => {
     const { user, onSubmit } = setup();
 

--- a/ui/litellm-dashboard/src/components/common_components/user_search_modal.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/user_search_modal.tsx
@@ -165,6 +165,8 @@ const UserSearchModal: React.FC<UserSearchModalProps> = ({
         <Combobox
           items={items}
           value={selected}
+          // @ts-expect-error TS2322 -- Combobox.Root narrows autoHighlight to boolean; the AriaCombobox it wraps
+          // accepts "always", the only value that highlights a list this component filters server-side
           autoHighlight="always"
           filter={null}
           onValueChange={(option: UserOption | null) => {

--- a/ui/litellm-dashboard/src/components/common_components/user_search_modal.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/user_search_modal.tsx
@@ -165,6 +165,7 @@ const UserSearchModal: React.FC<UserSearchModalProps> = ({
         <Combobox
           items={items}
           value={selected}
+          autoHighlight="always"
           filter={null}
           onValueChange={(option: UserOption | null) => {
             controlProps.onChange(option?.value);


### PR DESCRIPTION
## TLDR

Problem this solves:

- Typing a member's email and pressing Enter selects nobody
- The form still submits, sending an add with no email

How it solves it:

- Highlight the first match so Enter commits it
- Cover the keyboard path the click-only tests missed

## User Flow

Before: a team admin adds a member by keyboard and the add silently goes out empty

1. They open http://localhost:4000/ui/?page=teams, click a team, open the Members tab and click Add Member
2. They type `someone@example.com` into Email and the matching row appears under the field
3. They press Enter to pick it; the field stays empty and no one is selected
4. They click Add Member anyway, and the request that leaves the browser carries no email at all
5. No member is added and no success message appears

After: Enter picks the match the user is looking at

1. They open the same modal from http://localhost:4000/ui/?page=teams and click Add Member
2. They type `someone@example.com` and the matching row appears, already highlighted
3. They press Enter and the field now shows that email
4. They click Add Member and the request carries that email
5. The member appears in the team's roster

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

🐛 Bug Fix

## Caveats

- The modal still submits with no member selected
- That missing validation is left for a follow-up

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
