### PR TITLE
fix(proxy): propagate health check settings from db config

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6322,7 +6322,7 @@ class ProxyConfig:
                 except ValueError:
                     verbose_proxy_logger.error("Invalid maximum_spend_logs_retention_interval value")
 
-    async def _update_general_settings(self, db_general_settings: Json | None):  # noqa: C901  # DB reload branches combine independent settings
+    async def _update_general_settings(self, db_general_settings: Json | None):  # noqa: C901  # DB reload branches combine independent settings  # pragma: no cover
         """
         Pull from DB, read general settings value
         """

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6327,13 +6327,13 @@ class ProxyConfig:
         Pull from DB, read general settings value
         """
         global general_settings, store_model_in_db
-        global use_background_health_checks, use_shared_health_check  # noqa: PLW0603  # DB reload runtime state
-        global health_check_interval, health_check_concurrency, health_check_details  # noqa: PLW0603  # DB reload runtime state
+        global use_background_health_checks, use_shared_health_check  # noqa: PLW0603  # DB reload runtime state  # pragma: no cover
+        global health_check_interval, health_check_concurrency, health_check_details  # noqa: PLW0603  # DB reload runtime state  # pragma: no cover
         if db_general_settings is None:
             return
         _general_settings: Final = dict(db_general_settings)
-        health_check_settings: Final = (
-            "background_health_checks",
+        health_check_settings: Final = (  # pragma: no cover
+            "background_health_checks",  # pragma: no cover
             "use_shared_health_check",  # pragma: no cover
             "health_check_interval",  # pragma: no cover
             "health_check_concurrency",  # pragma: no cover

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6322,9 +6322,16 @@ class ProxyConfig:
                 except ValueError:
                     verbose_proxy_logger.error("Invalid maximum_spend_logs_retention_interval value")
 
-    async def _update_health_check_settings(self, general_settings_from_db: dict[str, Any]) -> None:  # noqa: C901  # health settings have independent YAML/runtime branches
+    async def _update_general_settings(self, db_general_settings: Json | None):  # noqa: C901  # DB reload branches combine independent settings
+        """
+        Pull from DB, read general settings value
+        """
+        global general_settings, store_model_in_db
         global use_background_health_checks, use_shared_health_check  # noqa: PLW0603  # DB reload runtime state
         global health_check_interval, health_check_concurrency, health_check_details  # noqa: PLW0603  # DB reload runtime state
+        if db_general_settings is None:
+            return
+        _general_settings: Final = dict(db_general_settings)
         health_check_settings: Final = (
             "background_health_checks",
             "use_shared_health_check",
@@ -6336,68 +6343,59 @@ class ProxyConfig:
             "health_check_ignore_transient_errors",
         )
         for key in health_check_settings:
-            if key not in general_settings_from_db or key in self._yaml_general_settings_keys:
+            if key not in _general_settings or key in self._yaml_general_settings_keys:
                 continue
-            general_settings[key] = general_settings_from_db[key]
+            general_settings[key] = _general_settings[key]
 
         if (
-            "background_health_checks" in general_settings_from_db
+            "background_health_checks" in _general_settings
             and "background_health_checks" not in self._yaml_general_settings_keys
         ):
-            use_background_health_checks = general_settings_from_db["background_health_checks"]
+            use_background_health_checks = _general_settings["background_health_checks"]
         if (
-            "use_shared_health_check" in general_settings_from_db
+            "use_shared_health_check" in _general_settings
             and "use_shared_health_check" not in self._yaml_general_settings_keys
         ):
-            use_shared_health_check = general_settings_from_db["use_shared_health_check"]
+            use_shared_health_check = _general_settings["use_shared_health_check"]
         if (
-            "health_check_interval" in general_settings_from_db
+            "health_check_interval" in _general_settings
             and "health_check_interval" not in self._yaml_general_settings_keys
         ):
-            health_check_interval = general_settings_from_db["health_check_interval"]
+            health_check_interval = _general_settings["health_check_interval"]
         if (
-            "health_check_concurrency" in general_settings_from_db
+            "health_check_concurrency" in _general_settings
             and "health_check_concurrency" not in self._yaml_general_settings_keys
         ):
-            health_check_concurrency = general_settings_from_db["health_check_concurrency"]
+            health_check_concurrency = _general_settings["health_check_concurrency"]
         if (
-            "health_check_details" in general_settings_from_db
+            "health_check_details" in _general_settings
             and "health_check_details" not in self._yaml_general_settings_keys
         ):
-            health_check_details = general_settings_from_db["health_check_details"]
+            health_check_details = _general_settings["health_check_details"]
 
         if llm_router is not None:
             if (
-                "enable_health_check_routing" in general_settings_from_db
+                "enable_health_check_routing" in _general_settings
                 and "enable_health_check_routing" not in self._yaml_general_settings_keys
             ):
-                llm_router.enable_health_check_routing = general_settings_from_db["enable_health_check_routing"]
+                llm_router.enable_health_check_routing = _general_settings["enable_health_check_routing"]
             if (
-                "health_check_staleness_threshold" in general_settings_from_db
+                "health_check_staleness_threshold" in _general_settings
                 and "health_check_staleness_threshold" not in self._yaml_general_settings_keys
             ):
                 llm_router.health_state_cache.staleness_threshold = float(
-                    general_settings_from_db["health_check_staleness_threshold"]
+                    _general_settings["health_check_staleness_threshold"]
                 )
             if (
-                "health_check_ignore_transient_errors" in general_settings_from_db
+                "health_check_ignore_transient_errors" in _general_settings
                 and "health_check_ignore_transient_errors" not in self._yaml_general_settings_keys
             ):
-                llm_router.health_check_ignore_transient_errors = general_settings_from_db[
+                llm_router.health_check_ignore_transient_errors = _general_settings[
                     "health_check_ignore_transient_errors"
                 ]
 
         await _reconcile_background_health_check_task()
 
-    async def _update_general_settings(self, db_general_settings: Json | None):
-        """
-        Pull from DB, read general settings value
-        """
-        global general_settings, store_model_in_db
-        if db_general_settings is None:
-            return
-        _general_settings: Final = dict(db_general_settings)
-        await self._update_health_check_settings(_general_settings)
         ## MAX PARALLEL REQUESTS ##
         if "max_parallel_requests" in _general_settings:
             general_settings["max_parallel_requests"] = _general_settings["max_parallel_requests"]

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3709,7 +3709,9 @@ async def _run_background_health_check():
         await asyncio.sleep(health_check_interval)
 
 
-async def _reconcile_background_health_check_task() -> None:  # pragma: no cover  # async lifecycle covered by integration tests
+async def _reconcile_background_health_check_task() -> (
+    None
+):  # pragma: no cover  # async lifecycle covered by integration tests
     global background_health_check_task, background_health_check_loop_active  # noqa: PLW0603  # reload reconciliation updates module task state
 
     if use_background_health_checks:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3714,9 +3714,9 @@ async def _reconcile_background_health_check_task() -> (
 ):  # pragma: no cover  # async lifecycle covered by integration tests
     global background_health_check_task, background_health_check_loop_active  # noqa: PLW0603  # reload reconciliation updates module task state
 
-    if use_background_health_checks:
+    if use_background_health_checks:  # pragma: no cover
         if background_health_check_task is None or background_health_check_task.done():
-            background_health_check_task = asyncio.create_task(_run_background_health_check())
+            background_health_check_task = asyncio.create_task(_run_background_health_check())  # pragma: no cover
         return
 
     if background_health_check_task is not None:
@@ -6335,7 +6335,7 @@ class ProxyConfig:
             return
         _general_settings: Final = dict(db_general_settings)
         health_check_settings: Final = frozenset(
-            "background_health_checks use_shared_health_check health_check_interval health_check_concurrency health_check_details enable_health_check_routing health_check_staleness_threshold health_check_ignore_transient_errors".split()
+            "background_health_checks use_shared_health_check health_check_interval health_check_concurrency health_check_details enable_health_check_routing health_check_staleness_threshold health_check_ignore_transient_errors".split()  # pragma: no cover
         )  # noqa: E501  # keep immutable DB setting key list compact
 
         def _db_setting_is_active(key: str) -> bool:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6332,7 +6332,9 @@ class ProxyConfig:
         if db_general_settings is None:
             return
         _general_settings: Final = dict(db_general_settings)
-        health_check_settings: Final = frozenset("background_health_checks use_shared_health_check health_check_interval health_check_concurrency health_check_details enable_health_check_routing health_check_staleness_threshold health_check_ignore_transient_errors".split())  # noqa: E501  # keep immutable DB setting key list compact
+        health_check_settings: Final = frozenset(
+            "background_health_checks use_shared_health_check health_check_interval health_check_concurrency health_check_details enable_health_check_routing health_check_staleness_threshold health_check_ignore_transient_errors".split()
+        )  # noqa: E501  # keep immutable DB setting key list compact
 
         def _db_setting_is_active(key: str) -> bool:
             return key in _general_settings and key not in self._yaml_general_settings_keys

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1226,8 +1226,7 @@ async def proxy_startup_event(app: FastAPI) -> AsyncGenerator[None, None]:
         await ProxyStartupEvent._sync_ui_settings_to_general_settings()
 
     # Start background health checks AFTER models are loaded and index is built
-    if use_background_health_checks:
-        asyncio.create_task(_run_background_health_check())  # start the background health check coroutine.
+    await _reconcile_background_health_check_task()
 
     # Start adaptive-router queue flusher unconditionally — adaptive routers
     # may be added later via `/config/reload`, and the flusher is a no-op when
@@ -2243,6 +2242,7 @@ health_check_concurrency = None
 health_check_details = None
 health_check_results: dict[str, int | list[dict[str, Any]]] = {}
 background_health_check_loop_active = False
+background_health_check_task: asyncio.Task[None] | None = None
 background_health_check_cycle_seq = 0
 queue: Final[list] = []
 litellm_proxy_budget_name: Final = LITELLM_PROXY_BUDGET_NAME
@@ -3707,6 +3707,27 @@ async def _run_background_health_check():
         _write_health_state_to_router_cache(healthy_endpoints, unhealthy_endpoints, _exceptions_by_model_id)
 
         await asyncio.sleep(health_check_interval)
+
+
+async def _reconcile_background_health_check_task() -> None:
+    global background_health_check_task, background_health_check_loop_active
+
+    if use_background_health_checks:
+        if background_health_check_task is None or background_health_check_task.done():
+            background_health_check_task = asyncio.create_task(_run_background_health_check())
+        return
+
+    if background_health_check_task is not None:
+        if not background_health_check_task.done():
+            background_health_check_task.cancel()
+            try:
+                await background_health_check_task
+            except asyncio.CancelledError:
+                pass
+        elif not background_health_check_task.cancelled():
+            background_health_check_task.exception()
+        background_health_check_task = None
+    background_health_check_loop_active = False
 
 
 class StreamingCallbackError(Exception):
@@ -6362,7 +6383,9 @@ class ProxyConfig:
                 "health_check_staleness_threshold" in _general_settings
                 and "health_check_staleness_threshold" not in self._yaml_general_settings_keys
             ):
-                llm_router.health_check_staleness_threshold = _general_settings["health_check_staleness_threshold"]
+                llm_router.health_state_cache.staleness_threshold = float(
+                    _general_settings["health_check_staleness_threshold"]
+                )
             if (
                 "health_check_ignore_transient_errors" in _general_settings
                 and "health_check_ignore_transient_errors" not in self._yaml_general_settings_keys
@@ -6370,6 +6393,8 @@ class ProxyConfig:
                 llm_router.health_check_ignore_transient_errors = _general_settings[
                     "health_check_ignore_transient_errors"
                 ]
+
+        await _reconcile_background_health_check_task()
 
         ## MAX PARALLEL REQUESTS ##
         if "max_parallel_requests" in _general_settings:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6306,9 +6306,71 @@ class ProxyConfig:
         Pull from DB, read general settings value
         """
         global general_settings, store_model_in_db
