### PR TITLE
fix(deepseek): stop v4 thinking mode from 400ing on tool_choice="required"

### DIFF
--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -2,7 +2,7 @@
 Translates from OpenAI's `/v1/chat/completions` to DeepSeek's `/v1/chat/completions`
 """
 
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Mapping
 from typing import Any, Final, Literal, cast, overload
 
 import litellm
@@ -14,6 +14,25 @@ from litellm.types.llms.openai import AllMessageValues
 from litellm.utils import supports_reasoning
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
+
+# Model families the DeepSeek API runs in thinking mode unless the caller turns
+# it off, as opposed to the families where thinking is opt-in. Compared against
+# the model name with any provider prefix stripped.
+#
+# This cannot be read off model_prices_and_context_window.json: every
+# reasoning-capable DeepSeek entry there carries `supports_reasoning: true`,
+# including deepseek-v3.1 / v3.2 / reasoner, where thinking is opt-in and
+# tool_choice="required" is accepted while thinking is off. No capability flag
+# distinguishes "reasoning is on unless disabled" from "reasoning is available",
+# so the family is listed here.
+THINKING_ON_BY_DEFAULT_MODELS: Final = ("deepseek-v4",)
+
+# tool_choice values the DeepSeek API accepts outside thinking mode but rejects
+# while it is active. `"any"` is deliberately absent: DeepSeek rejects it in
+# every mode, thinking or not, with a deserialization error naming the values it
+# accepts - that is a separate bug from this one, and `"any"` is not an
+# OpenAI-spec tool_choice value to begin with.
+TOOL_CHOICES_REJECTED_IN_THINKING_MODE: Final = ("required",)
 
 
 class DeepSeekChatConfig(OpenAIGPTConfig):
@@ -58,7 +77,71 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         elif reasoning_effort is not None:
             optional_params["thinking"] = {"type": "disabled" if reasoning_effort == "none" else "enabled"}
 
+        if self._tool_choice_is_rejected_in_thinking_mode(model=model, optional_params=optional_params):
+            litellm.verbose_logger.warning(
+                "DeepSeek thinking mode does not accept tool_choice=%r; sending "
+                "tool_choice='auto' for model %r instead. The model now decides "
+                "whether to call a tool, so a tool call is no longer forced. Turn "
+                "thinking off (thinking={'type': 'disabled'} or "
+                "reasoning_effort='none') to keep the requested tool_choice.",
+                optional_params["tool_choice"],
+                model,
+            )
+            optional_params["tool_choice"] = "auto"
+            return optional_params
+
         return optional_params
+
+    @staticmethod
+    def _thinking_on_by_default(model: str) -> bool:
+        """
+        Whether the API enables thinking mode for this model unless the caller disables it.
+        """
+        model_name: Final = model.rsplit("/", 1)[-1].lower()
+        return model_name.startswith(THINKING_ON_BY_DEFAULT_MODELS)
+
+    def _thinking_mode_will_be_active(self, model: str, optional_params: Mapping[str, Any]) -> bool:
+        """
+        Whether the request being built will run in thinking mode - the caller
+        enabled it, or the model runs it by default and the caller did not
+        disable it.
+
+        Reads the `thinking` value already resolved into `optional_params`, i.e.
+        what is about to be sent, rather than the `supports_reasoning`
+        capability flag: that flag is also true for models where thinking is
+        merely available, and a deployment missing from the cost map still runs
+        in thinking mode.
+        """
+        thinking: Final = optional_params.get("thinking")
+        thinking_type: Final = thinking.get("type") if isinstance(thinking, dict) else None
+        if thinking_type in ("enabled", "disabled"):
+            return thinking_type == "enabled"
+        return self._thinking_on_by_default(model)
+
+    def _tool_choice_is_rejected_in_thinking_mode(self, model: str, optional_params: Mapping[str, Any]) -> bool:
+        """
+        DeepSeek rejects `tool_choice="required"` and the
+        `{"type": "function", ...}` form while thinking mode is active:
+
+            400 - Thinking mode does not support this tool_choice
+
+        Only "auto" and "none" get through. deepseek-v4-pro / deepseek-v4-flash
+        run in thinking mode by default, so callers hit this without ever
+        passing `thinking` - every SDK that hardcodes `tool_choice="required"`
+        to force a tool call (the OpenAI Agents SDK delegation path, LangChain's
+        `bind_tools(tool_choice=...)`) fails on the first turn.
+
+        The caller asked for a stronger guarantee than DeepSeek gives here, so
+        downgrading to "auto" is lossy - but the alternative is a 400 that
+        honours the requested tool_choice even less. A caller that needs the
+        guarantee can turn thinking off with `thinking={"type": "disabled"}` or
+        `reasoning_effort="none"`, which leaves tool_choice untouched.
+
+        Reference: https://api-docs.deepseek.com/guides/thinking_mode
+        """
+        tool_choice: Final = optional_params.get("tool_choice")
+        is_rejected: Final = tool_choice in TOOL_CHOICES_REJECTED_IN_THINKING_MODE or isinstance(tool_choice, dict)
+        return is_rejected and self._thinking_mode_will_be_active(model=model, optional_params=optional_params)
 
     def _fill_reasoning_content(self, messages: list[AllMessageValues]) -> list[AllMessageValues]:
         """

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -106,3 +106,87 @@ async def test_async_transform_request_strips_unsupported_tools_from_body():
 def test_thinking_mode_active_bool_thinking_returns_false_without_crashing():
     config = DeepSeekChatConfig()
     assert config._thinking_mode_active(model="deepseek-reasoner", optional_params={"thinking": True}) is False
