### PR TITLE
test(ui): open the member role select by keyboard so the payload test stops flaking

### DIFF
--- a/ui/litellm-dashboard/src/components/common_components/user_search_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/user_search_modal.test.tsx
@@ -130,7 +130,8 @@ describe("UserSearchModal submit payload", () => {
     const { onSubmit } = setup();
     const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
 
-    await user.click(screen.getByLabelText("Member Role"));
+    act(() => screen.getByLabelText("Member Role").focus());
+    await user.keyboard("{Enter}");
     await user.click(await screen.findByRole("option", { name: /^admin/ }));
     await user.click(save());
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- UI Unit Tests failed on 4 of the last 6 staging runs
- One `user_search_modal` case misses the base-ui select popup

How it solves it:

- Open the Member Role select with Enter, not a mouse click
- The keyboard path opens synchronously, with no animation frame
- The option is still picked by mouse, so the payload contract holds

## User Flow

n/a, test-only change with no user-facing behavior

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

n/a, test-only change with no runtime surface to curl

Root cause, confirmed locally rather than assumed: base-ui wires its select trigger with `event: "mousedown"`, and that path defers `setOpen` into a `requestAnimationFrame`, so a mouse click only opens the popup once a frame lands. `findByRole` allows 1s for that, which a loaded 14-fork runner can miss, and the run then reports exactly the CI error, `Unable to find role="option" and name /^admin/`. Replacing the global `requestAnimationFrame` with a 2.5s deferred one reproduces that failure on demand, and the same starved probe passes on the keyboard path in 215ms because `onClick` opens synchronously. The file passes 9/9 both before and after the merge with staging, and reverting the component's `onValueChange` wiring to a no-op still fails this case, so it did not turn into a test that always passes

## Type

✅ Test

## Caveats (if any)

- Other suites open base-ui selects by click and share this latent risk
- Supersedes #37486, which skipped the case instead

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
