### PR TITLE
test: derive vertex batch cost expectation from the cost map

### DIFF
--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -895,6 +895,7 @@ async def test_handle_completed_vertex_batch_computes_cost_usage_and_models(monk
     batch_output = pricing["output_cost_per_token_batches"]
 
     assert batch_input < pricing["input_cost_per_token"]
+    assert batch_output < pricing["output_cost_per_token"]
     assert cost > 0
     assert cost == pytest.approx(30 * batch_input + 15 * batch_output)
     assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (30, 15, 45)

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -890,8 +890,13 @@ async def test_handle_completed_vertex_batch_computes_cost_usage_and_models(monk
         litellm_params={"vertex_project": "proj-1", "vertex_location": "us-central1"},
     )
 
+    pricing = litellm.model_cost["vertex_ai/gemini-3.6-flash"]
+    batch_input = pricing["input_cost_per_token_batches"]
+    batch_output = pricing["output_cost_per_token_batches"]
+
+    assert batch_input < pricing["input_cost_per_token"]
     assert cost > 0
-    assert cost == pytest.approx(30 * 7.5e-07 + 15 * 3.75e-06)
+    assert cost == pytest.approx(30 * batch_input + 15 * batch_output)
     assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (30, 15, 45)
     assert models == ["gemini-3.6-flash", "gemini-3.6-flash"]
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `misc / Run tests` is red on every PR into staging
- One batch-cost test still expects standard Vertex rates
- Vertex batch pricing halved in the cost map on 2026-08-17
- The red check blocks merges on unrelated PRs

How it solves it:

- Read the batch rates from the cost map, not hardcoded numbers
- Also assert both batch rates sit below the standard rates
- Keeps passing when the promo pricing gets restored

## User Flow

Before: a contributor opening any PR into staging gets a red required check on a test they never touched, so their PR cannot merge

1. They push a branch and open a PR at https://github.com/BerriAI/litellm/pull/37432
2. GitHub shows `misc / Run tests` red in the checks list, next to a green `frontend-lint` and a green `Build and push`
3. They open the job log and read `assert 3.9375e-05 == 7.875e-05`, pointing at a batch-cost test their diff never touches
4. The PR page reads "Merging is blocked" with "Required statuses must pass", so nothing lands until someone else fixes the test

After: the same contributor gets a green check and can merge

1. They push a branch and open a PR at https://github.com/BerriAI/litellm/pull/37432
2. GitHub shows `misc / Run tests` green in the checks list, next to a green `frontend-lint` and a green `Build and push`
3. There is no failing job log to open
4. The PR page reads "All checks have passed" and the merge button is live

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR changes one test assertion and no runtime code, so the live proxy answers identically on both sides. That is the point of the first case: the gateway was already billing Vertex batches at half price, and only the test had missed it. Each side runs a proxy booted from its own tree, both serving the same config:

```yaml
model_list:
  - model_name: gemini-batch
    litellm_params:
      model: vertex_ai/gemini-3.6-flash
      vertex_project: os.environ/VERTEX_PROJECT
      vertex_location: us-central1

general_settings:
  master_key: sk-1234
```

### Before (8941f2a622)

#### What a customer is billed for a Vertex batch

1. Boot the proxy from the base tree and ask it what the model costs:

```bash
python litellm/proxy/proxy_cli.py --config vbc_config.yaml --port 55117

curl -s http://localhost:55117/model/info -H "Authorization: Bearer sk-1234" \
  | python3 -c "import json,sys; d=json.load(sys.stdin)['data'][0]['model_info']; print(json.dumps({k: d[k] for k in ('input_cost_per_token','output_cost_per_token','input_cost_per_token_batches','output_cost_per_token_batches')}, indent=2))"
```

2. The batch rates come back at half the standard rates:

```json
{
  "input_cost_per_token": 7.5e-07,
  "output_cost_per_token": 3.75e-06,
  "input_cost_per_token_batches": 3.75e-07,
  "output_cost_per_token_batches": 1.875e-06
}
```

So a batch of 30 prompt and 15 completion tokens costs `30 * 3.75e-07 + 15 * 1.875e-06`, which is `3.9375e-05`

#### The batch-cost suite CI actually runs

1. Run the file the red job names:

```bash
python -m pytest tests/test_litellm/batches/test_batch_utils.py -q -p no:randomly
```

2. It fails on the stale expectation, exactly as CI reports it:

```
        assert cost > 0
>       assert cost == pytest.approx(30 * 7.5e-07 + 15 * 3.75e-06)
E       assert 3.9375e-05 == 7.875e-05 ± 7.9e-11
E
E         comparison failed
E         Obtained: 3.9375e-05
E         Expected: 7.875e-05 ± 7.9e-11

tests/test_litellm/batches/test_batch_utils.py:894: AssertionError
=========================== short test summary info ============================
FAILED tests/test_litellm/batches/test_batch_utils.py::test_handle_completed_vertex_batch_computes_cost_usage_and_models
1 failed, 94 passed in 0.35s
```

### After (df0d8ff15e)

#### What a customer is billed for a Vertex batch

1. Boot the proxy from this branch and ask it the same question:

```bash
python litellm/proxy/proxy_cli.py --config vbc_config.yaml --port 49395

curl -s http://localhost:49395/model/info -H "Authorization: Bearer sk-1234" \
  | python3 -c "import json,sys; d=json.load(sys.stdin)['data'][0]['model_info']; print(json.dumps({k: d[k] for k in ('input_cost_per_token','output_cost_per_token','input_cost_per_token_batches','output_cost_per_token_batches')}, indent=2))"
```

2. Same answer, since no runtime code changed:

```json
{
  "input_cost_per_token": 7.5e-07,
  "output_cost_per_token": 3.75e-06,
  "input_cost_per_token_batches": 3.75e-07,
  "output_cost_per_token_batches": 1.875e-06
}
```

#### The batch-cost suite CI actually runs

1. Run the same file:

```bash
python -m pytest tests/test_litellm/batches/test_batch_utils.py -q -p no:randomly
```

2. It passes, now expecting the same `3.9375e-05` the live proxy prices:

```
........................................................................ [ 75%]
.......................                                                  [100%]
95 passed in 0.32s
```

## Type

✅ Test

## Caveats (if any)

- Reads the cost map, so promo pricing changes no longer break it
- Dropping the batch-rate keys would raise KeyError, not an assertion

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] df0d8ff15ea2f65e9f1ba90209239f241cf16d91 passes /live-pr-risk