+
+
+def _map(model: str, **non_default_params) -> dict:
+    """Map params the way litellm does for a real request, from an empty optional_params."""
+    return DeepSeekChatConfig().map_openai_params(
+        non_default_params=non_default_params,
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+
+def test_v4_rejects_tool_choice_required_so_it_is_downgraded_to_auto():
+    """deepseek-v4 runs in thinking mode by default, which 400s on tool_choice='required'."""
+    result = _map("deepseek/deepseek-v4-pro", tool_choice="required")
+
+    assert result["tool_choice"] == "auto"
+
+
+def test_v4_leaves_tool_choice_any_alone():
+    """
+    DeepSeek rejects "any" in every mode, thinking or not, with a
+    deserialization error listing the values it accepts. That is a different bug
+    from the thinking-mode restriction, so rewriting it here would hide an
+    invalid value rather than work around a provider limit.
+    """
+    result = _map("deepseek-v4-flash", tool_choice="any")
+
+    assert result["tool_choice"] == "any"
+
+
+def test_v4_named_function_tool_choice_is_downgraded_to_auto():
+    result = _map("deepseek/deepseek-v4-pro", tool_choice={"type": "function", "function": {"name": "get_weather"}})
+
+    assert result["tool_choice"] == "auto"
+
+
+def test_v4_keeps_tool_choice_auto():
+    result = _map("deepseek/deepseek-v4-pro", tool_choice="auto")
+
+    assert result["tool_choice"] == "auto"
+
+
+def test_v4_keeps_tool_choice_none():
+    """'none' forbids tool calls and is accepted in thinking mode - downgrading it would allow them."""
+    result = _map("deepseek/deepseek-v4-pro", tool_choice="none")
+
+    assert result["tool_choice"] == "none"
+
+
+def test_non_reasoning_model_keeps_tool_choice_required():
+    result = _map("deepseek/deepseek-chat", tool_choice="required")
+
+    assert result["tool_choice"] == "required"
+
+
+def test_opt_in_reasoning_model_keeps_tool_choice_required_while_thinking_is_off():
+    """
+    deepseek-v3.2 carries supports_reasoning=true but only enters thinking mode
+    on request, so it still accepts 'required'. Keying the downgrade off the
+    capability flag instead of the model family would break this call.
+    """
+    result = _map("deepseek/deepseek-v3.2", tool_choice="required")
+
+    assert result["tool_choice"] == "required"
+
+
+def test_explicit_thinking_downgrades_tool_choice_on_any_model():
+    result = _map("deepseek-reasoner", thinking={"type": "enabled"}, tool_choice="required")
+
+    assert result["tool_choice"] == "auto"
+
+
+def test_v4_keeps_tool_choice_required_when_thinking_is_explicitly_disabled():
+    """Disabling thinking is the caller's escape hatch for keeping a forced tool_choice."""
+    result = _map("deepseek/deepseek-v4-pro", thinking={"type": "disabled"}, tool_choice="required")
+
+    assert result["tool_choice"] == "required"
+
+
+def test_v4_keeps_tool_choice_required_when_reasoning_effort_is_none():
+    result = _map("deepseek/deepseek-v4-pro", reasoning_effort="none", tool_choice="required")
+
+    assert result["tool_choice"] == "required"


### PR DESCRIPTION
# PR title

```
fix(deepseek): stop v4 thinking mode from 400ing on tool_choice="required"
```

---

## TLDR

Problem this solves:

- DeepSeek V4 rejects `tool_choice="required"` with a 400
- V4 runs thinking mode by default, so callers hit it unprompted
- Any SDK that forces a tool call breaks on the first turn

How it solves it:

- Send `tool_choice="auto"` when the request runs in thinking mode
- Only for the V4 family; opt-in reasoning models are untouched
- Warns on downgrade; disabling thinking keeps the forced choice

## User Flow

Before: a developer whose agent forces a tool call gets a 400 from every DeepSeek V4 request, and nothing they change in their own code fixes it.

1. They point their agent framework at `deepseek/deepseek-v4-flash`. Their framework forces a tool call, as agent frameworks do when they need a structured answer rather than prose.
2. They send `POST https://litellm-domain/v1/chat/completions` with their tool list and `"tool_choice": "required"`.
3. The response is `400` with `Thinking mode does not support this tool_choice`. No tokens are billed and no answer comes back.
4. They read the DeepSeek docs, which state that thinking mode supports tool calls and say nothing about `tool_choice`, so the error looks like a gateway bug rather than a provider limit.
5. They try `deepseek/deepseek-v3.2` instead, where the same request returns `200`, and conclude V4 is unusable with their framework.

After: the same request returns a normal answer, and the developer is told in the logs what was changed on their behalf.

1. They point their agent framework at `deepseek/deepseek-v4-flash`. Their framework forces a tool call, as before.
2. They send `POST https://litellm-domain/v1/chat/completions` with their tool list and `"tool_choice": "required"`.
3. The response is `200` and carries a `tool_calls` entry naming one of their tools, so their agent proceeds to the next turn.
4. The proxy logs a warning naming the model and the `tool_choice` they asked for, so the developer can see that a forced choice became a free choice and is no longer guaranteed.
5. If they need the hard guarantee back, they send `"reasoning_effort": "none"` alongside `"tool_choice": "required"`, and the forced choice is passed through to DeepSeek untouched.

## Relevant issues

<!-- No open issue tracks this exactly. Closest prior art is PR #27628, which was closed for an unsigned
     CLA, not on technical grounds. Delete this section or fill it in if an issue is filed first. -->

Supersedes #27628 (closed 2026-08-18 for an unsigned CLA; both automated reviews there raised design
points, which this PR answers in "Alternatives considered" below).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Real calls against `deepseek/deepseek-v4-flash`, no mocks. Both cases send `tool_choice="required"`;
case 2 additionally disables thinking, to show the restriction is a property of thinking mode rather
than of the model.

