### PR TITLE
fix(vertex): floor reasoning_effort to low on gemini-3.7-flash

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -889,7 +889,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         elif reasoning_effort == "high":
             return {"thinkingLevel": "high", "includeThoughts": True}
         elif reasoning_effort == "disable":
-            # Gemini 3 cannot fully disable thinking, so we use "minimal" for the models that accept it, "low" for others.
+            # Gemini 3 cannot fully disable thinking; "minimal" where accepted, "low" otherwise.
             if is_gemini3flash:
                 return {"thinkingLevel": "minimal", "includeThoughts": False}
             else:

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -281,11 +281,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         HIGH for it, while earlier 3.x-flash models (3.0, 3.1, 3.5, 3.6) still accept it.
         """
         lowered: Final = model.lower()
-        return (
-            "flash" in lowered
-            and "gemini-3" in lowered
-            and "gemini-3.7" not in lowered
-        )
+        return "flash" in lowered and "gemini-3" in lowered and "gemini-3.7" not in lowered
 
     @staticmethod
     def _forward_gemini_function_call_id(model: str) -> bool:
@@ -967,9 +963,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                     # Follow provider defaults unless explicitly opted into legacy behavior.
                     if litellm.enable_gemini_default_thinking_level_low is True:
                         params["thinkingLevel"] = (
-                            "minimal"
-                            if VertexGeminiConfig._is_gemini3_flash_supports_minimal(model)
-                            else "low"
+                            "minimal" if VertexGeminiConfig._is_gemini3_flash_supports_minimal(model) else "low"
                         )
             else:
                 # Thinking disabled

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -273,6 +273,21 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         return False
 
     @staticmethod
+    def _is_gemini3_flash_supports_minimal(model: str) -> bool:
+        """
+        Whether a gemini-3.x-flash model accepts THINKING_LEVEL_MINIMAL.
+
+        gemini-3.7-flash dropped MINIMAL support: Vertex only accepts LOW, MEDIUM, and
+        HIGH for it, while earlier 3.x-flash models (3.0, 3.1, 3.5, 3.6) still accept it.
+        """
+        lowered: Final = model.lower()
+        return (
+            "flash" in lowered
+            and "gemini-3" in lowered
+            and "gemini-3.7" not in lowered
+        )
+
+    @staticmethod
     def _forward_gemini_function_call_id(model: str) -> bool:
         """
         Whether to include `id` on function_call / function_response parts.
@@ -856,10 +871,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         Returns:
             GeminiThinkingConfig with thinkingLevel and includeThoughts
         """
-        # Check if this is gemini-3-flash which supports MINIMAL thinking level
-        # Covers gemini-3-flash, gemini-3-flash-preview, gemini-3.1-flash, gemini-3.1-flash-lite-preview,
-        # gemini-3.5-flash, and any future 3.x-flash variants.
-        is_gemini3flash: Final = model and ("flash" in model.lower() and "gemini-3" in model.lower())
+        is_gemini3flash: Final = bool(model) and VertexGeminiConfig._is_gemini3_flash_supports_minimal(model)
+        is_gemini3_flash_family: Final = bool(model) and "flash" in model.lower() and "gemini-3" in model.lower()
         is_gemini31pro: Final = model and ("gemini-3.1-pro-preview" in model.lower())
         if reasoning_effort == "minimal":
             if is_gemini3flash:
@@ -869,20 +882,20 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         elif reasoning_effort == "low":
             return {"thinkingLevel": "low", "includeThoughts": True}
         elif reasoning_effort == "medium":
-            if is_gemini31pro or is_gemini3flash:
+            if is_gemini31pro or is_gemini3_flash_family:
                 return {"thinkingLevel": "medium", "includeThoughts": True}
             else:
                 return {"thinkingLevel": "high", "includeThoughts": True}
         elif reasoning_effort == "high":
             return {"thinkingLevel": "high", "includeThoughts": True}
         elif reasoning_effort == "disable":
-            # Gemini 3 cannot fully disable thinking, so we use "minimal" for gemini-3-flash-preview, "low" for others
+            # Gemini 3 cannot fully disable thinking, so we use "minimal" for the models that accept it, "low" for others.
             if is_gemini3flash:
                 return {"thinkingLevel": "minimal", "includeThoughts": False}
             else:
                 return {"thinkingLevel": "low", "includeThoughts": False}
         elif reasoning_effort == "none":
-            # For gemini-3-flash-preview, use "minimal" instead of "low"
+            # Same as disable: "minimal" where accepted, "low" otherwise.
             if is_gemini3flash:
                 return {"thinkingLevel": "minimal", "includeThoughts": False}
             else:
@@ -953,8 +966,11 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                     params["includeThoughts"] = True
                     # Follow provider defaults unless explicitly opted into legacy behavior.
                     if litellm.enable_gemini_default_thinking_level_low is True:
-                        is_gemini3flash: Final = "gemini-3" in model.lower() and "flash" in model.lower()
-                        params["thinkingLevel"] = "minimal" if is_gemini3flash else "low"
+                        params["thinkingLevel"] = (
+                            "minimal"
+                            if VertexGeminiConfig._is_gemini3_flash_supports_minimal(model)
+                            else "low"
+                        )
             else:
                 # Thinking disabled
                 params["includeThoughts"] = False

--- a/tests/llm_translation/test_gemini.py
+++ b/tests/llm_translation/test_gemini.py
@@ -1806,6 +1806,64 @@ def test_gemini_31_flash_lite_reasoning_effort_minimal():
     ), "gemini-3.1-flash-lite-preview should use thinkingLevel, not thinkingBudget"
 
 
+def test_gemini_37_flash_reasoning_effort_no_minimal():
+    """
+    gemini-3.7-flash dropped THINKING_LEVEL_MINIMAL support on Vertex; only LOW, MEDIUM,
+    and HIGH are accepted. reasoning_effort values that previously mapped to "minimal"
+    (minimal, none, disable) must resolve to "low" instead so they return 200.
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/37314
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    # Values that used to map to "minimal" must now floor at "low" on 3.7.
+    for reasoning_effort in ("minimal", "none", "disable"):
+        result = VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
+            reasoning_effort=reasoning_effort,
+            model="gemini-3.7-flash",
+        )
+        assert (
+            result["thinkingLevel"] == "low"
+        ), f"gemini-3.7-flash {reasoning_effort} should map to 'low', got '{result['thinkingLevel']}'"
+        assert result["includeThoughts"] is (reasoning_effort != "none" and reasoning_effort != "disable")
+
+    # Explicit low/medium/high are unaffected.
+    for reasoning_effort, expected_level in (
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+    ):
+        result = VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
+            reasoning_effort=reasoning_effort,
+            model="gemini-3.7-flash",
+        )
+        assert (
+            result["thinkingLevel"] == expected_level
+        ), f"gemini-3.7-flash {reasoning_effort} should map to '{expected_level}', got '{result['thinkingLevel']}'"
+
+
+def test_gemini_36_flash_reasoning_effort_minimal_still_supported():
+    """
+    gemini-3.6-flash still accepts THINKING_LEVEL_MINIMAL, so the fix for 3.7 must not
+    regress the earlier 3.x-flash models.
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    for model in ("gemini-3.6-flash", "gemini-3.5-flash"):
+        result = VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
+            reasoning_effort="minimal",
+            model=model,
+        )
+        assert (
+            result["thinkingLevel"] == "minimal"
+        ), f"{model} should keep thinkingLevel='minimal', got '{result['thinkingLevel']}'"
+        assert result["includeThoughts"] is True
+
+
 def test_gemini_image_size_limit_exceeded(monkeypatch):
     """
     Test that large images exceeding MAX_IMAGE_URL_DOWNLOAD_SIZE_MB are rejected.

