### PR TITLE
refactor(ui): host KeyLifecycleSettings tests in react-hook-form instead of antd Form

### DIFF
--- a/ui/litellm-dashboard/src/components/common_components/KeyLifecycleSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/KeyLifecycleSettings.test.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-// eslint-disable-next-line no-restricted-imports -- exercising KeyLifecycleSettings requires hosting it in a real antd Form (the component it's built on)
-import { Form } from "antd";
+import { Controller, useForm } from "react-hook-form";
 import userEvent, { PointerEventsCheckLevel } from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { renderWithProviders, screen, waitFor } from "../../../tests/test-utils";
@@ -15,30 +14,37 @@ interface HarnessProps {
 }
 
 const Harness: React.FC<HarnessProps> = ({ isCreateMode = true, onFinish = () => {} }) => {
-  const [form] = Form.useForm();
+  const form = useForm<{ duration: string }>({ defaultValues: { duration: "" } });
   const [autoRotationEnabled, setAutoRotationEnabled] = useState(false);
   const [rotationInterval, setRotationInterval] = useState("");
   const [neverExpire, setNeverExpire] = useState(false);
 
   return (
-    <Form form={form} onFinish={onFinish}>
-      <Form.Item name="duration" initialValue="" noStyle>
-        <KeyLifecycleSettings
-          autoRotationEnabled={autoRotationEnabled}
-          onAutoRotationChange={setAutoRotationEnabled}
-          rotationInterval={rotationInterval}
-          onRotationIntervalChange={setRotationInterval}
-          isCreateMode={isCreateMode}
-          neverExpire={neverExpire}
-          onNeverExpireChange={setNeverExpire}
-        />
-      </Form.Item>
+    <form onSubmit={form.handleSubmit(onFinish)}>
+      <Controller
+        control={form.control}
+        name="duration"
+        render={({ field }) => (
+          <KeyLifecycleSettings
+            id={field.name}
+            value={field.value}
+            onChange={field.onChange}
+            autoRotationEnabled={autoRotationEnabled}
+            onAutoRotationChange={setAutoRotationEnabled}
+            rotationInterval={rotationInterval}
+            onRotationIntervalChange={setRotationInterval}
+            isCreateMode={isCreateMode}
+            neverExpire={neverExpire}
+            onNeverExpireChange={setNeverExpire}
+          />
+        )}
+      />
       <button type="submit">submit</button>
-      <button type="button" onClick={() => form.resetFields()}>
+      <button type="button" onClick={() => form.reset()}>
         reset
       </button>
       <span data-testid="rotation-interval-value">{rotationInterval}</span>
-    </Form>
+    </form>
   );
 };
 
@@ -169,7 +175,7 @@ describe("KeyLifecycleSettings", () => {
     });
 
     it("shows the custom interval input when Custom interval is selected, without propagating yet", async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
       renderWithProviders(<Harness />);
 
       await user.click(screen.getByRole("switch"));
@@ -184,7 +190,7 @@ describe("KeyLifecycleSettings", () => {
     });
 
     it("propagates a typed custom interval to the parent", async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
       renderWithProviders(<Harness />);
 
       await user.click(screen.getByRole("switch"));


### PR DESCRIPTION
## TLDR

Problem this solves:

- This suite hosted the component in a real antd `Form`
- Its suppression claimed that hosting was required
- The create key form stopped driving it that way

How it solves it:

- Harness moves to react-hook-form with an explicit `Controller`
- `value`, `onChange` and `id` now arrive as visible props
- The `no-restricted-imports` suppression goes away with the import

## User Flow

This is a test-only change, so there is no behavior for a user to observe on either side, and the two lists are identical by construction. The flow below is the one the suite covers, and it reads the same before and after because the component itself is untouched.

Before: a proxy admin sets an expiry and a rotation schedule on a new key

1. They open http://localhost:4000/ui/?page=api-keys and click "+ Create New Key"
2. They expand "Key Lifecycle" and pick an expiry from the duration control
3. They tick "Never expire" and the duration control stops accepting input
4. They untick it, turn on auto rotation, and pick a rotation interval
5. They click "Create Key" and the key comes back with the expiry and interval they chose

After: the same admin sees the same screens and gets the same key back

1. They open http://localhost:4000/ui/?page=api-keys and click "+ Create New Key"
2. They expand "Key Lifecycle" and pick an expiry from the duration control
3. They tick "Never expire" and the duration control stops accepting input
4. They untick it, turn on auto rotation, and pick a rotation interval
5. They click "Create Key" and the key comes back with the expiry and interval they chose

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

No shipped code changes here, so there is nothing for a live proxy to show differently. The component under test is byte-identical on both sides, and the check that matters is that it still behaves the same in the product.

Setup, done once and left running for both captures:

1. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
2. Start the dashboard dev server: `cd ui/litellm-dashboard && npm run dev`
3. Open http://localhost:3000/?page=api-keys, open DevTools, and filter the Network tab on `key/generate`

### Before (8941f2a622)

#### Expiry, never-expire, and rotation

1. Click "+ Create New Key", type `lifecycle-proof` into Key Name, expand "Key Lifecycle"
2. Set the duration to `30d`, tick "Never expire", and confirm the duration control is disabled
3. Untick "Never expire", turn on auto rotation, set the rotation interval to `7d`
4. Click "Create Key" and record the `/key/generate` Request Payload

### After (91cf27aa0a)

#### Expiry, never-expire, and rotation

1. Same steps as Before
2. Record the `/key/generate` Request Payload and compare it key for key against the Before capture

## Type

✅ Test

## Caveats

- Test-only: the component and every shipped file are untouched
- `value`, `onChange` and `id` are the component's own declared props
- Two auto-rotation cases were racing the select popup already

`KeyLifecycleSettings` has always taken `value`, `onChange` and `id` as its own props; antd's `Form.Item` was supplying them invisibly rather than adding an API of its own. So the harness drives the same contract either way, and the component file is untouched by this PR. What changed is which host supplies the props, and #37442 moved the create key form onto supplying them directly, which is the integration this suite now mirrors.

## A latent race this surfaced

Two of the auto-rotation cases were racing the Base UI select popup before this PR, and the antd harness was hiding it rather than avoiding it. `findByText` resolves the moment the option text lands in the DOM, but the popup still carries `pointer-events: none` until its open transition settles, so a click that arrives in that window is rejected. Every extra render is another chance to land in it, which is why the failure rate tracks the harness rather than the component: 0 failures in 6 runs under antd, 1 in 6 under plain React state, 5 in 6 under a react-hook-form `Controller`. The component is identical in all three.

Both cases now take the same `PointerEventsCheckLevel.Never` that their sibling case in this file already used for this exact interaction, which stops user-event asserting on a CSS property jsdom never animates. That is the only thing it relaxes, and the assertions were checked to still bite: removing the click turns the first case red, and stubbing the propagation callback turns the second red along with two others. Ten consecutive runs pass.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
