### PR TITLE
fix(llm_translation): handle dict reasoning_effort in Ollama and Bedrock transformation

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -918,10 +918,12 @@ class AmazonConverseConfig(BaseConfig):
                         litellm.verbose_logger.warning(DROP_UNSUPPORTED_ADAPTIVE_THINKING_WARNING, model)
                 else:
                     optional_params["thinking"] = value
-            elif param == "reasoning_effort" and isinstance(value, str):
-                self._handle_reasoning_effort_parameter(
-                    model=model, reasoning_effort=value, optional_params=optional_params
-                )
+            elif param == "reasoning_effort":
+                effort_value = value.get("effort") if isinstance(value, dict) else value
+                if isinstance(effort_value, str):
+                    self._handle_reasoning_effort_parameter(
+                        model=model, reasoning_effort=effort_value, optional_params=optional_params
+                    )
             elif param == "output_config" and isinstance(value, dict):
                 mapped_output_config = dict(value)
                 normalize_bedrock_opus_output_config_effort(model=model, output_config=mapped_output_config)

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -147,7 +147,7 @@ class OllamaChatConfig(BaseConfig):
         non_default_params: dict,
         optional_params: dict,
         model: str,
-        drop_params: bool,
+        drop_params: bool = False,
     ) -> dict:
         for param, value in non_default_params.items():
             if param == "max_tokens" or param == "max_completion_tokens":
@@ -170,10 +170,12 @@ class OllamaChatConfig(BaseConfig):
                 if value.get("json_schema") and value["json_schema"].get("schema"):
                     optional_params["format"] = value["json_schema"]["schema"]
             if param == "reasoning_effort" and value is not None:
-                if model.startswith("gpt-oss"):
-                    optional_params["think"] = value
-                else:
-                    optional_params["think"] = value in {"low", "medium", "high"}
+                effort_value = value.get("effort") if isinstance(value, dict) else value
+                if effort_value is not None:
+                    if model.startswith("gpt-oss"):
+                        optional_params["think"] = effort_value
+                    else:
+                        optional_params["think"] = effort_value in {"low", "medium", "high"}
             ### FUNCTION CALLING LOGIC ###
             # Ollama 0.4+ supports native tool calling - pass tools directly
             # and let Ollama handle model capability detection

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -147,7 +147,7 @@ class OllamaChatConfig(BaseConfig):
         non_default_params: dict,
         optional_params: dict,
         model: str,
-        drop_params: bool = False,
+        drop_params: bool,
     ) -> dict:
         for param, value in non_default_params.items():
             if param == "max_tokens" or param == "max_completion_tokens":

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -160,7 +160,7 @@ class OllamaConfig(BaseConfig):
         non_default_params: dict,
         optional_params: dict,
         model: str,
-        drop_params: bool = False,
+        drop_params: bool,
     ) -> dict:
         for param, value in non_default_params.items():
             if param == "max_tokens" or param == "max_completion_tokens":

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -160,7 +160,7 @@ class OllamaConfig(BaseConfig):
         non_default_params: dict,
         optional_params: dict,
         model: str,
-        drop_params: bool,
+        drop_params: bool = False,
     ) -> dict:
         for param, value in non_default_params.items():
             if param == "max_tokens" or param == "max_completion_tokens":
@@ -178,10 +178,12 @@ class OllamaConfig(BaseConfig):
             elif param == "stop":
                 optional_params["stop"] = value
             elif param == "reasoning_effort" and value is not None:
-                if model.startswith("gpt-oss"):
-                    optional_params["think"] = value
-                else:
-                    optional_params["think"] = value in {"low", "medium", "high"}
+                effort_value = value.get("effort") if isinstance(value, dict) else value
+                if effort_value is not None:
+                    if model.startswith("gpt-oss"):
+                        optional_params["think"] = effort_value
+                    else:
+                        optional_params["think"] = effort_value in {"low", "medium", "high"}
             elif param == "response_format" and isinstance(value, dict):
                 if value["type"] == "json_object":
                     optional_params["format"] = "json"

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -906,3 +906,51 @@ class TestOllamaToolCallTransformation:
         assert tool_msg["content"] == "Sunny, 72°F"
         assert "tool_call_id" in tool_msg, "tool_call_id must be forwarded to Ollama"
         assert tool_msg["tool_call_id"] == "call_abc123"
