### PR TITLE
perf(otel): build the credential-scoped tracer Resource once per logger

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -42,6 +42,7 @@ from litellm.types.utils import (
 # OpenTelemetry imports moved to individual functions to avoid import errors when not installed
 
 if TYPE_CHECKING:
+    from opentelemetry.sdk.resources import Resource as _Resource
     from opentelemetry.sdk.trace import TracerProvider as _SDKTracerProvider
     from opentelemetry.sdk.trace.export import SpanExporter as _SpanExporter
     from opentelemetry.trace import Context as _Context
@@ -389,6 +390,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         self._tracer_provider_cache: OrderedDict[str, _CachedTracerProvider] = OrderedDict()
         self._tracer_provider_cache_lock: Final = threading.Lock()
         self._max_dynamic_tracer_providers: Final = max(1, max_dynamic_tracer_providers)
+        self._litellm_resource_memo: _Resource | None = None
         self._init_tracing(tracer_provider)
 
         _debug_otel: Final = str(os.getenv("DEBUG_OTEL", "False")).lower()
@@ -414,7 +416,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         self._init_otel_logger_on_litellm_proxy()
 
     @staticmethod
-    def _get_litellm_resource(config: OpenTelemetryConfig):
+    def _get_litellm_resource(config: OpenTelemetryConfig) -> "_Resource":
         """Create an OpenTelemetry Resource using config-driven defaults."""
         from opentelemetry.sdk.resources import OTELResourceDetector, Resource
 
@@ -428,6 +430,21 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         otel_resource_detector: Final = OTELResourceDetector()
         env_resource: Final = otel_resource_detector.detect()
         return base_resource.merge(env_resource)
+
+    def _litellm_resource(self) -> "_Resource":
+        """The Resource every provider on this logger is built with, frozen at first use.
+
+        ``Resource.create`` scans every installed distribution's entry points, roughly 3ms and
+        200 file opens, and the dynamic providers reach it from the async logging path. Freezing
+        also keeps them consistent with whatever this logger built at startup. ``cached_property``
+        locks class-wide before 3.12, which this file still supports.
+        """
+        memo: Final = self._litellm_resource_memo
+        if memo is not None:
+            return memo
+        built: Final = self._get_litellm_resource(self.config)
+        self._litellm_resource_memo = built
+        return built
 
     def _init_otel_logger_on_litellm_proxy(self):
         """
@@ -596,7 +613,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         from opentelemetry.trace import SpanKind
 
         def create_tracer_provider():
-            provider: Final = TracerProvider(resource=self._get_litellm_resource(self.config))
+            provider: Final = TracerProvider(resource=self._litellm_resource())
             provider.add_span_processor(self._get_span_processor())
             return provider
 
@@ -634,7 +651,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             metric_reader: Final = self._get_metric_reader()
             return MeterProvider(
                 metric_readers=[metric_reader],
-                resource=self._get_litellm_resource(self.config),
+                resource=self._litellm_resource(),
             )
 
         meter_provider = self._get_or_create_provider(
@@ -692,7 +709,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 
         def create_logger_provider():
-            provider: Final = OTLoggerProvider(resource=self._get_litellm_resource(self.config))
+            provider: Final = OTLoggerProvider(resource=self._litellm_resource())
             log_exporter: Final = self._get_log_exporter()
             provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
             return provider
@@ -1144,9 +1161,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         owns_exporter: Final = _provider_owns_exporter(dynamic_config.exporter)
 
         def _build() -> "_SDKTracerProvider":
-            provider: Final = TracerProvider(
-                resource=self._get_litellm_resource(self.config), shutdown_on_exit=owns_exporter
-            )
+            provider: Final = TracerProvider(resource=self._litellm_resource(), shutdown_on_exit=owns_exporter)
             provider.add_span_processor(self._get_span_processor(config_override=dynamic_config))
             return provider
 
@@ -1162,9 +1177,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         owns_exporter: Final = _provider_owns_exporter(self.OTEL_EXPORTER)
 
         def _build() -> "_SDKTracerProvider":
-            provider: Final = TracerProvider(
-                resource=self._get_litellm_resource(self.config), shutdown_on_exit=owns_exporter
-            )
+            provider: Final = TracerProvider(resource=self._litellm_resource(), shutdown_on_exit=owns_exporter)
             provider.add_span_processor(self._get_span_processor(dynamic_headers=dynamic_headers))
             return provider
 

--- a/ruff-strict-budget.json
+++ b/ruff-strict-budget.json
@@ -18,7 +18,7 @@
     "limit": 711
   },
   "ANN205": {
-    "limit": 113
+    "limit": 112
   },
   "ANN206": {
     "limit": 133

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -6213,6 +6213,32 @@ class TestDynamicTracerProviderCache(unittest.TestCase):
 
         self.assertTrue(entry.owns_exporter)
         self.assertIsNotNone(entry.provider._atexit_handler)
+
+    def test_dynamic_providers_share_one_resource(self):
+        """Building the Resource scans every installed distribution's entry points, and the
+        dynamic providers reach it from the async logging path, so one logger builds it once."""
+        logger = self._logger(cap=8)
+
+        for i in range(4):
+            logger._get_tracer_with_dynamic_headers({"authorization": f"Basic tenant-{i}"})
+
+        entries = list(logger._tracer_provider_cache.values())
+        self.assertEqual(len(entries), 4)
+        self.assertEqual(len({id(entry.provider.resource) for entry in entries}), 1)
+        self.assertIs(entries[0].provider.resource, logger._litellm_resource())
+
+    def test_resource_is_memoized_per_logger_not_shared(self):
+        """Two loggers must not share a Resource; the second's service.name would be wrong."""
+        first = self._logger()
+        second = OpenTelemetry(
+            config=OpenTelemetryConfig(exporter="console", skip_set_global=True, service_name="svc-second")
+        )
+        self.addCleanup(second._tracer_provider.shutdown)
+
+        self.assertIsNot(first._litellm_resource(), second._litellm_resource())
+        self.assertEqual(second._litellm_resource().attributes.get("service.name"), "svc-second")
+
+
 class TestOpenTelemetryDatabaseSemconvAttributes(unittest.TestCase):
     """A Postgres service span must name the PostgreSQL server it reached.
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every credential-scoped tracer build recreated the OpenTelemetry Resource
- Building it scans every installed distribution's entry points
- That is roughly 3ms and 200 blocking file opens, per build
- It runs on the event loop that serves requests
- Past the provider cache bound, every request pays it

How it solves it:

- Build the Resource once per logger and reuse it
- It derives only from that logger's config and process env
- Nothing about the cache, its bound, or eviction changes

## User Flow

Before: an operator whose teams and keys each carry their own observability credentials sees throughput sag once enough of them are active at once, with nothing in the logs to explain it

1. They set `litellm_settings.callbacks: ["langfuse_otel"]` and give each key its own `metadata.logging` credentials
2. Active credential sets grow past the 256 the proxy keeps warm
3. They drive 2000 concurrent completions at POST https://litellm-domain/v1/chat/completions and see 58 requests per second, median 1.01s, p90 1.47s
4. Every request returns 200 and every trace still arrives, so nothing looks wrong
5. Adding replicas is the only lever, since the cost is per request and invisible

After: the same proxy under the same load serves more of it

1. They set the same callbacks and the same per-key credentials
2. Active credential sets grow past the same 256
3. They drive the same 2000 concurrent completions and see 80 requests per second, median 0.73s, p90 1.01s
4. Every request returns 200 and every trace still arrives, unchanged
5. Below the bound the two are indistinguishable, so a proxy that never reaches it sees no difference

## Relevant issues

## Linear ticket

Refs LIT-5437

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, identical on both sides: one proxy per side against one Postgres, real Gemini behind the proxy, `store_model_in_db: true`, and 300 keys per side that each carry their own `langfuse_otel` credentials so each key is its own credential set. 300 sets against a bound of 256 means every request past the warm-up is a cache miss. Each proxy prints the tree it loaded and a fix-symbol probe at startup, so the side is proven rather than assumed

```yaml
model_list:
  - model_name: gemini-flash
    litellm_params:
      model: gemini/gemini-3.6-flash
      api_key: os.environ/GEMINI_API_KEY

general_settings:
  master_key: sk-lit5437
  store_model_in_db: true

litellm_settings:
  callbacks: ["langfuse_otel"]
  drop_params: true
```

```bash
$ for i in $(seq 1 300); do
    curl -s -X POST "$PROXY/key/generate" -H "$AUTH" -H 'Content-Type: application/json' \
      -d "{\"models\":[\"gemini-flash\"],\"metadata\":{\"logging\":[{\"callback_name\":\"langfuse_otel\",\"callback_type\":\"success\",\"callback_vars\":{\"langfuse_public_key\":\"pk-$i\",\"langfuse_secret_key\":\"sk-$i\",\"langfuse_host\":\"http://127.0.0.1:4999\"}}]}}" \
      | sed -n 's/.*"key":"\([^"]*\)".*/\1/p'
  done > keys.txt

$ grep . keys.txt | xargs -P $PAR -I@ curl -s -m 60 -X POST "$PROXY/v1/chat/completions" \
    -H "Authorization: Bearer @" -H 'Content-Type: application/json' \
    -d '{"model":"gemini-flash","messages":[{"role":"user","content":"hi"}],"max_tokens":5}' \
    -o /dev/null -w '%{http_code} %{time_total}\n'
```

### Before (59c7e7a17d)

#### Loop has slack, 700 completions at 24 concurrent

1. Confirm the side

   ```
   TREE       /Users/yucheng/litellm-wt/lit5437_base/litellm/__init__.py
   HAS_FIX    False
   ```

2. Drive 700 completions at 24 concurrent

   ```
   elapsed=24s rps=29 ok=700/700 median=0.776240s p90=0.953293s
   ```

#### Loop saturated, 2000 completions at 64 concurrent

1. Round 1

   ```
   elapsed=34s rps=58 ok=2000/2000 median=1.014435s p90=1.469314s
   ```

2. Round 2, with the two sides started in the opposite order

   ```
   elapsed=37s rps=54 ok=2000/2000 median=1.108508s p90=1.569317s
   ```

### After (aa1d9c8564)

#### Loop has slack, 700 completions at 24 concurrent

1. Confirm the side

   ```
   TREE       /Users/yucheng/litellm-wt/lit5437_followup/litellm/__init__.py
   HAS_FIX    True
   ```

2. Drive 700 completions at 24 concurrent

   ```
   elapsed=23s rps=30 ok=700/700 median=0.754987s p90=0.891414s
   ```

#### Loop saturated, 2000 completions at 64 concurrent

1. Round 1

   ```
   elapsed=25s rps=80 ok=2000/2000 median=0.731674s p90=1.007158s
   ```

2. Round 2, with the two sides started in the opposite order

   ```
   elapsed=29s rps=68 ok=2000/2000 median=0.841651s p90=1.158621s
   ```

The 24-concurrent case is the control. There the provider latency dominates and the loop has room, so the two sides are level, which is what a change that only frees event-loop time should look like. The gap appears once the loop is the constraint. Both sides answered 200 on every one of the 5400 completions

## Type

🚄 Infrastructure

## Caveats

- Freezing means env changes applied without a restart no longer reach new providers
- Previously they reached dynamic providers only, so the process ran half applied
- `ArizeLogger` overrides `_init_tracing`, so it keeps one extra build
- `arize_phoenix` and the OTEL v2 cache pay the same cost; noted on LIT-5437
- `weave_otel` reaches the changed path but no test drives it there
- Proof is throughput, not span content, so the sink is local rather than a real project

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/37542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit aa1d9c8564b21c91c93ea02886c7ca8e32ce4d7b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->