Shared setup:

```bash
export DEEPSEEK_API_KEY=...
cat > /tmp/probe.py <<'PY'
import json, sys, litellm
extra = {"reasoning_effort": "none"} if len(sys.argv) > 1 else {}
try:
    r = litellm.completion(
        model="deepseek/deepseek-v4-flash",
        messages=[{"role": "user", "content": "What is the weather in Istanbul?"}],
        tools=[{"type": "function", "function": {
            "name": "get_weather",
            "parameters": {"type": "object",
                           "properties": {"city": {"type": "string"}},
                           "required": ["city"]}}}],
        tool_choice="required",
        **extra,
    )
    c = r.choices[0]
    print("200", c.finish_reason, [t.function.name for t in c.message.tool_calls or []],
          json.loads((c.message.tool_calls or [None])[0].function.arguments))
except Exception as e:
    print(type(e).__name__, getattr(e, "status_code", ""), str(e)[:200])
PY
```

### Before (`c696fdfb`)

#### case 1 — thinking mode at its default (on)

1. `git checkout c696fdfb && python /tmp/probe.py`
2. Observed — the reported bug:

```
BadRequestError 400 litellm.BadRequestError: DeepseekException - {"error":{"message":"Thinking mode does not support this tool_choice","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}
```

#### case 2 — thinking explicitly disabled

