### PR TITLE
fix(proxy): log call IDs for request failures

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1322,13 +1322,29 @@ def _has_attribute_error_in_chain(exc: Exception) -> bool:
 _CLIENT_DISCONNECT_DETAIL: Final = "Client disconnected the request"
 
 
-def _log_llm_api_exception(e: Exception) -> None:
+def _log_llm_api_exception(e: Exception, litellm_call_id: object | None = None) -> None:
     if getattr(e, "status_code", None) == 499 and getattr(e, "detail", None) == _CLIENT_DISCONNECT_DETAIL:
+        if litellm_call_id is None:
+            verbose_proxy_logger.info(
+                "litellm.proxy.proxy_server._handle_llm_api_exception(): client disconnected, upstream LLM request cancelled"
+            )
+            return
         verbose_proxy_logger.info(
-            "litellm.proxy.proxy_server._handle_llm_api_exception(): client disconnected, upstream LLM request cancelled"
+            "litellm.proxy.proxy_server._handle_llm_api_exception(): "
+            "client disconnected, upstream LLM request cancelled, litellm_call_id=%s",
+            litellm_call_id,
         )
         return
-    verbose_proxy_logger.exception("litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occured - %s", e)
+    if litellm_call_id is None:
+        verbose_proxy_logger.exception(
+            "litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occured - %s", e
+        )
+        return
+    verbose_proxy_logger.exception(
+        "litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occured - %s, litellm_call_id=%s",
+        e,
+        litellm_call_id,
+    )
 
 
 async def _cancel_llm_call_on_client_disconnect(
@@ -3046,7 +3062,7 @@ class ProxyBaseLLMRequestProcessing:
         version: str | None = None,
     ):
         """Raises ProxyException (OpenAI API compatible) if an exception is raised"""
-        _log_llm_api_exception(e)
+        _log_llm_api_exception(e, litellm_call_id=self.data.get("litellm_call_id"))
         # Allow callbacks to transform the error response
         transformed_exception: Final = await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict,

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -27,6 +27,7 @@ from litellm.proxy.common_request_processing import (
     _extract_error_from_sse_chunk,
     _get_cost_breakdown_from_logging_obj,
     _has_attribute_error_in_chain,
+    _log_llm_api_exception,
     _is_azure_model_router_request,
     _UpstreamClosingStreamingResponse,
     open_sse_before_first_byte,
@@ -2656,6 +2657,89 @@ class TestHasAttributeErrorInChain:
         exc_a.__context__ = exc_b
         exc_b.__context__ = exc_a  # circular
         assert _has_attribute_error_in_chain(exc_a) is False
+
+
+class TestLogLLMApiException:
+    def test_logs_call_id_without_request_data(self):
+        error = TimeoutError("upstream timed out")
+
+        with patch("litellm.proxy.common_request_processing.verbose_proxy_logger.exception") as log_exception:
+            _log_llm_api_exception(error, litellm_call_id="call-a")
+
+        log_exception.assert_called_once_with(
+            "litellm.proxy.proxy_server._handle_llm_api_exception(): "
+            "Exception occured - %s, litellm_call_id=%s",
+            error,
+            "call-a",
+        )
+
+    def test_preserves_log_format_when_call_id_is_missing(self):
+        error = ValueError("upstream failed")
+
+        with patch("litellm.proxy.common_request_processing.verbose_proxy_logger.exception") as log_exception:
+            _log_llm_api_exception(error)
+
+        log_exception.assert_called_once_with(
+            "litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occured - %s", error
+        )
+
+    def test_logs_distinct_call_ids_for_concurrent_failures(self):
+        first_error = TimeoutError("first request timed out")
+        second_error = TimeoutError("second request timed out")
+
+        with patch("litellm.proxy.common_request_processing.verbose_proxy_logger.exception") as log_exception:
+            _log_llm_api_exception(first_error, litellm_call_id="call-first")
+            _log_llm_api_exception(second_error, litellm_call_id="call-second")
+
+        assert [call.args[-1] for call in log_exception.call_args_list] == ["call-first", "call-second"]
+
+    def test_logs_call_id_for_client_disconnect(self):
+        error = HTTPException(status_code=499, detail="Client disconnected the request")
+
+        with patch("litellm.proxy.common_request_processing.verbose_proxy_logger.info") as log_info:
+            _log_llm_api_exception(error, litellm_call_id="call-disconnected")
+
+        log_info.assert_called_once_with(
+            "litellm.proxy.proxy_server._handle_llm_api_exception(): "
+            "client disconnected, upstream LLM request cancelled, litellm_call_id=%s",
+            "call-disconnected",
+        )
+
+    def test_preserves_client_disconnect_log_format_when_call_id_is_missing(self):
+        error = HTTPException(status_code=499, detail="Client disconnected the request")
+
+        with patch("litellm.proxy.common_request_processing.verbose_proxy_logger.info") as log_info:
+            _log_llm_api_exception(error)
+
+        log_info.assert_called_once_with(
+            "litellm.proxy.proxy_server._handle_llm_api_exception(): "
+            "client disconnected, upstream LLM request cancelled"
+        )
+
+    @pytest.mark.asyncio
+    async def test_handler_passes_request_call_id_without_request_body(self):
+        error = TimeoutError("upstream timed out")
+        processor = ProxyBaseLLMRequestProcessing(
+            data={"litellm_call_id": "call-b", "messages": [{"content": "do-not-log"}]}
+        )
+        proxy_logging_obj = MagicMock(spec=ProxyLogging)
+        proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+        proxy_logging_obj.post_call_response_headers_hook = AsyncMock(return_value={})
+
+        with patch("litellm.proxy.common_request_processing.verbose_proxy_logger.exception") as log_exception:
+            with pytest.raises(ProxyException):
+                await processor._handle_llm_api_exception(
+                    e=error,
+                    user_api_key_dict=ProxyUserAPIKeyAuth(api_key="sk-test"),
+                    proxy_logging_obj=proxy_logging_obj,
+                )
+
+        log_exception.assert_called_once_with(
+            "litellm.proxy.proxy_server._handle_llm_api_exception(): "
+            "Exception occured - %s, litellm_call_id=%s",
+            error,
+            "call-b",
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Failed proxy logs cannot be linked to a request

How it solves it:

- Logs `litellm_call_id` for error and disconnect paths
- Preserves the existing format when the ID is absent

## User Flow

Before: a developer receives a failed chat completion but cannot connect its error log to that request

1. They send POST https://litellm-domain/v1/chat/completions while other requests are in flight
2. One request fails and the client receives an error response with `x-litellm-call-id`
3. They inspect the proxy error log but cannot identify the matching request

After: the same failure can be correlated from the proxy error log

1. They send POST https://litellm-domain/v1/chat/completions while other requests are in flight
2. One request fails and the client receives an error response with `x-litellm-call-id`
3. They inspect the proxy error log and match its `litellm_call_id` to the response header

## Relevant issues

Closes #37532

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] Focused regression tests pass locally
- [ ] Full lint and CI checks are pending
- [x] My PR scope is isolated to one problem

## Screenshots / Proof of Fix

No live-provider run was performed because this local environment has no configured provider credential. The draft includes provider-free regression coverage for the error, client-disconnect, absent-ID, distinct-ID, and request-body boundaries

## Type

🐛 Bug Fix

## Caveats (if any)

- Draft pending CI and a live-provider verification

### Final Attestation

- [x] The regression tests cover the affected logging branches and preserve no-ID behavior