### PR TITLE
fix(complexity-router): gate the reasoning override on a non-SIMPLE score

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -1020,13 +1020,14 @@ class ComplexityRouter(CustomLogger):
         weights: Final = self.config.dimension_weights
         weighted_score: Final = sum(d.score * weights.get(d.name, 0) for d in dimensions)
 
-        # Check for reasoning override (2+ reasoning markers)
+        boundaries: Final = self._effective_tier_boundaries()
+        scored_above_simple: Final = weighted_score >= boundaries["simple_medium"]
+
         # Reuse match count from _score_keyword_match to avoid scanning twice
-        if reasoning_match_count >= 2:
+        if reasoning_match_count >= 2 and scored_above_simple:
             return ComplexityTier.REASONING, weighted_score, tuple(signals), "reasoning_override"
 
         # Map score to tier
-        boundaries: Final = self._effective_tier_boundaries()
         if weighted_score < boundaries["simple_medium"]:
             tier = ComplexityTier.SIMPLE
         elif weighted_score < boundaries["medium_complex"]:

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -267,6 +267,24 @@ class TestReasoningMarkerScoring:
         # 2+ reasoning markers should force REASONING tier
         assert tier == ComplexityTier.REASONING
 
+    def test_reasoning_override_does_not_rescue_a_simple_score(self, complexity_router):
+        """Reasoning markers on an otherwise trivial prompt must not reach REASONING."""
+        prompt = "hi, step by step, pros and cons"
+        tier, score, signals = complexity_router.classify(prompt)
+        assert score < complexity_router.config.tier_boundaries["simple_medium"]
+        assert any("step by step" in s and "pros and cons" in s for s in signals)
+        assert tier == ComplexityTier.SIMPLE
+
+    def test_reasoning_override_applies_at_the_simple_medium_boundary(self, complexity_router):
+        """A score sitting exactly on simple_medium is not SIMPLE, so the override still promotes it."""
+        prompt = (
+            "Give me the pros and cons, step by step, of moving our checkout service "
+            "to an event-driven architecture."
+        )
+        tier, score, signals = complexity_router.classify(prompt)
+        assert score == complexity_router.config.tier_boundaries["simple_medium"]
+        assert tier == ComplexityTier.REASONING
+
     def test_system_prompt_reasoning_not_counted(self, complexity_router):
         """Reasoning markers in system prompt should not count for override."""
         user_prompt = "What is 2+2?"

--- a/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
@@ -93,7 +93,7 @@ const HowClassificationWorks: React.FC<{ value: ComplexityRouterConfigValue }> =
           </li>
           <li>
             <strong>{effectiveTierLabel("REASONING", value.tier_labels)}</strong>: Score &gt; {ranges.complexReasoning}{" "}
-            (or 2+ reasoning markers)
+            (or 2+ reasoning markers with a score of at least {ranges.simpleMedium})
           </li>
         </ul>
       )}

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.test.tsx
@@ -59,7 +59,9 @@ describe("RoutingDecisionCard", () => {
         }}
       />,
     );
-    expect(screen.getByText("Heuristic, REASONING override (2 or more reasoning markers)")).toBeInTheDocument();
+    expect(
+      screen.getByText("Heuristic, REASONING override (2 or more reasoning markers, score above the lowest tier)"),
+    ).toBeInTheDocument();
     expect(screen.getByText("0.20")).toBeInTheDocument();
     // The score did not decide this tier, so NO band explanation may render at all.
     // Asserting the absence of one specific band would pass vacuously: 0.20 sits in
