### PR TITLE
fix(ui): toggle unlimited budget when its text is clicked

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/user_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/user_edit_view.test.tsx
@@ -231,8 +231,23 @@ describe("UserEditView", () => {
     renderWithProviders(<UserEditView {...defaultProps} />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Unlimited Budget")).toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: "Unlimited Budget" })).toBeInTheDocument();
     });
+  });
+
+  it("should check unlimited budget when clicking its visible text", async () => {
+    renderWithProviders(<UserEditView {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("spinbutton", { name: /max budget/i })).toBeEnabled();
+    });
+
+    await userEvent.click(screen.getByText("Unlimited Budget"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("checkbox", { name: "Unlimited Budget" })).toBeChecked();
+    });
+    expect(screen.getByRole("spinbutton", { name: /max budget/i })).toBeDisabled();
   });
 
   it("should set unlimited budget checkbox when max_budget is null", async () => {
@@ -247,7 +262,7 @@ describe("UserEditView", () => {
     renderWithProviders(<UserEditView {...defaultProps} userData={userDataWithNullBudget} />);
 
     await waitFor(() => {
-      const checkbox = screen.getByLabelText("Unlimited Budget");
+      const checkbox = screen.getByRole("checkbox", { name: "Unlimited Budget" });
       expect(checkbox).toBeChecked();
     });
   });
@@ -282,10 +297,10 @@ describe("UserEditView", () => {
     renderWithProviders(<UserEditView {...defaultProps} />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Unlimited Budget")).toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: "Unlimited Budget" })).toBeInTheDocument();
     });
 
-    const checkbox = screen.getByLabelText("Unlimited Budget");
+    const checkbox = screen.getByRole("checkbox", { name: "Unlimited Budget" });
     await userEvent.click(checkbox);
 
     await waitFor(() => {
@@ -400,7 +415,7 @@ describe("UserEditView", () => {
     const budgetInput = screen.getByRole("spinbutton", { name: /max budget/i });
     await userEvent.clear(budgetInput);
 
-    const checkbox = screen.getByLabelText("Unlimited Budget");
+    const checkbox = screen.getByRole("checkbox", { name: "Unlimited Budget" });
     expect(checkbox).not.toBeChecked();
 
     const submitButton = screen.getByRole("button", { name: /save changes/i });
@@ -416,10 +431,10 @@ describe("UserEditView", () => {
     renderWithProviders(<UserEditView {...defaultProps} onSubmit={onSubmitMock} />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Unlimited Budget")).toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: "Unlimited Budget" })).toBeInTheDocument();
     });
 
-    const checkbox = screen.getByLabelText("Unlimited Budget");
+    const checkbox = screen.getByRole("checkbox", { name: "Unlimited Budget" });
     await userEvent.click(checkbox);
 
     await waitFor(() => {
@@ -494,7 +509,7 @@ describe("UserEditView", () => {
     renderWithProviders(<UserEditView {...defaultProps} userData={userDataWithUndefinedBudget} />);
 
     await waitFor(() => {
-      const checkbox = screen.getByLabelText("Unlimited Budget");
+      const checkbox = screen.getByRole("checkbox", { name: "Unlimited Budget" });
       expect(checkbox).toBeChecked();
     });
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/user_edit_view.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/user_edit_view.tsx
@@ -256,14 +256,10 @@ export function UserEditView({
             label={
               <>
                 Max Budget (USD)
-                <span className="ml-3 inline-flex items-center gap-2 font-normal">
-                  <Checkbox
-                    aria-label="Unlimited Budget"
-                    checked={unlimitedBudget}
-                    onCheckedChange={handleUnlimitedBudgetChange}
-                  />
+                <label className="ml-3 inline-flex items-center gap-2 font-normal">
+                  <Checkbox checked={unlimitedBudget} onCheckedChange={handleUnlimitedBudgetChange} />
                   Unlimited Budget
-                </span>
+                </label>
               </>
             }
           >


### PR DESCRIPTION
## TLDR

Problem this solves:

- Clicking "Unlimited Budget" text no longer ticks the box
- It focuses the Max Budget input instead
- Regression from the antd to react-hook-form port

How it solves it:

- Wrap the checkbox and its text in their own label
- Outer field label still points at the number input

## User Flow

Before: an admin editing a user cannot turn off that user's budget cap by clicking the words next to the box

1. They open http://localhost:4000/ui/?page=users and click a user, then Edit
2. They click the words "Unlimited Budget" next to the checkbox
3. The box stays unticked, the cursor lands in the Max Budget field, and saving keeps the old cap
4. Only a click on the small square itself, roughly 16px wide, ticks the box

After: clicking the words works, so the admin removes the cap the way the rest of the form behaves

1. They open http://localhost:4000/ui/?page=users and click a user, then Edit
2. They click the words "Unlimited Budget" next to the checkbox
3. The box ticks, Max Budget clears and greys out, and saving stores the user with no budget cap
4. Clicking the square itself still works the same as before

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (3f2e0badb4)

### After (f3ea6b80e8)

## Type

🐛 Bug Fix

## Caveats (if any)

- Nested label, same shape antd rendered before

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
