### PR TITLE
fix(vertex_ai): only fall back to a placeholder thought signature on the first parallel function call

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1200,13 +1200,14 @@ def _encode_tool_call_id_with_signature(tool_call_id: str, thought_signature: st
     return tool_call_id
 
 
-def _get_thought_signature_from_tool(tool: dict, model: str | None = None) -> str | None:
+def _get_thought_signature_from_tool(tool: dict) -> str | None:
     """Extract thought signature from tool call's provider_specific_fields.
 
     If not provided try to extract thought signature from tool call id
 
     Checks both tool.provider_specific_fields and tool.function.provider_specific_fields.
-    If no signature is found and model is gemini-3, returns a dummy signature.
+    Returns None when the tool call carries no signature; callers decide whether a
+    placeholder signature is needed.
     """
     # First check tool's provider_specific_fields
     provider_fields: Final = tool.get("provider_specific_fields") or {}
@@ -1236,13 +1237,6 @@ def _get_thought_signature_from_tool(tool: dict, model: str | None = None) -> st
         if len(parts) == 2:
             _, signature = parts
             return signature
-    # If no signature found and model is gemini-3, return dummy signature
-    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
-        VertexGeminiConfig,
-    )
-
-    if model and VertexGeminiConfig._is_gemini_3_or_newer(model):
-        return _get_dummy_thought_signature()
     return None
 
 
@@ -1312,8 +1306,10 @@ def convert_to_gemini_tool_call_invoke(
             VertexGeminiConfig,
         )
 
+        needs_dummy_signature: Final = model is not None and VertexGeminiConfig._is_gemini_3_or_newer(model)
+
         if tool_calls is not None:
-            for idx, tool in enumerate(tool_calls):
+            for tool in tool_calls:
                 if "function" in tool:
                     gemini_function_call: VertexFunctionCall | None = _gemini_tool_call_invoke_helper(
                         function_call_params=tool["function"],
@@ -1321,7 +1317,10 @@ def convert_to_gemini_tool_call_invoke(
                     )
                     if gemini_function_call is not None:
                         part_dict: VertexPartType = {"function_call": gemini_function_call}
-                        thought_signature = _get_thought_signature_from_tool(dict(tool), model=model)
+                        thought_signature = _get_thought_signature_from_tool(dict(tool))
+                        is_first_function_call = len(_parts_list) == 0
+                        if not thought_signature and is_first_function_call and needs_dummy_signature:
+                            thought_signature = _get_dummy_thought_signature()
                         if thought_signature:
                             part_dict["thoughtSignature"] = thought_signature
 
@@ -1344,7 +1343,7 @@ def convert_to_gemini_tool_call_invoke(
                     thought_signature = provider_fields.get("thought_signature")
 
                 # If no signature found and model is gemini-3, use dummy signature
-                if not thought_signature and model and VertexGeminiConfig._is_gemini_3_or_newer(model):
+                if not thought_signature and needs_dummy_signature:
                     thought_signature = _get_dummy_thought_signature()
 
                 if thought_signature:

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1245,10 +1245,14 @@ def _get_dummy_thought_signature() -> str:
 
     This is used when transferring conversation history from older models
     (like gemini-2.5-flash) to gemini-3, which requires thought_signature
-    for strict validation.
+    for strict validation. Google documents it as a last resort that "will
+    negatively impact model performance", so callers must only fall back to it
+    when no real signature is available.
+
+    See:
+    https://ai.google.dev/gemini-api/docs/thought-signatures#faqs
+    https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/thinking/thought-signatures
     """
-    # Return a base64-encoded dummy signature string
-    # Below dummy signature is recommended by google - https://ai.google.dev/gemini-api/docs/thought-signatures#faqs
     dummy_data: Final = b"skip_thought_signature_validator"
     return base64.b64encode(dummy_data).decode("utf-8")
 
@@ -1318,6 +1322,9 @@ def convert_to_gemini_tool_call_invoke(
                     if gemini_function_call is not None:
                         part_dict: VertexPartType = {"function_call": gemini_function_call}
                         thought_signature = _get_thought_signature_from_tool(dict(tool))
+                        # Gemini signs only the first functionCall part of a parallel batch, so scope the
+                        # placeholder fallback to that part instead of fabricating one per sibling call:
+                        # https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/thinking/thought-signatures#parallel_function_calling_example
                         is_first_function_call = len(_parts_list) == 0
                         if not thought_signature and is_first_function_call and needs_dummy_signature:
                             thought_signature = _get_dummy_thought_signature()

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -645,10 +645,9 @@ def _collect_tool_call_thought_signatures(
     the text part as well would send two copies and double-bill the previous
     turn's reasoning tokens on gemini-3 and newer models.
 
-    Detection deliberately calls _get_thought_signature_from_tool without the
-    model argument: with a gemini-3 model that helper synthesizes a dummy
-    signature for unsigned tool calls, which must not suppress a real
-    text-part signature (e.g. replaying gemini-2.5 history to a newer model).
+    Only real signatures count here; a synthesized placeholder must not
+    suppress a genuine text-part signature (e.g. replaying gemini-2.5 history
+    to a newer model).
     """
     signatures: tuple[str, ...] = ()
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -1,5 +1,7 @@
 import base64
 
+import pytest
+
 from litellm.litellm_core_utils.prompt_templates.factory import (
     convert_to_gemini_tool_call_result,
 )
@@ -1050,6 +1052,40 @@ def test_parallel_tool_call_history_replayed_through_full_message_conversion():
     assert model_parts[0]["thoughtSignature"] == REAL_THOUGHT_SIGNATURE
     assert "thoughtSignature" not in model_parts[1]
     assert "thoughtSignature" not in model_parts[2]
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gemini-3-pro-preview",
+        "gemini-3-flash-preview",
+        "gemini-3.1-pro-preview",
+        "gemini-3.6-flash",
+        "gemini-3.7-flash",
+        "vertex_ai/gemini-3.7-flash",
+        "gemini/gemini-3.7-flash",
+    ],
+)
+def test_placeholder_scoped_to_first_call_across_gemini_3_variants(model):
+    """Every gemini-3 family member, bare or provider-prefixed, gets one placeholder at most."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        _get_dummy_thought_signature,
+        convert_to_gemini_tool_call_invoke,
+    )
+
+    gemini_parts = convert_to_gemini_tool_call_invoke(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": _parallel_tool_calls(None, None, None),
+        },
+        model=model,
+    )
+
+    assert len(gemini_parts) == 3
+    assert gemini_parts[0]["thoughtSignature"] == _get_dummy_thought_signature()
+    assert "thoughtSignature" not in gemini_parts[1]
+    assert "thoughtSignature" not in gemini_parts[2]
 
 
 def test_signed_text_part_survives_alongside_unsigned_parallel_tool_calls():

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -830,13 +830,14 @@ def _parallel_tool_calls_signed_via_id(*signatures):
 
 
 REAL_THOUGHT_SIGNATURE = "Co4CAdHtim/rWgXbz2Ghp4tShzLeMASrPw6JJyYIC3cbVyZnKzU3uv8/wVzyS2sKRPL2m8QQHHXbNQhEEz500G7n"
+PLACEHOLDER_SIGNATURE = base64.b64encode(b"skip_thought_signature_validator").decode(
+    "utf-8"
+)
 
 
 def test_dummy_signature_only_on_first_parallel_tool_call():
-    """Gemini only returns a thought signature on the first of N parallel function calls.
-
-    The sibling calls carry no signature, so replaying them must not fabricate one.
-    """
+    """Google documents the placeholder as a last resort that degrades quality, so an unsigned
+    parallel turn replayed to gemini-3 gets a budget of exactly one."""
     from litellm.litellm_core_utils.prompt_templates.factory import (
         convert_to_gemini_tool_call_invoke,
     )
@@ -850,17 +851,15 @@ def test_dummy_signature_only_on_first_parallel_tool_call():
         model="gemini-3-pro-preview",
     )
 
-    expected_dummy = base64.b64encode(b"skip_thought_signature_validator").decode(
-        "utf-8"
-    )
     assert len(gemini_parts) == 3
-    assert gemini_parts[0]["thoughtSignature"] == expected_dummy
+    assert gemini_parts[0]["thoughtSignature"] == PLACEHOLDER_SIGNATURE
     assert "thoughtSignature" not in gemini_parts[1]
     assert "thoughtSignature" not in gemini_parts[2]
 
 
 def test_real_signature_on_first_parallel_tool_call_leaves_siblings_empty():
-    """The real signature from Gemini rides on the first call; siblings stay signature-free."""
+    """Gemini signs only the first of N parallel function calls, so a faithful replay has
+    nothing to attach to the siblings."""
     from litellm.litellm_core_utils.prompt_templates.factory import (
         convert_to_gemini_tool_call_invoke,
     )
@@ -881,7 +880,8 @@ def test_real_signature_on_first_parallel_tool_call_leaves_siblings_empty():
 
 
 def test_real_signature_on_later_parallel_tool_call_is_preserved():
-    """A signature attached to a non-first call is still forwarded as-is."""
+    """Clients may reorder or drop calls, so a signature that lands on a non-first call is
+    still the model's own and must survive the round trip."""
     from litellm.litellm_core_utils.prompt_templates.factory import (
         convert_to_gemini_tool_call_invoke,
     )
