### PR TITLE
fix(anthropic adapter): keep tool_result blocks that render no text

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -416,34 +416,23 @@ class LiteLLMAnthropicMessagesAdapter:
                                 # image becomes a structured image_url part
                                 if len(content_items) == 1:
                                     c = content_items[0]
-                                    if isinstance(c, str):
+                                    if isinstance(c, dict) and c.get("type") == "image":
+                                        image_part = self._tool_result_image_part(c.get("source"))
                                         tool_result = ChatCompletionToolMessage(
                                             role="tool",
                                             tool_call_id=content.get("tool_use_id", ""),
-                                            content=c,
+                                            content=[image_part]  # mutable-ok: content must be a json list
+                                            if image_part
+                                            else "",
                                         )
-                                        self._add_cache_control_if_applicable(content, tool_result, model)
-                                        tool_message_list.append(tool_result)
-                                    elif isinstance(c, dict):
-                                        if c.get("type") == "text":
-                                            tool_result = ChatCompletionToolMessage(
-                                                role="tool",
-                                                tool_call_id=content.get("tool_use_id", ""),
-                                                content=c.get("text", ""),
-                                            )
-                                            self._add_cache_control_if_applicable(content, tool_result, model)
-                                            tool_message_list.append(tool_result)
-                                        elif c.get("type") == "image":
-                                            image_part = self._tool_result_image_part(c.get("source"))
-                                            tool_result = ChatCompletionToolMessage(
-                                                role="tool",
-                                                tool_call_id=content.get("tool_use_id", ""),
-                                                content=[image_part]  # mutable-ok: content must be a json list
-                                                if image_part
-                                                else "",
-                                            )
-                                            self._add_cache_control_if_applicable(content, tool_result, model)
-                                            tool_message_list.append(tool_result)
+                                    else:
+                                        tool_result = ChatCompletionToolMessage(
+                                            role="tool",
+                                            tool_call_id=content.get("tool_use_id", ""),
+                                            content=self._tool_result_block_text(c),
+                                        )
+                                    self._add_cache_control_if_applicable(content, tool_result, model)
+                                    tool_message_list.append(tool_result)
                                 else:
                                     # For multiple content items, combine into a single tool message
                                     # with list content to preserve all items while having one tool_use_id
@@ -451,29 +440,26 @@ class LiteLLMAnthropicMessagesAdapter:
                                         ChatCompletionTextObject | ChatCompletionImageObject
                                     ] = []
                                     for c in content_items:
-                                        if isinstance(c, str):
-                                            combined_content_parts.append(ChatCompletionTextObject(type="text", text=c))
-                                        elif isinstance(c, dict):
-                                            if c.get("type") == "text":
-                                                combined_content_parts.append(
-                                                    ChatCompletionTextObject(
-                                                        type="text",
-                                                        text=c.get("text", ""),
-                                                    )
+                                        if isinstance(c, dict) and c.get("type") == "image":
+                                            image_part = self._tool_result_image_part(c.get("source"))
+                                            if image_part:
+                                                combined_content_parts.append(image_part)
+                                        else:
+                                            combined_content_parts.append(
+                                                ChatCompletionTextObject(
+                                                    type="text",
+                                                    text=self._tool_result_block_text(c),
                                                 )
-                                            elif c.get("type") == "image":
-                                                image_part = self._tool_result_image_part(c.get("source"))
-                                                if image_part:
-                                                    combined_content_parts.append(image_part)
-                                    # Create a single tool message with combined content
-                                    if combined_content_parts:
-                                        tool_result = ChatCompletionToolMessage(
-                                            role="tool",
-                                            tool_call_id=content.get("tool_use_id", ""),
-                                            content=combined_content_parts,
-                                        )
-                                        self._add_cache_control_if_applicable(content, tool_result, model)
-                                        tool_message_list.append(tool_result)
+                                            )
+                                    # Always emit the tool message, even when nothing rendered: a
+                                    # tool_call with no tool result is rejected upstream.
+                                    tool_result = ChatCompletionToolMessage(
+                                        role="tool",
+                                        tool_call_id=content.get("tool_use_id", ""),
+                                        content=combined_content_parts or "",
+                                    )
+                                    self._add_cache_control_if_applicable(content, tool_result, model)
+                                    tool_message_list.append(tool_result)
 
             if len(tool_message_list) > 0:
                 new_messages.extend(tool_message_list)
@@ -1170,6 +1156,28 @@ class LiteLLMAnthropicMessagesAdapter:
         if not openai_image_url:
             return None
         return ChatCompletionImageObject(type="image_url", image_url=ChatCompletionImageUrlObject(url=openai_image_url))
+
+    @staticmethod
+    def _tool_result_block_text(block: object) -> str:
+        """Render a non-image `tool_result` content block as text.
+
+        Every tool_result must yield a tool message, including ones whose blocks we do
+        not model - e.g. the `tool_reference` blocks Claude Code's deferred tool loading
+        returns. Dropping one leaves a tool call with no result, which providers reject
+        (Gemini: "Please ensure that the number of function response parts is equal to
+        the number of function call parts of the function call turn.").
+        """
+        if isinstance(block, str):
+            return block
+        if not isinstance(block, dict):
+            return str(block)
+        block_type = block.get("type")
+        if block_type == "text":
+            return str(block.get("text", ""))
+        if block_type == "tool_reference":
+            return f"[Loaded tool: {block.get('tool_name', '')}]"
+        # Placeholder, not a serialisation: unknown blocks may carry base64 payloads.
+        return f"[{block_type or 'unknown'} block]"
 
     def _translate_openai_content_to_anthropic(
         self,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1479,6 +1479,138 @@ def test_translate_anthropic_messages_to_openai_tool_result_single_item_backward
     assert tool_message["content"] == "72°F and sunny"
 
 
+@pytest.mark.parametrize(
+    "tool_result_content, expected_content",
+    [
+        ([{"type": "tool_reference", "tool_name": "Read"}], "[Loaded tool: Read]"),
+        ([], ""),
+        ([{"type": "future_block"}], "[future_block block]"),
+    ],
+)
+def test_translate_anthropic_messages_to_openai_tool_result_without_text_still_emits_tool_message(
+    tool_result_content, expected_content
+):
+    """
+    A tool_result whose content renders to no text must still produce a tool message.
+
+    Claude Code's deferred tool loading (ToolSearch) returns `tool_reference` blocks.
+    Dropping the tool message leaves a tool_call with no result, which providers reject
+    - Gemini with "Please ensure that the number of function response parts is equal to
+    the number of function call parts of the function call turn."
+    """
+
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[{"type": "text", "text": "Search for a tool"}],
+        ),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "toolu_search",
+                    "name": "ToolSearch",
+                    "input": {"query": "read"},
+                }
+            ],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_search",
+                    "content": tool_result_content,
+                }
+            ],
+        ),
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
+
+    tool_messages = [
+        msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"
+    ]
+
+    assert len(tool_messages) == 1, (
+        f"Every tool_use needs exactly one tool result, got {len(tool_messages)} "
+        f"for content {tool_result_content}"
+    )
+    assert tool_messages[0]["tool_call_id"] == "toolu_search"
+    assert tool_messages[0]["content"] == expected_content
+
+
+def test_translate_anthropic_messages_to_openai_parallel_tool_results_keep_pairing():
+    """
+    Two parallel tool_use blocks, one answered by tool_reference blocks, must still
+    produce two tool messages - the shape that 400s on vertex_ai/gemini.
+    """
+
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[{"type": "text", "text": "Search and read"}],
+        ),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "toolu_search",
+                    "name": "ToolSearch",
+                    "input": {"query": "read"},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "toolu_weather",
+                    "name": "get_weather",
+                    "input": {"location": "Boston"},
+                },
+            ],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_search",
+                    "content": [
+                        {"type": "tool_reference", "tool_name": "Read"},
+                        {"type": "tool_reference", "tool_name": "Edit"},
+                    ],
+                },
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_weather",
+                    "content": "72°F and sunny",
+                },
+            ],
+        ),
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
+
+    tool_call_ids = [
+        msg["tool_call_id"]
+        for msg in result
+        if isinstance(msg, dict) and msg.get("role") == "tool"
+    ]
+
+    assert tool_call_ids == ["toolu_search", "toolu_weather"]
+    search_message = next(
+        msg
+        for msg in result
+        if isinstance(msg, dict) and msg.get("tool_call_id") == "toolu_search"
+    )
+    assert search_message["content"] == [
+        {"type": "text", "text": "[Loaded tool: Read]"},
+        {"type": "text", "text": "[Loaded tool: Edit]"},
+    ]
+
+
 def test_streaming_chunk_with_both_text_and_tool_calls_issue_18238():
     """
     When a streaming choice contains both text content and tool_calls,


### PR DESCRIPTION
## Relevant issues

Fixes #37462. Same class of defect as #36540 (there: `/v1/messages` → Responses API; here: the shared Anthropic→OpenAI adapter that the Gemini path goes through).

## The bug

`translate_anthropic_messages_to_openai` only recognised `text` and `image` blocks inside a `tool_result` list. Anything else produced **no `role:"tool"` message at all**, so the `tool_call` it answers lost its result. Two spots, both in `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`:

- single-item list — the `text` / `image` `if/elif` chain had no `else`
- multi-item list, and `[]` — `if combined_content_parts:` skipped the append when nothing rendered

Claude Code's deferred tool loading (`ToolSearch`) hits this on every use: its tool result is a list of `tool_reference` blocks with no text.

```json
{ "type": "tool_result", "tool_use_id": "call_1",
  "content": [{"type": "tool_reference", "tool_name": "Read"}] }
```

Downstream is innocent — `convert_to_gemini_tool_call_result` has no empty-content skip and `_gemini_convert_messages_with_history` appends 1:1; the tool message simply never arrives. Vertex sees N `functionCall` parts answered by N-1 `functionResponse` parts and rejects the whole `contents`:

```
Please ensure that the number of function response parts is equal to the
number of function call parts of the function call turn.
```

The turn is already in history, so retries replay it and the session stays broken.

Verified against a proxy on `v1.98.0-rc.1` → `vertex_ai/gemini-3.7-flash`: two `tool_use` blocks, two `tool_result` blocks, only the first result's shape varying.

| first `tool_result.content` | before |
|---|---|
| `"20C"` | 200 |
| `[{"type": "text", "text": "20C"}]` | 200 |
| `[{"type": "tool_reference", "tool_name": "Read"}]` | 400 |
| `[]` | 400 |

A single-call turn hides it: with one `tool_use` and one dropped result the response turn collapses entirely and Gemini never runs the pairing check. It needs parallel tool calls where at least one sibling result does render.

## The change

Every `tool_result` now emits exactly one tool message. Unknown blocks degrade to text instead of vanishing:

- `tool_reference` → `[Loaded tool: <name>]`
- any other unrecognised type → `[<type> block]`

A placeholder rather than a JSON dump on purpose — unknown blocks may carry base64 payloads, and dumping a `document` block's `source.data` into a tool result would be its own bug.

Their semantics don't need to survive: Claude Code re-injects the discovered tool schemas into `tools` itself, so the block is a history marker. What must survive is the item.

Behaviour kept identical for everything already handled: single text block still yields string content (backward compat), single image still yields a one-element list, mixed lists still combine into one message.

## Tests

Added to `tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py`:

- `test_translate_anthropic_messages_to_openai_tool_result_without_text_still_emits_tool_message` — parametrized over `tool_reference`, `[]`, and an unknown block type
- `test_translate_anthropic_messages_to_openai_parallel_tool_results_keep_pairing` — the exact shape that 400s on Gemini

Both fail on `main`, pass with this change.

```
tests/test_litellm/llms/anthropic/            51 failed, 1319 passed
same suite at the parent commit               51 failed, 1315 passed
```

The 51 failures are pre-existing and unrelated (`files/`, `count_tokens/`); the delta is the 4 added tests. `ruff check` on the changed file reports the same 3 pre-existing findings before and after.

## Type

🐛 Bug Fix
