### PR TITLE
fix(ollama): support dictionary reasoning_effort parameter (#37452)

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -170,10 +170,13 @@ class OllamaChatConfig(BaseConfig):
                 if value.get("json_schema") and value["json_schema"].get("schema"):
                     optional_params["format"] = value["json_schema"]["schema"]
             if param == "reasoning_effort" and value is not None:
-                if model.startswith("gpt-oss"):
-                    optional_params["think"] = value
-                else:
-                    optional_params["think"] = value in {"low", "medium", "high"}
+                if isinstance(value, dict):
+                    value = value.get("effort")
+                if value is not None:
+                    if model.startswith("gpt-oss"):
+                        optional_params["think"] = value
+                    else:
+                        optional_params["think"] = value in {"low", "medium", "high"}
             ### FUNCTION CALLING LOGIC ###
             # Ollama 0.4+ supports native tool calling - pass tools directly
             # and let Ollama handle model capability detection


### PR DESCRIPTION
# Title
fix(ollama): support dictionary reasoning_effort parameter from Responses API bridge (#37452)

## Description
- Updates `OllamaChatConfig.map_openai_params` to safely extract `"effort"` when `reasoning_effort` is passed as a dict (from the Responses API bridge).
- Prevents `TypeError: unhashable type: 'dict'` exception when calling `ollama_chat` models through `/v1/responses` with reasoning configurations containing a `summary` field.

Closes #37452
