### PR TITLE
fix(proxy): populate deployment attribution on failed-request spend logs

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -216,6 +216,15 @@ def _extract_usage_for_ocr_call(response_obj: Any, response_obj_dict: dict) -> d
         return {}
 
 
+def _sl_attribution_fallback(
+    standard_logging_payload: StandardLoggingPayload | None,
+    field: Literal["model_id", "model_group", "api_base", "custom_llm_provider"],
+) -> str:
+    if standard_logging_payload is None:
+        return ""
+    return standard_logging_payload.get(field) or ""
+
+
 def get_logging_payload(kwargs, response_obj, start_time, end_time) -> SpendLogsPayload:
     if kwargs is None:
         kwargs = {}
@@ -288,8 +297,15 @@ def get_logging_payload(kwargs, response_obj, start_time, end_time) -> SpendLogs
     ):  # use 'tags' from standard logging payload instead
         request_tags = safe_dumps(standard_logging_payload["request_tags"])
 
-    _model_id: Final = metadata.get("model_info", {}).get("id", "")
-    _model_group: Final = metadata.get("model_group", "")
+    _model_id: Final = metadata.get("model_info", {}).get("id", "") or _sl_attribution_fallback(
+        standard_logging_payload, "model_id"
+    )
+    _model_group: Final = metadata.get("model_group", "") or _sl_attribution_fallback(
+        standard_logging_payload, "model_group"
+    )
+    _api_base: Final = litellm_params.get("api_base", "") or _sl_attribution_fallback(
+        standard_logging_payload, "api_base"
+    )
 
     # Extract overhead from hidden_params if available
     litellm_overhead_time_ms = None
@@ -389,7 +405,11 @@ def get_logging_payload(kwargs, response_obj, start_time, end_time) -> SpendLogs
 
     # Extract agent_id for A2A requests (set directly on model_call_details)
     agent_id: Final[str | None] = kwargs.get("agent_id") or metadata.get("agent_id")
-    custom_llm_provider: Final = kwargs.get("custom_llm_provider")
+    custom_llm_provider: Final = (
+        kwargs.get("custom_llm_provider")
+        or _sl_attribution_fallback(standard_logging_payload, "custom_llm_provider")
+        or None
+    )
     raw_model: Final = cast(str, kwargs.get("model") or "")
     model_name: Final = reconstruct_model_name(raw_model, custom_llm_provider, metadata or {})
 
@@ -414,13 +434,13 @@ def get_logging_payload(kwargs, response_obj, start_time, end_time) -> SpendLogs
             completion_tokens=usage.get("completion_tokens", standard_logging_completion_tokens),
             request_tags=request_tags,
             end_user=end_user_id or "",
-            api_base=litellm_params.get("api_base", ""),
+            api_base=_api_base,
             model_group=_model_group,
             model_id=_model_id,
             mcp_namespaced_tool_name=mcp_namespaced_tool_name,
             agent_id=agent_id,
             requester_ip_address=clean_metadata.get("requester_ip_address", None),
-            custom_llm_provider=kwargs.get("custom_llm_provider", ""),
+            custom_llm_provider=custom_llm_provider or "",
             messages=_get_messages_for_spend_logs_payload(
                 standard_logging_payload=standard_logging_payload, metadata=metadata
             ),

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -539,7 +539,7 @@ def _failure_fields_to_lift(request_data: Mapping[str, object]) -> Mapping[str, 
     _entries: Final = (
         ("first_api_call_start_time", _first_handoff),
         ("combined_usage_object", None if _usage_to_lift is None else _usage_to_lift[0]),
-        ("response_cost", None if _usage_to_lift is None else _usage_to_lift[1]),
+        ("response_cost", None if _usage_to_lift is None else (_usage_to_lift[1] or 0.0)),
         ("standard_logging_object", _model_call_details.get("standard_logging_object")),
     )
     return MappingProxyType({key: value for key, value in _entries if value is not None})
@@ -2322,6 +2322,9 @@ class ProxyLogging:
                 original_exception=original_exception,
             )
 