+
+
+class TestOllamaReasoningEffortMapping:
+    """
+    Test reasoning_effort mapping with string and dict formats (Responses API bridge).
+    Regression: https://github.com/BerriAI/litellm/issues/37452
+    """
+
+    def test_map_openai_params_reasoning_effort_string(self):
+        config = OllamaChatConfig()
+        # "low", "medium", "high" map to True for standard models
+        assert config.map_openai_params({"reasoning_effort": "low"}, {}, "qwen3") == {"think": True}
+        assert config.map_openai_params({"reasoning_effort": "medium"}, {}, "qwen3") == {"think": True}
+        assert config.map_openai_params({"reasoning_effort": "high"}, {}, "qwen3") == {"think": True}
+        assert config.map_openai_params({"reasoning_effort": "none"}, {}, "qwen3") == {"think": False}
+
+    def test_map_openai_params_reasoning_effort_dict_with_effort(self):
+        config = OllamaChatConfig()
+        result = config.map_openai_params(
+            {"reasoning_effort": {"effort": "medium", "summary": "auto"}}, {}, "qwen3"
+        )
+        assert result == {"think": True}
+
+        result_low = config.map_openai_params(
+            {"reasoning_effort": {"effort": "low"}}, {}, "qwen3"
+        )
+        assert result_low == {"think": True}
+
+        result_none = config.map_openai_params(
+            {"reasoning_effort": {"effort": "none"}}, {}, "qwen3"
+        )
+        assert result_none == {"think": False}
+
+    def test_map_openai_params_reasoning_effort_dict_summary_only(self):
+        config = OllamaChatConfig()
+        # When only summary is present without effort, no "think" param is set
+        result = config.map_openai_params(
+            {"reasoning_effort": {"summary": "auto"}}, {}, "qwen3"
+        )
+        assert "think" not in result
+
+    def test_map_openai_params_reasoning_effort_gpt_oss(self):
+        config = OllamaChatConfig()
+        result = config.map_openai_params(
+            {"reasoning_effort": {"effort": "medium"}}, {}, "gpt-oss-123"
+        )
+        assert result == {"think": "medium"}
+

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -916,41 +916,30 @@ class TestOllamaReasoningEffortMapping:
 
     def test_map_openai_params_reasoning_effort_string(self):
         config = OllamaChatConfig()
-        # "low", "medium", "high" map to True for standard models
-        assert config.map_openai_params({"reasoning_effort": "low"}, {}, "qwen3") == {"think": True}
-        assert config.map_openai_params({"reasoning_effort": "medium"}, {}, "qwen3") == {"think": True}
-        assert config.map_openai_params({"reasoning_effort": "high"}, {}, "qwen3") == {"think": True}
-        assert config.map_openai_params({"reasoning_effort": "none"}, {}, "qwen3") == {"think": False}
+        assert config.map_openai_params({"reasoning_effort": "low"}, {}, "qwen3", False) == {"think": True}
+        assert config.map_openai_params({"reasoning_effort": "medium"}, {}, "qwen3", False) == {"think": True}
+        assert config.map_openai_params({"reasoning_effort": "high"}, {}, "qwen3", False) == {"think": True}
+        assert config.map_openai_params({"reasoning_effort": "none"}, {}, "qwen3", False) == {"think": False}
 
     def test_map_openai_params_reasoning_effort_dict_with_effort(self):
         config = OllamaChatConfig()
         result = config.map_openai_params(
-            {"reasoning_effort": {"effort": "medium", "summary": "auto"}}, {}, "qwen3"
+            {"reasoning_effort": {"effort": "medium", "summary": "auto"}}, {}, "qwen3", False
         )
         assert result == {"think": True}
 
-        result_low = config.map_openai_params(
-            {"reasoning_effort": {"effort": "low"}}, {}, "qwen3"
-        )
+        result_low = config.map_openai_params({"reasoning_effort": {"effort": "low"}}, {}, "qwen3", False)
         assert result_low == {"think": True}
 
