### PR TITLE
fix: set supports_vision to false for novita/openai/gpt-oss-120b

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -45324,7 +45324,7 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_system_messages": true,
         "supports_response_schema": true,
         "supports_reasoning": true

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -45324,7 +45324,7 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_system_messages": true,
         "supports_response_schema": true,
         "supports_reasoning": true


### PR DESCRIPTION
## Why are these changes needed?

The `novita/openai/gpt-oss-120b` entry had `supports_vision: true`, but gpt-oss-120b is a text-only model without vision support.

Fixes #37584

## Change type

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance improvement
- [ ] Test update
- [ ] CI/CD changes
- [ ] Other

## Checklists

### I submitted a PR to `use-prompt` repo
- [ ] I submitted the `use-prompt` update in a separate PR
- [ ] Not applicable

### Model (if applicable)
- [ ] Model is already in the repo under the right provider folder, if not, I submitted a PR to `litellm` with the following changes:
  - [ ] Model added to `model_prices_and_context_window_backup.json`
  - [ ] Model added to `litellm/model_prices_and_context_window_backup.json`
  - [ ] Model added to relevant `provider_list` in `schema.prisma`
  - [ ] Model added to `litellm/llms/<provider>/chat/transformation.py`
  - [ ] Model added to `litellm/llms/<provider>/<sub-provider>/chat/transformation.py` if needed
  - [ ] Model added to relevant test in `tests_llm_completion`
- [x] Model is already in the repo and I submitted a PR to `litellm` with the following changes:
  - [x] Model added to `model_prices_and_context_window_backup.json`
  - [x] Model added to `litellm/model_prices_and_context_window_backup.json`
- [ ] Not applicable

### Billed as tokens (if applicable)

### Billed as characters (if applicable)

### Billed per request (if applicable)

### Billed per image (if applicable)

### Billed per audio (if applicable)

### Billed per second (if applicable)

## Related Issues

- Fixes #37584