@@ -188,7 +190,9 @@ describe("RoutingDecisionCard", () => {
     // `signals` is gone under redaction; the cause alone must suppress the band.
     render(<RoutingDecisionCard decision={{ ...heuristic, cause: "reasoning_override", signals: undefined }} />);
     expect(screen.queryByText(/SIMPLE|MEDIUM|COMPLEX|at or above/)).not.toBeInTheDocument();
-    expect(screen.getByText("Heuristic, REASONING override (2 or more reasoning markers)")).toBeInTheDocument();
+    expect(
+      screen.getByText("Heuristic, REASONING override (2 or more reasoning markers, score above the lowest tier)"),
+    ).toBeInTheDocument();
   });
 
   it("shows the operator's tier name on the badge instead of the canonical one", () => {
@@ -212,7 +216,9 @@ describe("RoutingDecisionCard", () => {
     render(
       <RoutingDecisionCard decision={{ ...heuristic, cause: "reasoning_override", score: 0.2, tier_label: "Deep" }} />,
     );
-    expect(screen.getByText("Heuristic, Deep override (2 or more reasoning markers)")).toBeInTheDocument();
+    expect(
+      screen.getByText("Heuristic, Deep override (2 or more reasoning markers, score above the lowest tier)"),
+    ).toBeInTheDocument();
   });
 
   it("falls back to the raw cause for a value this build does not know", () => {

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.tsx
@@ -72,7 +72,7 @@ function describeCause(decision: RoutingDecision): string {
     case "heuristic_scorer":
       return "Heuristic scorer";
     case "reasoning_override":
-      return `Heuristic, ${tierLabel ?? "REASONING"} override (2 or more reasoning markers)`;
+      return `Heuristic, ${tierLabel ?? "REASONING"} override (2 or more reasoning markers, score above the lowest tier)`;
     case "llm_classifier":
       return classifierModel ? `LLM classifier (${classifierModel})` : "LLM classifier";
     case "literal_keyword_match":


### PR DESCRIPTION
## TLDR

Problem this solves:

- Two reasoning keywords bought the top tier at any score
- "hi, step by step, pros and cons" scored 0.100, routed REASONING
- Cheapest-band prompts paid 5x for nothing

How it solves it:

- Override now requires the score to clear simple_medium
- Promotion from MEDIUM or COMPLEX is untouched
- Admin UI copy states the added score condition

## User Flow

Before: an operator routing through the complexity autorouter watches short, chatty prompts get billed at the most expensive tier

1. They send POST http://localhost:4000/v1/chat/completions with `"model": "complexity-router"` and the message `hi, step by step, pros and cons`
2. The reply comes back with `x-litellm-model-name: anthropic/claude-opus-5`, the top tier, and `x-litellm-response-cost: 0.00169`
3. They send the same request with a real design question, `Give me the pros and cons, step by step, of moving our checkout service to an event-driven architecture.`
4. That reply also comes back from `anthropic/claude-opus-5`, so the two requests are indistinguishable by the model that served them

After: the same operator sees the greeting priced at the cheapest tier, and the real design question keeps the top tier

1. They send POST http://localhost:4000/v1/chat/completions with `"model": "complexity-router"` and the message `hi, step by step, pros and cons`
2. The reply now comes back with `x-litellm-model-name: anthropic/claude-haiku-4-5` and `x-litellm-response-cost: 0.000336`, roughly a fifth of the previous bill
3. They send the same request with a real design question, `Give me the pros and cons, step by step, of moving our checkout service to an event-driven architecture.`
4. That reply still comes back from `anthropic/claude-opus-5`, unchanged

## Relevant issues

- Gates the complexity router's reasoning override on a non-SIMPLE weighted score
- Stops two stock reasoning phrases buying the top tier on trivial prompts
- Updates the Admin UI copy that described the override as markers only

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup for both runs, a complexity autorouter with one distinct real model per tier so the tier that won is visible in the response headers

```yaml
model_list:
  - model_name: complexity-router
    litellm_params:
      model: auto_router/complexity_router/complexity-router
      complexity_router_config:
        tiers:
          SIMPLE: tier-simple
          MEDIUM: tier-medium
          COMPLEX: tier-complex
          REASONING: tier-reasoning
  - model_name: tier-simple
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_base: os.environ/GW_BASE
      api_key: os.environ/GW_KEY
  - model_name: tier-medium
    litellm_params:
      model: anthropic/claude-sonnet-4-5
      api_base: os.environ/GW_BASE
      api_key: os.environ/GW_KEY
  - model_name: tier-complex
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_base: os.environ/GW_BASE
      api_key: os.environ/GW_KEY
  - model_name: tier-reasoning
    litellm_params:
      model: anthropic/claude-opus-5
      api_base: os.environ/GW_BASE
      api_key: os.environ/GW_KEY
litellm_settings:
  drop_params: True
general_settings:
  master_key: sk-1234
```

`GW_BASE` points at an internal gateway that fronts the real Anthropic API, used because the direct key on this box has no credits left. The calls are real, billed, and the per-request cost is in the headers below


### Before (4bb3152cc5)

#### Case 1: trivial prompt carrying two reasoning phrases

1. Run

```bash
curl -s -D - -o /dev/null http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"complexity-router","max_tokens":64,"messages":[{"role":"user","content":"hi, step by step, pros and cons"}]}' \
  | grep -iE "^x-litellm-model-name|^x-litellm-response-cost:"
```

2. Output, the top tier answers a seven token greeting

```
x-litellm-model-name: anthropic/claude-opus-5
x-litellm-response-cost: 0.00169
```

#### Case 2: genuine reasoning request

1. Run

```bash
curl -s -D - -o /dev/null http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"complexity-router","max_tokens":64,"messages":[{"role":"user","content":"Give me the pros and cons, step by step, of moving our checkout service to an event-driven architecture."}]}' \
  | grep -iE "^x-litellm-model-name|^x-litellm-response-cost:"
```

2. Output

```
x-litellm-model-name: anthropic/claude-opus-5
x-litellm-response-cost: 0.0017900000000000001
```

### After (df4bf1eb0b)

#### Case 1: trivial prompt carrying two reasoning phrases

1. Run the identical command from the Before section
2. Output, the score keeps it in the cheapest tier

```
x-litellm-model-name: anthropic/claude-haiku-4-5
x-litellm-response-cost: 0.00033600000000000004
```

#### Case 2: genuine reasoning request

1. Run the identical command from the Before section
2. Output, unchanged

```
x-litellm-model-name: anthropic/claude-opus-5
x-litellm-response-cost: 0.0017900000000000001
```

### UI copy, screenshots pending

The two strings that described the override as markers alone now name the score condition. To capture them, go to http://localhost:3000/ui/?page=new_model, pick the autorouter tab with heuristic scoring, and read the tier range list, where the top tier line now reads "or 2+ reasoning markers with a score of at least 0.15". Then open a routed request at http://localhost:4000/ui/?page=logs and expand its routing decision card, which now reads "Heuristic, REASONING override (2 or more reasoning markers, score above the lowest tier)"

## Type

🐛 Bug Fix

## Caveats (if any)

- Threshold is the simple_medium boundary, not yet configurable
- A follow-up PR adds a reasoning_override_min_score knob

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tier selection and spend for prompts that hit multiple reasoning keywords with low complexity scores; behavior is intentional but affects production routing economics.
> 
> **Overview**
> **Heuristic routing:** The **reasoning override** (two or more reasoning keywords) no longer forces **REASONING** when the weighted score stays below the **simple/medium** boundary. Promotion still applies when the score is at or above that threshold—including exactly on the boundary—so genuine design questions with marker phrases keep the top tier while chatty prompts like `hi, step by step, pros and cons` stay **SIMPLE**.
> 
> **Tests** lock in the simple-score case and the boundary behavior.
> 
> **Dashboard copy** in the add-model tier explainer and log **Routing decision** card now states that the override also needs a score above the lowest tier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df4bf1eb0be3d2d47d700ac135627c975bece563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->