1. `git checkout c696fdfb && python /tmp/probe.py no-thinking`
2. Observed — the same forced `tool_choice` is accepted once thinking is off:

```
200 tool_calls ['get_weather'] {'city': 'Istanbul'}
```

### After (`af4df201`)

#### case 1 — thinking mode at its default (on)

1. `git checkout af4df201 && python /tmp/probe.py`
2. Observed — the request now succeeds, and the downgrade is announced in the log:

```
200 tool_calls ['get_weather'] {'city': 'Istanbul'}

WARNING  LiteLLM: DeepSeek thinking mode does not accept tool_choice='required'; sending
tool_choice='auto' for model 'deepseek-v4-flash' instead. The model now decides whether to call a
tool, so a tool call is no longer forced. Turn thinking off (thinking={'type': 'disabled'} or
reasoning_effort='none') to keep the requested tool_choice.
```

#### case 2 — thinking explicitly disabled

1. `git checkout af4df201 && python /tmp/probe.py no-thinking`
2. Observed — byte-for-byte the Before behaviour, and **no** warning, because `tool_choice` was passed
   through untouched:

```
200 tool_calls ['get_weather'] {'city': 'Istanbul'}
```

In all three successful runs the model returned exactly one tool call, with `finish_reason` of
`tool_calls`, empty `content`, and arguments that parsed as JSON and matched the tool's schema.

To be precise about what After/case 1 does and does not show: that tool call was **not forced**. The
request went to DeepSeek as `tool_choice="auto"`, so calling the tool was the model's choice — near
certain with a single obvious tool and a matching question, but a choice. Case 1 demonstrates that the
400 is gone and that the downgrade is announced, not that the caller's guarantee survived. The path
that preserves the guarantee is case 2.

## Type

🐛 Bug Fix

## Caveats (if any)

- Forced tool choice becomes model choice in thinking mode
- Escape hatch: disable thinking to keep `required`
- Family list is hardcoded; no capability flag exists yet
- `tool_choice="any"` still 400s; separate bug, left alone

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

---

# Background for reviewers

## The bug

`deepseek-v4-pro` and `deepseek-v4-flash` reject the two forced `tool_choice` values while thinking
mode is active, and accept them once it is off. Measured against `deepseek-v4-flash`:

| `tool_choice` | thinking on (default / `enabled`) | thinking `disabled` |
| --- | --- | --- |
| `"required"` | **400** | 200, tool called |
| `{"type": "function", "function": {"name": "..."}}` | **400** | 200, tool called |
| `"auto"` | 200 | 200 |
| `"none"` | 200 | 200 |
| omitted | 200 | 200 |

The 400 body is identical for both rejected forms:

```json
{"error": {"message": "Thinking mode does not support this tool_choice", "type": "invalid_request_error", "param": null, "code": "invalid_request_error"}}
```

The restriction is a property of thinking mode, not of the model: with
`thinking={"type": "disabled"}`, `deepseek-v4-flash` accepts a named-function `tool_choice` and calls
the tool on 10 of 10 runs, and none of those responses carry
`usage.completion_tokens_details.reasoning_tokens` — so thinking really was off rather than the
parameter being ignored.