-        result_none = config.map_openai_params(
-            {"reasoning_effort": {"effort": "none"}}, {}, "qwen3"
-        )
+        result_none = config.map_openai_params({"reasoning_effort": {"effort": "none"}}, {}, "qwen3", False)
         assert result_none == {"think": False}
 
     def test_map_openai_params_reasoning_effort_dict_summary_only(self):
         config = OllamaChatConfig()
-        # When only summary is present without effort, no "think" param is set
-        result = config.map_openai_params(
-            {"reasoning_effort": {"summary": "auto"}}, {}, "qwen3"
-        )
+        result = config.map_openai_params({"reasoning_effort": {"summary": "auto"}}, {}, "qwen3", False)
         assert "think" not in result
 
     def test_map_openai_params_reasoning_effort_gpt_oss(self):
         config = OllamaChatConfig()
-        result = config.map_openai_params(
-            {"reasoning_effort": {"effort": "medium"}}, {}, "gpt-oss-123"
-        )
+        result = config.map_openai_params({"reasoning_effort": {"effort": "medium"}}, {}, "gpt-oss-123", False)
         assert result == {"think": "medium"}
-

--- a/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
@@ -507,3 +507,27 @@ class TestOllamaTextCompletionResponseIterator:
         assert result["usage"]["prompt_tokens"] == 10
         assert result["usage"]["completion_tokens"] == 5
         assert result["usage"]["total_tokens"] == 15
+
+
+class TestOllamaCompletionReasoningEffortMapping:
+    @pytest.mark.parametrize(
+        ("reasoning_effort", "model", "expected"),
+        [
+            ("medium", "qwen3", {"think": True}),
+            ("none", "qwen3", {"think": False}),
+            ({"effort": "medium", "summary": "auto"}, "qwen3", {"think": True}),
+            ({"effort": "medium"}, "gpt-oss-123", {"think": "medium"}),
+            ({"summary": "auto"}, "qwen3", {}),
+        ],
+    )
+    def test_map_openai_params_reasoning_effort(self, reasoning_effort, model, expected):
+        config = OllamaConfig()
+
+        result = config.map_openai_params(
+            {"reasoning_effort": reasoning_effort},
+            {},
+            model,
+            False,
+        )
+
+        assert result == expected


### PR DESCRIPTION
<!-- Thank you for contributing to LiteLLM!

If you are making a change to the server / proxy, please make sure you have added related tests in the test_litellm directory!
-->

## What does this PR do?
Fixes `TypeError: unhashable type: 'dict'` when calling `/v1/responses` or completions with a `reasoning` parameter dictionary (for example `{"effort": "medium", "summary": "auto"}` or `{"summary": "auto"}`) against `ollama_chat/*` and `ollama/*` models, as well as Bedrock Converse models.

### Problem
The Responses API bridge preserves the reasoning object when `summary` is present so downstream handlers can access it. In `OllamaChatConfig.map_openai_params` and `OllamaConfig.map_openai_params`, set membership was evaluated directly on `value`. When `value` is a dictionary, hashing fails with `TypeError: unhashable type: 'dict'`.

### Fix
- Extract `effort_value = value.get("effort") if isinstance(value, dict) else value` in both Ollama transformations.
- Support dictionary `reasoning_effort` in `AmazonConverseConfig` similarly.
- Cover chat and completion mappings for string values, dictionary values with effort, summary-only dictionaries, and `gpt-oss` models.
- Keep the existing required `drop_params` method contract unchanged.

Closes #37452

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Tests added / updated

## How Has This Been Tested?
```
pytest tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py -q
48 passed, 1 warning in 4.43s
```
- Verified string `reasoning_effort` (`low`, `medium`, `high`, `none`) maps to the expected `think` value.
- Verified dict `reasoning_effort` with `effort` maps correctly in both chat and completion paths.
- Verified summary-only dict input does not crash and omits `think`.
- Verified `gpt-oss` dict effort preserves the named effort level.
