### PR TITLE
feat(proxy): fast-fail validation for batch input files at /v1/files

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2439,6 +2439,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="max request size in MB, if a request is larger than this size it will be rejected",
     )
+    max_batch_file_size_mb: int | None = Field(
+        None,
+        description="max batch input file size in MB for /v1/files uploads with purpose=batch, if a file is larger than this size it will be rejected before being forwarded to the provider",
+    )
     max_response_size_mb: int | None = Field(
         None,
         description="max response size in MB, if a response is larger than this size it will be rejected",

--- a/litellm/proxy/openai_files_endpoints/batch_file_validation.py
+++ b/litellm/proxy/openai_files_endpoints/batch_file_validation.py
@@ -108,7 +108,7 @@ def check_batch_file_upload(
 ) -> BatchFileValidationFailure | None:
     if filename is None or not filename.lower().endswith(".jsonl"):
         return BatchFileWrongExtension(filename=filename or "")
-    if max_batch_file_size_mb is not None:
+    if max_batch_file_size_mb is not None and max_batch_file_size_mb > 0:
         size_bytes: Final = _file_size_bytes(file_source)
         if size_bytes > max_batch_file_size_mb * _MB:
             return BatchFileTooLarge(size_bytes=size_bytes, limit_mb=max_batch_file_size_mb)

--- a/litellm/proxy/openai_files_endpoints/batch_file_validation.py
+++ b/litellm/proxy/openai_files_endpoints/batch_file_validation.py
@@ -1,0 +1,182 @@
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass
+from itertools import chain
+from typing import BinaryIO, Final, NoReturn, assert_never
+
+from litellm.proxy._types import ProxyException
+
+BATCH_LINE_REQUIRED_KEYS: Final = ("custom_id", "method", "url", "body")
+_MB: Final = 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class BatchFileTooLarge:
+    size_bytes: int
+    limit_mb: int
+
+
+@dataclass(frozen=True, slots=True)
+class BatchFileWrongExtension:
+    filename: str
+
+
+@dataclass(frozen=True, slots=True)
+class BatchFileEmpty:
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class BatchFileInvalidJsonLine:
+    line_number: int
+
+
+@dataclass(frozen=True, slots=True)
+class BatchFileLineNotObject:
+    line_number: int
+
+
+@dataclass(frozen=True, slots=True)
+class BatchFileMissingLineKey:
+    line_number: int
+    key: str
+
+
+BatchFileValidationFailure = (
+    BatchFileTooLarge
+    | BatchFileWrongExtension
+    | BatchFileEmpty
+    | BatchFileInvalidJsonLine
+    | BatchFileLineNotObject
+    | BatchFileMissingLineKey
+)
+
+
+def _file_size_bytes(file_source: bytes | BinaryIO) -> int:
+    if isinstance(file_source, bytes):
+        return len(file_source)
+    file_source.seek(0, 2)
+    size: Final = file_source.tell()
+    file_source.seek(0)
+    return size
+
+
+def _iter_lines(file_source: bytes | BinaryIO) -> Iterator[bytes]:
+    if isinstance(file_source, bytes):
+        return iter(file_source.splitlines())
+    file_source.seek(0)
+    return iter(file_source)
+
+
+def _check_line(line_number: int, raw_line: bytes) -> BatchFileValidationFailure | None:
+    try:
+        parsed: Final = json.loads(raw_line)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return BatchFileInvalidJsonLine(line_number=line_number)
+    if not isinstance(parsed, dict):
+        return BatchFileLineNotObject(line_number=line_number)
+    missing: Final = next((key for key in BATCH_LINE_REQUIRED_KEYS if key not in parsed), None)
+    if missing is None:
+        return None
+    return BatchFileMissingLineKey(line_number=line_number, key=missing)
+
+
+def _scan_lines(file_source: bytes | BinaryIO) -> BatchFileValidationFailure | None:
+    content_lines: Final = (
+        (line_number, raw_line)
+        for line_number, raw_line in enumerate(_iter_lines(file_source), start=1)
+        if raw_line.strip()
+    )
+    first_line: Final = next(content_lines, None)
+    if first_line is None:
+        return BatchFileEmpty()
+    return next(
+        (
+            failure
+            for line_number, raw_line in chain((first_line,), content_lines)
+            for failure in (_check_line(line_number, raw_line),)
+            if failure is not None
+        ),
+        None,
+    )
+
+
+def check_batch_file_upload(
+    filename: str | None,
+    file_source: bytes | BinaryIO,
+    max_batch_file_size_mb: int | None,
+) -> BatchFileValidationFailure | None:
+    if filename is None or not filename.lower().endswith(".jsonl"):
+        return BatchFileWrongExtension(filename=filename or "")
+    if max_batch_file_size_mb is not None:
+        size_bytes: Final = _file_size_bytes(file_source)
+        if size_bytes > max_batch_file_size_mb * _MB:
+            return BatchFileTooLarge(size_bytes=size_bytes, limit_mb=max_batch_file_size_mb)
+    scan_failure: Final = _scan_lines(file_source)
+    if not isinstance(file_source, bytes):
+        file_source.seek(0)
+    return scan_failure
+
+
+def raise_batch_file_validation_failure(failure: BatchFileValidationFailure) -> NoReturn:
+    match failure:
+        case BatchFileTooLarge(size_bytes=size_bytes, limit_mb=limit_mb):
+            raise ProxyException(
+                message=(
+                    f"Batch input file is {size_bytes / _MB:.1f} MB, which exceeds the configured "
+                    f"max_batch_file_size_mb of {limit_mb} MB. The file was not forwarded to the provider."
+                ),
+                type="invalid_request_error",
+                param="file",
+                code=413,
+            )
+        case BatchFileWrongExtension(filename=filename):
+            raise ProxyException(
+                message=(
+                    f"Invalid file format for Batch API: '{filename}'. "
+                    "Batch input files must be .jsonl files. The file was not forwarded to the provider."
+                ),
+                type="invalid_request_error",
+                param="file",
+                code=400,
+            )
+        case BatchFileEmpty():
+            raise ProxyException(
+                message="Batch input file has no request lines. The file was not forwarded to the provider.",
+                type="invalid_request_error",
+                param="file",
+                code=400,
+            )
+        case BatchFileInvalidJsonLine(line_number=line_number):
+            raise ProxyException(
+                message=(
+                    f"Batch input file line {line_number} is not valid JSON. "
+                    "The file was not forwarded to the provider."
+                ),
+                type="invalid_request_error",
+                param="file",
+                code=400,
+            )
+        case BatchFileLineNotObject(line_number=line_number):
+            raise ProxyException(
+                message=(
+                    f"Batch input file line {line_number} must be a JSON object. "
+                    "The file was not forwarded to the provider."
+                ),
+                type="invalid_request_error",
+                param="file",
+                code=400,
+            )
+        case BatchFileMissingLineKey(line_number=line_number, key=key):
+            raise ProxyException(
+                message=(
+                    f"Missing required parameter: '{key}' (batch input file line {line_number}). "
+                    f"Each line must be a JSON object with keys {', '.join(BATCH_LINE_REQUIRED_KEYS)}. "
+                    "The file was not forwarded to the provider."
+                ),
+                type="invalid_request_error",
+                param=key,
+                code=400,
+            )
+        case _:
+            assert_never(failure)

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -21,6 +21,7 @@ from fastapi import (
     UploadFile,
     status,
 )
+from pydantic import TypeAdapter
 
 import litellm
 from litellm import CreateFileRequest, get_secret_str
@@ -40,6 +41,10 @@ from litellm.proxy.common_utils.openai_endpoint_utils import (
     get_custom_llm_provider_from_request_body,
     get_custom_llm_provider_from_request_headers,
     get_custom_llm_provider_from_request_query,
+)
+from litellm.proxy.openai_files_endpoints.batch_file_validation import (
+    check_batch_file_upload,
+    raise_batch_file_validation_failure,
 )
 from litellm.proxy.openai_files_endpoints.common_utils import (
     _is_base64_encoded_unified_file_id,
@@ -64,6 +69,8 @@ from litellm.types.llms.openai import (
 )
 
 router: Final = APIRouter()
+
+_MAX_BATCH_FILE_SIZE_MB_ADAPTER: Final = TypeAdapter(int | None)
 
 files_config = None
 
@@ -361,17 +368,26 @@ async def create_file(
 
         # Prepare the data for forwarding
 
-        # Replace with:
         valid_purposes: Final = get_args(OpenAIFilesPurpose)
         if purpose not in valid_purposes:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": f"Invalid purpose: {purpose}. Must be one of: {valid_purposes}",
-                },
+            raise ProxyException(
+                message=f"Invalid purpose: {purpose}. Must be one of: {valid_purposes}",
+                type="invalid_request_error",
+                param="purpose",
+                code=400,
             )
         # Cast purpose to OpenAIFilesPurpose type
         purpose = cast(OpenAIFilesPurpose, purpose)
+
+        if purpose == "batch":
+            batch_file_failure: Final = await asyncio.to_thread(
+                check_batch_file_upload,
+                file.filename,
+                file_source,
+                _MAX_BATCH_FILE_SIZE_MB_ADAPTER.validate_python(general_settings.get("max_batch_file_size_mb")),
+            )
+            if batch_file_failure is not None:
+                raise_batch_file_validation_failure(batch_file_failure)
 
         data = {}
 
@@ -552,6 +568,8 @@ async def create_file(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.create_file(): Exception occured - %s", e)
+        if isinstance(e, ProxyException):
+            raise e
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15689,6 +15689,7 @@ _GENERAL_SETTINGS_CONFIG_LIST_FIELD_TYPES: Final[Mapping[str, str]] = MappingPro
         "max_parallel_requests": "Integer",
         "global_max_parallel_requests": "Integer",
         "max_request_size_mb": "Integer",
+        "max_batch_file_size_mb": "Integer",
         "max_response_size_mb": "Integer",
         "proxy_config_reload_interval_seconds": "Integer",
         "pass_through_endpoints": "PydanticModel",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6316,6 +6316,9 @@ class ProxyConfig:
         if "global_max_parallel_requests" in _general_settings:
             general_settings["global_max_parallel_requests"] = _general_settings["global_max_parallel_requests"]
 
+        if "max_batch_file_size_mb" not in self._yaml_general_settings_keys:
+            general_settings["max_batch_file_size_mb"] = _general_settings.get("max_batch_file_size_mb")
+
         ## ALERTING ARGS ##
         if "alerting_args" in _general_settings:
             general_settings["alerting_args"] = _general_settings["alerting_args"]

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_batch_file_validation.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_batch_file_validation.py
@@ -1,0 +1,170 @@
+import io
+
+import pytest
+
+from litellm.proxy._types import ProxyException
+from litellm.proxy.openai_files_endpoints.batch_file_validation import (
+    BATCH_LINE_REQUIRED_KEYS,
+    BatchFileEmpty,
+    BatchFileInvalidJsonLine,
+    BatchFileLineNotObject,
+    BatchFileMissingLineKey,
+    BatchFileTooLarge,
+    BatchFileWrongExtension,
+    check_batch_file_upload,
+    raise_batch_file_validation_failure,
+)
+
+VALID_LINE = (
+    b'{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions",'
+    b' "body": {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "hi"}]}}'
+)
+
+
+def test_valid_bytes_pass():
+    assert check_batch_file_upload("batch.jsonl", VALID_LINE + b"\n" + VALID_LINE + b"\n", 10) is None
+
+
+def test_valid_binaryio_passes_and_resets_position():
+    handle = io.BytesIO(VALID_LINE + b"\n" + VALID_LINE + b"\n")
+    handle.seek(17)
+    assert check_batch_file_upload("batch.jsonl", handle, 10) is None
+    assert handle.tell() == 0
+
+
+def test_uppercase_extension_accepted():
+    assert check_batch_file_upload("BATCH.JSONL", VALID_LINE, None) is None
+
+
+@pytest.mark.parametrize("filename", ["batch.csv", "batch.json", "batch", None])
+def test_wrong_extension_rejected(filename):
+    assert check_batch_file_upload(filename, VALID_LINE, None) == BatchFileWrongExtension(filename=filename or "")
+
+
+def test_size_over_cap_rejected_for_bytes():
+    content = b"x" * (2 * 1024 * 1024)
+    assert check_batch_file_upload("batch.jsonl", content, 1) == BatchFileTooLarge(
+        size_bytes=len(content), limit_mb=1
+    )
+
+
+def test_size_over_cap_rejected_for_binaryio():
+    content = b"x" * (2 * 1024 * 1024)
+    assert check_batch_file_upload("batch.jsonl", io.BytesIO(content), 1) == BatchFileTooLarge(
+        size_bytes=len(content), limit_mb=1
+    )
+
+
+def test_size_exactly_at_cap_allowed():
+    line = VALID_LINE + b"\n"
+    padding_key = b'{"custom_id": "pad", "method": "POST", "url": "/v1/chat/completions", "body": {"note": "'
+    pad_line = padding_key + b"a" * (1024 * 1024 - len(line) - len(padding_key) - len(b'"}}\n')) + b'"}}\n'
+    content = line + pad_line
+    assert len(content) == 1024 * 1024
+    assert check_batch_file_upload("batch.jsonl", content, 1) is None
+
+
+def test_no_cap_skips_size_check():
+    content = (VALID_LINE + b"\n") * 5000
+    assert check_batch_file_upload("batch.jsonl", content, None) is None
+
+
+@pytest.mark.parametrize("content", [b"", b"\n\n", b"  \n\t\n"])
+def test_empty_file_rejected(content):
+    assert check_batch_file_upload("batch.jsonl", content, None) == BatchFileEmpty()
+
+
+def test_invalid_json_line_rejected_with_line_number():
+    content = VALID_LINE + b"\n" + b"not json at all\n" + VALID_LINE + b"\n"
+    assert check_batch_file_upload("batch.jsonl", content, None) == BatchFileInvalidJsonLine(line_number=2)
+
+
+def test_non_utf8_line_rejected_as_invalid_json():
+    assert check_batch_file_upload("batch.jsonl", b"\xff\xfe\x00\x01\n", None) == BatchFileInvalidJsonLine(
+        line_number=1
+    )
+
+
+def test_non_object_line_rejected():
+    content = VALID_LINE + b"\n" + b'["custom_id", "method"]\n'
+    assert check_batch_file_upload("batch.jsonl", content, None) == BatchFileLineNotObject(line_number=2)
+
+
+@pytest.mark.parametrize("missing_key", BATCH_LINE_REQUIRED_KEYS)
+def test_missing_required_key_rejected(missing_key):
+    import json
+
+    line_dict = {
+        "custom_id": "req-1",
+        "method": "POST",
+        "url": "/v1/chat/completions",
+        "body": {"model": "gpt-4.1-nano"},
+    }
+    del line_dict[missing_key]
+    content = VALID_LINE + b"\n" + json.dumps(line_dict).encode() + b"\n"
+    assert check_batch_file_upload("batch.jsonl", content, None) == BatchFileMissingLineKey(
+        line_number=2, key=missing_key
+    )
+
+
+def test_blank_lines_do_not_shift_line_numbers():
+    content = b"\n" + VALID_LINE + b"\n\n" + b"broken\n"
+    assert check_batch_file_upload("batch.jsonl", content, None) == BatchFileInvalidJsonLine(line_number=4)
+
+
+def test_failed_scan_leaves_handle_open_and_reset():
+    handle = io.BytesIO(b"not json\n" + VALID_LINE + b"\n")
+    assert check_batch_file_upload("batch.jsonl", handle, None) == BatchFileInvalidJsonLine(line_number=1)
+    assert not handle.closed
+    assert handle.tell() == 0
+
+
+def test_scan_stops_at_first_failure():
+    class ExplodingLines(io.BytesIO):
+        def __init__(self):
+            super().__init__(b"not json\n" + VALID_LINE + b"\n")
+            self.lines_read = 0
+
+        def __next__(self):
+            self.lines_read += 1
+            return super().__next__()
+
+    handle = ExplodingLines()
+    assert check_batch_file_upload("batch.jsonl", handle, None) == BatchFileInvalidJsonLine(line_number=1)
+    assert handle.lines_read == 1
+
+
+@pytest.mark.parametrize(
+    "failure, expected_code, expected_param, expected_fragments",
+    [
+        (
+            BatchFileTooLarge(size_bytes=220200960, limit_mb=10),
+            "413",
+            "file",
+            ("210.0 MB", "max_batch_file_size_mb", "10 MB", "not forwarded"),
+        ),
+        (
+            BatchFileWrongExtension(filename="batch.csv"),
+            "400",
+            "file",
+            ("batch.csv", ".jsonl", "not forwarded"),
+        ),
+        (BatchFileEmpty(), "400", "file", ("no request lines", "not forwarded")),
+        (BatchFileInvalidJsonLine(line_number=3), "400", "file", ("line 3", "not valid JSON")),
+        (BatchFileLineNotObject(line_number=2), "400", "file", ("line 2", "JSON object")),
+        (
+            BatchFileMissingLineKey(line_number=5, key="method"),
+            "400",
+            "method",
+            ("'method'", "line 5", "custom_id, method, url, body"),
+        ),
+    ],
+)
+def test_failures_map_to_openai_shaped_proxy_exceptions(failure, expected_code, expected_param, expected_fragments):
+    with pytest.raises(ProxyException) as exc_info:
+        raise_batch_file_validation_failure(failure)
+    assert exc_info.value.code == expected_code
+    assert exc_info.value.type == "invalid_request_error"
+    assert exc_info.value.param == expected_param
+    for fragment in expected_fragments:
+        assert fragment in exc_info.value.message

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_batch_file_validation.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_batch_file_validation.py
@@ -69,6 +69,12 @@ def test_no_cap_skips_size_check():
     assert check_batch_file_upload("batch.jsonl", content, None) is None
 
 
+@pytest.mark.parametrize("cap", [0, -3])
+def test_nonpositive_cap_disables_size_check(cap):
+    content = (VALID_LINE + b"\n") * 5000
+    assert check_batch_file_upload("batch.jsonl", content, cap) is None
+
+
 @pytest.mark.parametrize("content", [b"", b"\n\n", b"  \n\t\n"])
 def test_empty_file_rejected(content):
     assert check_batch_file_upload("batch.jsonl", content, None) == BatchFileEmpty()

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
@@ -31,6 +31,11 @@ from litellm.caching.caching import DualCache
 from litellm.proxy.proxy_server import hash_token
 from litellm.proxy.utils import ProxyLogging
 
+VALID_BATCH_LINE = (
+    b'{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions",'
+    b' "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "hi"}]}}\n'
+)
+
 
 @pytest.fixture
 def llm_router() -> Router:
@@ -1602,7 +1607,7 @@ def _post_file_with_team_metadata(
     user_key = UserAPIKeyAuth(api_key="test-key", team_metadata=team_metadata)
     app.dependency_overrides[user_api_key_auth] = lambda: user_key
 
-    test_file = ("mydata.jsonl", b'{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "hi"}]}}', "application/jsonl")
+    test_file = ("mydata.jsonl", VALID_BATCH_LINE, "application/jsonl")
     try:
         response = client.post(
             "/v1/files",
@@ -1706,7 +1711,7 @@ def _post_file_raw(
     user_key = UserAPIKeyAuth(api_key="test-key", team_metadata=team_metadata)
     app.dependency_overrides[user_api_key_auth] = lambda: user_key
 
-    test_file = ("mydata.jsonl", b'{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "hi"}]}}', "application/jsonl")
+    test_file = ("mydata.jsonl", VALID_BATCH_LINE, "application/jsonl")
     try:
         response = client.post(
             "/v1/files",
@@ -2752,7 +2757,7 @@ def test_create_file_provider_only_resolves_named_vertex_credentials(
     try:
         response = client.post(
             "/v1/files",
-            files={"file": ("batch.jsonl", b'{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "hi"}]}}', "application/jsonl")},
+            files={"file": ("batch.jsonl", VALID_BATCH_LINE, "application/jsonl")},
             data={"purpose": "batch"},
             headers={
                 "Authorization": "Bearer test-key",
@@ -2994,7 +2999,7 @@ def test_create_file_provider_only_skips_other_team_vertex_deployment(
     try:
         response = client.post(
             "/v1/files",
-            files={"file": ("batch.jsonl", b'{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "hi"}]}}', "application/jsonl")},
+            files={"file": ("batch.jsonl", VALID_BATCH_LINE, "application/jsonl")},
             data={"purpose": "batch"},
             headers={
                 "Authorization": "Bearer test-key",
@@ -3344,12 +3349,6 @@ def test_raw_provider_file_id_retrieve_allowed_when_managed_files_not_required(
 
     assert response.status_code == 200, response.text
     mock_retrieve.assert_called_once()
-
-
-VALID_BATCH_LINE = (
-    b'{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions",'
-    b' "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "hi"}]}}\n'
-)
 
 
 def _setup_batch_upload_endpoint(monkeypatch, llm_router: Router) -> list:

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
@@ -225,7 +225,10 @@ def test_invalid_purpose(mocker: MockerFixture, monkeypatch, llm_router: Router)
 
     assert response.status_code == 400
     print(f"response: {response.json()}")
-    assert "Invalid purpose: my-bad-purpose" in response.json()["error"]["message"]
+    error = response.json()["error"]
+    assert "Invalid purpose: my-bad-purpose" in error["message"]
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "purpose"
 
 
 def test_get_file_content_rejects_raw_cloud_storage_uri(llm_router: Router):
@@ -1599,7 +1602,7 @@ def _post_file_with_team_metadata(
     user_key = UserAPIKeyAuth(api_key="test-key", team_metadata=team_metadata)
     app.dependency_overrides[user_api_key_auth] = lambda: user_key
 
-    test_file = ("mydata.jsonl", b'{"prompt": "Hello"}', "application/json")
+    test_file = ("mydata.jsonl", b'{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "hi"}]}}', "application/jsonl")
     try:
         response = client.post(
             "/v1/files",
@@ -1703,7 +1706,7 @@ def _post_file_raw(
     user_key = UserAPIKeyAuth(api_key="test-key", team_metadata=team_metadata)
     app.dependency_overrides[user_api_key_auth] = lambda: user_key
 
-    test_file = ("mydata.jsonl", b'{"prompt": "Hello"}', "application/json")
+    test_file = ("mydata.jsonl", b'{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "hi"}]}}', "application/jsonl")
     try:
         response = client.post(
             "/v1/files",
@@ -2749,7 +2752,7 @@ def test_create_file_provider_only_resolves_named_vertex_credentials(
     try:
         response = client.post(
             "/v1/files",
-            files={"file": ("batch.jsonl", b"{}", "application/jsonl")},
+            files={"file": ("batch.jsonl", b'{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "hi"}]}}', "application/jsonl")},
             data={"purpose": "batch"},
             headers={
                 "Authorization": "Bearer test-key",
@@ -2991,7 +2994,7 @@ def test_create_file_provider_only_skips_other_team_vertex_deployment(
     try:
         response = client.post(
             "/v1/files",
-            files={"file": ("batch.jsonl", b"{}", "application/jsonl")},
+            files={"file": ("batch.jsonl", b'{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "hi"}]}}', "application/jsonl")},
             data={"purpose": "batch"},
             headers={
                 "Authorization": "Bearer test-key",
@@ -3341,3 +3344,176 @@ def test_raw_provider_file_id_retrieve_allowed_when_managed_files_not_required(
 
     assert response.status_code == 200, response.text
     mock_retrieve.assert_called_once()
+
+
+VALID_BATCH_LINE = (
+    b'{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions",'
+    b' "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "hi"}]}}\n'
+)
+
+
+def _setup_batch_upload_endpoint(monkeypatch, llm_router: Router) -> list:
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+    from litellm.proxy.openai_files_endpoints import files_endpoints as fe
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.master_key", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", llm_router)
+    setup_proxy_logging_object(monkeypatch, llm_router)
+
+    forwarded_calls: list = []
+
+    async def fake_route_create_file(**kwargs):
+        forwarded_calls.append(kwargs)
+        return OpenAIFileObject(
+            id="dummy-id",
+            object="file",
+            bytes=0,
+            created_at=1234567890,
+            filename="batch.jsonl",
+            purpose="batch",
+            status="uploaded",
+        )
+
+    monkeypatch.setattr(fe, "route_create_file", fake_route_create_file)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="test-user"
+    )
+    return forwarded_calls
+
+
+def _teardown_batch_upload_endpoint():
+    import litellm.proxy.proxy_server as ps
+
+    app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_create_file_batch_over_max_batch_file_size_mb_rejected_before_forwarding(
+    monkeypatch, llm_router: Router
+):
+    import litellm.proxy.proxy_server as ps
+
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+    monkeypatch.setitem(ps.general_settings, "max_batch_file_size_mb", 1)
+
+    oversized = VALID_BATCH_LINE * (2 * 1024 * 1024 // len(VALID_BATCH_LINE) + 1)
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("batch.jsonl", oversized, "application/jsonl")},
+            data={"purpose": "batch"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+
+    assert response.status_code == 413, response.text
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "file"
+    assert "max_batch_file_size_mb" in error["message"]
+    assert "1 MB" in error["message"]
+    assert forwarded_calls == []
+
+
+def test_create_file_batch_under_max_batch_file_size_mb_forwards(monkeypatch, llm_router: Router):
+    import litellm.proxy.proxy_server as ps
+
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+    monkeypatch.setitem(ps.general_settings, "max_batch_file_size_mb", 1)
+
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("batch.jsonl", VALID_BATCH_LINE, "application/jsonl")},
+            data={"purpose": "batch"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+
+    assert response.status_code == 200, response.text
+    assert len(forwarded_calls) == 1
+
+
+def test_create_file_batch_wrong_extension_rejected_before_forwarding(monkeypatch, llm_router: Router):
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("batch.csv", VALID_BATCH_LINE, "text/csv")},
+            data={"purpose": "batch"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+
+    assert response.status_code == 400, response.text
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "file"
+    assert "batch.csv" in error["message"]
+    assert ".jsonl" in error["message"]
+    assert forwarded_calls == []
+
+
+def test_create_file_batch_missing_line_key_rejected_before_forwarding(monkeypatch, llm_router: Router):
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+
+    bad_line = b'{"custom_id": "req-1", "url": "/v1/chat/completions", "body": {"model": "gpt-3.5-turbo"}}\n'
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("batch.jsonl", VALID_BATCH_LINE + bad_line, "application/jsonl")},
+            data={"purpose": "batch"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+
+    assert response.status_code == 400, response.text
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "method"
+    assert "line 2" in error["message"]
+    assert forwarded_calls == []
+
+
+def test_create_file_batch_invalid_json_line_rejected_before_forwarding(monkeypatch, llm_router: Router):
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("batch.jsonl", b"this is not jsonl\n", "application/jsonl")},
+            data={"purpose": "batch"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+
+    assert response.status_code == 400, response.text
+    error = response.json()["error"]
+    assert error["param"] == "file"
+    assert "line 1" in error["message"]
+    assert "not valid JSON" in error["message"]
+    assert forwarded_calls == []
+
+
+def test_create_file_non_batch_purpose_skips_batch_validation(monkeypatch, llm_router: Router):
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("notes.txt", b"plain text, not jsonl", "text/plain")},
+            data={"purpose": "user_data"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+
+    assert response.status_code == 200, response.text
+    assert len(forwarded_calls) == 1

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -2443,6 +2443,43 @@ async def test_ProxyConfig__update_general_settings_updates_max_parallel(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_ProxyConfig__update_general_settings_applies_db_max_batch_file_size_mb(monkeypatch):
+    monkeypatch.setattr("litellm.proxy.proxy_server.general_settings", {})
+    pc = ProxyConfig()
+    await pc._update_general_settings({"max_batch_file_size_mb": 5})
+    from litellm.proxy import proxy_server as ps
+
+    assert ps.general_settings.get("max_batch_file_size_mb") == 5
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__update_general_settings_yaml_max_batch_file_size_mb_wins_over_db(monkeypatch):
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.general_settings",
+        {"max_batch_file_size_mb": 3},
+    )
+    pc = ProxyConfig()
+    pc._yaml_general_settings_keys = {"max_batch_file_size_mb"}
+    await pc._update_general_settings({"max_batch_file_size_mb": 5})
+    from litellm.proxy import proxy_server as ps
+
+    assert ps.general_settings.get("max_batch_file_size_mb") == 3
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__update_general_settings_cleared_db_max_batch_file_size_mb_lifts_cap(monkeypatch):
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.general_settings",
+        {"max_batch_file_size_mb": 8},
+    )
+    pc = ProxyConfig()
+    await pc._update_general_settings({"max_parallel_requests": 1})
+    from litellm.proxy import proxy_server as ps
+
+    assert ps.general_settings.get("max_batch_file_size_mb") is None
+
+
+@pytest.mark.asyncio
 async def test_ProxyConfig__update_general_settings_none_input_noop():
     pc = ProxyConfig()
     # None input returns early.

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -24053,6 +24053,11 @@ export interface components {
              */
             master_key?: string | null;
             /**
+             * Max Batch File Size Mb
+             * @description max batch input file size in MB for /v1/files uploads with purpose=batch, if a file is larger than this size it will be rejected before being forwarded to the provider
+             */
+            max_batch_file_size_mb?: number | null;
+            /**
              * Max Parallel Requests
              * @description maximum parallel requests for each api key
              */


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bad batch input files stream fully to the provider before failing
- Failures surface minutes later, degraded, without naming the bad field
- No knob caps batch file size; `max_request_size_mb` caps every route

How it solves it:

- New `general_settings.max_batch_file_size_mb` rejects oversized batch uploads with 413
- Settable in config.yaml or from the admin dashboard; dashboard edits apply on the next periodic config reload, no restart
- `purpose=batch` uploads validated locally: `.jsonl` extension, JSON lines, required keys
- Errors are OpenAI-shaped, naming the offending param and line number

## User Flow

Before: a developer running a batch job through the gateway only learns their input file is bad after it has fully streamed to the provider, and the size cap their admin configured does nothing

1. The proxy admin sets `max_batch_file_size_mb: 10` under `general_settings` and restarts; the proxy boots clean and silently ignores the knob
2. The developer sends POST https://litellm-domain/v1/files with `purpose=batch` and a 210 MB `batch.jsonl`; the request streams for minutes, the whole file crosses the wire, and only then the provider's own error comes back
3. They retry with `batch.csv`; it returns 200 OK and a `file-...` id as if the file were fine
4. They send POST https://litellm-domain/v1/batches with that id; it returns a `batch_...` id, and about a minute later GET https://litellm-domain/v1/batches/{batch_id} shows status `failed` with `Missing required parameter: 'method'`, the first hint anything was wrong

After: the same developer gets an immediate 4xx at upload time that names the offending field, and nothing invalid ever reaches the provider

1. The proxy admin sets `max_batch_file_size_mb: 10` under `general_settings` in config.yaml, or saves it from the admin dashboard (POST https://litellm-domain/config/field/update), where it takes effect on the next periodic config reload without a restart
2. The developer sends POST https://litellm-domain/v1/files with `purpose=batch` and a 210 MB `batch.jsonl`; it returns 413 instantly with `"param": "file"` and a message naming `max_batch_file_size_mb` and saying the file was not forwarded
3. They retry with `batch.csv`; it returns 400 instantly with `"param": "file"` saying batch input files must be `.jsonl`
4. They fix the extension, but one line lacks `"method"`; the upload returns 400 with `"param": "method"` naming that exact line, so they fix the file, the upload returns 200 with a `file-...` id, and the batch runs instead of failing a minute later

## Relevant issues

## Linear ticket

Resolves LIT-5274

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both sides. Config `config.yaml` (real OpenAI key from the environment, real provider spend):

```yaml
model_list:
  - model_name: gpt-4.1-nano
    litellm_params:
      model: openai/gpt-4.1-nano
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234
  store_model_in_db: true
  max_batch_file_size_mb: 10

files_settings:
  - custom_llm_provider: openai
    api_key: os.environ/OPENAI_API_KEY
```

Input files generated with:

```bash
python3 - <<'EOF'
import json
def line(i, pad=""):
    return json.dumps({"custom_id": f"req-{i}", "method": "POST", "url": "/v1/chat/completions",
        "body": {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": f"Say hi {i} {pad}"}], "max_tokens": 5}})
with open("good_small.jsonl","w") as f:
    for i in range(20): f.write(line(i)+"\n")
pad="x"*4000
with open("big_12mb.jsonl","w") as f:
    i=0; n=0
    while n<12*1024*1024:
        s=line(i,pad)+"\n"; f.write(s); n+=len(s); i+=1
open("notes.txt","w").write("hello there\nthis is plain prose\nnot a batch file\n")
with open("bad_lines.jsonl","w") as f:
    for i in range(5): f.write(json.dumps({"custom_id": f"x{i}", "foo": "bar"})+"\n")
EOF
```

Each side boots a live proxy with a real Postgres via `.venv/bin/python litellm/proxy/proxy_cli.py --config config.yaml --port <port> --detailed_debug` (Before on port 47743 at the merge base, After on port 41783 at the PR tip; the dashboard-set-cap case boots a third proxy on port 49327 against a fresh Postgres with a config that omits `max_batch_file_size_mb` and sets `proxy_config_reload_interval_seconds: 5`), readiness `{"status":"healthy","db":"connected"}`. All requests send `-H "Authorization: Bearer sk-1234"`

### Before (a613773fca)

#### Oversized file (12 MB vs cap 10 MB)

1. Command:

   ```bash
   curl -s -X POST http://localhost:47743/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F file=@big_12mb.jsonl -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

2. Observed output, the cap is silently ignored and the 12 MB file is forwarded to OpenAI:

   ```
   {"id":"file-XvRwaFgKZknz9TZHxVyYCs","bytes":12585082,"created_at":1787176049,"filename":"big_12mb.jsonl","object":"file","purpose":"batch","status":"processed","expires_at":1789768049,"status_details":null}
   HTTP 200 time_total=2.358865s
   ```

#### Wrong file type (notes.txt)

1. Command:

   ```bash
   curl -s -X POST http://localhost:47743/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F file=@notes.txt -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

2. Observed output, a degraded provider-passthrough error after a round trip to OpenAI, `param` null and `message` a stringified python dict:

   ```
   {"error":{"message":"Error code: 400 - {'error': {'message': 'Invalid file format for Batch API. Must be .jsonl', 'type': 'invalid_request_error', 'param': None, 'code': None}, 'detail': {'message': 'Invalid file format for Batch API. Must be .jsonl', 'code': None}}","type":"invalid_request_error","param":null,"code":"400"}}
   HTTP 400 time_total=0.507576s
   ```

#### Malformed lines (rows missing "method")

1. Upload command:

   ```bash
   curl -s -X POST http://localhost:47743/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F file=@bad_lines.jsonl -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

2. Observed output, the malformed file is accepted:

   ```
   {"id":"file-52voFe6FU6MWyAwa1Uj39R","bytes":170,"created_at":1787176071,"filename":"bad_lines.jsonl","object":"file","purpose":"batch","status":"processed","expires_at":1789768071,"status_details":null}
   HTTP 200 time_total=0.824878s
   ```

3. Batch creation with that file id also returns 200:

   ```bash
   curl -s -X POST http://localhost:47743/v1/batches -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"input_file_id": "file-52voFe6FU6MWyAwa1Uj39R", "endpoint": "/v1/chat/completions", "completion_window": "24h"}' -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

   ```
   {"id":"batch_6a86249298dc8190818d6bd2581a12b3", ... "status":"validating", ...}
   HTTP 200 time_total=1.157464s
   ```

4. Polling GET /v1/batches/batch_6a86249298dc8190818d6bd2581a12b3 every 10s: status `failed` on the first poll, the first hint anything was wrong, ~10s and one provider round trip after upload:

   ```
   "errors": {
       "data": [
           {"code": "missing_required_parameter", "line": 1, "message": "Missing required parameter: 'method'.", "param": "method"},
           {"code": "missing_required_parameter", "line": 2, "message": "Missing required parameter: 'method'.", "param": "method"},
           {"code": "missing_required_parameter", "line": 3, "message": "Missing required parameter: 'method'.", "param": "method"},
           {"code": "missing_required_parameter", "line": 4, "message": "Missing required parameter: 'method'.", "param": "method"},
           {"code": "missing_required_parameter", "line": 5, "message": "Missing required parameter: 'method'.", "param": "method"}
       ],
       "object": "list"
   }
   ```

#### Invalid purpose (purpose=batches)

1. Command:

   ```bash
   curl -s -X POST http://localhost:47743/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batches -F file=@good_small.jsonl -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

2. Observed output, `type` and `param` are the literal strings "None" and `message` is a stringified python dict:

   ```
   {"error":{"message":"{'error': \"Invalid purpose: batches. Must be one of: ('assistants', 'assistants_output', 'batch', 'batch_output', 'fine-tune', 'fine-tune-results', 'vision', 'user_data', 'messages')\"}","type":"None","param":"None","code":"400"}}
   HTTP 400 time_total=1.702851s
   ```

#### Valid file end to end

1. Upload command:

   ```bash
   curl -s -X POST http://localhost:47743/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F file=@good_small.jsonl -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

   ```
   {"id":"file-McdpGEJ1WWKpvsscY1NsWz","bytes":3620,"created_at":1787176148,"filename":"good_small.jsonl","object":"file","purpose":"batch","status":"processed","expires_at":1789768148,"status_details":null}
   HTTP 200 time_total=0.564373s
   ```

2. Batch creation returns 200 with a `batch_...` id:

   ```bash
   curl -s -X POST http://localhost:47743/v1/batches -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"input_file_id": "file-McdpGEJ1WWKpvsscY1NsWz", "endpoint": "/v1/chat/completions", "completion_window": "24h"}' -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

3. Polling GET /v1/batches/batch_6a8624dfd6b48190998252dc52d74567 every 20s: status `completed` on the first poll, request_counts completed 20 / failed 0 / total 20, model gpt-4.1-nano-2025-04-14, output_file_id file-GdFQ9CiK9JthWNEFv2URQL

#### Managed files path (12 MB with target_model_names)

1. Command:

   ```bash
   curl -s -X POST http://localhost:47743/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F file=@big_12mb.jsonl -F target_model_names=gpt-4.1-nano -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

2. Observed output, 200 with a unified id and the 12 MB file forwarded despite the cap (the underlying `file-KHQkbZiCPnMa1ptBHpovYw` appears in proxy.log):

   ```
   {"id":"bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07dW5pZmllZF9pZCwzZDE3NzdlYy0zM2NlLTQ2Y2EtYmIxYS00NTMzZDZmM2I5ZjY7...","bytes":12585081,"created_at":1787176179,"filename":"modified_file.jsonl","object":"file","purpose":"batch","status":"uploaded","expires_at":1789768179,"status_details":null}
   HTTP 200 time_total=3.489447s
   ```

### After (9bb5483991)

#### Oversized file (12 MB vs cap 10 MB)

1. Command:

   ```bash
   curl -s -X POST http://localhost:41783/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F file=@big_12mb.jsonl -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

2. Observed output, instant 413 naming the knob, nothing forwarded (proxy log shows zero calls to api.openai.com/v1/files):

   ```
   {"error":{"message":"Batch input file is 12.0 MB, which exceeds the configured max_batch_file_size_mb of 10 MB. The file was not forwarded to the provider.","type":"invalid_request_error","param":"file","code":"413"}}
   HTTP 413 time_total=0.104812s
   ```

#### Wrong file type (notes.txt)

1. Command:

   ```bash
   curl -s -X POST http://localhost:41783/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F file=@notes.txt -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

2. Observed output, local 400 in 17ms with `param` "file", no provider round trip:

   ```
   {"error":{"message":"Invalid file format for Batch API: 'notes.txt'. Batch input files must be .jsonl files. The file was not forwarded to the provider.","type":"invalid_request_error","param":"file","code":"400"}}
   HTTP 400 time_total=0.016900s
   ```

#### Malformed lines (rows missing "method")

1. Upload command:

   ```bash
   curl -s -X POST http://localhost:41783/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F file=@bad_lines.jsonl -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

2. Observed output, instant 400 naming the missing key and its line; no file id exists, so no failed batch is ever created:

   ```
   {"error":{"message":"Missing required parameter: 'method' (batch input file line 1). Each line must be a JSON object with keys custom_id, method, url, body. The file was not forwarded to the provider.","type":"invalid_request_error","param":"method","code":"400"}}
   HTTP 400 time_total=0.013099s
   ```

#### Invalid purpose (purpose=batches)

1. Command:

   ```bash
   curl -s -X POST http://localhost:41783/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batches -F file=@good_small.jsonl -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

2. Observed output, a clean OpenAI-shaped error with `param` "purpose":

   ```
   {"error":{"message":"Invalid purpose: batches. Must be one of: ('assistants', 'assistants_output', 'batch', 'batch_output', 'fine-tune', 'fine-tune-results', 'vision', 'user_data', 'messages')","type":"invalid_request_error","param":"purpose","code":"400"}}
   HTTP 400 time_total=0.013765s
   ```

#### Valid file end to end

1. Upload command:

   ```bash
   curl -s -X POST http://localhost:41783/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F file=@good_small.jsonl
   ```

   ```
   {"id":"file-CH9GzT2VTwEQzpqmvm6fNS","bytes":3620,"created_at":1787179249,"filename":"good_small.jsonl","object":"file","purpose":"batch","status":"processed","expires_at":1789771249,"status_details":null}
   ```

2. Batch creation returns 200 with a `batch_...` id:

   ```bash
   curl -s -X POST http://localhost:41783/v1/batches -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"input_file_id": "file-CH9GzT2VTwEQzpqmvm6fNS", "endpoint": "/v1/chat/completions", "completion_window": "24h"}'
   ```

3. Polling GET /v1/batches/batch_6a8630f211cc819087d9a8a22f0673fd every 10s: status `completed` on poll 13, request_counts completed 20 / failed 0 / total 20, model gpt-4.1-nano-2025-04-14, output_file_id file-19VhiXKD3dBFsL2t5tJuce

4. Fetching the output file content returns the 20 real completions:

   ```bash
   curl -s http://localhost:41783/v1/files/file-19VhiXKD3dBFsL2t5tJuce/content -H "Authorization: Bearer sk-1234"
   ```

   ```
   {"id": "batch_req_6a8631630f548190987e10c6fd48f678", "custom_id": "req-0", "response": {"status_code": 200, ... "content": "Hi 0!", ...}, "error": null}
   ```

#### Managed files path (12 MB with target_model_names)

1. Command:

   ```bash
   curl -s -X POST http://localhost:41783/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F file=@big_12mb.jsonl -F target_model_names=gpt-4.1-nano -w "\nHTTP %{http_code} time_total=%{time_total}s\n"
   ```

2. Observed output, the managed-files route hits the same 413 before anything is forwarded:

   ```
   {"error":{"message":"Batch input file is 12.0 MB, which exceeds the configured max_batch_file_size_mb of 10 MB. The file was not forwarded to the provider.","type":"invalid_request_error","param":"file","code":"413"}}
   HTTP 413 time_total=0.026264s
   ```

#### Dashboard-set cap applies without a restart

At the merge base the setting does not exist, so the dashboard route rejects it:

```bash
curl -s -X POST http://localhost:42931/config/field/update -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"field_name": "max_batch_file_size_mb", "field_value": 10, "config_type": "general_settings"}' -w "\nHTTP %{http_code}\n"
```

```
{"detail":{"error":"Invalid field=max_batch_file_size_mb passed in."}}
HTTP 400
```

At the PR tip, against the proxy on port 49327 whose config sets no cap:

1. A 12 MB upload goes through, nothing rejects it:

   ```bash
   curl -s -X POST http://localhost:49327/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F file=@big_12mb.jsonl -w "\nHTTP %{http_code}\n"
   ```

   ```
   {"id":"file-MTLj5gDnaKSBUnysx5QWRr","bytes":12585082,"created_at":1787179455,"filename":"big_12mb.jsonl","object":"file","purpose":"batch","status":"processed","expires_at":1789771455,"status_details":null}
   HTTP 200
   ```

2. The admin saves the cap through the dashboard route:

   ```bash
   curl -s -X POST http://localhost:49327/config/field/update -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"field_name": "max_batch_file_size_mb", "field_value": 10, "config_type": "general_settings"}' -w "\nHTTP %{http_code}\n"
   ```

   ```
   {"param_name":"general_settings","param_value":{"max_batch_file_size_mb":10},"last_run_at":null,"reload_revision":0}
   HTTP 200
   ```

3. After `sleep 15` (one periodic reload at interval 5s, the proxy never restarts), the same upload is rejected:

   ```bash
   curl -s -X POST http://localhost:49327/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F file=@big_12mb.jsonl -w "\nHTTP %{http_code}\n"
   ```

   ```
   {"error":{"message":"Batch input file is 12.0 MB, which exceeds the configured max_batch_file_size_mb of 10 MB. The file was not forwarded to the provider.","type":"invalid_request_error","param":"file","code":"413"}}
   HTTP 413
   ```

## Type

🆕 New Feature

## Caveats (if any)

- Validation is uniform across providers; no per-provider line rules
- Caps on record count or file count are out of scope (P1)
- Nonpositive cap values disable the cap, matching max_request_size_mb
- A cap set in config.yaml takes precedence over a dashboard-saved value, matching how other general settings reload

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 9bb5483991 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9bb54839919c27477d7cc88ce4d1caef3b08ce59. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->