## Why callers hit it without asking for thinking mode

DeepSeek's own thinking-mode guide states that thinking mode is **enabled by default**, at `high` effort,
and that the effort mapping applies identically to `deepseek-v4-flash` and `deepseek-v4-pro`. So a caller
who never sends `thinking` or `reasoning_effort` is still in thinking mode, and still gets the 400.

That makes this a first-turn failure for every SDK that forces a tool call to get a structured answer —
the OpenAI Agents SDK's delegation path uses `ModelSettings(tool_choice="required")`, and LangChain's
`bind_tools(tool_choice=...)` does the same.

The same guide says *"The DeepSeek model's thinking mode supports tool calls"* and **does not mention
`tool_choice` anywhere**, so there is nothing in the documentation that would lead a caller to expect
this. The API reference lists `tool_choice` as supported without qualification.

## The fix

In `DeepSeekChatConfig.map_openai_params`, when the request will actually run in thinking mode and
`tool_choice` is one of the two rejected forms, send `"auto"` instead and log a warning.

"Will actually run in thinking mode" means: the caller enabled thinking, **or** the model is in the
always-on family and the caller did not disable it. Concretely:

| model | caller sent | `tool_choice` sent |
| --- | --- | --- |
| `deepseek-v4-pro` | `tool_choice="required"` | `"auto"` (downgraded) |
| `deepseek-v4-pro` | `tool_choice="required"`, `reasoning_effort="none"` | `"required"` (untouched) |
| `deepseek-v4-pro` | `tool_choice="none"` | `"none"` (untouched — `none` is valid and meaningful) |
| `deepseek-v3.2` | `tool_choice="required"` | `"required"` (untouched — thinking is off) |
| `deepseek-chat` | `tool_choice="required"` | `"required"` (untouched) |
| `deepseek-reasoner` | `tool_choice="required"`, `thinking={"type":"enabled"}` | `"auto"` (downgraded) |

## Alternatives considered

**Why not drop `tool_choice` from `get_supported_openai_params()`?** That is the existing house pattern
(`azure_ai`, `gpt_5`, `fireworks_ai` all do it), but it is a *parameter*-level switch and this is a
*value*-level constraint. Dropping the parameter would also discard `"none"`, which is valid in thinking
mode and carries real meaning — it forbids tool calls, so discarding it would let the model call tools
the caller explicitly ruled out. It would also raise `UnsupportedParamsError` for anyone running with
`drop_params=False`, turning a fixable request into a hard failure.

**Why not key off `supports_reasoning()` instead of a model-name list?** Because it does not separate the
two cases. Every reasoning-capable DeepSeek entry in `model_prices_and_context_window.json` carries
`supports_reasoning: true`, including `deepseek-v3.1`, `v3.2` and `deepseek-reasoner`, where thinking is
opt-in and `"required"` is accepted while thinking is off. Keying off that flag would downgrade
`tool_choice` on every v3.2 request and silently take forced tool calling away from models that support
it. `test_opt_in_reasoning_model_keeps_tool_choice_required_while_thinking_is_off` pins that behaviour.

The missing piece is a capability flag meaning "reasoning is on unless disabled", as distinct from
"reasoning is available". There isn't one today, so the family is a named module-level constant with a
comment explaining exactly that. **If maintainers would rather see this as a new key in
`model_prices_and_context_window.json`, say so and I will move it** — it is a strictly better home for it,
just a wider change than this fix.

(For the record, the V4 entries *are* in `model_prices_and_context_window.json` now — `deepseek-v4-pro`,
`deepseek-v4-flash` and their `deepseek/`-prefixed forms — so the fix does not depend on adding them.)

**Why not read `supports_reasoning()` for the caller-enabled branch?** The check reads the `thinking`
value already resolved into `optional_params`, i.e. what is about to be sent on the wire, rather than the
capability table. A deployment that is missing from the cost map — a custom deployment name, a
self-hosted V4 — still runs in thinking mode and still gets the 400, and the capability flag would miss it.

