### PR TITLE
fix(tests): keep a host PROXY_BASE_URL out of request-derived URL tests

### DIFF
--- a/tests/test_litellm/conftest.py
+++ b/tests/test_litellm/conftest.py
@@ -102,13 +102,7 @@ def isolate_host_aws_config(monkeypatch, isolated_aws_credentials_dir):
 
 @pytest.fixture(scope="function", autouse=True)
 def isolate_host_proxy_base_url(monkeypatch):
-    """Prevent a host PROXY_BASE_URL from outranking request-derived URLs during unit tests.
-
-    It is the first thing the proxy consults when it resolves its own public origin, so a value
-    left in the developer's shell or .env silently replaces the base_url every OAuth discovery,
-    redirect_uri, and registration assertion is written against. Tests that exercise a configured
-    public origin set it within their own body, which still wins over this.
-    """
+    """Prevent a host PROXY_BASE_URL from outranking request-derived URLs during unit tests."""
     monkeypatch.delenv("PROXY_BASE_URL", raising=False)
 
 

--- a/tests/test_litellm/conftest.py
+++ b/tests/test_litellm/conftest.py
@@ -100,6 +100,18 @@ def isolate_host_aws_config(monkeypatch, isolated_aws_credentials_dir):
     monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
 
 
+@pytest.fixture(scope="function", autouse=True)
+def isolate_host_proxy_base_url(monkeypatch):
+    """Prevent a host PROXY_BASE_URL from outranking request-derived URLs during unit tests.
+
+    It is the first thing the proxy consults when it resolves its own public origin, so a value
+    left in the developer's shell or .env silently replaces the base_url every OAuth discovery,
+    redirect_uri, and registration assertion is written against. Tests that exercise a configured
+    public origin set it within their own body, which still wins over this.
+    """
+    monkeypatch.delenv("PROXY_BASE_URL", raising=False)
+
+
 def _run_coroutine_if_needed(result):
     if not asyncio.iscoroutine(result):
         return

