### PR TITLE
fix(proxy): preserve timezone offsets when resetting multi-window budgets

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -1276,7 +1276,12 @@ class ResetBudgetJob:
         reset_at_str: Final = window.get("reset_at")
         if not reset_at_str:
             return False
-        reset_at: Final = datetime.fromisoformat(reset_at_str.replace("Z", "+00:00")).replace(tzinfo=None)
+        # Keep the parsed offset. Dropping it left the wall-clock reading of a
+        # "+08:00" boundary compared against a UTC now, which delays the reset by
+        # the offset; compute_budget_reset_at writes those offsets itself whenever
+        # the configured budget timezone is not UTC. _as_utc only fills in a
+        # tzinfo for legacy rows written naive, which always meant UTC.
+        reset_at: Final = _as_utc(datetime.fromisoformat(reset_at_str.replace("Z", "+00:00")))
         if reset_at > now:
             return False
         new_value: Final = await ResetBudgetJob._window_carried_spend(window, counter_key, spend_counter_cache)
@@ -1365,7 +1370,7 @@ class ResetBudgetJob:
 
         from litellm.proxy.proxy_server import spend_counter_cache
 
-        now: Final = datetime.utcnow()
+        now: Final = datetime.now(timezone.utc)
         for source in _WINDOW_SOURCES:
             try:
                 await self._reset_windows_for(source=source, now=now, spend_counter_cache=spend_counter_cache)

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -13,7 +13,7 @@ import pytest
 
 
 from litellm.caching.dual_cache import DualCache