--- a/tests/llm_translation/test_gemini.py
+++ b/tests/llm_translation/test_gemini.py
@@ -1649,6 +1649,15 @@ def test_anthropic_thinking_param_to_gemini_3_force_low_feature_flag():
         )
         assert result_pro["thinkingLevel"] == "low"
         assert result_pro["includeThoughts"] is True
+
+        # gemini-3.7-flash dropped MINIMAL support, so the forced-low mapping must
+        # not send "minimal" to it (issue #37314).
+        result_37 = VertexGeminiConfig._map_thinking_param(
+            thinking_param=thinking_param,
+            model="gemini-3.7-flash",
+        )
+        assert result_37["thinkingLevel"] == "low"
+        assert result_37["includeThoughts"] is True
     finally:
         litellm.enable_gemini_default_thinking_level_low = original_force_low_flag
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- gemini-3.7-flash returns HTTP 400 for reasoning_effort minimal, none, and disable
- Vertex dropped THINKING_LEVEL_MINIMAL for 3.7; only LOW, MEDIUM, HIGH are accepted
- The broad gemini-3.x-flash substring match still sent "minimal", so 3 of 6 effort values were unusable

How it solves it:

- Only send "minimal" for the 3.x-flash models that still accept it (3.0, 3.1, 3.5, 3.6)
- gemini-3.7-flash now floors minimal, none, and disable to "low"
- "medium" still maps to "medium" on 3.7 since the model accepts it

## User Flow

Before: a developer calling gemini-3.7-flash through the proxy with the lowest reasoning setting gets a hard error instead of an answer

1. They send POST http://localhost:4000/v1/chat/completions with model gemini-3.7-flash and reasoning_effort minimal
2. The proxy returns HTTP 400 with "Thinking level is unsupported: THINKING_LEVEL_MINIMAL"
3. Retrying with reasoning_effort none or disable returns the same 400

After: every documented reasoning_effort value resolves to a level Vertex accepts

1. They send the same POST with reasoning_effort minimal
2. The proxy maps it to thinkingLevel low and the request succeeds
3. none and disable also resolve to low and succeed
4. low, medium, and high map to their own levels as before

## Relevant issues

Fixes #37314

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

The fix is in pure request-parameter mapping with no network dependency, so the proof uses the request builder (no provider call is needed to observe the mapping). Unit tests cover the mapping directly and via the full map_openai_params flow.

### Before (current main)

#### minimal on gemini-3.7-flash maps to minimal

1. `VertexGeminiConfig._map_reasoning_effort_to_thinking_level("minimal", "gemini-3.7-flash")`
2. Returns `{"thinkingLevel": "minimal", "includeThoughts": True}`, which Vertex rejects with HTTP 400

### After (this PR)

#### minimal on gemini-3.7-flash floors to low

1. `VertexGeminiConfig._map_reasoning_effort_to_thinking_level("minimal", "gemini-3.7-flash")`
2. Returns `{"thinkingLevel": "low", "includeThoughts": True}`, accepted by Vertex

#### minimal on gemini-3.6-flash stays minimal

1. `VertexGeminiConfig._map_reasoning_effort_to_thinking_level("minimal", "gemini-3.6-flash")`
2. Returns `{"thinkingLevel": "minimal", "includeThoughts": True}` (unchanged, no regression)

## Type

🐛 Bug Fix

## Caveats

- 3.8+ flash models are unknown until they ship; if one also drops MINIMAL, the substring match needs a follow-up
- The Anthropic /v1/messages thinking.budget_tokens path is unaffected (defaults to provider levels unless the low-level feature flag is on)

## QA runbook