### PR TITLE
fix(logging): treat an empty prompt_id as no prompt in manager dispatch

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1157,7 +1157,7 @@ class Logging(LiteLLMLoggingBaseClass):
         )
 
         for logger in prompt_management_loggers:
-            if prompt_id is None and not self._prompt_manager_runs_without_prompt_id(
+            if not prompt_id and not self._prompt_manager_runs_without_prompt_id(
                 logger=logger,
                 prompt_spec=prompt_spec,
                 dynamic_callback_params=dynamic_callback_params,

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -7004,3 +7004,34 @@ def test_get_additional_headers_survives_a_thread_growing_headers_mid_copy():
         assert copied["llm_provider-x-custom-1999"] == "1999"
 
     _run_while_a_thread_grows(headers, read, reads=300)
+
+
+def test_prompt_hooks_skip_prompt_managers_when_prompt_id_is_empty(logging_obj, tmp_path, monkeypatch):
+    """
+    `should_run_prompt_management_hooks` gates on `if prompt_id`, so an empty string reaches
+    dispatch as a call that names no prompt. Dispatch gated on `prompt_id is None`, so it
+    handed the call to the dotprompt manager anyway and the cache_control hook never ran.
+    """
+    from litellm.integrations.dotprompt.dotprompt_manager import DotpromptManager
+
+    (tmp_path / "stem.prompt").write_text("---\nmodel: claude-opus-4-5\n---\nyou are a stem tutor\n")
+    dotprompt_manager = DotpromptManager(prompt_directory=str(tmp_path))
+    monkeypatch.setattr(litellm, "callbacks", [dotprompt_manager])
+
+    cache_control_params = {"cache_control_injection_points": [{"role": "system", "location": "message"}]}
+    messages = [
+        {"role": "system", "content": "you are a stem tutor"},
+        {"role": "user", "content": "hi"},
+    ]
+
+    assert logging_obj.should_run_prompt_management_hooks(prompt_id="", non_default_params=cache_control_params)
+
+    _, compiled_messages, _ = logging_obj.get_chat_completion_prompt(
+        model="claude-opus-4-5",
+        messages=messages,
+        non_default_params=cache_control_params,
+        prompt_variables=None,
+        prompt_id="",
+    )
+
+    assert compiled_messages[0]["cache_control"] == {"type": "ephemeral"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- An empty `prompt_id` silently drops `cache_control_injection_points`
- Two gates disagree on whether `""` names a prompt

How it solves it:

- Dispatch reads a blank `prompt_id` the way the entry gate does
- A manager that declines no longer shadows the cache-control hook

## User Flow

Before: a developer whose client sends an empty prompt id gets no prompt caching, and nothing tells them why

1. The admin sets `callbacks: ["dotprompt"]` and gives `claude-opus-4-5` a `cache_control_injection_points: [{role: system, location: message}]`
2. The developer sends POST http://localhost:4000/v1/chat/completions with a system message, a user message, and `"prompt_id": ""`
3. The response is HTTP 200 with a normal answer, so nothing looks broken
4. The provider never receives the system block marked for caching, so http://localhost:4000/ui/?page=logs bills the whole prompt as a write on every call and never as a cache read
5. The developer removes the `prompt_id` field and resends. That request does get the cache marker, so the empty string is the only difference

After: an empty prompt id behaves exactly like an absent one, and the prefix caches

1. The admin keeps the same config
2. The developer sends the same POST with `"prompt_id": ""`
3. The response is HTTP 200 with the same answer
4. The provider now receives the system block carrying `"cache_control": {"type": "ephemeral"}`, so http://localhost:4000/ui/?page=logs bills the next identical call as a cache read

## Relevant issues

Follow-up to #37469

That report is the prompt-less case, and 4829bb3a15 already fixed it on `litellm_internal_staging`. I re-verified: on `35416c702d` a call with no `prompt_id` gets the cache marker. What survives is the empty-string case, which is what this PR narrows to, so it does not close the issue on its own

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

`should_run_prompt_management_hooks` decides whether to run the prompt hooks at all, and it gates on `if prompt_id`, so `""` reaches dispatch as a call that names no prompt. `get_custom_logger_for_prompt_management` then gated on `prompt_id is None`, so `""` skipped the guard, dotprompt was selected, and it returned the messages untouched. The cache-control hook sits after that in the same chain and never ran

This is local preprocessing that happens before any provider request is built, so the run below drives real HTTP through the full SDK against an upstream that records what it receives. I have no provider credentials on this machine, so the upstream is a stub on 127.0.0.1 rather than Anthropic. What it proves is the system block on the wire, which is exactly the bytes the provider would have been sent

Shared setup, both cases:

```bash
mkdir -p /tmp/prompts
printf -- '---\nmodel: claude-opus-4-5\n---\nyou are a stem tutor\n' > /tmp/prompts/stem.prompt
export DOTPROMPT_DIRECTORY=/tmp/prompts

cat > /tmp/upstream.py <<'PY'
import json
from http.server import BaseHTTPRequestHandler, HTTPServer

CANNED = {"id": "msg_stub", "type": "message", "role": "assistant", "model": "claude-opus-4-5",
          "content": [{"type": "text", "text": "Hi from the stub upstream."}],
          "stop_reason": "end_turn", "usage": {"input_tokens": 12, "output_tokens": 6}}

class Handler(BaseHTTPRequestHandler):
    def do_POST(self):
        open("/tmp/last_request.json", "wb").write(self.rfile.read(int(self.headers["content-length"])))
        payload = json.dumps(CANNED).encode()
        self.send_response(200)
        self.send_header("content-type", "application/json")
        self.send_header("content-length", str(len(payload)))
        self.end_headers()
        self.wfile.write(payload)
    def log_message(self, *a): pass

HTTPServer(("127.0.0.1", 8899), Handler).serve_forever()
PY

cat > /tmp/call.py <<'PY'
import json, sys, litellm
litellm.callbacks = ["dotprompt"]
prompt_id = sys.argv[1] if len(sys.argv) > 1 else None
kwargs = {} if prompt_id is None else {"prompt_id": prompt_id}
r = litellm.completion(
    model="anthropic/claude-opus-4-5", api_key="sk-ant-stub", api_base="http://127.0.0.1:8899",
    messages=[{"role": "system", "content": "You are helpful."},
              {"role": "user", "content": "Hello"}],
    cache_control_injection_points=[{"role": "system", "location": "message"}], **kwargs)
print("HTTP 200:", r.choices[0].message.content)
print("system sent upstream:", json.dumps(json.load(open("/tmp/last_request.json"))["system"]))
PY

python /tmp/upstream.py &
```

### Before (35416c702d)

#### no prompt_id, the case #37469 reported

1. `python /tmp/call.py`
2. Output, already correct here because of 4829bb3a15:

```text
HTTP 200: Hi from the stub upstream.
system sent upstream: [{"type": "text", "text": "You are helpful.", "cache_control": {"type": "ephemeral"}}]
```

#### empty prompt_id

1. `python /tmp/call.py ""`
2. Output, note the missing `cache_control`:

```text
HTTP 200: Hi from the stub upstream.
system sent upstream: [{"type": "text", "text": "You are helpful."}]
```

### After (1514baa96e)

#### no prompt_id, the case #37469 reported

1. `python /tmp/call.py`
2. Output, unchanged:

```text
HTTP 200: Hi from the stub upstream.
system sent upstream: [{"type": "text", "text": "You are helpful.", "cache_control": {"type": "ephemeral"}}]
```

#### empty prompt_id

1. `python /tmp/call.py ""`
2. Output:

```text
HTTP 200: Hi from the stub upstream.
system sent upstream: [{"type": "text", "text": "You are helpful.", "cache_control": {"type": "ephemeral"}}]
```

## Type

🐛 Bug Fix

## Caveats (if any)

- `GenericPromptManager` accepts `""`; it stops being selected for it
- Whitespace-only ids still count as a real prompt
- Behaviour for a populated `prompt_id` is unchanged

On the first one, worth a maintainer's call before merge. `GenericPromptManager.should_run_prompt_management` returns True for `""` because it tests `prompt_id is not None`, so today it is selected and then compiles against an empty id. After this change it is skipped, same as every other in-tree manager. I read that as the predicate being wrong rather than behaviour to keep, but if you want `""` to stay a valid id for that manager, the fix belongs in the entry gate at `should_run_prompt_management_hooks` instead and I will move it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

