### PR TITLE
fix(langfuse passthrough): 401 instead of 500 for malformed Basic auth

### DIFF
--- a/litellm/proxy/vertex_ai_endpoints/langfuse_endpoints.py
+++ b/litellm/proxy/vertex_ai_endpoints/langfuse_endpoints.py
@@ -9,6 +9,7 @@ Logging Pass-Through Endpoints
 """
 
 import base64
+import binascii
 import os
 from base64 import b64encode
 from typing import Final
@@ -146,6 +147,27 @@ def _build_langfuse_proxy_target(
     return str(updated_url), custom_headers
 
 
+def _extract_api_key_from_basic_auth(authorization_header: str) -> str:
+    """Pull the secret half out of a `Basic base64(public_key:secret_key)` header.
+
+    Returns "" for every shape that does not carry one, rather than raising: a
+    missing header, a value that is not base64, base64 that is not utf-8, and a
+    decoded value with no ":" in it. `user_api_key_auth` then rejects the empty
+    key with the normal 401, instead of the route raising IndexError (or
+    binascii.Error, or UnicodeDecodeError) out of an unauthenticated request and
+    turning it into a 500 with a traceback in the proxy log.
+    """
+    encoded: Final = authorization_header.removeprefix("Basic ").strip()
+    if not encoded:
+        return ""
+    try:
+        decoded_str = base64.b64decode(encoded).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError):
+        return ""
+    _, separator, secret_key = decoded_str.partition(":")
+    return secret_key if separator else ""
+
+
 @router.api_route(
     "/langfuse/{endpoint:path}",
     methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
@@ -164,14 +186,8 @@ async def langfuse_proxy_route(
     from litellm.proxy.proxy_server import proxy_config
 
     ## CHECK FOR LITELLM API KEY IN THE QUERY PARAMS - ?..key=LITELLM_API_KEY
-    api_key = request.headers.get("Authorization") or ""
-
-    ## decrypt base64 hash
-    api_key = api_key.replace("Basic ", "")
-
-    decoded_bytes: Final = base64.b64decode(api_key)
-    decoded_str: Final = decoded_bytes.decode("utf-8")
-    api_key = decoded_str.split(":")[1]  # assume api key is passed in as secret key
+    ## decrypt base64 hash; the api key is passed in as the secret key
+    api_key: Final = _extract_api_key_from_basic_auth(request.headers.get("Authorization") or "")
 
     user_api_key_dict: Final = await user_api_key_auth(request=request, api_key=f"Bearer {api_key}")
 

--- a/tests/test_litellm/proxy/test_langfuse_passthrough_security.py
+++ b/tests/test_litellm/proxy/test_langfuse_passthrough_security.py
@@ -1,4 +1,5 @@
 import socket
+from base64 import b64encode
 
 import pytest
 from fastapi import HTTPException
@@ -6,6 +7,7 @@ from fastapi import HTTPException
 import litellm
 from litellm.proxy.vertex_ai_endpoints.langfuse_endpoints import (
     _build_langfuse_proxy_target,
+    _extract_api_key_from_basic_auth,
     _get_langfuse_proxy_credentials,
 )
 
@@ -100,3 +102,64 @@ def test_dynamic_langfuse_proxy_target_preserves_host_header_for_http(monkeypatc
 
     assert target_url == "http://8.8.8.8/api/public/projects"
     assert headers["Host"] == "langfuse.example"
+
+
+@pytest.mark.parametrize(
+    "authorization_header, expected",
+    [
+        # Every shape below except the two valid ones raised out of the route
+        # before, turning an unauthenticated request into a 500 with a traceback.
+        ("", ""),  # no Authorization header at all
+        ("Basic ", ""),  # header present, credentials empty
+        ("Basic " + b64encode(b"pk-lf-1:sk-lf-2").decode(), "sk-lf-2"),
+        (b64encode(b"pk-lf-1:sk-lf-2").decode(), "sk-lf-2"),  # bare base64, no scheme
+        ("Basic " + b64encode(b"sk-lf-2").decode(), ""),  # no ":" to split on
+        ("Basic YWJj=", ""),  # not decodable base64
+        ("Basic //4=", ""),  # decodes to bytes that are not utf-8
+        ("Bearer sk-1234", ""),  # wrong scheme
+    ],
+)
+def test_extract_api_key_from_basic_auth_never_raises(authorization_header, expected):
+    assert _extract_api_key_from_basic_auth(authorization_header) == expected
+
+
+def test_extract_api_key_keeps_a_secret_containing_a_colon():
+    """RFC 7617 puts everything after the first ":" in the password, so a secret
+    with a colon in it must survive whole. `split(":")[1]` truncated it to the
+    first segment, which then failed authentication for a non-obvious reason."""
+    header = "Basic " + b64encode(b"pk-lf-1:sk:with:colons").decode()
+
+    assert _extract_api_key_from_basic_auth(header) == "sk:with:colons"
+
+
+@pytest.mark.asyncio
+async def test_langfuse_route_hands_missing_credentials_to_the_authenticator(monkeypatch):
+    """An unauthenticated request must reach user_api_key_auth and be rejected
+    there, rather than raising IndexError before authentication runs."""
+    from fastapi import Request
+
+    from litellm.proxy.vertex_ai_endpoints import langfuse_endpoints
+
+    seen: dict = {}
+
+    async def fake_user_api_key_auth(request, api_key):
+        seen["api_key"] = api_key
+        raise HTTPException(status_code=401, detail={"error": "Authentication Error"})
+
+    monkeypatch.setattr(langfuse_endpoints, "user_api_key_auth", fake_user_api_key_auth)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/langfuse/zzz",
+            "headers": [],  # the reported case: no Authorization header
+            "query_string": b"",
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await langfuse_endpoints.langfuse_proxy_route(endpoint="zzz", request=request, fastapi_response=None)
+
+    assert exc.value.status_code == 401
+    assert seen["api_key"] == "Bearer "


### PR DESCRIPTION
## TLDR

Problem this solves:

- Unauthenticated `/langfuse/*` requests return 500, not 401
- The route decodes Basic credentials before authentication runs

How it solves it:

- Parse the header into "" when it carries no secret
- Let `user_api_key_auth` reject it with the normal 401

## User Flow

Before: an anonymous caller probing the Langfuse pass-through gets a server error, and the proxy logs a traceback for every such request

1. The proxy administrator runs LiteLLM with a master key
2. An anonymous caller sends `GET https://litellm-domain/langfuse/zzz` with no headers
3. The caller receives HTTP 500 `Internal server error`
4. The administrator sees an `IndexError` traceback in the proxy log, from a request that was never authenticated
5. Anyone can generate those tracebacks at will, on GET, POST, PUT, PATCH and DELETE

After: the same request is rejected as an authentication failure

1. Same proxy setup
2. The caller sends the same `GET https://litellm-domain/langfuse/zzz` with no headers
3. The caller receives HTTP 401 with the usual authentication error body
4. The log records an ordinary authentication rejection, no traceback
5. A caller with valid `Basic base64(public_key:secret_key)` credentials reaches Langfuse exactly as before

## Relevant issues

Fixes #37482

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

I do not have a running proxy with Postgres and Redis, so this is not a live-proxy curl run and I am not presenting it as one. The reporter already published that run in #37482. What follows is the same decode step, exercised directly at both commits, plus a route-level test that calls `langfuse_proxy_route` itself.

Shared setup: the header shapes a public endpoint actually receives.

```python
# proof.py
import base64
from litellm.proxy.vertex_ai_endpoints.langfuse_endpoints import _extract_api_key_from_basic_auth as new

def old(header: str) -> str:                       # the code on litellm_internal_staging
    api_key = header.replace("Basic ", "")
    return base64.b64decode(api_key).decode("utf-8").split(":")[1]

cases = {
    "missing header":  "",
    "valid":           "Basic " + base64.b64encode(b"pk-lf-1:sk-lf-2").decode(),
    "no colon":        "Basic " + base64.b64encode(b"sk-lf-2").decode(),
    "bad base64":      "Basic YWJj=",
    "non utf8":        "Basic //4=",
    "bearer":          "Bearer sk-1234",
    "bare base64":     base64.b64encode(b"pk-lf-1:sk-lf-2").decode(),
    "colon in secret": "Basic " + base64.b64encode(b"pk:sk:extra").decode(),
    "empty basic":     "Basic ",
}
```

### Before (b402fea)

1. Run the `old()` branch over the table
2. Output:

```
missing header     -> RAISED IndexError
valid              -> 'sk-lf-2'
no colon           -> RAISED IndexError
bad base64         -> RAISED IndexError
non utf8           -> RAISED UnicodeDecodeError
bearer             -> RAISED UnicodeDecodeError
bare base64        -> 'sk-lf-2'
colon in secret    -> 'sk'
empty basic        -> RAISED IndexError
```

Six of the nine raise before `user_api_key_auth` is ever called, which is the 500.

### After (dee54d4)

1. Run the same table through `_extract_api_key_from_basic_auth`
2. Output:

```
missing header     -> ''
valid              -> 'sk-lf-2'
no colon           -> ''
bad base64         -> ''
non utf8           -> ''
bearer             -> ''
bare base64        -> 'sk-lf-2'
colon in secret    -> 'sk:extra'
empty basic        -> ''
```

Nothing raises. `valid` and `bare base64` are byte-identical, so working clients are untouched. `colon in secret` is the one deliberate behaviour change, covered below.

Route level, with `user_api_key_auth` stubbed so the test asserts what the route hands it:

```
# against litellm_internal_staging
$ python3 -m pytest tests/test_litellm/proxy/test_route_only.py -q
>       api_key = decoded_str.split(":")[1]  # assume api key is passed in as secret key
E       IndexError: list index out of range
litellm/proxy/vertex_ai_endpoints/langfuse_endpoints.py:174: IndexError
1 failed

# on this branch
$ python3 -m pytest tests/test_litellm/proxy/test_route_only.py -q
1 passed
```

That test ships as `test_langfuse_route_hands_missing_credentials_to_the_authenticator` in `tests/test_litellm/proxy/test_langfuse_passthrough_security.py`; it asserts the route reaches `user_api_key_auth` with `"Bearer "` and surfaces its 401.

Whole file, and the auth suite around it:

```
$ python3 -m pytest tests/test_litellm/proxy/test_langfuse_passthrough_security.py -q
9 passed      # litellm_internal_staging
19 passed     # this branch

$ python3 -m pytest tests/test_litellm/proxy/auth/ tests/test_litellm/proxy/test_langfuse_passthrough_security.py -q
17 failed, 1482 passed   # litellm_internal_staging
17 failed, 1492 passed   # this branch
```

The 17 are identical on both sides and are pre-existing in my environment, not touched by this change; the delta is exactly the 10 tests added.

`ruff check` reports the same 2 findings on both files before and after, and `ruff format --check` is clean on both.

## Type

🐛 Bug Fix

## Caveats (if any)

- A secret containing ":" now survives whole, per RFC 7617
- `split(":")[1]` truncated it before, which failed auth confusingly
- Bare base64 with no `Basic ` prefix still works, as today