--- a/tests/test_litellm/test_conftest.py
+++ b/tests/test_litellm/test_conftest.py
@@ -1,0 +1,49 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final
+
+REPO_ROOT: Final = Path(__file__).resolve().parents[2]
+
+PROXY_BASE_URL_SENSITIVE_NODE: Final = (
+    "tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py"
+    "::TestTemporaryMCPSessionEndpoints"
+    "::test_mcp_token_opens_sealed_passthrough_code_and_exchanges_with_minted_client"
+)
+
+COVERAGE_SUBPROCESS_VARS: Final = frozenset(
+    {"COV_CORE_SOURCE", "COV_CORE_CONFIG", "COV_CORE_DATAFILE", "COV_CORE_CONTEXT", "COVERAGE_PROCESS_START"}
+)
+
+
+def test_host_proxy_base_url_cannot_reach_request_derived_url_tests():
+    """A PROXY_BASE_URL in the host environment must not reach tests that assert on request-derived URLs.
+
+    The proxy resolves its public origin from that variable before anything else, so a developer
+    who has one set for their own deployment used to watch dozens of OAuth discovery, redirect_uri,
+    and client registration cases fail on an origin no test ever asked for.
+    """
+    child_env: Final = {
+        key: value for key, value in os.environ.items() if key not in COVERAGE_SUBPROCESS_VARS
+    } | {"PROXY_BASE_URL": "https://leaked-host-origin.example.com"}
+
+    completed: Final = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            PROXY_BASE_URL_SENSITIVE_NODE,
+            "-q",
+            "--no-header",
+            "-p",
+            "no:cacheprovider",
+        ],
+        cwd=REPO_ROOT,
+        env=child_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/test_litellm/test_conftest.py
+++ b/tests/test_litellm/test_conftest.py
@@ -18,12 +18,6 @@ COVERAGE_SUBPROCESS_VARS: Final = frozenset(
 
 
 def test_host_proxy_base_url_cannot_reach_request_derived_url_tests():
-    """A PROXY_BASE_URL in the host environment must not reach tests that assert on request-derived URLs.
-
-    The proxy resolves its public origin from that variable before anything else, so a developer
-    who has one set for their own deployment used to watch dozens of OAuth discovery, redirect_uri,
-    and client registration cases fail on an origin no test ever asked for.
-    """
     child_env: Final = {
         key: value for key, value in os.environ.items() if key not in COVERAGE_SUBPROCESS_VARS
     } | {"PROXY_BASE_URL": "https://leaked-host-origin.example.com"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- The proxy reads its public origin from `PROXY_BASE_URL` first
- A developer who sets it locally fails 65 OAuth URL tests

How it solves it:

- An autouse fixture clears it for every unit test
- Sits beside the host AWS config isolation already in that conftest
- Tests needing a configured origin still set it themselves

## User Flow

No runtime code changes here, so nothing an API caller does or sees moves. The person this reaches is the developer running the unit suite on a machine that also has a proxy deployment configured

Before: a developer with `PROXY_BASE_URL` exported for their own proxy runs the MCP OAuth suites and watches dozens of unrelated cases fail

1. They set `PROXY_BASE_URL` to their gateway's public origin so their local proxy hands out correct OAuth discovery URLs
2. They run the MCP OAuth and URL helper suites and get 65 failures across five files they never touched
3. They read one and see `redirect_uri` came back as their own gateway origin plus `/callback` where the case expected the origin the request carried
4. Nothing in the diff explains it, so they either chase a phantom regression or clear their environment and rerun to find out the code was fine all along

After: the same developer, with the same variable still exported, runs the same suites and they all pass

1. They set `PROXY_BASE_URL` to their gateway's public origin so their local proxy hands out correct OAuth discovery URLs
2. They run the MCP OAuth and URL helper suites and all 676 cases pass
3. Their proxy still resolves its public origin from that variable when they actually start it, so the local deployment is unaffected

## Relevant issues

## Linear ticket

Resolves LIT-5798
https://linear.app/litellm-ai/issue/LIT-5798

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR touches test scaffolding and no runtime code, so there is no request whose response changes and nothing to curl against a live proxy. What changes is whether the suite still passes on a machine that has a proxy configured, so both sides below run with `PROXY_BASE_URL=https://litellm.mycorp.example.com` exported, which is what a developer running a local gateway has

```
FILES="tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py \
tests/test_litellm/proxy/_experimental/mcp_server/test_byok_oauth_endpoints.py \
tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py \
tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_env_vars.py \
tests/test_litellm/proxy/utils/helpers/test_url_helpers.py"
```

### Before (559310f077)

#### the suites a configured origin breaks

1. `PROXY_BASE_URL=https://litellm.mycorp.example.com uv run --no-sync pytest $FILES -q --no-header -n 4`
2. Output:

```
FAILED tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py::test_xff_misconfig_warning_emitted_once
65 failed, 611 passed, 34 warnings in 31.68s
```

#### the regression test that pins it

1. With the conftest fixture backed out: `uv run --no-sync pytest tests/test_litellm/test_conftest.py -q --no-header`
2. Output, with the leaked origin standing in for the one the request carried:

```
>       assert exchange_mock.await_args.kwargs["redirect_uri"] == "https://litellm.example.com/callback"
E       AssertionError: assert 'https://leak....com/callback' == 'https://lite....com/callback'
E         - https://litellm.example.com/callback
E         + https://leaked-host-origin.example.com/callback
1 failed in 34.26s
```

### After (69133f6baa)

The only commit since, 9ef6a8826d, trims two docstrings and changes no behavior, so this run still stands

#### the suites a configured origin breaks

1. `PROXY_BASE_URL=https://litellm.mycorp.example.com uv run --no-sync pytest $FILES -q --no-header -n 4`
2. Output:

```
676 passed, 33 warnings in 28.43s
```

#### the regression test that pins it

1. `uv run --no-sync pytest tests/test_litellm/test_conftest.py -q --no-header`
2. Output:

```
.                                                                        [100%]
1 passed in 30.11s
```

## Type

🐛 Bug Fix

## Changes

`get_request_base_url` consults `PROXY_BASE_URL` before it looks at the request at all, which is right for a deployment sitting behind an ingress and wrong for a unit test, because every OAuth discovery, `redirect_uri`, and dynamic client registration case builds a request with a known `base_url` and asserts on what comes back out. A value in the developer's shell or `.env` replaces that origin everywhere, so 65 cases across five files fail on an origin no test supplied

The conftest for `tests/test_litellm` already isolates host AWS configuration for exactly this reason, so the new fixture is one `delenv` sitting next to it. Every test that genuinely wants a configured public origin sets the variable inside its own body, and an autouse conftest fixture is ordered ahead of those, so they keep the value they set

The regression test runs one of the sensitive cases in a subprocess with the variable deliberately poisoned. That is the only way to check what a test's starting environment looks like from inside the same session, and it means deleting the fixture turns the test red rather than leaving a check that passes either way on a clean CI runner

It drops the coverage subprocess variables on the way into that child. Inheriting them makes the nested run measure coverage a second time, which took the case from 63 seconds to 282 in a CI-shaped run and buys nothing the parent's own measurement does not already have

## Caveats (if any)

- A host `SERVER_ROOT_PATH` still breaks two discovery cases and six A2A agent card cases, and a host `GOOGLE_CLIENT_ID` still breaks the empty-database SSO settings case. Same class of leak, different variables, each wants its own probe, so they stay out of this PR
- The regression only bites while its probe test keeps asserting on a request-derived URL; if that case changes, the check passes without proving anything

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 9ef6a8826d passes /live-pr-risk

