### PR TITLE
fix(anthropic): log partial stream spend when a /v1/messages client disconnects mid-stream

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
@@ -10,6 +10,7 @@ from typing_extensions import TypedDict
 
 from litellm.litellm_core_utils.core_helpers import process_response_headers
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 from litellm.proxy.pass_through_endpoints.success_handler import (
     PassThroughEndpointLogging,
 )
@@ -134,8 +135,11 @@ class BaseAnthropicMessagesStreamingIterator:
         if self.completion_start_time is not None:
             self.litellm_logging_obj.completion_start_time = self.completion_start_time
             self.litellm_logging_obj.model_call_details["completion_start_time"] = self.completion_start_time
-        asyncio.create_task(
-            PassThroughStreamingHandler._route_streaming_logging_to_handler(
+        # Enqueue on the rooted logging worker rather than asyncio.create_task:
+        # this also runs during generator teardown after a client disconnect,
+        # where an unrooted task could be garbage-collected before it bills.
+        GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
+            async_coroutine=PassThroughStreamingHandler._route_streaming_logging_to_handler(
                 litellm_logging_obj=self.litellm_logging_obj,
                 passthrough_success_handler_obj=GLOBAL_PASS_THROUGH_SUCCESS_HANDLER_OBJ,
                 url_route="/v1/messages",
@@ -197,13 +201,21 @@ class BaseAnthropicMessagesStreamingIterator:
         collected_chunks: Final = []
         saw_terminal_event = False
 
-        async for chunk in completion_stream:
-            if self.completion_start_time is None:
-                self.completion_start_time = datetime.now()
-            saw_terminal_event = saw_terminal_event or _is_terminal_stream_chunk(chunk)
-            encoded_chunk = self._convert_chunk_to_sse_format(chunk)
-            collected_chunks.append(encoded_chunk)
-            yield encoded_chunk
+        try:
+            async for chunk in completion_stream:
+                if self.completion_start_time is None:
+                    self.completion_start_time = datetime.now()
+                saw_terminal_event = saw_terminal_event or _is_terminal_stream_chunk(chunk)
+                encoded_chunk = self._convert_chunk_to_sse_format(chunk)
+                collected_chunks.append(encoded_chunk)
+                yield encoded_chunk
+        except (GeneratorExit, asyncio.CancelledError):
+            # A client disconnect tears the generator down at the yield, so the
+            # post-loop logging below never runs and the tokens already streamed
+            # (and billed by the provider) would never reach spend tracking. See LIT-5839.
+            if collected_chunks:
+                await self._handle_streaming_logging(collected_chunks)
+            raise
 
         if not saw_terminal_event:
             yield _incomplete_stream_error_sse_event()

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -842,8 +842,15 @@ class AmazonAnthropicClaudeMessagesConfig(
 
         patched_stream: Final = self._promote_message_stop_usage(completion_stream)
 
-        async for chunk in handler.async_sse_wrapper(patched_stream):
-            yield chunk
+        sse_stream: Final = handler.async_sse_wrapper(patched_stream)
+        try:
+            async for chunk in sse_stream:
+                yield chunk
+        finally:
+            # Close the inner generator deterministically so a client disconnect
+            # (GeneratorExit here) reaches async_sse_wrapper's partial-spend logging
+            # now instead of at garbage collection. See LIT-5839.
+            await sse_stream.aclose()
 
     @staticmethod
     def _merge_message_start_cache_into_delta_usage(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import sys
@@ -20,9 +21,11 @@ class _RecordingLoggingIterator(BaseAnthropicMessagesStreamingIterator):
     def __init__(self, litellm_logging_obj: LiteLLMLoggingObj, request_body: dict):
         super().__init__(litellm_logging_obj=litellm_logging_obj, request_body=request_body)
         self.logged_chunks: list = []
+        self.logging_call_count: int = 0
 
     async def _handle_streaming_logging(self, collected_chunks):
         self.logged_chunks = list(collected_chunks)
+        self.logging_call_count += 1
 
 
 def _make_logging_obj(test_name: str) -> LiteLLMLoggingObj:
@@ -231,6 +234,70 @@ async def test_async_sse_wrapper_excludes_synthetic_error_event_from_logged_chun
     assert chunks[-1].startswith(b"event: error\n")
     assert iterator.logged_chunks == chunks[:-1]
     assert not any(chunk.startswith(b"event: error\n") for chunk in iterator.logged_chunks)
+
+
+async def _events_then_hang(events):
+    for event in events:
+        yield event
+    await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_logs_partial_chunks_on_client_disconnect():
+    """
+    Regression test for LIT-5839: a client disconnect tears the generator
+    down with GeneratorExit at the yield, which used to skip the post-loop
+    logging dispatch entirely, so the partial output tokens the provider
+    already generated (and billed) never reached spend tracking.
+    """
+    iterator = _RecordingLoggingIterator(
+        litellm_logging_obj=_make_logging_obj("test_disconnect_logs_partial_chunks"),
+        request_body={},
+    )
+    wrapped = iterator.async_sse_wrapper(_events_then_hang(TRUNCATED_TOOL_USE_EVENTS))
+    streamed = [await wrapped.__anext__() for _ in range(len(TRUNCATED_TOOL_USE_EVENTS))]
+    assert iterator.logging_call_count == 0
+
+    await wrapped.aclose()
+
+    assert iterator.logging_call_count == 1
+    assert iterator.logged_chunks == streamed
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_logs_partial_chunks_on_cancellation():
+    iterator = _RecordingLoggingIterator(
+        litellm_logging_obj=_make_logging_obj("test_cancellation_logs_partial_chunks"),
+        request_body={},
+    )
+    wrapped = iterator.async_sse_wrapper(_events_then_hang(TRUNCATED_TOOL_USE_EVENTS))
+    streamed = [await wrapped.__anext__() for _ in range(len(TRUNCATED_TOOL_USE_EVENTS))]
+
+    consume_task = asyncio.ensure_future(wrapped.__anext__())
+    await asyncio.sleep(0.01)
+    consume_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await consume_task
+
+    assert iterator.logging_call_count == 1
+    assert iterator.logged_chunks == streamed
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_skips_logging_on_disconnect_before_first_chunk():
+    iterator = _RecordingLoggingIterator(
+        litellm_logging_obj=_make_logging_obj("test_disconnect_before_first_chunk"),
+        request_body={},
+    )
+    wrapped = iterator.async_sse_wrapper(_events_then_hang(()))
+
+    consume_task = asyncio.ensure_future(wrapped.__anext__())
+    await asyncio.sleep(0.01)
+    consume_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await consume_task
+
+    assert iterator.logging_call_count == 0
 
 
 def test_incomplete_stream_error_sse_event_is_valid_anthropic_error():

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -2948,3 +2948,38 @@ def test_bedrock_invoke_messages_allows_converted_websearch_function_tool():
         headers={},
     )
     assert result["tools"][0]["name"] == "litellm_web_search"
+
+
+@pytest.mark.asyncio
+async def test_bedrock_sse_wrapper_dispatches_logging_on_client_disconnect():
+    """
+    Regression test for LIT-5839: closing the outer bedrock_sse_wrapper
+    mid-stream (what the proxy does on a client disconnect) must close the
+    inner async_sse_wrapper deterministically so the partial-stream logging
+    fires. `completion_start_time` is only stamped on the logging object by
+    that dispatch, so it observing a value proves the whole chain ran.
+    """
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+
+    async def _hanging_stream():
+        yield {"type": "message_start", "message": {"id": "msg_1", "usage": {"input_tokens": 25, "output_tokens": 1}}}
+        yield {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "partial"}}
+        await asyncio.Event().wait()
+
+    logging_obj = LiteLLMLoggingObj(
+        model="bedrock/invoke/anthropic.claude-3-sonnet-20240229-v1:0",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="chat",
+        start_time=datetime.now(),
+        litellm_call_id="test_bedrock_sse_wrapper_disconnect_logging",
+        function_id="test_bedrock_sse_wrapper_disconnect_logging",
+    )
+    wrapped = cfg.bedrock_sse_wrapper(_hanging_stream(), litellm_logging_obj=logging_obj, request_body={})
+    await wrapped.__anext__()
+    await wrapped.__anext__()
+    assert logging_obj.completion_start_time is None
+
+    await wrapped.aclose()
+
+    assert logging_obj.completion_start_time is not None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Canceled Bedrock `/v1/messages` streams recorded zero spend
- Partial output tokens Bedrock already billed vanished from budgets

How it solves it:

- Client disconnects now dispatch the stream's spend logging on teardown
- Output tokens are recovered from the chunks already streamed

## User Flow

Before: a developer streams a Bedrock-backed answer through `/v1/messages`, their end user cancels mid-answer, and the request never shows up in spend tracking

1. They send POST https://litellm-domain/v1/messages with `"model": "bedrock-claude-opus-5"`, `"stream": true`, and `"max_tokens": 4000`
2. SSE events start arriving; mid-answer their end user hits stop, so the client closes the connection
3. They query GET https://litellm-domain/spend/logs?request_id=<x-litellm-call-id> and get `[]` back no matter how long they wait
4. https://litellm-domain/ui/?page=logs has no row for the request, so the tokens Bedrock generated and billed are invisible to budgets and chargeback

After: the same canceled stream lands in spend logs within seconds, with the partial output tokens counted

1. They send POST https://litellm-domain/v1/messages with `"model": "bedrock-claude-opus-5"`, `"stream": true`, and `"max_tokens": 4000`
2. SSE events start arriving; mid-answer their end user hits stop, so the client closes the connection
3. GET https://litellm-domain/spend/logs?request_id=<x-litellm-call-id> returns one `success` row seconds later, with the prompt tokens plus the output tokens generated before the cancel and their real cost
4. https://litellm-domain/ui/?page=logs shows the request with that partial spend, and a stream left to finish normally is logged exactly as before

## Relevant issues

## Linear ticket

Resolves LIT-5839

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, both sides identical: proxy from the tree under test with a fresh Postgres DB, real Bedrock calls in us-east-1

```yaml
model_list:
  - model_name: bedrock-claude-opus-5
    litellm_params:
      model: bedrock/us.anthropic.claude-opus-5
      aws_region_name: us-east-1
```

```bash
python litellm/proxy/proxy_cli.py --config repro_config.yaml --port 44545 --detailed_debug --use_v2_migration_resolver
```

### Before (eecb226762)

#### Control: stream left to complete

1. `curl -s -N -D headers http://127.0.0.1:44545/v1/messages -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "anthropic-version: 2023-06-01" -H "Content-Type: application/json" -d '{"model":"bedrock-claude-opus-5","stream":true,"max_tokens":600,"messages":[{"role":"user","content":"Write about 400 words on how rivers shape landscapes."}]}'`
2. Full SSE stream ends in `message_stop` with `"usage": {"input_tokens": 25, "output_tokens": 600}`, `x-litellm-call-id: 23eea144-e8c7-4fe1-8a72-f5d28be8d648`
3. `curl -s "http://127.0.0.1:44545/spend/logs?request_id=23eea144-e8c7-4fe1-8a72-f5d28be8d648" -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns one row: `status success, call_type anthropic_messages, prompt_tokens 25, completion_tokens 600, total_tokens 625, spend 0.0166375`

#### Client disconnect mid-stream

1. Same POST with `"max_tokens": 4000` and a longer prompt, piped through `| head -n 150` so curl exits mid-stream after 50 SSE events, `x-litellm-call-id: 62b260f4-c72f-4a79-987f-3aea51b6a521`
2. `curl -s "http://127.0.0.1:44545/spend/logs?request_id=62b260f4-c72f-4a79-987f-3aea51b6a521" -H "Authorization: Bearer $LITELLM_MASTER_KEY"` polled every 3s for 45s returns `[]` every time: the tokens Bedrock generated and billed are never tracked

### After (9209bb6744)

#### Control: stream left to complete

1. Same POST as Before, `x-litellm-call-id: 23c11e3c-09f9-47dd-88fd-94b7a40b9b8c`
2. Full SSE stream ends in `message_stop` with `"usage": {"input_tokens": 25, "output_tokens": 600}`
3. `curl -s "http://127.0.0.1:44545/spend/logs?request_id=23c11e3c-09f9-47dd-88fd-94b7a40b9b8c" -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns one row identical in shape to Before: `status success, call_type anthropic_messages, prompt_tokens 25, completion_tokens 600, total_tokens 625, spend 0.0166375`

#### Client disconnect mid-stream

1. Same POST piped through `| head -n 150`, curl exits after 50 SSE events, `x-litellm-call-id: 61a2b61c-13d0-4bcf-b50a-6cc21a69427a`
2. `curl -s "http://127.0.0.1:44545/spend/logs?request_id=61a2b61c-13d0-4bcf-b50a-6cc21a69427a" -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns one row at the first 3s poll: `status success, call_type anthropic_messages, prompt_tokens 23, completion_tokens 115, total_tokens 138, spend 0.003289`

## Type

🐛 Bug Fix

## Caveats (if any)

- Upstream provider stream errors still take the failure-logging path, unchanged

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 9209bb6744 passes /live-pr-risk