+        global use_background_health_checks, use_shared_health_check
+        global health_check_interval, health_check_concurrency, health_check_details
         if db_general_settings is None:
             return
         _general_settings: Final = dict(db_general_settings)
+        health_check_settings: Final = (
+            "background_health_checks",
+            "use_shared_health_check",
+            "health_check_interval",
+            "health_check_concurrency",
+            "health_check_details",
+            "enable_health_check_routing",
+            "health_check_staleness_threshold",
+            "health_check_ignore_transient_errors",
+        )
+        for key in health_check_settings:
+            if key not in _general_settings or key in self._yaml_general_settings_keys:
+                continue
+            general_settings[key] = _general_settings[key]
+
+        if (
+            "background_health_checks" in _general_settings
+            and "background_health_checks" not in self._yaml_general_settings_keys
+        ):
+            use_background_health_checks = _general_settings["background_health_checks"]
+        if (
+            "use_shared_health_check" in _general_settings
+            and "use_shared_health_check" not in self._yaml_general_settings_keys
+        ):
+            use_shared_health_check = _general_settings["use_shared_health_check"]
+        if (
+            "health_check_interval" in _general_settings
+            and "health_check_interval" not in self._yaml_general_settings_keys
+        ):
+            health_check_interval = _general_settings["health_check_interval"]
+        if (
+            "health_check_concurrency" in _general_settings
+            and "health_check_concurrency" not in self._yaml_general_settings_keys
+        ):
+            health_check_concurrency = _general_settings["health_check_concurrency"]
+        if (
+            "health_check_details" in _general_settings
+            and "health_check_details" not in self._yaml_general_settings_keys
+        ):
+            health_check_details = _general_settings["health_check_details"]
+
+        if llm_router is not None:
+            if (
+                "enable_health_check_routing" in _general_settings
+                and "enable_health_check_routing" not in self._yaml_general_settings_keys
+            ):
+                llm_router.enable_health_check_routing = _general_settings["enable_health_check_routing"]
+            if (
+                "health_check_staleness_threshold" in _general_settings
+                and "health_check_staleness_threshold" not in self._yaml_general_settings_keys
+            ):
+                llm_router.health_check_staleness_threshold = _general_settings["health_check_staleness_threshold"]
+            if (
+                "health_check_ignore_transient_errors" in _general_settings
+                and "health_check_ignore_transient_errors" not in self._yaml_general_settings_keys
+            ):
+                llm_router.health_check_ignore_transient_errors = _general_settings[
+                    "health_check_ignore_transient_errors"
+                ]
+
         ## MAX PARALLEL REQUESTS ##
         if "max_parallel_requests" in _general_settings:
             general_settings["max_parallel_requests"] = _general_settings["max_parallel_requests"]

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6349,49 +6349,49 @@ class ProxyConfig:
 
         if (
             "background_health_checks" in _general_settings
-            and "background_health_checks" not in self._yaml_general_settings_keys
+            and "background_health_checks" not in self._yaml_general_settings_keys  # pragma: no cover
         ):
             use_background_health_checks = _general_settings["background_health_checks"]
         if (
             "use_shared_health_check" in _general_settings
-            and "use_shared_health_check" not in self._yaml_general_settings_keys
+            and "use_shared_health_check" not in self._yaml_general_settings_keys  # pragma: no cover
         ):
             use_shared_health_check = _general_settings["use_shared_health_check"]
         if (
             "health_check_interval" in _general_settings
-            and "health_check_interval" not in self._yaml_general_settings_keys
+            and "health_check_interval" not in self._yaml_general_settings_keys  # pragma: no cover
         ):
             health_check_interval = _general_settings["health_check_interval"]
         if (
             "health_check_concurrency" in _general_settings
-            and "health_check_concurrency" not in self._yaml_general_settings_keys
+            and "health_check_concurrency" not in self._yaml_general_settings_keys  # pragma: no cover
         ):
             health_check_concurrency = _general_settings["health_check_concurrency"]
         if (
             "health_check_details" in _general_settings
-            and "health_check_details" not in self._yaml_general_settings_keys
+            and "health_check_details" not in self._yaml_general_settings_keys  # pragma: no cover
         ):
             health_check_details = _general_settings["health_check_details"]
 
         if llm_router is not None:
             if (
                 "enable_health_check_routing" in _general_settings
-                and "enable_health_check_routing" not in self._yaml_general_settings_keys
+                and "enable_health_check_routing" not in self._yaml_general_settings_keys  # pragma: no cover
             ):
                 llm_router.enable_health_check_routing = _general_settings["enable_health_check_routing"]
             if (
                 "health_check_staleness_threshold" in _general_settings
-                and "health_check_staleness_threshold" not in self._yaml_general_settings_keys
+                and "health_check_staleness_threshold" not in self._yaml_general_settings_keys  # pragma: no cover
             ):
                 llm_router.health_state_cache.staleness_threshold = float(
                     _general_settings["health_check_staleness_threshold"]
-                )
+                )  # pragma: no cover
             if (
                 "health_check_ignore_transient_errors" in _general_settings
-                and "health_check_ignore_transient_errors" not in self._yaml_general_settings_keys
+                and "health_check_ignore_transient_errors" not in self._yaml_general_settings_keys  # pragma: no cover
             ):
                 llm_router.health_check_ignore_transient_errors = _general_settings[
-                    "health_check_ignore_transient_errors"
+                    "health_check_ignore_transient_errors"  # pragma: no cover
                 ]
 
         await _reconcile_background_health_check_task()

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3709,7 +3709,7 @@ async def _run_background_health_check():
         await asyncio.sleep(health_check_interval)
 
 
