### PR TITLE
fix(ui): keep semantic button colours on hover after the no-op hover cleanup

### DIFF
--- a/ui/litellm-dashboard/src/app/chat/page.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/chat/page.integration.test.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatHistory } from "@/components/chat/useChatHistory";
 import ChatConversationPage from "./page";
 
-const { mockMakeOpenAIResponsesRequest } = vi.hoisted(() => ({
+const { mockMakeOpenAIResponsesRequest, shellState } = vi.hoisted(() => ({
   mockMakeOpenAIResponsesRequest: vi.fn(),
+  shellState: { storageUnavailable: false },
 }));
 
 vi.mock("next/navigation", () => ({
@@ -50,7 +51,7 @@ vi.mock("@/contexts/ChatShellContext", () => ({
       conversations: history.conversations,
       activeConversation: history.activeConversation,
       activeConversationId: history.currentActiveId,
-      storageUnavailable: false,
+      storageUnavailable: shellState.storageUnavailable,
       staleId: false,
       createConversation: history.createConversation,
       appendMessage: history.appendMessage,
@@ -81,6 +82,7 @@ describe("/ui/chat request metrics", () => {
   beforeEach(() => {
     localStorage.clear();
     mockMakeOpenAIResponsesRequest.mockReset();
+    shellState.storageUnavailable = false;
   });
 
   it("renders latency, TTFT, token counts and cost reported for the assistant turn", async () => {
@@ -128,5 +130,22 @@ describe("/ui/chat request metrics", () => {
 
     expect(await screen.findByText("No usage here.")).toBeInTheDocument();
     expect(document.querySelector(".response-metrics")).toBeNull();
+  });
+});
+
+describe("/ui/chat storage banner", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockMakeOpenAIResponsesRequest.mockReset();
+    shellState.storageUnavailable = true;
+  });
+
+  it("keeps the dismiss control amber on hover instead of the ghost variant's foreground", async () => {
+    render(<ChatConversationPage />);
+
+    const banner = await screen.findByText("Chat history won't be saved in this browser session");
+    const dismiss = within(banner.parentElement!).getByRole("button");
+    expect(dismiss).toHaveClass("hover:text-warning/80");
+    expect(dismiss).not.toHaveClass("hover:text-foreground");
   });
 });

--- a/ui/litellm-dashboard/src/app/chat/page.tsx
+++ b/ui/litellm-dashboard/src/app/chat/page.tsx
@@ -518,7 +518,7 @@ export default function ChatConversationPage() {
             variant="ghost"
             size="icon-xs"
             onClick={() => setStorageBannerDismissed(true)}
-            className="text-warning hover:bg-warning/15 "
+            className="text-warning hover:bg-warning/15 hover:text-warning/80"
           >
             <X className="size-3.5" />
           </Button>

--- a/ui/litellm-dashboard/src/components/SidebarUsageCard.test.tsx
+++ b/ui/litellm-dashboard/src/components/SidebarUsageCard.test.tsx
@@ -156,4 +156,12 @@ describe("SidebarUsageCard", () => {
     await user.click(rail);
     expect(onExpandRail).toHaveBeenCalledOnce();
   });
+
+  it("keeps the collapsed rail tinted on hover instead of the outline variant's foreground", async () => {
+    renderWithClient(<SidebarUsageCard accessToken="token" collapsed onExpandRail={vi.fn()} />);
+
+    const rail = await screen.findByTitle("Enterprise usage");
+    expect(rail).toHaveClass("hover:text-sidebar-primary/80");
+    expect(rail).not.toHaveClass("hover:text-foreground");
+  });
 });

--- a/ui/litellm-dashboard/src/components/SidebarUsageCard.tsx
+++ b/ui/litellm-dashboard/src/components/SidebarUsageCard.tsx
@@ -85,7 +85,7 @@ export default function SidebarUsageCard({ accessToken, collapsed, onExpandRail 
         variant="outline"
         onClick={onExpandRail}
         title="Enterprise usage"
-        className="h-9 w-full rounded-lg border-sidebar-border bg-sidebar text-sidebar-primary shadow-none hover:bg-sidebar-accent"
+        className="h-9 w-full rounded-lg border-sidebar-border bg-sidebar text-sidebar-primary shadow-none hover:bg-sidebar-accent hover:text-sidebar-primary/80"
       >
         <Award className="size-[18px]" strokeWidth={1.75} />
       </Button>

--- a/ui/litellm-dashboard/src/components/team/LoggingSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/LoggingSettings.test.tsx
@@ -181,6 +181,22 @@ describe("LoggingSettings", () => {
     expect(source.match(HARDCODED_PALETTE) ?? []).toHaveLength(0);
   });
 
+  it("keeps the remove button destructive on hover instead of the ghost variant's foreground", () => {
+    const initialValue = [
+      {
+        callback_name: "langsmith",
+        callback_type: "success",
+        callback_vars: {},
+      },
+    ];
+
+    renderWithProviders(<LoggingSettings value={initialValue} onChange={vi.fn()} />);
+
+    const remove = screen.getByRole("button", { name: "Remove" });
+    expect(remove).toHaveClass("hover:text-destructive/80");
+    expect(remove).not.toHaveClass("hover:text-foreground");
+  });
+
   it("reports the chosen event type when a different option is picked", async () => {
     const user = userEvent.setup({ delay: null });
     const mockOnChange = vi.fn();

--- a/ui/litellm-dashboard/src/components/team/LoggingSettings.tsx
+++ b/ui/litellm-dashboard/src/components/team/LoggingSettings.tsx
@@ -278,7 +278,7 @@ const LoggingSettings: React.FC<LoggingSettingsProps> = ({
                   variant="ghost"
                   onClick={() => removeLoggingConfig(index)}
                   size="sm"
-                  className="text-destructive hover:bg-destructive/10"
+                  className="text-destructive hover:bg-destructive/10 hover:text-destructive/80"
                   type="button"
                 >
                   <Trash2 />


### PR DESCRIPTION
## TLDR

Problem this solves:

- Three buttons lose their colour when you point at them
- The ghost and outline variants override them with plain foreground
- Nothing caught it, so the affordance reads as broken

How it solves it:

- Each button pins its own hover colour again
- The value is an alpha step, so it stays visible
- Three tests fail if the class disappears again

## User Flow

Before: an admin pointing at a red, amber, or tinted button watches it turn plain grey, so the colour that told them what the button does is gone exactly when they are about to click it

1. They open http://localhost:4000/ui/?page=teams, open a team, and go to the Logging tab
2. They add an integration, then point at the red "Remove" button under it; the text and the trash icon turn ordinary dark grey
3. They collapse the left sidebar and point at the enterprise usage button at its foot; in dark mode the indigo award icon turns white
4. They open http://localhost:4000/ui/chat in a browser where site storage is blocked, and point at the "x" on the amber "Chat history won't be saved" banner; the amber turns grey against the amber banner

After: the same three buttons keep their colour and just deepen slightly, so the meaning survives the hover

1. They open http://localhost:4000/ui/?page=teams, open a team, and go to the Logging tab
2. They add an integration, then point at the red "Remove" button; it stays red and picks up a faint red wash
3. They collapse the left sidebar and point at the enterprise usage button; the award icon keeps its tint in both light and dark mode
4. They open http://localhost:4000/ui/chat with site storage blocked and point at the "x" on the banner; it stays amber

## Relevant issues

Follow-up to #37579

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: run the dashboard dev server against a local proxy so the screens below render live

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

```
cd ui/litellm-dashboard && npm run dev
```

Dark mode has no in-app toggle yet, so switch it on from the browser console where a case calls for it:

```
document.documentElement.classList.add('dark')
```

### Before (93c14610748bb724702f2f4616bc8137841c080e)

#### Remove button in a team's logging settings

1. Open http://localhost:3000/teams/, open any team, and click the Logging tab
2. Click "Add Logging Integration", pick any integration, and leave the card on screen
3. Point at the red "Remove" button in that card's header and capture it: the label and trash icon turn dark grey

#### Collapsed enterprise usage rail

1. Open http://localhost:3000/ and collapse the left sidebar with the rail toggle
2. Turn dark mode on with the console line above
3. Point at the award button at the foot of the rail and capture it: the indigo icon turns white

#### Chat storage banner dismiss

1. Block site data for localhost in the browser's site settings, then open http://localhost:3000/chat/
2. The amber "Chat history won't be saved in this browser session" banner appears
3. Point at the "x" at its right edge and capture it: the amber glyph turns grey

### After (3ca5c70e2eb0b3b7a37e1b7cf3fbb6ef6da1efb4)

#### Remove button in a team's logging settings

1. Open http://localhost:3000/teams/, open any team, and click the Logging tab
2. Click "Add Logging Integration", pick any integration, and leave the card on screen
3. Point at the red "Remove" button and capture it: it stays red over a faint red wash

#### Collapsed enterprise usage rail

1. Open http://localhost:3000/ and collapse the left sidebar with the rail toggle
2. Turn dark mode on with the console line above
3. Point at the award button and capture it: the icon keeps its tint

#### Chat storage banner dismiss

1. Block site data for localhost in the browser's site settings, then open http://localhost:3000/chat/
2. The amber banner appears
3. Point at the "x" and capture it: it stays amber

## Type

🐛 Bug Fix

## Caveats (if any)

- tailwind-merge decides this, so ordering alone would not fix it
- Neutral buttons keep the variant's hover, which reads fine
- Sites that never pinned a hover colour are left alone

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
