### PR TITLE
fix(tests): price the vertex batch cost test from rates it registers itself

### DIFF
--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -19,6 +19,7 @@ import logging
 import os
 import sys
 from types import MappingProxyType
+from typing import Final
 
 import httpx
 import pytest
@@ -874,9 +875,25 @@ async def test_output_file_content_vertex_foreign_bucket_rejected_by_real_valida
 async def test_handle_completed_vertex_batch_computes_cost_usage_and_models(monkeypatch):
     import litellm.files.main as files_main
 
+    model: Final = "batch-priced-test-model"
+    litellm.register_model(
+        {
+            f"vertex_ai/{model}": {
+                "litellm_provider": "vertex_ai",
+                "mode": "chat",
+                "input_cost_per_token": 2e-06,
+                "output_cost_per_token": 8e-06,
+                "input_cost_per_token_batches": 3e-07,
+                "output_cost_per_token_batches": 5e-07,
+                "cache_read_input_token_cost": 0.0,
+                "cache_creation_input_token_cost": 0.0,
+            }
+        }
+    )
+
     rows = [
-        _vertex_openai_row("request-1", "gemini-3.6-flash", 10, 5),
-        _vertex_openai_row("request-2", "gemini-3.6-flash", 20, 10),
+        _vertex_openai_row("request-1", model, 10, 5),
+        _vertex_openai_row("request-2", model, 20, 10),
     ]
 
     async def fake_afile_content(**kw):
@@ -891,9 +908,9 @@ async def test_handle_completed_vertex_batch_computes_cost_usage_and_models(monk
     )
 
     assert cost > 0
-    assert cost == pytest.approx(30 * 7.5e-07 + 15 * 3.75e-06)
+    assert cost == pytest.approx(30 * 3e-07 + 15 * 5e-07)
     assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (30, 15, 45)
-    assert models == ["gemini-3.6-flash", "gemini-3.6-flash"]
+    assert models == [model, model]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex batch cost test hardcoded gemini-3.6-flash's published batch rates
- Halving those rates left the required misc unit-test job red on staging

How it solves it:

- The test registers its own vertex model with fixed rates
- Batch rates are not half the standard ones, so the assertion still bites
- A future price refresh can no longer make it stale

## User Flow

No runtime code changes here, so nothing an API caller does or sees moves. The person this reaches is the contributor whose PR is blocked by a red required check

Before: a contributor opens any PR and the required misc unit-test job fails on a batch pricing assertion they never touched

1. They open a pull request against litellm_internal_staging
2. They watch the checks on their pull request, and "Unit Tests: MCP, Secrets, Containers & Misc / misc / Run tests" reports failure after about 10 minutes
3. They open the job and read `assert 3.9375e-05 == 7.875e-05`, pointing at a vertex batch cost case with no connection to their change
4. The same job is failing on pushes straight to litellm_internal_staging, so there is nothing they can fix on their own branch and the required check stays red

After: the same contributor opens the same PR and the job goes green

1. They open a pull request against litellm_internal_staging
2. They watch the checks on their pull request, and "Unit Tests: MCP, Secrets, Containers & Misc / misc / Run tests" reports success
3. There is no unrelated pricing failure to read past, so the only check results left are the ones their own change produced

## Relevant issues

## Linear ticket

Resolves LIT-5799
https://linear.app/litellm-ai/issue/LIT-5799

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR edits one test file and no runtime code, so there is no request whose response changes and nothing to curl against a live proxy. The observable thing that changes is the required check, so the proof below is that check's own failing case, captured on both sides, plus a mutation run showing the repaired assertion still catches the bug it exists to catch

### Before (559310f077)

#### the failing assertion

1. `uv run --no-sync pytest "tests/test_litellm/batches/test_batch_utils.py::test_handle_completed_vertex_batch_computes_cost_usage_and_models" -q --no-header`
2. Output:

```
        assert cost > 0
>       assert cost == pytest.approx(30 * 7.5e-07 + 15 * 3.75e-06)
E       assert 3.9375e-05 == 7.875e-05 +- 7.9e-11
E         comparison failed
E         Obtained: 3.9375e-05
E         Expected: 7.875e-05 +- 7.9e-11
1 failed in 0.61s
```

#### the assertion still catches standard-vs-batch pricing

1. Swap the batch call type for the plain completion one so the cost map hands back standard rates instead of batch rates, then re-run the same case:

```
sed -i '140s/CallTypes.aretrieve_batch.value/CallTypes.completion.value/' litellm/batches/batch_utils.py
uv run --no-sync pytest "tests/test_litellm/batches/test_batch_utils.py::test_handle_completed_vertex_batch_computes_cost_usage_and_models" -q --no-header
```

2. Output: it passes. Halving the model's rates left the stale literals sitting exactly on the new standard rates, so the case was demanding standard pricing, and deleting the batch call type is what turns it green

```
1 passed in 0.45s
```

### After (983ab0f24e)

#### the failing assertion

1. `uv run --no-sync pytest "tests/test_litellm/batches/test_batch_utils.py::test_handle_completed_vertex_batch_computes_cost_usage_and_models" -q --no-header`
2. Output:

```
.                                                                        [100%]
1 passed in 0.44s
```

#### the assertion still catches standard-vs-batch pricing

1. Swap the batch call type for the plain completion one so the cost map hands back standard rates instead of batch rates, then re-run the same case:

```
sed -i '140s/CallTypes.aretrieve_batch.value/CallTypes.completion.value/' litellm/batches/batch_utils.py
uv run --no-sync pytest "tests/test_litellm/batches/test_batch_utils.py::test_handle_completed_vertex_batch_computes_cost_usage_and_models" -q --no-header
```

2. Output: the case fails under the mutation and passes once it is reverted, so the repaired assertion is still load-bearing

```
1 failed in 0.52s
```

#### the whole file

1. `uv run --no-sync pytest tests/test_litellm/batches/test_batch_utils.py -q --no-header`
2. Output:

```
95 passed in 0.75s
```

## Type

🐛 Bug Fix

## Changes

The test asserted `30 * 7.5e-07 + 15 * 3.75e-06`, which were gemini-3.6-flash's batch rates when it was written. Commit 94a29e0708 repriced that model at Google's introductory rates and halved every tier, batch included, so the code kept pricing the batch correctly at the new rates while the test kept demanding the old ones, and the failure read as exactly double

Because every tier halved by the same factor, those old batch literals landed precisely on the model's new standard rates, so the case had quietly inverted into an assertion that batches get billed at standard prices. That is what the second Before case above shows: taking the batch call type out of the cost lookup is what makes the old case pass

Rather than copy the new numbers in and wait for the next refresh to break it again, the case now registers a vertex model of its own with rates it owns. Its batch rates are deliberately not half its standard rates, so the assertion pins the specific fields the batch path is supposed to read instead of any across-the-board discount, and swapping the batch call type for the completion one still fails the case

## Caveats (if any)

- The pinned gemini prices in the cost-calc tests can still go stale

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

