### PR TITLE
fix(spend-logs): backfill created_at/updated_at from row endTime instead of migration time

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260819000000_backfill_spend_log_timestamps/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260819000000_backfill_spend_log_timestamps/migration.sql
@@ -1,0 +1,4 @@
+UPDATE "LiteLLM_SpendLogs"
+SET "created_at" = "endTime",
+    "updated_at" = "endTime"
+WHERE "created_at" > "endTime" + interval '1 hour';


### PR DESCRIPTION
## TLDR

Problem this solves:

- #37361 stamps every pre-existing spend log row with migration time
- Export checkpoints then see all history as freshly written

How it solves it:

- Follow-up migration backfills `created_at`/`updated_at` from each row's `endTime`
- Guard only rewrites rows stamped over an hour past `endTime`
- Same guard makes re-runs no-ops and spares genuine rows

## User Flow

Before: a data engineer upgrades the gateway and every historical spend log row comes back stamped with the upgrade moment, so their incremental export treats months of history as written just now

1. For months their app has been sending POST https://litellm-domain/v1/chat/completions, and GET https://litellm-domain/spend/logs?request_id=<id> shows each logged row with `startTime` and `endTime` but no `created_at`
2. They upgrade the gateway and it boots normally
3. They send GET https://litellm-domain/spend/logs?start_date=<months back>&end_date=<today>&summarize=false with the master key
4. Every pre-upgrade row carries identical `created_at` and `updated_at` equal to the moment the upgrade ran, so a request that finished on 2026-07-20 claims it was written on 2026-08-19
5. Their export job checkpoints on `created_at`, so the entire history collapses into one checkpoint window and write-time ordering is meaningless for everything before the upgrade

After: the same upgrade backfills each historical row's write timestamps from the row's own completion time, so the export sees honest values

1. For months their app has been sending POST https://litellm-domain/v1/chat/completions, and GET https://litellm-domain/spend/logs?request_id=<id> shows each logged row with `startTime` and `endTime` but no `created_at`
2. They upgrade the gateway and it boots normally
3. They send GET https://litellm-domain/spend/logs?start_date=<months back>&end_date=<today>&summarize=false with the master key
4. Every pre-upgrade row carries `created_at` and `updated_at` equal to that row's own `endTime`, so the request that finished on 2026-07-20 says it was written on 2026-07-20
5. A fresh POST https://litellm-domain/v1/chat/completions logs a row whose `created_at` is its real write time, so the checkpoint job works across old and new rows alike

## Relevant issues

Follow-up to #37361

## Linear ticket

Resolves LIT-5854

## Why a follow-up migration instead of editing the merged one

`prisma migrate deploy` (both the default resolver and `--use_v2_migration_resolver` front with it) skips migrations already recorded by name in `_prisma_migrations` without re-reading their SQL. Verified live on a scratch database: after applying the merged `20260818000000_add_spend_log_timestamps`, appending the backfill UPDATE to that same file and re-running deploy prints "No pending migrations to apply", the edited SQL never executes, and the recorded checksum stays the original. The default resolver's post-deploy sanity check diffs the live schema against schema.prisma, and a data-only edit produces no schema diff, so it never re-runs there either. Editing in place would therefore silently skip every database that already applied the original migration, which is exactly the population holding the bad stamps. A follow-up migration runs exactly once on every migrate-managed database, old or fresh

The WHERE guard doubles as the idempotence story: after one pass `created_at` equals `endTime`, so a second execution matches zero rows (verified, `UPDATE 0`). That matters beyond re-deploys because the default resolver's pooler-URL fallback executes every migration file directly via `prisma db execute` instead of consulting the ledger

The guard boundary is deliberate. Rows written in the final hour before the upgrade keep their stamp, which is at most an hour off. Genuine rows are written within seconds of their `endTime`, so an hour of headroom also absorbs realistic app-to-database clock skew, and `endTime` is NOT NULL so no row can be nulled or skipped on that account. Even a pathological genuine row that trips the guard (a spend write delayed by over an hour) just gets set to its own `endTime`, which is the more honest value anyway

