### PR TITLE
fix(anthropic): handle Authorization header case-insensitively

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -83,7 +83,10 @@ def optionally_handle_anthropic_oauth(headers: dict, api_key: str | None) -> tup
         Tuple of (updated headers, api_key)
     """
     # Check Authorization header (passthrough / forwarded requests)
-    auth_header: Final = headers.get("authorization", "")
+    auth_header: Final = next(
+        (value for key, value in headers.items() if key.lower() == "authorization"),
+        "",
+    )
     if auth_header and auth_header.startswith(f"Bearer {ANTHROPIC_OAUTH_TOKEN_PREFIX}"):
         api_key = auth_header.replace("Bearer ", "")
         headers.pop("x-api-key", None)

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -47,6 +47,24 @@ class TestOptionallyHandleAnthropicOAuth:
         assert updated_headers["anthropic-dangerous-direct-browser-access"] == "true"
         assert "x-api-key" not in updated_headers
 
+    def test_oauth_token_in_capitalized_authorization_header(self):
+        """OAuth detection should treat HTTP header names as case-insensitive."""
+        from litellm.llms.anthropic.common_utils import (
+            optionally_handle_anthropic_oauth,
+        )
+
+        headers = {"Authorization": f"Bearer {FAKE_OAUTH_TOKEN}"}
+        updated_headers, extracted_api_key = optionally_handle_anthropic_oauth(
+            headers, None
+        )
+
+        assert extracted_api_key == FAKE_OAUTH_TOKEN
+        assert updated_headers["anthropic-beta"] == "oauth-2025-04-20"
+        assert (
+            updated_headers["anthropic-dangerous-direct-browser-access"] == "true"
+        )
+        assert "x-api-key" not in updated_headers
+
     def test_oauth_token_in_api_key_directly(self):
         """OAuth token passed as api_key should set Authorization: Bearer header."""
         from litellm.llms.anthropic.common_utils import (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Capitalized `Authorization` headers bypass Anthropic OAuth detection.
- Standard HTTP header casing can therefore break OAuth requests.

How it solves it:

- Looks up `Authorization` header names case-insensitively.
- Adds a regression test for capitalized header casing.

## User Flow

Before: a developer sends an Anthropic OAuth token using the standard `Authorization` header casing, but LiteLLM does not recognize it as OAuth.

1. They send an Anthropic request with `Authorization: Bearer sk-ant-oat...`.
2. LiteLLM fails to recognize that capitalized header as the OAuth credential.
3. The request does not receive the expected Anthropic OAuth authentication handling.

After: the same request is recognized regardless of HTTP header-name casing.

1. They send the same Anthropic request with `Authorization: Bearer sk-ant-oat...`.
2. LiteLLM recognizes the OAuth credential case-insensitively.
3. The request receives the expected Anthropic OAuth authentication handling.

## Relevant issues


## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

No live E2E proof attached yet. This draft currently includes regression-test coverage for the header-casing behavior.

## Type

🐛 Bug Fix

## Caveats (if any)

- `make lint` passes locally.
- Anthropic common-utils tests pass: 152/152.
- LLM suite: 9003 passed, 83 skipped, 1 unrelated Vertex AI failure.
- Repository-wide `make test-unit` hit an unrelated pytest collection collision.

### Final Attestation

- [x] The regression test covers the capitalized `Authorization` edge case.