**Why is `tool_choice="any"` left alone?** It looks like it belongs with the others, but it fails for an
unrelated reason. DeepSeek rejects `"any"` whether thinking is on *or* off, and with a different error —
a deserialization failure, not the thinking-mode message:

```json
{"error": {"message": "Failed to deserialize the JSON body into the target type: tool_choice: expected one of `none`, `auto`, `required` or a tool at ...", "type": "invalid_request_error", "param": null, "code": "invalid_request_error"}}
```

`"any"` is not an OpenAI-spec `tool_choice` value either, and that error message already tells the caller
exactly what is wrong. Rewriting it here would hide an invalid value rather than work around a provider
limit, and would fix it only in thinking mode — leaving the same call broken with thinking off. Out of
scope for this PR.

## On widening the caller's `tool_choice`

This trades a guarantee for a working request, and that deserves to be explicit:

- **The previous behaviour was not "forced tool calling".** It was a guaranteed 400. No tool was called
  either way; the difference is whether the caller gets an answer.
- **"auto" is not a coin flip here.** On `deepseek-v4-flash` with one tool defined and a prompt that
  calls for it, `tool_choice="auto"` produced a tool call on **10 of 10** runs — `finish_reason` of
  `tool_calls`, empty `content`, and arguments that parsed and validated against the tool's schema every
  time. Downgrading costs the guarantee, not the behaviour.
- **It is not silent.** Every downgrade logs a warning naming the model and the original value, and says
  how to get the guarantee back.
- **The caller keeps a measured escape hatch.** Case 2 of the proof above runs it end to end: with
  `reasoning_effort="none"`, `tool_choice="required"` reaches DeepSeek untouched and the tool is called,
  on this PR and on the merge base alike. Directly against the API the same holds across repeats — a
  named-function `tool_choice` succeeds on 10 of 10 runs and `"required"` on 3 of 3, with no
  `reasoning_tokens` in any response, confirming thinking was genuinely off rather than the parameter
  being ignored.
- **It is narrow.** Only `"required"` and the dict form are touched, only while thinking mode is active.
  `"auto"` and `"none"` always pass through unchanged.

## Prior art

Both merged, both the same downgrade for the same reason on Claude's extended thinking:

- [langchain-ai/langchain#35544](https://github.com/langchain-ai/langchain/pull/35544) — *"fix(anthropic):
  drop forced tool_choice when thinking is enabled"*, merged 2026-03-05.
- [langchain-ai/langchain-litellm#126](https://github.com/langchain-ai/langchain-litellm/pull/126) — *"fix:
  downgrade `tool_choice` to auto when thinking is enabled on Claude"*, merged 2026-04-03. Same shape as
  this PR: scoped to one model family, downgrades to `"auto"`, warns on downgrade.

## Tests

10 new cases in `tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py`, all mocked,
no network:

- `test_v4_rejects_tool_choice_required_so_it_is_downgraded_to_auto`
- `test_v4_named_function_tool_choice_is_downgraded_to_auto`
- `test_v4_leaves_tool_choice_any_alone`
- `test_v4_keeps_tool_choice_auto`
- `test_v4_keeps_tool_choice_none`
- `test_non_reasoning_model_keeps_tool_choice_required`
- `test_opt_in_reasoning_model_keeps_tool_choice_required_while_thinking_is_off`
- `test_explicit_thinking_downgrades_tool_choice_on_any_model`
- `test_v4_keeps_tool_choice_required_when_thinking_is_explicitly_disabled`
- `test_v4_keeps_tool_choice_required_when_reasoning_effort_is_none`

They map params from an empty `optional_params`, the way a real request does, rather than pre-seeding the
value under test.

```
$ pytest tests/test_litellm/llms/deepseek -q
23 passed
```

Reverting only the source change fails exactly the three downgrade cases and leaves the seven
pass-through cases green, so the guards are guarding something.

## Breaking change

No. The only requests whose behaviour changes are the ones that currently return a 400.
