### PR TITLE
feat(ui): add mounted-field projections for the MCP server form graph

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mountedServerFields.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mountedServerFields.test.ts
@@ -111,15 +111,17 @@ describe("edit root: auth_type gates", () => {
   });
 
   it("mounts the seven aws credentials only for aws_sigv4", () => {
-    expect(editCreds({ transport: "http", auth_type: "aws_sigv4" })).toStrictEqual([
-      "aws_region_name",
-      "aws_service_name",
-      "aws_access_key_id",
-      "aws_secret_access_key",
-      "aws_session_token",
-      "aws_role_name",
-      "aws_session_name",
-    ]);
+    expect(sorted(editCreds({ transport: "http", auth_type: "aws_sigv4" }))).toStrictEqual(
+      sorted([
+        "aws_region_name",
+        "aws_service_name",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "aws_role_name",
+        "aws_session_name",
+      ]),
+    );
     expect(editCreds(HTTP_NONE)).not.toContain("aws_region_name");
   });
 
@@ -136,7 +138,9 @@ describe("edit root: children that gate by early return null", () => {
   it("mounts dcr_bridge and the declared-app credentials only for the client-forwarded modes", () => {
     for (const authType of ["true_passthrough", "oauth_delegate"]) {
       expect(editRoot({ transport: "http", auth_type: authType })).toContain("dcr_bridge");
-      expect(editCreds({ transport: "http", auth_type: authType })).toStrictEqual(["client_id", "client_secret"]);
+      expect(sorted(editCreds({ transport: "http", auth_type: authType }))).toStrictEqual(
+        sorted(["client_id", "client_secret"]),
+      );
     }
     expect(editRoot(HTTP_NONE)).not.toContain("dcr_bridge");
     expect(editRoot({ transport: "http", auth_type: "oauth2" })).not.toContain("dcr_bridge");

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mountedServerFields.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mountedServerFields.test.ts
@@ -1,0 +1,493 @@
+import { describe, expect, it } from "vitest";
+import {
+  mountedCreateFieldNames,
+  mountedEditFieldNames,
+  projectMountedCreateValues,
+  projectMountedEditValues,
+} from "./mountedServerFields";
+
+const editRoot = (values: Record<string, unknown>) => mountedEditFieldNames(values).root;
+const editCreds = (values: Record<string, unknown>) => mountedEditFieldNames(values).credentials;
+const createRoot = (values: Record<string, unknown>) => mountedCreateFieldNames(values).root;
+const createCreds = (values: Record<string, unknown>) => mountedCreateFieldNames(values).credentials;
+
+const HTTP_NONE = { transport: "http", auth_type: "none" };
+
+describe("edit root: transport gates", () => {
+  it("mounts url for http but not spec_path or the stdio group", () => {
+    const root = editRoot(HTTP_NONE);
+    expect(root).toContain("url");
+    expect(root).not.toContain("spec_path");
+    expect(root).not.toContain("command");
+    expect(root).not.toContain("stdio_config");
+  });
+
+  it("mounts url for sse", () => {
+    expect(editRoot({ transport: "sse", auth_type: "none" })).toContain("url");
+  });
+
+  it("mounts spec_path and not url for openapi", () => {
+    const root = editRoot({ transport: "openapi", auth_type: "none" });
+    expect(root).toContain("spec_path");
+    expect(root).not.toContain("url");
+  });
+
+  it("swaps the whole auth subtree for the stdio group on stdio", () => {
+    const root = editRoot({ transport: "stdio", auth_type: "oauth2" });
+    expect(root).toStrictEqual([
+      "server_name",
+      "alias",
+      "description",
+      "transport",
+      "max_concurrent_requests",
+      "command",
+      "args",
+      "env_json",
+      "stdio_config",
+      "env_vars",
+      "allow_all_keys",
+      "available_on_public_internet",
+      "mcp_access_groups",
+      "extra_headers",
+      "static_headers",
+    ]);
+  });
+
+  it("drops every credential on stdio even when auth_type is stored as oauth2", () => {
+    expect(editCreds({ transport: "stdio", auth_type: "oauth2" })).toStrictEqual([]);
+  });
+});
+
+describe("edit root: auth_type gates", () => {
+  it("mounts credentials.auth_value only for the four value-bearing auth types", () => {
+    for (const authType of ["api_key", "bearer_token", "token", "basic"]) {
+      expect(editCreds({ transport: "http", auth_type: authType })).toStrictEqual(["auth_value"]);
+    }
+    expect(editCreds(HTTP_NONE)).toStrictEqual([]);
+  });
+
+  it("swaps the oauth2 endpoint set on the M2M flow", () => {
+    const m2m = editRoot({ transport: "http", auth_type: "oauth2", oauth_flow_type: "m2m" });
+    const interactive = editRoot({ transport: "http", auth_type: "oauth2", oauth_flow_type: "interactive" });
+    expect(m2m).toContain("token_url");
+    expect(m2m).not.toContain("issuer");
+    expect(m2m).not.toContain("registration_url");
+    expect(interactive).toContain("issuer");
+    expect(interactive).toContain("registration_url");
+  });
+
+  it("mounts token_validation_json ONLY on the interactive oauth2 branch", () => {
+    expect(editRoot({ transport: "http", auth_type: "oauth2", oauth_flow_type: "interactive" })).toContain(
+      "token_validation_json",
+    );
+    expect(editRoot({ transport: "http", auth_type: "oauth2", oauth_flow_type: "m2m" })).not.toContain(
+      "token_validation_json",
+    );
+    expect(editRoot({ transport: "http", auth_type: "oauth2_token_exchange" })).not.toContain("token_validation_json");
+    expect(editRoot(HTTP_NONE)).not.toContain("token_validation_json");
+  });
+
+  it("mounts token_storage_ttl_seconds only on the interactive oauth2 branch", () => {
+    expect(editRoot({ transport: "http", auth_type: "oauth2", oauth_flow_type: "interactive" })).toContain(
+      "token_storage_ttl_seconds",
+    );
+    expect(editRoot({ transport: "http", auth_type: "oauth2", oauth_flow_type: "m2m" })).not.toContain(
+      "token_storage_ttl_seconds",
+    );
+  });
+
+  it("gates audience and subject_token_type on the entra_obo token-exchange profile", () => {
+    const rfc = editRoot({ transport: "http", auth_type: "oauth2_token_exchange", token_exchange_profile: "rfc8693" });
+    const entra = editRoot({
+      transport: "http",
+      auth_type: "oauth2_token_exchange",
+      token_exchange_profile: "entra_obo",
+    });
+    expect(rfc).toContain("audience");
+    expect(rfc).toContain("subject_token_type");
+    expect(entra).not.toContain("audience");
+    expect(entra).not.toContain("subject_token_type");
+    expect(entra).toContain("token_exchange_profile");
+  });
+
+  it("mounts the seven aws credentials only for aws_sigv4", () => {
+    expect(editCreds({ transport: "http", auth_type: "aws_sigv4" })).toStrictEqual([
+      "aws_region_name",
+      "aws_service_name",
+      "aws_access_key_id",
+      "aws_secret_access_key",
+      "aws_session_token",
+      "aws_role_name",
+      "aws_session_name",
+    ]);
+    expect(editCreds(HTTP_NONE)).not.toContain("aws_region_name");
+  });
+
+  it("mounts the id-jag credential set only for oauth2_id_jag", () => {
+    const creds = editCreds({ transport: "http", auth_type: "oauth2_id_jag" });
+    expect(creds).toContain("id_jag_resource_token_endpoint");
+    expect(creds).toContain("client_private_key");
+    expect(creds).toContain("client_assertion_signing_alg");
+    expect(editCreds(HTTP_NONE)).not.toContain("id_jag_resource_token_endpoint");
+  });
+});
+
+describe("edit root: children that gate by early return null", () => {
+  it("mounts dcr_bridge and the declared-app credentials only for the client-forwarded modes", () => {
+    for (const authType of ["true_passthrough", "oauth_delegate"]) {
+      expect(editRoot({ transport: "http", auth_type: authType })).toContain("dcr_bridge");
+      expect(editCreds({ transport: "http", auth_type: authType })).toStrictEqual(["client_id", "client_secret"]);
+    }
+    expect(editRoot(HTTP_NONE)).not.toContain("dcr_bridge");
+    expect(editRoot({ transport: "http", auth_type: "oauth2" })).not.toContain("dcr_bridge");
+  });
+
+  it("unmounts dcr_bridge with its parent section on stdio", () => {
+    expect(editRoot({ transport: "stdio", auth_type: "true_passthrough" })).not.toContain("dcr_bridge");
+  });
+});
+
+describe("edit root: permission-section gates", () => {
+  it("mounts delegate_auth_to_upstream only for oauth2", () => {
+    expect(editRoot({ transport: "http", auth_type: "oauth2" })).toContain("delegate_auth_to_upstream");
+    expect(editRoot(HTTP_NONE)).not.toContain("delegate_auth_to_upstream");
+    expect(editRoot({ transport: "http", auth_type: "api_key" })).not.toContain("delegate_auth_to_upstream");
+  });
+
+  it("mounts oauth_passthrough only for none-auth WITH an Authorization extra header", () => {
+    expect(editRoot({ ...HTTP_NONE, extra_headers: ["Authorization"] })).toContain("oauth_passthrough");
+    expect(editRoot({ ...HTTP_NONE, extra_headers: ["authorization"] })).toContain("oauth_passthrough");
+    expect(editRoot({ ...HTTP_NONE, extra_headers: ["X-Other"] })).not.toContain("oauth_passthrough");
+    expect(editRoot(HTTP_NONE)).not.toContain("oauth_passthrough");
+    expect(editRoot({ transport: "http", auth_type: "oauth2", extra_headers: ["Authorization"] })).not.toContain(
+      "oauth_passthrough",
+    );
+  });
+
+  it("treats an absent auth_type as none-auth for the oauth_passthrough gate", () => {
+    expect(editRoot({ transport: "http", extra_headers: ["Authorization"] })).toContain("oauth_passthrough");
+  });
+});
+
+describe("create root: where it diverges from edit", () => {
+  it("mounts source_url, which the edit root has no binding for", () => {
+    expect(createRoot({ transport: "http", auth_type: "none" })).toContain("source_url");
+    expect(editRoot(HTTP_NONE)).not.toContain("source_url");
+  });
+
+  it("gates url on an allow-list, so a blank transport mounts NEITHER url nor auth_type", () => {
+    const blank = createRoot({ transport: "" });
+    expect(blank).not.toContain("url");
+    expect(blank).not.toContain("auth_type");
+    expect(editRoot({ transport: "" })).toContain("url");
+    expect(editRoot({ transport: "" })).toContain("auth_type");
+  });
+
+  it("mounts stdio_config on stdio but never the edit root's command/args/env_json", () => {
+    const root = createRoot({ transport: "stdio" });
+    expect(root).toContain("stdio_config");
+    expect(root).not.toContain("command");
+    expect(root).not.toContain("args");
+    expect(root).not.toContain("env_json");
+  });
+
+  it("mounts the byok fields only for openapi with is_byok on", () => {
+    expect(createRoot({ transport: "openapi", auth_type: "none" })).toContain("is_byok");
+    expect(createRoot({ transport: "openapi", auth_type: "none" })).not.toContain("byok_description");
+    const on = createRoot({ transport: "openapi", auth_type: "none", is_byok: true });
+    expect(on).toContain("byok_description");
+    expect(on).toContain("byok_api_key_help_url");
+    expect(createRoot({ transport: "http", auth_type: "none", is_byok: true })).not.toContain("byok_description");
+  });
+
+  it("drops every credential while the transport is unset", () => {
+    expect(createCreds({ transport: "", auth_type: "aws_sigv4" })).toStrictEqual([]);
+    expect(createCreds({ transport: "http", auth_type: "aws_sigv4" })).toContain("aws_region_name");
+  });
+});
+
+const ALWAYS = ["server_name", "alias", "description", "transport", "max_concurrent_requests"];
+const PERMS = [
+  "allow_all_keys",
+  "available_on_public_internet",
+  "mcp_access_groups",
+  "extra_headers",
+  "static_headers",
+];
+const sorted = (xs: readonly string[]) => [...xs].sort();
+
+const expectEditSets = (
+  values: Record<string, unknown>,
+  expected: { root: readonly string[]; credentials: readonly string[] },
+) => {
+  expect(sorted(editRoot(values))).toStrictEqual(sorted(expected.root));
+  expect(sorted(editCreds(values))).toStrictEqual(sorted(expected.credentials));
+};
+
+const expectCreateSets = (
+  values: Record<string, unknown>,
+  expected: { root: readonly string[]; credentials: readonly string[] },
+) => {
+  expect(sorted(createRoot(values))).toStrictEqual(sorted(expected.root));
+  expect(sorted(createCreds(values))).toStrictEqual(sorted(expected.credentials));
+};
+
+describe("edit root: exact mounted set per auth configuration", () => {
+  it("http + none", () => {
+    expectEditSets(HTTP_NONE, { root: [...ALWAYS, "url", "auth_type", "env_vars", ...PERMS], credentials: [] });
+  });
+
+  it("http + api_key", () => {
+    expectEditSets(
+      { transport: "http", auth_type: "api_key" },
+      { root: [...ALWAYS, "url", "auth_type", "env_vars", ...PERMS], credentials: ["auth_value"] },
+    );
+  });
+
+  it("http + oauth2 M2M", () => {
+    expectEditSets(
+      { transport: "http", auth_type: "oauth2", oauth_flow_type: "m2m" },
+      {
+        root: [
+          ...ALWAYS,
+          "url",
+          "auth_type",
+          "oauth_flow_type",
+          "token_url",
+          "env_vars",
+          ...PERMS,
+          "delegate_auth_to_upstream",
+        ],
+        credentials: ["client_id", "client_secret", "token_endpoint_auth_method", "scopes", "upstream_resource"],
+      },
+    );
+  });
+
+  it("http + oauth2 interactive", () => {
+    expectEditSets(
+      { transport: "http", auth_type: "oauth2", oauth_flow_type: "interactive" },
+      {
+        root: [
+          ...ALWAYS,
+          "url",
+          "auth_type",
+          "oauth_flow_type",
+          "issuer",
+          "authorization_url",
+          "token_url",
+          "registration_url",
+          "token_validation_json",
+          "token_storage_ttl_seconds",
+          "env_vars",
+          ...PERMS,
+          "delegate_auth_to_upstream",
+        ],
+        credentials: ["client_id", "client_secret", "scopes", "upstream_resource", "token_endpoint_auth_method"],
+      },
+    );
+  });
+
+  it("http + token exchange, rfc8693", () => {
+    expectEditSets(
+      { transport: "http", auth_type: "oauth2_token_exchange", token_exchange_profile: "rfc8693" },
+      {
+        root: [
+          ...ALWAYS,
+          "url",
+          "auth_type",
+          "token_exchange_profile",
+          "token_exchange_endpoint",
+          "audience",
+          "subject_token_type",
+          "env_vars",
+          ...PERMS,
+        ],
+        credentials: ["client_id", "client_secret", "scopes"],
+      },
+    );
+  });
+
+  it("http + token exchange, entra_obo keeps the endpoint while dropping audience and subject_token_type", () => {
+    expectEditSets(
+      { transport: "http", auth_type: "oauth2_token_exchange", token_exchange_profile: "entra_obo" },
+      {
+        root: [
+          ...ALWAYS,
+          "url",
+          "auth_type",
+          "token_exchange_profile",
+          "token_exchange_endpoint",
+          "env_vars",
+          ...PERMS,
+        ],
+        credentials: ["client_id", "client_secret", "scopes"],
+      },
+    );
+  });
+
+  it("http + id-jag", () => {
+    expectEditSets(
+      { transport: "http", auth_type: "oauth2_id_jag" },
+      {
+        root: [
+          ...ALWAYS,
+          "url",
+          "auth_type",
+          "token_exchange_endpoint",
+          "audience",
+          "subject_token_type",
+          "env_vars",
+          ...PERMS,
+        ],
+        credentials: [
+          "id_jag_resource_token_endpoint",
+          "client_id",
+          "client_secret",
+          "client_private_key",
+          "client_private_key_id",
+          "client_assertion_signing_alg",
+          "id_jag_resource",
+          "scopes",
+        ],
+      },
+    );
+  });
+
+  it("http + true_passthrough", () => {
+    expectEditSets(
+      { transport: "http", auth_type: "true_passthrough" },
+      {
+        root: [...ALWAYS, "url", "auth_type", "dcr_bridge", "env_vars", ...PERMS],
+        credentials: ["client_id", "client_secret"],
+      },
+    );
+  });
+
+  it("openapi + none", () => {
+    expectEditSets(
+      { transport: "openapi", auth_type: "none" },
+      { root: [...ALWAYS, "spec_path", "auth_type", "env_vars", ...PERMS], credentials: [] },
+    );
+  });
+});
+
+describe("create root: exact mounted set per configuration", () => {
+  it("http + none", () => {
+    expectCreateSets(
+      { transport: "http", auth_type: "none" },
+      { root: [...ALWAYS, "source_url", "url", "auth_type", "env_vars", ...PERMS], credentials: [] },
+    );
+  });
+
+  it("openapi with byok on", () => {
+    expectCreateSets(
+      { transport: "openapi", auth_type: "none", is_byok: true },
+      {
+        root: [
+          ...ALWAYS,
+          "source_url",
+          "spec_path",
+          "is_byok",
+          "byok_description",
+          "byok_api_key_help_url",
+          "auth_type",
+          "env_vars",
+          ...PERMS,
+        ],
+        credentials: [],
+      },
+    );
+  });
+
+  it("stdio", () => {
+    expectCreateSets(
+      { transport: "stdio" },
+      { root: [...ALWAYS, "source_url", "stdio_config", "env_vars", ...PERMS], credentials: [] },
+    );
+  });
+
+  it("transport still unset", () => {
+    expectCreateSets({ transport: "" }, { root: [...ALWAYS, "source_url", "env_vars", ...PERMS], credentials: [] });
+  });
+
+  it("http + oauth2 interactive", () => {
+    expectCreateSets(
+      { transport: "http", auth_type: "oauth2", oauth_flow_type: "interactive" },
+      {
+        root: [
+          ...ALWAYS,
+          "source_url",
+          "url",
+          "auth_type",
+          "oauth_flow_type",
+          "issuer",
+          "authorization_url",
+          "token_url",
+          "registration_url",
+          "token_validation_json",
+          "token_storage_ttl_seconds",
+          "env_vars",
+          ...PERMS,
+          "delegate_auth_to_upstream",
+        ],
+        credentials: ["client_id", "client_secret", "scopes", "upstream_resource", "token_endpoint_auth_method"],
+      },
+    );
+  });
+
+  it("http + oauth_delegate mounts dcr_bridge and the declared app", () => {
+    expectCreateSets(
+      { transport: "http", auth_type: "oauth_delegate" },
+      {
+        root: [...ALWAYS, "source_url", "url", "auth_type", "dcr_bridge", "env_vars", ...PERMS],
+        credentials: ["client_id", "client_secret"],
+      },
+    );
+  });
+});
+
+describe("projection shape", () => {
+  it("EMITS a mounted-but-unset field as a key holding undefined, matching antd onFinish", () => {
+    const projected = projectMountedEditValues({ transport: "http", auth_type: "none", server_name: "s" });
+    expect("description" in projected).toBe(true);
+    expect(projected.description).toBeUndefined();
+    expect(Object.keys(projected)).toContain("max_concurrent_requests");
+  });
+
+  it("emits mounted-but-unset CREDENTIAL keys as undefined rather than omitting them", () => {
+    const projected = projectMountedEditValues({ transport: "http", auth_type: "api_key" });
+    expect(Object.keys(projected.credentials as object)).toStrictEqual(["auth_value"]);
+    expect((projected.credentials as Record<string, unknown>).auth_value).toBeUndefined();
+  });
+
+  it("omits the credentials key entirely when no credential field is mounted", () => {
+    expect("credentials" in projectMountedEditValues(HTTP_NONE)).toBe(false);
+  });
+
+  it("drops an unmounted field even when the store still holds a value for it", () => {
+    const storeWithStaleHttpValues = {
+      transport: "stdio",
+      auth_type: "oauth2",
+      url: "https://kept-in-store.example",
+      issuer: "https://kept-in-store.example",
+      command: "npx",
+    };
+    const projected = projectMountedEditValues(storeWithStaleHttpValues);
+    expect("url" in projected).toBe(false);
+    expect("issuer" in projected).toBe(false);
+    expect(projected.command).toBe("npx");
+  });
+
+  it("passes Form.List rows through whole, since antd does not project a row to its mounted sub-fields", () => {
+    const row = { name: "N", value: "V", scope: "user", description: "D" };
+    const projected = projectMountedEditValues({ ...HTTP_NONE, env_vars: [row] });
+    expect(projected.env_vars).toStrictEqual([row]);
+  });
+
+  it("keeps static_headers rows whole", () => {
+    const rows = [{ header: "X-A", value: "1" }];
+    expect(
+      projectMountedCreateValues({ transport: "http", auth_type: "none", static_headers: rows }).static_headers,
+    ).toStrictEqual(rows);
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mountedServerFields.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mountedServerFields.ts
@@ -1,0 +1,195 @@
+import { AUTH_TYPE, OAUTH_FLOW, TRANSPORT, isClientForwardedTokenMode } from "@/components/mcp_tools/types";
+import { AUTH_TYPES_REQUIRING_AUTH_VALUE } from "./createServerPayload";
+
+export interface MountedFieldNames {
+  readonly root: readonly string[];
+  readonly credentials: readonly string[];
+}
+
+const ENTRA_OBO_PROFILE = "entra_obo";
+
+const ALWAYS_MOUNTED_ROOT = ["server_name", "alias", "description", "transport", "max_concurrent_requests"] as const;
+
+const PERMISSION_SECTION_ROOT = [
+  "allow_all_keys",
+  "available_on_public_internet",
+  "mcp_access_groups",
+  "extra_headers",
+  "static_headers",
+] as const;
+
+const OAUTH_M2M_CREDENTIALS = [
+  "client_id",
+  "client_secret",
+  "token_endpoint_auth_method",
+  "scopes",
+  "upstream_resource",
+] as const;
+
+const OAUTH_INTERACTIVE_CREDENTIALS = [
+  "client_id",
+  "client_secret",
+  "scopes",
+  "upstream_resource",
+  "token_endpoint_auth_method",
+] as const;
+
+const OAUTH_INTERACTIVE_ROOT = [
+  "issuer",
+  "authorization_url",
+  "token_url",
+  "registration_url",
+  "token_validation_json",
+  "token_storage_ttl_seconds",
+] as const;
+
+const ID_JAG_CREDENTIALS = [
+  "id_jag_resource_token_endpoint",
+  "client_id",
+  "client_secret",
+  "client_private_key",
+  "client_private_key_id",
+  "client_assertion_signing_alg",
+  "id_jag_resource",
+  "scopes",
+] as const;
+
+const AWS_SIGV4_CREDENTIALS = [
+  "aws_region_name",
+  "aws_service_name",
+  "aws_access_key_id",
+  "aws_secret_access_key",
+  "aws_session_token",
+  "aws_role_name",
+  "aws_session_name",
+] as const;
+
+const hasAuthorizationExtraHeader = (extraHeaders: unknown): boolean =>
+  Array.isArray(extraHeaders) && extraHeaders.some((h) => typeof h === "string" && h.toLowerCase() === "authorization");
+
+interface AuthSubtreeGates {
+  readonly authType: string | undefined;
+  readonly oauthFlowType: string | undefined;
+  readonly tokenExchangeProfile: string | undefined;
+}
+
+const authSubtreeRoot = ({ authType, oauthFlowType, tokenExchangeProfile }: AuthSubtreeGates): readonly string[] => {
+  if (authType === AUTH_TYPE.OAUTH2) {
+    return oauthFlowType === OAUTH_FLOW.M2M
+      ? ["oauth_flow_type", "token_url"]
+      : ["oauth_flow_type", ...OAUTH_INTERACTIVE_ROOT];
+  }
+  if (authType === AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE) {
+    return tokenExchangeProfile === ENTRA_OBO_PROFILE
+      ? ["token_exchange_profile", "token_exchange_endpoint"]
+      : ["token_exchange_profile", "token_exchange_endpoint", "audience", "subject_token_type"];
+  }
+  if (authType === AUTH_TYPE.OAUTH2_ID_JAG) {
+    return ["token_exchange_endpoint", "audience", "subject_token_type"];
+  }
+  return [];
+};
+
+const authSubtreeCredentials = ({ authType, oauthFlowType }: AuthSubtreeGates): readonly string[] => {
+  const authValue = AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(authType as string) ? ["auth_value"] : [];
+  const clientForwarded = isClientForwardedTokenMode(authType) ? ["client_id", "client_secret"] : [];
+  if (authType === AUTH_TYPE.OAUTH2) {
+    return [
+      ...authValue,
+      ...(oauthFlowType === OAUTH_FLOW.M2M ? OAUTH_M2M_CREDENTIALS : OAUTH_INTERACTIVE_CREDENTIALS),
+    ];
+  }
+  if (authType === AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE) {
+    return [...authValue, "client_id", "client_secret", "scopes"];
+  }
+  if (authType === AUTH_TYPE.OAUTH2_ID_JAG) {
+    return [...authValue, ...ID_JAG_CREDENTIALS];
+  }
+  if (authType === AUTH_TYPE.AWS_SIGV4) {
+    return [...authValue, ...AWS_SIGV4_CREDENTIALS];
+  }
+  return [...authValue, ...clientForwarded];
+};
+
+const permissionSectionRoot = (authType: string | undefined, extraHeaders: unknown): readonly string[] => {
+  const isNoneAuth = authType === AUTH_TYPE.NONE || authType == null;
+  return [
+    ...PERMISSION_SECTION_ROOT,
+    ...(authType === AUTH_TYPE.OAUTH2 ? ["delegate_auth_to_upstream"] : []),
+    ...(isNoneAuth && hasAuthorizationExtraHeader(extraHeaders) ? ["oauth_passthrough"] : []),
+  ];
+};
+
+const dedupe = (names: readonly string[]): readonly string[] => Array.from(new Set(names));
+
+export const mountedEditFieldNames = (values: Record<string, unknown>): MountedFieldNames => {
+  const transport = values.transport as string | undefined;
+  const isStdio = transport === "stdio";
+  const isOpenApi = transport === TRANSPORT.OPENAPI;
+  const isMcp = !isStdio && !isOpenApi;
+  const gates: AuthSubtreeGates = {
+    authType: isStdio ? undefined : (values.auth_type as string | undefined),
+    oauthFlowType: values.oauth_flow_type as string | undefined,
+    tokenExchangeProfile: values.token_exchange_profile as string | undefined,
+  };
+
+  return {
+    root: dedupe([
+      ...ALWAYS_MOUNTED_ROOT,
+      ...(isMcp ? ["url"] : []),
+      ...(isOpenApi ? ["spec_path"] : []),
+      ...(isStdio ? ["command", "args", "env_json", "stdio_config"] : ["auth_type"]),
+      ...(isStdio ? [] : authSubtreeRoot(gates)),
+      ...(!isStdio && isClientForwardedTokenMode(gates.authType) ? ["dcr_bridge"] : []),
+      "env_vars",
+      ...permissionSectionRoot(gates.authType, values.extra_headers),
+    ]),
+    credentials: isStdio ? [] : dedupe(authSubtreeCredentials(gates)),
+  };
+};
+
+export const mountedCreateFieldNames = (values: Record<string, unknown>): MountedFieldNames => {
+  const transport = values.transport as string | undefined;
+  const isStdio = transport === "stdio";
+  const isOpenApi = transport === TRANSPORT.OPENAPI;
+  const authSectionMounted = !isStdio && transport !== "" && transport !== undefined;
+  const gates: AuthSubtreeGates = {
+    authType: authSectionMounted ? (values.auth_type as string | undefined) : undefined,
+    oauthFlowType: values.oauth_flow_type as string | undefined,
+    tokenExchangeProfile: values.token_exchange_profile as string | undefined,
+  };
+
+  return {
+    root: dedupe([
+      ...ALWAYS_MOUNTED_ROOT,
+      "source_url",
+      ...(transport === "http" || transport === "sse" ? ["url"] : []),
+      ...(isOpenApi ? ["spec_path", "is_byok"] : []),
+      ...(isOpenApi && values.is_byok ? ["byok_description", "byok_api_key_help_url"] : []),
+      ...(authSectionMounted ? ["auth_type"] : []),
+      ...(authSectionMounted ? authSubtreeRoot(gates) : []),
+      ...(authSectionMounted && isClientForwardedTokenMode(gates.authType) ? ["dcr_bridge"] : []),
+      ...(isStdio ? ["stdio_config"] : []),
+      "env_vars",
+      ...permissionSectionRoot(gates.authType, values.extra_headers),
+    ]),
+    credentials: authSectionMounted ? dedupe(authSubtreeCredentials(gates)) : [],
+  };
+};
+
+const pickEmitting = (source: Record<string, unknown> | undefined, names: readonly string[]): Record<string, unknown> =>
+  Object.fromEntries(names.map((name) => [name, source?.[name]]));
+
+const projectWith =
+  (namesOf: (values: Record<string, unknown>) => MountedFieldNames) =>
+  (values: Record<string, unknown>): Record<string, unknown> => {
+    const names = namesOf(values);
+    const credentials = values.credentials as Record<string, unknown> | undefined;
+    return {
+      ...pickEmitting(values, names.root),
+      ...(names.credentials.length > 0 ? { credentials: pickEmitting(credentials, names.credentials) } : {}),
+    };
+  };
+
+export const projectMountedEditValues = projectWith(mountedEditFieldNames);
+export const projectMountedCreateValues = projectWith(mountedCreateFieldNames);


### PR DESCRIPTION
## TLDR

Problem this solves:

- antd submits only mounted fields; react-hook-form submits the whole store
- The MCP server form graph gates 89 bindings behind 22 conditions
- Four of those gates are invisible when reading the roots' JSX
- Porting the graph without them written down silently changes the payload

How it solves it:

- Adds pure mounted-field projections for both MCP server roots
- Covers all 22 gates with unit tests, one case per gate
- Pins three antd behaviours measured by probe, not assumed
- Touches no JSX; nothing imports the module yet

## User Flow

No user-visible change, so the two flows below are identical by construction. The new module is not imported anywhere; it is groundwork the form port will consume.

Before: an admin edits an MCP server and saves

1. They open the MCP Servers page and edit a server
2. They change a field and click Save Changes
3. The server updates

After: unchanged, step for step

1. They open the MCP Servers page and edit a server
2. They change a field and click Save Changes
3. The server updates

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

There is no runtime behaviour to demonstrate. The module is not imported by any component, so no request an end user can make reaches it and a live proxy would show nothing either way. Recording that plainly rather than presenting a test run as a proof of fix.

What the change is verified by instead is a per-field deletion battery over the projections, which is the instrument that decides whether each of the 89 bindings is load-bearing. Each of the 80 emitted field-name sites is deleted one at a time and the suite must go red for it. The harness gates every entry on the mutation applying, the file still compiling, and the suite running the expected test count, and reports INVALID rather than a verdict when any gate fails.

Result, at the tip of this branch:

```
RED     80
GREEN   0
INVALID 0
tree restored byte-identical: true
```

The first run of that battery was 46 RED / 32 GREEN / 9 INVALID. Every survivor was investigated individually rather than banked. Thirty-two were real coverage holes, closed by pinning the exact mounted set per auth configuration instead of spot-checking membership. The nine INVALID were the harness correctly refusing to score a mutation of a gate's comparison value, plus one output-parsing bug in the harness itself that mislabelled a genuine red. That one is worth naming: it failed safe, but it means the first run's greens were the finding and its invalids were not.

A kill rate of 80 out of 80 is only worth something if the battery can also let something live, so it is checked against a mutation that provably cannot matter: swapping two names inside one credential array. The projected object holds the same keys, and key order is not observable in the payload, so that mutation has to survive.

It did not. It went red, and the two assertions it tripped turned out to compare the returned array against a source-order literal, pinning order rather than membership. Those two now sort both sides like the other fifteen already did. Deleting any of the eighty names still fails the suite, reordering two of them no longer does.

The last survivor to fall was `token_exchange_endpoint` on the Entra OBO branch. Deleting it left the suite green because the Entra case asserted the two fields that drop and never asserted the endpoint that stays. That would have dropped the token exchange endpoint from the payload for Entra OBO servers.

## Type

🚄 Infrastructure
✅ Test

## Caveats (if any)

- Nothing imports the projections yet; the port consumes them
- antd `useWatch` returns undefined for an unmounted field, RHF `watch` does not
- That divergence moves mount gates, so it changes the payload, and it is not fixed here
- `Form.List` child names are generated at runtime, so no static scan rules out duplicates

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

