### PR TITLE
fix(health_check): preserve resolved api_base and api_key in ahealth_check (#37321)

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8395,12 +8395,16 @@ async def ahealth_check(
         api_base_from_params: Final = model_params.get("api_base", None)
         api_key_from_params: Final = model_params.get("api_key", None)
 
-        model, custom_llm_provider, _, _ = get_llm_provider(
+        model, custom_llm_provider, dynamic_api_key, returned_api_base = get_llm_provider(
             model=model,
             custom_llm_provider=custom_llm_provider_from_params,
             api_base=api_base_from_params,
             api_key=api_key_from_params,
         )
+        if returned_api_base is not None and not model_params.get("api_base"):
+            model_params["api_base"] = returned_api_base
+        if dynamic_api_key is not None and not model_params.get("api_key"):
+            model_params["api_key"] = dynamic_api_key
         if model in litellm.model_cost and mode is None:
             mode = litellm.model_cost[model].get("mode")
 


### PR DESCRIPTION
# Title
fix(health_check): capture and apply dynamic api_base and api_key from get_llm_provider in ahealth_check (#37321)

## Description
- Updates `ahealth_check` in `litellm/main.py` to capture `dynamic_api_key` and `returned_api_base` from `get_llm_provider`.
- Ensures health checks for `hosted_vllm/` and OpenAI-compatible providers correctly use resolved `api_base` and credentials rather than failing with false-positive `Unauthorized` / empty `api_base` errors.

Closes #37321
