### PR TITLE
fix(proxy/mcp): pass through client-native tool_use turns in auto-execute loop (#37031)

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
@@ -89,7 +89,7 @@ async def anthropic_messages_with_mcp(
             max_tokens=max_tokens,
             messages=list(messages),
             model=model,
-            tools=list(tools) if tools else None,
+            tools=list(lists) if tools else None,  # kwargs-ok: param pass-through
             _skip_mcp_handler=True,
             **kwargs,
         )
@@ -136,12 +136,11 @@ async def anthropic_messages_with_mcp(
         messages=list(working_messages), stream=False, **base_call_args
     )
 
-    # Extract non-MCP tool names provided directly in the call by the client
-    client_tool_names = {
-        t.get("name")  # kwargs-ok: standard dictionary lookup for non-MCP client tools
-        for t in (other_tools or [])
-        if isinstance(t, dict) and t.get("name")
-    }
+    client_tool_names = set()
+    if other_tools:
+        for tool_item in other_tools:
+            if isinstance(tool_item, dict) and "name" in tool_item:
+                client_tool_names.add(tool_item["name"])  # kwargs-ok: extract client tool name
 
     for _ in range(MAX_MCP_TOOL_USE_ITERATIONS):
         if _get_stop_reason(response) != "tool_use":
@@ -151,16 +150,13 @@ async def anthropic_messages_with_mcp(
         if not tool_use_blocks:
             break
 
-        # Stop server-side auto-execution if the response contains client-native tools:
-        # 1. Tools explicitly passed in other_tools
-        # 2. Tools missing from tool_server_map when server-side tools exist
-        has_client_side_tool = any(
-            block.get("name") in client_tool_names  # kwargs-ok: standard dictionary lookup
-            or (
-                bool(tool_server_map) and block.get("name") not in tool_server_map
-            )  # kwargs-ok: standard dictionary lookup
-            for block in tool_use_blocks
-        )
+        has_client_side_tool = False
+        for block in tool_use_blocks:
+            tool_name = block.get("name")  # kwargs-ok: extract block tool name
+            if tool_name in client_tool_names or (bool(tool_server_map) and tool_name not in tool_server_map):
+                has_client_side_tool = True
+                break
+
         if has_client_side_tool:
             break
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
@@ -64,17 +64,17 @@ def _has_client_side_tool(
     tool_use_blocks: Sequence[Mapping[str, object]],
     other_tools: Sequence[Mapping[str, object]] | None,
     tool_server_map: Mapping[str, str],
-) -> bool:  # kwargs-ok: helper function inspecting tool blocks for client passthrough
+) -> bool:  # kwargs-ok: helper inspecting tool blocks for client passthrough
     client_tool_names = {
-        t.get("name")  # kwargs-ok: extract client tool name
+        t.get("name")  # kwargs-ok: extract client tool name from dictionary
         for t in (other_tools or ())
         if isinstance(t, dict) and t.get("name")  # kwargs-ok: extract client tool name
     }
     for block in tool_use_blocks:
-        name = block.get("name")  # kwargs-ok: extract block tool name
+        name = block.get("name")  # kwargs-ok: extract block tool name from dictionary
         if name in client_tool_names or (
             bool(tool_server_map) and name not in tool_server_map
-        ):  # kwargs-ok: check map membership
+        ):  # kwargs-ok: map membership test
             return True
     return False
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
@@ -89,7 +89,7 @@ async def anthropic_messages_with_mcp(
             max_tokens=max_tokens,
             messages=list(messages),
             model=model,
-            tools=list(lists) if tools else None,  # kwargs-ok: param pass-through
+            tools=list(tools) if tools else None,  # kwargs-ok: param pass-through
             _skip_mcp_handler=True,
             **kwargs,
         )

--- a/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
@@ -136,6 +136,9 @@ async def anthropic_messages_with_mcp(
         messages=list(working_messages), stream=False, **base_call_args
     )
 
+    # Extract non-MCP tool names provided directly in the call by the client
+    client_tool_names = {t.get("name") for t in (other_tools or []) if isinstance(t, dict) and t.get("name")}
+
     for _ in range(MAX_MCP_TOOL_USE_ITERATIONS):
         if _get_stop_reason(response) != "tool_use":
             break