+        # Auth and pass-through failures reach this hook with the raw request
+        # body unstripped, so only the logging object may supply this key.
+        request_data.pop("standard_logging_object", None)
         request_data.update(_failure_fields_to_lift(request_data))
 
         # Remove before callbacks iterate — not serialisable

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -517,6 +517,34 @@ def _failure_usage_to_lift(
     return estimated_usage, 0.0
 
 
+_EMPTY_LIFT: Final = MappingProxyType({})
+
+
+def _failure_fields_to_lift(request_data: Mapping[str, object]) -> Mapping[str, object]:
+    """Failure-path callbacks run after ``litellm_logging_obj`` is popped from
+    request_data (it is not serialisable), so the caller merges these fields
+    onto request_data first: the first-handoff instant for preprocessing
+    latency, recovered or estimated usage for token counts, and the standard
+    logging object for deployment attribution on failed-request spend logs."""
+    _logging_obj: Final = request_data.get("litellm_logging_obj")
+    if _logging_obj is None:
+        return _EMPTY_LIFT
+    _model_call_details: Final = getattr(_logging_obj, "model_call_details", {})
+    _first_handoff: Final = _model_call_details.get("first_api_call_start_time")
+    _usage_to_lift: Final = _failure_usage_to_lift(
+        model_call_details=_model_call_details,
+        request_body=request_data,
+        dispatched=_first_handoff is not None,
+    )
+    _entries: Final = (
+        ("first_api_call_start_time", _first_handoff),
+        ("combined_usage_object", None if _usage_to_lift is None else _usage_to_lift[0]),
+        ("response_cost", None if _usage_to_lift is None else _usage_to_lift[1]),
+        ("standard_logging_object", _model_call_details.get("standard_logging_object")),
+    )
+    return MappingProxyType({key: value for key, value in _entries if value is not None})
+
+
 @dataclass(frozen=True)
 class _CallbackCapabilities:
     """Cached per-hook capability flags derived from ``litellm.callbacks``.
@@ -2294,29 +2322,7 @@ class ProxyLogging:
                 original_exception=original_exception,
             )
 
-        # Lift the first-handoff instant onto request_data (top-level
-        # internal key, not metadata) so failure-path callbacks can still
-        # compute preprocessing latency after the logging object is popped.
-        _logging_obj: Final = request_data.get("litellm_logging_obj")
-        if _logging_obj is not None:
-            _model_call_details: Final = getattr(_logging_obj, "model_call_details", {})
-            _first_handoff: Final = _model_call_details.get("first_api_call_start_time")
-            if _first_handoff is not None:
-                request_data["first_api_call_start_time"] = _first_handoff
-
-            # Lift recovered partial-stream usage, or an estimated input-side
-            # usage for a dispatched failure, onto request_data so the
-            # failure-path spend callbacks (which run after the logging object
-            # is popped) record real token counts instead of zero.
-            _usage_to_lift: Final = _failure_usage_to_lift(
-                model_call_details=_model_call_details,
-                request_body=request_data,
-                dispatched=_first_handoff is not None,
-            )
-            if _usage_to_lift is not None:
-                _lifted_usage, _lifted_cost = _usage_to_lift
-                request_data["combined_usage_object"] = _lifted_usage
-                request_data["response_cost"] = _lifted_cost
+        request_data.update(_failure_fields_to_lift(request_data))
 
         # Remove before callbacks iterate — not serialisable
         request_data.pop("litellm_logging_obj", None)

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2309,6 +2309,11 @@ class ProxyLogging:
                 )
             )
 
+        # Auth and pass-through failure bodies are unstripped client input, and
+        # the logging handler below flattens body keys into model_call_details,
+        # so drop the key before it can masquerade as the built payload.
+        request_data.pop("standard_logging_object", None)
+
         ### LOGGING ###
         if self._is_proxy_only_llm_api_error(
             original_exception=original_exception,
@@ -2322,9 +2327,6 @@ class ProxyLogging:
                 original_exception=original_exception,
             )
 
-        # Auth and pass-through failures reach this hook with the raw request
-        # body unstripped, so only the logging object may supply this key.
-        request_data.pop("standard_logging_object", None)
         request_data.update(_failure_fields_to_lift(request_data))
 
         # Remove before callbacks iterate — not serialisable

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -3164,3 +3164,80 @@ def test_batch_cost_row_id_is_stable_across_repeated_accounting():
     ]
 
     assert ids[0] == ids[1] == "batch_same_batch_cost"
+
+
+def _make_failed_request_standard_logging_payload() -> StandardLoggingPayload:
+    base: Final = _make_standard_logging_payload_with_usage_object(usage_object={})
+    return cast(
+        StandardLoggingPayload,
+        {
+            **base,
+            "status": "failure",
+            "call_type": "aresponses",
+            "model_id": "mid-123",
+            "model_group": "group-x",
+            "api_base": "https://api.openai.com/v1/responses",
+            "custom_llm_provider": "openai",
+        },
+    )
+
+
+def test_get_logging_payload_failed_request_falls_back_to_standard_logging_payload():
+    """Failed-request kwargs from the proxy failure hook carry no deployment info
+    (LIT-5795), so the attribution columns must come from the failure-time
+    standard_logging_object."""
+    payload = get_logging_payload(
+        kwargs={
+            "model": "group-x",
+            "litellm_params": {"metadata": {"user_api_key": "test-key", "status": "failure"}},
+            "standard_logging_object": _make_failed_request_standard_logging_payload(),
+        },
+        response_obj={},
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+    assert payload["model_id"] == "mid-123"
+    assert payload["model_group"] == "group-x"
+    assert payload["api_base"] == "https://api.openai.com/v1/responses"
+    assert payload["custom_llm_provider"] == "openai"
+
+
+def test_get_logging_payload_request_kwargs_win_over_standard_logging_payload():
+    payload = get_logging_payload(
+        kwargs={
+            "model": "group-y",
+            "custom_llm_provider": "anthropic",
+            "litellm_params": {
+                "api_base": "https://kwargs.example.com",
+                "metadata": {
+                    "user_api_key": "test-key",
+                    "model_group": "kwargs-group",
+                    "model_info": {"id": "kwargs-mid"},
+                },
+            },
+            "standard_logging_object": _make_failed_request_standard_logging_payload(),
+        },
+        response_obj={},
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+    assert payload["model_id"] == "kwargs-mid"
+    assert payload["model_group"] == "kwargs-group"
+    assert payload["api_base"] == "https://kwargs.example.com"
+    assert payload["custom_llm_provider"] == "anthropic"
+
+
+def test_get_logging_payload_failed_request_without_standard_logging_payload_leaves_fields_empty():
+    payload = get_logging_payload(
+        kwargs={
+            "model": "group-x",
+            "litellm_params": {"metadata": {"user_api_key": "test-key", "status": "failure"}},
+        },
+        response_obj={},
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+    assert payload["model_id"] == ""
+    assert payload["model_group"] == ""
+    assert payload["api_base"] == ""
+    assert payload["custom_llm_provider"] == ""

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -557,6 +557,41 @@ class TestPostCallFailureHookLiftsStandardLoggingObject:
         assert "standard_logging_object" not in request_data_with_obj
 
     @pytest.mark.asyncio
+    async def test_pass_through_failure_never_relifts_client_supplied_key(self):
+        from datetime import datetime
+        from unittest.mock import AsyncMock, patch
+
+        from fastapi import HTTPException
+
+        from litellm.litellm_core_utils.litellm_logging import Logging
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        logging_obj = Logging(
+            model="claude-haiku-4-5",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=False,
+            call_type="pass_through_endpoint",
+            start_time=datetime.now(),
+            litellm_call_id="test-call-id",
+            function_id="test-function-id",
+        )
+        request_data = {
+            "litellm_logging_obj": logging_obj,
+            "standard_logging_object": {"model_id": "client-injected"},
+            "metadata": {},
+        }
+        proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
+        proxy_logging_obj.alert_types = []
+        with patch.object(proxy_logging_obj, "update_request_status", new=AsyncMock()):
+            await proxy_logging_obj.post_call_failure_hook(
+                request_data=request_data,
+                original_exception=HTTPException(status_code=401, detail="unauthorized"),
+                user_api_key_dict=UserAPIKeyAuth(request_route="/v1/chat/completions"),
+            )
+        assert "standard_logging_object" not in request_data
+        assert "standard_logging_object" not in logging_obj.model_call_details
+
+    @pytest.mark.asyncio
     async def test_no_standard_logging_object_is_noop(self):
         logging_obj = MagicMock()
         logging_obj.model_call_details = {}

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -478,6 +478,59 @@ class TestPostCallFailureHookLiftsRecoveredPartialSpend:
         assert "response_cost" not in request_data
 
 
+class TestPostCallFailureHookLiftsStandardLoggingObject:
+    """Failure callbacks read standard_logging_object from request_data, but
+    post_call_failure_hook pops litellm_logging_obj before they run. The hook
+    must lift the logging obj's standard_logging_object onto request_data so
+    failed-request spend logs keep deployment attribution (LIT-5795).
+    """
+
+    async def _run(self, request_data):
+        from unittest.mock import AsyncMock, patch
+
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
+        proxy_logging_obj.alert_types = []
+        with patch.object(proxy_logging_obj, "update_request_status", new=AsyncMock()):
+            await proxy_logging_obj.post_call_failure_hook(
+                request_data=request_data,
+                original_exception=Exception("boom"),
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_lifts_standard_logging_object(self):
+        sl_object = {"model_id": "mid-123", "model_group": "group-x"}
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {"standard_logging_object": sl_object}
+        request_data = {"litellm_logging_obj": logging_obj, "metadata": {}}
+        await self._run(request_data)
+        assert request_data["standard_logging_object"] is sl_object
+        assert "litellm_logging_obj" not in request_data
+
+    @pytest.mark.asyncio
+    async def test_logging_obj_value_overwrites_preexisting_key(self):
+        authoritative = {"model_id": "from-logging-obj"}
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {"standard_logging_object": authoritative}
+        request_data = {
+            "litellm_logging_obj": logging_obj,
+            "standard_logging_object": {"model_id": "client-injected"},
+            "metadata": {},
+        }
+        await self._run(request_data)
+        assert request_data["standard_logging_object"] is authoritative
+
+    @pytest.mark.asyncio
+    async def test_no_standard_logging_object_is_noop(self):
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {}
+        request_data = {"litellm_logging_obj": logging_obj, "metadata": {}}
+        await self._run(request_data)
+        assert "standard_logging_object" not in request_data
+
+
 class TestPostCallFailureHookEstimatesDispatchedInputTokens:
     """A non-stream request that failed after dispatch (timeout, provider
     error) consumed provider-billed input tokens but recovered no usage.

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -469,6 +469,23 @@ class TestPostCallFailureHookLiftsRecoveredPartialSpend:
         assert "litellm_logging_obj" not in request_data
 
     @pytest.mark.asyncio
+    async def test_recovered_usage_without_cost_clobbers_client_cost_with_zero(self):
+        from litellm.types.utils import Usage
+
+        recovered_usage = Usage(prompt_tokens=30, completion_tokens=1, total_tokens=31)
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {"combined_usage_object": recovered_usage}
+        request_data = {
+            "litellm_logging_obj": logging_obj,
+            "response_cost": 999.0,
+            "metadata": {},
+        }
+        await self._run(request_data)
+
+        assert request_data["combined_usage_object"] is recovered_usage
+        assert request_data["response_cost"] == 0.0
+
+    @pytest.mark.asyncio
     async def test_no_recovered_usage_is_noop(self):
         logging_obj = MagicMock()
         logging_obj.model_call_details = {}
@@ -521,6 +538,23 @@ class TestPostCallFailureHookLiftsStandardLoggingObject:
         }
         await self._run(request_data)
         assert request_data["standard_logging_object"] is authoritative
+
+    @pytest.mark.asyncio
+    async def test_client_supplied_key_is_stripped_when_logging_obj_supplies_none(self):
+        spoofed = {"model_id": "client-injected"}
+        request_data = {"standard_logging_object": spoofed, "metadata": {}}
+        await self._run(request_data)
+        assert "standard_logging_object" not in request_data
+
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {}
+        request_data_with_obj = {
+            "litellm_logging_obj": logging_obj,
+            "standard_logging_object": spoofed,
+            "metadata": {},
+        }
+        await self._run(request_data_with_obj)
+        assert "standard_logging_object" not in request_data_with_obj
 
     @pytest.mark.asyncio
     async def test_no_standard_logging_object_is_noop(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Failed requests log with blank model id, api base, model group
- /v1/responses and /v1/messages failures lose the deployment entirely
- Admins cannot tell which deployment or provider a failure hit

How it solves it:

- Failure logging already builds a payload carrying the deployment details
- That payload now rides along into the failed request's spend log
- Spend log attribution columns fall back to it when blank
- Values resolved at request time still win; success rows unchanged
- Client-sent logging fields in the raw body are stripped first
- A recovered token count with unknown cost records $0

## User Flow

Before: the admin investigating a failed call finds the log row blank on every deployment field, so they cannot tell which deployment failed

1. A developer sends POST https://litellm-domain/v1/responses with `"model": "gpt-5.4-mini"` and a `"previous_response_id"` that no longer exists
2. They get back a 400 with "Previous response with id 'resp_ffff...' not found."
3. The admin opens https://litellm-domain/ui/?page=logs and clicks the failed row
4. Model ID, API Base, and Model Group all show "-", and Provider is blank, so nothing says which deployment or upstream endpoint the failure hit
5. Separately, any caller who adds a `"standard_logging_object": {...}` field to their request body makes their failed call vanish from https://litellm-domain/ui/?page=logs entirely, even when the call was rejected for a bad key, so their failures leave no audit trail

After: the same failed row names the deployment, its API base, its model group, and the provider, and the doctored request body changes nothing

1. A developer sends POST https://litellm-domain/v1/responses with `"model": "gpt-5.4-mini"` and a `"previous_response_id"` that no longer exists
2. They get back the same 400
3. The admin opens https://litellm-domain/ui/?page=logs and clicks the failed row
4. Model ID shows the deployment's id, API Base shows `https://api.openai.com/v1/responses`, Model Group shows `gpt-5.4-mini`, and Provider shows `openai`, exactly like the neighboring success rows
5. The caller who adds `"standard_logging_object": {...}` or `"response_cost": 123.45` to their request body no longer hides or reprices anything: the failed call still shows up in the logs with its own row and a spend of $0

## Relevant issues

## Linear ticket

Resolves LIT-5795

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs ran a live proxy from a detached worktree at the named commit, each with its own Postgres DB, real OpenAI and Anthropic API calls, and no mocks (Before on port 51830, After on port 52741). Three deployments: `gpt-5.4-mini` (openai/gpt-5.4-mini, valid key), `claude-haiku-4-5` (anthropic/claude-haiku-4-5, valid key), and `broken-gpt` (openai/gpt-5.4-mini with an invalid api_key). Evidence surface is the route the Admin UI Logs page is backed by, jq-projected to the attribution fields:

```bash
curl -s "http://127.0.0.1:<port>/spend/logs?summarize=false&start_date=2026-08-19&end_date=2026-08-20" \
  -H "Authorization: Bearer sk-1234" \
  | jq '[.[] | select(.status == "failure")] | map({request_id, status, call_type, model, model_id, model_group, api_base, custom_llm_provider})'
```

### Before (e126975468ee9dbc981b2458b4f7fed2c60c80f1)

#### /v1/responses (previous_response_id not found)

1. Failing request:

```bash
curl -s -w "\nHTTP_STATUS:%{http_code}\n" http://127.0.0.1:51830/v1/responses \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.4-mini","input":"say hi","previous_response_id":"resp_ffffffffffffffffffffffffffffffff"}'
```

2. Observed response:

```
{"error":{"message":"litellm.BadRequestError: OpenAIException - ... \"Previous response with id 'resp_ffffffffffffffffffffffffffffffff' not found.\" ...","type":null,"param":null,"code":"400"}}
HTTP_STATUS:400
```

3. Waited ~14s for the spend log writer flush, then queried the logs API. Observed failure row, every attribution field empty:

```json
{
  "request_id": "8bc84232-5035-4f52-bc07-54f8f8fd47fe",
  "status": "failure",
  "call_type": "",
  "model": "gpt-5.4-mini",
  "model_id": "",
  "model_group": "",
  "api_base": "",
  "custom_llm_provider": ""
}
```

#### /v1/chat/completions (invalid provider key on deployment broken-gpt)

1. Failing request:

```bash
curl -s -w "\nHTTP_STATUS:%{http_code}\n" http://127.0.0.1:51830/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"broken-gpt","messages":[{"role":"user","content":"hi"}]}'
```

2. Observed response:

```
{"error":{"message":"litellm.AuthenticationError: AuthenticationError: OpenAIException - Incorrect API key provided: sk-inval************epro. ...","type":null,"param":null,"code":"401"}}
HTTP_STATUS:401
```

3. Waited ~14s, queried the logs API. Observed failure row: model_id and model_group populated on this endpoint at base, but api_base and custom_llm_provider empty:

```json
{
  "request_id": "6bdf06fc-1d3a-4a3d-a0b1-ca080ea173fb",
  "status": "failure",
  "call_type": "",
  "model": "openai/gpt-5.4-mini",
  "model_id": "92b96561548bf3aeb8a0ec1dd850fe8146c3e70f34ef9036c08ef39a9816c077",
  "model_group": "broken-gpt",
  "api_base": "",
  "custom_llm_provider": ""
}
```

#### /v1/messages (temperature out of range)

1. Failing request:

```bash
curl -s -w "\nHTTP_STATUS:%{http_code}\n" http://127.0.0.1:51830/v1/messages \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"claude-haiku-4-5","max_tokens":50,"temperature":5,"messages":[{"role":"user","content":"hi"}]}'
```

2. Observed response:

```
{"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"temperature: range: 0..1\"},...}","type":"None","param":"None","code":"400"}}
HTTP_STATUS:400
```

3. Waited ~14s, queried the logs API. Observed failure row, every attribution field empty:

```json
{
  "request_id": "2ed5d86a-36e3-4cda-a50a-efa380ca0319",
  "status": "failure",
  "call_type": "",
  "model": "claude-haiku-4-5",
  "model_id": "",
  "model_group": "",
  "api_base": "",
  "custom_llm_provider": ""
}
```

#### Success controls (one per endpoint)

1. One successful request per endpoint, all HTTP 200:

```bash
curl -s http://127.0.0.1:51830/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.4-mini","input":"say hi"}'
curl -s http://127.0.0.1:51830/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"hi"}]}'
curl -s http://127.0.0.1:51830/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"claude-haiku-4-5","max_tokens":50,"messages":[{"role":"user","content":"hi"}]}'
```

2. Waited ~14s, queried the logs API filtered to success rows. All three fully attributed, in contrast to the failure rows above:

```json
[
  {
    "request_id": "resp_1ivtr... (trimmed)",
    "call_type": "aresponses",
    "model": "openai/gpt-5.4-mini",
    "model_id": "fbb196c899041a89ba318c64bd6f9d4ca15e6d1b6831cecc0c6fde81870b6e4c",
    "model_group": "gpt-5.4-mini",
    "api_base": "https://api.openai.com/v1/responses",
    "custom_llm_provider": "openai"
  },
  {
    "request_id": "chatcmpl-EEk4h41ttWc8vV9sK5oTQj1dh4kcM",
    "call_type": "acompletion",
    "model": "openai/gpt-5.4-mini",
    "model_id": "fbb196c899041a89ba318c64bd6f9d4ca15e6d1b6831cecc0c6fde81870b6e4c",
    "model_group": "gpt-5.4-mini",
    "api_base": "https://api.openai.com/v1/",
    "custom_llm_provider": "openai"
  },
  {
    "request_id": "chatcmpl-96a5d2ef-16b8-4d49-a239-fdb8f3b57776",
    "call_type": "anthropic_messages",
    "model": "anthropic/claude-haiku-4-5",
    "model_id": "4b9748d0db2078012c2095dd56003aab650c017c3b70485f276a4d7c1f99cb70",
    "model_group": "claude-haiku-4-5",
    "api_base": "https://api.anthropic.com/v1/messages",
    "custom_llm_provider": "anthropic"
  }
]
```

#### Doctored request body (spoofed standard_logging_object and response_cost)

1. Failing request with a bad proxy key and attacker-controlled logging fields in the body:

```bash
curl -s -w "\nHTTP_STATUS:%{http_code}\n" http://127.0.0.1:51830/v1/chat/completions \
  -H "Authorization: Bearer sk-not-a-real-key" -H "Content-Type: application/json" \
  -d '{"model":"broken-gpt","messages":[{"role":"user","content":"hi"}],"standard_logging_object":{"model_id":"attacker-mid","model_group":"attacker-group","api_base":"https://attacker.example"},"response_cost":123.45}'
```

2. Observed response:

```
{"error":{"message":"Authentication Error, Invalid proxy server token passed. ...","type":"token_not_found_in_db","param":"key","code":"401"}}
HTTP_STATUS:401
```

3. Waited ~14s, queried the logs API: no new row appears (count unchanged at 9). The same request without the doctored field does write a row, and the proxy log shows why this one vanished:

```
LiteLLM Proxy:ERROR: spend_log_error_logger.py:83 - Spend tracking - update_database failed. Spend log insertion or daily transaction enqueue may not have completed for this request. ...
  File ".../litellm/proxy/spend_tracking/spend_tracking_utils.py", line 282, in get_logging_payload
    end_user_id = end_user_id or standard_logging_payload["metadata"].get("user_api_key_end_user_id")
KeyError: 'metadata'
```

### After (919bf1a09785c020dd859605cb1074bfa6c42383)

#### /v1/responses (previous_response_id not found)

1. Failing request:

```bash
curl -s -w "\nHTTP_STATUS:%{http_code}\n" http://127.0.0.1:52741/v1/responses \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.4-mini","input":"say hi","previous_response_id":"resp_ffffffffffffffffffffffffffffffff"}'
```

2. Observed response: same 400 as Before ("Previous response with id 'resp_ffffffffffffffffffffffffffffffff' not found.")

3. Waited ~14s, queried the logs API. Observed failure row, all four attribution fields populated with the gpt-5.4-mini deployment's values:

```json
{
  "request_id": "6ebbe20e-bae6-4a66-b0f3-6f739db527a6",
  "status": "failure",
  "call_type": "",
  "model": "gpt-5.4-mini",
  "model_id": "fbb196c899041a89ba318c64bd6f9d4ca15e6d1b6831cecc0c6fde81870b6e4c",
  "model_group": "gpt-5.4-mini",
  "api_base": "https://api.openai.com/v1/responses",
  "custom_llm_provider": "openai"
}
```

#### /v1/chat/completions (invalid provider key on deployment broken-gpt)

1. Failing request:

```bash
curl -s -w "\nHTTP_STATUS:%{http_code}\n" http://127.0.0.1:52741/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"broken-gpt","messages":[{"role":"user","content":"hi"}]}'
```

2. Observed response: same 401 as Before (Incorrect API key provided)

3. Waited ~14s, queried the logs API. Observed failure row: all four attribution fields populated, api_base and custom_llm_provider newly so:

```json
{
  "request_id": "ba531e42-9f0b-4edd-a267-bb89d5f5a2f9",
  "status": "failure",
  "call_type": "",
  "model": "openai/gpt-5.4-mini",
  "model_id": "92b96561548bf3aeb8a0ec1dd850fe8146c3e70f34ef9036c08ef39a9816c077",
  "model_group": "broken-gpt",
  "api_base": "https://api.openai.com/v1",
  "custom_llm_provider": "openai"
}
```

#### /v1/messages (temperature out of range)

1. Failing request:

```bash
curl -s -w "\nHTTP_STATUS:%{http_code}\n" http://127.0.0.1:52741/v1/messages \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"claude-haiku-4-5","max_tokens":50,"temperature":5,"messages":[{"role":"user","content":"hi"}]}'
```

2. Observed response: same 400 as Before ("temperature: range: 0..1")

3. Waited ~14s, queried the logs API. Observed failure row, all four attribution fields populated with the claude-haiku-4-5 deployment's values:

```json
{
  "request_id": "03c08e1c-b339-411b-aaca-7ba596fece92",
  "status": "failure",
  "call_type": "",
  "model": "claude-haiku-4-5",
  "model_id": "4b9748d0db2078012c2095dd56003aab650c017c3b70485f276a4d7c1f99cb70",
  "model_group": "claude-haiku-4-5",
  "api_base": "https://api.anthropic.com/v1/messages",
  "custom_llm_provider": "anthropic"
}
```

4. Re-polled the same rows minutes later: identical values, so no late update changes them

#### Success controls (one per endpoint)

1. Same three successful requests as Before, all HTTP 200

2. Waited ~14s, queried the logs API filtered to success rows. All three fully attributed with field values identical to Before, so no regression:

```json
[
  {
    "request_id": "resp_AogHIfg... (trimmed)",
    "call_type": "aresponses",
    "model": "openai/gpt-5.4-mini",
    "model_id": "fbb196c899041a89ba318c64bd6f9d4ca15e6d1b6831cecc0c6fde81870b6e4c",
    "model_group": "gpt-5.4-mini",
    "api_base": "https://api.openai.com/v1/responses",
    "custom_llm_provider": "openai"
  },
  {
    "request_id": "chatcmpl-EEkXPbxkZAyGycr00SfxFeeVNvjOt",
    "call_type": "acompletion",
    "model": "openai/gpt-5.4-mini",
    "model_id": "fbb196c899041a89ba318c64bd6f9d4ca15e6d1b6831cecc0c6fde81870b6e4c",
    "model_group": "gpt-5.4-mini",
    "api_base": "https://api.openai.com/v1/",
    "custom_llm_provider": "openai"
  },
  {
    "request_id": "chatcmpl-9e7bd309-fb9b-4881-b8cf-255a400e2798",
    "call_type": "anthropic_messages",
    "model": "anthropic/claude-haiku-4-5",
    "model_id": "4b9748d0db2078012c2095dd56003aab650c017c3b70485f276a4d7c1f99cb70",
    "model_group": "claude-haiku-4-5",
    "api_base": "https://api.anthropic.com/v1/messages",
    "custom_llm_provider": "anthropic"
  }
]
```

#### Doctored request body (spoofed standard_logging_object and response_cost)

1. Same request as Before, bad proxy key plus attacker-controlled logging fields:

```bash
curl -s -w "\nHTTP_STATUS:%{http_code}\n" http://127.0.0.1:52741/v1/chat/completions \
  -H "Authorization: Bearer sk-not-a-real-key" -H "Content-Type: application/json" \
  -d '{"model":"broken-gpt","messages":[{"role":"user","content":"hi"}],"standard_logging_object":{"model_id":"attacker-mid","model_group":"attacker-group","api_base":"https://attacker.example"},"response_cost":123.45}'
```

2. Observed response: same 401 as Before

3. Waited ~14s, queried the logs API: the row count went 23 to 24, and the new row carries none of the attacker values and $0 spend:

```json
{
  "request_id": "7170c36d-132c-4255-80e7-9490fcc53f49",
  "status": "failure",
  "model": "broken-gpt",
  "model_id": "",
  "model_group": "",
  "api_base": "",
  "custom_llm_provider": "",
  "spend": 0.0,
  "request_tags": []
}
```

Observations:

- call_type empty on failure rows before and after (pre-existing)
- Failure rows keep the group name in the model column
- Failed-request api_base matches the same deployment's success row
- Attributed failure rows now also carry User-Agent request tags, matching success rows

## Type

🐛 Bug Fix

## Caveats (if any)

- Failures before a deployment is picked keep only the model group
- Failure rows still log empty call_type (pre-existing, unchanged)
- Failure rows now carry User-Agent request tags, like success rows
- Bedrock failure rows gain provider-prefixed model names (code-read, not live-verified)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

CHECKED: live-pr-risk at 919bf1a09785c020dd859605cb1074bfa6c42383. The tip's only code delta over the prior pass is moving the client standard_logging_object strip above the failure logging handler (that handler flattens unrecognized body keys into model_call_details, and the pass-through path never overwrites them with the built payload), graph-walked to the same dependents as before. Re-driven live at this tip: all three endpoint failure cases, the three success controls, and the doctored-body spoof, plus a mutation-checked regression test on the pass-through relift. Earlier full-graph findings carry over unchanged. Bedrock model-name prefixing on failure rows reasoned from code, not live-verified

- [x] dce207add43a6ece53a5a0a12458dd7edf03ed3e passes /live-pr-risk
- [x] 919bf1a09785c020dd859605cb1074bfa6c42383 passes /live-pr-risk
