### PR TITLE
test(batches): derive vertex batch cost expectations from the cost map

### DIFF
--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -890,8 +890,11 @@ async def test_handle_completed_vertex_batch_computes_cost_usage_and_models(monk
         litellm_params={"vertex_project": "proj-1", "vertex_location": "us-central1"},
     )
 
+    batch_rates = litellm.model_cost["vertex_ai/gemini-3.6-flash"]
     assert cost > 0
-    assert cost == pytest.approx(30 * 7.5e-07 + 15 * 3.75e-06)
+    assert cost == pytest.approx(
+        30 * batch_rates["input_cost_per_token_batches"] + 15 * batch_rates["output_cost_per_token_batches"]
+    )
     assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (30, 15, 45)
     assert models == ["gemini-3.6-flash", "gemini-3.6-flash"]
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- staging CI fails on test_handle_completed_vertex_batch_computes_cost_usage_and_models
- 94a29e0708 halved gemini-3.6-flash rates but missed this test
- every open PR now inherits the red shard

How it solves it:

- the test reads batch-tier rates from litellm.model_cost
- it still proves batch cost uses *_batches rates, not regular ones
- and that usage aggregates across rows
- future repricings stop breaking it

## User Flow

Before: a contributor's unrelated PR goes red on a shard they never touched

1. They push any branch and CI runs tests/test_litellm/batches/test_batch_utils.py
2. The shard fails: `assert 3.9375e-05 == 7.875e-05 ± 7.9e-11` in test_handle_completed_vertex_batch_computes_cost_usage_and_models
3. The failure reproduces on litellm_internal_staging itself with no changes at all

After: the same shard is green on staging and on unrelated PRs

1. They push the same branch and CI runs the same shard
2. The batch test derives its expected cost from the cost map's `input_cost_per_token_batches` / `output_cost_per_token_batches` for gemini-3.6-flash and passes
3. If batch cost calculation ever used the regular (non-batch) rates, the expectation would be off by 2x and the test would still fail, so the assertion keeps its teeth

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR changes a test expectation only, so there is no live-proxy behavior to demonstrate; the observable surface is the test run itself, shown against a checkout at each commit.

Cause, for the record: commit 94a29e0708 repriced gemini-3.6-flash to introductory rates, halving the batch tier the test hardcodes:

```
-        "input_cost_per_token_batches": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
```

### Before (413fc7e517, litellm_internal_staging tip)

1. `python -m pytest tests/test_litellm/batches/test_batch_utils.py::test_handle_completed_vertex_batch_computes_cost_usage_and_models -q`
2. Observed: `assert 3.9375e-05 == 7.875e-05 ± 7.9e-11 ... comparison failed. Obtained: 3.9375e-05. Expected: 7.875e-05 ± 7.9e-11` — `1 failed`

### After (4ca56b16c0)

1. `python -m pytest tests/test_litellm/batches/test_batch_utils.py -q` (whole file)
2. Observed: `95 passed`

## Type

✅ Test

## Caveats (if any)

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
