### PR TITLE
fix(prompt_management): prioritize cache control hook over generic prompt management (#37469)

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -982,22 +982,36 @@ class Logging(LiteLLMLoggingBaseClass):
             if auto_detected_logger is not None:
                 return auto_detected_logger
 
-        # Then check for any registered CustomPromptManagement loggers (fallback)
-        prompt_management_loggers: Final = litellm.logging_callback_manager.get_custom_loggers_for_type(
-            callback_type=CustomPromptManagement
-        )
-
-        if prompt_management_loggers:
-            logger: Final = prompt_management_loggers[0]
-            self.model_call_details["prompt_integration"] = logger.__class__.__name__
-            return logger
-
+        # Check Anthropic cache control hook before fallback prompt management loggers
         if (
             anthropic_cache_control_logger
             := AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(non_default_params)
         ):
             self.model_call_details["prompt_integration"] = anthropic_cache_control_logger.__class__.__name__
             return anthropic_cache_control_logger
+
+        # Then check for any registered CustomPromptManagement loggers (fallback)
+        prompt_management_loggers: Final = litellm.logging_callback_manager.get_custom_loggers_for_type(
+            callback_type=CustomPromptManagement
+        )
+
+        if prompt_management_loggers:
+            if prompt_id is not None:
+                logger: Final = prompt_management_loggers[0]
+                self.model_call_details["prompt_integration"] = logger.__class__.__name__
+                return logger
+            for logger in prompt_management_loggers:
+                if hasattr(logger, "should_run_prompt_management"):
+                    try:
+                        if logger.should_run_prompt_management(
+                            prompt_id=prompt_id,
+                            prompt_spec=prompt_spec,
+                            dynamic_callback_params=dynamic_callback_params or self.standard_callback_dynamic_params,
+                        ):
+                            self.model_call_details["prompt_integration"] = logger.__class__.__name__
+                            return logger
+                    except Exception:
+                        continue
 
         #########################################################
         # Vector Store / Knowledge Base hooks

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -1996,3 +1996,56 @@ class TestAnthropicPromptCachingEnvVars:
         """An unparseable TTL must fall back to Anthropic's 5m default, never reach the provider verbatim."""
         _, ttl = self._import_litellm_with_env({"LITELLM_ANTHROPIC_PROMPT_CACHING_TTL": value})
         assert ttl is None
+
+
+def test_cache_control_injection_points_precedence_over_generic_prompt_management():
+    """
+    Regression test for issue #37469:
+    Ensure cache_control_injection_points prioritizes AnthropicCacheControlHook
+    and does not fail with ValueError when a CustomPromptManagement logger is registered.
+    """
+    from litellm.integrations.custom_prompt_management import CustomPromptManagement
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+    from litellm.types.utils import CallTypes
+    import time
+    import uuid
+
+    class DummyPromptManagement(CustomPromptManagement):
+        def should_run_prompt_management(self, prompt_id, prompt_spec, dynamic_callback_params):
+            return prompt_id is not None
+
+        def get_chat_completion_prompt(self, *args, **kwargs):
+            if not kwargs.get("prompt_id"):
+                raise ValueError("prompt_id is required for Prompt Management Base class")
+            return "model", [], {}
+
+    dummy_pm = DummyPromptManagement()
+    litellm.callbacks = [dummy_pm]
+    litellm.logging_callback_manager.add_litellm_callback(dummy_pm)
+
+    logging_obj = LiteLLMLoggingObj(
+        model="claude-opus-4.8",
+        messages=[{"role": "user", "content": "hello"}],
+        stream=False,
+        call_type=CallTypes.completion,
+        start_time=time.time(),
+        litellm_call_id=str(uuid.uuid4()),
+        function_id=str(uuid.uuid4()),
+    )
+
+    non_default_params = {
+        "cache_control_injection_points": [
+            {"role": "system", "location": "message"}
+        ]
+    }
+
+    logger = logging_obj.get_custom_logger_for_prompt_management(
+        model="claude-opus-4.8",
+        non_default_params=non_default_params,
+        prompt_id=None,
+        dynamic_callback_params=StandardCallbackDynamicParams(),
+    )
+
+    assert logger is not None
+    assert logger.__class__.__name__ == "AnthropicCacheControlHook"
+


### PR DESCRIPTION
## Description
Fixes #37469

When `cache_control_injection_points` is configured under `litellm_params`, `should_run_prompt_management_hooks()` correctly returns `True`. However, in `get_custom_logger_for_prompt_management()`:
1. `AnthropicCacheControlHook` (which is designed specifically for `cache_control_injection_points`) was evaluated *after* generic `CustomPromptManagement` loggers.
2. If any generic prompt management logger (such as Dotprompt, Langfuse Prompt, or Portkey) was registered in callbacks, `get_custom_logger_for_prompt_management()` unconditionally returned `prompt_management_loggers[0]`, even when `prompt_id` was `None`.
3. This caused ordinary completion requests to unexpectedly enter Dotprompt / prompt-management preprocessing and crash with `ValueError: prompt_id is required for Prompt Management Base class` (which was wrapped as an `APIConnectionError` and retried 5 times before failing with HTTP 500).

### Solution:
- In `litellm/litellm_core_utils/litellm_logging.py`, check `AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(non_default_params)` before falling back to generic prompt management loggers.
- If `prompt_id` is `None`, guard generic `CustomPromptManagement` loggers by querying `logger.should_run_prompt_management(...)` rather than unconditionally returning the first registered logger.
- Added regression unit tests in `tests/test_litellm/integrations/test_anthropic_cache_control_hook.py`.

## Testing
- Unit tests in `test_anthropic_cache_control_hook.py` pass 100% green.
