### PR TITLE
fix(logging): serialize mixed-type sets safely

### DIFF
--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -62,7 +62,10 @@ def safe_dumps(
             seen.remove(id(obj))
             return result
         elif isinstance(obj, set):
-            result = sorted([_serialize(item, seen, depth + 1, key) for item in obj])
+            result = sorted(
+                [_serialize(item, seen, depth + 1, key) for item in obj],
+                key=lambda item: json.dumps(item, sort_keys=True, default=str),
+            )
             seen.remove(id(obj))
             return result
         elif isinstance(obj, BaseModel):

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -69,6 +69,14 @@ def test_complex_types():
     assert result["tuple"] == [4, 5, 6]  # Tuples are converted to lists
 
 
+def test_set_with_mixed_types():
+    data = {"metadata": {"labels": {"beta", 7, None}}}
+
+    result = json.loads(safe_dumps(data))
+
+    assert result["metadata"]["labels"] == ["beta", 7, None]
+
+
 def test_unserializable_object():
     # Test handling of unserializable objects
     class TestClass:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mixed-type metadata sets break JSON log serialization
- A TypeError prevents the log record from being emitted

How it solves it:

- Sort serialized set values by their JSON representation
- Preserve deterministic output across heterogeneous values

## User Flow

Before: a Python developer using JSON logs loses a record when metadata contains mixed set values

1. They enable JSON logging in their Python application
2. They emit an INFO record with label metadata containing `"beta"`, `7`, and `None`
3. Logging raises `TypeError: '<' not supported between instances of 'str' and 'NoneType'`

After: the same record is emitted as valid JSON with every label preserved

1. They enable JSON logging in their Python application
2. They emit the same INFO record with label metadata containing `"beta"`, `7`, and `None`
3. Logging emits a JSON record whose labels are `["beta", 7, null]`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The same Python 3.12 environment and logging script were used for both runs

### Before (`c696fdfb05c2b11d9f7f4d06b23f4e783c85ef54`)

1. Run this logging script:

   ```bash
   python - <<'PY'
   import logging
   from litellm._logging import JsonFormatter

   record = logging.LogRecord("litellm", logging.INFO, __file__, 1, "request", (), None)
   record.metadata = {"labels": {"beta", 7, None}}
   print(JsonFormatter().format(record))
   PY
   ```

2. Observe `TypeError: '<' not supported between instances of 'str' and 'NoneType'`

### After (`b0689f99a472f128e7a7e3e4b32d69c9bc14f6d9`)

1. Run the same logging script:

   ```bash
   python - <<'PY'
   import logging
   from litellm._logging import JsonFormatter

   record = logging.LogRecord("litellm", logging.INFO, __file__, 1, "request", (), None)
   record.metadata = {"labels": {"beta", 7, None}}
   print(JsonFormatter().format(record))
   PY
   ```

2. Observe `{"metadata": {"labels": ["beta", 7, null]}}` in the emitted JSON record

## Type

Bug Fix

## Caveats (if any)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
