### PR TITLE
fix(ci): gate backend unit tests on the pull request's own file list

### DIFF
--- a/.github/actions/detect-backend-changes/action.yml
+++ b/.github/actions/detect-backend-changes/action.yml
@@ -3,9 +3,18 @@ description: >-
   Classify the pull request's changed files with .circleci/scripts/classify_changes.sh
   and expose decision=run|skip. decision=skip means only ui/**, **.md or **.mdx files
   changed, so callers can short-circuit expensive steps while the job still completes
-  successfully and satisfies its required status check. The decision defaults to run for
-  any non pull_request event or whenever the changed set cannot be resolved, so tests are
-  never skipped when the classification is uncertain.
+  successfully and satisfies its required status check. The file list comes from the
+  pull request itself rather than from a git diff, because the checked-out merge ref is
+  recomputed as the base branch advances and would otherwise attribute the base
+  branch's own commits to the pull request. The decision defaults to run for any non
+  pull_request event or whenever the changed set cannot be resolved, so tests are never
+  skipped when the classification is uncertain.
+
+inputs:
+  github-token:
+    description: "Token used to list the pull request's files; needs pull-requests: read"
+    required: false
+    default: ${{ github.token }}
 
 outputs:
   decision:
@@ -18,31 +27,8 @@ runs:
     - id: classify
       shell: bash
       env:
-        BASE_SHA: ${{ github.event.pull_request.base.sha }}
-      run: |
-        set -uo pipefail
-        if [ -z "${BASE_SHA:-}" ]; then
-          echo "detect-backend-changes: not a pull_request event; running job"
-          echo "decision=run" >> "${GITHUB_OUTPUT}"
-          exit 0
-        fi
-        if ! git fetch --no-tags --depth=1 origin "${BASE_SHA}" >/dev/null 2>&1; then
-          echo "detect-backend-changes: could not fetch base ${BASE_SHA}; running job"
-          echo "decision=run" >> "${GITHUB_OUTPUT}"
-          exit 0
-        fi
-        changed="$(git diff --name-only "${BASE_SHA}" HEAD 2>/dev/null)" || {
-          echo "detect-backend-changes: git diff failed; running job"
-          echo "decision=run" >> "${GITHUB_OUTPUT}"
-          exit 0
-        }
-        if [ -z "${changed}" ]; then
-          echo "detect-backend-changes: no changed files vs ${BASE_SHA}; skipping job"
-          echo "decision=skip" >> "${GITHUB_OUTPUT}"
-          exit 0
-        fi
-        echo "detect-backend-changes: changed files vs ${BASE_SHA}:"
-        printf '%s\n' "${changed}" | sed 's/^/  /'
-        decision="$(printf '%s\n' "${changed}" | bash .circleci/scripts/classify_changes.sh backend)" || decision="run"
-        echo "detect-backend-changes: decision=${decision}"
-        echo "decision=${decision}" >> "${GITHUB_OUTPUT}"
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        CHANGED_FILE_COUNT: ${{ github.event.pull_request.changed_files }}
+      run: bash "${GITHUB_ACTION_PATH}/../../scripts/detect_backend_changes.sh"

--- a/.github/scripts/detect_backend_changes.sh
+++ b/.github/scripts/detect_backend_changes.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+readonly API_FILE_CEILING=3000
+
+decide() {
+  echo "detect-backend-changes: decision=$1"
+  [ -z "${GITHUB_OUTPUT:-}" ] || echo "decision=$1" >>"${GITHUB_OUTPUT}"
+  exit 0
+}
+
+run_full() {
+  echo "detect-backend-changes: $1; running job"
+  decide run
+}
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+classify="${here}/../../.circleci/scripts/classify_changes.sh"
+
+[ -n "${PR_NUMBER:-}" ] || run_full "not a pull_request event"
+[ -n "${REPO:-}" ] || run_full "no repository in the environment"
+
+case "${CHANGED_FILE_COUNT:-}" in
+'' | *[!0-9]*) run_full "the event payload carries no changed_files count" ;;
+esac
+[ "${CHANGED_FILE_COUNT}" -le "${API_FILE_CEILING}" ] ||
+  run_full "PR #${PR_NUMBER} changes ${CHANGED_FILE_COUNT} files, past the ${API_FILE_CEILING}-file listing ceiling"
+
+changed="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')" ||
+  run_full "could not list the files on PR #${PR_NUMBER}"
+[ -n "${changed}" ] || run_full "the API listed no files on PR #${PR_NUMBER}"
+
+echo "detect-backend-changes: files changed by PR #${PR_NUMBER}:"
+printf '%s\n' "${changed}" | sed 's/^/  /'
+
+decision="$(printf '%s\n' "${changed}" | bash "${classify}" backend)" ||
+  run_full "classify_changes.sh failed"
+case "${decision}" in
+run | skip) decide "${decision}" ;;
+*) run_full "classify_changes.sh printed an unexpected decision: ${decision}" ;;
+esac

--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -60,6 +60,9 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.job-timeout-minutes }}
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       decision: ${{ steps.changes.outputs.decision }}
 

--- a/.github/workflows/test-unit-documentation.yml
+++ b/.github/workflows/test-unit-documentation.yml
@@ -23,6 +23,9 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/tests/test_litellm/test_detect_backend_changes.py
+++ b/tests/test_litellm/test_detect_backend_changes.py
@@ -1,0 +1,189 @@
+"""Regression tests for the GitHub Actions change-based job gating.
+
+`.github/scripts/detect_backend_changes.sh` decides whether a pull request's
+backend unit-test jobs do real work. It asks the API which files the pull
+request touches and hands them to `classify_changes.sh`. The contract locked in
+here:
+
+  * a UI-only pull request skips backend jobs even when the checked-out merge
+    ref carries backend commits from the base branch
+  * anything the classification cannot resolve (no pull request, an API
+    failure, a truncated file list, a broken classifier) runs the job
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "detect_backend_changes.sh"
+CLASSIFIER = REPO_ROOT / ".circleci" / "scripts" / "classify_changes.sh"
+
+UI_FILE = "ui/litellm-dashboard/src/components/Teams.tsx"
+BACKEND_FILE = "litellm/proxy/proxy_server.py"
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _merge_ref_checkout(tmp_path: Path) -> Path:
+    """A checkout shaped like `refs/pull/N/merge`: a UI-only branch merged into a
+    base tip that has moved ahead by a backend commit since the branch was cut."""
+    work = tmp_path / "work"
+    work.mkdir()
+    _git(work, "init", "-q", "-b", "main")
+    _git(work, "config", "user.email", "t@t")
+    _git(work, "config", "user.name", "t")
+    (work / "seed.txt").write_text("seed\n")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-qm", "base")
+
+    _git(work, "checkout", "-q", "-b", "feature")
+    ui = work / UI_FILE
+    ui.parent.mkdir(parents=True, exist_ok=True)
+    ui.write_text("export const Teams = () => null\n")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-qm", "ui change")
+
+    _git(work, "checkout", "-q", "main")
+    backend = work / BACKEND_FILE
+    backend.parent.mkdir(parents=True, exist_ok=True)
+    backend.write_text("x = 1\n")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-qm", "someone else's backend change")
+
+    _git(work, "merge", "-q", "--no-ff", "-m", "Merge feature into main", "feature")
+    return work
+
+
+def _scripts_tree(tmp_path: Path, classifier_body: str | None = None) -> Path:
+    """Copy the scripts into a throwaway tree, preserving their relative layout."""
+    root = tmp_path / "tree"
+    (root / ".github" / "scripts").mkdir(parents=True)
+    (root / ".circleci" / "scripts").mkdir(parents=True)
+    shutil.copy(SCRIPT, root / ".github" / "scripts" / SCRIPT.name)
+    target = root / ".circleci" / "scripts" / CLASSIFIER.name
+    if classifier_body is None:
+        shutil.copy(CLASSIFIER, target)
+    else:
+        target.write_text(classifier_body)
+    target.chmod(0o755)
+    return root
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    files: list[str],
+    cwd: Path | None = None,
+    pr_number: str = "37540",
+    changed_file_count: str | None = None,
+    gh_exit_code: int = 0,
+    classifier_body: str | None = None,
+) -> tuple[str, str]:
+    """Run the script against a stubbed `gh`; returns (decision, stdout)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    listing = "".join(f"echo {f}\n" for f in files)
+    stub = bin_dir / "gh"
+    stub.write_text(f"#!/usr/bin/env bash\n{listing}exit {gh_exit_code}\n")
+    stub.chmod(0o755)
+
+    output_file = tmp_path / "github_output"
+    output_file.write_text("")
+
+    env = {k: v for k, v in os.environ.items() if k not in {"GH_TOKEN", "GITHUB_TOKEN"}}
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["GITHUB_OUTPUT"] = str(output_file)
+    env["REPO"] = "BerriAI/litellm"
+    env["PR_NUMBER"] = pr_number
+    env["CHANGED_FILE_COUNT"] = changed_file_count if changed_file_count is not None else str(len(files))
+
+    tree = _scripts_tree(tmp_path, classifier_body)
+    result = subprocess.run(
+        ["bash", str(tree / ".github" / "scripts" / SCRIPT.name)],
+        cwd=cwd or tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return output_file.read_text().strip(), result.stdout
+
+
+def test_ui_only_pr_skips_even_when_the_merge_ref_carries_backend_commits(tmp_path: Path) -> None:
+    """The bug this replaces: diffing the checked-out merge ref against the event's
+    base sha attributed the base branch's own backend commits to the pull request,
+    so every UI-only PR ran the full backend suite."""
+    work = _merge_ref_checkout(tmp_path)
+    tracked = subprocess.run(
+        ["git", "diff", "--name-only", "HEAD~2", "HEAD"],
+        cwd=work,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    assert BACKEND_FILE in tracked, "the checkout must contain the base branch's backend commit"
+
+    decision, _ = _run(tmp_path, files=[UI_FILE], cwd=work)
+    assert decision == "decision=skip"
+
+
+def test_backend_file_in_the_pr_runs(tmp_path: Path) -> None:
+    decision, _ = _run(tmp_path, files=[UI_FILE, BACKEND_FILE])
+    assert decision == "decision=run"
+
+
+def test_docs_only_pr_skips(tmp_path: Path) -> None:
+    decision, _ = _run(tmp_path, files=["README.md", "docs/my-website/index.mdx"])
+    assert decision == "decision=skip"
+
+
+def test_non_pull_request_event_runs(tmp_path: Path) -> None:
+    decision, stdout = _run(tmp_path, files=[UI_FILE], pr_number="")
+    assert decision == "decision=run"
+    assert "not a pull_request event" in stdout
+
+
+def test_api_failure_runs(tmp_path: Path) -> None:
+    decision, stdout = _run(tmp_path, files=[], gh_exit_code=1)
+    assert decision == "decision=run"
+    assert "could not list the files" in stdout
+
+
+def test_empty_file_list_runs(tmp_path: Path) -> None:
+    decision, stdout = _run(tmp_path, files=[], changed_file_count="0")
+    assert decision == "decision=run"
+    assert "listed no files" in stdout
+
+
+def test_pr_past_the_listing_ceiling_runs(tmp_path: Path) -> None:
+    """The API caps its file listing, so a larger PR would be classified from a
+    truncated set and could skip backend jobs it needs."""
+    decision, stdout = _run(tmp_path, files=[UI_FILE], changed_file_count="3001")
+    assert decision == "decision=run"
+    assert "past the 3000-file listing ceiling" in stdout
+
+
+def test_broken_classifier_runs(tmp_path: Path) -> None:
+    decision, stdout = _run(
+        tmp_path,
+        files=[UI_FILE],
+        classifier_body="#!/usr/bin/env bash\nexit 1\n",
+    )
+    assert decision == "decision=run"
+    assert "classify_changes.sh failed" in stdout
+
+
+def test_unexpected_classifier_output_runs(tmp_path: Path) -> None:
+    decision, stdout = _run(
+        tmp_path,
+        files=[UI_FILE],
+        classifier_body="#!/usr/bin/env bash\ncat >/dev/null\necho maybe\n",
+    )
+    assert decision == "decision=run"
+    assert "unexpected decision: maybe" in stdout


### PR DESCRIPTION
## TLDR

Problem this solves:

- UI-only PRs run every backend unit-test shard, for nothing
- The change filter read a diff whose two ends move independently
- Base-branch commits got attributed to the PR under review

How it solves it:

- Take the file list from the pull request itself
- Same set the Files changed tab shows, immune to base movement
- Every unresolved case still falls open to running the job

## User Flow

Before: a contributor opens a UI-only pull request and waits on the full backend suite anyway

1. They push a branch that touches only `ui/litellm-dashboard/**` and open a PR against `litellm_internal_staging`
2. Every backend shard on the checks tab starts running, each taking 8 to 12 minutes
3. They open a shard's log and the "Detect backend-relevant changes" step lists backend files they never touched, then prints `decision=run`
4. They wait roughly 25 minutes for checks that could not have been affected by the change

After: the same pull request short-circuits those shards in seconds

1. They push the same branch and open the same PR
2. The same step lists only the `ui/**` files the PR touches, then prints `decision=skip`
3. Every backend shard reports green in under a minute, having installed nothing and run no tests
4. Nothing else about the checks tab changes: UI lint, UI unit tests, and the build still run in full

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both sides replay the real inputs of PR #37540's own CI, taken from the "misc / Run tests" job of run 32311341666: the event payload's base sha was `5d6033f8b4b65a8dd1c67a75695deb20112f7f72`, and `actions/checkout` resolved `refs/pull/37540/merge` to `3c89148cf374f5f72e5a04b568740d4abcc2ab2c`, whose subject reads `Merge e7c8d31c into 634e6995`. Those two SHAs are the whole bug: `634e6995` is four commits ahead of `5d6033f8`, so the diff between them carries staging's own work

```bash
git fetch origin 3c89148cf374f5f72e5a04b568740d4abcc2ab2c
git worktree add --detach /tmp/before-tree 3c89148cf374f5f72e5a04b568740d4abcc2ab2c
git fetch origin refs/pull/37550/merge
git worktree add --detach /tmp/before-tree-37550 FETCH_HEAD
```

The second case is this pull request itself, which touches `.github/` and `tests/`. It has to keep running the backend shards on both sides, so the gate is shown not to over-skip

### Before (663e647bc857ce17f9b01194814f5abc14a287e3)

#### UI-only pull request (#37540)

1. Run the gate exactly as the job ran it, from the merge ref, against the payload's base sha:

```bash
cd /tmp/before-tree
GITHUB_OUTPUT=/tmp/before_output \
  BASE_SHA=5d6033f8b4b65a8dd1c67a75695deb20112f7f72 \
  bash /tmp/old_detect.sh
```

2. It reports 90 changed files against the 63 the pull request touches. 25 of the 27 extras are backend:

```
detect-backend-changes: changed files vs 5d6033f8b4b65a8dd1c67a75695deb20112f7f72:
  litellm-proxy-extras/litellm_proxy_extras/migrations/20260814000000_add_proxy_worker_heartbeat/migration.sql
  litellm-proxy-extras/litellm_proxy_extras/schema.prisma
  litellm/llms/base_llm/search/transformation.py
  litellm/llms/bedrock/search/__init__.py
  litellm/llms/bedrock/search/transformation.py
  litellm/llms/custom_httpx/llm_http_handler.py
  litellm/model_prices_and_context_window_backup.json
  litellm/proxy/db/db_spend_update_writer.py
  litellm/proxy/db/exception_handler.py
  litellm/proxy/db/proxy_worker_heartbeat.py
  litellm/proxy/example_config_yaml/agentcore_websearch_config.yaml
  litellm/proxy/health_endpoints/_health_endpoints.py
  litellm/proxy/proxy_server.py
  litellm/proxy/schema.prisma
  litellm/proxy/utils.py
  litellm/types/utils.py
  litellm/utils.py
  model_prices_and_context_window.json
  schema.prisma
  tests/test_litellm/llms/bedrock/search/test_agentcore_search_transformation.py
  tests/test_litellm/proxy/db/test_db_spend_update_writer.py
  tests/test_litellm/proxy/db/test_exception_handler.py
  tests/test_litellm/proxy/db/test_proxy_worker_heartbeat.py
  tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
  tests/test_litellm/proxy/utils/prisma_and_spend/test_proxy_update_spend.py
  ... 65 ui/litellm-dashboard/** files elided, 2 of which are also staging's, not the PR's ...
detect-backend-changes: decision=run
```

3. `decision=run` is what every backend shard on that PR saw, which is why they all installed dependencies and ran their tests

#### Backend-touching pull request (this PR, #37550)

1. Run the old gate from that pull request's merge ref, against its base sha:

```bash
cd /tmp/before-tree-37550
GITHUB_OUTPUT=/tmp/o1 \
  BASE_SHA=75a290ec1d738654b56dd2639bd7dd5349caea57 \
  bash /tmp/old_detect.sh
```

2. It lists the five files and runs, which is the correct answer here:

```
detect-backend-changes: changed files vs 75a290ec1d738654b56dd2639bd7dd5349caea57:
  .github/actions/detect-backend-changes/action.yml
  .github/scripts/detect_backend_changes.sh
  .github/workflows/_test-unit-base.yml
  .github/workflows/test-unit-documentation.yml
  tests/test_litellm/test_detect_backend_changes.py
detect-backend-changes: decision=run
```


### After (4aeca02b4181c7ee2b96195be0e84568905bfebf)

#### UI-only pull request (#37540)

1. Run the new gate against the same pull request, from any directory:

```bash
REPO=BerriAI/litellm PR_NUMBER=37540 CHANGED_FILE_COUNT=63 \
  bash .github/scripts/detect_backend_changes.sh
```

2. It lists the 63 files the PR actually touches, all of them under `ui/`, and skips:

```
detect-backend-changes: files changed by PR #37540:
  ui/litellm-dashboard/eslint-suppressions.json
  ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsModal/AccessGroupEditModal.tsx
  ...
  ui/litellm-dashboard/src/components/update_model_credentials_modal.tsx
  ui/litellm-dashboard/tests/setupTests.ts
detect-backend-changes: decision=skip
```

3. Each backend shard now stops after that step, still reporting success so its required status check is satisfied

#### Backend-touching pull request (this PR, #37550)

1. Run the new gate against this pull request:

```bash
REPO=BerriAI/litellm PR_NUMBER=37550 CHANGED_FILE_COUNT=5 \
  bash .github/scripts/detect_backend_changes.sh
```

2. It lists the same five files and reaches the same answer as before the change:

```
detect-backend-changes: files changed by PR #37550:
  .github/actions/detect-backend-changes/action.yml
  .github/scripts/detect_backend_changes.sh
  .github/workflows/_test-unit-base.yml
  .github/workflows/test-unit-documentation.yml
  tests/test_litellm/test_detect_backend_changes.py
detect-backend-changes: decision=run
```

3. This PR's own checks tab shows every backend shard running in full, as it should


## Type

🐛 Bug Fix
🚄 Infrastructure

## Caveats (if any)

- Needs `pull-requests: read`, added to both consuming workflows
- PRs past the API's 3000-file listing ceiling run everything, deliberately
- This PR touches `.github/` and `tests/`, so its own backend shards run

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
