### PR TITLE
fix(ui): clear pass-through header rows when the create modal is reopened

### DIFF
--- a/ui/litellm-dashboard/src/components/add_pass_through.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_pass_through.integration.test.tsx
@@ -34,19 +34,58 @@ const openModal = async (user: User) => {
   await screen.findByText("Route Configuration");
 };
 
-const fillRequiredFields = async (user: User) => {
-  fireEvent.change(screen.getByPlaceholderText("bria"), { target: { value: "bria" } });
+interface RequiredFieldValues {
+  path?: string;
+  target?: string;
+  headerName?: string;
+  headerValue?: string;
+}
+
+const fillRequiredFields = async (user: User, values: RequiredFieldValues = {}) => {
+  const {
+    path = "bria",
+    target = "https://example.com",
+    headerName = "Authorization",
+    headerValue = "Bearer abc",
+  } = values;
+
+  fireEvent.change(screen.getByPlaceholderText("bria"), { target: { value: path } });
   fireEvent.change(screen.getByPlaceholderText("https://engine.prod.bria-api.com"), {
-    target: { value: "https://example.com" },
+    target: { value: target },
   });
   await user.click(screen.getByRole("button", { name: /add header/i }));
-  fireEvent.change(screen.getByPlaceholderText("Header Name"), { target: { value: "Authorization" } });
-  fireEvent.change(screen.getByPlaceholderText("Header Value"), { target: { value: "Bearer abc" } });
+  fireEvent.change(screen.getByPlaceholderText("Header Name"), { target: { value: headerName } });
+  fireEvent.change(screen.getByPlaceholderText("Header Value"), { target: { value: headerValue } });
+};
+
+const addQueryParam = async (user: User, name: string, value: string) => {
+  await user.click(screen.getByRole("button", { name: /add query parameter/i }));
+  fireEvent.change(screen.getByPlaceholderText("Parameter Name (e.g., version)"), { target: { value: name } });
+  fireEvent.change(screen.getByPlaceholderText("Parameter Value (e.g., v1)"), { target: { value } });
 };
 
 const submit = async (user: User) => user.click(screen.getByRole("button", { name: "Add Pass-Through Endpoint" }));
 
 const lastPayload = () => createPassThroughEndpoint.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+
+const reopenedFields: RequiredFieldValues = {
+  path: "adobe",
+  target: "https://adobe.example.com",
+  headerName: "x-api-key",
+  headerValue: "second-secret",
+};
+
+const reopenedPayload = {
+  path: "/adobe",
+  target: "https://adobe.example.com",
+  headers: { "x-api-key": "second-secret" },
+  include_subpath: true,
+  methods: undefined,
+  default_query_params: undefined,
+  auth: undefined,
+  timeout: undefined,
+  cost_per_request: undefined,
+};
 
 describe("add_pass_through submit payload", () => {
   beforeEach(() => {
@@ -217,5 +256,36 @@ describe("add_pass_through submit payload", () => {
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(createPassThroughEndpoint).not.toHaveBeenCalled();
+  });
+
+  it("leaves no header or query parameter rows behind when the modal is cancelled and reopened", async () => {
+    const user = setup();
+    renderForm();
+    await openModal(user);
+    await fillRequiredFields(user);
+    await addQueryParam(user, "version", "v1");
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await openModal(user);
+
+    expect(screen.queryByPlaceholderText("Header Name")).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Parameter Name (e.g., version)")).not.toBeInTheDocument();
+  });
+
+  it("submits the reopened endpoint instead of rejecting it as missing headers", async () => {
+    const user = setup();
+    renderForm();
+    await openModal(user);
+    await fillRequiredFields(user);
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await openModal(user);
+    await fillRequiredFields(user, reopenedFields);
+
+    await submit(user);
+
+    await waitFor(() => expect(createPassThroughEndpoint).toHaveBeenCalled());
+    expect(screen.queryByText("Please configure the headers")).not.toBeInTheDocument();
+    expect(lastPayload()).toStrictEqual(reopenedPayload);
   });
 });

--- a/ui/litellm-dashboard/src/components/add_pass_through.tsx
+++ b/ui/litellm-dashboard/src/components/add_pass_through.tsx
@@ -9,7 +9,7 @@ import { z } from "zod/v4";
 
 import { createPassThroughEndpoint } from "./networking";
 import NumericalInput from "./shared/numerical_input";
-import KeyValueInput from "./key_value_input";
+import KeyValueInput, { type KeyValuePair } from "./key_value_input";
 import QueryParamInput from "./query_param_input";
 import { passThroughItem } from "./PassThroughSettings/PassThroughSettings";
 import RoutePreview from "./route_preview";
@@ -31,6 +31,8 @@ const HTTP_METHOD_OPTIONS = HTTP_METHODS.map((method) => ({ label: method, value
 
 type GuardrailSettings = Record<string, { request_fields?: string[]; response_fields?: string[] } | null>;
 
+const keyValuePairsSchema = z.array(z.tuple([z.string(), z.string()]));
+
 const passThroughFormSchema = z.object({
   path: z.string().min(1, "Path is required").regex(/^\//, "Path is required"),
   target: z
@@ -39,8 +41,10 @@ const passThroughFormSchema = z.object({
     .pipe(z.url({ error: "Please enter a valid URL" })),
   methods: z.array(z.string()).optional(),
   include_subpath: z.boolean(),
-  headers: z.record(z.string(), z.string(), { error: "Please configure the headers" }),
-  default_query_params: z.record(z.string(), z.string()).optional(),
+  headers: keyValuePairsSchema.refine((pairs) => pairs.some(([name]) => name !== ""), {
+    error: "Please configure the headers",
+  }),
+  default_query_params: keyValuePairsSchema.optional(),
   auth: z.boolean().optional(),
   timeout: z.string().optional(),
   cost_per_request: z.string().optional(),
@@ -53,7 +57,7 @@ const emptyFormValues = {
   target: "",
   methods: undefined,
   include_subpath: true,
-  headers: undefined,
+  headers: [],
   default_query_params: undefined,
   auth: undefined,
   timeout: undefined,
@@ -71,6 +75,14 @@ const labelWithHint = (label: React.ReactNode, hint: string): React.ReactNode =>
 );
 
 const optionalText = (raw: string): string | undefined => (raw === "" ? undefined : raw);
+
+const toRecord = (pairs: readonly KeyValuePair[]): Record<string, string> =>
+  Object.fromEntries(pairs.filter(([name]) => name !== ""));
+
+const optionalRecord = (pairs: readonly KeyValuePair[] | undefined): Record<string, string> | undefined => {
+  const record = toRecord(pairs ?? []);
+  return Object.keys(record).length > 0 ? record : undefined;
+};
 
 interface AddFallbacksProps {
   accessToken: string;
@@ -109,8 +121,8 @@ const AddPassThroughEndpoint: React.FC<AddFallbacksProps> = ({
         target: values.target,
         methods: values.methods,
         include_subpath: values.include_subpath,
-        headers: values.headers,
-        default_query_params: values.default_query_params,
+        headers: toRecord(values.headers),
+        default_query_params: optionalRecord(values.default_query_params),
         ...(premiumUser ? { auth: values.auth } : {}),
         timeout: values.timeout,
         cost_per_request: values.cost_per_request,

--- a/ui/litellm-dashboard/src/components/key_value_input.test.tsx
+++ b/ui/litellm-dashboard/src/components/key_value_input.test.tsx
@@ -1,12 +1,26 @@
+import { useState } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import KeyValueInput from "./key_value_input";
+import KeyValueInput, { type KeyValuePair } from "./key_value_input";
+
+const ControlledKeyValueInput = ({ onChange }: { onChange?: (value: readonly KeyValuePair[]) => void }) => {
+  const [value, setValue] = useState<readonly KeyValuePair[]>([]);
+  return (
+    <KeyValueInput
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
 
 describe("KeyValueInput", () => {
   it("renders existing header pairs", () => {
-    render(<KeyValueInput value={{ Authorization: "Bearer token" }} />);
+    render(<KeyValueInput value={[["Authorization", "Bearer token"]]} />);
 
     expect(screen.getByPlaceholderText("Header Name")).toHaveValue("Authorization");
     expect(screen.getByPlaceholderText("Header Value")).toHaveValue("Bearer token");
@@ -15,12 +29,54 @@ describe("KeyValueInput", () => {
   it("adds a header row and emits edits", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    render(<KeyValueInput onChange={onChange} />);
+    render(<ControlledKeyValueInput onChange={onChange} />);
 
     await user.click(screen.getByRole("button", { name: /Add Header$/ }));
     fireEvent.change(screen.getByPlaceholderText("Header Name"), { target: { value: "X-Trace" } });
     fireEvent.change(screen.getByPlaceholderText("Header Value"), { target: { value: "enabled" } });
 
-    expect(onChange).toHaveBeenLastCalledWith({ "X-Trace": "enabled" });
+    expect(onChange).toHaveBeenLastCalledWith([["X-Trace", "enabled"]]);
+  });
+
+  it("renders no rows once the value prop goes back to empty", () => {
+    const { rerender } = render(<KeyValueInput value={[["Authorization", "Bearer token"]]} />);
+    expect(screen.getByPlaceholderText("Header Name")).toHaveValue("Authorization");
+
+    rerender(<KeyValueInput value={[]} />);
+
+    expect(screen.queryByPlaceholderText("Header Name")).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Header Value")).not.toBeInTheDocument();
+  });
+
+  it("keeps a half-typed row editable while its name is still empty", async () => {
+    const user = userEvent.setup();
+    render(<ControlledKeyValueInput />);
+
+    await user.click(screen.getByRole("button", { name: /Add Header$/ }));
+    await user.click(screen.getByRole("button", { name: /Add Header$/ }));
+    expect(screen.getAllByPlaceholderText("Header Name")).toHaveLength(2);
+
+    fireEvent.change(screen.getAllByPlaceholderText("Header Value")[1], { target: { value: "pending" } });
+
+    expect(screen.getAllByPlaceholderText("Header Name")).toHaveLength(2);
+    expect(screen.getAllByPlaceholderText("Header Value")[1]).toHaveValue("pending");
+  });
+
+  it("removes only the row whose remove button is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <KeyValueInput
+        value={[
+          ["a", "1"],
+          ["b", "2"],
+        ]}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove header 1" }));
+
+    expect(onChange).toHaveBeenLastCalledWith([["b", "2"]]);
   });
 });

--- a/ui/litellm-dashboard/src/components/key_value_input.tsx
+++ b/ui/litellm-dashboard/src/components/key_value_input.tsx
@@ -1,40 +1,30 @@
-import React, { useState } from "react";
+import React from "react";
 import { Minus, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
+export type KeyValuePair = readonly [string, string];
+
 interface KeyValueInputProps {
-  value?: Record<string, string>;
-  onChange?: (value: Record<string, string>) => void;
+  value?: readonly KeyValuePair[];
+  onChange?: (value: readonly KeyValuePair[]) => void;
 }
 
-const KeyValueInput: React.FC<KeyValueInputProps> = ({ value = {}, onChange }) => {
-  const [pairs, setPairs] = useState<[string, string][]>(Object.entries(value));
+const KeyValueInput: React.FC<KeyValueInputProps> = ({ value = [], onChange }) => {
+  const handleAdd = () => onChange?.([...value, ["", ""]]);
 
-  const handleAdd = () => {
-    setPairs([...pairs, ["", ""]]);
-  };
+  const handleRemove = (index: number) => onChange?.(value.filter((_, i) => i !== index));
 
-  const handleRemove = (index: number) => {
-    const newPairs = pairs.filter((_, i) => i !== index);
-    setPairs(newPairs);
-    onChange?.(Object.fromEntries(newPairs));
-  };
-
-  const handleChange = (index: number, key: string, val: string) => {
-    const newPairs = [...pairs];
-    newPairs[index] = [key, val];
-    setPairs(newPairs);
-    onChange?.(Object.fromEntries(newPairs));
-  };
+  const handleChange = (index: number, pair: KeyValuePair) =>
+    onChange?.(value.map((existing, i) => (i === index ? pair : existing)));
 
   return (
     <div className="space-y-2">
-      {pairs.map(([key, val], index) => (
+      {value.map(([key, val], index) => (
         <div key={index} className="flex items-center gap-2">
-          <Input placeholder="Header Name" value={key} onChange={(e) => handleChange(index, e.target.value, val)} />
-          <Input placeholder="Header Value" value={val} onChange={(e) => handleChange(index, key, e.target.value)} />
+          <Input placeholder="Header Name" value={key} onChange={(e) => handleChange(index, [e.target.value, val])} />
+          <Input placeholder="Header Value" value={val} onChange={(e) => handleChange(index, [key, e.target.value])} />
           <Button
             type="button"
             variant="ghost"

--- a/ui/litellm-dashboard/src/components/query_param_input.test.tsx
+++ b/ui/litellm-dashboard/src/components/query_param_input.test.tsx
@@ -1,12 +1,27 @@
+import { useState } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import QueryParamInput from "./query_param_input";
+import type { KeyValuePair } from "./key_value_input";
+
+const ControlledQueryParamInput = ({ onChange }: { onChange?: (value: readonly KeyValuePair[]) => void }) => {
+  const [value, setValue] = useState<readonly KeyValuePair[]>([]);
+  return (
+    <QueryParamInput
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
 
 describe("QueryParamInput", () => {
   it("renders existing query parameter pairs", () => {
-    render(<QueryParamInput value={{ version: "v1" }} />);
+    render(<QueryParamInput value={[["version", "v1"]]} />);
 
     expect(screen.getByPlaceholderText("Parameter Name (e.g., version)")).toHaveValue("version");
     expect(screen.getByPlaceholderText("Parameter Value (e.g., v1)")).toHaveValue("v1");
@@ -15,12 +30,31 @@ describe("QueryParamInput", () => {
   it("adds a query parameter row and emits edits", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    render(<QueryParamInput onChange={onChange} />);
+    render(<ControlledQueryParamInput onChange={onChange} />);
 
     await user.click(screen.getByRole("button", { name: /Add Query Parameter$/ }));
     fireEvent.change(screen.getByPlaceholderText("Parameter Name (e.g., version)"), { target: { value: "region" } });
     fireEvent.change(screen.getByPlaceholderText("Parameter Value (e.g., v1)"), { target: { value: "us-west" } });
 
-    expect(onChange).toHaveBeenLastCalledWith({ region: "us-west" });
+    expect(onChange).toHaveBeenLastCalledWith([["region", "us-west"]]);
+  });
+
+  it("renders no rows once the value prop goes back to empty", () => {
+    const { rerender } = render(<QueryParamInput value={[["version", "v1"]]} />);
+    expect(screen.getByPlaceholderText("Parameter Name (e.g., version)")).toHaveValue("version");
+
+    rerender(<QueryParamInput value={[]} />);
+
+    expect(screen.queryByPlaceholderText("Parameter Name (e.g., version)")).not.toBeInTheDocument();
+  });
+
+  it("keeps a half-typed row editable while its name is still empty", async () => {
+    const user = userEvent.setup();
+    render(<ControlledQueryParamInput />);
+
+    await user.click(screen.getByRole("button", { name: /Add Query Parameter$/ }));
+    await user.click(screen.getByRole("button", { name: /Add Query Parameter$/ }));
+
+    expect(screen.getAllByPlaceholderText("Parameter Name (e.g., version)")).toHaveLength(2);
   });
 });

--- a/ui/litellm-dashboard/src/components/query_param_input.tsx
+++ b/ui/litellm-dashboard/src/components/query_param_input.tsx
@@ -1,47 +1,36 @@
-import React, { useState } from "react";
+import React from "react";
 import { Minus, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import type { KeyValuePair } from "./key_value_input";
 
 interface QueryParamInputProps {
-  value?: Record<string, string>;
-  onChange?: (value: Record<string, string>) => void;
+  value?: readonly KeyValuePair[];
+  onChange?: (value: readonly KeyValuePair[]) => void;
 }
 
-const QueryParamInput: React.FC<QueryParamInputProps> = ({ value = {}, onChange }) => {
-  const [pairs, setPairs] = useState<[string, string][]>(Object.entries(value));
+const QueryParamInput: React.FC<QueryParamInputProps> = ({ value = [], onChange }) => {
+  const handleAdd = () => onChange?.([...value, ["", ""]]);
 
-  const handleAdd = () => {
-    setPairs([...pairs, ["", ""]]);
-  };
+  const handleRemove = (index: number) => onChange?.(value.filter((_, i) => i !== index));
 
-  const handleRemove = (index: number) => {
-    const newPairs = pairs.filter((_, i) => i !== index);
-    setPairs(newPairs);
-    onChange?.(Object.fromEntries(newPairs));
-  };
-
-  const handleChange = (index: number, key: string, val: string) => {
-    const newPairs = [...pairs];
-    newPairs[index] = [key, val];
-    setPairs(newPairs);
-    onChange?.(Object.fromEntries(newPairs));
-  };
+  const handleChange = (index: number, pair: KeyValuePair) =>
+    onChange?.(value.map((existing, i) => (i === index ? pair : existing)));
 
   return (
     <div className="space-y-2">
-      {pairs.map(([key, val], index) => (
+      {value.map(([key, val], index) => (
         <div key={index} className="flex items-center gap-2">
           <Input
             placeholder="Parameter Name (e.g., version)"
             value={key}
-            onChange={(e) => handleChange(index, e.target.value, val)}
+            onChange={(e) => handleChange(index, [e.target.value, val])}
           />
           <Input
             placeholder="Parameter Value (e.g., v1)"
             value={val}
-            onChange={(e) => handleChange(index, key, e.target.value)}
+            onChange={(e) => handleChange(index, [key, e.target.value])}
           />
           <Button
             type="button"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cancelling the pass-through create modal leaves header rows on screen
- The stale row blocks the next create with "Please configure the headers"
- No request is sent, and the row looks correctly filled in
- Query parameter rows leak across the same cancel

How it solves it:

- Header and query parameter inputs are now controlled off their value prop
- The value is an array of pairs, so half-typed rows survive
- A form reset clears the rows like every other field
- The submitted payload is unchanged, still a record

## User Flow

Before: an admin who cancels the pass-through create modal cannot create anything afterwards, and the error blames headers they can see are filled in

1. They open http://localhost:4000/ui/?page=llm-playground, pick Models + Endpoints, then the Pass-Through Endpoints tab, and click "+ Add Pass-Through Endpoint"
2. They fill Path Prefix `/bria` and Target URL `https://engine.prod.bria-api.com`, click "Add Header", and fill `Authorization` / `Bearer abc`
3. They change their mind and click Cancel
4. They click "+ Add Pass-Through Endpoint" again. Path Prefix and Target URL are empty, but a header row is still on screen holding `Authorization` and `Bearer abc`
5. They fill a fresh `/adobe` and `https://adobe.example.com` and click "Add Pass-Through Endpoint"
6. Nothing is created. The form shows "Please configure the headers" under a header row that visibly has a name and a value, and no request leaves the browser
7. The only way forward is to type a character into the header value that already looks filled in, which nobody would think to do

After: the reopened modal is empty, and the next endpoint is created normally

1. Same as before, through step 3
2. They click "+ Add Pass-Through Endpoint" again. Path Prefix, Target URL and the header rows are all empty
3. They fill a fresh `/adobe` and `https://adobe.example.com`, click "Add Header", and fill `x-api-key` / `second-secret`
4. They click "Add Pass-Through Endpoint" and the endpoint is created, appearing in the Pass-Through Endpoints list

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup, same for both sides: run the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`, run `npm run dev` in `ui/litellm-dashboard`, and open the dashboard on port 3000. Keep the browser network tab open so an absent request is visible

### Before (3f2e0badb4)

1. Go to Models + Endpoints, open the Pass-Through Endpoints tab, click "+ Add Pass-Through Endpoint"
2. Fill Path Prefix `/bria` and Target URL `https://engine.prod.bria-api.com`, click "Add Header", fill `Authorization` and `Bearer abc`
3. Click Cancel, then click "+ Add Pass-Through Endpoint" again. Screenshot the modal: Path Prefix and Target URL are empty, the header row still shows `Authorization` and `Bearer abc`
4. Fill Path Prefix `/adobe` and Target URL `https://adobe.example.com`, then click "Add Pass-Through Endpoint"
5. Screenshot the result: "Please configure the headers" under the filled-looking header row, and no POST to `/config/pass_through_endpoint` in the network tab

### After (d1e2594ed3)

1. Go to Models + Endpoints, open the Pass-Through Endpoints tab, click "+ Add Pass-Through Endpoint"
2. Fill Path Prefix `/bria` and Target URL `https://engine.prod.bria-api.com`, click "Add Header", fill `Authorization` and `Bearer abc`
3. Click Cancel, then click "+ Add Pass-Through Endpoint" again. Screenshot the modal: Path Prefix, Target URL and the header rows are all empty
4. Fill Path Prefix `/adobe` and Target URL `https://adobe.example.com`, click "Add Header", fill `x-api-key` and `second-secret`, then click "Add Pass-Through Endpoint"
5. Screenshot the result: the success toast and the new `/adobe` row in the Pass-Through Endpoints list, plus the POST to `/config/pass_through_endpoint` in the network tab
6. Repeat steps 2 and 3 for the Default Query Parameters section to confirm those rows clear too

## Type

🐛 Bug Fix

## Caveats (if any)

- Headers now need one row with a non-empty name to submit
- That was previously enforced by accident, not on purpose

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
