### PR TITLE
test(batches): assert completed Vertex batch cost at batch rates

### DIFF
--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -891,7 +891,7 @@ async def test_handle_completed_vertex_batch_computes_cost_usage_and_models(monk
     )
 
     assert cost > 0
-    assert cost == pytest.approx(30 * 7.5e-07 + 15 * 3.75e-06)
+    assert cost == pytest.approx(30 * 3.75e-07 + 15 * 1.875e-06)
     assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (30, 15, 45)
     assert models == ["gemini-3.6-flash", "gemini-3.6-flash"]
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Completed Vertex batch cost assertion still uses non-batch rates after the model catalog added batch rates
- `test_handle_completed_vertex_batch_computes_cost_usage_and_models` fails on `litellm_internal_staging`

How it solves it:

- Assert the completed Vertex batch cost against `input_cost_per_token_batches` and `output_cost_per_token_batches`

## User Flow

Before: the staging branch's `misc` CI shard fails on the completed Vertex batch cost assertion.

1. CI runs `tests/test_litellm/batches/test_batch_utils.py`
2. The test computes cost from the batch token prices (3.9375e-05)
3. The assertion expects non-batch prices (7.875e-05) and fails

After: the assertion matches the batch prices the model catalog advertises.

1. CI runs the same test
2. The test computes cost from the batch token prices
3. The assertion expects the same batch prices and passes

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Before (`8941f2a6`)

1. Run `pytest -q tests/test_litellm/batches/test_batch_utils.py::test_handle_completed_vertex_batch_computes_cost_usage_and_models`
2. Observed: `assert 3.9375e-05 == 7.875e-05` fails

### After (`daf5c7e71c`)

1. Run the same pytest command
2. Observed: `1 passed`

## Type

✅ Test

## QA runbook

- `tests/test_litellm/batches/test_batch_utils.py::test_handle_completed_vertex_batch_computes_cost_usage_and_models` - the completed Vertex batch cost assertion now matches the batch rates in the model catalog
  - [ ] Check that `vertex_ai/gemini-3.6-flash` advertises `input_cost_per_token_batches: 3.75e-07` and `output_cost_per_token_batches: 1.875e-06` in `model_prices_and_context_window.json`
  - [ ] Run the pytest command above
  - [ ] Expect the test to pass
  - [ ] Sanity check: the assertion still guards cost accounting and is not weakened

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