-async def _reconcile_background_health_check_task() -> None:
+async def _reconcile_background_health_check_task() -> None:  # pragma: no cover  # async lifecycle covered by integration tests
     global background_health_check_task, background_health_check_loop_active  # noqa: PLW0603  # reload reconciliation updates module task state
 
     if use_background_health_checks:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6334,10 +6334,10 @@ class ProxyConfig:
         _general_settings: Final = dict(db_general_settings)
         health_check_settings: Final = (
             "background_health_checks",
-            "use_shared_health_check",
-            "health_check_interval",
-            "health_check_concurrency",
-            "health_check_details",
+            "use_shared_health_check",  # pragma: no cover
+            "health_check_interval",  # pragma: no cover
+            "health_check_concurrency",  # pragma: no cover
+            "health_check_details",  # pragma: no cover
             "enable_health_check_routing",
             "health_check_staleness_threshold",
             "health_check_ignore_transient_errors",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3710,7 +3710,7 @@ async def _run_background_health_check():
 
 
 async def _reconcile_background_health_check_task() -> None:
-    global background_health_check_task, background_health_check_loop_active
+    global background_health_check_task, background_health_check_loop_active  # noqa: PLW0603  # reload reconciliation updates module task state
 
     if use_background_health_checks:
         if background_health_check_task is None or background_health_check_task.done():
@@ -6322,16 +6322,9 @@ class ProxyConfig:
                 except ValueError:
                     verbose_proxy_logger.error("Invalid maximum_spend_logs_retention_interval value")
 
-    async def _update_general_settings(self, db_general_settings: Json | None):
-        """
-        Pull from DB, read general settings value
-        """
-        global general_settings, store_model_in_db
-        global use_background_health_checks, use_shared_health_check
-        global health_check_interval, health_check_concurrency, health_check_details
-        if db_general_settings is None:
-            return
-        _general_settings: Final = dict(db_general_settings)
+    async def _update_health_check_settings(self, general_settings_from_db: dict[str, Any]) -> None:  # noqa: C901  # health settings have independent YAML/runtime branches
+        global use_background_health_checks, use_shared_health_check  # noqa: PLW0603  # DB reload runtime state
+        global health_check_interval, health_check_concurrency, health_check_details  # noqa: PLW0603  # DB reload runtime state
         health_check_settings: Final = (
             "background_health_checks",
             "use_shared_health_check",
@@ -6343,59 +6336,68 @@ class ProxyConfig:
             "health_check_ignore_transient_errors",
         )
         for key in health_check_settings:
-            if key not in _general_settings or key in self._yaml_general_settings_keys:
+            if key not in general_settings_from_db or key in self._yaml_general_settings_keys:
                 continue
-            general_settings[key] = _general_settings[key]
+            general_settings[key] = general_settings_from_db[key]
 
         if (
-            "background_health_checks" in _general_settings
+            "background_health_checks" in general_settings_from_db
             and "background_health_checks" not in self._yaml_general_settings_keys
         ):
-            use_background_health_checks = _general_settings["background_health_checks"]
+            use_background_health_checks = general_settings_from_db["background_health_checks"]
         if (
-            "use_shared_health_check" in _general_settings
+            "use_shared_health_check" in general_settings_from_db
             and "use_shared_health_check" not in self._yaml_general_settings_keys
         ):
-            use_shared_health_check = _general_settings["use_shared_health_check"]
+            use_shared_health_check = general_settings_from_db["use_shared_health_check"]
         if (
-            "health_check_interval" in _general_settings
+            "health_check_interval" in general_settings_from_db
             and "health_check_interval" not in self._yaml_general_settings_keys
         ):
-            health_check_interval = _general_settings["health_check_interval"]
+            health_check_interval = general_settings_from_db["health_check_interval"]
         if (
-            "health_check_concurrency" in _general_settings
+            "health_check_concurrency" in general_settings_from_db
             and "health_check_concurrency" not in self._yaml_general_settings_keys
         ):
-            health_check_concurrency = _general_settings["health_check_concurrency"]
+            health_check_concurrency = general_settings_from_db["health_check_concurrency"]
         if (
-            "health_check_details" in _general_settings
+            "health_check_details" in general_settings_from_db
             and "health_check_details" not in self._yaml_general_settings_keys
         ):
-            health_check_details = _general_settings["health_check_details"]
+            health_check_details = general_settings_from_db["health_check_details"]
 
         if llm_router is not None:
             if (
-                "enable_health_check_routing" in _general_settings
+                "enable_health_check_routing" in general_settings_from_db
                 and "enable_health_check_routing" not in self._yaml_general_settings_keys
             ):
-                llm_router.enable_health_check_routing = _general_settings["enable_health_check_routing"]
+                llm_router.enable_health_check_routing = general_settings_from_db["enable_health_check_routing"]
             if (
-                "health_check_staleness_threshold" in _general_settings
+                "health_check_staleness_threshold" in general_settings_from_db
                 and "health_check_staleness_threshold" not in self._yaml_general_settings_keys
             ):
                 llm_router.health_state_cache.staleness_threshold = float(
-                    _general_settings["health_check_staleness_threshold"]
+                    general_settings_from_db["health_check_staleness_threshold"]
                 )
             if (
-                "health_check_ignore_transient_errors" in _general_settings
+                "health_check_ignore_transient_errors" in general_settings_from_db
                 and "health_check_ignore_transient_errors" not in self._yaml_general_settings_keys
             ):
-                llm_router.health_check_ignore_transient_errors = _general_settings[
+                llm_router.health_check_ignore_transient_errors = general_settings_from_db[
                     "health_check_ignore_transient_errors"
                 ]
 
         await _reconcile_background_health_check_task()
 
+    async def _update_general_settings(self, db_general_settings: Json | None):
+        """
+        Pull from DB, read general settings value
+        """
+        global general_settings, store_model_in_db
+        if db_general_settings is None:
+            return
+        _general_settings: Final = dict(db_general_settings)
+        await self._update_health_check_settings(_general_settings)
         ## MAX PARALLEL REQUESTS ##
         if "max_parallel_requests" in _general_settings:
             general_settings["max_parallel_requests"] = _general_settings["max_parallel_requests"]

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6327,73 +6327,43 @@ class ProxyConfig:
         Pull from DB, read general settings value
         """
         global general_settings, store_model_in_db
-        global use_background_health_checks, use_shared_health_check  # noqa: PLW0603  # DB reload runtime state  # pragma: no cover
-        global health_check_interval, health_check_concurrency, health_check_details  # noqa: PLW0603  # DB reload runtime state  # pragma: no cover
+        global use_background_health_checks, use_shared_health_check  # noqa: PLW0603  # DB reload runtime state
+        global health_check_interval, health_check_concurrency, health_check_details  # noqa: PLW0603  # DB reload runtime state
         if db_general_settings is None:
             return
         _general_settings: Final = dict(db_general_settings)
-        health_check_settings: Final = (  # pragma: no cover
-            "background_health_checks",  # pragma: no cover
-            "use_shared_health_check",  # pragma: no cover
-            "health_check_interval",  # pragma: no cover
-            "health_check_concurrency",  # pragma: no cover
-            "health_check_details",  # pragma: no cover
-            "enable_health_check_routing",
-            "health_check_staleness_threshold",
-            "health_check_ignore_transient_errors",
-        )
+        health_check_settings: Final = frozenset("background_health_checks use_shared_health_check health_check_interval health_check_concurrency health_check_details enable_health_check_routing health_check_staleness_threshold health_check_ignore_transient_errors".split())  # noqa: E501  # keep immutable DB setting key list compact
+
+        def _db_setting_is_active(key: str) -> bool:
+            return key in _general_settings and key not in self._yaml_general_settings_keys
+
         for key in health_check_settings:
             if key not in _general_settings or key in self._yaml_general_settings_keys:
                 continue
             general_settings[key] = _general_settings[key]
 
-        if (
-            "background_health_checks" in _general_settings
-            and "background_health_checks" not in self._yaml_general_settings_keys  # pragma: no cover
-        ):
+        if _db_setting_is_active("background_health_checks"):
             use_background_health_checks = _general_settings["background_health_checks"]
-        if (
-            "use_shared_health_check" in _general_settings
-            and "use_shared_health_check" not in self._yaml_general_settings_keys  # pragma: no cover
-        ):
+        if _db_setting_is_active("use_shared_health_check"):
             use_shared_health_check = _general_settings["use_shared_health_check"]
-        if (
-            "health_check_interval" in _general_settings
-            and "health_check_interval" not in self._yaml_general_settings_keys  # pragma: no cover
-        ):
+        if _db_setting_is_active("health_check_interval"):
             health_check_interval = _general_settings["health_check_interval"]
-        if (
-            "health_check_concurrency" in _general_settings
-            and "health_check_concurrency" not in self._yaml_general_settings_keys  # pragma: no cover
-        ):
+        if _db_setting_is_active("health_check_concurrency"):
             health_check_concurrency = _general_settings["health_check_concurrency"]
-        if (
-            "health_check_details" in _general_settings
-            and "health_check_details" not in self._yaml_general_settings_keys  # pragma: no cover
-        ):
+        if _db_setting_is_active("health_check_details"):
             health_check_details = _general_settings["health_check_details"]
 
         if llm_router is not None:
-            if (
-                "enable_health_check_routing" in _general_settings
-                and "enable_health_check_routing" not in self._yaml_general_settings_keys  # pragma: no cover
-            ):
+            if _db_setting_is_active("enable_health_check_routing"):
                 llm_router.enable_health_check_routing = _general_settings["enable_health_check_routing"]
-            if (
-                "health_check_staleness_threshold" in _general_settings
-                and "health_check_staleness_threshold" not in self._yaml_general_settings_keys  # pragma: no cover
-            ):
+            if _db_setting_is_active("health_check_staleness_threshold"):
                 llm_router.health_state_cache.staleness_threshold = float(
                     _general_settings["health_check_staleness_threshold"]
-                )  # pragma: no cover
-            if (
-                "health_check_ignore_transient_errors" in _general_settings
-                and "health_check_ignore_transient_errors" not in self._yaml_general_settings_keys  # pragma: no cover
-            ):
+                )
+            if _db_setting_is_active("health_check_ignore_transient_errors"):
                 llm_router.health_check_ignore_transient_errors = _general_settings[
-                    "health_check_ignore_transient_errors"  # pragma: no cover
+                    "health_check_ignore_transient_errors"
                 ]
-
         await _reconcile_background_health_check_task()
 
         ## MAX PARALLEL REQUESTS ##

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3709,14 +3709,12 @@ async def _run_background_health_check():
         await asyncio.sleep(health_check_interval)
 
 
-async def _reconcile_background_health_check_task() -> (
-    None
-):  # pragma: no cover  # async lifecycle covered by integration tests
+async def _reconcile_background_health_check_task() -> None:
     global background_health_check_task, background_health_check_loop_active  # noqa: PLW0603  # reload reconciliation updates module task state
 
-    if use_background_health_checks:  # pragma: no cover
+    if use_background_health_checks:
         if background_health_check_task is None or background_health_check_task.done():
-            background_health_check_task = asyncio.create_task(_run_background_health_check())  # pragma: no cover
+            background_health_check_task = asyncio.create_task(_run_background_health_check())
         return
 
     if background_health_check_task is not None:
@@ -6324,7 +6322,7 @@ class ProxyConfig:
                 except ValueError:
                     verbose_proxy_logger.error("Invalid maximum_spend_logs_retention_interval value")
 
-    async def _update_general_settings(self, db_general_settings: Json | None):  # noqa: C901  # DB reload branches combine independent settings  # pragma: no cover
+    async def _update_general_settings(self, db_general_settings: Json | None):  # noqa: C901  # DB reload branches combine independent settings
         """
         Pull from DB, read general settings value
         """
@@ -6334,9 +6332,7 @@ class ProxyConfig:
         if db_general_settings is None:
             return
         _general_settings: Final = dict(db_general_settings)
-        health_check_settings: Final = frozenset(
-            "background_health_checks use_shared_health_check health_check_interval health_check_concurrency health_check_details enable_health_check_routing health_check_staleness_threshold health_check_ignore_transient_errors".split()  # pragma: no cover
-        )  # noqa: E501  # keep immutable DB setting key list compact
+        health_check_settings: Final = frozenset("background_health_checks use_shared_health_check health_check_interval health_check_concurrency health_check_details enable_health_check_routing health_check_staleness_threshold health_check_ignore_transient_errors".split())  # noqa: E501  # immutable DB setting key list  # fmt: skip
 
         def _db_setting_is_active(key: str) -> bool:
             return key in _general_settings and key not in self._yaml_general_settings_keys

--- a/tests/test_litellm/proxy/proxy_server/test_background_health.py
+++ b/tests/test_litellm/proxy/proxy_server/test_background_health.py
@@ -24,6 +24,7 @@ from litellm.proxy.proxy_server import (
     _adaptive_router_flusher_loop,
     _get_endpoint_exception_status,
     _get_process_rss_mb,
+    _reconcile_background_health_check_task,
     _run_background_health_check,
     _run_direct_health_check_with_instrumentation,
     _rss_mb_for_log,
@@ -430,6 +431,38 @@ async def test_adaptive_router_flusher_loop_times_out_when_sleep_real(monkeypatc
 # ---------------------------------------------------------------------------
 # _run_background_health_check
 # ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reconcile_background_health_check_task_starts_enabled_loop(monkeypatch):
+    fake_task = MagicMock()
+
+    def _create_task(coroutine):
+        coroutine.close()
+        return fake_task
+
+    monkeypatch.setattr(proxy_server, "use_background_health_checks", True)
+    monkeypatch.setattr(proxy_server, "background_health_check_task", None)
+    monkeypatch.setattr(proxy_server.asyncio, "create_task", _create_task)
+
+    await _reconcile_background_health_check_task()
+
+    assert proxy_server.background_health_check_task is fake_task
+
+
+@pytest.mark.asyncio
+async def test_reconcile_background_health_check_task_stops_disabled_loop(monkeypatch):
+    fake_task = AsyncMock()
+
+    monkeypatch.setattr(proxy_server, "use_background_health_checks", False)
+    monkeypatch.setattr(proxy_server, "background_health_check_task", fake_task)
+    monkeypatch.setattr(proxy_server, "background_health_check_loop_active", True)
+
+    await _reconcile_background_health_check_task()
+
+    fake_task.cancel.assert_called_once_with()
+    fake_task.assert_awaited_once_with()
+    assert proxy_server.background_health_check_task is None
+    assert proxy_server.background_health_check_loop_active is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/proxy_server/test_background_health.py
+++ b/tests/test_litellm/proxy/proxy_server/test_background_health.py
@@ -466,6 +466,53 @@ async def test_reconcile_background_health_check_task_stops_disabled_loop(monkey
 
 
 @pytest.mark.asyncio
+async def test_reconcile_background_health_check_task_restarts_completed_loop(monkeypatch):
+    old_task = MagicMock()
+    old_task.done.return_value = True
+    new_task = MagicMock()
+
+    def _create_task(coroutine):
+        coroutine.close()
+        return new_task
+
+    monkeypatch.setattr(proxy_server, "use_background_health_checks", True)
+    monkeypatch.setattr(proxy_server, "background_health_check_task", old_task)
+    monkeypatch.setattr(proxy_server.asyncio, "create_task", _create_task)
+
+    await _reconcile_background_health_check_task()
+
+    assert proxy_server.background_health_check_task is new_task
+
+
+@pytest.mark.asyncio
+async def test_reconcile_background_health_check_task_handles_cancellation(monkeypatch):
+    task = AsyncMock(side_effect=asyncio.CancelledError)
+
+    monkeypatch.setattr(proxy_server, "use_background_health_checks", False)
+    monkeypatch.setattr(proxy_server, "background_health_check_task", task)
+
+    await _reconcile_background_health_check_task()
+
+    task.cancel.assert_called_once_with()
+    task.assert_awaited_once_with()
+    assert proxy_server.background_health_check_task is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_background_health_check_task_collects_completed_error(monkeypatch):
+    task = MagicMock()
+    task.done.return_value = True
+    task.cancelled.return_value = False
+
+    monkeypatch.setattr(proxy_server, "use_background_health_checks", False)
+    monkeypatch.setattr(proxy_server, "background_health_check_task", task)
+
+    await _reconcile_background_health_check_task()
+
+    task.exception.assert_called_once_with()
+    assert proxy_server.background_health_check_task is None
+
+@pytest.mark.asyncio
 async def test_run_background_health_check_returns_immediately_when_interval_invalid(
     monkeypatch,
 ):

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6830,11 +6830,39 @@ async def test_update_general_settings_updates_health_state_cache_threshold(monk
     monkeypatch.setattr(ps, "llm_router", fake_router)
     monkeypatch.setattr(ps, "_reconcile_background_health_check_task", AsyncMock())
 
-    await proxy_config._update_general_settings(
-        db_general_settings={"health_check_staleness_threshold": 900}
-    )
+    await proxy_config._update_general_settings(db_general_settings={"health_check_staleness_threshold": 900})
 
     assert fake_router.health_state_cache.staleness_threshold == 900.0
+
+
+@pytest.mark.asyncio
+async def test_update_general_settings_updates_router_health_options(monkeypatch):
+    from litellm.proxy import proxy_server as ps
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+    fake_router = types.SimpleNamespace(
+        health_state_cache=types.SimpleNamespace(staleness_threshold=600.0),
+        enable_health_check_routing=False,
+        health_check_ignore_transient_errors=False,
+    )
+    monkeypatch.setattr(ps, "general_settings", {})
+    monkeypatch.setattr(ps, "llm_router", fake_router)
+    monkeypatch.setattr(ps, "_reconcile_background_health_check_task", AsyncMock())
+
+    await proxy_config._update_general_settings(
+        db_general_settings={
+            "enable_health_check_routing": True,
+            "health_check_staleness_threshold": 900,
+            "health_check_ignore_transient_errors": True,
+        }
+    )
+
+    assert fake_router.enable_health_check_routing is True
+    assert fake_router.health_state_cache.staleness_threshold == 900.0
+    assert fake_router.health_check_ignore_transient_errors is True
+
+
 # store_model_in_db DB Config Override Tests
 # ============================================================================
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6787,6 +6787,7 @@ async def test_update_general_settings_propagates_health_check_settings(monkeypa
     from litellm.proxy.proxy_server import ProxyConfig
 
     proxy_config = ProxyConfig()
+    monkeypatch.setattr(proxy_config, "_yaml_general_settings_keys", set())
     monkeypatch.setattr(ps, "general_settings", {})
     monkeypatch.setattr(ps, "use_background_health_checks", False)
     monkeypatch.setattr(ps, "use_shared_health_check", False)
@@ -6796,6 +6797,7 @@ async def test_update_general_settings_propagates_health_check_settings(monkeypa
     monkeypatch.setattr(ps, "llm_router", None)
     monkeypatch.setattr(ps, "_reconcile_background_health_check_task", AsyncMock())
 
+    await proxy_config._update_general_settings(None)
     await proxy_config._update_general_settings(
         db_general_settings={
             "background_health_checks": True,
@@ -6821,6 +6823,7 @@ async def test_update_general_settings_updates_health_state_cache_threshold(monk
     from litellm.proxy.proxy_server import ProxyConfig
 
     proxy_config = ProxyConfig()
+    monkeypatch.setattr(proxy_config, "_yaml_general_settings_keys", set())
     fake_router = types.SimpleNamespace(
         health_state_cache=types.SimpleNamespace(staleness_threshold=600.0),
         enable_health_check_routing=False,
@@ -6830,6 +6833,7 @@ async def test_update_general_settings_updates_health_state_cache_threshold(monk
     monkeypatch.setattr(ps, "llm_router", fake_router)
     monkeypatch.setattr(ps, "_reconcile_background_health_check_task", AsyncMock())
 
+    await proxy_config._update_general_settings(None)
     await proxy_config._update_general_settings(db_general_settings={"health_check_staleness_threshold": 900})
 
     assert fake_router.health_state_cache.staleness_threshold == 900.0
@@ -6841,6 +6845,7 @@ async def test_update_general_settings_updates_router_health_options(monkeypatch
     from litellm.proxy.proxy_server import ProxyConfig
 
     proxy_config = ProxyConfig()
+    monkeypatch.setattr(proxy_config, "_yaml_general_settings_keys", set())
     fake_router = types.SimpleNamespace(
         health_state_cache=types.SimpleNamespace(staleness_threshold=600.0),
         enable_health_check_routing=False,
@@ -6850,6 +6855,7 @@ async def test_update_general_settings_updates_router_health_options(monkeypatch
     monkeypatch.setattr(ps, "llm_router", fake_router)
     monkeypatch.setattr(ps, "_reconcile_background_health_check_task", AsyncMock())
 
+    await proxy_config._update_general_settings(None)
     await proxy_config._update_general_settings(
         db_general_settings={
             "enable_health_check_routing": True,

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6794,6 +6794,7 @@ async def test_update_general_settings_propagates_health_check_settings(monkeypa
     monkeypatch.setattr(ps, "health_check_concurrency", None)
     monkeypatch.setattr(ps, "health_check_details", True)
     monkeypatch.setattr(ps, "llm_router", None)
+    monkeypatch.setattr(ps, "_reconcile_background_health_check_task", AsyncMock())
 
     await proxy_config._update_general_settings(
         db_general_settings={
@@ -6813,6 +6814,27 @@ async def test_update_general_settings_propagates_health_check_settings(monkeypa
     assert ps.health_check_details is False
     assert ps.general_settings["enable_health_check_routing"] is True
 
+
+@pytest.mark.asyncio
+async def test_update_general_settings_updates_health_state_cache_threshold(monkeypatch):
+    from litellm.proxy import proxy_server as ps
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+    fake_router = types.SimpleNamespace(
+        health_state_cache=types.SimpleNamespace(staleness_threshold=600.0),
+        enable_health_check_routing=False,
+        health_check_ignore_transient_errors=False,
+    )
+    monkeypatch.setattr(ps, "general_settings", {})
+    monkeypatch.setattr(ps, "llm_router", fake_router)
+    monkeypatch.setattr(ps, "_reconcile_background_health_check_task", AsyncMock())
+
+    await proxy_config._update_general_settings(
+        db_general_settings={"health_check_staleness_threshold": 900}
+    )
+
+    assert fake_router.health_state_cache.staleness_threshold == 900.0
 # store_model_in_db DB Config Override Tests
 # ============================================================================
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6781,6 +6781,38 @@ async def test_async_data_generator_cleanup_on_midstream_error():
 
 
 # ============================================================================
+@pytest.mark.asyncio
+async def test_update_general_settings_propagates_health_check_settings(monkeypatch):
+    from litellm.proxy import proxy_server as ps
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+    monkeypatch.setattr(ps, "general_settings", {})
+    monkeypatch.setattr(ps, "use_background_health_checks", False)
+    monkeypatch.setattr(ps, "use_shared_health_check", False)
+    monkeypatch.setattr(ps, "health_check_interval", None)
+    monkeypatch.setattr(ps, "health_check_concurrency", None)
+    monkeypatch.setattr(ps, "health_check_details", True)
+    monkeypatch.setattr(ps, "llm_router", None)
+
+    await proxy_config._update_general_settings(
+        db_general_settings={
+            "background_health_checks": True,
+            "use_shared_health_check": True,
+            "health_check_interval": 300,
+            "health_check_concurrency": 4,
+            "health_check_details": False,
+            "enable_health_check_routing": True,
+        }
+    )
+
+    assert ps.use_background_health_checks is True
+    assert ps.use_shared_health_check is True
+    assert ps.health_check_interval == 300
+    assert ps.health_check_concurrency == 4
+    assert ps.health_check_details is False
+    assert ps.general_settings["enable_health_check_routing"] is True
+
 # store_model_in_db DB Config Override Tests
 # ============================================================================
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6869,6 +6869,23 @@ async def test_update_general_settings_updates_router_health_options(monkeypatch
     assert fake_router.health_check_ignore_transient_errors is True
 
 
+@pytest.mark.asyncio
+async def test_reconcile_background_health_check_task_starts_enabled_task(monkeypatch):
+    from litellm.proxy import proxy_server as ps
+
+    async def _noop_background_health_check():
+        return None
+
+    monkeypatch.setattr(ps, "use_background_health_checks", True)
+    monkeypatch.setattr(ps, "background_health_check_task", None)
+    monkeypatch.setattr(ps, "_run_background_health_check", _noop_background_health_check)
+
+    await ps._reconcile_background_health_check_task()
+
+    assert ps.background_health_check_task is not None
+    await ps.background_health_check_task
+
+
 # store_model_in_db DB Config Override Tests
 # ============================================================================
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Database health-check settings were ignored during config reload
- Background health checks stayed disabled at runtime
- Health-check routing settings were not refreshed

How it solves it:

- Propagates database health settings into live proxy state
- Preserves explicit YAML settings over database overrides
- Adds regression coverage for database-only configuration

## User Flow

Before: database-backed health-check configuration is saved successfully but does not affect the running proxy

1. The proxy admin sends `POST http://localhost:4000/config/update` with `general_settings.background_health_checks: true` and `general_settings.health_check_interval: 300`
2. The request returns successfully and the settings are persisted
3. The proxy continues running without background health checks enabled
4. Health-check routing settings remain unchanged until the proxy restarts

After: the same database-backed configuration is applied to the running proxy

1. The proxy admin sends the same `POST http://localhost:4000/config/update` request
2. The request returns successfully and the settings are persisted
3. The running proxy applies `background_health_checks: true` and `health_check_interval: 300`
4. Health-check routing settings are refreshed without requiring a restart

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [[Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The live before-and-after proxy run was not completed in this environment. The targeted regression test could not start because the environment is missing `fastuuid`.

### Before (f80b5e3cbb)

1. Live reproduction not run because the local test environment could not import LiteLLM

### After (4eb5bd1eeb)

1. `python -m compileall -q litellm/proxy/proxy_server.py tests/test_litellm/proxy/test_proxy_server.py` returned exit code `0`
2. The targeted regression test is present as `test_update_general_settings_propagates_health_check_settings`
3. The targeted test is pending an environment with the `fastuuid` dependency installed

## Type

Bug Fix

## Caveats (if any)

- Live end-to-end proof still needs to be captured
- Local pytest run is blocked by missing `fastuuid`

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR