### PR TITLE
refactor(ui): migrate the MCP servers pages off antd

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -521,45 +521,17 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/mcp-servers/_components/AwsSigV4Fields.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/(dashboard)/mcp-servers/_components/CreateMCPServer.tsx": {
     "max-lines": {
       "count": 1
     },
     "no-nested-ternary": {
       "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/DcrBridgeToggle.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/IdJagFormFields.tsx": {
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/MCPNetworkSettings.tsx": {
     "react-hooks/immutability": {
       "count": 2
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/MCPPermissionManagement.test.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/MCPPermissionManagement.tsx": {
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/MCPSubmissionsTab.tsx": {
@@ -586,17 +558,11 @@
   "src/app/(dashboard)/mcp-servers/_components/OAuthFormFields.tsx": {
     "no-nested-ternary": {
       "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/OpenAPIFormSection.tsx": {
     "local/no-complex-jsx-arrow": {
       "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 2
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/OpenAPIQuickPicker.tsx": {
@@ -604,32 +570,7 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/mcp-servers/_components/OpenApiByokFields.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/(dashboard)/mcp-servers/_components/PassthroughAuthorizeSection.test.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/PassthroughAuthorizeSection.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/StdioConfiguration.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/TokenEndpointAuthMethodField.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/TokenExchangeFormFields.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -692,15 +633,6 @@
     },
     "max-lines": {
       "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/immutability": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 5
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/mcp_server_view.tsx": {
@@ -1986,14 +1918,6 @@
       "count": 1
     }
   },
-  "src/components/mcp_server_management/MCPServerSelector.tsx": {
-    "local/no-complex-jsx-arrow": {
-      "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/components/mcp_server_management/MCPToolPermissions.tsx": {
     "local/no-complex-jsx-arrow": {
       "count": 1
@@ -2006,9 +1930,6 @@
   },
   "src/components/mcp_tools/MCPToolArgumentsForm.tsx": {
     "no-nested-ternary": {
-      "count": 1
-    },
-    "no-restricted-imports": {
       "count": 1
     }
   },

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/AwsSigV4Fields.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/AwsSigV4Fields.tsx
@@ -1,9 +1,11 @@
-import React from "react";
-import { Input, Tooltip } from "antd";
 import { Info } from "lucide-react";
+import React from "react";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 
 import { MountedFormField } from "@/components/common_components/MountedFormField";
 import { antdRequired } from "@/components/common_components/antdFormRules";
+import { PasswordInput } from "@/components/shared/PasswordInput";
+import { Input } from "@/components/ui/input";
 import { requiredWhenSiblingSet, textControl } from "./mcpFieldRules";
 
 const fieldClassName = "rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500";
@@ -11,9 +13,9 @@ const fieldClassName = "rounded-lg border-gray-300 focus:border-blue-500 focus:r
 const FieldLabel: React.FC<{ label: string; tooltip: string }> = ({ label, tooltip }) => (
   <span className="text-sm font-medium text-gray-700 flex items-center">
     {label}
-    <Tooltip title={tooltip}>
+    <SimpleTooltip content={tooltip}>
       <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-    </Tooltip>
+    </SimpleTooltip>
   </span>
 );
 
@@ -71,10 +73,10 @@ const AwsSigV4Fields: React.FC = () => (
       }}
     >
       {(control) => (
-        <Input.Password
+        <PasswordInput
           {...textControl(control)}
           placeholder="AKIA... (optional — uses IAM role if blank)"
-          className={fieldClassName}
+          groupClassName={fieldClassName}
         />
       )}
     </MountedFormField>
@@ -94,10 +96,10 @@ const AwsSigV4Fields: React.FC = () => (
       }}
     >
       {(control) => (
-        <Input.Password
+        <PasswordInput
           {...textControl(control)}
           placeholder="Enter secret key (optional — uses IAM role if blank)"
-          className={fieldClassName}
+          groupClassName={fieldClassName}
         />
       )}
     </MountedFormField>
@@ -106,10 +108,10 @@ const AwsSigV4Fields: React.FC = () => (
       name={["credentials", "aws_session_token"]}
     >
       {(control) => (
-        <Input.Password
+        <PasswordInput
           {...textControl(control)}
           placeholder="Enter session token (optional)"
-          className={fieldClassName}
+          groupClassName={fieldClassName}
         />
       )}
     </MountedFormField>

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/CreateMCPServer.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/CreateMCPServer.integration.test.tsx
@@ -2074,7 +2074,7 @@ describe("CreateMCPServer dcr_bridge toggle", () => {
     updated_by: "user-1",
   };
 
-  const getDcrToggle = () => document.getElementById("dcr_bridge");
+  const getDcrToggle = () => screen.queryByRole("switch", { name: /Gateway-hosted sign-in \(DCR bridge\)/ });
 
   async function setupHttpServerForm() {
     render(<CreateMCPServer {...defaultProps} />);

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/CreateMCPServer.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/CreateMCPServer.integration.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as networking from "@/components/networking";
 import { setToken } from "@/utils/mcpTokenStore";
 import CreateMCPServer from "./CreateMCPServer";
-import { selectAntOption } from "./testUtils";
+import { selectOption } from "./testUtils";
 
 vi.mock("@/components/networking", () => ({
   createMCPServer: vi.fn(),
@@ -129,7 +129,7 @@ describe("CreateMCPServer", () => {
     expect(screen.getByText("Submit MCP Server for Review")).toBeInTheDocument();
     expect(screen.queryByText("Add New MCP Server")).not.toBeInTheDocument();
 
-    await selectAntOption("Transport Type", "Streamable HTTP");
+    await selectOption("Transport Type", "Streamable HTTP");
     await waitFor(() => {
       expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
     });
@@ -141,7 +141,7 @@ describe("CreateMCPServer", () => {
         target: { value: "https://example.com/mcp" },
       });
     });
-    await selectAntOption("Authentication", "None");
+    await selectOption("Authentication", "None");
 
     vi.mocked(networking.registerMCPServer).mockResolvedValue({
       server_id: "submitted-1",
@@ -167,7 +167,7 @@ describe("CreateMCPServer", () => {
   it("should show transport type options", async () => {
     render(<CreateMCPServer {...defaultProps} />);
 
-    await selectAntOption("Transport Type", "Streamable HTTP");
+    await selectOption("Transport Type", "Streamable HTTP");
 
     // Verify the option was applied by checking the URL field appears
     await waitFor(() => {
@@ -178,7 +178,7 @@ describe("CreateMCPServer", () => {
   describe("when HTTP transport is selected", () => {
     async function selectHttpTransport() {
       render(<CreateMCPServer {...defaultProps} />);
-      await selectAntOption("Transport Type", "Streamable HTTP");
+      await selectOption("Transport Type", "Streamable HTTP");
 
       // Wait for URL field to appear (confirms transport was set)
       await waitFor(() => {
@@ -201,7 +201,7 @@ describe("CreateMCPServer", () => {
     it("should show auth value field when API Key auth type is selected", async () => {
       await selectHttpTransport();
 
-      await selectAntOption("Authentication", "API Key");
+      await selectOption("Authentication", "API Key");
 
       await waitFor(() => {
         expect(screen.getByText("Authentication Value")).toBeInTheDocument();
@@ -211,7 +211,7 @@ describe("CreateMCPServer", () => {
     it("should warn that LiteLLM auth is disabled when True Passthrough is selected", async () => {
       await selectHttpTransport();
 
-      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
 
       await waitFor(() => {
         expect(
@@ -223,7 +223,7 @@ describe("CreateMCPServer", () => {
     it("should not show the True Passthrough warning when OAuth Delegate is selected", async () => {
       await selectHttpTransport();
 
-      await selectAntOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
+      await selectOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
 
       await waitFor(() => {
         expect(screen.getAllByText("OAuth Delegate (client-supplied upstream token)").length).toBeGreaterThan(0);
@@ -238,7 +238,7 @@ describe("CreateMCPServer", () => {
       async (optionLabel) => {
         await selectHttpTransport();
 
-        await selectAntOption("Authentication", optionLabel);
+        await selectOption("Authentication", optionLabel);
 
         await waitFor(() => {
           expect(screen.getByRole("button", { name: "Authorize & Fetch Tools (browser-only)" })).toBeInTheDocument();
@@ -251,7 +251,7 @@ describe("CreateMCPServer", () => {
     it("should not show the browser-only authorize section for API Key auth", async () => {
       await selectHttpTransport();
 
-      await selectAntOption("Authentication", "API Key");
+      await selectOption("Authentication", "API Key");
 
       await waitFor(() => {
         expect(screen.getByText("Authentication Value")).toBeInTheDocument();
@@ -273,7 +273,7 @@ describe("CreateMCPServer", () => {
       fireEvent.change(urlInput, { target: { value: "https://example.com/mcp" } });
 
       // Select API Key auth type
-      await selectAntOption("Authentication", "API Key");
+      await selectOption("Authentication", "API Key");
 
       await waitFor(() => {
         expect(screen.getByText("Authentication Value")).toBeInTheDocument();
@@ -315,7 +315,7 @@ describe("CreateMCPServer", () => {
       const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
       fireEvent.change(urlInput, { target: { value: "https://example.com/mcp" } });
 
-      await selectAntOption("Authentication", "Bearer Token");
+      await selectOption("Authentication", "Bearer Token");
 
       await waitFor(() => {
         expect(screen.getByText("Authentication Value")).toBeInTheDocument();
@@ -356,7 +356,7 @@ describe("CreateMCPServer", () => {
       const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
       fireEvent.change(urlInput, { target: { value: "https://example.com/mcp" } });
 
-      await selectAntOption("Authentication", "API Key");
+      await selectOption("Authentication", "API Key");
 
       await waitFor(() => {
         expect(screen.getByText("Authentication Value")).toBeInTheDocument();
@@ -402,7 +402,7 @@ describe("CreateMCPServer", () => {
         target: { value: "https://example.com/mcp" },
       });
 
-      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
 
       // Simulate the browser Authorize & Fetch flow handing back an upstream token.
       await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
@@ -430,7 +430,7 @@ describe("CreateMCPServer", () => {
         target: { value: "https://example.com/mcp" },
       });
 
-      await selectAntOption("Authentication", optionLabel);
+      await selectOption("Authentication", optionLabel);
 
       await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
       await act(async () => {
@@ -496,7 +496,7 @@ describe("CreateMCPServer", () => {
           target: { value: "https://example.com/mcp" },
         });
 
-        await selectAntOption("Authentication", optionLabel);
+        await selectOption("Authentication", optionLabel);
 
         // Admin declares the org's pre-registered upstream app; unlike the browser-authorized
         // token, this is config and must survive onto the server row so internal users'
@@ -560,7 +560,7 @@ describe("CreateMCPServer", () => {
         target: { value: "https://example.com/mcp" },
       });
 
-      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
 
       fireEvent.change(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), {
         target: { value: "org-app-client-id" },
@@ -620,7 +620,7 @@ describe("CreateMCPServer", () => {
         target: { value: "https://example.com/mcp" },
       });
 
-      await selectAntOption("Authentication", "OAuth");
+      await selectOption("Authentication", "OAuth");
 
       // The oauth2 onTokenReceived branch writes the fetched token AND the DCR client into
       // form.credentials; both are minted for the oauth2 identity.
@@ -635,7 +635,7 @@ describe("CreateMCPServer", () => {
       // Switching into a client-forwarded mode changes the identity with auth_type in the changed
       // values, so the preserve carve-out must NOT apply: the minted material would otherwise ride
       // into a mode that now persists credentials onto the server row.
-      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
 
       const switchedServer = {
         server_id: "switched-server",
@@ -669,7 +669,7 @@ describe("CreateMCPServer", () => {
       fireEvent.change(screen.getByPlaceholderText("https://your-mcp-server.com"), {
         target: { value: "https://example.com/mcp" },
       });
-      await selectAntOption("Authentication", "OAuth");
+      await selectOption("Authentication", "OAuth");
 
       await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
       await act(async () => {
@@ -689,14 +689,14 @@ describe("CreateMCPServer", () => {
 
     it("clears the DCR ref and the upstream warning when the modal closes so nothing leaks to the next session", async () => {
       const { rerender } = render(<CreateMCPServer {...defaultProps} />);
-      await selectAntOption("Transport Type", "Streamable HTTP");
+      await selectOption("Transport Type", "Streamable HTTP");
       expect(await screen.findByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
       const user = userEvent.setup({ delay: null });
       fireEvent.change(getServerNameInput(), { target: { value: "Leak_Server" } });
       fireEvent.change(screen.getByPlaceholderText("https://your-mcp-server.com"), {
         target: { value: "https://example.com/mcp" },
       });
-      await selectAntOption("Authentication", "OAuth");
+      await selectOption("Authentication", "OAuth");
 
       await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
       await act(async () => {
@@ -725,7 +725,7 @@ describe("CreateMCPServer", () => {
       fireEvent.change(screen.getByPlaceholderText("https://your-mcp-server.com"), {
         target: { value: "https://example.com/mcp" },
       });
-      await selectAntOption("Authentication", "OAuth");
+      await selectOption("Authentication", "OAuth");
 
       await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
       await act(async () => {
@@ -767,7 +767,7 @@ describe("CreateMCPServer", () => {
       await selectHttpTransport();
       fillText(getServerNameInput(), "CF_Switch_Keep");
       fillText(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
-      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
       fillText(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), "app-id");
       fillText(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "app-secret");
 
@@ -776,7 +776,7 @@ describe("CreateMCPServer", () => {
         oauthHook.onTokenReceived!({ access_token: "cf-tok", token_type: "Bearer" }, undefined);
       });
 
-      await selectAntOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
+      await selectOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
 
       const switched = {
         server_id: "cf-switch-keep",
@@ -804,7 +804,7 @@ describe("CreateMCPServer", () => {
       await selectHttpTransport();
       fillText(getServerNameInput(), "CF_Round");
       fillText(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
-      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
       fillText(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), "app-id");
       fillText(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "app-secret");
 
@@ -813,8 +813,8 @@ describe("CreateMCPServer", () => {
         oauthHook.onTokenReceived!({ access_token: "cf-tok", token_type: "Bearer" }, undefined);
       });
 
-      await selectAntOption("Authentication", "OAuth");
-      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await selectOption("Authentication", "OAuth");
+      await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
 
       const cfRoundServer = {
         server_id: "cf-round",
@@ -845,7 +845,7 @@ describe("CreateMCPServer", () => {
       fireEvent.change(screen.getByPlaceholderText("https://your-mcp-server.com"), {
         target: { value: "https://example.com/mcp" },
       });
-      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
       fireEvent.change(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), {
         target: { value: "app-id" },
       });
@@ -871,7 +871,7 @@ describe("CreateMCPServer", () => {
       fireEvent.change(screen.getByPlaceholderText("https://your-mcp-server.com"), {
         target: { value: "https://example.com/mcp" },
       });
-      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
       fireEvent.change(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), {
         target: { value: "app-id" },
       });
@@ -919,7 +919,7 @@ describe("CreateMCPServer", () => {
       fireEvent.change(screen.getByPlaceholderText("https://your-mcp-server.com"), {
         target: { value: "https://example.com/mcp" },
       });
-      await selectAntOption("Authentication", "OAuth");
+      await selectOption("Authentication", "OAuth");
 
       await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
       const firstToken = { access_token: "T1", refresh_token: "R1", scope: "read", token_type: "Bearer" };
@@ -939,7 +939,7 @@ describe("CreateMCPServer", () => {
     it("should not show auth value field when None auth type is selected", async () => {
       await selectHttpTransport();
 
-      await selectAntOption("Authentication", "None");
+      await selectOption("Authentication", "None");
 
       // Auth value field should not appear for "None"
       await waitFor(() => {
@@ -958,7 +958,7 @@ describe("CreateMCPServer", () => {
       const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
       fireEvent.change(urlInput, { target: { value: "https://example.com/mcp" } });
 
-      await selectAntOption("Authentication", "None");
+      await selectOption("Authentication", "None");
 
       vi.mocked(networking.createMCPServer).mockResolvedValue({
         server_id: "new-server-1",
@@ -992,20 +992,20 @@ describe("CreateMCPServer", () => {
       await selectHttpTransport();
 
       // Plain OAuth must not render the token-exchange section.
-      await selectAntOption("Authentication", "OAuth");
+      await selectOption("Authentication", "OAuth");
       await waitFor(() => {
         expect(screen.queryByText("Token Exchange Endpoint (optional)")).not.toBeInTheDocument();
       });
       expect(screen.queryByText("Subject Token Type (optional)")).not.toBeInTheDocument();
 
-      await selectAntOption("Authentication", "OAuth Token Exchange (OBO)");
+      await selectOption("Authentication", "OAuth Token Exchange (OBO)");
       await waitFor(() => {
         expect(screen.getByText("Token Exchange Endpoint (optional)")).toBeInTheDocument();
       });
       expect(screen.getByText("Subject Token Type (optional)")).toBeInTheDocument();
 
       // Switching away hides the section again.
-      await selectAntOption("Authentication", "API Key");
+      await selectOption("Authentication", "API Key");
       await waitFor(() => {
         expect(screen.queryByText("Token Exchange Endpoint (optional)")).not.toBeInTheDocument();
       });
@@ -1015,11 +1015,11 @@ describe("CreateMCPServer", () => {
       // whole Authentication section (the section-level transport gate), taking the
       // token-exchange fields with it — their required client_id/client_secret rules
       // cannot block a stdio submit because antd does not validate unmounted fields.
-      await selectAntOption("Authentication", "OAuth Token Exchange (OBO)");
+      await selectOption("Authentication", "OAuth Token Exchange (OBO)");
       await waitFor(() => {
         expect(screen.getByText("Token Exchange Endpoint (optional)")).toBeInTheDocument();
       });
-      await selectAntOption("Transport Type", "Standard Input/Output");
+      await selectOption("Transport Type", "Standard Input/Output");
       await waitFor(() => {
         expect(screen.queryByText("Token Exchange Endpoint (optional)")).not.toBeInTheDocument();
       });
@@ -1037,7 +1037,7 @@ describe("CreateMCPServer", () => {
       const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
       fireEvent.change(urlInput, { target: { value: "https://example.com/mcp" } });
 
-      await selectAntOption("Authentication", "None");
+      await selectOption("Authentication", "None");
 
       const limitInput = screen.getByPlaceholderText("e.g. 10");
       fireEvent.change(limitInput, { target: { value: "5" } });
@@ -1079,7 +1079,7 @@ describe("CreateMCPServer", () => {
       const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
       fireEvent.change(urlInput, { target: { value: "https://upstream.example.com/mcp" } });
 
-      await selectAntOption("Authentication", "OAuth Token Exchange (OBO)");
+      await selectOption("Authentication", "OAuth Token Exchange (OBO)");
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText("https://idp.example.com/oauth2/token")).toBeInTheDocument();
@@ -1131,20 +1131,20 @@ describe("CreateMCPServer", () => {
       await selectHttpTransport();
 
       // The sibling OBO mode must not render the ID-JAG section.
-      await selectAntOption("Authentication", "OAuth Token Exchange (OBO)");
+      await selectOption("Authentication", "OAuth Token Exchange (OBO)");
       await waitFor(() => {
         expect(screen.queryByText("Org Token Endpoint (leg 1)")).not.toBeInTheDocument();
       });
       expect(screen.queryByText("Resource Token Endpoint (leg 2)")).not.toBeInTheDocument();
 
-      await selectAntOption("Authentication", "ID-JAG (Okta Cross App Access)");
+      await selectOption("Authentication", "ID-JAG (Okta Cross App Access)");
       await waitFor(() => {
         expect(screen.getByText("Org Token Endpoint (leg 1)")).toBeInTheDocument();
       });
       expect(screen.getByText("Resource Token Endpoint (leg 2)")).toBeInTheDocument();
       expect(screen.getByText("Client Private Key (PEM)")).toBeInTheDocument();
 
-      await selectAntOption("Authentication", "API Key");
+      await selectOption("Authentication", "API Key");
       await waitFor(() => {
         expect(screen.queryByText("Org Token Endpoint (leg 1)")).not.toBeInTheDocument();
       });
@@ -1159,7 +1159,7 @@ describe("CreateMCPServer", () => {
         target: { value: "https://upstream.example.com/mcp" },
       });
 
-      await selectAntOption("Authentication", "ID-JAG (Okta Cross App Access)");
+      await selectOption("Authentication", "ID-JAG (Okta Cross App Access)");
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText("https://your-org.okta.com/oauth2/v1/token")).toBeInTheDocument();
@@ -1222,7 +1222,7 @@ describe("CreateMCPServer", () => {
         target: { value: "https://upstream.example.com/mcp" },
       });
 
-      await selectAntOption("Authentication", "ID-JAG (Okta Cross App Access)");
+      await selectOption("Authentication", "ID-JAG (Okta Cross App Access)");
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText("https://your-org.okta.com/oauth2/v1/token")).toBeInTheDocument();
@@ -1259,12 +1259,12 @@ describe("CreateMCPServer", () => {
         target: { value: "https://upstream.example.com/mcp" },
       });
 
-      await selectAntOption("Authentication", "OAuth Token Exchange (OBO)");
+      await selectOption("Authentication", "OAuth Token Exchange (OBO)");
       await waitFor(() => {
         expect(screen.getByPlaceholderText("https://idp.example.com/oauth2/token")).toBeInTheDocument();
       });
 
-      await selectAntOption("Profile", "Microsoft Entra OBO");
+      await selectOption("Profile", "Microsoft Entra OBO");
 
       fireEvent.change(screen.getByPlaceholderText("https://idp.example.com/oauth2/token"), {
         target: { value: "https://login.microsoftonline.com/tenant/oauth2/v2.0/token" },
@@ -1301,7 +1301,7 @@ describe("CreateMCPServer", () => {
       const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
       fireEvent.change(urlInput, { target: { value: "https://example.com/mcp" } });
 
-      await selectAntOption("Authentication", "None");
+      await selectOption("Authentication", "None");
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Disable all tools" }));
@@ -1339,13 +1339,13 @@ describe("CreateMCPServer", () => {
     /** Select HTTP transport + OAuth auth, then wait for the OAuth form to appear. */
     async function setupOAuthInteractive() {
       render(<CreateMCPServer {...defaultProps} />);
-      await selectAntOption("Transport Type", "Streamable HTTP");
+      await selectOption("Transport Type", "Streamable HTTP");
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
       });
 
-      await selectAntOption("Authentication", "OAuth");
+      await selectOption("Authentication", "OAuth");
 
       // Wait for OAuthFormFields to render (OAuth Flow Type selector is the sentinel)
       await waitFor(() => {
@@ -1376,7 +1376,7 @@ describe("CreateMCPServer", () => {
       oauthHook.reset.mockClear();
 
       // Switching the Authentication mode changes the OAuth identity, so the held token is discarded.
-      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
 
       await waitFor(() => expect(oauthHook.reset).toHaveBeenCalled());
     });
@@ -1421,7 +1421,7 @@ describe("CreateMCPServer", () => {
       });
       vi.mocked(networking.testMCPToolsListRequest).mockClear();
 
-      await selectAntOption("Authentication", "API Key");
+      await selectOption("Authentication", "API Key");
 
       await waitFor(() => expect(vi.mocked(networking.testMCPToolsListRequest)).toHaveBeenCalled());
       for (const call of vi.mocked(networking.testMCPToolsListRequest).mock.calls) {
@@ -1443,7 +1443,7 @@ describe("CreateMCPServer", () => {
       });
       oauthHook.reset.mockClear();
 
-      await selectAntOption("Transport Type", "Server-Sent Events (SSE)");
+      await selectOption("Transport Type", "Server-Sent Events (SSE)");
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
@@ -1545,11 +1545,11 @@ describe("CreateMCPServer", () => {
 
     it("invalidates the DCR client and OAuth flow when the OpenAPI spec URL changes after Authorize & Fetch", async () => {
       render(<CreateMCPServer {...defaultProps} />);
-      await selectAntOption("Transport Type", "OpenAPI Spec");
+      await selectOption("Transport Type", "OpenAPI Spec");
       await waitFor(() => {
         expect(screen.getByPlaceholderText("https://petstore3.swagger.io/api/v3/openapi.json")).toBeInTheDocument();
       });
-      await selectAntOption("Authentication", "OAuth");
+      await selectOption("Authentication", "OAuth");
       await waitFor(() => {
         expect(screen.getByText("OAuth Flow Type")).toBeInTheDocument();
       });
@@ -1601,11 +1601,11 @@ describe("CreateMCPServer", () => {
 
     it("invalidates the DCR client and OAuth flow when the transport changes after Authorize & Fetch", async () => {
       render(<CreateMCPServer {...defaultProps} />);
-      await selectAntOption("Transport Type", "OpenAPI Spec");
+      await selectOption("Transport Type", "OpenAPI Spec");
       await waitFor(() => {
         expect(screen.getByPlaceholderText("https://petstore3.swagger.io/api/v3/openapi.json")).toBeInTheDocument();
       });
-      await selectAntOption("Authentication", "OAuth");
+      await selectOption("Authentication", "OAuth");
       await waitFor(() => {
         expect(screen.getByText("OAuth Flow Type")).toBeInTheDocument();
       });
@@ -1624,7 +1624,7 @@ describe("CreateMCPServer", () => {
       });
       oauthHook.reset.mockClear();
 
-      await selectAntOption("Transport Type", "Streamable HTTP");
+      await selectOption("Transport Type", "Streamable HTTP");
       await waitFor(() => {
         expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
       });
@@ -1688,7 +1688,7 @@ describe("CreateMCPServer", () => {
         fireEvent.change(urlInput, { target: { value: "https://example.com/mcp" } });
       });
 
-      await selectAntOption("Token Endpoint Auth Method (optional)", "Client Secret Basic");
+      await selectOption("Token Endpoint Auth Method (optional)", "Client Secret Basic");
 
       const submitButton = screen.getByRole("button", { name: "Add MCP Server" });
       await act(async () => {
@@ -1804,11 +1804,11 @@ describe("CreateMCPServer", () => {
 
       const { rerender } = render(<CreateMCPServer {...defaultProps} />);
 
-      await selectAntOption("Transport Type", "Streamable HTTP");
+      await selectOption("Transport Type", "Streamable HTTP");
       await waitFor(() => {
         expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
       });
-      await selectAntOption("Authentication", "OAuth");
+      await selectOption("Authentication", "OAuth");
       await waitFor(() => {
         expect(screen.getByText("OAuth Flow Type")).toBeInTheDocument();
       });
@@ -1858,11 +1858,11 @@ describe("CreateMCPServer", () => {
 
       const { rerender } = render(<CreateMCPServer {...defaultProps} />);
 
-      await selectAntOption("Transport Type", "Streamable HTTP");
+      await selectOption("Transport Type", "Streamable HTTP");
       await waitFor(() => {
         expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
       });
-      await selectAntOption("Authentication", "OAuth");
+      await selectOption("Authentication", "OAuth");
       await waitFor(() => {
         expect(screen.getByText("OAuth Flow Type")).toBeInTheDocument();
       });
@@ -1915,7 +1915,7 @@ describe("CreateMCPServer", () => {
     it("should not show auth type or URL fields", async () => {
       render(<CreateMCPServer {...defaultProps} />);
 
-      await selectAntOption("Transport Type", "Standard Input/Output");
+      await selectOption("Transport Type", "Standard Input/Output");
 
       // Auth and URL fields should not be present for stdio
       await waitFor(() => {
@@ -1984,7 +1984,7 @@ describe("CreateMCPServer oauth2_flow persistence", () => {
 
   async function setupHttpServerForm() {
     render(<CreateMCPServer {...defaultProps} />);
-    await selectAntOption("Transport Type", "Streamable HTTP");
+    await selectOption("Transport Type", "Streamable HTTP");
     await waitFor(() => {
       expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
     });
@@ -2013,7 +2013,7 @@ describe("CreateMCPServer oauth2_flow persistence", () => {
   it("persists authorization_code for an interactive OAuth create", async () => {
     vi.mocked(networking.createMCPServer).mockResolvedValue(createdServer);
     await setupHttpServerForm();
-    await selectAntOption("Authentication", "OAuth");
+    await selectOption("Authentication", "OAuth");
     await waitFor(() => {
       expect(screen.getByText("OAuth Flow Type")).toBeInTheDocument();
     });
@@ -2026,11 +2026,11 @@ describe("CreateMCPServer oauth2_flow persistence", () => {
   it("persists client_credentials for an M2M OAuth create", async () => {
     vi.mocked(networking.createMCPServer).mockResolvedValue({ ...createdServer, oauth2_flow: "client_credentials" });
     await setupHttpServerForm();
-    await selectAntOption("Authentication", "OAuth");
+    await selectOption("Authentication", "OAuth");
     await waitFor(() => {
       expect(screen.getByText("OAuth Flow Type")).toBeInTheDocument();
     });
-    await selectAntOption("OAuth Flow Type", "Machine-to-Machine (M2M)");
+    await selectOption("OAuth Flow Type", "Machine-to-Machine (M2M)");
     await waitFor(() => {
       expect(screen.getByPlaceholderText("Enter OAuth client ID")).toBeInTheDocument();
     });
@@ -2078,7 +2078,7 @@ describe("CreateMCPServer dcr_bridge toggle", () => {
 
   async function setupHttpServerForm() {
     render(<CreateMCPServer {...defaultProps} />);
-    await selectAntOption("Transport Type", "Streamable HTTP");
+    await selectOption("Transport Type", "Streamable HTTP");
     await waitFor(() => {
       expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
     });
@@ -2109,7 +2109,7 @@ describe("CreateMCPServer dcr_bridge toggle", () => {
     async (optionLabel) => {
       await setupHttpServerForm();
 
-      await selectAntOption("Authentication", optionLabel);
+      await selectOption("Authentication", optionLabel);
 
       await waitFor(() => {
         expect(getDcrToggle()).toBeInTheDocument();
@@ -2122,7 +2122,7 @@ describe("CreateMCPServer dcr_bridge toggle", () => {
   it.each([["None"], ["API Key"], ["OAuth"]])("does not render the toggle for %s", async (optionLabel) => {
     await setupHttpServerForm();
 
-    await selectAntOption("Authentication", optionLabel);
+    await selectOption("Authentication", optionLabel);
 
     await waitFor(() => {
       expect(screen.queryByText("Gateway-hosted sign-in (DCR bridge)")).not.toBeInTheDocument();
@@ -2133,7 +2133,7 @@ describe("CreateMCPServer dcr_bridge toggle", () => {
   it("renders the toggle between the OAuth client fields and the Authorize button", async () => {
     await setupHttpServerForm();
 
-    await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+    await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
 
     await waitFor(() => {
       expect(getDcrToggle()).toBeInTheDocument();
@@ -2151,7 +2151,7 @@ describe("CreateMCPServer dcr_bridge toggle", () => {
   ])("sends dcr_bridge: true by default on create for %s", async (authType, optionLabel) => {
     vi.mocked(networking.createMCPServer).mockResolvedValue({ ...createdServer, auth_type: authType });
     await setupHttpServerForm();
-    await selectAntOption("Authentication", optionLabel);
+    await selectOption("Authentication", optionLabel);
     await waitFor(() => {
       expect(getDcrToggle()).toBeInTheDocument();
     });
@@ -2163,7 +2163,7 @@ describe("CreateMCPServer dcr_bridge toggle", () => {
   it("sends an explicit dcr_bridge: false when the toggle is unchecked", async () => {
     vi.mocked(networking.createMCPServer).mockResolvedValue({ ...createdServer, auth_type: "oauth_delegate" });
     await setupHttpServerForm();
-    await selectAntOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
+    await selectOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
     await waitFor(() => {
       expect(getDcrToggle()).toBeInTheDocument();
     });
@@ -2184,7 +2184,7 @@ describe("CreateMCPServer dcr_bridge toggle", () => {
   it("forces dcr_bridge: false when the auth type is switched away after toggling", async () => {
     vi.mocked(networking.createMCPServer).mockResolvedValue({ ...createdServer, auth_type: "none" });
     await setupHttpServerForm();
-    await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+    await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
     await waitFor(() => {
       expect(getDcrToggle()).toBeInTheDocument();
     });
@@ -2192,7 +2192,7 @@ describe("CreateMCPServer dcr_bridge toggle", () => {
       fireEvent.click(getDcrToggle()!);
     });
 
-    await selectAntOption("Authentication", "None");
+    await selectOption("Authentication", "None");
     await waitFor(() => {
       expect(getDcrToggle()).not.toBeInTheDocument();
     });
@@ -2204,7 +2204,7 @@ describe("CreateMCPServer dcr_bridge toggle", () => {
   it("preserves the toggle value when switching between the two client-forwarded modes", async () => {
     vi.mocked(networking.createMCPServer).mockResolvedValue({ ...createdServer, auth_type: "oauth_delegate" });
     await setupHttpServerForm();
-    await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+    await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
     await waitFor(() => {
       expect(getDcrToggle()).toBeInTheDocument();
     });
@@ -2212,7 +2212,7 @@ describe("CreateMCPServer dcr_bridge toggle", () => {
 
     // The field is mounted in both client-forwarded modes, so switching between them keeps the
     // live toggle value rather than forcing it back to the default or to false.
-    await selectAntOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
+    await selectOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
     await waitFor(() => {
       expect(getDcrToggle()).toBeInTheDocument();
     });

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/CreateMCPServer.permissions.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/CreateMCPServer.permissions.integration.test.tsx
@@ -58,15 +58,7 @@ const defaultProps = {
 
 const getServerNameInput = () => document.getElementById("server_name") as HTMLInputElement;
 
-const switchFor = (labelText: string): HTMLElement => {
-  const label = screen.getByText(labelText);
-  const row = label.closest(".flex.items-start.justify-between");
-  const control = row?.querySelector("button[role='switch']");
-  if (control === null || control === undefined) {
-    throw new Error(`no switch found for "${labelText}"`);
-  }
-  return control as HTMLElement;
-};
+const switchFor = (labelText: string): HTMLElement => screen.getByRole("switch", { name: labelText });
 
 const fillMinimalHttpServer = async (name: string) => {
   await selectAntOption("Transport Type", "Streamable HTTP");

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/CreateMCPServer.permissions.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/CreateMCPServer.permissions.integration.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as networking from "@/components/networking";
 import CreateMCPServer from "./CreateMCPServer";
-import { selectAntOption } from "./testUtils";
+import { selectOption } from "./testUtils";
 
 vi.mock("@/components/networking", () => ({
   createMCPServer: vi.fn(),
@@ -58,17 +58,29 @@ const defaultProps = {
 
 const getServerNameInput = () => document.getElementById("server_name") as HTMLInputElement;
 
-const switchFor = (labelText: string): HTMLElement => screen.getByRole("switch", { name: labelText });
+// The switches live behind a collapsed panel, so they only reach the accessibility tree once an
+// operator expands it.
+const expandPermissionPanel = async (): Promise<void> => {
+  const trigger = screen.getByRole("button", { name: /Permission Management/ });
+  if (trigger.getAttribute("aria-expanded") !== "true") {
+    await userEvent.setup({ delay: null }).click(trigger);
+  }
+};
+
+const switchFor = async (labelText: string): Promise<HTMLElement> => {
+  await expandPermissionPanel();
+  return screen.getByRole("switch", { name: labelText });
+};
 
 const fillMinimalHttpServer = async (name: string) => {
-  await selectAntOption("Transport Type", "Streamable HTTP");
+  await selectOption("Transport Type", "Streamable HTTP");
   await waitFor(() => {
     expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
   });
   const user = userEvent.setup({ delay: null });
   await user.type(getServerNameInput(), name);
   await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
-  await selectAntOption("Authentication", "None");
+  await selectOption("Authentication", "None");
 };
 
 const submitAndReadPayload = async () => {
@@ -112,8 +124,9 @@ describe("CreateMCPServer permission toggles reaching the payload", () => {
     render(<CreateMCPServer {...defaultProps} />);
     await fillMinimalHttpServer("Perm_Server");
 
+    const allowAllKeys = await switchFor("Allow All LiteLLM Keys");
     await act(async () => {
-      fireEvent.click(switchFor("Allow All LiteLLM Keys"));
+      fireEvent.click(allowAllKeys);
     });
 
     const payload = await submitAndReadPayload();
@@ -125,7 +138,7 @@ describe("CreateMCPServer permission toggles reaching the payload", () => {
     render(<CreateMCPServer {...defaultProps} />);
     await fillMinimalHttpServer("Perm_Server");
 
-    const internalOnly = switchFor("Internal network only");
+    const internalOnly = await switchFor("Internal network only");
     expect(internalOnly).toHaveAttribute("aria-checked", "false");
 
     await act(async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/CreateMCPServer.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/CreateMCPServer.tsx
@@ -1,9 +1,13 @@
 import React, { useState } from "react";
-import { Tooltip, Select, Input as AntdInput, InputNumber, Collapse } from "antd";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
-import { Info } from "lucide-react";
+import { ChevronDown, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { SimpleTooltip } from "@/components/ui/tooltip";
+import { PasswordInput } from "@/components/shared/PasswordInput";
 import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
 import { createMCPServer, registerMCPServer, storeMCPOAuthUserCredential } from "@/components/networking";
 import { setToken } from "@/utils/mcpTokenStore";
@@ -14,6 +18,8 @@ import {
   MCPServer,
   MCPServerCostInfo,
   TRANSPORT,
+  TRANSPORT_ITEMS,
+  AUTH_TYPE_ITEMS,
   getMcpOAuthMode,
   MCP_OAUTH2_FLOW_M2M,
   isClientForwardedTokenMode,
@@ -59,9 +65,8 @@ import {
 } from "@/components/common_components/MountedFormField";
 import { antdRequired, antdRules } from "@/components/common_components/antdFormRules";
 import { allFieldsValue, mountedPaths, resetFields, setFieldsValue, singleBranchChange } from "./mcpFormStore";
-import { numberControl, notOnlyWhitespace, selectControl, textControl } from "./mcpFieldRules";
+import { numberControl, notOnlyWhitespace, selectControl, selectTriggerControl, textControl } from "./mcpFieldRules";
 import mcpLogo from "../../../../../public/assets/logos/mcp_logo.png";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
 export const mcpLogoImg = mcpLogo.src;
 
@@ -122,7 +127,6 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
   const [toolNameToDescription, setToolNameToDescription] = useState<Record<string, string>>({});
   const [transportType, setTransportType] = useState<string>("");
   const [keyTools, setKeyTools] = useState<OpenAPIKeyTool[]>([]);
-  const [searchValue, setSearchValue] = useState<string>("");
   const [oauthAccessToken, setOauthAccessToken] = useState<string | null>(null);
   const [logoUrl, setLogoUrl] = useState<string | undefined>(undefined);
   const [oauthDocsUrl, setOauthDocsUrl] = useState<string | null>(null);
@@ -174,7 +178,6 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
       costConfig,
       allowedTools,
       hasToolAllowlistInteraction,
-      searchValue,
       aliasManuallyEdited,
       logoUrl,
       authorizedIdentity,
@@ -339,9 +342,6 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     }
     if (restored.hasToolAllowlistInteraction !== undefined) {
       setHasToolAllowlistInteraction(restored.hasToolAllowlistInteraction);
-    }
-    if (restored.searchValue) {
-      setSearchValue(restored.searchValue);
     }
     if (restored.aliasManuallyEdited !== undefined) {
       setAliasManuallyEdited(restored.aliasManuallyEdited);
@@ -527,37 +527,13 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     setFormValues(allFieldsValue(form));
   };
 
-  // Generate options with existing groups and potential new group
-  const getAccessGroupOptions = () => {
-    const existingOptions = availableAccessGroups.map((group: string) => ({
-      value: group,
-      label: (
-        <div className="flex items-center gap-2">
-          <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-          <span className="font-medium">{group}</span>
-        </div>
-      ),
-    }));
-
-    // If search value doesn't match any existing group and is not empty, add "create new group" option
-    if (
-      searchValue &&
-      !availableAccessGroups.some((group) => group.toLowerCase().includes(searchValue.toLowerCase()))
-    ) {
-      existingOptions.push({
-        value: searchValue,
-        label: (
-          <div className="flex items-center gap-2">
-            <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
-            <span className="font-medium">{searchValue}</span>
-            <span className="text-gray-400 text-xs ml-1">create new group</span>
-          </div>
-        ),
-      });
-    }
-
-    return existingOptions;
-  };
+  const handleTransportSelected =
+    (onChange: (value: string) => void) =>
+    (value: string | null): void => {
+      if (value === null) return;
+      onChange(value);
+      handleTransportChange(value);
+    };
 
   // Auto-populate alias from server_name unless manually edited
   React.useEffect(() => {
@@ -647,31 +623,19 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     <Dialog open={isModalVisible} onOpenChange={(open) => !open && handleCancel()}>
       <DialogContent className="top-8 max-h-[calc(100dvh-4rem)] translate-y-0 overflow-y-auto sm:max-w-[1000px]">
         <DialogHeader>
-          <div className="flex items-center pb-4 border-b border-gray-100" style={{ gap: 12 }}>
+          <div className="flex items-center gap-3 border-b border-border pb-4">
             {onBackToDiscovery && (
-              <button
-                onClick={onBackToDiscovery}
-                className="text-sm text-blue-600 hover:text-blue-800 cursor-pointer bg-transparent border-none"
-                style={{ flexShrink: 0 }}
-              >
+              <Button variant="link" size="sm" className="shrink-0 px-0" onClick={onBackToDiscovery}>
                 &#8592;
-              </button>
+              </Button>
             )}
-            <img
-              src={mcpLogoImg}
-              alt="MCP Logo"
-              className="w-8 h-8 object-contain"
-              style={{
-                height: "20px",
-                width: "20px",
-                objectFit: "contain",
-              }}
-            />
-            <DialogTitle className="text-xl font-semibold text-gray-900">
+            <img src={mcpLogoImg} alt="MCP Logo" className="size-5 object-contain" />
+            <DialogTitle className="text-xl font-semibold">
               {isAdmin ? "Add New MCP Server" : "Submit MCP Server for Review"}
             </DialogTitle>
           </div>
         </DialogHeader>
+
         <div className="mt-6">
           <FormProvider {...form}>
             <MountedFormProvider value={{ control: form.control, registry }}>
@@ -687,9 +651,9 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                     label={
                       <span className="text-sm font-medium text-gray-700 flex items-center">
                         MCP Server Name
-                        <Tooltip title="Best practice: Use a descriptive name that indicates the server's purpose (e.g., 'GitHub_MCP', 'Email_Service'). Cannot contain spaces or hyphens; use underscores instead. Names must comply with SEP-986 and will be rejected if invalid (https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-names).">
+                        <SimpleTooltip content="Best practice: Use a descriptive name that indicates the server's purpose (e.g., 'GitHub_MCP', 'Email_Service'). Cannot contain spaces or hyphens; use underscores instead. Names must comply with SEP-986 and will be rejected if invalid (https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-names).">
                           <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                        </Tooltip>
+                        </SimpleTooltip>
                       </span>
                     }
                     name="server_name"
@@ -708,9 +672,9 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                     label={
                       <span className="text-sm font-medium text-gray-700 flex items-center">
                         Alias
-                        <Tooltip title="A short, unique identifier for this server. Defaults to the server name if not provided. Cannot contain spaces or hyphens; use underscores instead.">
+                        <SimpleTooltip content="A short, unique identifier for this server. Defaults to the server name if not provided. Cannot contain spaces or hyphens; use underscores instead.">
                           <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                        </Tooltip>
+                        </SimpleTooltip>
                       </span>
                     }
                     name="alias"
@@ -765,19 +729,20 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                   >
                     {(control) => (
                       <Select
-                        {...selectControl<string>(control)}
-                        placeholder="Select transport"
-                        className="rounded-lg"
-                        size="large"
-                        onChange={(value: string) => {
-                          control.onChange(value);
-                          handleTransportChange(value);
-                        }}
+                        items={TRANSPORT_ITEMS}
+                        value={(control.value as string | undefined) ?? null}
+                        onValueChange={handleTransportSelected(control.onChange)}
                       >
-                        <Select.Option value="http">Streamable HTTP (Recommended)</Select.Option>
-                        <Select.Option value="sse">Server-Sent Events (SSE)</Select.Option>
-                        <Select.Option value="stdio">Standard Input/Output (stdio)</Select.Option>
-                        <Select.Option value={TRANSPORT.OPENAPI}>OpenAPI Spec</Select.Option>
+                        <SelectTrigger {...selectTriggerControl(control)} className="w-full rounded-lg">
+                          <SelectValue placeholder="Select transport" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {TRANSPORT_ITEMS.map((item) => (
+                            <SelectItem key={item.value} value={item.value}>
+                              {item.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
                       </Select>
                     )}
                   </MountedFormField>
@@ -796,7 +761,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                       }}
                     >
                       {(control) => (
-                        <AntdInput
+                        <Input
                           {...textControl(control)}
                           placeholder="https://your-mcp-server.com"
                           className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
@@ -826,135 +791,114 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                     label={
                       <span className="text-sm font-medium text-gray-700 flex items-center">
                         Max Concurrent Requests (optional)
-                        <Tooltip title="Maximum number of tool calls LiteLLM will run against this server at the same time. Additional calls wait for a free slot. Leave blank for no limit.">
+                        <SimpleTooltip content="Maximum number of tool calls LiteLLM will run against this server at the same time. Additional calls wait for a free slot. Leave blank for no limit.">
                           <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                        </Tooltip>
+                        </SimpleTooltip>
                       </span>
                     }
                     name="max_concurrent_requests"
                   >
                     {(control) => (
-                      <InputNumber
-                        {...numberControl(control)}
+                      <Input
+                        {...numberControl(control, 0)}
                         min={1}
-                        precision={0}
+                        step={1}
                         placeholder="e.g. 10"
-                        style={{ width: "100%" }}
-                        className="rounded-lg"
+                        className="w-full rounded-lg"
                       />
                     )}
                   </MountedFormField>
 
                   {/* Authentication - show for HTTP, SSE, and OpenAPI */}
                   {transportType !== "stdio" && transportType !== "" && (
-                    <Collapse
-                      defaultActiveKey={["auth"]}
-                      className="mb-4"
-                      items={[
-                        {
-                          key: "auth",
-                          label: <span className="text-sm font-semibold text-gray-700">Authentication</span>,
-                          children: (
-                            <>
-                              <MountedFormField
-                                name="auth_type"
-                                required
-                                rules={{ validate: { required: antdRequired("Please select an auth type") } }}
-                              >
-                                {(control) => (
-                                  <Select
-                                    {...selectControl<string>(control)}
-                                    placeholder="Select auth type"
-                                    className="rounded-lg"
-                                    size="large"
-                                    virtual={false}
-                                  >
-                                    <Select.Option value="none">None</Select.Option>
-                                    <Select.Option value="api_key">API Key</Select.Option>
-                                    <Select.Option value="bearer_token">Bearer Token</Select.Option>
-                                    <Select.Option value="token">Token</Select.Option>
-                                    <Select.Option value="basic">Basic Auth</Select.Option>
-                                    <Select.Option value="oauth2">OAuth</Select.Option>
-                                    <Select.Option value="oauth2_token_exchange">
-                                      OAuth Token Exchange (OBO)
-                                    </Select.Option>
-                                    <Select.Option value="oauth2_id_jag">ID-JAG (Okta Cross App Access)</Select.Option>
-                                    <Select.Option value="aws_sigv4">AWS SigV4 (Bedrock AgentCore MCPs)</Select.Option>
-                                    <Select.Option value="true_passthrough">
-                                      True Passthrough (no LiteLLM auth)
-                                    </Select.Option>
-                                    <Select.Option value="oauth_delegate">
-                                      OAuth Delegate (client-supplied upstream token)
-                                    </Select.Option>
-                                  </Select>
-                                )}
-                              </MountedFormField>
+                    <Collapsible defaultOpen className="mb-4">
+                      <CollapsibleTrigger className="group flex w-full items-center justify-between gap-4 py-2 text-left">
+                        <span className="text-sm font-semibold text-gray-700">Authentication settings</span>
+                        <ChevronDown className="size-4 text-gray-500 transition-transform group-data-[panel-open]:rotate-180" />
+                      </CollapsibleTrigger>
+                      <CollapsibleContent keepMounted className="space-y-6 pt-2">
+                        <MountedFormField
+                          label="Authentication"
+                          name="auth_type"
+                          required
+                          rules={{ validate: { required: antdRequired("Please select an auth type") } }}
+                        >
+                          {(control) => (
+                            <Select {...selectControl<string>(control)} items={AUTH_TYPE_ITEMS}>
+                              <SelectTrigger {...selectTriggerControl(control)} className="w-full rounded-lg">
+                                <SelectValue placeholder="Select auth type" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {AUTH_TYPE_ITEMS.map((item) => (
+                                  <SelectItem key={item.value} value={item.value}>
+                                    {item.label}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          )}
+                        </MountedFormField>
 
-                              <TruePassthroughWarning authType={authType} />
+                        <TruePassthroughWarning authType={authType} />
 
-                              <PassthroughAuthorizeSection
-                                authType={authType}
-                                dcrBridgeInitialChecked
-                                oauthFlow={{
-                                  startOAuthFlow,
-                                  status: oauthStatus,
-                                  error: oauthError,
-                                  tokenResponse: oauthTokenResponse,
-                                }}
-                                appMayNotMatchUpstream={appMayNotMatchUpstream}
+                        <PassthroughAuthorizeSection
+                          authType={authType}
+                          dcrBridgeInitialChecked
+                          oauthFlow={{
+                            startOAuthFlow,
+                            status: oauthStatus,
+                            error: oauthError,
+                            tokenResponse: oauthTokenResponse,
+                          }}
+                          appMayNotMatchUpstream={appMayNotMatchUpstream}
+                        />
+
+                        {shouldShowAuthValueField && (
+                          <MountedFormField
+                            label={
+                              <span className="text-sm font-medium text-gray-700 flex items-center">
+                                Authentication Value
+                                <SimpleTooltip content="Token, password, or header value to send with each request for the selected auth type.">
+                                  <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
+                                </SimpleTooltip>
+                              </span>
+                            }
+                            name={["credentials", "auth_value"]}
+                            rules={{
+                              validate: {
+                                notWhitespace: notOnlyWhitespace("Authentication value cannot be empty whitespace"),
+                              },
+                            }}
+                          >
+                            {(control) => (
+                              <PasswordInput
+                                {...textControl(control)}
+                                placeholder="Enter token or secret"
+                                groupClassName="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                               />
+                            )}
+                          </MountedFormField>
+                        )}
 
-                              {shouldShowAuthValueField && (
-                                <MountedFormField
-                                  label={
-                                    <span className="text-sm font-medium text-gray-700 flex items-center">
-                                      Authentication Value
-                                      <Tooltip title="Token, password, or header value to send with each request for the selected auth type.">
-                                        <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                                      </Tooltip>
-                                    </span>
-                                  }
-                                  name={["credentials", "auth_value"]}
-                                  rules={{
-                                    validate: {
-                                      notWhitespace: notOnlyWhitespace(
-                                        "Authentication value cannot be empty whitespace",
-                                      ),
-                                    },
-                                  }}
-                                >
-                                  {(control) => (
-                                    <AntdInput.Password
-                                      {...textControl(control)}
-                                      placeholder="Enter token or secret"
-                                      className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
-                                    />
-                                  )}
-                                </MountedFormField>
-                              )}
+                        {isOAuthAuthType && (
+                          <OAuthFormFields
+                            isM2M={isM2MFlow}
+                            initialFlowType={OAUTH_FLOW.INTERACTIVE}
+                            docsUrl={oauthDocsUrl}
+                            oauthFlow={{
+                              startOAuthFlow,
+                              status: oauthStatus,
+                              error: oauthError,
+                              tokenResponse: oauthTokenResponse,
+                            }}
+                          />
+                        )}
 
-                              {isOAuthAuthType && (
-                                <OAuthFormFields
-                                  isM2M={isM2MFlow}
-                                  initialFlowType={OAUTH_FLOW.INTERACTIVE}
-                                  docsUrl={oauthDocsUrl}
-                                  oauthFlow={{
-                                    startOAuthFlow,
-                                    status: oauthStatus,
-                                    error: oauthError,
-                                    tokenResponse: oauthTokenResponse,
-                                  }}
-                                />
-                              )}
+                        {isTokenExchangeAuthType && <TokenExchangeFormFields />}
 
-                              {isTokenExchangeAuthType && <TokenExchangeFormFields />}
-
-                              {isIdJagAuthType && <IdJagFormFields />}
-                            </>
-                          ),
-                        },
-                      ]}
-                    />
+                        {isIdJagAuthType && <IdJagFormFields />}
+                      </CollapsibleContent>
+                    </Collapsible>
                   )}
 
                   {transportType !== "stdio" && transportType !== "" && isAwsSigV4AuthType && <AwsSigV4Fields />}
@@ -974,9 +918,6 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                     availableAccessGroups={availableAccessGroups}
                     mcpServer={null}
                     mountedAuthType={authSectionMounted ? watchedAuthType : undefined}
-                    searchValue={searchValue}
-                    setSearchValue={setSearchValue}
-                    getAccessGroupOptions={getAccessGroupOptions}
                   />
                 </div>
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/DcrBridgeToggle.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/DcrBridgeToggle.tsx
@@ -1,7 +1,8 @@
-import React from "react";
-import { Switch, Tooltip } from "antd";
 import { Info } from "lucide-react";
+import React from "react";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 
+import { Switch } from "@/components/ui/switch";
 import { MountedFormField } from "@/components/common_components/MountedFormField";
 import { isClientForwardedTokenMode } from "@/components/mcp_tools/types";
 import { switchControl } from "./mcpFieldRules";
@@ -28,9 +29,9 @@ export default function DcrBridgeToggle({
       label={
         <span className="text-sm font-medium text-gray-700 flex items-center">
           Gateway-hosted sign-in (DCR bridge)
-          <Tooltip title="Lets OAuth-only clients like Claude Desktop register and sign in through the gateway. Turn off to relay the upstream server's own OAuth metadata instead (for clients pre-registered with the upstream IdP).">
+          <SimpleTooltip content="Lets OAuth-only clients like Claude Desktop register and sign in through the gateway. Turn off to relay the upstream server's own OAuth metadata instead (for clients pre-registered with the upstream IdP).">
             <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-          </Tooltip>
+          </SimpleTooltip>
         </span>
       }
       name="dcr_bridge"

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/EnvVarsSection.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/EnvVarsSection.tsx
@@ -1,7 +1,10 @@
-import React from "react";
-import { Input, Select, Tooltip, Typography } from "antd";
-import { Button } from "@/components/ui/button";
 import { CircleMinus, Info, Plus } from "lucide-react";
+import React from "react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { SimpleTooltip } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 
 import {
@@ -10,10 +13,8 @@ import {
   type MountedFormValues,
 } from "@/components/common_components/MountedFormField";
 import { antdRequired } from "@/components/common_components/antdFormRules";
-import { matchesPattern, selectControl, textControl } from "./mcpFieldRules";
+import { matchesPattern, selectControl, selectTriggerControl, textControl } from "./mcpFieldRules";
 import { listControl } from "./mcpFormStore";
-
-const { Text } = Typography;
 
 const SCOPE_OPTIONS = [
   { value: "global", label: "Instance" },
@@ -40,11 +41,9 @@ const EnvVarsSection: React.FC = () => {
   return (
     <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
       <div className="flex items-center gap-2 mb-1">
-        <Text strong className="text-sm">
-          Variables
-        </Text>
-        <Tooltip
-          title={
+        <strong className="text-sm font-semibold">Variables</strong>
+        <SimpleTooltip
+          content={
             <>
               Define variables you can interpolate in Static Headers or Authentication using{" "}
               <code>{"${VAR_NAME}"}</code>. <br />
@@ -56,14 +55,14 @@ const EnvVarsSection: React.FC = () => {
           }
         >
           <Info className="size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-        </Tooltip>
+        </SimpleTooltip>
       </div>
-      <Text className="text-xs text-gray-600 block mb-3">
+      <span className="mb-3 block text-xs text-gray-600">
         Reference these in Static Headers or Authentication as <code>{"${VAR_NAME}"}</code>. For example:{" "}
         <code className="bg-white px-1 rounded-sm border border-gray-200">
           {"${DB_PROTOCOL}://${CORP_USERNAME}:${CORP_PASSWORD}@${DB_HOSTNAME}"}
         </code>
-      </Text>
+      </span>
 
       <div className="space-y-2">
         {fields.length > 0 && (
@@ -97,7 +96,20 @@ const EnvVarsSection: React.FC = () => {
               <ScopedValueOrDescription index={index} />
             </div>
             <MountedFormField name={["env_vars", String(index), "scope"]} className="mb-0 w-40" defaultValue="global">
-              {(control) => <Select {...selectControl<string>(control)} options={SCOPE_OPTIONS} />}
+              {(control) => (
+                <Select {...selectControl<string>(control)} items={SCOPE_OPTIONS}>
+                  <SelectTrigger {...selectTriggerControl(control)} className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SCOPE_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
             </MountedFormField>
             <div style={{ width: 24, height: 32 }} className="flex items-center justify-center">
               <CircleMinus
@@ -125,19 +137,17 @@ const ScopedValueOrDescription: React.FC<{ index: number }> = ({ index }) => {
     return (
       <MountedFormField name={["env_vars", String(index), "description"]} className="mb-0">
         {(control) => (
-          <Input
-            {...textControl(control)}
-            addonBefore={
-              <Tooltip title="Per-user variables have no shared value. This text is only a hint shown to each user when they fill in their own value.">
+          <InputGroup>
+            <InputGroupAddon>
+              <SimpleTooltip content="Per-user variables have no shared value. This text is only a hint shown to each user when they fill in their own value.">
                 <span className="text-xs text-gray-500 cursor-help whitespace-nowrap">
                   <Info className="mr-1 inline size-3 align-text-bottom" />
                   Hint
                 </span>
-              </Tooltip>
-            }
-            placeholder="e.g. Your DB username"
-            styles={{ input: { color: "#9ca3af" } }}
-          />
+              </SimpleTooltip>
+            </InputGroupAddon>
+            <InputGroupInput {...textControl(control)} placeholder="e.g. Your DB username" className="text-gray-400" />
+          </InputGroup>
         )}
       </MountedFormField>
     );

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/IdJagFormFields.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/IdJagFormFields.tsx
@@ -1,10 +1,14 @@
-import React from "react";
-import { Input, Select, Tooltip } from "antd";
 import { Info } from "lucide-react";
+import React from "react";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 
 import { MountedFormField } from "@/components/common_components/MountedFormField";
 import { antdRequired } from "@/components/common_components/antdFormRules";
-import { requiredUnlessSiblingSet, selectControl, textControl } from "./mcpFieldRules";
+import { MultiSelect } from "@/components/shared/MultiSelect";
+import { PasswordInput } from "@/components/shared/PasswordInput";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { requiredUnlessSiblingSet, tagsControl, textControl } from "./mcpFieldRules";
 
 interface IdJagFormFieldsProps {
   isEditing?: boolean;
@@ -15,9 +19,9 @@ const fieldClassName = "rounded-lg border-gray-300 focus:border-blue-500 focus:r
 const FieldLabel: React.FC<{ label: string; tooltip: string }> = ({ label, tooltip }) => (
   <span className="text-sm font-medium text-gray-700 flex items-center">
     {label}
-    <Tooltip title={tooltip}>
+    <SimpleTooltip content={tooltip}>
       <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-    </Tooltip>
+    </SimpleTooltip>
   </span>
 );
 
@@ -75,10 +79,10 @@ const IdJagFormFields: React.FC<IdJagFormFieldsProps> = ({ isEditing = false }) 
         rules={requiredWhenCreating("Client ID is required for ID-JAG")}
       >
         {(control) => (
-          <Input.Password
+          <PasswordInput
             {...textControl(control)}
             placeholder={`Enter OAuth client ID${placeholderSuffix}`}
-            className={fieldClassName}
+            groupClassName={fieldClassName}
           />
         )}
       </MountedFormField>
@@ -105,10 +109,10 @@ const IdJagFormFields: React.FC<IdJagFormFieldsProps> = ({ isEditing = false }) 
         }
       >
         {(control) => (
-          <Input.Password
+          <PasswordInput
             {...textControl(control)}
             placeholder={`Enter OAuth client secret${placeholderSuffix}`}
-            className={fieldClassName}
+            groupClassName={fieldClassName}
           />
         )}
       </MountedFormField>
@@ -122,7 +126,7 @@ const IdJagFormFields: React.FC<IdJagFormFieldsProps> = ({ isEditing = false }) 
         name={PRIVATE_KEY_PATH}
       >
         {(control) => (
-          <Input.TextArea
+          <Textarea
             {...textControl(control)}
             rows={3}
             placeholder={`-----BEGIN PRIVATE KEY-----${placeholderSuffix}`}
@@ -199,16 +203,7 @@ const IdJagFormFields: React.FC<IdJagFormFieldsProps> = ({ isEditing = false }) 
         label={<FieldLabel label="Scopes (optional)" tooltip="Scopes requested on leg 1 of the exchange." />}
         name={["credentials", "scopes"]}
       >
-        {(control) => (
-          <Select
-            {...selectControl(control)}
-            mode="tags"
-            tokenSeparators={[","]}
-            placeholder="Add scopes"
-            className="rounded-lg"
-            size="large"
-          />
-        )}
+        {(control) => <MultiSelect {...tagsControl(control)} placeholder="Add scopes" className="rounded-lg" />}
       </MountedFormField>
     </>
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/IdJagFormFields.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/IdJagFormFields.tsx
@@ -8,7 +8,7 @@ import { MultiSelect } from "@/components/shared/MultiSelect";
 import { PasswordInput } from "@/components/shared/PasswordInput";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { requiredUnlessSiblingSet, scopesControl, textControl } from "./mcpFieldRules";
+import { requiredUnlessSiblingSet, tagsControl, textControl } from "./mcpFieldRules";
 
 interface IdJagFormFieldsProps {
   isEditing?: boolean;
@@ -203,7 +203,7 @@ const IdJagFormFields: React.FC<IdJagFormFieldsProps> = ({ isEditing = false }) 
         label={<FieldLabel label="Scopes (optional)" tooltip="Scopes requested on leg 1 of the exchange." />}
         name={["credentials", "scopes"]}
       >
-        {(control) => <MultiSelect {...scopesControl(control)} placeholder="Add scopes" className="rounded-lg" />}
+        {(control) => <MultiSelect {...tagsControl(control)} placeholder="Add scopes" className="rounded-lg" />}
       </MountedFormField>
     </>
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/IdJagFormFields.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/IdJagFormFields.tsx
@@ -8,7 +8,7 @@ import { MultiSelect } from "@/components/shared/MultiSelect";
 import { PasswordInput } from "@/components/shared/PasswordInput";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { requiredUnlessSiblingSet, tagsControl, textControl } from "./mcpFieldRules";
+import { requiredUnlessSiblingSet, scopesControl, textControl } from "./mcpFieldRules";
 
 interface IdJagFormFieldsProps {
   isEditing?: boolean;
@@ -203,7 +203,7 @@ const IdJagFormFields: React.FC<IdJagFormFieldsProps> = ({ isEditing = false }) 
         label={<FieldLabel label="Scopes (optional)" tooltip="Scopes requested on leg 1 of the exchange." />}
         name={["credentials", "scopes"]}
       >
-        {(control) => <MultiSelect {...tagsControl(control)} placeholder="Add scopes" className="rounded-lg" />}
+        {(control) => <MultiSelect {...scopesControl(control)} placeholder="Add scopes" className="rounded-lg" />}
       </MountedFormField>
     </>
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPPermissionManagement.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPPermissionManagement.test.tsx
@@ -31,11 +31,7 @@ describe("MCPPermissionManagement", () => {
   it("should default allow_all_keys switch to unchecked for new servers", async () => {
     renderWithForm();
     await expandPanel();
-    // Find the switch associated with "Allow All LiteLLM Keys" text
-    // The first switch in the component is for allow_all_keys
-    const switches = screen.getAllByRole("switch");
-    const toggle = switches[0];
-    expect(toggle).not.toBeChecked();
+    expect(screen.getByRole("switch", { name: "Allow All LiteLLM Keys" })).not.toBeChecked();
   });
 
   const renderWithInitialValues = (initialValues: Record<string, unknown>, props = {}) =>

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPPermissionManagement.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPPermissionManagement.tsx
@@ -1,30 +1,28 @@
 import React, { useEffect } from "react";
-import { Select, Tooltip, Collapse, Input, Space, Switch } from "antd";
-import { CircleMinus, Info, Plus, TriangleAlert } from "lucide-react";
+import { MultiSelect } from "@/components/shared/MultiSelect";
+import { SimpleTooltip } from "@/components/ui/tooltip";
+import { ChevronRight, CircleMinus, Info, Plus, TriangleAlert, X } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/shared/Alert";
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/ui/input-group";
+import { Switch } from "@/components/ui/switch";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import { MCPServer, AUTH_TYPE } from "@/components/mcp_tools/types";
 import {
   MountedFormField,
   useMountedName,
+  type MountedFieldControlProps,
   type MountedFormValues,
 } from "@/components/common_components/MountedFormField";
 import { antdRequired } from "@/components/common_components/antdFormRules";
 import { Field, FieldLabel } from "@/components/shared/form/field";
-import { invertedSwitchControl, selectControl, switchControl, textControl } from "./mcpFieldRules";
+import { invertedSwitchControl, switchControl, tagsControl, textControl } from "./mcpFieldRules";
 import { listControl } from "./mcpFormStore";
-const { Panel } = Collapse;
 
 interface MCPPermissionManagementProps {
   availableAccessGroups: string[];
   mcpServer: MCPServer | null;
-  searchValue: string;
-  setSearchValue: (value: string) => void;
-  getAccessGroupOptions: () => Array<{
-    value: string;
-    label: React.ReactNode;
-  }>;
   /**
    * The auth type as seen through the gate that mounts the auth_type field.
    * Callers pass undefined whenever that field is unmounted, because both
@@ -34,6 +32,26 @@ interface MCPPermissionManagementProps {
   mountedAuthType: string | null | undefined;
 }
 
+const ClearableInput: React.FC<{
+  control: MountedFieldControlProps;
+  placeholder: string;
+  clearLabel: string;
+}> = ({ control, placeholder, clearLabel }) => {
+  const text = textControl(control);
+  return (
+    <InputGroup className="rounded-lg">
+      <InputGroupInput {...text} placeholder={placeholder} />
+      {text.value !== "" && (
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton size="icon-xs" aria-label={clearLabel} onClick={() => control.onChange("")}>
+            <X />
+          </InputGroupButton>
+        </InputGroupAddon>
+      )}
+    </InputGroup>
+  );
+};
+
 const StaticHeadersFieldArray: React.FC = () => {
   const { control } = useFormContext<MountedFormValues>();
   const { fields, append, remove } = useFieldArray({ control: listControl(control), name: "static_headers" });
@@ -42,19 +60,17 @@ const StaticHeadersFieldArray: React.FC = () => {
   return (
     <div className="space-y-3">
       {fields.map((item, index) => (
-        <Space key={item.id} className="flex w-full" align="baseline" size="middle">
+        <div key={item.id} className="flex w-full items-baseline gap-4">
           <MountedFormField
             name={["static_headers", String(index), "header"]}
             className="flex-1"
             rules={{ validate: { required: antdRequired("Header name is required") } }}
           >
             {(headerControl) => (
-              <Input
-                {...textControl(headerControl)}
-                size="large"
-                allowClear
-                className="rounded-lg"
+              <ClearableInput
+                control={headerControl}
                 placeholder="Header name (e.g., X-API-Key)"
+                clearLabel="Clear header name"
               />
             )}
           </MountedFormField>
@@ -64,20 +80,14 @@ const StaticHeadersFieldArray: React.FC = () => {
             rules={{ validate: { required: antdRequired("Header value is required") } }}
           >
             {(valueControl) => (
-              <Input
-                {...textControl(valueControl)}
-                size="large"
-                allowClear
-                className="rounded-lg"
-                placeholder="Header value"
-              />
+              <ClearableInput control={valueControl} placeholder="Header value" clearLabel="Clear header value" />
             )}
           </MountedFormField>
           <CircleMinus
             onClick={() => remove(index)}
             className="size-4 text-gray-500 hover:text-red-500 cursor-pointer"
           />
-        </Space>
+        </div>
       ))}
       <Button variant="outline" className="w-full border-dashed" onClick={() => append({})}>
         <Plus />
@@ -90,9 +100,6 @@ const StaticHeadersFieldArray: React.FC = () => {
 const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
   availableAccessGroups,
   mcpServer,
-  searchValue,
-  setSearchValue,
-  getAccessGroupOptions,
   mountedAuthType,
 }) => {
   const { setValue } = useFormContext<MountedFormValues>();
@@ -174,36 +181,35 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
   }, [canEnableOAuthPassthrough, setValue]);
 
   return (
-    <Collapse className="bg-gray-50 border border-gray-200 rounded-lg" expandIconPosition="end" ghost={false}>
-      <Panel
-        header={
-          <div className="flex items-center">
-            <div className="flex items-center space-x-2">
-              <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
-              <h3 className="text-lg font-semibold text-gray-900">Permission Management / Access Control</h3>
-            </div>
-            <p className="text-sm text-gray-600 ml-4">Configure access permissions and security settings (Optional)</p>
-          </div>
-        }
-        key="permissions"
-        className="border-0"
-        forceRender
-      >
+    <Collapsible className="bg-gray-50 border border-gray-200 rounded-lg">
+      <CollapsibleTrigger className="group flex w-full items-center justify-between gap-4 p-4 text-left">
+        <span className="flex items-center">
+          <span className="flex items-center space-x-2">
+            <span className="w-2 h-2 bg-blue-500 rounded-full"></span>
+            <span className="text-lg font-semibold text-gray-900">Permission Management / Access Control</span>
+          </span>
+          <span className="text-sm text-gray-600 ml-4">
+            Configure access permissions and security settings (Optional)
+          </span>
+        </span>
+        <ChevronRight className="size-4 shrink-0 text-muted-foreground transition-transform group-data-panel-open:rotate-90" />
+      </CollapsibleTrigger>
+      <CollapsibleContent keepMounted className="px-4 pb-4">
         <div className="space-y-6 pt-4">
           <div className="flex items-start justify-between gap-4">
             <div>
               <span className="text-sm font-medium text-gray-700 flex items-center">
                 Allow All LiteLLM Keys
-                <Tooltip title="When enabled, every API key can access this MCP server.">
+                <SimpleTooltip content="When enabled, every API key can access this MCP server.">
                   <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                </Tooltip>
+                </SimpleTooltip>
               </span>
               <p className="text-sm text-gray-600 mt-1">
                 Enable if this server should be &quot;public&quot; to all keys.
               </p>
             </div>
             <MountedFormField name="allow_all_keys" defaultValue={mcpServer?.allow_all_keys ?? false} className="mb-0">
-              {(control) => <Switch {...switchControl(control)} />}
+              {(control) => <Switch aria-label="Allow All LiteLLM Keys" {...switchControl(control)} />}
             </MountedFormField>
           </div>
 
@@ -211,16 +217,16 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
             <div>
               <span className="text-sm font-medium text-gray-700 flex items-center">
                 Internal network only
-                <Tooltip title="When on, only requests from within your internal network are accepted. Turn off to allow external clients (other clusters, ChatGPT, etc). API key authentication is always required regardless of this setting.">
+                <SimpleTooltip content="When on, only requests from within your internal network are accepted. Turn off to allow external clients (other clusters, ChatGPT, etc). API key authentication is always required regardless of this setting.">
                   <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                </Tooltip>
+                </SimpleTooltip>
               </span>
               <p className="text-sm text-gray-600 mt-1">
                 Turn on to restrict access to callers within your internal network only.
               </p>
             </div>
             <MountedFormField name="available_on_public_internet" defaultValue={true} className="mb-0">
-              {(control) => <Switch {...invertedSwitchControl(control)} />}
+              {(control) => <Switch aria-label="Internal network only" {...invertedSwitchControl(control)} />}
             </MountedFormField>
           </div>
 
@@ -229,9 +235,9 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
               <div>
                 <span className="text-sm font-medium text-gray-700 flex items-center">
                   Delegate auth to upstream (PKCE passthrough)
-                  <Tooltip title="When on, LiteLLM skips its own API key/SSO check for this server and lets the client complete PKCE directly with the upstream MCP server. Only honored when Auth Type is oauth2. No spend tracking or per-key rate limiting will run on this route.">
+                  <SimpleTooltip content="When on, LiteLLM skips its own API key/SSO check for this server and lets the client complete PKCE directly with the upstream MCP server. Only honored when Auth Type is oauth2. No spend tracking or per-key rate limiting will run on this route.">
                     <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                  </Tooltip>
+                  </SimpleTooltip>
                 </span>
                 <p className="text-sm text-gray-600 mt-1">
                   Bypass LiteLLM auth so clients authenticate directly with the upstream OAuth MCP server.
@@ -242,7 +248,9 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
                 defaultValue={mcpServer?.delegate_auth_to_upstream ?? false}
                 className="mb-0"
               >
-                {(control) => <Switch {...switchControl(control)} />}
+                {(control) => (
+                  <Switch aria-label="Delegate auth to upstream (PKCE passthrough)" {...switchControl(control)} />
+                )}
               </MountedFormField>
             </div>
           )}
@@ -252,9 +260,9 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
               <div>
                 <span className="text-sm font-medium text-gray-700 flex items-center">
                   OAuth pass-through
-                  <Tooltip title="When on, this server is treated as an OAuth pass-through: the gateway proxies the upstream /.well-known/oauth-protected-resource metadata, emits spec-compliant 401 challenges when no bearer is supplied, and propagates upstream 401/403 responses. Only honored when Auth Type is None and 'Authorization' is in Extra Headers.">
+                  <SimpleTooltip content="When on, this server is treated as an OAuth pass-through: the gateway proxies the upstream /.well-known/oauth-protected-resource metadata, emits spec-compliant 401 challenges when no bearer is supplied, and propagates upstream 401/403 responses. Only honored when Auth Type is None and 'Authorization' is in Extra Headers.">
                     <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                  </Tooltip>
+                  </SimpleTooltip>
                 </span>
                 <p className="text-sm text-gray-600 mt-1">
                   Forward upstream OAuth discovery and 401 challenges so clients negotiate OAuth directly with the
@@ -266,7 +274,7 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
                 defaultValue={mcpServer?.oauth_passthrough ?? false}
                 className="mb-0"
               >
-                {(control) => <Switch {...switchControl(control)} />}
+                {(control) => <Switch aria-label="OAuth pass-through" {...switchControl(control)} />}
               </MountedFormField>
             </div>
           )}
@@ -287,27 +295,20 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
             label={
               <span className="text-sm font-medium text-gray-700 flex items-center">
                 MCP Access Groups
-                <Tooltip title="Specify access groups for this MCP server. Users must be in at least one of these groups to access the server.">
+                <SimpleTooltip content="Specify access groups for this MCP server. Users must be in at least one of these groups to access the server.">
                   <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                </Tooltip>
+                </SimpleTooltip>
               </span>
             }
             name="mcp_access_groups"
             className="mb-4"
           >
             {(control) => (
-              <Select
-                {...selectControl(control)}
-                mode="tags"
-                showSearch
+              <MultiSelect
+                {...tagsControl(control)}
+                options={availableAccessGroups.map((group) => ({ label: group, value: group }))}
                 placeholder="Select existing groups or type to create new ones"
-                optionFilterProp="value"
-                filterOption={(input, option) => (option?.value ?? "").toLowerCase().includes(input.toLowerCase())}
-                onSearch={(value) => setSearchValue(value)}
-                tokenSeparators={[","]}
-                options={getAccessGroupOptions()}
-                maxTagCount="responsive"
-                allowClear
+                className="rounded-lg"
               />
             )}
           </MountedFormField>
@@ -316,9 +317,9 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
             label={
               <span className="text-sm font-medium text-gray-700 flex items-center">
                 Extra Headers
-                <Tooltip title="Forward custom headers from incoming requests to this MCP server (e.g., Authorization, X-Custom-Header, User-Agent)">
+                <SimpleTooltip content="Forward custom headers from incoming requests to this MCP server (e.g., Authorization, X-Custom-Header, User-Agent)">
                   <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                </Tooltip>
+                </SimpleTooltip>
                 {mcpServer?.extra_headers && mcpServer.extra_headers.length > 0 && (
                   <span className="ml-2 text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded-full">
                     {mcpServer.extra_headers.length} configured
@@ -329,18 +330,14 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
             name="extra_headers"
           >
             {(control) => (
-              <Select
-                {...selectControl(control)}
-                mode="tags"
+              <MultiSelect
+                {...tagsControl(control)}
                 placeholder={
                   mcpServer?.extra_headers && mcpServer.extra_headers.length > 0
                     ? `Currently: ${mcpServer.extra_headers.join(", ")}`
                     : "Enter header names (e.g., Authorization, X-Custom-Header)"
                 }
                 className="rounded-lg"
-                size="large"
-                tokenSeparators={[","]}
-                allowClear
               />
             )}
           </MountedFormField>
@@ -349,16 +346,16 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
             <FieldLabel>
               <span className="text-sm font-medium text-gray-700 flex items-center">
                 Static Headers
-                <Tooltip title="Send these key-value headers with every request to this MCP server.">
+                <SimpleTooltip content="Send these key-value headers with every request to this MCP server.">
                   <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                </Tooltip>
+                </SimpleTooltip>
               </span>
             </FieldLabel>
             <StaticHeadersFieldArray />
           </Field>
         </div>
-      </Panel>
-    </Collapse>
+      </CollapsibleContent>
+    </Collapsible>
   );
 };
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/OAuthFormFields.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/OAuthFormFields.tsx
@@ -16,7 +16,7 @@ import {
   parsesAsJson,
   selectControl,
   selectTriggerControl,
-  tagsControl,
+  scopesControl,
   textControl,
 } from "./mcpFieldRules";
 
@@ -172,7 +172,7 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             }
             name={["credentials", "scopes"]}
           >
-            {(control) => <MultiSelect {...tagsControl(control)} placeholder="Add scopes" className="rounded-lg" />}
+            {(control) => <MultiSelect {...scopesControl(control)} placeholder="Add scopes" className="rounded-lg" />}
           </MountedFormField>
           <UpstreamResourceField />
         </>
@@ -234,7 +234,7 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             }
             name={["credentials", "scopes"]}
           >
-            {(control) => <MultiSelect {...tagsControl(control)} placeholder="Add scopes" className="rounded-lg" />}
+            {(control) => <MultiSelect {...scopesControl(control)} placeholder="Add scopes" className="rounded-lg" />}
           </MountedFormField>
           <UpstreamResourceField />
           <MountedFormField

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/OAuthFormFields.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/OAuthFormFields.tsx
@@ -16,7 +16,7 @@ import {
   parsesAsJson,
   selectControl,
   selectTriggerControl,
-  scopesControl,
+  tagsControl,
   textControl,
 } from "./mcpFieldRules";
 
@@ -172,7 +172,7 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             }
             name={["credentials", "scopes"]}
           >
-            {(control) => <MultiSelect {...scopesControl(control)} placeholder="Add scopes" className="rounded-lg" />}
+            {(control) => <MultiSelect {...tagsControl(control)} placeholder="Add scopes" className="rounded-lg" />}
           </MountedFormField>
           <UpstreamResourceField />
         </>
@@ -234,7 +234,7 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             }
             name={["credentials", "scopes"]}
           >
-            {(control) => <MultiSelect {...scopesControl(control)} placeholder="Add scopes" className="rounded-lg" />}
+            {(control) => <MultiSelect {...tagsControl(control)} placeholder="Add scopes" className="rounded-lg" />}
           </MountedFormField>
           <UpstreamResourceField />
           <MountedFormField

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/OAuthFormFields.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/OAuthFormFields.tsx
@@ -1,13 +1,24 @@
-import React from "react";
-import { Input as AntdInput, InputNumber, Select, Tooltip } from "antd";
 import { Info } from "lucide-react";
+import React from "react";
+import { MultiSelect } from "@/components/shared/MultiSelect";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { SimpleTooltip } from "@/components/ui/tooltip";
+import { PasswordInput } from "@/components/shared/PasswordInput";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { OAUTH_FLOW } from "@/components/mcp_tools/types";
 import { MountedFormField } from "@/components/common_components/MountedFormField";
 import { antdRequired } from "@/components/common_components/antdFormRules";
 import TokenEndpointAuthMethodField from "./TokenEndpointAuthMethodField";
-import { numberControl, parsesAsJson, selectControl, textControl } from "./mcpFieldRules";
+import {
+  numberControl,
+  parsesAsJson,
+  selectControl,
+  selectTriggerControl,
+  tagsControl,
+  textControl,
+} from "./mcpFieldRules";
 
 interface OAuthFlowStatus {
   startOAuthFlow: () => void;
@@ -27,6 +38,11 @@ interface OAuthFormFieldsProps {
 
 const fieldClassName = "rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500";
 
+const OAUTH_FLOW_ITEMS = [
+  { value: OAUTH_FLOW.M2M, label: "Machine-to-Machine (M2M)" },
+  { value: OAUTH_FLOW.INTERACTIVE, label: "Interactive (PKCE)" },
+];
+
 const UPSTREAM_RESOURCE_TOOLTIP =
   "RFC 8707 resource indicator sent to the authorization server so it mints a token audienced for this MCP server. " +
   "Leave blank to send nothing, which is the default and what most providers expect. Use 'auto' to send this server's " +
@@ -37,9 +53,9 @@ const UPSTREAM_RESOURCE_TOOLTIP =
 const FieldLabel: React.FC<{ label: string; tooltip: string }> = ({ label, tooltip }) => (
   <span className="text-sm font-medium text-gray-700 flex items-center">
     {label}
-    <Tooltip title={tooltip}>
+    <SimpleTooltip content={tooltip}>
       <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-    </Tooltip>
+    </SimpleTooltip>
   </span>
 );
 
@@ -78,19 +94,24 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
         {...(initialFlowType ? { defaultValue: initialFlowType } : {})}
       >
         {(control) => (
-          <Select {...selectControl(control)} placeholder="Select OAuth flow" className="rounded-lg" size="large">
-            <Select.Option value={OAUTH_FLOW.M2M}>
-              <div>
-                <span className="font-medium">Machine-to-Machine (M2M)</span>
-                <span className="text-gray-400 text-xs ml-2">server-to-server, no user interaction</span>
-              </div>
-            </Select.Option>
-            <Select.Option value={OAUTH_FLOW.INTERACTIVE}>
-              <div>
-                <span className="font-medium">Interactive (PKCE)</span>
-                <span className="text-gray-400 text-xs ml-2">browser-based user authorization</span>
-              </div>
-            </Select.Option>
+          <Select {...selectControl<string>(control)} items={OAUTH_FLOW_ITEMS}>
+            <SelectTrigger {...selectTriggerControl(control)} className="w-full rounded-lg">
+              <SelectValue placeholder="Select OAuth flow" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={OAUTH_FLOW.M2M}>
+                <div>
+                  <span className="font-medium">Machine-to-Machine (M2M)</span>
+                  <span className="ml-2 text-xs text-muted-foreground">server-to-server, no user interaction</span>
+                </div>
+              </SelectItem>
+              <SelectItem value={OAUTH_FLOW.INTERACTIVE}>
+                <div>
+                  <span className="font-medium">Interactive (PKCE)</span>
+                  <span className="ml-2 text-xs text-muted-foreground">browser-based user authorization</span>
+                </div>
+              </SelectItem>
+            </SelectContent>
           </Select>
         )}
       </MountedFormField>
@@ -104,10 +125,10 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             rules={requiredWhenCreating("Client ID is required for M2M OAuth")}
           >
             {(control) => (
-              <AntdInput.Password
+              <PasswordInput
                 {...textControl(control)}
                 placeholder={`Enter OAuth client ID${placeholderSuffix}`}
-                className={fieldClassName}
+                groupClassName={fieldClassName}
               />
             )}
           </MountedFormField>
@@ -120,10 +141,10 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             rules={requiredWhenCreating("Client Secret is required for M2M OAuth")}
           >
             {(control) => (
-              <AntdInput.Password
+              <PasswordInput
                 {...textControl(control)}
                 placeholder={`Enter OAuth client secret${placeholderSuffix}`}
-                className={fieldClassName}
+                groupClassName={fieldClassName}
               />
             )}
           </MountedFormField>
@@ -151,16 +172,7 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             }
             name={["credentials", "scopes"]}
           >
-            {(control) => (
-              <Select
-                {...selectControl(control)}
-                mode="tags"
-                tokenSeparators={[","]}
-                placeholder="Add scopes"
-                className="rounded-lg"
-                size="large"
-              />
-            )}
+            {(control) => <MultiSelect {...tagsControl(control)} placeholder="Add scopes" className="rounded-lg" />}
           </MountedFormField>
           <UpstreamResourceField />
         </>
@@ -189,10 +201,10 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             name={["credentials", "client_id"]}
           >
             {(control) => (
-              <AntdInput.Password
+              <PasswordInput
                 {...textControl(control)}
                 placeholder={`Enter client ID${placeholderSuffix}`}
-                className={fieldClassName}
+                groupClassName={fieldClassName}
               />
             )}
           </MountedFormField>
@@ -206,10 +218,10 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             name={["credentials", "client_secret"]}
           >
             {(control) => (
-              <AntdInput.Password
+              <PasswordInput
                 {...textControl(control)}
                 placeholder={`Enter client secret${placeholderSuffix}`}
-                className={fieldClassName}
+                groupClassName={fieldClassName}
               />
             )}
           </MountedFormField>
@@ -222,16 +234,7 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             }
             name={["credentials", "scopes"]}
           >
-            {(control) => (
-              <Select
-                {...selectControl(control)}
-                mode="tags"
-                tokenSeparators={[","]}
-                placeholder="Add scopes"
-                className="rounded-lg"
-                size="large"
-              />
-            )}
+            {(control) => <MultiSelect {...tagsControl(control)} placeholder="Add scopes" className="rounded-lg" />}
           </MountedFormField>
           <UpstreamResourceField />
           <MountedFormField
@@ -305,7 +308,7 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             rules={{ validate: { json: parsesAsJson("Must be valid JSON") } }}
           >
             {(control) => (
-              <AntdInput.TextArea
+              <Textarea
                 {...textControl(control)}
                 placeholder={'{\n  "organization": "my-org",\n  "team.id": "123"\n}'}
                 rows={4}
@@ -323,13 +326,7 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             name="token_storage_ttl_seconds"
           >
             {(control) => (
-              <InputNumber
-                {...numberControl(control)}
-                min={1}
-                placeholder="e.g. 3600"
-                className="w-full rounded-lg"
-                style={{ width: "100%" }}
-              />
+              <Input {...numberControl(control)} min={1} placeholder="e.g. 3600" className="w-full rounded-lg" />
             )}
           </MountedFormField>
           {oauthFlow && (

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/OpenAPIFormSection.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/OpenAPIFormSection.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from "react";
-import { Input, Tooltip } from "antd";
 import { Info } from "lucide-react";
+import React, { useState } from "react";
+import { SimpleTooltip } from "@/components/ui/tooltip";
+import { Input } from "@/components/ui/input";
 import { AUTH_TYPE, OAUTH_FLOW } from "@/components/mcp_tools/types";
 import { MountedFormField } from "@/components/common_components/MountedFormField";
 import { antdRequired } from "@/components/common_components/antdFormRules";
@@ -68,9 +69,9 @@ const OpenAPIFormSection: React.FC<OpenAPIFormSectionProps> = ({
         label={
           <span className="text-sm font-medium text-gray-700 flex items-center">
             OpenAPI Spec URL
-            <Tooltip title="URL to an OpenAPI specification (JSON or YAML). MCP tools will be automatically generated from the API endpoints defined in the spec.">
+            <SimpleTooltip content="URL to an OpenAPI specification (JSON or YAML). MCP tools will be automatically generated from the API endpoints defined in the spec.">
               <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-            </Tooltip>
+            </SimpleTooltip>
           </span>
         }
         name="spec_path"

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/OpenApiByokFields.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/OpenApiByokFields.tsx
@@ -1,10 +1,13 @@
-import React from "react";
-import { Input, Select, Switch, Tooltip } from "antd";
 import { Info } from "lucide-react";
+import React from "react";
+import { MultiSelect } from "@/components/shared/MultiSelect";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { useWatch } from "react-hook-form";
 
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { MountedFormField } from "@/components/common_components/MountedFormField";
-import { selectControl, switchControl, textControl } from "./mcpFieldRules";
+import { switchControl, tagsControl, textControl } from "./mcpFieldRules";
 
 const AUTH_HEADER_FORMATS: Readonly<Record<string, string>> = {
   bearer_token: "Authorization: Bearer {key}",
@@ -25,9 +28,9 @@ const OpenApiByokFields: React.FC = () => {
         label={
           <span className="text-sm font-medium text-gray-700 flex items-center gap-2">
             BYOK (Bring Your Own Key)
-            <Tooltip title="When enabled, each user provides their own API key for this service. Keys are stored per-user and never shared.">
+            <SimpleTooltip content="When enabled, each user provides their own API key for this service. Keys are stored per-user and never shared.">
               <Info className="size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-            </Tooltip>
+            </SimpleTooltip>
           </span>
         }
         name="is_byok"
@@ -61,20 +64,18 @@ const OpenApiByokFields: React.FC = () => {
             label={
               <span className="text-sm font-medium text-gray-700">
                 Access Description
-                <Tooltip title="List of permissions shown to users in the connection modal (e.g. 'Create and manage Jira issues')">
+                <SimpleTooltip content="List of permissions shown to users in the connection modal (e.g. 'Create and manage Jira issues')">
                   <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                </Tooltip>
+                </SimpleTooltip>
               </span>
             }
             name="byok_description"
           >
             {(control) => (
-              <Select
-                {...selectControl(control)}
-                mode="tags"
+              <MultiSelect
+                {...tagsControl(control)}
                 placeholder="Add access description items (press Enter after each)"
                 className="w-full"
-                tokenSeparators={[","]}
               />
             )}
           </MountedFormField>
@@ -83,9 +84,9 @@ const OpenApiByokFields: React.FC = () => {
             label={
               <span className="text-sm font-medium text-gray-700">
                 API Key Help URL
-                <Tooltip title="Optional link shown to users to help them find their API key">
+                <SimpleTooltip content="Optional link shown to users to help them find their API key">
                   <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                </Tooltip>
+                </SimpleTooltip>
               </span>
             }
             name="byok_api_key_help_url"

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/PassthroughAuthorizeSection.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/PassthroughAuthorizeSection.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { Checkbox, Input } from "antd";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { PasswordInput } from "@/components/shared/PasswordInput";
 import DcrBridgeToggle from "./DcrBridgeToggle";
 import { MountedFormField } from "@/components/common_components/MountedFormField";
 import { textControl } from "./mcpFieldRules";
@@ -90,11 +92,11 @@ export default function PassthroughAuthorizeSection({
         help={clientIdExtra}
       >
         {(control) => (
-          <Input.Password
+          <PasswordInput
             {...textControl(control)}
             placeholder={clientIdPlaceholder}
             disabled={removeStoredApp}
-            className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+            groupClassName="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
           />
         )}
       </MountedFormField>
@@ -103,21 +105,20 @@ export default function PassthroughAuthorizeSection({
         name={["credentials", "client_secret"]}
       >
         {(control) => (
-          <Input.Password
+          <PasswordInput
             {...textControl(control)}
             placeholder={clientSecretPlaceholder}
             disabled={removeStoredApp}
-            className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+            groupClassName="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
           />
         )}
       </MountedFormField>
       <DcrBridgeToggle authType={authType} initialChecked={dcrBridgeInitialChecked} />
       {isEditing && onRemoveStoredAppChange && (
-        <Checkbox checked={removeStoredApp} onChange={(e) => onRemoveStoredAppChange(e.target.checked)}>
-          <span className="text-sm text-gray-700">
-            Remove the saved OAuth app on save (the server goes back to dynamic client registration)
-          </span>
-        </Checkbox>
+        <Label className="items-start leading-normal font-normal text-gray-700">
+          <Checkbox className="mt-0.5" checked={removeStoredApp} onCheckedChange={onRemoveStoredAppChange} />
+          Remove the saved OAuth app on save (the server goes back to dynamic client registration)
+        </Label>
       )}
       <Button
         variant="outline"

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/StdioConfiguration.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/StdioConfiguration.tsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { Input, Tooltip } from "antd";
 import { Info } from "lucide-react";
+import React from "react";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 
 import { MountedFormField } from "@/components/common_components/MountedFormField";
 import { antdRequired } from "@/components/common_components/antdFormRules";
+import { Textarea } from "@/components/ui/textarea";
 import { parsesAsJson, textControl } from "./mcpFieldRules";
 
 interface StdioConfigurationProps {
@@ -36,9 +37,9 @@ const StdioConfiguration: React.FC<StdioConfigurationProps> = ({ isVisible, requ
       label={
         <span className="text-sm font-medium text-gray-700 flex items-center">
           Stdio Configuration (JSON)
-          <Tooltip title="Paste your stdio MCP server configuration in JSON format. You can use the full mcpServers structure from config.yaml or just the inner server configuration.">
+          <SimpleTooltip content="Paste your stdio MCP server configuration in JSON format. You can use the full mcpServers structure from config.yaml or just the inner server configuration.">
             <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-          </Tooltip>
+          </SimpleTooltip>
         </span>
       }
       name="stdio_config"
@@ -51,7 +52,7 @@ const StdioConfiguration: React.FC<StdioConfigurationProps> = ({ isVisible, requ
       }}
     >
       {(control) => (
-        <Input.TextArea
+        <Textarea
           {...textControl(control)}
           placeholder={PLACEHOLDER}
           rows={12}

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/TokenEndpointAuthMethodField.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/TokenEndpointAuthMethodField.tsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { Select, Tooltip } from "antd";
 import { Info } from "lucide-react";
+import React from "react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 
 import { MountedFormField } from "@/components/common_components/MountedFormField";
-import { selectControl } from "./mcpFieldRules";
+import { selectControl, selectTriggerControl } from "./mcpFieldRules";
 
 const TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS = [
   { value: "client_secret_basic", label: "Client Secret Basic" },
@@ -19,25 +20,33 @@ const TokenEndpointAuthMethodField: React.FC<TokenEndpointAuthMethodFieldProps> 
     label={
       <span className="text-sm font-medium text-gray-700 flex items-center">
         Token Endpoint Auth Method (optional)
-        <Tooltip title="How the proxy authenticates to the upstream OAuth token endpoint. Client Secret Basic sends the client credentials in an HTTP Basic Authorization header; leave blank to use the default, Client Secret Post, which sends them in the request body.">
+        <SimpleTooltip content="How the proxy authenticates to the upstream OAuth token endpoint. Client Secret Basic sends the client credentials in an HTTP Basic Authorization header; leave blank to use the default, Client Secret Post, which sends them in the request body.">
           <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-        </Tooltip>
+        </SimpleTooltip>
       </span>
     }
     name={["credentials", "token_endpoint_auth_method"]}
   >
-    {(control) => (
-      <Select
-        {...selectControl(control)}
-        allowClear
-        placeholder={
-          isEditing ? "Leave blank to keep existing (default Client Secret Post)" : "Default (Client Secret Post)"
-        }
-        className="rounded-lg"
-        size="large"
-        options={TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS}
-      />
-    )}
+    {(control) => {
+      const placeholder = isEditing
+        ? "Leave blank to keep existing (default Client Secret Post)"
+        : "Default (Client Secret Post)";
+      return (
+        <Select {...selectControl<string>(control)} items={TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS}>
+          <SelectTrigger {...selectTriggerControl(control)} className="w-full rounded-lg">
+            <SelectValue placeholder={placeholder} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={null}>{placeholder}</SelectItem>
+            {TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+    }}
   </MountedFormField>
 );
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/TokenExchangeFormFields.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/TokenExchangeFormFields.tsx
@@ -1,11 +1,15 @@
-import React from "react";
-import { Input, Select, Tooltip } from "antd";
 import { Info } from "lucide-react";
+import React from "react";
+import { MultiSelect } from "@/components/shared/MultiSelect";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { useWatch } from "react-hook-form";
 
 import { MountedFormField } from "@/components/common_components/MountedFormField";
 import { antdRequired } from "@/components/common_components/antdFormRules";
-import { selectControl, textControl } from "./mcpFieldRules";
+import { PasswordInput } from "@/components/shared/PasswordInput";
+import { Input } from "@/components/ui/input";
+import { selectControl, selectTriggerControl, tagsControl, textControl } from "./mcpFieldRules";
 
 interface TokenExchangeFormFieldsProps {
   isEditing?: boolean;
@@ -13,12 +17,17 @@ interface TokenExchangeFormFieldsProps {
 
 const fieldClassName = "rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500";
 
+const TOKEN_EXCHANGE_PROFILE_ITEMS = [
+  { value: "rfc8693", label: "RFC 8693 (standard)" },
+  { value: "entra_obo", label: "Microsoft Entra OBO" },
+];
+
 const FieldLabel: React.FC<{ label: string; tooltip: string }> = ({ label, tooltip }) => (
   <span className="text-sm font-medium text-gray-700 flex items-center">
     {label}
-    <Tooltip title={tooltip}>
+    <SimpleTooltip content={tooltip}>
       <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-    </Tooltip>
+    </SimpleTooltip>
   </span>
 );
 
@@ -41,13 +50,17 @@ const TokenExchangeFormFields: React.FC<TokenExchangeFormFieldsProps> = ({ isEdi
         {...(isEditing ? {} : { defaultValue: "rfc8693" })}
       >
         {(control) => (
-          <Select {...selectControl(control)} className="rounded-lg" size="large">
-            <Select.Option value="rfc8693">
-              <span className="font-medium">RFC 8693 (standard)</span>
-            </Select.Option>
-            <Select.Option value="entra_obo">
-              <span className="font-medium">Microsoft Entra OBO</span>
-            </Select.Option>
+          <Select {...selectControl<string>(control)} items={TOKEN_EXCHANGE_PROFILE_ITEMS}>
+            <SelectTrigger {...selectTriggerControl(control)} className="w-full rounded-lg">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TOKEN_EXCHANGE_PROFILE_ITEMS.map((item) => (
+                <SelectItem key={item.value} value={item.value}>
+                  <span className="font-medium">{item.label}</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
           </Select>
         )}
       </MountedFormField>
@@ -80,10 +93,10 @@ const TokenExchangeFormFields: React.FC<TokenExchangeFormFieldsProps> = ({ isEdi
         rules={requiredWhenCreating("Client ID is required for token exchange")}
       >
         {(control) => (
-          <Input.Password
+          <PasswordInput
             {...textControl(control)}
             placeholder={`Enter OAuth client ID${placeholderSuffix}`}
-            className={fieldClassName}
+            groupClassName={fieldClassName}
           />
         )}
       </MountedFormField>
@@ -99,10 +112,10 @@ const TokenExchangeFormFields: React.FC<TokenExchangeFormFieldsProps> = ({ isEdi
         rules={requiredWhenCreating("Client Secret is required for token exchange")}
       >
         {(control) => (
-          <Input.Password
+          <PasswordInput
             {...textControl(control)}
             placeholder={`Enter OAuth client secret${placeholderSuffix}`}
-            className={fieldClassName}
+            groupClassName={fieldClassName}
           />
         )}
       </MountedFormField>
@@ -164,13 +177,10 @@ const TokenExchangeFormFields: React.FC<TokenExchangeFormFieldsProps> = ({ isEdi
         }
       >
         {(control) => (
-          <Select
-            {...selectControl(control)}
-            mode="tags"
-            tokenSeparators={[","]}
+          <MultiSelect
+            {...tagsControl(control)}
             placeholder={isEntraObo ? "api://<app-id>/.default" : "Add scopes"}
             className="rounded-lg"
-            size="large"
           />
         )}
       </MountedFormField>

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/TokenExchangeFormFields.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/TokenExchangeFormFields.tsx
@@ -9,7 +9,7 @@ import { MountedFormField } from "@/components/common_components/MountedFormFiel
 import { antdRequired } from "@/components/common_components/antdFormRules";
 import { PasswordInput } from "@/components/shared/PasswordInput";
 import { Input } from "@/components/ui/input";
-import { selectControl, selectTriggerControl, tagsControl, textControl } from "./mcpFieldRules";
+import { selectControl, selectTriggerControl, scopesControl, textControl } from "./mcpFieldRules";
 
 interface TokenExchangeFormFieldsProps {
   isEditing?: boolean;
@@ -178,7 +178,7 @@ const TokenExchangeFormFields: React.FC<TokenExchangeFormFieldsProps> = ({ isEdi
       >
         {(control) => (
           <MultiSelect
-            {...tagsControl(control)}
+            {...scopesControl(control)}
             placeholder={isEntraObo ? "api://<app-id>/.default" : "Add scopes"}
             className="rounded-lg"
           />

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/TokenExchangeFormFields.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/TokenExchangeFormFields.tsx
@@ -9,7 +9,7 @@ import { MountedFormField } from "@/components/common_components/MountedFormFiel
 import { antdRequired } from "@/components/common_components/antdFormRules";
 import { PasswordInput } from "@/components/shared/PasswordInput";
 import { Input } from "@/components/ui/input";
-import { selectControl, selectTriggerControl, scopesControl, textControl } from "./mcpFieldRules";
+import { selectControl, selectTriggerControl, tagsControl, textControl } from "./mcpFieldRules";
 
 interface TokenExchangeFormFieldsProps {
   isEditing?: boolean;
@@ -178,7 +178,7 @@ const TokenExchangeFormFields: React.FC<TokenExchangeFormFieldsProps> = ({ isEdi
       >
         {(control) => (
           <MultiSelect
-            {...scopesControl(control)}
+            {...tagsControl(control)}
             placeholder={isEntraObo ? "api://<app-id>/.default" : "Add scopes"}
             className="rounded-lg"
           />

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/UserEnvVarsModal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/UserEnvVarsModal.tsx
@@ -1,7 +1,5 @@
 import React from "react";
-import { Spin, Tag, Typography } from "antd";
 import { CircleAlert, Info } from "lucide-react";
-import { Alert, AlertTitle } from "@/components/shared/Alert";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { z } from "zod/v4";
 import { MCPServer, MCPUserEnvVarsStatus, MCPUserEnvVarSpec } from "@/components/mcp_tools/types";
@@ -9,13 +7,13 @@ import { getMCPUserEnvVars, storeMCPUserEnvVars } from "@/components/networking"
 import { toast } from "@/lib/toast";
 import { FieldGroup } from "@/components/shared/form/field";
 import { FormField } from "@/components/shared/form/FormField";
+import { Alert, AlertTitle } from "@/components/shared/Alert";
 import { PasswordInput } from "@/components/shared/PasswordInput";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
 import { useZodForm } from "@/lib/forms/useZodForm";
-
-const { Text } = Typography;
 
 interface UserEnvVarsModalProps {
   server: MCPServer | null;
@@ -57,7 +55,7 @@ const UserEnvVarsForm: React.FC<UserEnvVarsFormProps> = ({ required, isSaving, o
             label={
               <span className="flex items-center gap-2">
                 <span className="font-mono text-sm font-semibold">{spec.name}</span>
-                {spec.is_set && <Tag color="green">Set</Tag>}
+                {spec.is_set && <Badge variant="secondary">Set</Badge>}
               </span>
             }
           >
@@ -130,21 +128,20 @@ const UserEnvVarsModal: React.FC<UserEnvVarsModalProps> = ({ server, open, acces
   const isSaving = saveMutation.isPending;
 
   return (
-    <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
+    <Dialog open={open} onOpenChange={(opened) => !opened && onClose()}>
       <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[520px]">
         <DialogHeader>
           <div className="flex items-center gap-2">
-            <DialogTitle>Set your credentials</DialogTitle>
-            <Tag color="blue">Per-user</Tag>
+            <DialogTitle className="text-base font-semibold">Set your credentials</DialogTitle>
+            <Badge variant="info">Per-user</Badge>
           </div>
-          <Text type="secondary" className="text-xs">
-            {displayName}
-          </Text>
+          <span className="text-xs text-muted-foreground">{displayName}</span>
         </DialogHeader>
-        <div className="space-y-4 mt-2">
+
+        <div className="mt-2 space-y-4">
           {isLoading ? (
             <div className="flex items-center justify-center py-8">
-              <Spin />
+              <UiLoadingSpinner className="size-5" />
             </div>
           ) : isError ? (
             <Alert variant="error">
@@ -158,11 +155,11 @@ const UserEnvVarsModal: React.FC<UserEnvVarsModalProps> = ({ server, open, acces
             </Alert>
           ) : (
             <>
-              <Text className="text-sm text-muted-foreground block">
+              <span className="block text-sm text-muted-foreground">
                 These values are private to you. Your admin configured this MCP server to require these per-user
                 credentials. Saved values are never shown back; leave an already-set field blank to keep it, or enter a
                 value to set or change it.
-              </Text>
+              </span>
               <UserEnvVarsForm required={required} isSaving={isSaving} onCancel={onClose} onSubmit={handleSave} />
             </>
           )}

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/createOAuthUiState.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/createOAuthUiState.test.ts
@@ -13,7 +13,6 @@ const fullSnapshot: CreateUiSnapshot = {
   costConfig: { default_cost_per_query: 0.02 },
   allowedTools: ["search"],
   hasToolAllowlistInteraction: true,
-  searchValue: "group-a",
   aliasManuallyEdited: true,
   logoUrl: "https://cdn/logo.png",
   authorizedIdentity: "identity-abc",
@@ -82,9 +81,8 @@ describe("createOAuthUiState", () => {
   });
 
   it("omits falsy scalars so a restore never blanks freshly mounted state", () => {
-    seedRaw({ searchValue: "", logoUrl: "", transportType: "", modalVisible: false });
+    seedRaw({ logoUrl: "", transportType: "", modalVisible: false });
     const restored = readCreateUiSnapshot();
-    expect(restored).not.toHaveProperty("searchValue");
     expect(restored).not.toHaveProperty("logoUrl");
     expect(restored).not.toHaveProperty("transportType");
     expect(restored).not.toHaveProperty("modalVisible");

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/createOAuthUiState.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/createOAuthUiState.ts
@@ -14,7 +14,6 @@ export interface CreateUiSnapshot {
   readonly costConfig: MCPServerCostInfo;
   readonly allowedTools: readonly string[];
   readonly hasToolAllowlistInteraction: boolean;
-  readonly searchValue: string;
   readonly aliasManuallyEdited: boolean;
   readonly logoUrl: string | undefined;
   readonly authorizedIdentity: string | undefined;
@@ -29,7 +28,6 @@ export type RestoredUiSnapshot = {
   readonly costConfig?: MCPServerCostInfo;
   readonly allowedTools?: readonly string[];
   readonly hasToolAllowlistInteraction?: boolean;
-  readonly searchValue?: string;
   readonly aliasManuallyEdited?: boolean;
   readonly logoUrl?: string;
   readonly authorizedIdentity?: string;
@@ -83,7 +81,6 @@ export const readCreateUiSnapshot = (): RestoredUiSnapshot | null => {
       ...(typeof parsed.hasToolAllowlistInteraction === "boolean"
         ? { hasToolAllowlistInteraction: parsed.hasToolAllowlistInteraction }
         : {}),
-      ...(parsed.searchValue ? { searchValue: parsed.searchValue } : {}),
       ...(typeof parsed.aliasManuallyEdited === "boolean" ? { aliasManuallyEdited: parsed.aliasManuallyEdited } : {}),
       ...(parsed.logoUrl ? { logoUrl: parsed.logoUrl } : {}),
     };

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.test.ts
@@ -5,57 +5,28 @@ import { tagsControl } from "./mcpFieldRules";
 const controlWith = (value: unknown, onChange = vi.fn()): MountedFieldControlProps =>
   ({ id: "field", name: "field", value, onChange, onBlur: vi.fn() }) as unknown as MountedFieldControlProps;
 
-// These fields were antd Selects with tokenSeparators={[","]}: a comma commits a tag, and nothing
-// else does. The shadcn tag input commits the whole typed string as one custom value instead, so
-// every case below pins the antd rule the migration has to preserve.
+// These fields were antd Selects with tokenSeparators={[","]}, so a comma commits a tag as an admin
+// types. MultiSelect owns that rule now, which leaves this adapter one job: hand the stored value to
+// the input and the edited value back, without rewriting either. Stdio args are process argv, so a
+// comma inside one and a deliberately repeated flag both have to survive a round trip.
 describe("tagsControl", () => {
-  it("splits the comma-separated headers an admin commits as one entry", () => {
-    const onChange = vi.fn();
-    tagsControl(controlWith([], onChange)).onValueChange(["Authorization,X-Custom-Header"]);
-
-    expect(onChange).toHaveBeenCalledWith(["Authorization", "X-Custom-Header"]);
+  it("keeps a stored argument that contains a comma as one argument", () => {
+    expect(tagsControl(controlWith(["--filter=a,b", "--verbose"])).value).toStrictEqual(["--filter=a,b", "--verbose"]);
   });
 
-  it("trims the space an admin types after each comma", () => {
-    const onChange = vi.fn();
-    tagsControl(controlWith([], onChange)).onValueChange(["read, write, admin"]);
-
-    expect(onChange).toHaveBeenCalledWith(["read", "write", "admin"]);
+  it("keeps a repeated stdio flag rather than collapsing it to one", () => {
+    expect(tagsControl(controlWith(["-v", "-v"])).value).toStrictEqual(["-v", "-v"]);
   });
 
-  it("keeps already-committed tags intact while splitting only the entry that needs it", () => {
-    const onChange = vi.fn();
-    tagsControl(controlWith(["group-a"], onChange)).onValueChange(["group-a", "group-b,group-c"]);
-
-    expect(onChange).toHaveBeenCalledWith(["group-a", "group-b", "group-c"]);
+  it("offers each repeated tag once, since the dropdown keys its entries by value", () => {
+    expect(tagsControl(controlWith(["-v", "-v"])).options).toStrictEqual([{ label: "-v", value: "-v" }]);
   });
 
-  it("drops the duplicate when a typed entry repeats a tag that is already selected", () => {
-    const onChange = vi.fn();
-    tagsControl(controlWith(["read"], onChange)).onValueChange(["read", "read,write"]);
-
-    expect(onChange).toHaveBeenCalledWith(["read", "write"]);
-  });
-
-  it("preserves the interior spaces of a stdio argument, which a comma alone may split", () => {
+  it("stores the edited tags exactly as the input committed them", () => {
     const onChange = vi.fn();
     tagsControl(controlWith(["npx"], onChange)).onValueChange(["npx", "--header=X-Trace: on"]);
 
     expect(onChange).toHaveBeenCalledWith(["npx", "--header=X-Trace: on"]);
-  });
-
-  it("keeps a scope URI whole, since it carries no comma", () => {
-    const onChange = vi.fn();
-    tagsControl(controlWith([], onChange)).onValueChange(["api://app-id/.default"]);
-
-    expect(onChange).toHaveBeenCalledWith(["api://app-id/.default"]);
-  });
-
-  it("splits a stored delimited string rather than rendering it as one tag", () => {
-    expect(tagsControl(controlWith("Authorization,X-Custom-Header")).value).toStrictEqual([
-      "Authorization",
-      "X-Custom-Header",
-    ]);
   });
 
   it("renders a stored list unchanged", () => {
@@ -63,15 +34,16 @@ describe("tagsControl", () => {
   });
 
   it("clears to an empty list rather than a blank tag when the field is emptied", () => {
-    const onChange = vi.fn();
-    tagsControl(controlWith("", onChange)).onValueChange([""]);
-
     expect(tagsControl(controlWith("")).value).toStrictEqual([]);
-    expect(onChange).toHaveBeenCalledWith([]);
+    expect(tagsControl(controlWith([""])).value).toStrictEqual([]);
   });
 
   it("ignores a stored value that is neither a string nor a list", () => {
     expect(tagsControl(controlWith(null)).value).toStrictEqual([]);
     expect(tagsControl(controlWith(42)).value).toStrictEqual([]);
+  });
+
+  it("wraps a bare stored string into the single tag the antd field would have shown", () => {
+    expect(tagsControl(controlWith("Authorization")).value).toStrictEqual(["Authorization"]);
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MountedFieldControlProps } from "@/components/common_components/MountedFormField";
+import { tagsControl } from "./mcpFieldRules";
+
+const controlWith = (value: unknown, onChange = vi.fn()): MountedFieldControlProps =>
+  ({ id: "scopes", name: "scopes", value, onChange, onBlur: vi.fn() }) as unknown as MountedFieldControlProps;
+
+describe("tagsControl", () => {
+  it("splits a stored delimited string into one tag per scope", () => {
+    expect(tagsControl(controlWith("read write admin")).value).toStrictEqual(["read", "write", "admin"]);
+  });
+
+  it("splits a comma-delimited entry the tag input committed as a single custom value", () => {
+    const onChange = vi.fn();
+    tagsControl(controlWith([], onChange)).onValueChange(["read,write"]);
+
+    expect(onChange).toHaveBeenCalledWith(["read", "write"]);
+  });
+
+  it("keeps already-split tags intact while splitting only the entry that needs it", () => {
+    const onChange = vi.fn();
+    tagsControl(controlWith(["read"], onChange)).onValueChange(["read", "write, admin"]);
+
+    expect(onChange).toHaveBeenCalledWith(["read", "write", "admin"]);
+  });
+
+  it("drops the duplicate when a typed entry repeats a tag that is already selected", () => {
+    const onChange = vi.fn();
+    tagsControl(controlWith(["read"], onChange)).onValueChange(["read", "read,write"]);
+
+    expect(onChange).toHaveBeenCalledWith(["read", "write"]);
+  });
+
+  it("clears to an empty list rather than a blank tag when the field is emptied", () => {
+    const onChange = vi.fn();
+    tagsControl(controlWith("", onChange)).onValueChange([""]);
+
+    expect(tagsControl(controlWith("")).value).toStrictEqual([]);
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("ignores a stored value that is neither a string nor a list", () => {
+    expect(tagsControl(controlWith(null)).value).toStrictEqual([]);
+    expect(tagsControl(controlWith(42)).value).toStrictEqual([]);
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.test.ts
@@ -1,37 +1,79 @@
 import { describe, expect, it, vi } from "vitest";
 import type { MountedFieldControlProps } from "@/components/common_components/MountedFormField";
-import { tagsControl } from "./mcpFieldRules";
+import { scopesControl, tagsControl } from "./mcpFieldRules";
 
 const controlWith = (value: unknown, onChange = vi.fn()): MountedFieldControlProps =>
-  ({ id: "scopes", name: "scopes", value, onChange, onBlur: vi.fn() }) as unknown as MountedFieldControlProps;
+  ({ id: "field", name: "field", value, onChange, onBlur: vi.fn() }) as unknown as MountedFieldControlProps;
 
-describe("tagsControl", () => {
+describe("scopesControl", () => {
   it("splits a stored delimited string into one tag per scope", () => {
-    expect(tagsControl(controlWith("read write admin")).value).toStrictEqual(["read", "write", "admin"]);
+    expect(scopesControl(controlWith("read write admin")).value).toStrictEqual(["read", "write", "admin"]);
   });
 
   it("splits a comma-delimited entry the tag input committed as a single custom value", () => {
     const onChange = vi.fn();
-    tagsControl(controlWith([], onChange)).onValueChange(["read,write"]);
+    scopesControl(controlWith([], onChange)).onValueChange(["read,write"]);
 
     expect(onChange).toHaveBeenCalledWith(["read", "write"]);
   });
 
-  it("keeps already-split tags intact while splitting only the entry that needs it", () => {
+  it("keeps already-split scopes intact while splitting only the entry that needs it", () => {
     const onChange = vi.fn();
-    tagsControl(controlWith(["read"], onChange)).onValueChange(["read", "write, admin"]);
+    scopesControl(controlWith(["read"], onChange)).onValueChange(["read", "write, admin"]);
 
     expect(onChange).toHaveBeenCalledWith(["read", "write", "admin"]);
   });
 
-  it("drops the duplicate when a typed entry repeats a tag that is already selected", () => {
+  it("drops the duplicate when a typed entry repeats a scope that is already selected", () => {
     const onChange = vi.fn();
-    tagsControl(controlWith(["read"], onChange)).onValueChange(["read", "read,write"]);
+    scopesControl(controlWith(["read"], onChange)).onValueChange(["read", "read,write"]);
 
     expect(onChange).toHaveBeenCalledWith(["read", "write"]);
   });
 
-  it("clears to an empty list rather than a blank tag when the field is emptied", () => {
+  it("keeps a URI-shaped scope whole, since it carries no delimiter", () => {
+    const onChange = vi.fn();
+    scopesControl(controlWith([], onChange)).onValueChange(["api://app-id/.default"]);
+
+    expect(onChange).toHaveBeenCalledWith(["api://app-id/.default"]);
+  });
+
+  it("clears to an empty list rather than a blank scope when the field is emptied", () => {
+    const onChange = vi.fn();
+    scopesControl(controlWith("", onChange)).onValueChange([""]);
+
+    expect(scopesControl(controlWith("")).value).toStrictEqual([]);
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+});
+
+describe("tagsControl", () => {
+  it("preserves a stdio argument that contains spaces, which is one argv entry", () => {
+    const onChange = vi.fn();
+    tagsControl(controlWith(["npx"], onChange)).onValueChange(["npx", "--header=X-Trace: on"]);
+
+    expect(onChange).toHaveBeenCalledWith(["npx", "--header=X-Trace: on"]);
+  });
+
+  it("preserves a comma inside an entry, which is part of the value and not a separator", () => {
+    const onChange = vi.fn();
+    tagsControl(controlWith([], onChange)).onValueChange(["Create, update and delete issues"]);
+
+    expect(onChange).toHaveBeenCalledWith(["Create, update and delete issues"]);
+  });
+
+  it("keeps a repeated entry, since two argv entries may legitimately be identical", () => {
+    const onChange = vi.fn();
+    tagsControl(controlWith([], onChange)).onValueChange(["-v", "-v"]);
+
+    expect(onChange).toHaveBeenCalledWith(["-v", "-v"]);
+  });
+
+  it("renders a stored list unchanged", () => {
+    expect(tagsControl(controlWith(["run", "--flag a"])).value).toStrictEqual(["run", "--flag a"]);
+  });
+
+  it("drops the blank entry a cleared field leaves behind", () => {
     const onChange = vi.fn();
     tagsControl(controlWith("", onChange)).onValueChange([""]);
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.test.ts
@@ -1,79 +1,68 @@
 import { describe, expect, it, vi } from "vitest";
 import type { MountedFieldControlProps } from "@/components/common_components/MountedFormField";
-import { scopesControl, tagsControl } from "./mcpFieldRules";
+import { tagsControl } from "./mcpFieldRules";
 
 const controlWith = (value: unknown, onChange = vi.fn()): MountedFieldControlProps =>
   ({ id: "field", name: "field", value, onChange, onBlur: vi.fn() }) as unknown as MountedFieldControlProps;
 
-describe("scopesControl", () => {
-  it("splits a stored delimited string into one tag per scope", () => {
-    expect(scopesControl(controlWith("read write admin")).value).toStrictEqual(["read", "write", "admin"]);
+// These fields were antd Selects with tokenSeparators={[","]}: a comma commits a tag, and nothing
+// else does. The shadcn tag input commits the whole typed string as one custom value instead, so
+// every case below pins the antd rule the migration has to preserve.
+describe("tagsControl", () => {
+  it("splits the comma-separated headers an admin commits as one entry", () => {
+    const onChange = vi.fn();
+    tagsControl(controlWith([], onChange)).onValueChange(["Authorization,X-Custom-Header"]);
+
+    expect(onChange).toHaveBeenCalledWith(["Authorization", "X-Custom-Header"]);
   });
 
-  it("splits a comma-delimited entry the tag input committed as a single custom value", () => {
+  it("trims the space an admin types after each comma", () => {
     const onChange = vi.fn();
-    scopesControl(controlWith([], onChange)).onValueChange(["read,write"]);
-
-    expect(onChange).toHaveBeenCalledWith(["read", "write"]);
-  });
-
-  it("keeps already-split scopes intact while splitting only the entry that needs it", () => {
-    const onChange = vi.fn();
-    scopesControl(controlWith(["read"], onChange)).onValueChange(["read", "write, admin"]);
+    tagsControl(controlWith([], onChange)).onValueChange(["read, write, admin"]);
 
     expect(onChange).toHaveBeenCalledWith(["read", "write", "admin"]);
   });
 
-  it("drops the duplicate when a typed entry repeats a scope that is already selected", () => {
+  it("keeps already-committed tags intact while splitting only the entry that needs it", () => {
     const onChange = vi.fn();
-    scopesControl(controlWith(["read"], onChange)).onValueChange(["read", "read,write"]);
+    tagsControl(controlWith(["group-a"], onChange)).onValueChange(["group-a", "group-b,group-c"]);
+
+    expect(onChange).toHaveBeenCalledWith(["group-a", "group-b", "group-c"]);
+  });
+
+  it("drops the duplicate when a typed entry repeats a tag that is already selected", () => {
+    const onChange = vi.fn();
+    tagsControl(controlWith(["read"], onChange)).onValueChange(["read", "read,write"]);
 
     expect(onChange).toHaveBeenCalledWith(["read", "write"]);
   });
 
-  it("keeps a URI-shaped scope whole, since it carries no delimiter", () => {
-    const onChange = vi.fn();
-    scopesControl(controlWith([], onChange)).onValueChange(["api://app-id/.default"]);
-
-    expect(onChange).toHaveBeenCalledWith(["api://app-id/.default"]);
-  });
-
-  it("clears to an empty list rather than a blank scope when the field is emptied", () => {
-    const onChange = vi.fn();
-    scopesControl(controlWith("", onChange)).onValueChange([""]);
-
-    expect(scopesControl(controlWith("")).value).toStrictEqual([]);
-    expect(onChange).toHaveBeenCalledWith([]);
-  });
-});
-
-describe("tagsControl", () => {
-  it("preserves a stdio argument that contains spaces, which is one argv entry", () => {
+  it("preserves the interior spaces of a stdio argument, which a comma alone may split", () => {
     const onChange = vi.fn();
     tagsControl(controlWith(["npx"], onChange)).onValueChange(["npx", "--header=X-Trace: on"]);
 
     expect(onChange).toHaveBeenCalledWith(["npx", "--header=X-Trace: on"]);
   });
 
-  it("preserves a comma inside an entry, which is part of the value and not a separator", () => {
+  it("keeps a scope URI whole, since it carries no comma", () => {
     const onChange = vi.fn();
-    tagsControl(controlWith([], onChange)).onValueChange(["Create, update and delete issues"]);
+    tagsControl(controlWith([], onChange)).onValueChange(["api://app-id/.default"]);
 
-    expect(onChange).toHaveBeenCalledWith(["Create, update and delete issues"]);
+    expect(onChange).toHaveBeenCalledWith(["api://app-id/.default"]);
   });
 
-  it("keeps a repeated entry, since two argv entries may legitimately be identical", () => {
-    const onChange = vi.fn();
-    tagsControl(controlWith([], onChange)).onValueChange(["-v", "-v"]);
-
-    expect(onChange).toHaveBeenCalledWith(["-v", "-v"]);
+  it("splits a stored delimited string rather than rendering it as one tag", () => {
+    expect(tagsControl(controlWith("Authorization,X-Custom-Header")).value).toStrictEqual([
+      "Authorization",
+      "X-Custom-Header",
+    ]);
   });
 
   it("renders a stored list unchanged", () => {
     expect(tagsControl(controlWith(["run", "--flag a"])).value).toStrictEqual(["run", "--flag a"]);
   });
 
-  it("drops the blank entry a cleared field leaves behind", () => {
+  it("clears to an empty list rather than a blank tag when the field is emptied", () => {
     const onChange = vi.fn();
     tagsControl(controlWith("", onChange)).onValueChange([""]);
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.ts
@@ -1,3 +1,4 @@
+import type React from "react";
 import type { Validate } from "react-hook-form";
 
 import type { MountedFieldControlProps, MountedFormValues } from "@/components/common_components/MountedFormField";
@@ -20,27 +21,50 @@ export const textControl = (control: MountedFieldControlProps) => ({
 });
 
 export const selectControl = <TValue = unknown>(control: MountedFieldControlProps) => ({
-  ...ariaOf(control),
-  value: control.value as TValue,
-  onChange: control.onChange,
+  value: (control.value ?? null) as TValue | null,
+  onValueChange: control.onChange,
 });
 
-export const numberControl = (control: MountedFieldControlProps) => ({
+export const selectTriggerControl = (control: MountedFieldControlProps) => ariaOf(control);
+
+export const tagsControl = (control: MountedFieldControlProps) => {
+  const value = (control.value as string[] | undefined) ?? [];
+  return {
+    id: control.id,
+    options: value.map((tag) => ({ label: tag, value: tag })),
+    value,
+    onValueChange: control.onChange,
+    emptyText: "Type to add",
+    allowCustomValues: true,
+  };
+};
+
+const toNumberOrNull = (raw: string, precision: number | undefined): number | null => {
+  if (raw.trim() === "") return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return null;
+  return precision === undefined ? parsed : Number(parsed.toFixed(precision));
+};
+
+export const numberControl = (control: MountedFieldControlProps, precision?: number) => ({
   ...ariaOf(control),
-  value: control.value as number | null | undefined,
-  onChange: control.onChange,
+  name: control.name,
+  type: "number" as const,
+  value: control.value === null || control.value === undefined ? "" : String(control.value),
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+    control.onChange(toNumberOrNull(event.target.value, precision)),
 });
 
 export const switchControl = (control: MountedFieldControlProps) => ({
   ...ariaOf(control),
   checked: control.value === true,
-  onChange: control.onChange,
+  onCheckedChange: (checked: boolean) => control.onChange(checked),
 });
 
 export const invertedSwitchControl = (control: MountedFieldControlProps) => ({
   ...ariaOf(control),
   checked: control.value !== true,
-  onChange: (checked: boolean) => control.onChange(!checked),
+  onCheckedChange: (checked: boolean) => control.onChange(!checked),
 });
 
 export const valueAt = (values: MountedFormValues, path: readonly string[]): unknown =>

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.ts
@@ -27,26 +27,21 @@ export const selectControl = <TValue = unknown>(control: MountedFieldControlProp
 
 export const selectTriggerControl = (control: MountedFieldControlProps) => ariaOf(control);
 
-// Every one of these fields was an antd Select carrying tokenSeparators={[","]}, so a comma has
-// always committed a tag rather than becoming part of one, and only a comma has. The shadcn tag
-// input hands the whole typed string back as a single custom value instead, so apply that same rule
-// here, in both directions: a stored value can still be the bare string a cleared antd field left.
-const toTags = (value: unknown): string[] => [
-  ...new Set(
-    (Array.isArray(value) ? value : [value])
-      .flatMap((entry) => (typeof entry === "string" ? entry.split(",") : []))
-      .map((tag) => tag.trim())
-      .filter((tag) => tag !== ""),
-  ),
-];
+// These fields were antd Selects carrying tokenSeparators={[","]}, and MultiSelect applies that same
+// rule to what an admin types. So this only adapts the stored value: splitting or deduping it here
+// would rewrite stdio argv entries and repeated flags that nobody edited.
+const toTags = (value: unknown): string[] =>
+  (Array.isArray(value) ? value : [value]).filter(
+    (entry): entry is string => typeof entry === "string" && entry !== "",
+  );
 
 export const tagsControl = (control: MountedFieldControlProps) => {
   const value = toTags(control.value);
   return {
     id: control.id,
-    options: value.map((tag) => ({ label: tag, value: tag })),
+    options: [...new Set(value)].map((tag) => ({ label: tag, value: tag })),
     value,
-    onValueChange: (tags: readonly string[]) => control.onChange(toTags(tags)),
+    onValueChange: control.onChange,
     emptyText: "Type to add",
     allowCustomValues: true,
   };

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.ts
@@ -27,17 +27,17 @@ export const selectControl = <TValue = unknown>(control: MountedFieldControlProp
 
 export const selectTriggerControl = (control: MountedFieldControlProps) => ariaOf(control);
 
-// Tag fields are backed by a list, but a stored value can still arrive as the delimited string an
-// OAuth server returns (RFC 6749 uses space-delimited scopes) or as the empty string a cleared
-// antd field left behind, so normalise before the tag list renders.
+// Tag fields are backed by a list, but a single entry can still carry several tags: a stored value
+// arrives as the delimited string an OAuth server returns (RFC 6749 uses space-delimited scopes),
+// and the tag input commits whatever the admin typed as one custom value, so "read,write" would
+// otherwise be stored verbatim. Split and dedupe on the way in and on the way out.
 const toTags = (value: unknown): string[] => {
-  if (Array.isArray(value)) {
-    return value.filter((tag): tag is string => typeof tag === "string" && tag !== "");
-  }
-  if (typeof value === "string") {
-    return value.split(/[\s,]+/).filter((tag) => tag !== "");
-  }
-  return [];
+  const entries = Array.isArray(value) ? value : [value];
+  return [
+    ...new Set(
+      entries.flatMap((entry) => (typeof entry === "string" ? entry.split(/[\s,]+/) : [])).filter((tag) => tag !== ""),
+    ),
+  ];
 };
 
 export const tagsControl = (control: MountedFieldControlProps) => {
@@ -46,7 +46,7 @@ export const tagsControl = (control: MountedFieldControlProps) => {
     id: control.id,
     options: value.map((tag) => ({ label: tag, value: tag })),
     value,
-    onValueChange: control.onChange,
+    onValueChange: (tags: readonly string[]) => control.onChange(toTags(tags)),
     emptyText: "Type to add",
     allowCustomValues: true,
   };

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.ts
@@ -27,30 +27,37 @@ export const selectControl = <TValue = unknown>(control: MountedFieldControlProp
 
 export const selectTriggerControl = (control: MountedFieldControlProps) => ariaOf(control);
 
-// Tag fields are backed by a list, but a single entry can still carry several tags: a stored value
-// arrives as the delimited string an OAuth server returns (RFC 6749 uses space-delimited scopes),
-// and the tag input commits whatever the admin typed as one custom value, so "read,write" would
-// otherwise be stored verbatim. Split and dedupe on the way in and on the way out.
-const toTags = (value: unknown): string[] => {
-  const entries = Array.isArray(value) ? value : [value];
-  return [
-    ...new Set(
-      entries.flatMap((entry) => (typeof entry === "string" ? entry.split(/[\s,]+/) : [])).filter((tag) => tag !== ""),
-    ),
-  ];
-};
+const asTagList = (value: unknown): string[] =>
+  (Array.isArray(value) ? value : [value]).filter((tag): tag is string => typeof tag === "string" && tag !== "");
 
-export const tagsControl = (control: MountedFieldControlProps) => {
-  const value = toTags(control.value);
+// A scope list is delimited on both sides of the field: it is stored as the single space-delimited
+// string RFC 6749 defines, and the tag input hands back whatever the admin typed as one custom
+// value, so "read,write" would otherwise round-trip as a single malformed scope.
+const splitScopes = (value: unknown): string[] => [
+  ...new Set(
+    asTagList(value)
+      .flatMap((entry) => entry.split(/[\s,]+/))
+      .filter((scope) => scope !== ""),
+  ),
+];
+
+const tagField = (control: MountedFieldControlProps, normalise: (value: unknown) => string[]) => {
+  const value = normalise(control.value);
   return {
     id: control.id,
     options: value.map((tag) => ({ label: tag, value: tag })),
     value,
-    onValueChange: (tags: readonly string[]) => control.onChange(toTags(tags)),
+    onValueChange: (tags: readonly string[]) => control.onChange(normalise(tags)),
     emptyText: "Type to add",
     allowCustomValues: true,
   };
 };
+
+// Tags that are opaque to us: a stdio arg or an access description item may legitimately contain
+// spaces and commas, so each entry is stored exactly as the admin typed it.
+export const tagsControl = (control: MountedFieldControlProps) => tagField(control, asTagList);
+
+export const scopesControl = (control: MountedFieldControlProps) => tagField(control, splitScopes);
 
 const toNumberOrNull = (raw: string, precision: number | undefined): number | null => {
   if (raw.trim() === "") return null;

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.ts
@@ -27,37 +27,30 @@ export const selectControl = <TValue = unknown>(control: MountedFieldControlProp
 
 export const selectTriggerControl = (control: MountedFieldControlProps) => ariaOf(control);
 
-const asTagList = (value: unknown): string[] =>
-  (Array.isArray(value) ? value : [value]).filter((tag): tag is string => typeof tag === "string" && tag !== "");
-
-// A scope list is delimited on both sides of the field: it is stored as the single space-delimited
-// string RFC 6749 defines, and the tag input hands back whatever the admin typed as one custom
-// value, so "read,write" would otherwise round-trip as a single malformed scope.
-const splitScopes = (value: unknown): string[] => [
+// Every one of these fields was an antd Select carrying tokenSeparators={[","]}, so a comma has
+// always committed a tag rather than becoming part of one, and only a comma has. The shadcn tag
+// input hands the whole typed string back as a single custom value instead, so apply that same rule
+// here, in both directions: a stored value can still be the bare string a cleared antd field left.
+const toTags = (value: unknown): string[] => [
   ...new Set(
-    asTagList(value)
-      .flatMap((entry) => entry.split(/[\s,]+/))
-      .filter((scope) => scope !== ""),
+    (Array.isArray(value) ? value : [value])
+      .flatMap((entry) => (typeof entry === "string" ? entry.split(",") : []))
+      .map((tag) => tag.trim())
+      .filter((tag) => tag !== ""),
   ),
 ];
 
-const tagField = (control: MountedFieldControlProps, normalise: (value: unknown) => string[]) => {
-  const value = normalise(control.value);
+export const tagsControl = (control: MountedFieldControlProps) => {
+  const value = toTags(control.value);
   return {
     id: control.id,
     options: value.map((tag) => ({ label: tag, value: tag })),
     value,
-    onValueChange: (tags: readonly string[]) => control.onChange(normalise(tags)),
+    onValueChange: (tags: readonly string[]) => control.onChange(toTags(tags)),
     emptyText: "Type to add",
     allowCustomValues: true,
   };
 };
-
-// Tags that are opaque to us: a stdio arg or an access description item may legitimately contain
-// spaces and commas, so each entry is stored exactly as the admin typed it.
-export const tagsControl = (control: MountedFieldControlProps) => tagField(control, asTagList);
-
-export const scopesControl = (control: MountedFieldControlProps) => tagField(control, splitScopes);
 
 const toNumberOrNull = (raw: string, precision: number | undefined): number | null => {
   if (raw.trim() === "") return null;

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcpFieldRules.ts
@@ -27,8 +27,21 @@ export const selectControl = <TValue = unknown>(control: MountedFieldControlProp
 
 export const selectTriggerControl = (control: MountedFieldControlProps) => ariaOf(control);
 
+// Tag fields are backed by a list, but a stored value can still arrive as the delimited string an
+// OAuth server returns (RFC 6749 uses space-delimited scopes) or as the empty string a cleared
+// antd field left behind, so normalise before the tag list renders.
+const toTags = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value.filter((tag): tag is string => typeof tag === "string" && tag !== "");
+  }
+  if (typeof value === "string") {
+    return value.split(/[\s,]+/).filter((tag) => tag !== "");
+  }
+  return [];
+};
+
 export const tagsControl = (control: MountedFieldControlProps) => {
-  const value = (control.value as string[] | undefined) ?? [];
+  const value = toTags(control.value);
   return {
     id: control.id,
     options: value.map((tag) => ({ label: tag, value: tag })),

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_connect.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_connect.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable react/no-unescaped-entities */
 
-import React, { useState } from "react";
-import { Card, Typography, Space, Switch } from "antd";
+import React, { useId, useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/shared/Alert";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   CopyIcon,
@@ -19,8 +21,6 @@ import {
 } from "lucide-react";
 import { getProxyBaseUrl } from "@/components/networking";
 import { copyToClipboard as utilCopyToClipboard } from "@/utils/dataUtils";
-
-const { Title, Text } = Typography;
 
 interface CodeBlockProps {
   code: string;
@@ -47,6 +47,7 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
   accessGroups = ["dev-group"],
 }) => {
   const [useServerHeader, setUseServerHeader] = useState(false);
+  const serverHeaderToggleId = useId();
 
   const getHeadersConfig = () => {
     const headers: Record<string, any> = {
@@ -62,58 +63,65 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
   };
 
   return (
-    <Card className="border border-border">
-      <div className="flex items-center gap-3 mb-3">
-        <span className="p-2 rounded-lg bg-muted">{icon}</span>
-        <div>
-          <Title level={5} className="mb-0">
-            {title}
-          </Title>
-          <Text className="text-muted-foreground">{description}</Text>
-        </div>
-      </div>
-      {serverName && (title === "Implementation Example" || title === "Configuration") && (
-        <div className="mb-4">
-          <div className="flex items-center gap-2 mb-2">
-            <Switch size="small" checked={useServerHeader} onChange={setUseServerHeader} />
-            <Text className="text-sm">
-              Limit tools to specific MCP servers or MCP groups by passing the <code>x-mcp-servers</code> header
-            </Text>
+    <Card>
+      <CardContent>
+        <div className="flex items-center gap-3 mb-3">
+          <span className="p-2 rounded-lg bg-muted">{icon}</span>
+          <div>
+            <h5 className="mb-0 text-base font-semibold text-foreground">{title}</h5>
+            <span className="text-muted-foreground">{description}</span>
           </div>
-          {useServerHeader && (
-            <Alert className="mt-2" variant="info">
-              <Info />
-              <AlertTitle>Two Options</AlertTitle>
-              <AlertDescription>
-                <p>
-                  <strong>Option 1:</strong> Get a specific server: <code>"{serverName.replace(/\s+/g, "_")}"</code>
-                </p>
-                <p>
-                  <strong>Option 2:</strong> Get a group of MCPs: <code>"dev-group"</code>
-                </p>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  You can also mix both: <code>"Server1,dev-group"</code>
-                </p>
-              </AlertDescription>
-            </Alert>
-          )}
         </div>
-      )}
-      {React.Children.map(children, (child) => {
-        if (
-          React.isValidElement<CodeBlockProps>(child) &&
-          child.props.hasOwnProperty("code") &&
-          child.props.hasOwnProperty("copyKey")
-        ) {
-          const code = child.props.code;
-          if (code && code.includes('"headers":')) {
-            return React.cloneElement(child, {
-              code: code.replace(/"headers":\s*{[^}]*}/, `"headers": ${JSON.stringify(getHeadersConfig(), null, 8)}`),
-            });
+        {serverName && (title === "Implementation Example" || title === "Configuration") && (
+          <div className="mb-4">
+            <div className="flex items-center gap-2 mb-2">
+              <Switch
+                id={serverHeaderToggleId}
+                size="sm"
+                checked={useServerHeader}
+                onCheckedChange={setUseServerHeader}
+              />
+              <Label htmlFor={serverHeaderToggleId} className="font-normal leading-normal">
+                Limit tools to specific MCP servers or MCP groups by passing the <code>x-mcp-servers</code> header
+              </Label>
+            </div>
+            {useServerHeader && (
+              <Alert className="mt-2" variant="info">
+                <Info />
+                <AlertTitle>Two Options</AlertTitle>
+                <AlertDescription>
+                  <div>
+                    <p>
+                      <strong>Option 1:</strong> Get a specific server: <code>"{serverName.replace(/\s+/g, "_")}"</code>
+                    </p>
+                    <p>
+                      <strong>Option 2:</strong> Get a group of MCPs: <code>"dev-group"</code>
+                    </p>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      You can also mix both: <code>"Server1,dev-group"</code>
+                    </p>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            )}
+          </div>
+        )}
+        {React.Children.map(children, (child) => {
+          if (
+            React.isValidElement<CodeBlockProps>(child) &&
+            child.props.hasOwnProperty("code") &&
+            child.props.hasOwnProperty("copyKey")
+          ) {
+            const code = child.props.code;
+            if (code && code.includes('"headers":')) {
+              return React.cloneElement(child, {
+                code: code.replace(/"headers":\s*{[^}]*}/, `"headers": ${JSON.stringify(getHeadersConfig(), null, 8)}`),
+              });
+            }
           }
-        }
-        return child;
-      })}
+          return child;
+        })}
+      </CardContent>
     </Card>
   );
 };
@@ -147,25 +155,25 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
       {title && (
         <div className="flex items-center gap-2 mb-2">
           <Code size={16} className="text-blue-600 dark:text-blue-400" />
-          <Text strong className="text-foreground">
-            {title}
-          </Text>
+          <strong className="font-semibold text-foreground">{title}</strong>
         </div>
       )}
-      <Card className={`bg-muted border border-border relative ${className}`}>
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          onClick={() => copyToClipboard(code, copyKey)}
-          className={`absolute top-2 right-2 z-10 transition-all duration-200 ${
-            copiedStates[copyKey]
-              ? "text-green-600 bg-green-50 border-green-200 dark:text-green-400 dark:bg-green-950 dark:border-green-800"
-              : "text-muted-foreground hover:text-foreground hover:bg-accent"
-          }`}
-        >
-          {copiedStates[copyKey] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
-        </Button>
-        <pre className="text-sm overflow-x-auto pr-10 text-foreground font-mono leading-relaxed">{code}</pre>
+      <Card className={`relative bg-muted ${className}`}>
+        <CardContent>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => copyToClipboard(code, copyKey)}
+            className={`absolute top-2 right-2 z-10 transition-all duration-200 ${
+              copiedStates[copyKey]
+                ? "text-green-600 bg-green-50 border-green-200 dark:text-green-400 dark:bg-green-950 dark:border-green-800"
+                : "text-muted-foreground hover:text-foreground hover:bg-accent"
+            }`}
+          >
+            {copiedStates[copyKey] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+          </Button>
+          <pre className="text-sm overflow-x-auto pr-10 text-foreground font-mono leading-relaxed">{code}</pre>
+        </CardContent>
       </Card>
     </div>
   );
@@ -182,40 +190,36 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
         </div>
       </div>
       <div className="flex-1">
-        <Text strong className="text-foreground block mb-2">
-          {title}
-        </Text>
+        <strong className="mb-2 block font-semibold text-foreground">{title}</strong>
         {children}
       </div>
     </div>
   );
 
   const LiteLLMProxyTab = () => (
-    <Space direction="vertical" size="large" className="w-full">
+    <div className="flex w-full flex-col gap-6">
       <div className="bg-linear-to-r from-emerald-50 to-green-50 p-6 rounded-lg border border-emerald-100">
         <div className="flex items-center gap-3 mb-3">
           <Zap className="text-emerald-600" size={24} />
-          <Title level={4} className="mb-0 text-emerald-900">
-            LiteLLM Proxy API Integration
-          </Title>
+          <h4 className="mb-0 text-xl font-semibold text-emerald-900">LiteLLM Proxy API Integration</h4>
         </div>
-        <Text className="text-emerald-700">
+        <span className="text-emerald-700">
           Connect to LiteLLM Proxy Responses API for seamless tool integration with multiple model providers
-        </Text>
+        </span>
       </div>
 
-      <Space direction="vertical" size="large" className="w-full">
+      <div className="flex w-full flex-col gap-6">
         <FeatureCard
           icon={<KeyIcon className="text-emerald-600" size={16} />}
           title="Virtual Key Setup"
           description="Configure your LiteLLM Proxy Virtual Key for authentication"
         >
-          <Space direction="vertical" size="middle" className="w-full">
+          <div className="flex w-full flex-col gap-4">
             <div>
-              <Text>Get your Virtual Key from your LiteLLM Proxy dashboard or contact your administrator</Text>
+              <span>Get your Virtual Key from your LiteLLM Proxy dashboard or contact your administrator</span>
             </div>
             <CodeBlock title="Environment Variable" code='export LITELLM_API_KEY="sk-..."' copyKey="litellm-env" />
-          </Space>
+          </div>
         </FeatureCard>
 
         <FeatureCard
@@ -258,34 +262,33 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
             className="text-xs"
           />
         </FeatureCard>
-      </Space>
-    </Space>
+      </div>
+    </div>
   );
 
   const OpenAITab = () => (
-    <Space direction="vertical" size="large" className="w-full">
+    <div className="flex w-full flex-col gap-6">
       <div className="bg-linear-to-r from-blue-50 to-indigo-50 p-6 rounded-lg border border-blue-100 dark:from-blue-950 dark:to-indigo-950 dark:border-blue-900">
         <div className="flex items-center gap-3 mb-3">
           <Code className="text-blue-600 dark:text-blue-400" size={24} />
-          <Title level={4} className="mb-0 text-blue-900 dark:text-blue-100">
+          <h4 className="mb-0 text-xl font-semibold text-blue-900 dark:text-blue-100">
             OpenAI Responses API Integration
-          </Title>
+          </h4>
         </div>
-        <Text className="text-blue-700 dark:text-blue-300">
+        <span className="text-blue-700 dark:text-blue-300">
           Connect OpenAI Responses API to your LiteLLM MCP server for seamless tool integration
-        </Text>
+        </span>
       </div>
 
-      <Space direction="vertical" size="large" className="w-full">
+      <div className="flex w-full flex-col gap-6">
         <FeatureCard
           icon={<KeyIcon className="text-blue-600 dark:text-blue-400" size={16} />}
           title="API Key Setup"
           description="Configure your OpenAI API key for authentication"
         >
-          <Space direction="vertical" size="middle" className="w-full">
+          <div className="flex w-full flex-col gap-4">
             <div>
-              {/* eslint-disable-next-line react/no-unescaped-entities */}
-              <Text>
+              <span>
                 Get your API key from the{" "}
                 <a
                   href="https://platform.openai.com/api-keys"
@@ -295,10 +298,10 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
                 >
                   OpenAI platform <ExternalLinkIcon size={12} />
                 </a>
-              </Text>
+              </span>
             </div>
             <CodeBlock title="Environment Variable" code='export OPENAI_API_KEY="sk-..."' copyKey="openai-env" />
-          </Space>
+          </div>
         </FeatureCard>
 
         <FeatureCard
@@ -341,88 +344,84 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
             className="text-xs"
           />
         </FeatureCard>
-      </Space>
-    </Space>
+      </div>
+    </div>
   );
 
   const CursorTab = () => (
-    <Space direction="vertical" size="large" className="w-full">
+    <div className="flex w-full flex-col gap-6">
       <div className="bg-linear-to-r from-purple-50 to-blue-50 p-6 rounded-lg border border-purple-100">
         <div className="flex items-center gap-3 mb-3">
           <Terminal className="text-purple-600" size={24} />
-          <Title level={4} className="mb-0 text-purple-900">
-            Cursor IDE Integration
-          </Title>
+          <h4 className="mb-0 text-xl font-semibold text-purple-900">Cursor IDE Integration</h4>
         </div>
-        <Text className="text-purple-700">
+        <span className="text-purple-700">
           Use tools directly from Cursor IDE with LiteLLM MCP. Enable your AI assistant to perform real-world tasks
           without leaving your coding environment.
-        </Text>
+        </span>
       </div>
 
-      <Card className="border border-border">
-        <Title level={5} className="mb-4 text-foreground">
-          Setup Instructions
-        </Title>
-        <Space direction="vertical" size="large" className="w-full">
-          <StepCard step={1} title="Open Cursor Settings">
-            <Text className="text-muted-foreground">
-              Use the keyboard shortcut <code className="bg-muted px-2 py-1 rounded-sm">⇧+⌘+J</code> (Mac) or{" "}
-              <code className="bg-muted px-2 py-1 rounded-sm">Ctrl+Shift+J</code> (Windows/Linux)
-            </Text>
-          </StepCard>
+      <Card>
+        <CardContent>
+          <h5 className="mb-4 text-base font-semibold text-foreground">Setup Instructions</h5>
+          <div className="flex w-full flex-col gap-6">
+            <StepCard step={1} title="Open Cursor Settings">
+              <span className="text-muted-foreground">
+                Use the keyboard shortcut <code className="bg-muted px-2 py-1 rounded-sm">⇧+⌘+J</code> (Mac) or{" "}
+                <code className="bg-muted px-2 py-1 rounded-sm">Ctrl+Shift+J</code> (Windows/Linux)
+              </span>
+            </StepCard>
 
-          <StepCard step={2} title="Navigate to MCP Tools">
-            <Text className="text-muted-foreground">Go to the "MCP Tools" tab and click "New MCP Server"</Text>
-          </StepCard>
+            <StepCard step={2} title="Navigate to MCP Tools">
+              <span className="text-muted-foreground">Go to the "MCP Tools" tab and click "New MCP Server"</span>
+            </StepCard>
 
-          <StepCard step={3} title="Add Configuration">
-            <Text className="text-muted-foreground mb-3">
-              Copy the JSON configuration below and paste it into Cursor, then save with{" "}
-              <code className="bg-muted px-2 py-1 rounded-sm">Cmd+S</code> or{" "}
-              <code className="bg-muted px-2 py-1 rounded-sm">Ctrl+S</code>
-            </Text>
-            <FeatureCard
-              icon={<Code className="text-purple-600" size={16} />}
-              title="Configuration"
-              description="Cursor MCP configuration"
-              serverName="Zapier Gmail"
-              accessGroups={["dev-group"]}
-            >
-              <CodeBlock
-                code={`{
-  "mcpServers": {
-    "Zapier_MCP": {
-      "url": "${proxyBaseUrl}/mcp",
-      "headers": {
-        "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
-        "x-mcp-servers": "Zapier_MCP,dev-group"
+            <StepCard step={3} title="Add Configuration">
+              <span className="mb-3 text-muted-foreground">
+                Copy the JSON configuration below and paste it into Cursor, then save with{" "}
+                <code className="bg-muted px-2 py-1 rounded-sm">Cmd+S</code> or{" "}
+                <code className="bg-muted px-2 py-1 rounded-sm">Ctrl+S</code>
+              </span>
+              <FeatureCard
+                icon={<Code className="text-purple-600" size={16} />}
+                title="Configuration"
+                description="Cursor MCP configuration"
+                serverName="Zapier Gmail"
+                accessGroups={["dev-group"]}
+              >
+                <CodeBlock
+                  code={`{
+    "mcpServers": {
+      "Zapier_MCP": {
+        "url": "${proxyBaseUrl}/mcp",
+        "headers": {
+          "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
+          "x-mcp-servers": "Zapier_MCP,dev-group"
+        }
       }
     }
-  }
-}`}
-                copyKey="cursor-config"
-                className="text-xs"
-              />
-            </FeatureCard>
-          </StepCard>
-        </Space>
+  }`}
+                  copyKey="cursor-config"
+                  className="text-xs"
+                />
+              </FeatureCard>
+            </StepCard>
+          </div>
+        </CardContent>
       </Card>
-    </Space>
+    </div>
   );
 
   const StreamableHTTPTab = () => (
-    <Space direction="vertical" size="large" className="w-full">
+    <div className="flex w-full flex-col gap-6">
       <div className="bg-linear-to-r from-green-50 to-teal-50 p-6 rounded-lg border border-green-100">
         <div className="flex items-center gap-3 mb-3">
           <Globe className="text-green-600 dark:text-green-400" size={24} />
-          <Title level={4} className="mb-0 text-green-900 dark:text-green-100">
-            Streamable HTTP Transport
-          </Title>
+          <h4 className="mb-0 text-xl font-semibold text-green-900 dark:text-green-100">Streamable HTTP Transport</h4>
         </div>
-        <Text className="text-green-700 dark:text-green-300">
+        <span className="text-green-700 dark:text-green-300">
           Connect to LiteLLM MCP using HTTP transport. Compatible with any MCP client that supports HTTP streaming.
-        </Text>
+        </span>
       </div>
 
       <FeatureCard
@@ -430,12 +429,12 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
         title="Universal MCP Connection"
         description="Use this URL with any MCP client that supports HTTP transport"
       >
-        <Space direction="vertical" size="middle" className="w-full">
+        <div className="flex w-full flex-col gap-4">
           <div>
-            <Text>
+            <span>
               Each MCP client supports different transports. Refer to your client documentation to determine the
               appropriate transport method.
-            </Text>
+            </span>
           </div>
           <CodeBlock title="Server URL" code={`${proxyBaseUrl}/mcp`} copyKey="http-server-url" />
           <CodeBlock
@@ -466,14 +465,14 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
               Learn more about MCP transports
             </Button>
           </div>
-        </Space>
+        </div>
       </FeatureCard>
-    </Space>
+    </div>
   );
 
   return (
     <div>
-      <Space direction="vertical" size="large" className="w-full">
+      <div className="flex w-full flex-col gap-6">
         <div>
           <h2 className="text-3xl font-bold text-foreground mb-3">Connect to your MCP client</h2>
           <p className="text-lg text-muted-foreground">
@@ -524,7 +523,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
             <StreamableHTTPTab />
           </TabsContent>
         </Tabs>
-      </Space>
+      </div>
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.test.tsx
@@ -6,7 +6,7 @@ import MCPServerEdit, { EDIT_OAUTH_UI_STATE_KEY } from "./mcp_server_edit";
 import { setSecureItem } from "@/utils/secureStorage";
 import * as networking from "@/components/networking";
 import { toast } from "@/lib/toast";
-import { selectAntOption } from "./testUtils";
+import { selectOption } from "./testUtils";
 
 vi.mock("@/components/networking", () => ({
   updateMCPServer: vi.fn(),
@@ -370,7 +370,7 @@ describe("MCPServerEdit (true passthrough warning)", () => {
       />,
     );
 
-    await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+    await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
 
     await waitFor(() => {
       expect(mockOauth.getTemporaryPayload).toBeTruthy();
@@ -407,7 +407,7 @@ describe("MCPServerEdit (auth type switch)", () => {
       />,
     );
 
-    await selectAntOption("Authentication", "OAuth Token Exchange (OBO)");
+    await selectOption("Authentication", "OAuth Token Exchange (OBO)");
 
     const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
     await act(async () => {
@@ -484,7 +484,7 @@ describe("MCPServerEdit OAuth token invalidation", () => {
     });
     mockOauth.reset.mockClear();
 
-    await selectAntOption("Transport Type", "Standard Input/Output (stdio)");
+    await selectOption("Transport Type", "Standard Input/Output (stdio)");
 
     await waitFor(() => expect(mockOauth.reset).toHaveBeenCalled());
     expect(mockRemoveToken).toHaveBeenCalledWith("oauth_server_1", undefined);
@@ -602,7 +602,7 @@ describe("MCPServerEdit OAuth token invalidation", () => {
     });
     mockOauth.reset.mockClear();
 
-    await selectAntOption("Transport Type", "Server-Sent Events (SSE)");
+    await selectOption("Transport Type", "Server-Sent Events (SSE)");
 
     expect(mockOauth.reset).not.toHaveBeenCalled();
     expect(mockRemoveToken).not.toHaveBeenCalled();
@@ -861,7 +861,7 @@ describe("MCPServerEdit (interactive OAuth)", () => {
       expect(screen.getByText("Token Endpoint Auth Method (optional)")).toBeInTheDocument();
     });
 
-    await selectAntOption("Token Endpoint Auth Method (optional)", "Client Secret Basic");
+    await selectOption("Token Endpoint Auth Method (optional)", "Client Secret Basic");
 
     const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
     await act(async () => {
@@ -1695,9 +1695,9 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
       />,
     );
 
-    await selectAntOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
+    await selectOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
     mockOauth.tokenResponse = { access_token: "fresh-tok", token_type: "bearer" };
-    await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+    await selectOption("Authentication", "True Passthrough (no LiteLLM auth)");
 
     await waitFor(() => {
       const withHeaders = vi
@@ -1838,7 +1838,7 @@ describe("MCPServerEdit oauth2_flow selector", () => {
       />,
     );
 
-    await selectAntOption("OAuth Flow Type", "Machine-to-Machine (M2M)");
+    await selectOption("OAuth Flow Type", "Machine-to-Machine (M2M)");
 
     const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
     await act(async () => {
@@ -1870,7 +1870,7 @@ describe("MCPServerEdit oauth2_flow selector", () => {
       />,
     );
 
-    await selectAntOption("OAuth Flow Type", "Interactive (PKCE)");
+    await selectOption("OAuth Flow Type", "Interactive (PKCE)");
 
     const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
     await act(async () => {
@@ -1968,7 +1968,7 @@ describe("MCPServerEdit OAuth flow prefill display", () => {
 
     expect(screen.getByText("This server has no OAuth flow set")).toBeInTheDocument();
 
-    await selectAntOption("OAuth Flow Type", "Machine-to-Machine (M2M)");
+    await selectOption("OAuth Flow Type", "Machine-to-Machine (M2M)");
 
     await waitFor(() => {
       expect(screen.queryByText("This server has no OAuth flow set")).not.toBeInTheDocument();
@@ -2184,7 +2184,7 @@ describe("MCPServerEdit (dcr_bridge toggle)", () => {
       expect(getDcrToggle()).toBeInTheDocument();
     });
 
-    await selectAntOption("Authentication", "API Key");
+    await selectOption("Authentication", "API Key");
     await waitFor(() => {
       expect(getDcrToggle()).not.toBeInTheDocument();
     });
@@ -2210,7 +2210,7 @@ describe("MCPServerEdit (dcr_bridge toggle)", () => {
 
     // The field stays mounted across the two client-forwarded modes, so the live toggle value is
     // preserved rather than forced false by the switch.
-    await selectAntOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
+    await selectOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
     await waitFor(() => {
       expect(getDcrToggle()).toBeInTheDocument();
     });

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.test.tsx
@@ -2062,7 +2062,7 @@ describe("MCPServerEdit (dcr_bridge toggle)", () => {
     mockOauth.tokenResponse = null;
   });
 
-  const getDcrToggle = () => document.getElementById("dcr_bridge");
+  const getDcrToggle = () => screen.queryByRole("switch", { name: /Gateway-hosted sign-in \(DCR bridge\)/ });
 
   function renderEdit(server: Record<string, unknown>) {
     render(

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx
@@ -165,7 +165,6 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   const [tools, setTools] = useState<any[]>([]);
   const [isLoadingTools, setIsLoadingTools] = useState(false);
   const [toolsError, setToolsError] = useState<string | null>(null);
-  const [searchValue, setSearchValue] = useState<string>("");
   const [aliasManuallyEdited, setAliasManuallyEdited] = useState(false);
   const [removeStoredApp, setRemoveStoredApp] = useState(false);
   // Set when the upstream identity (url/endpoints) changed while a declared app is present, so the
@@ -227,7 +226,6 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
           costConfig,
           allowedTools,
           hasToolAllowlistInteraction,
-          searchValue,
           aliasManuallyEdited,
         }),
       );
@@ -411,9 +409,6 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       }
       if (typeof parsed.hasToolAllowlistInteraction === "boolean") {
         setHasToolAllowlistInteraction(parsed.hasToolAllowlistInteraction);
-      }
-      if (parsed.searchValue) {
-        setSearchValue(parsed.searchValue);
       }
       if (typeof parsed.aliasManuallyEdited === "boolean") {
         setAliasManuallyEdited(parsed.aliasManuallyEdited);
@@ -662,6 +657,14 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     }
   };
 
+  const handleTransportSelected =
+    (onChange: (value: string) => void) =>
+    (value: string | null): void => {
+      if (value === null) return;
+      onChange(value);
+      handleTransportChange(value);
+    };
+
   const valuesChangeRef = React.useRef(handleFormValuesChange);
   valuesChangeRef.current = handleFormValuesChange;
 
@@ -815,11 +818,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                     <Select
                       items={TRANSPORT_ITEMS}
                       value={(control.value as string | undefined) ?? null}
-                      onValueChange={(value: string | null) => {
-                        if (value === null) return;
-                        control.onChange(value);
-                        handleTransportChange(value);
-                      }}
+                      onValueChange={handleTransportSelected(control.onChange)}
                     >
                       <SelectTrigger {...selectTriggerControl(control)} className="w-full">
                         <SelectValue />

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx
@@ -1,9 +1,14 @@
 import React, { useState, useEffect } from "react";
-import { Select, Tooltip, Input, InputNumber } from "antd";
+import { MultiSelect } from "@/components/shared/MultiSelect";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Info, TriangleAlert } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/shared/Alert";
 import { FormProvider, useForm } from "react-hook-form";
+import { PasswordInput } from "@/components/shared/PasswordInput";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   AUTH_TYPE,
@@ -20,6 +25,8 @@ import {
   MCPServer,
   MCPServerCostInfo,
   TRANSPORT,
+  TRANSPORT_ITEMS,
+  AUTH_TYPE_ITEMS,
   getMcpOAuthMode,
   oauth2FlowToFormValue,
 } from "@/components/mcp_tools/types";
@@ -62,7 +69,15 @@ import {
   singleBranchChange,
   useMountedValues,
 } from "./mcpFormStore";
-import { numberControl, notOnlyWhitespace, parsesAsJsonObject, selectControl, textControl } from "./mcpFieldRules";
+import {
+  numberControl,
+  notOnlyWhitespace,
+  parsesAsJsonObject,
+  selectControl,
+  selectTriggerControl,
+  tagsControl,
+  textControl,
+} from "./mcpFieldRules";
 import { getSecureItem, setSecureItem } from "@/utils/secureStorage";
 
 interface MCPServerEditProps {
@@ -610,38 +625,6 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     }
   };
 
-  // Generate options with existing groups and potential new group
-  const getAccessGroupOptions = () => {
-    const existingOptions = availableAccessGroups.map((group: string) => ({
-      value: group,
-      label: (
-        <div className="flex items-center gap-2">
-          <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-          <span className="font-medium">{group}</span>
-        </div>
-      ),
-    }));
-
-    // If search value doesn't match any existing group and is not empty, add "create new group" option
-    if (
-      searchValue &&
-      !availableAccessGroups.some((group) => group.toLowerCase().includes(searchValue.toLowerCase()))
-    ) {
-      existingOptions.push({
-        value: searchValue,
-        label: (
-          <div className="flex items-center gap-2">
-            <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
-            <span className="font-medium">{searchValue}</span>
-            <span className="text-gray-400 text-xs ml-1">create new group</span>
-          </div>
-        ),
-      });
-    }
-
-    return existingOptions;
-  };
-
   const handleTransportChange = (value: string) => {
     // Clear fields that are not relevant for the selected transport.
     if (value === "stdio") {
@@ -830,16 +813,24 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                 >
                   {(control) => (
                     <Select
-                      {...selectControl<string>(control)}
-                      onChange={(value: string) => {
+                      items={TRANSPORT_ITEMS}
+                      value={(control.value as string | undefined) ?? null}
+                      onValueChange={(value: string | null) => {
+                        if (value === null) return;
                         control.onChange(value);
                         handleTransportChange(value);
                       }}
                     >
-                      <Select.Option value="http">Streamable HTTP (Recommended)</Select.Option>
-                      <Select.Option value="sse">Server-Sent Events (SSE)</Select.Option>
-                      <Select.Option value="stdio">Standard Input/Output (stdio)</Select.Option>
-                      <Select.Option value={TRANSPORT.OPENAPI}>OpenAPI Spec</Select.Option>
+                      <SelectTrigger {...selectTriggerControl(control)} className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {TRANSPORT_ITEMS.map((item) => (
+                          <SelectItem key={item.value} value={item.value}>
+                            {item.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
                     </Select>
                   )}
                 </MountedFormField>
@@ -873,9 +864,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                     label={
                       <span className="text-sm font-medium text-gray-700 flex items-center">
                         OpenAPI Spec URL
-                        <Tooltip title="URL to an OpenAPI specification (JSON or YAML). MCP tools will be automatically generated from the API endpoints defined in the spec.">
+                        <SimpleTooltip content="URL to an OpenAPI specification (JSON or YAML). MCP tools will be automatically generated from the API endpoints defined in the spec.">
                           <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                        </Tooltip>
+                        </SimpleTooltip>
                       </span>
                     }
                     name="spec_path"
@@ -896,21 +887,20 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                   label={
                     <span className="text-sm font-medium text-gray-700 flex items-center">
                       Max Concurrent Requests (optional)
-                      <Tooltip title="Maximum number of tool calls LiteLLM will run against this server at the same time. Additional calls wait for a free slot. Leave blank for no limit.">
+                      <SimpleTooltip content="Maximum number of tool calls LiteLLM will run against this server at the same time. Additional calls wait for a free slot. Leave blank for no limit.">
                         <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                      </Tooltip>
+                      </SimpleTooltip>
                     </span>
                   }
                   name="max_concurrent_requests"
                 >
                   {(control) => (
-                    <InputNumber
-                      {...numberControl(control)}
+                    <Input
+                      {...numberControl(control, 0)}
                       min={1}
-                      precision={0}
+                      step={1}
                       placeholder="e.g. 10"
-                      style={{ width: "100%" }}
-                      className="rounded-lg"
+                      className="w-full rounded-lg"
                     />
                   )}
                 </MountedFormField>
@@ -925,20 +915,17 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                       rules={{ validate: { required: antdRequired("Authentication is required") } }}
                     >
                       {(control) => (
-                        <Select {...selectControl<string>(control)} virtual={false}>
-                          <Select.Option value="none">None</Select.Option>
-                          <Select.Option value="api_key">API Key</Select.Option>
-                          <Select.Option value="bearer_token">Bearer Token</Select.Option>
-                          <Select.Option value="token">Token</Select.Option>
-                          <Select.Option value="basic">Basic Auth</Select.Option>
-                          <Select.Option value="oauth2">OAuth</Select.Option>
-                          <Select.Option value="oauth2_token_exchange">OAuth Token Exchange (OBO)</Select.Option>
-                          <Select.Option value="oauth2_id_jag">ID-JAG (Okta Cross App Access)</Select.Option>
-                          <Select.Option value="aws_sigv4">AWS SigV4 (Bedrock AgentCore MCPs)</Select.Option>
-                          <Select.Option value="true_passthrough">True Passthrough (no LiteLLM auth)</Select.Option>
-                          <Select.Option value="oauth_delegate">
-                            OAuth Delegate (client-supplied upstream token)
-                          </Select.Option>
+                        <Select {...selectControl<string>(control)} items={AUTH_TYPE_ITEMS}>
+                          <SelectTrigger {...selectTriggerControl(control)} className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {AUTH_TYPE_ITEMS.map((item) => (
+                              <SelectItem key={item.value} value={item.value}>
+                                {item.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
                         </Select>
                       )}
                     </MountedFormField>
@@ -984,11 +971,8 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
 
                     <MountedFormField label="Args" name="args">
                       {(control) => (
-                        <Select
-                          {...selectControl<string[]>(control)}
-                          mode="tags"
-                          size="large"
-                          tokenSeparators={[","]}
+                        <MultiSelect
+                          {...tagsControl(control)}
                           placeholder="Add args (press enter or comma)"
                           className="rounded-lg"
                         />
@@ -1005,7 +989,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                       }}
                     >
                       {(control) => (
-                        <Input.TextArea
+                        <Textarea
                           {...textControl(control)}
                           rows={6}
                           className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500 font-mono text-sm"
@@ -1024,19 +1008,19 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                     label={
                       <span className="text-sm font-medium text-gray-700 flex items-center">
                         Authentication Value
-                        <Tooltip title="Token, password, or header value to send with each request for the selected auth type.">
+                        <SimpleTooltip content="Token, password, or header value to send with each request for the selected auth type.">
                           <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                        </Tooltip>
+                        </SimpleTooltip>
                       </span>
                     }
                     name={["credentials", "auth_value"]}
                     rules={{ validate: { notWhitespace: notOnlyWhitespace("Authentication value cannot be empty") } }}
                   >
                     {(control) => (
-                      <Input.Password
+                      <PasswordInput
                         {...textControl(control)}
                         placeholder="Enter token or secret (leave blank to keep existing)"
-                        className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                        groupClassName="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                       />
                     )}
                   </MountedFormField>
@@ -1089,9 +1073,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                       label={
                         <span className="text-sm font-medium text-gray-700 flex items-center">
                           AWS Region
-                          <Tooltip title="AWS region for SigV4 signing (e.g., us-east-1)">
+                          <SimpleTooltip content="AWS region for SigV4 signing (e.g., us-east-1)">
                             <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                          </Tooltip>
+                          </SimpleTooltip>
                         </span>
                       }
                       name={["credentials", "aws_region_name"]}
@@ -1108,9 +1092,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                       label={
                         <span className="text-sm font-medium text-gray-700 flex items-center">
                           AWS Service Name
-                          <Tooltip title="AWS service name for SigV4 signing. Defaults to 'bedrock-agentcore'.">
+                          <SimpleTooltip content="AWS service name for SigV4 signing. Defaults to 'bedrock-agentcore'.">
                             <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                          </Tooltip>
+                          </SimpleTooltip>
                         </span>
                       }
                       name={["credentials", "aws_service_name"]}
@@ -1127,18 +1111,18 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                       label={
                         <span className="text-sm font-medium text-gray-700 flex items-center">
                           AWS Access Key ID
-                          <Tooltip title="Optional. If not provided, falls back to the boto3 credential chain (IAM role, env vars, etc.).">
+                          <SimpleTooltip content="Optional. If not provided, falls back to the boto3 credential chain (IAM role, env vars, etc.).">
                             <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                          </Tooltip>
+                          </SimpleTooltip>
                         </span>
                       }
                       name={["credentials", "aws_access_key_id"]}
                     >
                       {(control) => (
-                        <Input.Password
+                        <PasswordInput
                           {...textControl(control)}
                           placeholder="Leave blank to keep existing"
-                          className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                          groupClassName="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                         />
                       )}
                     </MountedFormField>
@@ -1146,18 +1130,18 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                       label={
                         <span className="text-sm font-medium text-gray-700 flex items-center">
                           AWS Secret Access Key
-                          <Tooltip title="Optional. Required if AWS Access Key ID is provided.">
+                          <SimpleTooltip content="Optional. Required if AWS Access Key ID is provided.">
                             <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                          </Tooltip>
+                          </SimpleTooltip>
                         </span>
                       }
                       name={["credentials", "aws_secret_access_key"]}
                     >
                       {(control) => (
-                        <Input.Password
+                        <PasswordInput
                           {...textControl(control)}
                           placeholder="Leave blank to keep existing"
-                          className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                          groupClassName="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                         />
                       )}
                     </MountedFormField>
@@ -1165,18 +1149,18 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                       label={
                         <span className="text-sm font-medium text-gray-700 flex items-center">
                           AWS Session Token
-                          <Tooltip title="Optional. Only needed for temporary STS credentials.">
+                          <SimpleTooltip content="Optional. Only needed for temporary STS credentials.">
                             <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                          </Tooltip>
+                          </SimpleTooltip>
                         </span>
                       }
                       name={["credentials", "aws_session_token"]}
                     >
                       {(control) => (
-                        <Input.Password
+                        <PasswordInput
                           {...textControl(control)}
                           placeholder="Leave blank to keep existing"
-                          className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                          groupClassName="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                         />
                       )}
                     </MountedFormField>
@@ -1184,9 +1168,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                       label={
                         <span className="text-sm font-medium text-gray-700 flex items-center">
                           AWS Role ARN
-                          <Tooltip title="Optional. IAM role ARN to assume via STS before signing. If set, LiteLLM calls sts:AssumeRole to get temporary credentials.">
+                          <SimpleTooltip content="Optional. IAM role ARN to assume via STS before signing. If set, LiteLLM calls sts:AssumeRole to get temporary credentials.">
                             <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                          </Tooltip>
+                          </SimpleTooltip>
                         </span>
                       }
                       name={["credentials", "aws_role_name"]}
@@ -1203,9 +1187,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                       label={
                         <span className="text-sm font-medium text-gray-700 flex items-center">
                           AWS Session Name
-                          <Tooltip title="Optional. Session name for the AssumeRole call — appears in CloudTrail logs. Auto-generated if omitted.">
+                          <SimpleTooltip content="Optional. Session name for the AssumeRole call — appears in CloudTrail logs. Auto-generated if omitted.">
                             <Info className="ml-2 size-4 text-blue-400 hover:text-blue-600 cursor-help" />
-                          </Tooltip>
+                          </SimpleTooltip>
                         </span>
                       }
                       name={["credentials", "aws_session_name"]}
@@ -1232,9 +1216,6 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                     availableAccessGroups={availableAccessGroups}
                     mcpServer={mcpServer}
                     mountedAuthType={authType}
-                    searchValue={searchValue}
-                    setSearchValue={setSearchValue}
-                    getAccessGroupOptions={getAccessGroupOptions}
                   />
                 </div>
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/testUtils.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/testUtils.ts
@@ -1,28 +1,12 @@
-import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { expect } from "vitest";
 
-export async function selectAntOption(labelText: string, optionText: string) {
-  const label = screen.getByText(labelText);
-  const select =
-    label.closest("[data-slot='field']")?.querySelector(".ant-select") ??
-    label.closest(".ant-form-item")?.querySelector(".ant-select") ??
-    label.closest(".ant-collapse-item")?.querySelector(".ant-select") ??
-    label.closest("div")?.querySelector(".ant-select") ??
-    null;
+export async function selectOption(labelText: string, optionText: string) {
+  const user = userEvent.setup({ delay: null });
+  await user.click(screen.getByLabelText(labelText));
 
-  act(() => {
-    fireEvent.mouseDown(select!.querySelector(".ant-select-selector")!);
-  });
-
-  await waitFor(() => {
-    expect(document.querySelectorAll(".ant-select-item-option").length).toBeGreaterThan(0);
-  });
-
-  const option = Array.from(document.querySelectorAll(".ant-select-item-option")).find((el) =>
-    el.textContent?.includes(optionText),
-  );
+  const option = (await screen.findAllByRole("option")).find((el) => el.textContent?.includes(optionText));
   expect(option).toBeTruthy();
-  act(() => {
-    fireEvent.click(option!);
-  });
+  await user.click(option!);
 }

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.test.tsx
@@ -15,28 +15,6 @@ vi.mock("@/app/(dashboard)/hooks/mcpServers/useMCPToolsets", () => ({
   useMCPToolsets: vi.fn(),
 }));
 
-vi.mock("antd", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("antd")>();
-  const Select = ({ value, onChange, children, mode }: any) => (
-    <select
-      data-testid="mcp-select"
-      multiple={mode === "multiple"}
-      value={value}
-      onChange={(e) => onChange(Array.from(e.target.selectedOptions, (o) => (o as HTMLOptionElement).value))}
-    >
-      {children}
-    </select>
-  );
-  Select.displayName = "MockSelect";
-  Select.Option = ({ value, disabled, label }: any) => (
-    <option value={value} disabled={disabled}>
-      {label}
-    </option>
-  );
-  Select.Option.displayName = "MockSelectOption";
-  return { ...actual, Select };
-});
-
 import { useMCPAccessGroups } from "@/app/(dashboard)/hooks/mcpServers/useMCPAccessGroups";
 import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers";
 import { useMCPToolsets } from "@/app/(dashboard)/hooks/mcpServers/useMCPToolsets";
@@ -44,6 +22,15 @@ import { useMCPToolsets } from "@/app/(dashboard)/hooks/mcpServers/useMCPToolset
 const mockUseMCPServers = vi.mocked(useMCPServers);
 const mockUseMCPAccessGroups = vi.mocked(useMCPAccessGroups);
 const mockUseMCPToolsets = vi.mocked(useMCPToolsets);
+
+// The dropdown mounts its list asynchronously, so opening means waiting for the options too.
+const openSelector = async (user: ReturnType<typeof userEvent.setup>): Promise<void> => {
+  await user.click(screen.getByRole("combobox"));
+  await screen.findAllByRole("option");
+};
+
+const optionByLabel = (label: string): HTMLElement | undefined =>
+  screen.queryAllByRole("option").find((option) => option.textContent?.startsWith(label));
 
 const setupMcpMocks = () => {
   mockUseMCPServers.mockReturnValue({
@@ -60,19 +47,20 @@ describe("MCPServerSelector no-mcp-servers option", () => {
     setupMcpMocks();
   });
 
-  const optionByValue = (value: string) =>
-    Array.from(screen.getByTestId("mcp-select").querySelectorAll("option")).find(
-      (o) => (o as HTMLOptionElement).value === value,
-    ) as HTMLOptionElement | undefined;
-
-  it("hides the No MCP Servers option by default", () => {
+  it("hides the No MCP Servers option by default", async () => {
+    const user = userEvent.setup();
     renderWithProviders(
       <MCPServerSelector accessToken="tok" onChange={vi.fn()} value={{ servers: [], accessGroups: [] }} />,
     );
-    expect(optionByValue(NO_MCP_SERVERS_SENTINEL)).toBeUndefined();
+
+    await openSelector(user);
+
+    expect(optionByLabel("Server One")).toBeDefined();
+    expect(optionByLabel("No MCP Servers")).toBeUndefined();
   });
 
   it("emits an exclusive sentinel when No MCP Servers is selected", async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     renderWithProviders(
       <MCPServerSelector
@@ -82,14 +70,15 @@ describe("MCPServerSelector no-mcp-servers option", () => {
         value={{ servers: ["srv-1"], accessGroups: [] }}
       />,
     );
-    expect(optionByValue(NO_MCP_SERVERS_SENTINEL)).toBeDefined();
 
-    await userEvent.selectOptions(screen.getByTestId("mcp-select"), [NO_MCP_SERVERS_SENTINEL]);
+    await openSelector(user);
+    await user.click(optionByLabel("No MCP Servers")!);
 
     expect(onChange).toHaveBeenCalledWith({ servers: [NO_MCP_SERVERS_SENTINEL], accessGroups: [], toolsets: [] });
   });
 
-  it("disables real server options while the sentinel is selected", () => {
+  it("disables real server options while the sentinel is selected", async () => {
+    const user = userEvent.setup();
     renderWithProviders(
       <MCPServerSelector
         accessToken="tok"
@@ -98,8 +87,11 @@ describe("MCPServerSelector no-mcp-servers option", () => {
         value={{ servers: [NO_MCP_SERVERS_SENTINEL], accessGroups: [] }}
       />,
     );
-    expect(optionByValue("srv-1")?.disabled).toBe(true);
-    expect(optionByValue(NO_MCP_SERVERS_SENTINEL)?.disabled).toBe(false);
+
+    await openSelector(user);
+
+    expect(optionByLabel("Server One")).toHaveAttribute("aria-disabled", "true");
+    expect(optionByLabel("No MCP Servers")).not.toHaveAttribute("aria-disabled", "true");
   });
 });
 
@@ -109,19 +101,20 @@ describe("MCPServerSelector all-proxy-mcpservers option", () => {
     setupMcpMocks();
   });
 
-  const optionByValue = (value: string) =>
-    Array.from(screen.getByTestId("mcp-select").querySelectorAll("option")).find(
-      (o) => (o as HTMLOptionElement).value === value,
-    ) as HTMLOptionElement | undefined;
-
-  it("hides the All Proxy MCP Servers option by default", () => {
+  it("hides the All Proxy MCP Servers option by default", async () => {
+    const user = userEvent.setup();
     renderWithProviders(
       <MCPServerSelector accessToken="tok" onChange={vi.fn()} value={{ servers: [], accessGroups: [] }} />,
     );
-    expect(optionByValue(ALL_PROXY_MCP_SERVERS_SENTINEL)).toBeUndefined();
+
+    await openSelector(user);
+
+    expect(optionByLabel("Server One")).toBeDefined();
+    expect(optionByLabel("All Proxy MCP Servers")).toBeUndefined();
   });
 
   it("emits an exclusive sentinel when All Proxy MCP Servers is selected", async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     renderWithProviders(
       <MCPServerSelector
@@ -131,9 +124,9 @@ describe("MCPServerSelector all-proxy-mcpservers option", () => {
         value={{ servers: ["srv-1"], accessGroups: [] }}
       />,
     );
-    expect(optionByValue(ALL_PROXY_MCP_SERVERS_SENTINEL)).toBeDefined();
 
-    await userEvent.selectOptions(screen.getByTestId("mcp-select"), [ALL_PROXY_MCP_SERVERS_SENTINEL]);
+    await openSelector(user);
+    await user.click(optionByLabel("All Proxy MCP Servers")!);
 
     expect(onChange).toHaveBeenCalledWith({
       servers: [ALL_PROXY_MCP_SERVERS_SENTINEL],
@@ -142,7 +135,8 @@ describe("MCPServerSelector all-proxy-mcpservers option", () => {
     });
   });
 
-  it("disables real server options while the sentinel is selected", () => {
+  it("disables real server options while the sentinel is selected", async () => {
+    const user = userEvent.setup();
     renderWithProviders(
       <MCPServerSelector
         accessToken="tok"
@@ -151,11 +145,15 @@ describe("MCPServerSelector all-proxy-mcpservers option", () => {
         value={{ servers: [ALL_PROXY_MCP_SERVERS_SENTINEL], accessGroups: [] }}
       />,
     );
-    expect(optionByValue("srv-1")?.disabled).toBe(true);
-    expect(optionByValue(ALL_PROXY_MCP_SERVERS_SENTINEL)?.disabled).toBe(false);
+
+    await openSelector(user);
+
+    expect(optionByLabel("Server One")).toHaveAttribute("aria-disabled", "true");
+    expect(optionByLabel("All Proxy MCP Servers")).not.toHaveAttribute("aria-disabled", "true");
   });
 
-  it("renders the friendly option, not the raw literal, when the sentinel is already stored but the flag is off", () => {
+  it("renders the friendly label, not the raw literal, when the sentinel is already stored but the flag is off", async () => {
+    const user = userEvent.setup();
     renderWithProviders(
       <MCPServerSelector
         accessToken="tok"
@@ -163,9 +161,12 @@ describe("MCPServerSelector all-proxy-mcpservers option", () => {
         value={{ servers: [ALL_PROXY_MCP_SERVERS_SENTINEL], accessGroups: [] }}
       />,
     );
-    const option = optionByValue(ALL_PROXY_MCP_SERVERS_SENTINEL);
-    expect(option).toBeDefined();
-    expect(option?.textContent).toContain("All Proxy MCP Servers");
-    expect(optionByValue("srv-1")?.disabled).toBe(true);
+
+    expect(screen.getByLabelText("All Proxy MCP Servers")).toBeInTheDocument();
+    expect(screen.queryByText(ALL_PROXY_MCP_SERVERS_SENTINEL)).not.toBeInTheDocument();
+
+    await openSelector(user);
+
+    expect(optionByLabel("Server One")).toHaveAttribute("aria-disabled", "true");
   });
 });

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
@@ -1,7 +1,7 @@
 import { useMCPAccessGroups } from "@/app/(dashboard)/hooks/mcpServers/useMCPAccessGroups";
 import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers";
 import { useMCPToolsets } from "@/app/(dashboard)/hooks/mcpServers/useMCPToolsets";
-import { Select } from "antd";
+import { MultiSelect, type MultiSelectOption } from "@/components/shared/MultiSelect";
 import React from "react";
 import { ALL_PROXY_MCP_SERVERS_SENTINEL, NO_MCP_SERVERS_SENTINEL } from "@/components/mcp_tools/constants";
 
@@ -42,38 +42,24 @@ const MCPServerSelector: React.FC<MCPServerSelectorProps> = ({
 
   const accessGroupSet = new Set(accessGroups);
 
-  // Combine options: access groups (green) + servers (blue) + toolsets (purple)
+  // Combine options: access groups + servers + toolsets
   const options = [
     ...accessGroups.map((group) => ({
       label: group,
       value: group,
-      type: "accessGroup" as const,
-      searchText: `${group} Access Group`,
+      description: "Access Group",
     })),
     ...mcpServers.map((server) => ({
       label: `${server.server_name || server.server_id} (${server.server_id})`,
       value: server.server_id,
-      type: "server" as const,
-      searchText: `${server.server_name || server.server_id} ${server.server_id} MCP Server`,
+      description: "MCP Server",
     })),
     ...toolsets.map((toolset) => ({
       label: toolset.toolset_name,
       value: `${TOOLSET_PREFIX}${toolset.toolset_id}`,
-      type: "toolset" as const,
-      searchText: `${toolset.toolset_name} ${toolset.toolset_id} Toolset`,
+      description: "Toolset",
     })),
   ];
-
-  const colorByType: Record<string, string> = {
-    accessGroup: "#52c41a",
-    server: "#1890ff",
-    toolset: "#722ed1",
-  };
-  const labelByType: Record<string, string> = {
-    accessGroup: "Access Group",
-    server: "MCP Server",
-    toolset: "Toolset",
-  };
 
   // Flatten value for Select — prefix toolset IDs
   const selectedValues = [
@@ -105,76 +91,31 @@ const MCPServerSelector: React.FC<MCPServerSelectorProps> = ({
     onChange({ servers, accessGroups: accessGroupsSelected, toolsets: toolsetsSelected });
   };
 
+  const selectOptions: MultiSelectOption[] = [
+    ...(allowAllProxyMcpServers || hasAllProxyMcpServersSelected
+      ? [{ label: "All Proxy MCP Servers", value: ALL_PROXY_MCP_SERVERS_SENTINEL }]
+      : []),
+    ...(allowNoMcpServers
+      ? [{ label: "No MCP Servers", value: NO_MCP_SERVERS_SENTINEL, description: "Block all" }]
+      : []),
+    ...options.map((opt) => ({
+      ...opt,
+      disabled: hasNoMcpServersSelected || hasAllProxyMcpServersSelected,
+    })),
+  ];
+
   return (
     <div>
-      <Select
-        mode="multiple"
-        placeholder={placeholder}
-        onChange={handleChange}
+      <MultiSelect
+        options={selectOptions}
         value={selectedValues}
+        onValueChange={handleChange}
+        placeholder={placeholder}
+        emptyText="No MCP servers found"
         loading={loading}
-        className={className}
-        allowClear
-        showSearch
-        style={{ width: "100%" }}
         disabled={disabled}
-        filterOption={(input, option) => {
-          if (option?.value === NO_MCP_SERVERS_SENTINEL) return true;
-          if (option?.value === ALL_PROXY_MCP_SERVERS_SENTINEL) return true;
-          const searchText = options.find((opt) => opt.value === option?.value)?.searchText || "";
-          return searchText.toLowerCase().includes(input.toLowerCase());
-        }}
-      >
-        {(allowAllProxyMcpServers || hasAllProxyMcpServersSelected) && (
-          <Select.Option
-            key={ALL_PROXY_MCP_SERVERS_SENTINEL}
-            value={ALL_PROXY_MCP_SERVERS_SENTINEL}
-            label="All Proxy MCP Servers"
-          >
-            <span style={{ color: "#1890ff", fontWeight: 500 }}>All Proxy MCP Servers</span>
-          </Select.Option>
-        )}
-        {allowNoMcpServers && (
-          <Select.Option key={NO_MCP_SERVERS_SENTINEL} value={NO_MCP_SERVERS_SENTINEL} label="No MCP Servers">
-            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-              <span style={{ flex: 1 }}>No MCP Servers</span>
-              <span style={{ color: "#8c8c8c", fontSize: "12px", fontWeight: 500, opacity: 0.8 }}>Block all</span>
-            </div>
-          </Select.Option>
-        )}
-        {options.map((opt) => (
-          <Select.Option
-            key={opt.value}
-            value={opt.value}
-            label={opt.label}
-            disabled={hasNoMcpServersSelected || hasAllProxyMcpServersSelected}
-          >
-            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-              <span
-                style={{
-                  display: "inline-block",
-                  width: 8,
-                  height: 8,
-                  borderRadius: "50%",
-                  background: colorByType[opt.type],
-                  flexShrink: 0,
-                }}
-              />
-              <span style={{ flex: 1 }}>{opt.label}</span>
-              <span
-                style={{
-                  color: colorByType[opt.type],
-                  fontSize: "12px",
-                  fontWeight: 500,
-                  opacity: 0.8,
-                }}
-              >
-                {labelByType[opt.type]}
-              </span>
-            </div>
-          </Select.Option>
-        ))}
-      </Select>
+        className={`w-full ${className ?? ""}`}
+      />
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPToolArgumentsForm.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPToolArgumentsForm.tsx
@@ -1,10 +1,10 @@
 import React, { forwardRef, useImperativeHandle, useMemo } from "react";
-import { Select } from "antd";
 import { CircleHelp } from "lucide-react";
 import { useForm, type Resolver } from "react-hook-form";
 import { FieldGroup } from "@/components/shared/form/field";
 import { FormField } from "@/components/shared/form/FormField";
 import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { MCPTool, InputSchema, InputSchemaProperty } from "./types";
@@ -12,6 +12,11 @@ import { MCPTool, InputSchema, InputSchemaProperty } from "./types";
 type ToolFormValues = Record<string, unknown>;
 
 const STRING_SCHEMA_MESSAGES: Readonly<Record<string, string>> = { input: "Please enter input for this tool" };
+
+const BOOLEAN_ITEMS = [
+  { value: true, label: "True" },
+  { value: false, label: "False" },
+];
 
 const isBlank = (value: unknown): boolean => value === undefined || value === null || value === "";
 
@@ -325,33 +330,43 @@ const MCPToolArgumentsForm = forwardRef<MCPToolArgumentsFormRef, MCPToolArgument
                   {(field) => {
                     if (prop.type === "string" && prop.enum) {
                       return (
-                        <Select
-                          id={field.id}
-                          value={field.value as string | undefined}
-                          onChange={field.onChange}
-                          onBlur={field.onBlur}
-                          placeholder={`Select ${key}`}
-                          allowClear={!required}
-                          options={prop.enum.map((v) => ({ value: v, label: v }))}
-                          className="w-full"
-                        />
+                        <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                          <SelectTrigger
+                            id={field.id}
+                            onBlur={field.onBlur}
+                            aria-invalid={field["aria-invalid"]}
+                            className="w-full"
+                          >
+                            <SelectValue placeholder={`Select ${key}`} />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {!required && <SelectItem value="">Select {key}</SelectItem>}
+                            {prop.enum.map((v) => (
+                              <SelectItem key={v} value={v}>
+                                {v}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                       );
                     }
                     if (prop.type === "boolean") {
                       return (
-                        <Select
-                          id={field.id}
-                          value={field.value as boolean | undefined}
-                          onChange={field.onChange}
-                          onBlur={field.onBlur}
-                          placeholder={`Select ${key}`}
-                          allowClear={!required}
-                          options={[
-                            { value: true, label: "True" },
-                            { value: false, label: "False" },
-                          ]}
-                          className="w-full"
-                        />
+                        <Select items={BOOLEAN_ITEMS} value={field.value ?? ""} onValueChange={field.onChange}>
+                          <SelectTrigger
+                            id={field.id}
+                            onBlur={field.onBlur}
+                            aria-invalid={field["aria-invalid"]}
+                            className="w-full"
+                          >
+                            <SelectValue placeholder={`Select ${key}`} />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {!required && <SelectItem value="">Select {key}</SelectItem>}
+                            <SelectItem value={true}>True</SelectItem>
+                            <SelectItem value={false}>False</SelectItem>
+                          </SelectContent>
+                        </Select>
                       );
                     }
                     if (prop.type === "number" || prop.type === "integer") {

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -46,6 +46,20 @@ export const AUTH_TYPE = {
   OAUTH_DELEGATE: "oauth_delegate",
 };
 
+export const AUTH_TYPE_ITEMS = [
+  { value: AUTH_TYPE.NONE, label: "None" },
+  { value: AUTH_TYPE.API_KEY, label: "API Key" },
+  { value: AUTH_TYPE.BEARER_TOKEN, label: "Bearer Token" },
+  { value: AUTH_TYPE.TOKEN, label: "Token" },
+  { value: AUTH_TYPE.BASIC, label: "Basic Auth" },
+  { value: AUTH_TYPE.OAUTH2, label: "OAuth" },
+  { value: AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE, label: "OAuth Token Exchange (OBO)" },
+  { value: AUTH_TYPE.OAUTH2_ID_JAG, label: "ID-JAG (Okta Cross App Access)" },
+  { value: AUTH_TYPE.AWS_SIGV4, label: "AWS SigV4 (Bedrock AgentCore MCPs)" },
+  { value: AUTH_TYPE.TRUE_PASSTHROUGH, label: "True Passthrough (no LiteLLM auth)" },
+  { value: AUTH_TYPE.OAUTH_DELEGATE, label: "OAuth Delegate (client-supplied upstream token)" },
+];
+
 // The two client-forwarded token modes: the caller supplies the upstream Authorization (forwarded
 // verbatim for true_passthrough, alongside LiteLLM admission for oauth_delegate). The dashboard holds
 // their token in sessionStorage instead of persisting it, and the browser-authorize temp payload keeps
@@ -249,6 +263,13 @@ export const TRANSPORT = {
   STDIO: "stdio",
   OPENAPI: "openapi",
 };
+
+export const TRANSPORT_ITEMS = [
+  { value: TRANSPORT.HTTP, label: "Streamable HTTP (Recommended)" },
+  { value: TRANSPORT.SSE, label: "Server-Sent Events (SSE)" },
+  { value: TRANSPORT.STDIO, label: "Standard Input/Output (stdio)" },
+  { value: TRANSPORT.OPENAPI, label: "OpenAPI Spec" },
+];
 
 export const handleTransport = (transport?: string | null, specPath?: string | null): string => {
   if (transport === null || transport === undefined) {

--- a/ui/litellm-dashboard/src/components/shared/MultiSelect.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/MultiSelect.test.tsx
@@ -102,6 +102,24 @@ describe("MultiSelect", () => {
     expect(onValueChange).toHaveBeenCalledWith(["udp", "kafka", "terraform"]);
   });
 
+  it("leaves an already selected value that contains a comma alone when a later entry is added", async () => {
+    const onValueChange = vi.fn();
+    render(
+      <MultiSelect
+        options={OPTIONS}
+        value={["--filter=a,b"]}
+        onValueChange={onValueChange}
+        allowCustomValues
+        placeholder="Select stores"
+      />,
+    );
+
+    await userEvent.type(screen.getByRole("combobox"), "--verbose");
+    await userEvent.click(await screen.findByText('Create "--verbose"'));
+
+    expect(onValueChange).toHaveBeenCalledWith(["--filter=a,b", "--verbose"]);
+  });
+
   it("clears every selection at once", async () => {
     const onValueChange = vi.fn();
     render(

--- a/ui/litellm-dashboard/src/components/shared/MultiSelect.tsx
+++ b/ui/litellm-dashboard/src/components/shared/MultiSelect.tsx
@@ -89,7 +89,7 @@ export function MultiSelect({
 
   const handleValueChange = (selected: MultiSelectOption[]) => {
     const next = allowCustomValues
-      ? selected.flatMap((option) => splitOnCommas(option.value))
+      ? selected.flatMap((option) => (value.includes(option.value) ? [option.value] : splitOnCommas(option.value)))
       : selected.map((option) => option.value);
     onValueChange(Array.from(new Set(next)));
     setQuery("");


### PR DESCRIPTION
## TLDR

Problem this solves:

- The MCP servers pages are the densest remaining antd surface
- Their test helpers drive antd DOM, so conversions break them
- Permission switches there have no accessible name, and the Authentication select has no label

How it solves it:

- Converts the create, edit, connect and permission screens to shadcn
- Rewrites the select and collapse test helpers onto the new DOM
- Adds aria-labels so switches are reachable by role and name
- Labels the Authentication select and the auth settings panel it sits in

## User Flow

One of four independent PRs taking the Admin UI off Ant Design. Behavior is unchanged; one accessibility gap is closed.

Before: an admin adding an MCP server fills in an antd form, and the permission toggles have no accessible name, so screen reader users hear an unlabelled switch

1. They open http://localhost:4000/ui/?page=mcp-servers and click Add New Server
2. They pick a transport and auth type from antd dropdowns
3. They expand the advanced section, an antd collapse panel, and toggle "Available on public internet"
4. They submit and the new server appears in the list

After: the same admin does the same task on shadcn controls, and every permission toggle announces what it controls

1. They open http://localhost:4000/ui/?page=mcp-servers and click Add New Server
2. They pick a transport and auth type from shadcn selects
3. They expand the advanced section, now a collapsible, and toggle "Available on public internet", which now has an accessible name
4. They expand "Authentication settings", also a collapsible, and the Authentication select now announces its own label
5. They submit and the new server appears in the list

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (7675ba8717)

1. Open http://localhost:4000/ui/?page=mcp-servers, click Add New Server, and screenshot the form with the transport dropdown open
2. Expand the advanced section and screenshot the permission toggles

### After (6c001f4870)

1. Same steps, screenshot the shadcn select open
2. Same steps, screenshot the toggles

## Type

🧹 Refactoring

## Caveats (if any)

- Needs the shared primitives from #37521 to typecheck
- Adds aria-labels to four previously unlabelled switches

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