schema.prisma is untouched in all three copies: #37361 already added the columns there, and this PR only corrects the data, so there is no schema change to sync. No unit test is added because the change is a single raw SQL migration and the repo has no harness that executes migration SQL against a database; the proof of fix below is the live upgrade run instead

## Deploy-time cost on large tables

The UPDATE seq-scans the table once and rewrites every row the guard matches, which on first upgrade is essentially every pre-existing row. Untouched TOASTed columns (`messages`, `response`, `proxy_server_request`) are not rewritten, only the main heap tuples, so a hundred-million-row table rewrites tens of GB of heap and emits a comparable WAL volume, with dead tuples up to doubling heap size until autovacuum reclaims them. The lock is ROW EXCLUSIVE, so concurrent reads and the append-only spend log inserts from still-running replicas proceed throughout; prior migrations built indexes on this same table non-concurrently, a stricter lock than this takes. Prisma applies the migration in one transaction, so an interrupted run rolls back whole rather than half-stamping the table, and the ledger guarantees the scan happens once per database ever

The honest worst case is time, not locking: prisma commands run under `LITELLM_PRISMA_COMMAND_TIMEOUT` (default 60s), and a table where this UPDATE needs longer will time out, roll back, and fail the boot until the operator raises that variable for the one deploy that performs the backfill. Since #37361 is in no tag yet, only internal staging and dev databases hold the bad stamps today, and shipping the backfill in the same rc keeps the affected population that small permanently

## Replacement heads-up for #37361