@@ -895,11 +895,8 @@ def test_real_signature_on_later_parallel_tool_call_is_preserved():
         model="gemini-3-pro-preview",
     )
 
-    expected_dummy = base64.b64encode(b"skip_thought_signature_validator").decode(
-        "utf-8"
-    )
     assert len(gemini_parts) == 2
-    assert gemini_parts[0]["thoughtSignature"] == expected_dummy
+    assert gemini_parts[0]["thoughtSignature"] == PLACEHOLDER_SIGNATURE
     assert gemini_parts[1]["thoughtSignature"] == REAL_THOUGHT_SIGNATURE
 
 
@@ -970,7 +967,6 @@ def test_placeholder_lands_on_first_emitted_part_not_first_tool_call_entry():
     """A non-function entry (e.g. an OpenAI custom tool call) emits no part, so it must not
     consume the one placeholder slot and leave the real first function call bare."""
     from litellm.litellm_core_utils.prompt_templates.factory import (
-        _get_dummy_thought_signature,
         convert_to_gemini_tool_call_invoke,
     )
 
@@ -984,7 +980,7 @@ def test_placeholder_lands_on_first_emitted_part_not_first_tool_call_entry():
     )
 
     assert len(gemini_parts) == 2
-    assert gemini_parts[0]["thoughtSignature"] == _get_dummy_thought_signature()
+    assert gemini_parts[0]["thoughtSignature"] == PLACEHOLDER_SIGNATURE
     assert "thoughtSignature" not in gemini_parts[1]
 
 
@@ -1056,20 +1052,60 @@ def test_parallel_tool_call_history_replayed_through_full_message_conversion():
 
 @pytest.mark.parametrize(
     "model",
+    ["gemini-3.5-flash", "vertex_ai/gemini-3.5-flash", "gemini/gemini-3.5-flash"],
+)
+def test_natively_signed_parallel_turn_never_carries_a_placeholder(model):
+    """A native gemini-3.5 parallel turn replays with zero skip_thought_signature_validator parts.
+
+    Fabricating the placeholder alongside a real signature is what produced empty text responses
+    on gemini-3.5 parallel function calling, so the whole payload has to stay placeholder-free.
+    """
+    import json
+
+    from litellm.llms.vertex_ai.gemini.transformation import (
+        _gemini_convert_messages_with_history,
+    )
+
+    messages = [
+        {"role": "user", "content": "Weather in Paris, London and Tokyo?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": _parallel_tool_calls_signed_via_id(
+                REAL_THOUGHT_SIGNATURE, None, None
+            ),
+        },
+    ]
+
+    contents = _gemini_convert_messages_with_history(messages=messages, model=model)
+
+    model_parts = contents[1]["parts"]
+    assert len(model_parts) == 3
+    assert model_parts[0]["thoughtSignature"] == REAL_THOUGHT_SIGNATURE
+    assert "thoughtSignature" not in model_parts[1]
+    assert "thoughtSignature" not in model_parts[2]
+    assert PLACEHOLDER_SIGNATURE not in json.dumps(contents)
+
+
+@pytest.mark.parametrize(
+    "model",
     [
         "gemini-3-pro-preview",
         "gemini-3-flash-preview",
         "gemini-3.1-pro-preview",
+        "gemini-3.5-flash",
         "gemini-3.6-flash",
         "gemini-3.7-flash",
+        "vertex_ai/gemini-3.5-flash",
         "vertex_ai/gemini-3.7-flash",
+        "gemini/gemini-3.5-flash",
         "gemini/gemini-3.7-flash",
     ],
 )
 def test_placeholder_scoped_to_first_call_across_gemini_3_variants(model):
