### PR TITLE
fix(proxy): accept inherited model sentinels in project key limits

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1416,6 +1416,11 @@ async def _check_team_key_limits(
     )
 
 
+_INHERITED_MODEL_SENTINELS: Final = frozenset(
+    {SpecialModelNames.all_team_models.value, SpecialModelNames.all_proxy_models.value}
+)
+
+
 async def _check_project_key_limits(
     project_id: str,
     data: GenerateKeyRequest | UpdateKeyRequest,
@@ -1425,7 +1430,8 @@ async def _check_project_key_limits(
     """
     Validate that key's models and budget respect its project's limits.
 
-    - Key models must be a subset of project models
+    - Key models must be a subset of project models, except the all-team-models / all-proxy-models
+      sentinels, which inherit a parent scope and are narrowed by the project at request time
     - Key max_budget must be <= project max_budget
     """
     project_obj: Final = await get_project_object(
@@ -1443,7 +1449,7 @@ async def _check_project_key_limits(
     # Validate key models are a subset of project models
     if data.models and len(project_obj.models) > 0:
         for m in data.models:
-            if m not in project_obj.models:
+            if m not in project_obj.models and m not in _INHERITED_MODEL_SENTINELS:
                 raise HTTPException(
                     status_code=400,
                     detail={

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -22,6 +22,7 @@ from litellm.proxy._types import (
     NewUserRequest,
     LiteLLM_BudgetTable,
     LiteLLM_OrganizationTable,
+    LiteLLM_ProjectTableCachedObj,
     LiteLLM_TeamTableCachedObj,
     LiteLLM_UserTable,
     LiteLLM_VerificationToken,
@@ -31,9 +32,12 @@ from litellm.proxy._types import (
     ResetSpendRequest,
     UpdateKeyRequest,
 )
+from litellm.proxy.auth.auth_checks import _project_cache_key
 from litellm.proxy.auth.user_api_key_auth import UserAPIKeyAuth
+from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     _check_org_key_limits,
+    _check_project_key_limits,
     _check_team_key_limits,
     _common_key_generation_helper,
     _enforce_upperbound_key_params,
@@ -16444,3 +16448,49 @@ async def test_regenerate_key_repoints_live_membership_not_the_key_row_it_read(
     assert await _authorized_models_for_key(
         access_groups, new_token_hash, ["ag-revoked-since", "ag-attached-since"]
     ) == ["attached-model"]
+
+
+async def _cache_with_project(project_id: str, project_models: list[str]) -> UserApiKeyCache:
+    user_api_key_cache = UserApiKeyCache()
+    await user_api_key_cache.async_set_cache(
+        key=_project_cache_key(project_id),
+        value=LiteLLM_ProjectTableCachedObj(project_id=project_id, team_id="team-lit-5823", models=project_models),
+        model_type=LiteLLM_ProjectTableCachedObj,
+    )
+    return user_api_key_cache
+
+
+@pytest.mark.parametrize("request_cls", [GenerateKeyRequest, UpdateKeyRequest])
+@pytest.mark.parametrize("sentinel", ["all-team-models", "all-proxy-models"])
+@pytest.mark.asyncio
+async def test_check_project_key_limits_accepts_inherited_model_sentinels(request_cls, sentinel):
+    """LIT-5823: the sentinels inherit a parent scope, so a project allowlist must not treat them as model names."""
+    user_api_key_cache = await _cache_with_project("proj-lit-5823", ["gpt-5.4-nano"])
+
+    await _check_project_key_limits(
+        project_id="proj-lit-5823",
+        data=request_cls(key="sk-lit-5823", models=[sentinel]),
+        prisma_client=MagicMock(),
+        user_api_key_cache=user_api_key_cache,
+    )
+
+
+@pytest.mark.parametrize("request_cls", [GenerateKeyRequest, UpdateKeyRequest])
+@pytest.mark.parametrize(
+    "key_models",
+    [["gpt-5.4-mini"], ["all-team-models", "gpt-5.4-mini"], ["gpt-5.4-nano", "all-proxy-models", "gpt-5.4-mini"]],
+)
+@pytest.mark.asyncio
+async def test_check_project_key_limits_still_rejects_real_model_outside_project(request_cls, key_models):
+    user_api_key_cache = await _cache_with_project("proj-lit-5823", ["gpt-5.4-nano"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _check_project_key_limits(
+            project_id="proj-lit-5823",
+            data=request_cls(key="sk-lit-5823", models=key_models),
+            prisma_client=MagicMock(),
+            user_api_key_cache=user_api_key_cache,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "Model 'gpt-5.4-mini' not in project's allowed models" in exc_info.value.detail["error"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Keys under a project reject the `all-team-models` sentinel
- Both `/key/generate` and `/key/update` 400 on it
- Team-level validation already accepts the sentinel; project-level did not

How it solves it:

- Project model check now skips `all-team-models` / `all-proxy-models`
- Request-time project enforcement still narrows what the key can call

## User Flow

Before: an admin creating a key under a project cannot give it the team's inherited model access; the sentinel is rejected as if it were a model name

1. The admin sends POST https://litellm-domain/key/generate with `{"team_id": "...", "project_id": "...", "models": ["all-team-models"]}`
2. The response is HTTP 400 with `Model 'all-team-models' not in project's allowed models. Project allowed models=['gpt-5.4-nano']`
3. They try flipping an existing project key instead, POST https://litellm-domain/key/update with `{"key": "sk-...", "models": ["all-team-models"]}`, and get the same 400
4. Their only workaround is hand-listing model names on every key, so keys stop tracking the team's list when it changes
5. No one gains or loses model access; key issuance under projects is simply broken for inherited scopes

After: the same request succeeds, and the key is still narrowed by the project's allowlist when it is used

1. The admin sends POST https://litellm-domain/key/generate with `{"team_id": "...", "project_id": "...", "models": ["all-team-models"]}`
2. The response is HTTP 200 and the key object shows `"models": ["all-team-models"]` with the project id attached
3. POST https://litellm-domain/key/update flipping an existing project key to `["all-team-models"]` also returns HTTP 200
4. A request with that key to a project-allowed model, POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.4-nano"`, returns HTTP 200 with a real completion
5. The same key on a team-allowed but project-excluded model, `"model": "gpt-5.4-mini"`, returns HTTP 403 `project not allowed to access model`, so the key holder still cannot reach anything outside the project's allowlist

## Relevant issues

## Linear ticket

Resolves LIT-5823

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup (fresh Postgres DB, proxy from the named commit, config with `gpt-5.4-nano` and `gpt-5.4-mini` served via `openai/`, enterprise license set so projects are available):

```bash
P=<proxy port>; K=sk-lit5823-master
TEAM_ID=$(curl -s -X POST http://127.0.0.1:$P/team/new -H "Authorization: Bearer $K" -H 'Content-Type: application/json' -d '{"team_alias":"lit5823-team","models":["gpt-5.4-nano","gpt-5.4-mini"]}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["team_id"])')
PROJECT_ID=$(curl -s -X POST http://127.0.0.1:$P/project/new -H "Authorization: Bearer $K" -H 'Content-Type: application/json' -d "{\"project_alias\":\"lit5823-project\",\"team_id\":\"$TEAM_ID\",\"models\":[\"gpt-5.4-nano\"]}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["project_id"])')
```

### Before (e126975468)

#### Generate a project key with the sentinel

1. `curl -s -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:$P/key/generate -H "Authorization: Bearer $K" -H 'Content-Type: application/json' -d "{\"team_id\":\"$TEAM_ID\",\"project_id\":\"$PROJECT_ID\",\"models\":[\"all-team-models\"],\"key_alias\":\"lit5823-sentinel-key\"}"`
2. Output:

```
{"error":{"message":"{'error': \"Model 'all-team-models' not in project's allowed models. Project allowed models=['gpt-5.4-nano']. Project: 0d2181c7-d99e-45e3-a93f-10764bb7243e\"}","type":"internal_server_error","param":"None","code":"400"}}
HTTP 400
```

#### Update a project key to the sentinel

1. Generate a plain in-project key: `NANO_KEY=$(curl -s -X POST http://127.0.0.1:$P/key/generate -H "Authorization: Bearer $K" -H 'Content-Type: application/json' -d "{\"team_id\":\"$TEAM_ID\",\"project_id\":\"$PROJECT_ID\",\"models\":[\"gpt-5.4-nano\"],\"key_alias\":\"lit5823-nano-key\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["key"])')` (HTTP 200)
2. `curl -s -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:$P/key/update -H "Authorization: Bearer $K" -H 'Content-Type: application/json' -d "{\"key\":\"$NANO_KEY\",\"models\":[\"all-team-models\"]}"`
3. Output:

```
{"error":{"message":"{'error': \"Model 'all-team-models' not in project's allowed models. Project allowed models=['gpt-5.4-nano']. Project: 0d2181c7-d99e-45e3-a93f-10764bb7243e\"}","type":"auth_error","param":"None","code":"400"}}
HTTP 400
```

#### Sentinel key at request time

1. No sentinel-scoped key exists to call with: the generate case above returned HTTP 400, so this case cannot run on this commit

#### Control: real out-of-project model still rejected

1. `curl -s -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:$P/key/generate -H "Authorization: Bearer $K" -H 'Content-Type: application/json' -d "{\"team_id\":\"$TEAM_ID\",\"project_id\":\"$PROJECT_ID\",\"models\":[\"gpt-5.4-mini\"],\"key_alias\":\"lit5823-mini-key\"}"`
2. Output:

```
{"error":{"message":"{'error': \"Model 'gpt-5.4-mini' not in project's allowed models. Project allowed models=['gpt-5.4-nano']. Project: 0d2181c7-d99e-45e3-a93f-10764bb7243e\"}","type":"internal_server_error","param":"None","code":"400"}}
HTTP 400
```

### After (74f12bf6ef)

#### Generate a project key with the sentinel

1. Same generate command as Before
2. Output (HTTP 200, key carries the sentinel and the project id):

```
{"key_alias":"lit5823-sentinel-key-p2","duration":null,"models":["all-team-models"],"spend":0.0, ... ,"key":"sk-W24-lKxbI23CRXaWd839WQ", ... ,"project_id":"0d2181c7-d99e-45e3-a93f-10764bb7243e", ... }
HTTP 200
```

#### Update a project key to the sentinel

1. Generate a plain in-project key as in Before (HTTP 200)
2. Same update command as Before
3. Output (HTTP 200, models flipped to the sentinel):

```
{"key":"sk-bBEoVplWRISuPyl05WXA8A", ... ,"models":["all-team-models"], ... ,"team_id":"da5609a3-05ee-4da5-9c6a-cb456bf8d2b4","project_id":"0d2181c7-d99e-45e3-a93f-10764bb7243e", ... }
HTTP 200
```

#### Sentinel key at request time

1. Project-allowed model with the sentinel key: `curl -s -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:$P/v1/chat/completions -H "Authorization: Bearer sk-W24-..." -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-nano","messages":[{"role":"user","content":"Say exactly: lit5823 ok"}]}'`
2. Output (real OpenAI completion):

```
{"id":"chatcmpl-EEhlsyP0f608IS3hUXjiOHqF0P4g5","created":1787173556,"model":"gpt-5.4-nano","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"lit5823 ok","role":"assistant", ... }}],"usage":{"completion_tokens":7,"prompt_tokens":13,"total_tokens":20, ... }}
HTTP 200
```

3. Team-allowed but project-excluded model with the same key: same command with `"model":"gpt-5.4-mini"`
4. Output (the sentinel does not widen the key past the project):

```
{"error":{"message":"project not allowed to access model. This project can only access models=['gpt-5.4-nano']. Tried to access gpt-5.4-mini","type":"project_model_access_denied","param":"model","code":"403"}}
HTTP 403
```

#### Control: real out-of-project model still rejected

1. Same generate command as Before with `gpt-5.4-mini`
2. Output:

```
{"error":{"message":"{'error': \"Model 'gpt-5.4-mini' not in project's allowed models. Project allowed models=['gpt-5.4-nano']. Project: 0d2181c7-d99e-45e3-a93f-10764bb7243e\"}","type":"internal_server_error","param":"None","code":"400"}}
HTTP 400
```

QA observations:

- Same 400 typed internal_server_error on generate, auth_error on update
- Pre-existing inconsistency; this PR leaves it alone
- /v1/models on a sentinel project key lists project-excluded team models
- Calls to those still 403; cosmetic, newly reachable state

## Type

🐛 Bug Fix

## Caveats (if any)

- Error `type` differs between generate and update for identical 400s; pre-existing
- /v1/models does not project-filter sentinel keys; calls still enforced

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 74f12bf6efbd931eb28b11015a7998cc95e455fd passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 74f12bf6efbd931eb28b11015a7998cc95e455fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->