-from litellm.proxy._types import LiteLLM_VerificationToken
+from litellm.proxy._types import Litellm_EntityType, LiteLLM_VerificationToken
 from litellm.proxy.common_utils import reset_budget_job as reset_budget_job_module
 from litellm.constants import (
     PROXY_BUDGET_RESCHEDULER_MIN_TIME,
@@ -3211,12 +3211,17 @@ class TestBudgetWindowResetAtOffsets:
 
     @staticmethod
     async def _expired(window: dict, now: datetime, tz: str = "UTC") -> bool:
+        # The spend-row roll is best effort and wrapped in its own try, so a mock
+        # client here exercises the reset decision without touching a database.
         return await ResetBudgetJob._reset_expired_window(
             window,
             "spend:key:tok-1:window:" + window["budget_duration"],
             DualCache(),
             now,
             BudgetResetSettings(timezone=tz, reset_time_of_day=dt_time(0, 0)),
+            MagicMock(),
+            Litellm_EntityType.KEY,
+            "tok-1",
         )
 
     @pytest.mark.asyncio
@@ -3283,7 +3288,14 @@ class TestBudgetWindowResetAtOffsets:
 
         results = [
             await ResetBudgetJob._reset_expired_window(
-                window, f"spend:key:tok-1:window:{window['budget_duration']}", cache, now, settings
+                window,
+                f"spend:key:tok-1:window:{window['budget_duration']}",
+                cache,
+                now,
+                settings,
+                MagicMock(),
+                Litellm_EntityType.KEY,
+                "tok-1",
             )
             for window in (due, not_due)
         ]

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -12,6 +12,7 @@ import prisma
 import pytest
 
 
+from litellm.caching.dual_cache import DualCache
 from litellm.proxy._types import LiteLLM_VerificationToken
 from litellm.proxy.common_utils import reset_budget_job as reset_budget_job_module
 from litellm.constants import (
@@ -3192,3 +3193,112 @@ def test_window_reset_zeroes_counter_when_rollover_disabled(monkeypatch):
 
     spend_counter_cache.in_memory_cache.set_cache.assert_any_call(key="spend:key:sk-off:window:1d", value=0.0)
     spend_counter_cache.async_get_cache.assert_not_awaited()
+
+class TestBudgetWindowResetAtOffsets:
+    """
+    Regression tests for https://github.com/BerriAI/litellm/issues/37454
+
+    `compute_budget_reset_at` writes `reset_at` in the configured budget
+    timezone, so a proxy on Asia/Shanghai stores `...T00:00:00+08:00`.
+    `_reset_expired_window` dropped that offset with `.replace(tzinfo=None)` and
+    compared the wall-clock reading against a UTC `now`, so the window stayed
+    enforced for another 8 hours after its own boundary.
+    """
+
+    @staticmethod
+    def _window(reset_at: str, budget_duration: str = "24h") -> dict:
+        return {"budget_duration": budget_duration, "max_budget": 100, "reset_at": reset_at}
+
+    @staticmethod
+    async def _expired(window: dict, now: datetime, tz: str = "UTC") -> bool:
+        return await ResetBudgetJob._reset_expired_window(
+            window,
+            "spend:key:tok-1:window:" + window["budget_duration"],
+            DualCache(),
+            now,
+            BudgetResetSettings(timezone=tz, reset_time_of_day=dt_time(0, 0)),
+        )
+
+    @pytest.mark.asyncio
+    async def test_offset_window_is_not_reset_a_minute_early(self):
+        window = self._window("2026-08-20T00:00:00+08:00")
+
+        assert (
+            await self._expired(window, datetime(2026, 8, 19, 15, 59, tzinfo=timezone.utc), tz="Asia/Shanghai") is False
+        )
+        assert window["reset_at"] == "2026-08-20T00:00:00+08:00"
+
+    @pytest.mark.asyncio
+    async def test_offset_window_is_reset_exactly_at_its_own_boundary(self):
+        """2026-08-19 16:00 UTC IS 2026-08-20 00:00+08:00, so the window is due.
+        Reading it as naive 2026-08-20 00:00 delayed this by the 8 hour offset."""
+        window = self._window("2026-08-20T00:00:00+08:00")
+
+        assert (
+            await self._expired(window, datetime(2026, 8, 19, 16, 0, tzinfo=timezone.utc), tz="Asia/Shanghai") is True
+        )
+        assert window["reset_at"] != "2026-08-20T00:00:00+08:00"
+
+    @pytest.mark.asyncio
+    async def test_negative_offset_window_is_not_reset_early(self):
+        """The offset cuts the other way too: a UTC-5 boundary is due later, not
+        sooner, and dropping the offset would fire it 5 hours early."""
+        window = self._window("2026-08-19T00:00:00-05:00")  # 2026-08-19 05:00 UTC
+
+        assert (
+            await self._expired(window, datetime(2026, 8, 19, 4, 59, tzinfo=timezone.utc), tz="America/New_York")
+            is False
+        )
+        assert (
+            await self._expired(window, datetime(2026, 8, 19, 5, 0, tzinfo=timezone.utc), tz="America/New_York") is True
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("reset_at", ["2026-08-19T12:00:00Z", "2026-08-19T12:00:00+00:00"])
+    async def test_utc_windows_are_unchanged(self, reset_at):
+        """The shapes that already worked must keep working: this is the control."""
+        assert await self._expired(self._window(reset_at), datetime(2026, 8, 19, 11, 59, tzinfo=timezone.utc)) is False
+        assert await self._expired(self._window(reset_at), datetime(2026, 8, 19, 12, 0, tzinfo=timezone.utc)) is True
+
+    @pytest.mark.asyncio
+    async def test_legacy_naive_reset_at_is_read_as_utc(self):
+        """Rows written before offsets were stored carry no tzinfo; they always
+        meant UTC, and `_as_utc` keeps reading them that way."""
+        window = self._window("2026-08-19T12:00:00")
+
+        assert await self._expired(window, datetime(2026, 8, 19, 11, 59, tzinfo=timezone.utc)) is False
+        assert (
+            await self._expired(self._window("2026-08-19T12:00:00"), datetime(2026, 8, 19, 12, 0, tzinfo=timezone.utc))
+            is True
+        )
+
+    @pytest.mark.asyncio
+    async def test_only_the_expired_window_is_reset(self):
+        """A key with 24h and 30d windows must lose only the 24h counter."""
+        cache = DualCache()
+        settings = BudgetResetSettings(timezone="Asia/Shanghai", reset_time_of_day=dt_time(0, 0))
+        now = datetime(2026, 8, 19, 16, 0, tzinfo=timezone.utc)
+        due = self._window("2026-08-20T00:00:00+08:00", budget_duration="24h")
+        not_due = self._window("2026-09-01T00:00:00+08:00", budget_duration="30d")
+
+        results = [
+            await ResetBudgetJob._reset_expired_window(
+                window, f"spend:key:tok-1:window:{window['budget_duration']}", cache, now, settings
+            )
+            for window in (due, not_due)
+        ]
+
+        assert results == [True, False]
+        assert cache.in_memory_cache.get_cache("spend:key:tok-1:window:24h") == 0.0
+        assert cache.in_memory_cache.get_cache("spend:key:tok-1:window:30d") is None
+        assert not_due["reset_at"] == "2026-09-01T00:00:00+08:00"
+
+    @pytest.mark.asyncio
+    async def test_the_written_reset_at_keeps_the_configured_offset(self):
+        """The offset this fix reads is one the job writes itself, so a reset
+        window round-trips through the same parser next tick."""
+        window = self._window("2026-08-20T00:00:00+08:00")
+
+        await self._expired(window, datetime(2026, 8, 19, 16, 0, tzinfo=timezone.utc), tz="Asia/Shanghai")
+
+        assert datetime.fromisoformat(window["reset_at"]).tzinfo is not None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Non-UTC budget windows reset at the wrong instant
- Positive offsets reset late, negative offsets reset early

How it solves it:

- Keep the offset the job itself wrote into `reset_at`
- Compare against an aware `now`, via the module's existing `_as_utc`

## User Flow

Before: a team on a UTC+8 proxy stays blocked for eight hours after its daily budget should have rolled over

1. The proxy administrator sets `budget_reset_timezone: Asia/Shanghai` in `litellm_settings`
2. They create a team with a multi-window budget, `POST https://litellm-domain/team/new` with `budget_limits: [{"budget_duration": "24h", "max_budget": 100}]`
3. The proxy stores that window's boundary as `2026-08-20T00:00:00+08:00`, local midnight
4. The team spends its 100 during the day; requests start returning `Budget has been exceeded`
5. Local midnight arrives (16:00 UTC) and the team is still blocked; `POST https://litellm-domain/v1/chat/completions` keeps returning the same budget error
6. It only starts working again at 08:00 local the next morning, so a "daily" budget locked them out for a third of the following day

After: the window reopens at local midnight

1. Same setup and same team
2. Same spend, same `Budget has been exceeded`
3. At local midnight, 16:00 UTC, the next `POST https://litellm-domain/v1/chat/completions` succeeds

A proxy on a negative offset had the mirror problem, and it is the more serious direction: an `America/New_York` window whose boundary is `2026-08-19T00:00:00-05:00` was reset at 2026-08-19 00:00 UTC, five hours before its own boundary, so callers got a fresh budget while the previous window was still running.

Proxies left on the default `UTC` see no change at all.

## Relevant issues

Fixes #37454

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

I do not have a proxy with Postgres and Redis running, so this is not a live end-to-end run and I am not calling it one. The comparison below runs the two versions of the due-check exactly as production pairs them: on `litellm_internal_staging` a naive `reset_at` against `datetime.utcnow()`, on this branch an aware `reset_at` against `datetime.now(timezone.utc)`. It reports the UTC instant each version first calls a window due, against the instant the window's own boundary names.

```python
# proof.py
from datetime import datetime, timedelta, timezone

def old_due_at(reset_at_str):                      # litellm_internal_staging
    naive = datetime.fromisoformat(reset_at_str.replace("Z", "+00:00")).replace(tzinfo=None)
    return naive.replace(tzinfo=timezone.utc)      # what it is compared against, via utcnow()

def true_due_at(reset_at_str):
    d = datetime.fromisoformat(reset_at_str.replace("Z", "+00:00"))
    if d.tzinfo is None:
        d = d.replace(tzinfo=timezone.utc)
    return d.astimezone(timezone.utc)

CASES = [
    ("budget_reset_timezone: Asia/Shanghai",    "2026-08-20T00:00:00+08:00"),
    ("budget_reset_timezone: Asia/Kolkata",     "2026-08-20T00:00:00+05:30"),
    ("budget_reset_timezone: America/New_York", "2026-08-19T00:00:00-05:00"),
    ("budget_reset_timezone: UTC",              "2026-08-19T12:00:00Z"),
    ("legacy row, no offset",                   "2026-08-19T12:00:00"),
]
```

### Before (b402fea)

1. `python3 proof.py`
2. Output:

```
configuration                            window boundary (UTC)    old code resets at       skew
budget_reset_timezone: Asia/Shanghai     2026-08-19 16:00         2026-08-20 00:00         8:00:00 late
budget_reset_timezone: Asia/Kolkata      2026-08-19 18:30         2026-08-20 00:00         5:30:00 late
budget_reset_timezone: America/New_York  2026-08-19 05:00         2026-08-19 00:00         5:00:00 early
budget_reset_timezone: UTC               2026-08-19 12:00         2026-08-19 12:00         on time
legacy row, no offset                    2026-08-19 12:00         2026-08-19 12:00         on time
```

### After (b52c570)

1. `python3 proof.py` with the branch's due-check
2. Output:

```
configuration                            window boundary (UTC)    this branch resets at    skew
budget_reset_timezone: Asia/Shanghai     2026-08-19 16:00         2026-08-19 16:00         on time
budget_reset_timezone: Asia/Kolkata      2026-08-19 18:30         2026-08-19 18:30         on time
budget_reset_timezone: America/New_York  2026-08-19 05:00         2026-08-19 05:00         on time
budget_reset_timezone: UTC               2026-08-19 12:00         2026-08-19 12:00         on time
legacy row, no offset                    2026-08-19 12:00         2026-08-19 12:00         on time
```

The last two rows are the ones that had to stay still, and they did.

Unit tests, `TestBudgetWindowResetAtOffsets` in `tests/test_litellm/proxy/common_utils/test_reset_budget_job.py`, covering the five cases the issue asks for: a `+08:00` window is not due a minute early, is due exactly at its own boundary, a `-05:00` window is not due early either, `Z` and `+00:00` are unchanged, a legacy naive value still reads as UTC, and with `24h` and `30d` windows on one key only the `24h` counter is cleared and only its `reset_at` is rewritten.

```
$ python3 -m pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py -q
75 passed     # litellm_internal_staging, its own tests
83 passed     # this branch
```

One thing to read carefully: running the new tests against the old code gives 8 failures, but they are not all the bug. Four are (the offset cases). The other four fail because the tests pass `now` as an aware datetime, which is what the caller passes after this change, and the old code makes `reset_at` naive, so the comparison raises `TypeError` rather than answering wrongly. The behavioural evidence is the skew table above, not that failure count.

`ruff check` goes from 66 findings to 65 on these two files (`datetime.utcnow()` was one of them) and `ruff format --check` is clean on both.

## Type

🐛 Bug Fix

## Caveats (if any)

- Legacy naive `reset_at` values keep reading as UTC, unchanged
- `_as_utc` attaches a tzinfo; it does not shift any instant
- Only `budget_limits` windows are touched, not `budget_reset_at`
