### PR TITLE
refactor(ui): migrate the antd Button call sites onto the shadcn Button

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -336,9 +336,6 @@
     "max-params": {
       "count": 1
     },
-    "no-restricted-imports": {
-      "count": 1
-    },
     "react-hooks/set-state-in-effect": {
       "count": 3
     }
@@ -1300,9 +1297,6 @@
   },
   "src/app/(dashboard)/tag-management/_components/tag_info.tsx": {
     "local/filename-pascal-case": {
-      "count": 1
-    },
-    "no-restricted-imports": {
       "count": 1
     },
     "react-hooks/set-state-in-effect": {

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/_components/GuardrailConfig.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/_components/GuardrailConfig.tsx
@@ -5,7 +5,8 @@ import {
   RollbackOutlined,
   SaveOutlined,
 } from "@ant-design/icons";
-import { Button, Input, Select, Switch } from "antd";
+import { Input, Select, Switch } from "antd";
+import { Button } from "@/components/ui/button";
 import React, { useState } from "react";
 
 interface GuardrailConfigProps {
@@ -56,13 +57,17 @@ export function GuardrailConfig({ guardrailName, guardrailType, provider }: Guar
               options={versions.map((v) => ({ value: v.id, label: v.label }))}
               style={{ width: 140 }}
             />
-            <Button type="link" size="small" onClick={() => setShowVersionHistory(!showVersionHistory)}>
+            <Button variant="link" size="sm" onClick={() => setShowVersionHistory(!showVersionHistory)}>
               {showVersionHistory ? "Hide history" : "View history"}
             </Button>
           </div>
           <div className="flex items-center gap-2">
-            <Button icon={<RollbackOutlined />}>Revert</Button>
-            <Button type="primary" icon={<SaveOutlined />}>
+            <Button variant="outline">
+              <RollbackOutlined />
+              Revert
+            </Button>
+            <Button>
+              <SaveOutlined />
               Save as v{parseInt(version.replace("v", ""), 10) + 1}
             </Button>
           </div>
@@ -194,12 +199,8 @@ export function GuardrailConfig({ guardrailName, guardrailType, provider }: Guar
         </p>
 
         <div className="flex items-center gap-3">
-          <Button
-            type="primary"
-            icon={rerunStatus === "running" ? undefined : <PlayCircleOutlined />}
-            loading={rerunStatus === "running"}
-            onClick={handleRerun}
-          >
+          <Button disabled={rerunStatus === "running"} aria-busy={rerunStatus === "running"} onClick={handleRerun}>
+            {rerunStatus === "running" ? null : <PlayCircleOutlined />}
             {rerunStatus === "running" ? "Running on 10 samples..." : "Re-run on failing logs"}
           </Button>
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.tsx
@@ -5,10 +5,9 @@ import {
   updateGuardrailCall,
 } from "@/components/networking";
 import { copyToClipboard as utilCopyToClipboard } from "@/utils/dataUtils";
-import { CodeOutlined, EyeInvisibleOutlined, InfoCircleOutlined, StopOutlined } from "@ant-design/icons";
+import { EyeInvisibleOutlined, InfoCircleOutlined, StopOutlined } from "@ant-design/icons";
 
-import { Button as AntdButton } from "antd";
-import { ArrowLeft, CheckIcon, CopyIcon } from "lucide-react";
+import { ArrowLeft, CheckIcon, Code, CopyIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -511,24 +510,26 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
   return (
     <div className="p-4">
       <div>
-        <AntdButton type="text" icon={<ArrowLeft className="w-4 h-4" />} onClick={onClose} className="mb-4">
+        <Button variant="ghost" onClick={onClose} className="mb-4">
+          <ArrowLeft className="w-4 h-4" />
           Back to Guardrails
-        </AntdButton>
+        </Button>
         <h1 className="text-2xl font-semibold">{guardrailData.guardrail_name || "Unnamed Guardrail"}</h1>
         <div className="flex items-center cursor-pointer">
           <p className="text-muted-foreground font-mono">{guardrailData.guardrail_id}</p>
 
-          <AntdButton
-            type="text"
-            size="small"
-            icon={copiedStates["guardrail-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+          <Button
+            variant="ghost"
+            size="icon-xs"
             onClick={() => copyToClipboard(guardrailData.guardrail_id, "guardrail-id")}
             className={`left-2 z-10 transition-all duration-200 ${
               copiedStates["guardrail-id"]
                 ? "text-green-600 bg-green-50 border-green-200 dark:text-green-400 dark:bg-green-950/40 dark:border-green-900"
                 : "text-muted-foreground hover:text-foreground hover:bg-muted"
             }`}
-          />
+          >
+            {copiedStates["guardrail-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+          </Button>
         </div>
       </div>
 
@@ -628,13 +629,14 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
               <Card className="block mt-6 p-6">
                 <div className="flex justify-between items-center mb-4">
                   <div className="flex items-center gap-2">
-                    <CodeOutlined className="text-blue-500" />
+                    <Code className="text-blue-500" />
                     <p className="font-medium text-lg">Custom Code</p>
                   </div>
                   {isAdmin && !isConfigGuardrail && (
-                    <AntdButton size="small" icon={<CodeOutlined />} onClick={() => setCustomCodeModalVisible(true)}>
+                    <Button variant="outline" size="sm" onClick={() => setCustomCodeModalVisible(true)}>
+                      <Code />
                       Edit Code
-                    </AntdButton>
+                    </Button>
                   )}
                 </div>
                 <div className="relative rounded-lg overflow-hidden border border-gray-700 bg-[#1e1e1e]">
@@ -671,11 +673,14 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
                   {!isEditing &&
                     !isConfigGuardrail &&
                     (guardrailData.litellm_params?.guardrail === "custom_code" ? (
-                      <AntdButton icon={<CodeOutlined />} onClick={() => setCustomCodeModalVisible(true)}>
+                      <Button variant="outline" onClick={() => setCustomCodeModalVisible(true)}>
+                        <Code />
                         Edit Code
-                      </AntdButton>
+                      </Button>
                     ) : (
-                      <AntdButton onClick={() => setIsEditing(true)}>Edit Settings</AntdButton>
+                      <Button variant="outline" onClick={() => setIsEditing(true)}>
+                        Edit Settings
+                      </Button>
                     ))}
                 </div>
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/EnvVarsSection.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/EnvVarsSection.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Input, Select, Button, Tooltip, Typography } from "antd";
+import { Input, Select, Tooltip, Typography } from "antd";
+import { Button } from "@/components/ui/button";
 import { InfoCircleOutlined, MinusCircleOutlined, PlusOutlined } from "@ant-design/icons";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 
@@ -106,7 +107,8 @@ const EnvVarsSection: React.FC = () => {
             </div>
           </div>
         ))}
-        <Button type="dashed" onClick={() => append({ scope: "global" })} icon={<PlusOutlined />} block>
+        <Button variant="outline" className="w-full border-dashed" onClick={() => append({ scope: "global" })}>
+          <PlusOutlined />
           Add Variable
         </Button>
       </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPPermissionManagement.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPPermissionManagement.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
-import { Alert, Select, Tooltip, Collapse, Input, Space, Button, Switch } from "antd";
+import { Alert, Select, Tooltip, Collapse, Input, Space, Switch } from "antd";
+import { Button } from "@/components/ui/button";
 import { InfoCircleOutlined, MinusCircleOutlined, PlusOutlined } from "@ant-design/icons";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import { MCPServer, AUTH_TYPE } from "@/components/mcp_tools/types";
@@ -77,7 +78,8 @@ const StaticHeadersFieldArray: React.FC = () => {
           />
         </Space>
       ))}
-      <Button type="dashed" onClick={() => append({})} icon={<PlusOutlined />} block>
+      <Button variant="outline" className="w-full border-dashed" onClick={() => append({})}>
+        <PlusOutlined />
         Add Static Header
       </Button>
     </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/PassthroughAuthorizeSection.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/PassthroughAuthorizeSection.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Button, Checkbox, Input } from "antd";
+import { Checkbox, Input } from "antd";
+import { Button } from "@/components/ui/button";
 import DcrBridgeToggle from "./DcrBridgeToggle";
 import { MountedFormField } from "@/components/common_components/MountedFormField";
 import { textControl } from "./mcpFieldRules";
@@ -119,6 +120,7 @@ export default function PassthroughAuthorizeSection({
         </Checkbox>
       )}
       <Button
+        variant="outline"
         onClick={oauthFlow.startOAuthFlow}
         disabled={oauthFlow.status === "authorizing" || oauthFlow.status === "exchanging"}
       >

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_connect.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_connect.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/no-unescaped-entities */
 
 import React, { useState } from "react";
-import { Card, Typography, Space, Alert, Button, Switch } from "antd";
+import { Card, Typography, Space, Alert, Switch } from "antd";
+import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CopyIcon, Code, Terminal, Globe, CheckIcon, ExternalLinkIcon, KeyIcon, ServerIcon, Zap } from "lucide-react";
 import { getProxyBaseUrl } from "@/components/networking";
@@ -145,16 +146,17 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
       )}
       <Card className={`bg-muted border border-border relative ${className}`}>
         <Button
-          type="text"
-          size="small"
-          icon={copiedStates[copyKey] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+          variant="ghost"
+          size="icon-xs"
           onClick={() => copyToClipboard(code, copyKey)}
           className={`absolute top-2 right-2 z-10 transition-all duration-200 ${
             copiedStates[copyKey]
               ? "text-green-600 bg-green-50 border-green-200 dark:text-green-400 dark:bg-green-950 dark:border-green-800"
               : "text-muted-foreground hover:text-foreground hover:bg-accent"
           }`}
-        />
+        >
+          {copiedStates[copyKey] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+        </Button>
         <pre className="text-sm overflow-x-auto pr-10 text-foreground font-mono leading-relaxed">{code}</pre>
       </Card>
     </div>
@@ -441,11 +443,18 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
           />
           <div className="mt-4">
             <Button
-              type="link"
+              variant="link"
               className="p-0 h-auto text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-              href="https://modelcontextprotocol.io/docs/concepts/transports"
-              icon={<ExternalLinkIcon size={14} />}
+              nativeButton={false}
+              render={
+                <a
+                  href="https://modelcontextprotocol.io/docs/concepts/transports"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              }
             >
+              <ExternalLinkIcon size={14} />
               Learn more about MCP transports
             </Button>
           </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Select, Button as AntdButton, Tooltip, Input, InputNumber, Alert } from "antd";
+import { Select, Tooltip, Input, InputNumber, Alert } from "antd";
 import { FormProvider, useForm } from "react-hook-form";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Button } from "@/components/ui/button";
@@ -1271,7 +1271,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                 </div>
 
                 <div className="flex justify-end gap-2">
-                  <AntdButton onClick={onCancel}>Cancel</AntdButton>
+                  <Button variant="outline" onClick={onCancel}>
+                    Cancel
+                  </Button>
                   <Button type="submit">Save Changes</Button>
                 </div>
               </form>
@@ -1284,7 +1286,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
             <MCPServerCostConfig value={costConfig} onChange={setCostConfig} tools={tools} disabled={isLoadingTools} />
 
             <div className="flex justify-end gap-2">
-              <AntdButton onClick={onCancel}>Cancel</AntdButton>
+              <Button variant="outline" onClick={onCancel}>
+                Cancel
+              </Button>
               <Button onClick={() => void submitForm()}>Save Changes</Button>
             </div>
           </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_info.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/prompt_info.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Button as AntButton, Modal } from "antd";
+import { Modal } from "antd";
 import {
   getPromptInfo,
   getPromptVersions,
@@ -191,17 +191,18 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
             <h1 className="text-2xl font-semibold">Prompt Details</h1>
             <div className="flex items-center cursor-pointer">
               <p className="text-sm text-gray-500 font-mono">{basePromptId}</p>
-              <AntButton
-                type="text"
-                size="small"
-                icon={copiedStates["prompt-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+              <Button
+                variant="ghost"
+                size="icon-xs"
                 onClick={() => copyToClipboard(basePromptId, "prompt-id")}
                 className={`left-2 z-10 transition-all duration-200 ${
                   copiedStates["prompt-id"]
                     ? "text-green-600 bg-green-50 border-green-200"
                     : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"
                 }`}
-              />
+              >
+                {copiedStates["prompt-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+              </Button>
             </div>
           </div>
           <div className="flex gap-2">
@@ -412,10 +413,9 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
               <Card className="block p-6">
                 <div className="flex justify-between items-center mb-4">
                   <h3 className="text-lg font-medium">Prompt Template</h3>
-                  <AntButton
-                    type="text"
-                    size="small"
-                    icon={copiedStates["prompt-content"] ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
+                  <Button
+                    variant="ghost"
+                    size="sm"
                     onClick={() => copyToClipboard(promptTemplate.content, "prompt-content")}
                     className={`transition-all duration-200 ${
                       copiedStates["prompt-content"]
@@ -423,8 +423,9 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
                         : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"
                     }`}
                   >
+                    {copiedStates["prompt-content"] ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
                     {copiedStates["prompt-content"] ? "Copied!" : "Copy Content"}
-                  </AntButton>
+                  </Button>
                 </div>
 
                 <div className="space-y-4">
@@ -462,10 +463,9 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
             <Card className="block p-6">
               <div className="flex justify-between items-center mb-4">
                 <h3 className="text-lg font-medium">Raw API Response</h3>
-                <AntButton
-                  type="text"
-                  size="small"
-                  icon={copiedStates["raw-json"] ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() => copyToClipboard(JSON.stringify(rawApiResponse, null, 2), "raw-json")}
                   className={`transition-all duration-200 ${
                     copiedStates["raw-json"]
@@ -473,8 +473,9 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
                       : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"
                   }`}
                 >
+                  {copiedStates["raw-json"] ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
                   {copiedStates["raw-json"] ? "Copied!" : "Copy JSON"}
-                </AntButton>
+                </Button>
               </div>
 
               <div className="p-4 bg-gray-50 rounded-md border overflow-auto">

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/tag_info.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/tag_info.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useEffect } from "react";
 import { SimpleTooltip } from "@/components/ui/tooltip";
-import { Button as AntdButton } from "antd";
 import { z } from "zod/v4";
 import { fetchUserModels } from "@/components/organisms/create_key_button";
 import { getModelDisplayName } from "@/components/key_team_helpers/fetch_available_models_team_key";
@@ -230,17 +229,18 @@ const TagInfoView: React.FC<TagInfoViewProps> = ({ tagId, onClose, accessToken, 
             <span className="font-mono px-2 py-1 bg-muted rounded-sm text-sm border border-border">
               {tagDetails.name}
             </span>
-            <AntdButton
-              type="text"
-              size="small"
-              icon={copiedStates["tag-name"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+            <Button
+              variant="ghost"
+              size="icon-xs"
               onClick={() => copyToClipboard(tagDetails.name, "tag-name")}
               className={`transition-all duration-200 ${
                 copiedStates["tag-name"]
                   ? "text-green-600 bg-green-50 border-green-200 dark:text-green-400 dark:bg-green-950 dark:border-green-800"
                   : "text-muted-foreground hover:text-foreground hover:bg-muted"
               }`}
-            />
+            >
+              {copiedStates["tag-name"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+            </Button>
           </div>
           <p className="text-sm text-muted-foreground">{tagDetails.description || "No description"}</p>
         </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/user_info_view.tsx
@@ -18,7 +18,7 @@ import {
   Member,
 } from "@/components/networking";
 import { SimpleTooltip } from "@/components/ui/tooltip";
-import { Button as AntdButton, Modal } from "antd";
+import { Modal } from "antd";
 import { Field, FieldGroup, FieldLabel } from "@/components/shared/form/field";
 import {
   Combobox,
@@ -405,17 +405,18 @@ export default function UserInfoView({
           <h2 className="text-xl font-semibold">{userData.user_email || "User"}</h2>
           <div className="flex items-center cursor-pointer">
             <span className="text-sm text-gray-500 font-mono">{userData.user_id}</span>
-            <AntdButton
-              type="text"
-              size="small"
-              icon={copiedStates["user-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+            <Button
+              variant="ghost"
+              size="icon-xs"
               onClick={() => copyToClipboard(userData.user_id, "user-id")}
               className={`left-2 z-10 transition-all duration-200 ${
                 copiedStates["user-id"]
                   ? "text-green-600 bg-green-50 border-green-200"
                   : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"
               }`}
-            />
+            >
+              {copiedStates["user-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+            </Button>
           </div>
         </div>
         {userRole && rolesWithWriteAccess.includes(userRole) && (
@@ -585,17 +586,18 @@ export default function UserInfoView({
                   <p className="font-medium">User ID</p>
                   <div className="flex items-center cursor-pointer">
                     <span className="font-mono">{userData.user_id}</span>
-                    <AntdButton
-                      type="text"
-                      size="small"
-                      icon={copiedStates["user-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
                       onClick={() => copyToClipboard(userData.user_id, "user-id")}
                       className={`left-2 z-10 transition-all duration-200 ${
                         copiedStates["user-id"]
                           ? "text-green-600 bg-green-50 border-green-200"
                           : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"
                       }`}
-                    />
+                    >
+                      {copiedStates["user-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+                    </Button>
                   </div>
                 </div>
 
@@ -760,9 +762,9 @@ export default function UserInfoView({
           </FieldGroup>
 
           <div className="text-right mt-4">
-            <AntdButton type="primary" htmlType="submit" loading={isAddingTeam} disabled={!selectedTeamId}>
+            <Button type="submit" disabled={isAddingTeam || !selectedTeamId} aria-busy={isAddingTeam}>
               {isAddingTeam ? "Adding..." : "Add to Team"}
-            </AntdButton>
+            </Button>
           </div>
         </form>
       </Modal>

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/PluginSettings/PluginSettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/PluginSettings/PluginSettings.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Button, Card, Modal, Space, Table, Typography } from "antd";
+import { Card, Modal, Space, Table, Typography } from "antd";
+import { Button } from "@/components/ui/button";
 import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
 import { Eye, EyeOff } from "lucide-react";
 import { getConfigFieldSetting, updateConfigFieldSetting } from "@/components/networking";
@@ -113,8 +114,12 @@ export default function PluginSettings() {
       key: "actions",
       render: (_: unknown, __: Plugin, idx: number) => (
         <Space>
-          <Button icon={<EditOutlined />} size="small" onClick={() => openEdit(idx)} />
-          <Button icon={<DeleteOutlined />} size="small" danger onClick={() => handleDelete(idx)} />
+          <Button variant="outline" size="icon-sm" onClick={() => openEdit(idx)}>
+            <EditOutlined />
+          </Button>
+          <Button variant="destructive" size="icon-sm" onClick={() => handleDelete(idx)}>
+            <DeleteOutlined />
+          </Button>
         </Space>
       ),
     },
@@ -131,7 +136,8 @@ export default function PluginSettings() {
         Each plugin must expose <Text code>GET /api/plugin-manifest</Text> returning nav items and capabilities.
       </Paragraph>
 
-      <Button type="primary" icon={<PlusOutlined />} onClick={openAdd} style={{ marginBottom: 16 }}>
+      <Button className="mb-4" onClick={openAdd}>
+        <PlusOutlined />
         Add Plugin
       </Button>
 

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -5,7 +5,8 @@ import { all_admin_roles, isUserTeamAdminForAnyTeam } from "@/utils/roles";
 import { modelCreationScope } from "@/utils/modelPermissions";
 import { Switch } from "@/components/ui/switch";
 import { Field, FieldLabel } from "@/components/shared/form/field";
-import { Select as AntdSelect, Button, Card, Col, Modal, Row, Tooltip, Typography, Alert } from "antd";
+import { Select as AntdSelect, Card, Col, Modal, Row, Tooltip, Typography, Alert } from "antd";
+import { Button } from "@/components/ui/button";
 import type { UploadProps } from "antd/es/upload";
 import React, { useEffect, useMemo, useState } from "react";
 import { FormProvider, useWatch, type UseFormReturn } from "react-hook-form";
@@ -418,10 +419,16 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
                     <Typography.Link href="https://github.com/BerriAI/litellm/issues">Need Help?</Typography.Link>
                   </Tooltip>
                   <div className="space-x-2">
-                    <Button data-testid="test-connect-btn" onClick={handleTestConnection} loading={isTestingConnection}>
+                    <Button
+                      variant="outline"
+                      data-testid="test-connect-btn"
+                      onClick={handleTestConnection}
+                      disabled={isTestingConnection}
+                      aria-busy={isTestingConnection}
+                    >
                       Test Connect
                     </Button>
-                    <Button data-testid="add-model-btn" htmlType="submit">
+                    <Button data-testid="add-model-btn" type="submit">
                       Add Model
                     </Button>
                   </div>
@@ -443,6 +450,7 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
         footer={[
           <Button
             key="close"
+            variant="outline"
             onClick={() => {
               setIsResultModalVisible(false);
               setIsTestingConnection(false);

--- a/ui/litellm-dashboard/src/components/add_model/KeywordTierRules.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/KeywordTierRules.tsx
@@ -1,6 +1,7 @@
 import { DeleteOutlined, InfoCircleOutlined, PlusOutlined } from "@ant-design/icons";
 import { SimpleTooltip } from "@/components/ui/tooltip";
-import { Button, Card, Empty, Select as AntdSelect, Typography } from "antd";
+import { Card, Empty, Select as AntdSelect, Typography } from "antd";
+import { Button } from "@/components/ui/button";
 import React from "react";
 
 import { emptyKeywordTierRuleIndexes } from "./complexity_router_keywords";
@@ -75,7 +76,8 @@ const KeywordTierRules: React.FC<KeywordTierRulesProps> = ({ rules, onChange, ti
             <InfoCircleOutlined className="text-gray-400" />
           </SimpleTooltip>
         </div>
-        <Button icon={<PlusOutlined />} onClick={addRule}>
+        <Button variant="outline" onClick={addRule}>
+          <PlusOutlined />
           Add keyword rule
         </Button>
       </div>
@@ -131,12 +133,14 @@ const KeywordTierRules: React.FC<KeywordTierRulesProps> = ({ rules, onChange, ti
                   />
                 </div>
                 <Button
-                  danger
-                  type="text"
-                  icon={<DeleteOutlined />}
+                  variant="ghost"
+                  size="icon"
+                  className="text-destructive hover:text-destructive"
                   aria-label={`Remove keyword rule ${index + 1}`}
                   onClick={() => removeRule(rule.id)}
-                />
+                >
+                  <DeleteOutlined />
+                </Button>
               </div>
             </Card>
           ))}

--- a/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
@@ -1,7 +1,8 @@
 import { useProviderFields } from "@/app/(dashboard)/hooks/providers/useProviderFields";
 import { UploadOutlined } from "@ant-design/icons";
 import { Input } from "@/components/ui/input";
-import { Button as Button2, Col, Input as AntdInput, Row, Select, Typography, Upload, UploadProps } from "antd";
+import { Col, Input as AntdInput, Row, Select, Typography, Upload, UploadProps } from "antd";
+import { Button } from "@/components/ui/button";
 import React from "react";
 import { useFormContext } from "react-hook-form";
 import { antdRequired } from "../common_components/antdFormRules";
@@ -255,7 +256,10 @@ const ProviderSpecificFields: React.FC<ProviderSpecificFieldsProps> = ({ selecte
             }
           }}
         >
-          <Button2 icon={<UploadOutlined />}>Click to Upload</Button2>
+          <Button variant="outline">
+            <UploadOutlined />
+            Click to Upload
+          </Button>
         </Upload>
       );
     }

--- a/ui/litellm-dashboard/src/components/key_team_helpers/BudgetFallbacksEditor.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/BudgetFallbacksEditor.tsx
@@ -1,5 +1,6 @@
 import { SimpleTooltip } from "@/components/ui/tooltip";
-import { Button, Select } from "antd";
+import { Select } from "antd";
+import { Button } from "@/components/ui/button";
 import { ArrowDown, Plus, X } from "lucide-react";
 import React, { useState } from "react";
 
@@ -62,7 +63,8 @@ export function BudgetFallbacksEditor({ value, onChange, availableModels }: Budg
         <div className="text-xs text-gray-500 mb-2">
           When a model exceeds its per-model budget, requests automatically reroute to fallback models
         </div>
-        <Button size="small" onClick={addEntry} icon={<Plus className="w-3 h-3" />}>
+        <Button variant="outline" size="sm" onClick={addEntry}>
+          <Plus className="w-3 h-3" />
           Add Budget Fallback
         </Button>
       </div>
@@ -143,7 +145,8 @@ export function BudgetFallbacksEditor({ value, onChange, availableModels }: Budg
           </div>
         );
       })}
-      <Button size="small" onClick={addEntry} icon={<Plus className="w-3 h-3" />}>
+      <Button variant="outline" size="sm" onClick={addEntry}>
+        <Plus className="w-3 h-3" />
         Add Budget Fallback
       </Button>
     </div>

--- a/ui/litellm-dashboard/src/components/key_team_helpers/BudgetWindowsEditor.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/BudgetWindowsEditor.tsx
@@ -1,4 +1,5 @@
-import { Button, InputNumber, Select } from "antd";
+import { InputNumber, Select } from "antd";
+import { Button } from "@/components/ui/button";
 import React from "react";
 
 export interface BudgetWindowEntry {
@@ -55,7 +56,12 @@ export function BudgetWindowsEditor({ value, onChange }: BudgetWindowsEditorProp
                 style={{ width: 160 }}
                 prefix="$"
               />
-              <Button type="text" danger size="small" onClick={() => removeWindow(idx)} style={{ padding: "0 4px" }}>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="px-1 text-destructive hover:text-destructive"
+                onClick={() => removeWindow(idx)}
+              >
                 ✕
               </Button>
             </div>
@@ -64,7 +70,8 @@ export function BudgetWindowsEditor({ value, onChange }: BudgetWindowsEditorProp
         );
       })}
       <Button
-        size="small"
+        variant="outline"
+        size="sm"
         onClick={(e) => {
           e.preventDefault();
           addWindow();

--- a/ui/litellm-dashboard/src/components/model_add/CredentialModal.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/CredentialModal.tsx
@@ -1,5 +1,6 @@
 import { Input } from "@/components/ui/input";
-import { Select as AntdSelect, Button, Modal, Tooltip, Typography } from "antd";
+import { Select as AntdSelect, Modal, Tooltip, Typography } from "antd";
+import { Button } from "@/components/ui/button";
 import type { UploadProps } from "antd/es/upload";
 import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
@@ -156,10 +157,10 @@ export default function CredentialModal({
               </Tooltip>
 
               <div>
-                <Button onClick={closeAndReset} style={{ marginRight: 10 }}>
+                <Button variant="outline" className="mr-2.5" onClick={closeAndReset}>
                   Cancel
                 </Button>
-                <Button htmlType="submit">{isEdit ? "Update Credential" : "Add Credential"}</Button>
+                <Button type="submit">{isEdit ? "Update Credential" : "Add Credential"}</Button>
               </div>
             </div>
           </form>

--- a/ui/litellm-dashboard/src/components/model_dashboard/ModelSettingsModal/ModelSettingsModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard/ModelSettingsModal/ModelSettingsModal.test.tsx
@@ -2,7 +2,7 @@ import { useProxyConfig } from "@/app/(dashboard)/hooks/proxyConfig/useProxyConf
 import { useStoreModelInDB } from "@/app/(dashboard)/hooks/storeModelInDB/useStoreModelInDB";
 import { toast } from "@/lib/toast";
 import { parseErrorMessage } from "@/components/shared/errorUtils";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "../../../../tests/test-utils";
@@ -225,7 +225,8 @@ describe("ModelSettingsModal", () => {
 
     const saveButton = screen.getByRole("button", { name: /Saving/i });
     expect(saveButton).toBeInTheDocument();
-    expect(within(saveButton).getByRole("img", { name: "loading" })).toBeInTheDocument();
+    expect(saveButton).toHaveAttribute("aria-busy", "true");
+    expect(saveButton).toBeDisabled();
   });
 
   it("should not render modal when isVisible is false", () => {

--- a/ui/litellm-dashboard/src/components/model_dashboard/ModelSettingsModal/ModelSettingsModal.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard/ModelSettingsModal/ModelSettingsModal.tsx
@@ -8,7 +8,8 @@ import { FieldGroup } from "@/components/shared/form/field";
 import { FormField } from "@/components/shared/form/FormField";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Button, Modal, Skeleton, Space, Typography } from "antd";
+import { Modal, Skeleton, Space, Typography } from "antd";
+import { Button } from "@/components/ui/button";
 import { CircleHelp } from "lucide-react";
 import React, { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
@@ -85,13 +86,12 @@ const ModelSettingsModal: React.FC<ModelSettingsModalProps> = ({ isVisible, onCa
       open={isVisible}
       footer={
         <Space>
-          <Button onClick={handleCancel} disabled={isPending || isLoadingConfig}>
+          <Button variant="outline" onClick={handleCancel} disabled={isPending || isLoadingConfig}>
             Cancel
           </Button>
           <Button
-            type="primary"
-            loading={isPending}
-            disabled={isLoadingConfig}
+            disabled={isPending || isLoadingConfig}
+            aria-busy={isPending}
             onClick={() => void form.handleSubmit(handleFormSubmit)()}
           >
             {isPending ? "Saving..." : "Save Settings"}

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SimpleTooltip } from "@/components/ui/tooltip";
-import { Button as AntdButton, Modal } from "antd";
+import { Modal } from "antd";
 import { applyPtuModelInfo } from "../utils/ptuModelInfo";
 import { usePtuCostAttributionEnabled } from "@/app/(dashboard)/hooks/uiSettings/usePtuCostAttributionEnabled";
 import { ArrowLeft, CheckIcon, CopyIcon } from "lucide-react";
@@ -600,10 +600,9 @@ export default function ModelInfoView({
           <h2 className="text-xl font-semibold">Public Model Name: {getDisplayModelName(modelData)}</h2>
           <div className="flex items-center cursor-pointer">
             <span className="text-sm text-muted-foreground font-mono">{modelData.model_info.id}</span>
-            <AntdButton
-              type="text"
-              size="small"
-              icon={copiedStates["model-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+            <Button
+              variant="ghost"
+              size="icon-xs"
               aria-label="Copy model ID"
               onClick={() => copyToClipboard(modelData.model_info.id, "model-id")}
               className={`left-2 z-10 transition-all duration-200 ${
@@ -611,54 +610,59 @@ export default function ModelInfoView({
                   ? "text-green-600 bg-green-50 border-green-200"
                   : "text-muted-foreground hover:text-foreground hover:bg-muted"
               }`}
-            />
+            >
+              {copiedStates["model-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+            </Button>
           </div>
         </div>
         <div className="flex gap-2">
           {(!isAnyAutoRouter || isComplexityRouterModel) && (
-            <AntdButton
-              icon={<RefreshIcon className="h-4 w-4" />}
+            <Button
+              variant="outline"
               onClick={handleTestConnection}
               className="flex items-center gap-2"
               data-testid="test-connection-button"
             >
+              <RefreshIcon className="h-4 w-4" />
               Test Connection
-            </AntdButton>
+            </Button>
           )}
 
           {!isAnyAutoRouter && (
             <>
-              <AntdButton
-                icon={<KeyIcon className="h-4 w-4" />}
+              <Button
+                variant="outline"
                 onClick={() => setIsUpdateCredentialsModalOpen(true)}
                 className="flex items-center"
                 disabled={!canEditModel}
                 data-testid="update-api-key-button"
               >
+                <KeyIcon className="h-4 w-4" />
                 Update API Key
-              </AntdButton>
+              </Button>
 
-              <AntdButton
-                icon={<KeyIcon className="h-4 w-4" />}
+              <Button
+                variant="outline"
                 onClick={() => setIsCredentialModalOpen(true)}
                 className="flex items-center"
                 disabled={!isAdmin}
                 data-testid="reuse-credentials-button"
               >
+                <KeyIcon className="h-4 w-4" />
                 Re-use Credentials
-              </AntdButton>
+              </Button>
             </>
           )}
-          <AntdButton
-            danger
-            icon={<TrashIcon className="h-4 w-4" />}
+          <Button
+            variant="destructive"
             onClick={() => setIsDeleteModalOpen(true)}
             className="flex items-center"
             disabled={!canEditModel}
             data-testid="delete-model-button"
           >
+            <TrashIcon className="h-4 w-4" />
             {deleteLabel}
-          </AntdButton>
+          </Button>
         </div>
       </div>
 
@@ -865,9 +869,9 @@ export default function ModelInfoView({
         open={isAutoRouterTestModalOpen}
         onCancel={() => setIsAutoRouterTestModalOpen(false)}
         footer={[
-          <AntdButton key="close" onClick={() => setIsAutoRouterTestModalOpen(false)}>
+          <Button key="close" variant="outline" onClick={() => setIsAutoRouterTestModalOpen(false)}>
             Close
-          </AntdButton>,
+          </Button>,
         ]}
         width={700}
       >

--- a/ui/litellm-dashboard/src/components/onboarding_link.tsx
+++ b/ui/litellm-dashboard/src/components/onboarding_link.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Button, Modal, Typography } from "antd";
+import { Modal, Typography } from "antd";
+import { Button } from "@/components/ui/button";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { toast } from "@/lib/toast";
 
@@ -98,9 +99,7 @@ export default function OnboardingModal({
       </div>
       <div className="flex justify-end mt-5">
         <CopyToClipboard text={getInvitationUrl()} onCopy={() => toast.success("Copied!")}>
-          <Button type="primary">
-            {modalType === "invitation" ? "Copy invitation link" : "Copy password reset link"}
-          </Button>
+          <Button>{modalType === "invitation" ? "Copy invitation link" : "Copy password reset link"}</Button>
         </CopyToClipboard>
       </div>
     </Modal>

--- a/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.tsx
@@ -1,6 +1,7 @@
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { CheckOutlined, CopyOutlined, SyncOutlined } from "@ant-design/icons";
-import { Alert, Button, Modal, Space } from "antd";
+import { Alert, Modal, Space } from "antd";
+import { Button } from "@/components/ui/button";
 import { CircleHelp } from "lucide-react";
 import React, { useEffect, useMemo, useState } from "react";
 import { useWatch } from "react-hook-form";
@@ -157,9 +158,12 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
         regeneratedKey
           ? [
               <Space key="footer-actions">
-                <Button onClick={handleClose}>Close</Button>
+                <Button variant="outline" onClick={handleClose}>
+                  Close
+                </Button>
                 <CopyToClipboard text={regeneratedKey} onCopy={handleCopyKey}>
-                  <Button type="primary" icon={copied ? <CheckOutlined /> : <CopyOutlined />}>
+                  <Button>
+                    {copied ? <CheckOutlined /> : <CopyOutlined />}
                     {copied ? "Copied" : "Copy Key"}
                   </Button>
                 </CopyToClipboard>
@@ -167,8 +171,11 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
             ]
           : [
               <Space key="footer-actions">
-                <Button onClick={handleClose}>Cancel</Button>
-                <Button type="primary" icon={<SyncOutlined />} onClick={handleRegenerateKey} loading={isRegenerating}>
+                <Button variant="outline" onClick={handleClose}>
+                  Cancel
+                </Button>
+                <Button onClick={handleRegenerateKey} disabled={isRegenerating} aria-busy={isRegenerating}>
+                  <SyncOutlined />
                   Regenerate
                 </Button>
               </Space>,

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Field, FieldLabel } from "@/components/shared/form/field";
-import { Button as Button2, Input as AntdInput, Modal, Radio, Select, Switch, Tag, Tooltip, Typography } from "antd";
+import { Input as AntdInput, Modal, Radio, Select, Switch, Tag, Tooltip, Typography } from "antd";
 import { ChevronDown } from "lucide-react";
 import { useDebouncedCallback } from "@tanstack/react-pacer/debouncer";
 import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
@@ -708,9 +708,9 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                           style={{ width: "100%" }}
                           notFoundContent={userSearchLoading ? "Searching..." : "No users found"}
                         />
-                        <Button2 onClick={() => setIsCreateUserModalVisible(true)} style={{ marginLeft: "8px" }}>
+                        <Button variant="outline" className="ml-2" onClick={() => setIsCreateUserModalVisible(true)}>
                           Create User
-                        </Button2>
+                        </Button>
                       </div>
                       <div className="text-xs text-muted-foreground">Search by email to find users</div>
                     </div>
@@ -1726,9 +1726,9 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
             )}
 
             <div style={{ textAlign: "right", marginTop: "10px" }}>
-              <Button2 htmlType="submit" disabled={isFormDisabled} style={{ opacity: isFormDisabled ? 0.5 : 1 }}>
+              <Button type="submit" disabled={isFormDisabled}>
                 Create Key
-              </Button2>
+              </Button>
             </div>
           </form>
         </MountedFormProvider>

--- a/ui/litellm-dashboard/src/components/routing_groups/index.tsx
+++ b/ui/litellm-dashboard/src/components/routing_groups/index.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { Button, Card, Flex, Input, Modal, Space, Typography } from "antd";
+import { Card, Flex, Input, Modal, Space, Typography } from "antd";
+import { Button } from "@/components/ui/button";
 import { PlusOutlined, ReloadOutlined, SearchOutlined } from "@ant-design/icons";
 import { useRoutingGroups, useSaveRoutingGroups } from "@/app/(dashboard)/hooks/routingGroups/useRoutingGroups";
 import { useRouterFields } from "@/app/(dashboard)/hooks/router/useRouterFields";
@@ -112,10 +113,17 @@ const RoutingGroups: React.FC = () => {
             className="max-w-sm"
           />
           <Flex align="center" gap={12}>
-            <Button icon={<ReloadOutlined />} onClick={() => refetch()} loading={isFetching && !isLoading}>
+            <Button
+              variant="outline"
+              onClick={() => refetch()}
+              disabled={isFetching && !isLoading}
+              aria-busy={isFetching && !isLoading}
+            >
+              <ReloadOutlined />
               Refresh
             </Button>
-            <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>
+            <Button onClick={openCreate}>
+              <PlusOutlined />
               Create Group
             </Button>
             <Text type="secondary" className="text-sm whitespace-nowrap">

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -27,7 +27,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input as UIInput } from "@/components/ui/input";
-import { Button as UIButton } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -39,7 +39,7 @@ import { MultiSelect } from "@/components/shared/MultiSelect";
 import { SearchSelect } from "@/components/shared/SearchSelect";
 import { useZodForm } from "@/lib/forms/useZodForm";
 import { TagsInput } from "@/app/(dashboard)/guardrails/_components/content_filter/TagsInput";
-import { Button, Tabs, Tooltip } from "antd";
+import { Tabs, Tooltip } from "antd";
 import { toast } from "@/lib/toast";
 import { CheckIcon, ChevronDown, CircleMinus, CopyIcon, Plus, Save } from "lucide-react";
 import React, { useEffect, useMemo, useState } from "react";
@@ -950,23 +950,25 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
     <div className="p-4">
       <div className="flex justify-between items-center mb-6">
         <div>
-          <Button type="text" icon={<ArrowLeftIcon className="h-4 w-4" />} onClick={onClose} className="mb-4">
+          <Button variant="ghost" onClick={onClose} className="mb-4">
+            <ArrowLeftIcon className="h-4 w-4" />
             Back to Teams
           </Button>
           <h1 className="text-2xl font-semibold">{info.team_alias}</h1>
           <div className="flex items-center">
             <p className="text-sm text-gray-500 font-mono">{info.team_id}</p>
             <Button
-              type="text"
-              size="small"
-              icon={copiedStates["team-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+              variant="ghost"
+              size="icon-xs"
               onClick={() => copyToClipboard(info.team_id, "team-id")}
               className={`left-2 z-10 transition-all duration-200 ${
                 copiedStates["team-id"]
                   ? "text-green-600 bg-green-50 border-green-200"
                   : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"
               }`}
-            />
+            >
+              {copiedStates["team-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+            </Button>
           </div>
         </div>
       </div>
@@ -1149,12 +1151,13 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                   <h3 className="text-lg font-medium">Team Settings</h3>
                   {canEditTeam && !isEditing && (
                     <Button
-                      icon={<EditOutlined className="h-4 w-4" />}
+                      variant="outline"
                       onClick={() => {
                         setTeamModelAliases(info.litellm_model_table?.model_aliases ?? {});
                         startEditing();
                       }}
                     >
+                      <EditOutlined className="h-4 w-4" />
                       Edit Settings
                     </Button>
                   )}
@@ -1444,7 +1447,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                                   />
                                 )}
                               </FormField>
-                              <UIButton
+                              <Button
                                 type="button"
                                 variant="ghost"
                                 size="icon"
@@ -1453,10 +1456,10 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                                 onClick={() => removeModelLimit(index)}
                               >
                                 <CircleMinus className="size-4" />
-                              </UIButton>
+                              </Button>
                             </div>
                           ))}
-                          <UIButton
+                          <Button
                             type="button"
                             variant="outline"
                             className="w-full border-dashed"
@@ -1464,7 +1467,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                           >
                             <Plus className="size-4" />
                             Add Model Limit
-                          </UIButton>
+                          </Button>
                         </Field>
 
                         <FormField
@@ -1749,18 +1752,18 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
                       <div className="sticky z-10 -inset-x-6 -bottom-6 border-t border-gray-200 bg-white p-4 pr-0">
                         <div className="flex items-center justify-end gap-2">
-                          <UIButton
+                          <Button
                             type="button"
                             variant="outline"
                             onClick={() => setIsEditing(false)}
                             disabled={isTeamSaving}
                           >
                             Cancel
-                          </UIButton>
-                          <UIButton type="submit" disabled={isTeamSaving}>
+                          </Button>
+                          <Button type="submit" disabled={isTeamSaving}>
                             {isTeamSaving ? <UiLoadingSpinner className="size-4" /> : <Save className="size-4" />}
                             Save Changes
-                          </UIButton>
+                          </Button>
                         </div>
                       </div>
                     </form>


### PR DESCRIPTION
## TLDR

Problem this solves:

- antd `Button` still rendered 58 controls across 24 files
- Mixed Button libraries drift apart visually and in behavior
- The antd import ban cannot reach zero while they remain

How it solves it:

- Moves every antd `Button` onto the shadcn `Button`
- Maps antd props to shadcn variants using already-merged precedent
- Clears antd entirely from two files, pruning their lint suppressions

## User Flow

This is a refactor, so every control keeps its label, position and handler. One link genuinely changes behavior for the user, and that is the flow below

Before: an admin reading the MCP connect instructions loses the page when they follow the transports docs link

1. They open http://localhost:4000/ui/?page=mcp-servers and select a server, then the Connect tab
2. They click "Learn more about MCP transports"
3. The dashboard navigates away to modelcontextprotocol.io in the same tab, so the server view and any unsaved state is gone, and they have to come back and re-select the server

After: the same link opens alongside the dashboard

1. They open http://localhost:4000/ui/?page=mcp-servers and select a server, then the Connect tab
2. They click "Learn more about MCP transports"
3. The docs open in a new tab and the dashboard stays exactly where it was, still on the same server

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

## Type

🧹 Refactoring

## Caveats (if any)

- The transports docs link now opens in a new tab
- Two files go antd-free; the other 22 keep other antd imports