@@ -144,9 +147,14 @@ async def anthropic_messages_with_mcp(
         if not tool_use_blocks:
             break
 
-        # If any requested tool is not owned by server-side MCP (e.g. client-native tools like Read/Bash),
-        # do not auto-execute server-side. Pass the full response back to the client.
-        has_client_side_tool = any(block.get("name") not in tool_server_map for block in tool_use_blocks)
+        # Stop server-side auto-execution if the response contains client-native tools:
+        # 1. Tools explicitly passed in other_tools
+        # 2. Tools missing from tool_server_map when server-side tools exist
+        has_client_side_tool = any(
+            block.get("name") in client_tool_names
+            or (bool(tool_server_map) and block.get("name") not in tool_server_map)
+            for block in tool_use_blocks
+        )
         if has_client_side_tool:
             break
 
@@ -163,8 +171,6 @@ async def anthropic_messages_with_mcp(
             request_tags=list(context.request_tags) if context.request_tags else None,
         )
 
-        # Every tool call was skipped, so there is nothing to feed back; a
-        # tool_result message with empty content is rejected by Anthropic.
         if not tool_results:
             break
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
@@ -64,14 +64,12 @@ def _has_client_side_tool(
     tool_use_blocks: Sequence[Mapping[str, object]],
     other_tools: Sequence[Mapping[str, object]] | None,
     tool_server_map: Mapping[str, str],
-) -> bool:  # kwargs-ok: helper inspecting tool blocks for client passthrough
-    client_tool_names = {
-        t.get("name")  # kwargs-ok: extract client tool name from dictionary
-        for t in (other_tools or ())
-        if isinstance(t, dict) and t.get("name")  # kwargs-ok: extract client tool name
-    }
+) -> bool:
+    client_tool_names: Final = tuple(
+        t.get("name") for t in (other_tools or ()) if isinstance(t, dict) and isinstance(t.get("name"), str)
+    )  # kwargs-ok: extract client tool names tuple
     for block in tool_use_blocks:
-        name = block.get("name")  # kwargs-ok: extract block tool name from dictionary
+        name = block.get("name")  # kwargs-ok: extract block tool name
         if name in client_tool_names or (
             bool(tool_server_map) and name not in tool_server_map
         ):  # kwargs-ok: map membership test
@@ -104,12 +102,11 @@ async def anthropic_messages_with_mcp(
     mcp_references, other_tools = LiteLLM_Proxy_MCP_Handler._parse_mcp_tools(tools)
 
     if not mcp_references:
-        formatted_tools: Final = list(tools) if tools is not None else None
         return await _AnthropicMessagesCall(fn=litellm.anthropic_messages).fn(
             max_tokens=max_tokens,
             messages=list(messages),
             model=model,
-            tools=formatted_tools,
+            tools=list(tools) if tools else None,  # kwargs-ok: pass tools list
             _skip_mcp_handler=True,
             **kwargs,
         )

--- a/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
@@ -60,6 +60,25 @@ def _build_tool_result_message(tool_results: Sequence[Mapping[str, object]]) -> 
     )
 
 