-    """Every gemini-3 family member, bare or provider-prefixed, gets one placeholder at most."""
+    """The gemini-3 gate is a substring match, so every family member and prefix form has to
+    land on the same one-placeholder budget rather than only the versions we happened to try."""
     from litellm.litellm_core_utils.prompt_templates.factory import (
-        _get_dummy_thought_signature,
         convert_to_gemini_tool_call_invoke,
     )
 
@@ -1083,17 +1119,14 @@ def test_placeholder_scoped_to_first_call_across_gemini_3_variants(model):
     )
 
     assert len(gemini_parts) == 3
-    assert gemini_parts[0]["thoughtSignature"] == _get_dummy_thought_signature()
+    assert gemini_parts[0]["thoughtSignature"] == PLACEHOLDER_SIGNATURE
     assert "thoughtSignature" not in gemini_parts[1]
     assert "thoughtSignature" not in gemini_parts[2]
 
 
 def test_signed_text_part_survives_alongside_unsigned_parallel_tool_calls():
-    """gemini-2.5 history with a signed text part and parallel unsigned calls: the text keeps its real
-    signature, only the first call gets the placeholder, and the siblings stay bare."""
-    from litellm.litellm_core_utils.prompt_templates.factory import (
-        _get_dummy_thought_signature,
-    )
+    """Text-part and function-call signatures are collected by separate code paths, so scoping the
+    placeholder must not disturb a real signature that arrived on the text part."""
     from litellm.llms.vertex_ai.gemini.transformation import (
         _gemini_convert_messages_with_history,
     )
@@ -1111,7 +1144,7 @@ def test_signed_text_part_survives_alongside_unsigned_parallel_tool_calls():
 
     assert parts[0]["text"] == "Checking all three cities."
     assert parts[0]["thoughtSignature"] == "real_25_signature"
-    assert parts[1]["thoughtSignature"] == _get_dummy_thought_signature()
+    assert parts[1]["thoughtSignature"] == PLACEHOLDER_SIGNATURE
     assert "thoughtSignature" not in parts[2]
     assert "thoughtSignature" not in parts[3]
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -806,6 +806,27 @@ def _parallel_tool_calls(*signatures):
     ]
 
 