The earlier contributor guidance, only trust `created_at` for rows written after the rollout, is obsolete once this lands. Replacement wording: `created_at`/`updated_at` are trustworthy across the whole table; rows that predate the upgrade carry their `endTime` as both values, and rows written within the hour before the upgrade may keep the upgrade-time stamp

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (migration-only PR, no harness executes migration SQL; proven via the live upgrade run below)
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live before/after upgrade run with a real proxy, a real Postgres, and real OpenAI calls. Two identical "old deployment" stacks were built at commit 73e7105e60 (pre #37361, so `LiteLLM_SpendLogs` has no `created_at`/`updated_at` columns), each with its own fresh database and live proxy, seeded with 3 real chat calls, and then the first two rows were aged 30 days to stand in for months-old history. The before leg is the control and upgrades to the litellm_internal_staging tip 629d7683f2, which has #37361 but not this PR. The after leg upgrades to this PR's head 096263db15

Seed, shown for the before leg (the after leg is identical with database `lit5854_qa_after` and port 47731):

```bash
createdb lit5854_qa_before
.venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 49662   # boots and applies the 152 migrations at this commit
for i in 1 2 3; do
  curl -sS http://localhost:49662/v1/chat/completions -H "Authorization: Bearer sk-qa-1234" -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.4-nano","messages":[{"role":"user","content":"hi"}]}'
done
psql lit5854_qa_before -c "UPDATE \"LiteLLM_SpendLogs\" SET \"startTime\" = \"startTime\" - interval '30 days', \"endTime\" = \"endTime\" - interval '30 days' WHERE request_id IN ('chatcmpl-EEkZoBblFxkEfhUfaP9koccOTyxeV', 'chatcmpl-EEkZoGyqnACjMnWuNGJCxDVfLgkGy');"
```

Upgrade: check out the target commit in place and reboot the proxy, which runs `prisma migrate deploy` at boot. The before leg log shows ``Applying migration `20260818000000_add_spend_log_timestamps` `` and the after leg additionally shows ``Applying migration `20260819000000_backfill_spend_log_timestamps` ``. Then one more real call through each upgraded proxy and the final dump:

```bash
curl -sS http://localhost:49662/v1/chat/completions -H "Authorization: Bearer sk-qa-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.4-nano","messages":[{"role":"user","content":"Reply with the single word: upgraded"}]}'
psql lit5854_qa_before -c 'SELECT request_id, "endTime", created_at, updated_at FROM "LiteLLM_SpendLogs" ORDER BY "endTime";'
```

Before leg (staging tip, no fix): every pre-upgrade row, the two 30-day-old ones included, reads `created_at` = 2026-08-19 17:10:09.405, the migration moment

```text
               request_id               |         endTime         |       created_at        |       updated_at
----------------------------------------+-------------------------+-------------------------+-------------------------
 chatcmpl-EEkZoBblFxkEfhUfaP9koccOTyxeV | 2026-07-21 00:05:40.307 | 2026-08-19 17:10:09.405 | 2026-08-19 17:10:09.405
 chatcmpl-EEkZoGyqnACjMnWuNGJCxDVfLgkGy | 2026-07-21 00:05:40.684 | 2026-08-19 17:10:09.405 | 2026-08-19 17:10:09.405
 chatcmpl-EEkZoaI97v89Io4anUtESU0sqtOhM | 2026-08-20 00:05:41.109 | 2026-08-19 17:10:09.405 | 2026-08-19 17:10:09.405
 chatcmpl-EEkfEiORM38TRNIG4iYki9tyu6HNi | 2026-08-20 00:11:16.38  | 2026-08-19 17:11:19.988 | 2026-08-19 17:11:19.988
```

After leg (this PR): the two 30-day-old rows read `created_at` = their own `endTime` exactly, the row written 5 minutes before the upgrade keeps its stamp per the one-hour guard, and the post-upgrade row gets its real write time, about 3 seconds after its `endTime`

```text
               request_id               |         endTime         |       created_at        |       updated_at
----------------------------------------+-------------------------+-------------------------+-------------------------
 chatcmpl-EEkZiuGG0ieJVI4UJn9xDP1Ww5xUS | 2026-07-21 00:05:34.897 | 2026-07-21 00:05:34.897 | 2026-07-21 00:05:34.897
 chatcmpl-EEkZjhOXeo6u4VPy3R0A2Skg7x7LU | 2026-07-21 00:05:35.332 | 2026-07-21 00:05:35.332 | 2026-07-21 00:05:35.332
 chatcmpl-EEkZj8Kf0mK9chWhWM19P8z5CgKGI | 2026-08-20 00:05:35.868 | 2026-08-19 17:10:09.405 | 2026-08-19 17:10:09.405
 chatcmpl-EEkfEgVGkK5Kd1WcenutAqSG76f8J | 2026-08-20 00:11:17.185 | 2026-08-19 17:11:19.947 | 2026-08-19 17:11:19.947
```

One display note on the raw dumps: this QA box's Postgres runs TimeZone America/Los_Angeles, so DB-generated `created_at` values render in local time while the app writes `endTime` in UTC, 7 hours apart. On a UTC production database both columns read on the same scale. The equality that matters is visible regardless: backfilled rows carry `created_at` = `endTime` to the millisecond

One more leg drives the exact population this migration exists for, a database that already applied `20260818000000` and holds the bad stamps (the before leg's database after its control run). Booting the PR head against it with `--use_v2_migration_resolver` applied only ``Applying migration `20260819000000_backfill_spend_log_timestamps` `` as the single pending migration and healed the history in place: the two months-old rows now read `created_at` = `endTime`, while the two rows stamped within the guard hour keep their stamps

```text
               request_id               |         endTime         |       created_at        |       updated_at
----------------------------------------+-------------------------+-------------------------+-------------------------
 chatcmpl-EEkZoBblFxkEfhUfaP9koccOTyxeV | 2026-07-21 00:05:40.307 | 2026-07-21 00:05:40.307 | 2026-07-21 00:05:40.307
 chatcmpl-EEkZoGyqnACjMnWuNGJCxDVfLgkGy | 2026-07-21 00:05:40.684 | 2026-07-21 00:05:40.684 | 2026-07-21 00:05:40.684
 chatcmpl-EEkZoaI97v89Io4anUtESU0sqtOhM | 2026-08-20 00:05:41.109 | 2026-08-19 17:10:09.405 | 2026-08-19 17:10:09.405
 chatcmpl-EEkfEiORM38TRNIG4iYki9tyu6HNi | 2026-08-20 00:11:16.38  | 2026-08-19 17:11:19.988 | 2026-08-19 17:11:19.988
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Rows written under an hour before upgrade keep the stamp
- `--use_prisma_db_push` deployments never run data migrations (pre-existing gap)
- Hundred-million-row tables may need `LITELLM_PRISMA_COMMAND_TIMEOUT` raised once

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 096263db15 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 096263db153cc8e1e3453d781dee8a3ebdbc3ddd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