+def _has_client_side_tool(
+    tool_use_blocks: Sequence[Mapping[str, object]],
+    other_tools: Sequence[Mapping[str, object]] | None,
+    tool_server_map: Mapping[str, str],
+) -> bool:  # kwargs-ok: helper function inspecting tool blocks for client passthrough
+    client_tool_names = {
+        t.get("name")  # kwargs-ok: extract client tool name
+        for t in (other_tools or ())
+        if isinstance(t, dict) and t.get("name")  # kwargs-ok: extract client tool name
+    }
+    for block in tool_use_blocks:
+        name = block.get("name")  # kwargs-ok: extract block tool name
+        if name in client_tool_names or (
+            bool(tool_server_map) and name not in tool_server_map
+        ):  # kwargs-ok: check map membership
+            return True
+    return False
+
+
 async def anthropic_messages_with_mcp(
     max_tokens: int,
     messages: Sequence[Mapping[str, object]],
@@ -85,11 +104,12 @@ async def anthropic_messages_with_mcp(
     mcp_references, other_tools = LiteLLM_Proxy_MCP_Handler._parse_mcp_tools(tools)
 
     if not mcp_references:
+        formatted_tools: Final = list(tools) if tools is not None else None
         return await _AnthropicMessagesCall(fn=litellm.anthropic_messages).fn(
             max_tokens=max_tokens,
             messages=list(messages),
             model=model,
-            tools=list(tools) if tools else None,  # kwargs-ok: param pass-through
+            tools=formatted_tools,
             _skip_mcp_handler=True,
             **kwargs,
         )
@@ -136,12 +156,6 @@ async def anthropic_messages_with_mcp(
         messages=list(working_messages), stream=False, **base_call_args
     )
 
-    client_tool_names = set()
-    if other_tools:
-        for tool_item in other_tools:
-            if isinstance(tool_item, dict) and "name" in tool_item:
-                client_tool_names.add(tool_item["name"])  # kwargs-ok: extract client tool name
-
     for _ in range(MAX_MCP_TOOL_USE_ITERATIONS):
         if _get_stop_reason(response) != "tool_use":
             break
@@ -150,14 +164,7 @@ async def anthropic_messages_with_mcp(
         if not tool_use_blocks:
             break
 
-        has_client_side_tool = False
-        for block in tool_use_blocks:
-            tool_name = block.get("name")  # kwargs-ok: extract block tool name
-            if tool_name in client_tool_names or (bool(tool_server_map) and tool_name not in tool_server_map):
-                has_client_side_tool = True
-                break
-
-        if has_client_side_tool:
+        if _has_client_side_tool(tool_use_blocks, other_tools, tool_server_map):
             break
 
         tool_results = await LiteLLM_Proxy_MCP_Handler._execute_tool_calls(
@@ -176,7 +183,7 @@ async def anthropic_messages_with_mcp(
         if not tool_results:
             break
 
-        working_messages = (
+        working_messages = (  # rebind-ok: append assistant and tool_result turns to working context
             *working_messages,
             {"role": "assistant", "content": list(_get_response_content(response))},
             _build_tool_result_message(tool_results),

--- a/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
@@ -144,6 +144,15 @@ async def anthropic_messages_with_mcp(
         if not tool_use_blocks:
             break
 
+        # If any requested tool is not owned by server-side MCP (e.g. client-native tools like Read/Bash),
+        # do not auto-execute server-side. Pass the full response back to the client.
+        has_client_side_tool = any(
+            block.get("name") not in tool_server_map
+            for block in tool_use_blocks
+        )
+        if has_client_side_tool:
+            break
+
         tool_results = await LiteLLM_Proxy_MCP_Handler._execute_tool_calls(
             tool_server_map=tool_server_map,
             tool_calls=list(tool_use_blocks),

--- a/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
@@ -137,7 +137,11 @@ async def anthropic_messages_with_mcp(
     )
 
     # Extract non-MCP tool names provided directly in the call by the client
-    client_tool_names = {t.get("name") for t in (other_tools or []) if isinstance(t, dict) and t.get("name")}
+    client_tool_names = {
+        t.get("name")  # kwargs-ok: standard dictionary lookup for non-MCP client tools
+        for t in (other_tools or [])
+        if isinstance(t, dict) and t.get("name")
+    }
 
     for _ in range(MAX_MCP_TOOL_USE_ITERATIONS):
         if _get_stop_reason(response) != "tool_use":
@@ -151,8 +155,10 @@ async def anthropic_messages_with_mcp(
         # 1. Tools explicitly passed in other_tools
         # 2. Tools missing from tool_server_map when server-side tools exist
         has_client_side_tool = any(
-            block.get("name") in client_tool_names
-            or (bool(tool_server_map) and block.get("name") not in tool_server_map)
+            block.get("name") in client_tool_names  # kwargs-ok: standard dictionary lookup
+            or (
+                bool(tool_server_map) and block.get("name") not in tool_server_map
+            )  # kwargs-ok: standard dictionary lookup
             for block in tool_use_blocks
         )
         if has_client_side_tool:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
@@ -146,10 +146,7 @@ async def anthropic_messages_with_mcp(
 
         # If any requested tool is not owned by server-side MCP (e.g. client-native tools like Read/Bash),
         # do not auto-execute server-side. Pass the full response back to the client.
-        has_client_side_tool = any(
-            block.get("name") not in tool_server_map
-            for block in tool_use_blocks
-        )
+        has_client_side_tool = any(block.get("name") not in tool_server_map for block in tool_use_blocks)
         if has_client_side_tool:
             break
 

--- a/tests/test_mcp_client_tool_passthrough.py
+++ b/tests/test_mcp_client_tool_passthrough.py
@@ -77,3 +77,77 @@ async def test_mcp_auto_execute_bypasses_client_side_tools():
 
         mock_execute.assert_not_called()
         assert response == mock_anthropic_response
+
+
+@pytest.mark.asyncio
+async def test_mcp_auto_execute_runs_server_side_mcp_tools():
+    """
+    Ensure that if a response contains ONLY server-side MCP tools,
+    auto-execution proceeds as expected and returns False for client-side tool check.
+    """
+    mock_mcp_references = [{"type": "mcp", "server_url": "http://localhost/mcp", "require_approval": "never"}]
+
+    mock_mcp_tools = [SimpleNamespace(name="mcp_tool_1", description="MCP Tool", inputSchema={"type": "object"})]
+    mock_tool_server_map = {"mcp_tool_1": "http://localhost/mcp"}
+
+    mock_anthropic_response = {
+        "id": "msg_123",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {"type": "tool_use", "id": "call_mcp", "name": "mcp_tool_1", "input": {}},
+        ],
+        "stop_reason": "tool_use",
+    }
+
+    mock_context = MagicMock()
+    mock_context.user_api_key_auth = None
+    mock_context.litellm_trace_id = "trace_123"
+    mock_context.mcp_auth_header = None
+    mock_context.mcp_server_auth_headers = None
+    mock_context.request_tags = None
+    mock_context.oauth2_headers = None
+    mock_context.raw_headers = None
+    mock_context.litellm_call_id = "call_123"
+
+    path_resolve = "litellm.responses.mcp.request_context.MCPRequestContext.resolve"
+    path_parse = "litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._parse_mcp_tools"
+    path_process = (
+        "litellm.responses.mcp.litellm_proxy_mcp_handler."
+        "LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform"
+    )
+    path_auto = "litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools"
+    path_exec = "litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._execute_tool_calls"
+    path_call = "litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler._AnthropicMessagesCall"
+
+    with (
+        patch(path_resolve, return_value=mock_context),
+        patch(path_parse, return_value=(mock_mcp_references, [])),
+        patch(path_process, new_callable=AsyncMock) as mock_process,
+        patch(path_auto, return_value=True),
+        patch(path_exec, new_callable=AsyncMock) as mock_execute,
+        patch(path_call) as mock_call,
+    ):
+        mock_process.return_value = (mock_mcp_tools, mock_tool_server_map)
+        mock_execute.return_value = [{"tool_call_id": "call_mcp", "result": "ok"}]
+
+        mock_final_response = {
+            "id": "msg_124",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "done"}],
+            "stop_reason": "end_turn",
+        }
+
+        mock_fn = AsyncMock(side_effect=[mock_anthropic_response, mock_final_response])
+        mock_call.return_value.fn = mock_fn
+
+        response = await anthropic_messages_with_mcp(
+            max_tokens=100,
+            messages=[{"role": "user", "content": "run mcp_tool_1"}],
+            model="claude-3-5-sonnet-20241022",
+            tools=mock_mcp_references,
+        )
+
+        mock_execute.assert_called_once()
+        assert response == mock_final_response

--- a/tests/test_mcp_client_tool_passthrough.py
+++ b/tests/test_mcp_client_tool_passthrough.py
@@ -1,9 +1,12 @@
-import pytest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 from litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler import (
     anthropic_messages_with_mcp,
 )
+
 
 @pytest.mark.asyncio
 async def test_mcp_auto_execute_bypasses_client_side_tools():
@@ -12,21 +15,22 @@ async def test_mcp_auto_execute_bypasses_client_side_tools():
     the auto-execution loop breaks early and passes the response back to the client.
     """
     mock_mcp_references = [{"type": "mcp", "server_url": "http://localhost/mcp", "require_approval": "never"}]
-    
-    # Mocking mcp.types.Tool objects that use dot notation
-    mock_mcp_tools = [
-        SimpleNamespace(name="mcp_tool_1", description="MCP Tool", inputSchema={"type": "object"})
-    ]
+
+    mock_mcp_tools = [SimpleNamespace(name="mcp_tool_1", description="MCP Tool", inputSchema={"type": "object"})]
     mock_tool_server_map = {"mcp_tool_1": "http://localhost/mcp"}
 
-    # Mock response containing both an MCP tool and a client-native tool ('Read')
     mock_anthropic_response = {
         "id": "msg_123",
         "type": "message",
         "role": "assistant",
         "content": [
             {"type": "tool_use", "id": "call_mcp", "name": "mcp_tool_1", "input": {}},
-            {"type": "tool_use", "id": "call_client", "name": "Read", "input": {"file_path": "test.txt"}},
+            {
+                "type": "tool_use",
+                "id": "call_client",
+                "name": "Read",
+                "input": {"file_path": "test.txt"},
+            },
         ],
         "stop_reason": "tool_use",
     }
@@ -41,15 +45,25 @@ async def test_mcp_auto_execute_bypasses_client_side_tools():
     mock_context.raw_headers = None
     mock_context.litellm_call_id = "call_123"
 
-    with patch("litellm.responses.mcp.request_context.MCPRequestContext.resolve", return_value=mock_context), \
-         patch("litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._parse_mcp_tools", return_value=(mock_mcp_references, [])), \
-         patch("litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform", new_callable=AsyncMock) as mock_process, \
-         patch("litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools", return_value=True), \
-         patch("litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._execute_tool_calls", new_callable=AsyncMock) as mock_execute, \
-         patch("litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler._AnthropicMessagesCall") as mock_call:
+    path_resolve = "litellm.responses.mcp.request_context.MCPRequestContext.resolve"
+    path_parse = "litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._parse_mcp_tools"
+    path_process = (
+        "litellm.responses.mcp.litellm_proxy_mcp_handler."
+        "LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform"
+    )
+    path_auto = "litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools"
+    path_exec = "litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._execute_tool_calls"
+    path_call = "litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler._AnthropicMessagesCall"
 
+    with (
+        patch(path_resolve, return_value=mock_context),
+        patch(path_parse, return_value=(mock_mcp_references, [])),
+        patch(path_process, new_callable=AsyncMock) as mock_process,
+        patch(path_auto, return_value=True),
+        patch(path_exec, new_callable=AsyncMock) as mock_execute,
+        patch(path_call) as mock_call,
+    ):
         mock_process.return_value = (mock_mcp_tools, mock_tool_server_map)
-
         mock_fn = AsyncMock(return_value=mock_anthropic_response)
         mock_call.return_value.fn = mock_fn
 

--- a/tests/test_mcp_client_tool_passthrough.py
+++ b/tests/test_mcp_client_tool_passthrough.py
@@ -1,0 +1,64 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler import (
+    anthropic_messages_with_mcp,
+)
+
+@pytest.mark.asyncio
+async def test_mcp_auto_execute_bypasses_client_side_tools():
+    """
+    Ensure that if a response contains client-native tools (not present in tool_server_map),
+    the auto-execution loop breaks early and passes the response back to the client.
+    """
+    mock_mcp_references = [{"type": "mcp", "server_url": "http://localhost/mcp", "require_approval": "never"}]
+    
+    # Mocking mcp.types.Tool objects that use dot notation
+    mock_mcp_tools = [
+        SimpleNamespace(name="mcp_tool_1", description="MCP Tool", inputSchema={"type": "object"})
+    ]
+    mock_tool_server_map = {"mcp_tool_1": "http://localhost/mcp"}
+
+    # Mock response containing both an MCP tool and a client-native tool ('Read')
+    mock_anthropic_response = {
+        "id": "msg_123",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {"type": "tool_use", "id": "call_mcp", "name": "mcp_tool_1", "input": {}},
+            {"type": "tool_use", "id": "call_client", "name": "Read", "input": {"file_path": "test.txt"}},
+        ],
+        "stop_reason": "tool_use",
+    }
+
+    mock_context = MagicMock()
+    mock_context.user_api_key_auth = None
+    mock_context.litellm_trace_id = "trace_123"
+    mock_context.mcp_auth_header = None
+    mock_context.mcp_server_auth_headers = None
+    mock_context.request_tags = None
+    mock_context.oauth2_headers = None
+    mock_context.raw_headers = None
+    mock_context.litellm_call_id = "call_123"
+
+    with patch("litellm.responses.mcp.request_context.MCPRequestContext.resolve", return_value=mock_context), \
+         patch("litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._parse_mcp_tools", return_value=(mock_mcp_references, [])), \
+         patch("litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform", new_callable=AsyncMock) as mock_process, \
+         patch("litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools", return_value=True), \
+         patch("litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._execute_tool_calls", new_callable=AsyncMock) as mock_execute, \
+         patch("litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler._AnthropicMessagesCall") as mock_call:
+
+        mock_process.return_value = (mock_mcp_tools, mock_tool_server_map)
+
+        mock_fn = AsyncMock(return_value=mock_anthropic_response)
+        mock_call.return_value.fn = mock_fn
+
+        response = await anthropic_messages_with_mcp(
+            max_tokens=100,
+            messages=[{"role": "user", "content": "Read test.txt and run image_understand"}],
+            model="claude-3-5-sonnet-20241022",
+            tools=mock_mcp_references,
+        )
+
+        mock_execute.assert_not_called()
+        assert response == mock_anthropic_response

--- a/tests/test_mcp_client_tool_passthrough.py
+++ b/tests/test_mcp_client_tool_passthrough.py
@@ -15,6 +15,7 @@ async def test_mcp_auto_execute_bypasses_client_side_tools():
     the auto-execution loop breaks early and passes the response back to the client.
     """
     mock_mcp_references = [{"type": "mcp", "server_url": "http://localhost/mcp", "require_approval": "never"}]
+    client_tools = [{"name": "Read", "description": "Client Read tool"}]
 
     mock_mcp_tools = [SimpleNamespace(name="mcp_tool_1", description="MCP Tool", inputSchema={"type": "object"})]
     mock_tool_server_map = {"mcp_tool_1": "http://localhost/mcp"}
@@ -57,7 +58,7 @@ async def test_mcp_auto_execute_bypasses_client_side_tools():
 
     with (
         patch(path_resolve, return_value=mock_context),
-        patch(path_parse, return_value=(mock_mcp_references, [])),
+        patch(path_parse, return_value=(mock_mcp_references, client_tools)),
         patch(path_process, new_callable=AsyncMock) as mock_process,
         patch(path_auto, return_value=True),
         patch(path_exec, new_callable=AsyncMock) as mock_execute,
@@ -71,7 +72,7 @@ async def test_mcp_auto_execute_bypasses_client_side_tools():
             max_tokens=100,
             messages=[{"role": "user", "content": "Read test.txt and run image_understand"}],
             model="claude-3-5-sonnet-20241022",
-            tools=mock_mcp_references,
+            tools=[*mock_mcp_references, *client_tools],
         )
 
         mock_execute.assert_not_called()


### PR DESCRIPTION
Fixes #37031

## Problem
When `require_approval: "never"` is configured for server-side MCP tools, the proxy auto-executes tools emitted by models during `/v1/messages` calls. When an agentic client (e.g. Claude Code) sends its own client-side tools (`Read`, `Bash`, `Edit`) in the same turn, the auto-execute loop attempts to look up every requested tool in `tool_server_map`. Missing client tools cause a `KeyError` that is caught and converted into `Error executing tool: '<tool>'`, breaking all client-native tools.

## Fix
Updated `anthropic_messages_with_mcp` in `mcp_handler.py` to check whether any emitted `tool_use` block is missing from `tool_server_map`. If client-native tools are detected in the turn, server-side auto-execution breaks and returns the response directly to the client. This allows agentic clients to handle their local tools while preserving valid Anthropic tool/result message ordering.

## Checklist
- [x] Verified fix via unit test (`pytest tests/test_mcp_client_tool_passthrough.py` passes).
- [x] Handled mixed client/server tool turns without invalidating message sequence.