+def _parallel_tool_calls_signed_via_id(*signatures):
+    """Parallel tool calls in the shape LiteLLM actually hands back to clients.
+
+    The signature rides in the tool call id behind __thought__, which is what an
+    OpenAI-format client echoes back on the next turn.
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        _encode_tool_call_id_with_signature,
+    )
+
+    return [
+        {
+            "id": _encode_tool_call_id_with_signature(f"call_{idx}", signature),
+            "type": "function",
+            "function": {"name": f"tool_{idx}", "arguments": '{"location": "Paris"}'},
+            "index": idx,
+        }
+        for idx, signature in enumerate(signatures)
+    ]
+
+
 REAL_THOUGHT_SIGNATURE = "Co4CAdHtim/rWgXbz2Ghp4tShzLeMASrPw6JJyYIC3cbVyZnKzU3uv8/wVzyS2sKRPL2m8QQHHXbNQhEEz500G7n"
 
 
@@ -897,6 +918,166 @@ def test_no_signatures_on_parallel_tool_calls_for_gemini_2_5():
 
     assert len(gemini_parts) == 2
     assert all("thoughtSignature" not in part for part in gemini_parts)
+
+
+def test_signature_embedded_in_tool_call_id_only_on_first_parallel_call():
+    """The production shape: the signature arrives inside the first call's id, siblings have bare ids."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        convert_to_gemini_tool_call_invoke,
+    )
+
+    gemini_parts = convert_to_gemini_tool_call_invoke(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": _parallel_tool_calls_signed_via_id(
+                REAL_THOUGHT_SIGNATURE, None, None
+            ),
+        },
+        model="gemini-3-pro-preview",
+    )
+
+    assert len(gemini_parts) == 3
+    assert gemini_parts[0]["thoughtSignature"] == REAL_THOUGHT_SIGNATURE
+    assert "thoughtSignature" not in gemini_parts[1]
+    assert "thoughtSignature" not in gemini_parts[2]
+
+
+def test_tool_level_provider_specific_fields_signature_leaves_siblings_empty():
+    """A signature on the tool call itself, rather than on its function, behaves the same way."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        convert_to_gemini_tool_call_invoke,
+    )
+
+    tool_calls = _parallel_tool_calls(None, None)
+    tool_calls[0]["provider_specific_fields"] = {
+        "thought_signature": REAL_THOUGHT_SIGNATURE
+    }
+
+    gemini_parts = convert_to_gemini_tool_call_invoke(
+        {"role": "assistant", "content": None, "tool_calls": tool_calls},
+        model="gemini-3-pro-preview",
+    )
+
+    assert len(gemini_parts) == 2
+    assert gemini_parts[0]["thoughtSignature"] == REAL_THOUGHT_SIGNATURE
+    assert "thoughtSignature" not in gemini_parts[1]
+
+
+def test_placeholder_lands_on_first_emitted_part_not_first_tool_call_entry():
+    """A non-function entry (e.g. an OpenAI custom tool call) emits no part, so it must not
+    consume the one placeholder slot and leave the real first function call bare."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        _get_dummy_thought_signature,
+        convert_to_gemini_tool_call_invoke,
+    )
+
+    tool_calls = [
+        {"id": "call_custom", "type": "custom", "custom": {"name": "noop", "input": ""}}
+    ] + _parallel_tool_calls(None, None)
+
+    gemini_parts = convert_to_gemini_tool_call_invoke(
+        {"role": "assistant", "content": None, "tool_calls": tool_calls},
+        model="gemini-3-pro-preview",
+    )
+
+    assert len(gemini_parts) == 2
+    assert gemini_parts[0]["thoughtSignature"] == _get_dummy_thought_signature()
+    assert "thoughtSignature" not in gemini_parts[1]
+
+
+def test_no_placeholder_when_model_is_unknown():
+    """Without a model there is nothing to prove the target needs a placeholder, so none is added."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        convert_to_gemini_tool_call_invoke,
+    )
+
+    gemini_parts = convert_to_gemini_tool_call_invoke(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": _parallel_tool_calls(None, None),
+        },
+    )
+
+    assert len(gemini_parts) == 2
+    assert all("thoughtSignature" not in part for part in gemini_parts)
+
+
+def test_real_signature_forwarded_to_gemini_2_5_without_placeholder_siblings():
+    """Older models still receive a real signature that a client replays, and still get no placeholder."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        convert_to_gemini_tool_call_invoke,
+    )
+
+    gemini_parts = convert_to_gemini_tool_call_invoke(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": _parallel_tool_calls(REAL_THOUGHT_SIGNATURE, None),
+        },
+        model="gemini-2.5-flash",
+    )
+
+    assert len(gemini_parts) == 2
+    assert gemini_parts[0]["thoughtSignature"] == REAL_THOUGHT_SIGNATURE
+    assert "thoughtSignature" not in gemini_parts[1]
+
+
+def test_parallel_tool_call_history_replayed_through_full_message_conversion():
+    """End to end through the message-history converter, the path a real /chat/completions replay takes."""
+    from litellm.llms.vertex_ai.gemini.transformation import (
+        _gemini_convert_messages_with_history,
+    )
+
+    messages = [
+        {"role": "user", "content": "Weather in Paris, London and Tokyo?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": _parallel_tool_calls_signed_via_id(
+                REAL_THOUGHT_SIGNATURE, None, None
+            ),
+        },
+    ]
+
+    contents = _gemini_convert_messages_with_history(
+        messages=messages, model="gemini-3-pro-preview"
+    )
+
+    model_parts = contents[1]["parts"]
+    assert len(model_parts) == 3
+    assert model_parts[0]["thoughtSignature"] == REAL_THOUGHT_SIGNATURE
+    assert "thoughtSignature" not in model_parts[1]
+    assert "thoughtSignature" not in model_parts[2]
+
+
+def test_signed_text_part_survives_alongside_unsigned_parallel_tool_calls():
+    """gemini-2.5 history with a signed text part and parallel unsigned calls: the text keeps its real
+    signature, only the first call gets the placeholder, and the siblings stay bare."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        _get_dummy_thought_signature,
+    )
+    from litellm.llms.vertex_ai.gemini.transformation import (
+        _gemini_convert_messages_with_history,
+    )
+
+    msg = {
+        "role": "assistant",
+        "content": "Checking all three cities.",
+        "provider_specific_fields": {"thought_signatures": ["real_25_signature"]},
+        "tool_calls": _parallel_tool_calls(None, None, None),
+    }
+
+    parts = _gemini_convert_messages_with_history(
+        messages=[msg], model="gemini-3-pro-preview"
+    )[0]["parts"]
+
+    assert parts[0]["text"] == "Checking all three cities."
+    assert parts[0]["thoughtSignature"] == "real_25_signature"
+    assert parts[1]["thoughtSignature"] == _get_dummy_thought_signature()
+    assert "thoughtSignature" not in parts[2]
+    assert "thoughtSignature" not in parts[3]
 
 
 # Tests for media_resolution (detail parameter) handling - Issue #17084

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -1,3 +1,5 @@
+import base64
+
 from litellm.litellm_core_utils.prompt_templates.factory import (
     convert_to_gemini_tool_call_result,
 )
@@ -782,6 +784,119 @@ def test_dummy_signature_with_function_call_mode():
         "utf-8"
     )
     assert gemini_parts[0]["thoughtSignature"] == expected_dummy
+
+
+def _parallel_tool_calls(*signatures):
+    return [
+        {
+            "id": f"call_{idx}",
+            "type": "function",
+            "function": {
+                "name": f"tool_{idx}",
+                "arguments": '{"location": "Paris"}',
+                **(
+                    {"provider_specific_fields": {"thought_signature": signature}}
+                    if signature is not None
+                    else {}
+                ),
+            },
+            "index": idx,
+        }
+        for idx, signature in enumerate(signatures)
+    ]
+
+
+REAL_THOUGHT_SIGNATURE = "Co4CAdHtim/rWgXbz2Ghp4tShzLeMASrPw6JJyYIC3cbVyZnKzU3uv8/wVzyS2sKRPL2m8QQHHXbNQhEEz500G7n"
+
+
+def test_dummy_signature_only_on_first_parallel_tool_call():
+    """Gemini only returns a thought signature on the first of N parallel function calls.
+
+    The sibling calls carry no signature, so replaying them must not fabricate one.
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        convert_to_gemini_tool_call_invoke,
+    )
+
+    gemini_parts = convert_to_gemini_tool_call_invoke(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": _parallel_tool_calls(None, None, None),
+        },
+        model="gemini-3-pro-preview",
+    )
+
+    expected_dummy = base64.b64encode(b"skip_thought_signature_validator").decode(
+        "utf-8"
+    )
+    assert len(gemini_parts) == 3
+    assert gemini_parts[0]["thoughtSignature"] == expected_dummy
+    assert "thoughtSignature" not in gemini_parts[1]
+    assert "thoughtSignature" not in gemini_parts[2]
+
+
+def test_real_signature_on_first_parallel_tool_call_leaves_siblings_empty():
+    """The real signature from Gemini rides on the first call; siblings stay signature-free."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        convert_to_gemini_tool_call_invoke,
+    )
+
+    gemini_parts = convert_to_gemini_tool_call_invoke(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": _parallel_tool_calls(REAL_THOUGHT_SIGNATURE, None, None),
+        },
+        model="gemini-3-pro-preview",
+    )
+
+    assert len(gemini_parts) == 3
+    assert gemini_parts[0]["thoughtSignature"] == REAL_THOUGHT_SIGNATURE
+    assert "thoughtSignature" not in gemini_parts[1]
+    assert "thoughtSignature" not in gemini_parts[2]
+
+
+def test_real_signature_on_later_parallel_tool_call_is_preserved():
+    """A signature attached to a non-first call is still forwarded as-is."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        convert_to_gemini_tool_call_invoke,
+    )
+
+    gemini_parts = convert_to_gemini_tool_call_invoke(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": _parallel_tool_calls(None, REAL_THOUGHT_SIGNATURE),
+        },
+        model="gemini-3-pro-preview",
+    )
+
+    expected_dummy = base64.b64encode(b"skip_thought_signature_validator").decode(
+        "utf-8"
+    )
+    assert len(gemini_parts) == 2
+    assert gemini_parts[0]["thoughtSignature"] == expected_dummy
+    assert gemini_parts[1]["thoughtSignature"] == REAL_THOUGHT_SIGNATURE
+
+
+def test_no_signatures_on_parallel_tool_calls_for_gemini_2_5():
+    """Non-gemini-3 models never get a placeholder signature, on any call."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        convert_to_gemini_tool_call_invoke,
+    )
+
+    gemini_parts = convert_to_gemini_tool_call_invoke(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": _parallel_tool_calls(None, None),
+        },
+        model="gemini-2.5-flash",
+    )
+
+    assert len(gemini_parts) == 2
+    assert all("thoughtSignature" not in part for part in gemini_parts)
 
 
 # Tests for media_resolution (detail parameter) handling - Issue #17084


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini signs only the first parallel function call
- LiteLLM fabricates a skip-validation placeholder on every sibling call
- Replayed history no longer matches what Gemini emitted

Google [documents both halves of this](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/thinking/thought-signatures#parallel_function_calling_example). On the expected shape: "In cases of parallel function calls in a single response, only the first functionCall part will contain the thought_signature." On the placeholder: "You can set thought_signature to skip_thought_signature_validator, but, this should be a last resort as it will negatively impact model performance." Fabricating one per sibling call is the opposite of a last resort, and it costs quality on every parallel tool-calling turn

That cost is measurable, not theoretical. Internal testing at Google found that setting `skip_thought_signature_validator` on parallel function calls causes gemini-3.5 to return empty text responses. Following the documented shape, one real signature on the first call and nothing on the siblings, reduced the error rate

How it solves it:

- Placeholder fallback now applies to the first function call only
- Unsigned sibling calls are replayed with no signature
- Real signatures on any call are still preserved

## User Flow

Before: a developer using parallel tool calling against a Gemini 3 model gets their conversation replayed with signatures the model never produced

1. They send POST https://litellm-domain/v1/chat/completions with a `get_weather` tool and ask for Paris, London and Tokyo in parallel
2. Three tool calls come back; only the first id carries a `__thought__` suffix, the other two are bare
3. They append the assistant turn plus three tool results and send the same POST again
4. The turn is replayed upstream with the real signature on Paris and a `skip_thought_signature_validator` placeholder attached to London and Tokyo, so two of the three calls claim a signature the model never returned

After: the same replay carries exactly the signatures the model produced

1. They send the same POST https://litellm-domain/v1/chat/completions with the same tool and prompt
2. Three tool calls come back; only the first id carries a `__thought__` suffix, the other two are bare
3. They append the assistant turn plus three tool results and send the same POST again
4. The turn is replayed upstream with the real signature on Paris and nothing on London or Tokyo, matching the original response, and the answer comes back covering all three cities

## Relevant issues

## Linear ticket

Resolves LIT-5888

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

E2e against real Vertex AI (`gemini-3.7-flash`, `vertex_location: global`). The observable that matters here is the exact payload Vertex receives on the replay turn, so the deployment's `api_base` points at a local recording relay that logs every request body and forwards it unchanged to the real `https://aiplatform.googleapis.com`. Proxy config:

```yaml
model_list:
  - model_name: vertex_ai/gemini-3.7-flash
    litellm_params:
      model: vertex_ai/gemini-3.7-flash
      vertex_project: <project>
      vertex_location: global
      api_base: http://127.0.0.1:<relay port>
general_settings:
  master_key: sk-1234
```

Both legs run the same two turns against their own proxy, booted from the commit under test:

```
# Turn 1: three cities, one get_weather tool, parallel calls requested
curl -sS "http://127.0.0.1:<proxy port>/v1/chat/completions" \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"model":"vertex_ai/gemini-3.7-flash","messages":[{"role":"user","content":"What is the weather in Paris, London and Tokyo? Call the get_weather tool once per city, all three in parallel."}],"tools":[{"type":"function","function":{"name":"get_weather","description":"get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]}'

# Turn 2: turn 1's user message + the assistant tool_calls message + three {"role":"tool","tool_call_id":...,"content":"20C"} results
curl -sS "http://127.0.0.1:<proxy port>/v1/chat/completions" \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d @turn2_payload.json
```

### Before (da7a10ebbdb16b34413566b0c980dac27af1de5b, the merge base)

Turn 1 returns three parallel tool calls, a signature only on the first id:

```
{"city": "Paris"}  id=call_2117163__thought__AY89a18pdiowbEw4FF1FoNDFGqoXixvwugvVO...
{"city": "London"}  id=call_2117164
{"city": "Tokyo"}  id=call_2117165
```

Turn 2 answers normally (200, `finish_reason: stop`): "The current weather in Paris, London, and Tokyo is: Paris 20°C, London 20°C, Tokyo 20°C". The model parts of that request as the relay recorded them on their way to Vertex:

```
get_weather({"city":"Paris"})   thoughtSignature=AY89a18pdiowbEw4FF1FoNDFGqoXixvwugvVOvu4gYXn...  (the model's real signature, 468 chars)
get_weather({"city":"London"})  thoughtSignature=c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I=  (fabricated placeholder)
get_weather({"city":"Tokyo"})   thoughtSignature=c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I=  (fabricated placeholder)
```

`c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I=` is base64 for `skip_thought_signature_validator`: London and Tokyo were sent claiming a signature the model never produced

### After (a5ad22b8a3f734b09ce5e05a68dab5c5205907a4, the PR tip)

Turn 1 returns three parallel tool calls, same shape as before, a signature only on the first id:

```
{"city": "Paris"}  id=call_2351596__thought__AY89a1/YoawiNHzbcgAo4j41xnvh25ItNyHlm...
{"city": "London"}  id=call_2351597
{"city": "Tokyo"}  id=call_2351598
```

Turn 2 answers normally (200, `finish_reason: stop`):

```
The weather in Paris, London, and Tokyo is currently:

* **Paris:** 20°C
* **London:** 20°C
* **Tokyo:** 20°C
```

The model parts of that request as the relay recorded them on their way to Vertex:

```
get_weather({"city":"Paris"})   thoughtSignature=AY89a1/YoawiNHzbcgAo4j41xnvh25ItNyHlmafAJ8Ln...  (the model's real signature, 452 chars)
get_weather({"city":"London"})  no thoughtSignature field
get_weather({"city":"Tokyo"})   no thoughtSignature field
```

Paris keeps its real signature and the two unsigned siblings are replayed bare, matching what Gemini returned. No placeholder anywhere in the request

Notes from the runs, both pre-existing behavior this PR leaves alone:

- Real signature also rides inside the first tool_call id
- Model parts serialize snake_case (`function_call`); Vertex accepts them

## Type

🐛 Bug Fix

## Caveats (if any)

- Placeholder still applies when the whole turn is unsigned, since Vertex returns a 400 on a turn with no signature anywhere. That keeps history migrated off pre-gemini-3 models working
- The gemini-3 gate on the placeholder is pre-existing behavior from #16812 and is unchanged here, only narrowed to the first call
- Through the proxy, a signature replayed inside a tool call id does not reach this code, so `provider_specific_fields.thought_signature` is the carrier that works there. Pre-existing and unchanged by this PR: the first call still gets a placeholder and the siblings go bare, which Vertex accepts

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] a5ad22b8a3f734b09ce5e05a68dab5c5205907a4 passes /live-pr-risk
