### PR TITLE
fix(ptu): hand the prune a plain delete filter the query builder can serialise

### DIFF
--- a/litellm/proxy/spend_tracking/ptu_flat_cost_rollup.py
+++ b/litellm/proxy/spend_tracking/ptu_flat_cost_rollup.py
@@ -730,14 +730,12 @@ def _prune_filter(*, date_str: str, cutoff: datetime, chunk: "tuple[str, ...] | 
     Returns a plain dict because the query builder serialises the mapping it is handed and
     rejects a read-only view of one.
     """
-    predicate: Final = {  # mutable-ok: prisma delete filter
+    return {  # mutable-ok: prisma delete filter
         "date": date_str,
         "api_key": PTU_SENTINEL_API_KEY,
         "updated_at": {"lt": cutoff},  # mutable-ok: prisma comparison filter
+        **({} if chunk is None else {"model": {"in": chunk}}),  # mutable-ok: prisma membership filter
     }
-    if chunk is not None:
-        predicate["model"] = {"in": chunk}  # mutable-ok: prisma membership filter
-    return predicate
 
 
 async def _prune_unrefreshed_sentinel_rows(

--- a/litellm/proxy/spend_tracking/ptu_flat_cost_rollup.py
+++ b/litellm/proxy/spend_tracking/ptu_flat_cost_rollup.py
@@ -724,6 +724,22 @@ async def _deliver_alert(alert: "Callable[[str], Awaitable[None]] | None", messa
         verbose_proxy_logger.error("PTU rollup: could not deliver the failed-charge alert: %s", exc)
 
 
+def _prune_filter(*, date_str: str, cutoff: datetime, chunk: "tuple[str, ...] | None") -> "Mapping[str, object]":
+    """One delete statement's predicate. An absent chunk leaves the sweep unbounded.
+
+    Returns a plain dict because the query builder serialises the mapping it is handed and
+    rejects a read-only view of one.
+    """
+    predicate: Final = {  # mutable-ok: prisma delete filter
+        "date": date_str,
+        "api_key": PTU_SENTINEL_API_KEY,
+        "updated_at": {"lt": cutoff},  # mutable-ok: prisma comparison filter
+    }
+    if chunk is not None:
+        predicate["model"] = {"in": chunk}  # mutable-ok: prisma membership filter
+    return predicate
+
+
 async def _prune_unrefreshed_sentinel_rows(
     prisma_client: "PrismaClient",
     *,
@@ -752,27 +768,15 @@ async def _prune_unrefreshed_sentinel_rows(
     that many deployments would otherwise hit every night with no handler above here.
     """
     cutoff: Final = run_started - timedelta(seconds=PTU_PRUNE_SKEW_GRACE_SECONDS)
-    unbounded: Final = {  # mutable-ok: prisma delete filter
-        "date": date_str,
-        "api_key": PTU_SENTINEL_API_KEY,
-        "updated_at": {"lt": cutoff},  # mutable-ok: prisma comparison filter
-    }
     ordered: Final = () if scanned_ids is None else tuple(sorted(scanned_ids))
-    filters: Final = (
-        (unbounded,)
+    chunks: Final = (
+        (None,)
         if scanned_ids is None
         else tuple(
-            MappingProxyType(
-                {
-                    **unbounded,
-                    "model": {  # mutable-ok: prisma membership filter
-                        "in": ordered[start : start + _PRUNE_ID_CHUNK_SIZE]
-                    },
-                }
-            )
-            for start in range(0, len(ordered), _PRUNE_ID_CHUNK_SIZE)
+            ordered[start : start + _PRUNE_ID_CHUNK_SIZE] for start in range(0, len(ordered), _PRUNE_ID_CHUNK_SIZE)
         )
     )
+    filters: Final = tuple(_prune_filter(date_str=date_str, cutoff=cutoff, chunk=chunk) for chunk in chunks)
     deletions: Final = tuple(
         [await prisma_client.db.litellm_dailyteamspend.delete_many(where=where) for where in filters]
     )

--- a/tests/test_litellm/proxy/spend_tracking/test_ptu_flat_cost_rollup.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_ptu_flat_cost_rollup.py
@@ -2067,7 +2067,8 @@ async def test_the_catch_up_pass_reaches_a_config_declared_deployment(monkeypatc
     """The catch-up shares the loader, so config deployments join it without being wired in.
     That is what prices the elapsed days of a reservation declared before today."""
     table = _FakeSentinelTable()
-    started = (datetime.now(timezone.utc) - timedelta(days=3)).strftime("%Y-%m-%dT00:00:00Z")
+    now = datetime.now(timezone.utc)
+    started = (now - timedelta(days=3)).strftime("%Y-%m-%dT00:00:00Z")
     entry = _router_entry(
         model_id="cfg-back",
         model_info={"ptu_count": 100, "cost_per_ptu_per_hour": 0.02, "team_id": "t", "ptu_effective_from": started},
@@ -2077,7 +2078,7 @@ async def test_the_catch_up_pass_reaches_a_config_declared_deployment(monkeypatc
     await run_scheduled_ptu_rollup(_prisma_for([], table), pod_lock_manager=_pod_lock(acquired=True))
 
     charged = sorted(day for (_, day, _, model) in table.rows if model == "cfg-back")
-    yesterday = (datetime.now(timezone.utc).date() - timedelta(days=1)).isoformat()
+    yesterday = (now.date() - timedelta(days=1)).isoformat()
     assert len(charged) == 3, charged
     assert charged[-1] == yesterday
     assert all(row["ptu_flat_cost"] == pytest.approx(48.0) for row in table.rows.values())

--- a/tests/test_litellm/proxy/spend_tracking/test_ptu_flat_cost_rollup.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_ptu_flat_cost_rollup.py
@@ -2045,3 +2045,39 @@ def test_the_router_lookup_returns_none_outside_a_proxy():
     finally:
         if real is not None:
             sys.modules["litellm.proxy.proxy_server"] = real
+
+
+@pytest.mark.parametrize("chunk", [None, ("dep-a", "dep-b")], ids=["unbounded", "bounded"])
+def test_the_prune_filter_is_a_plain_dict(chunk):
+    """The query builder serialises the mapping it is handed and rejects a read-only view of
+    one, which the in-memory table in these tests accepts happily. Only a live run caught it."""
+    predicate = ptu_rollup._prune_filter(date_str=DAY.isoformat(), cutoff=datetime.now(timezone.utc), chunk=chunk)
+
+    assert type(predicate) is dict
+    assert type(predicate["updated_at"]) is dict
+    if chunk is None:
+        assert "model" not in predicate
+    else:
+        assert type(predicate["model"]) is dict
+        assert predicate["model"]["in"] == chunk
+
+
+@pytest.mark.asyncio
+async def test_the_catch_up_pass_reaches_a_config_declared_deployment(monkeypatch):
+    """The catch-up shares the loader, so config deployments join it without being wired in.
+    That is what prices the elapsed days of a reservation declared before today."""
+    table = _FakeSentinelTable()
+    started = (datetime.now(timezone.utc) - timedelta(days=3)).strftime("%Y-%m-%dT00:00:00Z")
+    entry = _router_entry(
+        model_id="cfg-back",
+        model_info={"ptu_count": 100, "cost_per_ptu_per_hour": 0.02, "team_id": "t", "ptu_effective_from": started},
+    )
+    monkeypatch.setattr(ptu_rollup, "_running_router", lambda: _router_holding(entry))
+
+    await run_scheduled_ptu_rollup(_prisma_for([], table), pod_lock_manager=_pod_lock(acquired=True))
+
+    charged = sorted(day for (_, day, _, model) in table.rows if model == "cfg-back")
+    yesterday = (datetime.now(timezone.utc).date() - timedelta(days=1)).isoformat()
+    assert len(charged) == 3, charged
+    assert charged[-1] == yesterday
+    assert all(row["ptu_flat_cost"] == pytest.approx(48.0) for row in table.rows.values())


### PR DESCRIPTION
## TLDR

Problem this solves:

- The nightly PTU job raises once a config deployment is priced
- Its delete predicate is a read-only mapping the query builder rejects
- Charges land first, so the run looks like it produced rows

How it solves it:

- The predicate is built as a plain dict
- A test asserts that, since the in-memory fake accepts any mapping
- The catch-up pass gains a config-declared reservation case

## User Flow

Before: an admin who turns on PTU attribution with a deployment in `config.yaml` sees the day's costs appear and everything after it stop

1. The admin runs a proxy with `LITELLM_ENABLE_PTU_COST_ATTRIBUTION=True` and a provisioned-throughput deployment declared in `config.yaml`
2. The nightly job runs at 00:15 UTC and writes the team's reserved-capacity cost
3. It then raises, so the run never finishes
4. https://litellm-domain/ui/?page=usage shows the day's cost, which makes the run look successful
5. The lapsed-window alert never fires and the catch-up pass never runs, so a reservation whose window closed goes unannounced and earlier unpriced days are never filled in

After: the same job finishes

1. The admin runs the same proxy
2. The nightly job runs and writes the same cost
3. It completes, sweeping the rows it can account for
4. https://litellm-domain/ui/?page=usage shows the same figure
5. The lapsed-window alert and the catch-up pass both run

## Relevant issues

## Linear ticket

Refs LIT-5809

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real Postgres, the real scheduled entry point, one config-declared PTU deployment at 100 units and $0.02 an hour. Both sides run the same three lines against the same database, and the exit code is checked rather than the output skimmed, which is how the defect reached staging in the first place.

```python
proxy_server.llm_router = Router(model_list=yaml.safe_load(open("ptu.yaml"))["model_list"])
await run_scheduled_ptu_rollup(prisma, pod_lock_manager=<lock held>, target_date=date(2026, 8, 18))
await prisma.db.litellm_dailyteamspend.find_many(where={"api_key": "__ptu_flat_cost__"})
```

### Before (c2b3c4b1e4)

1. Run it

```
exit=1
TypeError: Type <class 'mappingproxy'> not serializable
```

2. Read the table back

```
1 sentinel row(s) written before it died
```

The charge is there, which is what makes the failure easy to miss: the upserts precede the sweep, so the usage view fills in and the run dies afterwards

### After (db015e9c8b)

1. Run it

```
exit=0
rollup: RollupResult(day=2026-08-18, models_processed=1, rows_written=1, rows_failed=0, lapsed=())
flat-cost rows: [('ptu-team-0001', 'gpt-4o-ptu', 48.0)]
```

2. Read the table back

```
tracebacks: 0
```

The run completes, so the lapsed-window alert and the catch-up pass that follow it both get to run

## Type

🐛 Bug Fix

## Changes

`_prune_unrefreshed_sentinel_rows` built its bounded predicate with `MappingProxyType`, and `prisma/builder.py` refuses to serialise a `mappingproxy`. A predicate builder now returns a plain dict for both the bounded and unbounded sweeps.

The unit suite could not catch this: its in-memory table accepts any mapping, so the delete looked fine. The new test asserts the predicate's concrete type, and a second one drives the catch-up pass over a config-declared reservation, which is the path the crash was blocking.

## QA runbook

## Caveats (if any)

- The annotation says Mapping; the test is what pins the concrete dict

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/37571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit db015e9c8bf2942d9455fda5e83100a83e97ba76. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
