### PR TITLE
fix(prompt_management): don't route no-prompt_id requests to prompt managers that can't run them

### DIFF
--- a/litellm/integrations/arize/arize_phoenix_prompt_manager.py
+++ b/litellm/integrations/arize/arize_phoenix_prompt_manager.py
@@ -359,10 +359,10 @@ class ArizePhoenixPromptManager(CustomPromptManagement):
         """
         Determine if prompt management should run based on the prompt_id.
 
-        For Arize Phoenix, we always return True and handle the prompt loading
-        in the _compile_prompt_helper method.
+        Arize Phoenix needs a prompt_id to compile, so it declines requests without one;
+        prompt loading itself happens in the _compile_prompt_helper method.
         """
-        return True
+        return prompt_id is not None
 
     def _compile_prompt_helper(
         self,

--- a/litellm/integrations/prompt_management_base.py
+++ b/litellm/integrations/prompt_management_base.py
@@ -165,7 +165,7 @@ class PromptManagementBase(ABC):
         ignore_prompt_manager_optional_params: bool | None = False,
     ) -> tuple[str, list[AllMessageValues], dict]:
         if prompt_id is None:
-            raise ValueError("prompt_id is required for Prompt Management Base class")
+            return model, messages, non_default_params
         if not self.should_run_prompt_management(
             prompt_id=prompt_id,
             prompt_spec=prompt_spec,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -832,8 +832,8 @@ class Logging(LiteLLMLoggingBaseClass):
 
         eg. AnthropicCacheControlHook and BedrockKnowledgeBaseHook both don't require a `prompt_id` to be passed in, they are triggered by dynamic params
         """
-        for param in non_default_params:
-            if param in DynamicPromptManagementParamLiteral.list_all_params():
+        for param in DynamicPromptManagementParamLiteral.list_all_params():
+            if non_default_params.get(param):
                 return True
 
         #############################################################################
@@ -966,6 +966,23 @@ class Logging(LiteLLMLoggingBaseClass):
 
         return None
 
+    @staticmethod
+    def _prompt_manager_runs_without_prompt_id(
+        logger: CustomLogger,
+        prompt_spec: PromptSpec | None,
+        dynamic_callback_params: StandardCallbackDynamicParams | None,
+    ) -> bool:
+        if not isinstance(logger, CustomPromptManagement):
+            return False
+        try:
+            return logger.should_run_prompt_management(
+                prompt_id=None,
+                prompt_spec=prompt_spec,
+                dynamic_callback_params=dynamic_callback_params or StandardCallbackDynamicParams(),
+            )
+        except Exception:
+            return False
+
     def get_custom_logger_for_prompt_management(
         self,
         model: str,
@@ -1016,8 +1033,13 @@ class Logging(LiteLLMLoggingBaseClass):
             callback_type=CustomPromptManagement
         )
 
-        if prompt_management_loggers:
-            logger: Final = prompt_management_loggers[0]
+        for logger in prompt_management_loggers:
+            if prompt_id is None and not self._prompt_manager_runs_without_prompt_id(
+                logger=logger,
+                prompt_spec=prompt_spec,
+                dynamic_callback_params=dynamic_callback_params,
+            ):
+                continue
             self.model_call_details["prompt_integration"] = logger.__class__.__name__
             return logger
 

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -5113,6 +5113,7 @@ def test_prompt_hooks_skip_prompt_managers_when_no_prompt_id(logging_obj, tmp_pa
     with a registered prompt manager (e.g. dotprompt): requests without a prompt_id 500'd with
     "prompt_id is required for Prompt Management Base class" instead of completing normally.
     """
+    from litellm.integrations.arize.arize_phoenix_prompt_manager import ArizePhoenixPromptManager
     from litellm.integrations.dotprompt.dotprompt_manager import DotpromptManager
     from litellm.integrations.vector_store_integrations.vector_store_pre_call_hook import (
         VectorStorePreCallHook,
@@ -5122,7 +5123,9 @@ def test_prompt_hooks_skip_prompt_managers_when_no_prompt_id(logging_obj, tmp_pa
 
     (tmp_path / "stem.prompt").write_text("---\nmodel: gemini-2.5-flash\n---\nyou are a stem tutor\n")
     dotprompt_manager = DotpromptManager(prompt_directory=str(tmp_path))
+    arize_manager = ArizePhoenixPromptManager(api_key="fake-key", api_base="http://127.0.0.1:9")
     litellm.logging_callback_manager.add_litellm_callback(dotprompt_manager)
+    litellm.logging_callback_manager.add_litellm_callback(arize_manager)
     monkeypatch.setattr(
         litellm,
         "vector_store_registry",
@@ -5154,6 +5157,10 @@ def test_prompt_hooks_skip_prompt_managers_when_no_prompt_id(logging_obj, tmp_pa
             dynamic_callback_params={},
         ) == ("gemini-2.5-flash", messages, {})
 
+        assert not arize_manager.should_run_prompt_management(
+            prompt_id=None, prompt_spec=None, dynamic_callback_params={}
+        )
+
         assert logging_obj.should_run_prompt_management_hooks(
             prompt_id=None, non_default_params={"vector_store_ids": ["vs_123"]}
         )
@@ -5177,9 +5184,10 @@ def test_prompt_hooks_skip_prompt_managers_when_no_prompt_id(logging_obj, tmp_pa
             DotpromptManager,
         )
     finally:
-        litellm.logging_callback_manager.remove_callback_from_list_by_object(litellm.callbacks, dotprompt_manager)
-        litellm.logging_callback_manager.remove_callback_from_list_by_object(
-            litellm._async_success_callback, dotprompt_manager
-        )
+        for manager in (dotprompt_manager, arize_manager):
+            litellm.logging_callback_manager.remove_callback_from_list_by_object(litellm.callbacks, manager)
+            litellm.logging_callback_manager.remove_callback_from_list_by_object(
+                litellm._async_success_callback, manager
+            )
         for hook in [cb for cb in litellm.callbacks if isinstance(cb, VectorStorePreCallHook)]:
             litellm.logging_callback_manager.remove_callback_from_list_by_object(litellm.callbacks, hook)

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -5115,6 +5115,7 @@ def test_prompt_hooks_skip_prompt_managers_when_no_prompt_id(logging_obj, tmp_pa
     """
     from litellm.integrations.arize.arize_phoenix_prompt_manager import ArizePhoenixPromptManager
     from litellm.integrations.dotprompt.dotprompt_manager import DotpromptManager
+    from litellm.integrations.vector_store_integrations.base_vector_store import BaseVectorStore
     from litellm.integrations.vector_store_integrations.vector_store_pre_call_hook import (
         VectorStorePreCallHook,
     )
@@ -5164,14 +5165,25 @@ def test_prompt_hooks_skip_prompt_managers_when_no_prompt_id(logging_obj, tmp_pa
         assert logging_obj.should_run_prompt_management_hooks(
             prompt_id=None, non_default_params={"vector_store_ids": ["vs_123"]}
         )
-        assert isinstance(
-            logging_obj.get_custom_logger_for_prompt_management(
-                model="gemini-2.5-flash",
-                non_default_params={"vector_store_ids": ["vs_123"]},
-                prompt_id=None,
-                dynamic_callback_params={},
-            ),
-            VectorStorePreCallHook,
+        selected_logger = logging_obj.get_custom_logger_for_prompt_management(
+            model="gemini-2.5-flash",
+            non_default_params={"vector_store_ids": ["vs_123"]},
+            prompt_id=None,
+            dynamic_callback_params={},
+        )
+        assert isinstance(selected_logger, VectorStorePreCallHook)
+
+        assert logging_obj._prompt_manager_runs_without_prompt_id(
+            logger=BaseVectorStore(), prompt_spec=None, dynamic_callback_params=None
+        )
+        assert not logging_obj._prompt_manager_runs_without_prompt_id(
+            logger=selected_logger, prompt_spec=None, dynamic_callback_params=None
+        )
+        assert not logging_obj._prompt_manager_runs_without_prompt_id(
+            logger=dotprompt_manager, prompt_spec=None, dynamic_callback_params=None
+        )
+        assert not logging_obj._prompt_manager_runs_without_prompt_id(
+            logger=arize_manager, prompt_spec=None, dynamic_callback_params=None
         )
 
         assert isinstance(

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -5105,3 +5105,81 @@ def test_set_cost_breakdown_stores_vertex_location():
         cost_for_built_in_tools_cost_usd_dollar=0.0,
     )
     assert no_location.cost_breakdown.get("vertex_location") is None
+
+
+def test_prompt_hooks_skip_prompt_managers_when_no_prompt_id(logging_obj, tmp_path, monkeypatch):
+    """
+    Regression for UI-injected `vector_store_ids: []` and always-on non-empty `vector_store_ids`
+    with a registered prompt manager (e.g. dotprompt): requests without a prompt_id 500'd with
+    "prompt_id is required for Prompt Management Base class" instead of completing normally.
+    """
+    from litellm.integrations.dotprompt.dotprompt_manager import DotpromptManager
+    from litellm.integrations.vector_store_integrations.vector_store_pre_call_hook import (
+        VectorStorePreCallHook,
+    )
+    from litellm.types.vector_stores import LiteLLM_ManagedVectorStore
+    from litellm.vector_stores.vector_store_registry import VectorStoreRegistry
+
+    (tmp_path / "stem.prompt").write_text("---\nmodel: gemini-2.5-flash\n---\nyou are a stem tutor\n")
+    dotprompt_manager = DotpromptManager(prompt_directory=str(tmp_path))
+    litellm.logging_callback_manager.add_litellm_callback(dotprompt_manager)
+    monkeypatch.setattr(
+        litellm,
+        "vector_store_registry",
+        VectorStoreRegistry(
+            vector_stores=[LiteLLM_ManagedVectorStore(vector_store_id="vs_123", custom_llm_provider="openai")]
+        ),
+    )
+
+    messages = [{"role": "user", "content": "hi"}]
+    try:
+        assert not logging_obj.should_run_prompt_management_hooks(
+            prompt_id=None, non_default_params={"vector_store_ids": []}
+        )
+
+        assert logging_obj.get_chat_completion_prompt(
+            model="gemini-2.5-flash",
+            messages=messages,
+            non_default_params={"vector_store_ids": []},
+            prompt_variables=None,
+            prompt_id=None,
+        ) == ("gemini-2.5-flash", messages, {"vector_store_ids": []})
+
+        assert dotprompt_manager.get_chat_completion_prompt(
+            model="gemini-2.5-flash",
+            messages=messages,
+            non_default_params={},
+            prompt_id=None,
+            prompt_variables=None,
+            dynamic_callback_params={},
+        ) == ("gemini-2.5-flash", messages, {})
+
+        assert logging_obj.should_run_prompt_management_hooks(
+            prompt_id=None, non_default_params={"vector_store_ids": ["vs_123"]}
+        )
+        assert isinstance(
+            logging_obj.get_custom_logger_for_prompt_management(
+                model="gemini-2.5-flash",
+                non_default_params={"vector_store_ids": ["vs_123"]},
+                prompt_id=None,
+                dynamic_callback_params={},
+            ),
+            VectorStorePreCallHook,
+        )
+
+        assert isinstance(
+            logging_obj.get_custom_logger_for_prompt_management(
+                model="gemini-2.5-flash",
+                non_default_params={},
+                prompt_id="stem",
+                dynamic_callback_params={},
+            ),
+            DotpromptManager,
+        )
+    finally:
+        litellm.logging_callback_manager.remove_callback_from_list_by_object(litellm.callbacks, dotprompt_manager)
+        litellm.logging_callback_manager.remove_callback_from_list_by_object(
+            litellm._async_success_callback, dotprompt_manager
+        )
+        for hook in [cb for cb in litellm.callbacks if isinstance(cb, VectorStorePreCallHook)]:
+            litellm.logging_callback_manager.remove_callback_from_list_by_object(litellm.callbacks, hook)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Admin UI stores DB models with empty `tags`/`guardrails`/`vector_store_ids` lists
- Those empty lists made every request run prompt-management hooks
- With any saved prompt registered, the first prompt manager grabbed the request
- Requests without `prompt_id` then 500'd: "prompt_id is required for Prompt Management Base class"

How it solves it:

- Empty dynamic params no longer count as a prompt-management trigger
- The fallback skips prompt managers that decline a missing `prompt_id`
- The sync path returns the request unchanged on missing `prompt_id`, matching async
- Arize Phoenix now declines runs without a `prompt_id`, like the other managers

## User Flow

Before: once any saved prompt exists on the gateway, every request against a model the admin added through the UI fails with a 500, on all three LLM endpoints, and always-on vector store retrieval never runs

1. The proxy admin adds a Vertex Gemini deployment on https://litellm-domain/ui/?page=models; saving from the UI stores it with empty `tags`, `guardrails`, and `vector_store_ids` lists
2. The admin registers an OpenAI vector store on https://litellm-domain/ui/?page=vector-stores and adds a second deployment whose `vector_store_ids` names it, so that model always answers from the knowledge base
3. The admin saves a reusable prompt via POST https://litellm-domain/prompts (or the UI prompts page)
4. A developer sends POST https://litellm-domain/v1/chat/completions with `{"model": "<the UI-added deployment>", "messages": [...]}` and no `prompt_id`
5. They get HTTP 500 with `litellm.APIConnectionError: prompt_id is required for Prompt Management Base class`, even though they never asked for a prompt
6. The same request against the knowledge base deployment fails with the identical 500, so no retrieval ever runs and no `search_results` come back
7. Their teammates on POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages get the same 500 from the same deployment
8. The only request that still works is one that passes `prompt_id`, which returns HTTP 200 with the saved prompt applied

After: the same requests return the model's normal completion on all three endpoints, and the knowledge base deployment answers from its vector store

1. The proxy admin adds a Vertex Gemini deployment on https://litellm-domain/ui/?page=models; saving from the UI stores it with empty `tags`, `guardrails`, and `vector_store_ids` lists
2. The admin registers an OpenAI vector store on https://litellm-domain/ui/?page=vector-stores and adds a second deployment whose `vector_store_ids` names it, so that model always answers from the knowledge base
3. The admin saves a reusable prompt via POST https://litellm-domain/prompts (or the UI prompts page)
4. A developer sends POST https://litellm-domain/v1/chat/completions with `{"model": "<the UI-added deployment>", "messages": [...]}` and no `prompt_id`
5. They get HTTP 200 with the model's completion
6. The same request against the knowledge base deployment returns HTTP 200, the answer drawn from the store, and `search_results` alongside it
7. Their teammates on POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages get HTTP 200 from the same deployment
8. A request that passes `prompt_id` still returns HTTP 200 with the saved prompt applied, unchanged
9. A deployment naming a model the provider does not serve on this route now surfaces the provider's own error, such as HTTP 400 from Vertex for a live native-audio model, instead of the gateway's 500

## Relevant issues

## Linear ticket

Resolves LIT-5866

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two live proxies, one booted from the merge base (7b574b9df6) on port 34811 and one from this PR's head (5c7604d7fa) on port 39217, both with `store_model_in_db: true` against a real Postgres, both driven through the identical runbook. Deployments went in via POST /model/new exactly as the Admin UI stores them, carrying empty `tags`, `guardrails`, and `vector_store_ids`: `gemini-flash-arrays` (vertex_ai/gemini-2.5-flash plus the empty lists), `gemini-live-2.5-flash-native-audio` (the customer's exact Vertex entry), `gemini-flash-kb` (`vector_store_ids` naming a real OpenAI vector store holding one note), and `gemini-2.5-flash-aistudio` (no lists, the control). A real OpenAI vector store went in via POST /vector_store/new and a dotprompt via POST /prompts, then each proxy was restarted so it loaded all of it from the DB the way a running gateway does. `$KEY` is an end-user virtual key from POST /key/generate. Every call hit real provider APIs

### Before (7b574b9df6, the merge base)

#### /v1/chat/completions, Vertex deployment with UI-injected empty lists, no prompt_id

1. `curl -s -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://127.0.0.1:34811/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model": "gemini-flash-arrays", "messages": [{"role": "user", "content": "Say hello in exactly three words"}]}'`
2. HTTP_STATUS:500 with the customer's stack, step for step:

```
{"error":{"message":"litellm.APIConnectionError: prompt_id is required for Prompt Management Base class
Traceback (most recent call last):
  File ".../litellm/main.py", line 638, in acompletion
  ...
  File ".../litellm/litellm_core_utils/litellm_logging.py", line 874, in get_chat_completion_prompt
    ) = custom_logger.get_chat_completion_prompt(
  File ".../litellm/integrations/dotprompt/dotprompt_manager.py", line 201, in get_chat_completion_prompt
    return PromptManagementBase.get_chat_completion_prompt(
  File ".../litellm/integrations/prompt_management_base.py", line 168, in get_chat_completion_prompt
    raise ValueError("prompt_id is required for Prompt Management Base class")
ValueError: prompt_id is required for Prompt Management Base class
. Received Model Group=gemini-flash-arrays
Available Model Group Fallbacks=None","code":"500"}}
```

#### /v1/chat/completions, customer-exact Vertex deployment

1. The same curl with `"model": "gemini-live-2.5-flash-native-audio"`
2. HTTP_STATUS:500, the identical `prompt_id is required for Prompt Management Base class` and stack

#### /v1/chat/completions, non-empty vector_store_ids

1. `curl -s -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://127.0.0.1:34811/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model": "gemini-flash-kb", "messages": [{"role": "user", "content": "What is the name of the purple axolotl?"}]}'`
2. HTTP_STATUS:500, the identical error: the prompt manager takes the request before any vector store retrieval runs

#### /v1/chat/completions, saved prompt via prompt_id (control)

1. `curl -s -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://127.0.0.1:34811/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model": "gemini-2.5-flash-aistudio", "prompt_id": "corsair", "messages": [{"role": "user", "content": "Say hello in one short sentence"}]}'`
2. `{"choices":[{"message":{"content":"Ahoy, matey!","role":"assistant"}}],"usage":{"prompt_tokens":24,"completion_tokens":94,...}}` then HTTP_STATUS:200, the saved pirate prompt applied

#### /v1/responses, same deployment, no prompt_id

1. `curl -s -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://127.0.0.1:34811/v1/responses -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model": "gemini-flash-arrays", "input": "Say hello in exactly three words"}'`
2. HTTP_STATUS:500, the identical `prompt_id is required for Prompt Management Base class`

#### /v1/messages, same deployment, no prompt_id

1. `curl -s -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://127.0.0.1:34811/v1/messages -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model": "gemini-flash-arrays", "max_tokens": 512, "messages": [{"role": "user", "content": "Say hello in exactly three words"}]}'`
2. HTTP_STATUS:500, the identical `prompt_id is required for Prompt Management Base class`

### After (5c7604d7fa, this PR's head)

#### /v1/chat/completions, Vertex deployment with UI-injected empty lists, no prompt_id

1. The same curl against port 39217
2. `{"id":"YcKGaoWbDKiMoM8P5ZGzsAI","model":"gemini-flash-arrays","choices":[{"finish_reason":"stop","message":{"content":"Hello there friend.","role":"assistant"}}],"usage":{"completion_tokens":26,"prompt_tokens":6,"total_tokens":32}}` then HTTP_STATUS:200, a real Vertex response

#### /v1/chat/completions, customer-exact Vertex deployment

1. The same curl with `"model": "gemini-live-2.5-flash-native-audio"`
2. `{"error":{"message":"litellm.BadRequestError: Vertex_aiException BadRequestError - {\"error\": {\"code\": 400, \"message\": \"gemini-live-2.5-flash-native-audio is not supported in the generateContent API.\", \"status\": \"INVALID_ARGUMENT\"}}. Received Model Group=gemini-live-2.5-flash-native-audio","code":"400"}}` then HTTP_STATUS:400. The gateway's 500 is gone and the request now reaches Vertex, which serves this model on its live API rather than generateContent

#### /v1/chat/completions, non-empty vector_store_ids

1. The same curl with `"model": "gemini-flash-kb"`
2. `{"choices":[{"message":{"content":"The name of the purple axolotl is **Zorp**.","provider_specific_fields":{"search_results":[{"object":"vector_store.search_results.page","data":[{"filename":"lit5866_notes.txt","score":0.9916502908685798,"content":[{"type":"text","text":"Company handbook: the LiteLLM QA test mascot is a purple axolotl named Zorp, adopted in 2019."}]}]}]}}}]}` then HTTP_STATUS:200. Zorp exists only inside the vector store, so the answer proves retrieval ran, and the real search results come back attached

#### /v1/chat/completions, saved prompt via prompt_id (control)

1. The same curl with `"prompt_id": "corsair"`
2. `{"choices":[{"message":{"content":"Ahoy!","role":"assistant"}}],"usage":{"prompt_tokens":24,"completion_tokens":203,...}}` then HTTP_STATUS:200, the same 24 prompt tokens as before the fix

#### /v1/responses, same deployment, no prompt_id

1. The same curl against port 39217
2. `{"id":"resp_Bm9rB75V8VuCjWoW...","object":"response","model":"gemini-flash-arrays","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello there! Hi."}]}],"usage":{"input_tokens":6,"output_tokens":28,"total_tokens":34}}` then HTTP_STATUS:200

#### /v1/messages, same deployment, no prompt_id

1. The same curl against port 39217
2. `{"id":"Z8KGas71HYCxoM8PjYCPsAI","type":"message","role":"assistant","model":"gemini-flash-arrays","content":[{"type":"text","text":"Hello there!"}],"stop_reason":"end_turn","usage":{"input_tokens":6,"output_tokens":26}}` then HTTP_STATUS:200

### What the run also turned up

- All three LLM endpoints failed identically before and pass after
- Vertex rejects live native-audio models on generateContent, upstream of us
- That 400 predates this PR, which only removes the gateway 500

## Type

🐛 Bug Fix

## Caveats (if any)

- A custom prompt manager still claims requests without a prompt_id
- So its model's always-on vector store retrieval stays skipped, unchanged here

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5c7604d7facd84df1767a8c2b65a3fb0cfb3873d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->