### PR TITLE
fix(passthrough): resolve vertex live credentials from db model deployments

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -244,6 +244,9 @@ AIOHTTP_NEEDS_CLEANUP_CLOSED: Final = (3, 13, 0) <= sys.version_info < (
 _max_size_env: Final = os.getenv("REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES")
 REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES: Final = int(_max_size_env) if _max_size_env is not None else None
 
+# RFC 6455 caps the close frame payload at 125 bytes, 2 of which carry the status code
+WEBSOCKET_CLOSE_REASON_MAX_BYTES: Final = 123
+
 # SSL/TLS cipher configuration for faster handshakes
 # Strategy: Strongly prefer fast modern ciphers, but allow fallback to commonly supported ones
 # This balances performance with broad compatibility

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -2397,8 +2397,8 @@ def _resolve_vertex_live_credentials(
     model: str | None,
 ) -> VertexPassThroughCredentials | None:
     """
-    Resolution order: credentials registered for the requested project/location, then any DB model entry
-    flagged ``use_in_pass_through``, then ``default_vertex_config`` and the ``DEFAULT_VERTEXAI_*`` env vars
+    Resolution order: an explicit project/location registration or ``default_vertex_config``, then any DB model
+    entry flagged ``use_in_pass_through``, then the ``DEFAULT_VERTEXAI_*`` env vars
     """
     keyed: Final = passthrough_endpoint_router.get_vertex_credentials(
         project_id=vertex_project,
@@ -2457,7 +2457,10 @@ def _resolve_alias_to_upstream_model(setup_model: str, llm_router: "Router | Non
     )
     if upstream is None:
         return setup_model
-    _, provider, _, _ = litellm.get_llm_provider(model=upstream)
+    try:
+        _, provider, _, _ = litellm.get_llm_provider(model=upstream)
+    except litellm.exceptions.BadRequestError:
+        return upstream
     return upstream.removeprefix(f"{provider}/")
 
 

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -2384,6 +2384,21 @@ VERTEX_LIVE_UNCONFIGURED_CLOSE_REASON: Final = (
 
 VERTEX_PUBLISHER_MODEL_PREFIX: Final = "publishers/google/models/"
 
+VERTEX_PUBLISHERS_SEGMENT: Final = "publishers/"
+
+
+def _vertex_publisher_model_suffix(model: str) -> str:
+    """
+    Turn whatever the client named into the ``publishers/<publisher>/models/<id>`` tail of a Vertex resource name.
+
+    Clients send bare ids, LiteLLM ids (``vertex_ai/gemini-live-2.5-flash``), and the Live SDK's ``models/<id>``,
+    and a publisher model id never contains a slash, so anything ahead of the last one is addressing, not identity
+    """
+    publishers_at: Final = model.find(VERTEX_PUBLISHERS_SEGMENT)
+    if publishers_at != -1:
+        return model[publishers_at:]
+    return f"{VERTEX_PUBLISHER_MODEL_PREFIX}{model.rsplit('/', 1)[-1]}"
+
 
 def _get_llm_router() -> "Router | None":
     from litellm.proxy.proxy_server import llm_router
@@ -2397,8 +2412,12 @@ def _resolve_vertex_live_credentials(
     model: str | None,
 ) -> VertexPassThroughCredentials | None:
     """
-    Resolution order: an explicit project/location registration or ``default_vertex_config``, then any DB model
-    entry flagged ``use_in_pass_through``, then the ``DEFAULT_VERTEXAI_*`` env vars
+    Resolution order: an explicit project/location registration, then ``default_vertex_config`` (which the proxy
+    fills from the ``DEFAULT_VERTEXAI_*`` env vars whenever the yaml leaves it out), then any DB model entry
+    flagged ``use_in_pass_through``.
+
+    DB entries come last on purpose: an operator who set a global default already said which project
+    pass-through traffic should bill to, and this route silently ignoring that would be the worse surprise
     """
     keyed: Final = passthrough_endpoint_router.get_vertex_credentials(
         project_id=vertex_project,
@@ -2436,22 +2455,23 @@ def _build_vertex_live_setup_model_rewriter(
         if setup_model.startswith("projects/"):
             return setup_model
         aliased: Final = _resolve_alias_to_upstream_model(setup_model, llm_router)
-        return (
-            f"projects/{vertex_project}/locations/{vertex_location}/"
-            f"{VERTEX_PUBLISHER_MODEL_PREFIX}{aliased.removeprefix(VERTEX_PUBLISHER_MODEL_PREFIX)}"
-        )
+        return f"projects/{vertex_project}/locations/{vertex_location}/{_vertex_publisher_model_suffix(aliased)}"
 
     return rewrite
 
 
 def _resolve_alias_to_upstream_model(setup_model: str, llm_router: "Router | None") -> str:
+    """
+    The Live SDK wraps whatever the caller typed as ``models/<name>``, so a gateway alias arrives prefixed
+    """
     if llm_router is None:
         return setup_model
+    candidates: Final = (setup_model, setup_model.rsplit("/", 1)[-1])
     upstream: Final = next(
         (
-            deployment["litellm_params"]["model"]
+            deployment["litellm_params"].get("model")
             for deployment in (llm_router.get_model_list() or ())
-            if deployment.get("model_name") == setup_model
+            if deployment.get("model_name") in candidates
         ),
         None,
     )
@@ -2500,9 +2520,7 @@ async def vertex_ai_live_websocket_passthrough(
         vertex_credentials_config.vertex_location if vertex_credentials_config is not None else None
     )
     credentials_value: Final = (
-        str(vertex_credentials_config.vertex_credentials)
-        if vertex_credentials_config is not None and vertex_credentials_config.vertex_credentials is not None
-        else None
+        vertex_credentials_config.vertex_credentials if vertex_credentials_config is not None else None
     )
 
     try:

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -9,8 +9,9 @@ Use litellm with Anthropic SDK, Vertex AI SDK, Cohere SDK, etc.
 import json
 import os
 import re
+from collections.abc import Callable
 from types import MappingProxyType
-from typing import Annotated, Any, Final, cast
+from typing import TYPE_CHECKING, Annotated, Any, Final, cast
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, WebSocket
@@ -55,10 +56,14 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
     LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
 )
+from litellm.types.passthrough_endpoints.vertex_ai import VertexPassThroughCredentials
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager
 
 from .passthrough_endpoint_router import PassthroughEndpointRouter
+
+if TYPE_CHECKING:
+    from litellm.router import Router
 
 vertex_llm_base: Final = VertexBase()
 router: Final = APIRouter()
@@ -2373,6 +2378,89 @@ async def cursor_proxy_route(
     return received_value
 
 
+VERTEX_LIVE_UNCONFIGURED_CLOSE_REASON: Final = (
+    "Vertex AI auth failed: set a use_in_pass_through vertex model, default_vertex_config, or DEFAULT_VERTEXAI_* env"
+)
+
+VERTEX_PUBLISHER_MODEL_PREFIX: Final = "publishers/google/models/"
+
+
+def _get_llm_router() -> "Router | None":
+    from litellm.proxy.proxy_server import llm_router
+
+    return llm_router
+
+
+def _resolve_vertex_live_credentials(
+    vertex_project: str | None,
+    vertex_location: str | None,
+    model: str | None,
+) -> VertexPassThroughCredentials | None:
+    """
+    Resolution order: credentials registered for the requested project/location, then any DB model entry
+    flagged ``use_in_pass_through``, then ``default_vertex_config`` and the ``DEFAULT_VERTEXAI_*`` env vars
+    """
+    keyed: Final = passthrough_endpoint_router.get_vertex_credentials(
+        project_id=vertex_project,
+        location=vertex_location,
+    )
+    if keyed is not None and keyed.vertex_project is not None:
+        return keyed
+    from_deployments: Final = passthrough_endpoint_router.get_vertex_credentials_from_router_deployments(model=model)
+    if from_deployments is not None:
+        return from_deployments
+    if keyed is not None:
+        return keyed
+    passthrough_endpoint_router.set_default_vertex_config()
+    return passthrough_endpoint_router.get_vertex_credentials(
+        project_id=vertex_project,
+        location=vertex_location,
+    )
+
+
+def _build_vertex_live_setup_model_rewriter(
+    vertex_project: str | None,
+    vertex_location: str | None,
+    llm_router: "Router | None",
+) -> Callable[[str], str] | None:
+    """
+    Rewrite the ``setup`` frame's model into the full Vertex resource path the Live API requires.
+
+    Clients address the gateway the way they address LiteLLM (bare id or model alias); Vertex reads anything
+    that is not a ``projects/...`` path as a project name and closes the socket
+    """
+    if vertex_project is None or vertex_location is None:
+        return None
+
+    def rewrite(setup_model: str) -> str:
+        if setup_model.startswith("projects/"):
+            return setup_model
+        aliased: Final = _resolve_alias_to_upstream_model(setup_model, llm_router)
+        return (
+            f"projects/{vertex_project}/locations/{vertex_location}/"
+            f"{VERTEX_PUBLISHER_MODEL_PREFIX}{aliased.removeprefix(VERTEX_PUBLISHER_MODEL_PREFIX)}"
+        )
+
+    return rewrite
+
+
+def _resolve_alias_to_upstream_model(setup_model: str, llm_router: "Router | None") -> str:
+    if llm_router is None:
+        return setup_model
+    upstream: Final = next(
+        (
+            deployment["litellm_params"]["model"]
+            for deployment in (llm_router.get_model_list() or ())
+            if deployment.get("model_name") == setup_model
+        ),
+        None,
+    )
+    if upstream is None:
+        return setup_model
+    _, provider, _, _ = litellm.get_llm_provider(model=upstream)
+    return upstream.removeprefix(f"{provider}/")
+
+
 async def vertex_ai_live_websocket_passthrough(
     websocket: WebSocket,
     model: str | None = None,
@@ -2396,51 +2484,40 @@ async def vertex_ai_live_websocket_passthrough(
     await websocket.accept()
 
     incoming_headers: Final = dict(websocket.headers)
-    vertex_credentials_config = passthrough_endpoint_router.get_vertex_credentials(
-        project_id=vertex_project,
-        location=vertex_location,
+    vertex_credentials_config: Final = _resolve_vertex_live_credentials(
+        vertex_project=vertex_project,
+        vertex_location=vertex_location,
+        model=model,
     )
 
-    if vertex_credentials_config is None:
-        # Attempt to load defaults from environment/config if not already initialised
-        passthrough_endpoint_router.set_default_vertex_config()
-        vertex_credentials_config = passthrough_endpoint_router.get_vertex_credentials(
-            project_id=vertex_project,
-            location=vertex_location,
-        )
-
-    resolved_project = vertex_project
-    resolved_location: str | None = vertex_location
-    credentials_value: str | None = None
-
-    if vertex_credentials_config is not None:
-        resolved_project = resolved_project or vertex_credentials_config.vertex_project
-        temp_location: Final = resolved_location or vertex_credentials_config.vertex_location
-        # Ensure resolved_location is a string
-        if isinstance(temp_location, dict) or temp_location is not None:
-            resolved_location = str(temp_location)
-        else:
-            resolved_location = None
-        credentials_value = (
-            str(vertex_credentials_config.vertex_credentials)
-            if vertex_credentials_config.vertex_credentials is not None
-            else None
-        )
+    configured_project: Final = vertex_project or (
+        vertex_credentials_config.vertex_project if vertex_credentials_config is not None else None
+    )
+    configured_location: Final = vertex_location or (
+        vertex_credentials_config.vertex_location if vertex_credentials_config is not None else None
+    )
+    credentials_value: Final = (
+        str(vertex_credentials_config.vertex_credentials)
+        if vertex_credentials_config is not None and vertex_credentials_config.vertex_credentials is not None
+        else None
+    )
 
     try:
-        resolved_location = resolved_location or (vertex_llm_base.get_default_vertex_location())
-        if model:
-            resolved_location = vertex_llm_base.get_vertex_region(
-                vertex_region=resolved_location,
+        resolved_location: Final = (
+            vertex_llm_base.get_vertex_region(
+                vertex_region=configured_location or vertex_llm_base.get_default_vertex_location(),
                 model=model,
             )
+            if model
+            else configured_location or vertex_llm_base.get_default_vertex_location()
+        )
 
         (
             access_token,
             resolved_project,
         ) = await vertex_llm_base._ensure_access_token_async(
             credentials=credentials_value,
-            project_id=resolved_project,
+            project_id=configured_project,
             custom_llm_provider="vertex_ai_beta",
         )
     except Exception as e:
@@ -2453,7 +2530,7 @@ async def vertex_ai_live_websocket_passthrough(
                 request_data={},
             )
         if websocket.client_state != WebSocketState.DISCONNECTED:
-            await websocket.close(code=1011, reason="Vertex AI authentication failed")
+            await websocket.close(code=1011, reason=VERTEX_LIVE_UNCONFIGURED_CLOSE_REASON)
         return
 
     host_location: Final = resolved_location or vertex_llm_base.get_default_vertex_location()
@@ -2485,6 +2562,11 @@ async def vertex_ai_live_websocket_passthrough(
         forward_headers=False,
         endpoint="/vertex_ai/live",
         accept_websocket=False,
+        setup_model_rewriter=_build_vertex_live_setup_model_rewriter(
+            vertex_project=resolved_project,
+            vertex_location=resolved_location,
+            llm_router=_get_llm_router(),
+        ),
     )
 
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -32,7 +32,7 @@ from websockets.exceptions import (
     ConnectionClosedOK,
     InvalidStatus,
 )
-from websockets.frames import EXTERNAL_CLOSE_CODES, Close
+from websockets.frames import Close, CloseCode
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -1928,11 +1928,26 @@ def _truncated_close_reason(reason: str) -> str:
     return encoded[:WEBSOCKET_CLOSE_REASON_MAX_BYTES].decode("utf-8", errors="ignore")
 
 
+SENDABLE_CLOSE_CODES: Final = frozenset(CloseCode) - frozenset(
+    {CloseCode.NO_STATUS_RCVD, CloseCode.ABNORMAL_CLOSURE, CloseCode.TLS_HANDSHAKE}
+)
+
+
+def _client_socket_is_open(websocket: WebSocket) -> bool:
+    """
+    Starlette tracks the two halves separately and raises on a second close, so both have to still be live
+    """
+    return (
+        websocket.client_state != WebSocketState.DISCONNECTED
+        and websocket.application_state != WebSocketState.DISCONNECTED
+    )
+
+
 def _upstream_close_to_relay(task_results: Iterable[object]) -> Close | None:
     """
     The upstream close worth telling the client about: anything other than a plain, reasonless normal close.
 
-    Codes outside ``EXTERNAL_CLOSE_CODES`` and the private range never travel on the wire (1006 for a socket that
+    Codes outside ``SENDABLE_CLOSE_CODES`` and the private range never travel on the wire (1006 for a socket that
     died without a close frame, 1005 for one that sent no code), so relaying them would build an invalid frame
     """
     upstream_close: Final = next((result for result in task_results if isinstance(result, Close)), None)
@@ -1940,7 +1955,7 @@ def _upstream_close_to_relay(task_results: Iterable[object]) -> Close | None:
         return None
     if upstream_close.code == 1000 and upstream_close.reason == "":
         return None
-    if upstream_close.code not in EXTERNAL_CLOSE_CODES and not 3000 <= upstream_close.code < 5000:
+    if upstream_close.code not in SENDABLE_CLOSE_CODES and not 3000 <= upstream_close.code < 5000:
         return None
     return upstream_close
 
@@ -2268,7 +2283,7 @@ async def websocket_passthrough_request(
                     raise exception
 
             upstream_close: Final = _upstream_close_to_relay(task.result() for task in done)
-            if upstream_close is not None and websocket.application_state != WebSocketState.DISCONNECTED:
+            if upstream_close is not None and _client_socket_is_open(websocket):
                 await websocket.close(
                     code=upstream_close.code,
                     reason=_truncated_close_reason(upstream_close.reason),
@@ -2359,7 +2374,7 @@ async def websocket_passthrough_request(
             ),
         )
 
-        if websocket.client_state != WebSocketState.DISCONNECTED:
+        if _client_socket_is_open(websocket):
             await websocket.close(
                 code=getattr(exc, "status_code", 1011),
                 reason="Upstream connection rejected",
@@ -2387,13 +2402,10 @@ async def websocket_passthrough_request(
             ),
         )
 
-        if websocket.client_state != WebSocketState.DISCONNECTED:
+        if _client_socket_is_open(websocket):
             await websocket.close(code=1011, reason="WebSocket passthrough error")
     finally:
-        if (
-            websocket.client_state != WebSocketState.DISCONNECTED
-            and websocket.application_state != WebSocketState.DISCONNECTED
-        ):
+        if _client_socket_is_open(websocket):
             await websocket.close()
 
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -32,7 +32,7 @@ from websockets.exceptions import (
     ConnectionClosedOK,
     InvalidStatus,
 )
-from websockets.frames import Close
+from websockets.frames import EXTERNAL_CLOSE_CODES, Close
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -1930,12 +1930,17 @@ def _truncated_close_reason(reason: str) -> str:
 
 def _upstream_close_to_relay(task_results: Iterable[object]) -> Close | None:
     """
-    The upstream close worth telling the client about: anything other than a plain, reasonless normal close
+    The upstream close worth telling the client about: anything other than a plain, reasonless normal close.
+
+    Codes outside ``EXTERNAL_CLOSE_CODES`` and the private range never travel on the wire (1006 for a socket that
+    died without a close frame, 1005 for one that sent no code), so relaying them would build an invalid frame
     """
     upstream_close: Final = next((result for result in task_results if isinstance(result, Close)), None)
     if upstream_close is None:
         return None
     if upstream_close.code == 1000 and upstream_close.reason == "":
+        return None
+    if upstream_close.code not in EXTERNAL_CLOSE_CODES and not 3000 <= upstream_close.code < 5000:
         return None
     return upstream_close
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -5,7 +5,7 @@ import json
 import posixpath
 import traceback
 from base64 import b64encode
-from collections.abc import AsyncGenerator, Callable, Mapping
+from collections.abc import AsyncGenerator, Callable, Iterable, Mapping
 from datetime import datetime
 from itertools import groupby
 from typing import Any, Final, TypedDict, cast
@@ -32,11 +32,15 @@ from websockets.exceptions import (
     ConnectionClosedOK,
     InvalidStatus,
 )
+from websockets.frames import Close
 
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
-from litellm.constants import MAXIMUM_TRACEBACK_LINES_TO_LOG
+from litellm.constants import (
+    MAXIMUM_TRACEBACK_LINES_TO_LOG,
+    WEBSOCKET_CLOSE_REASON_MAX_BYTES,
+)
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import (
@@ -1890,6 +1894,52 @@ def create_websocket_passthrough_route(
     return websocket_endpoint_func
 
 
+def _rewrite_vertex_live_setup_model(text_data: str, setup_model_rewriter: Callable[[str], str] | None) -> str:
+    """
+    Rewrite the model of a Vertex AI Live ``setup`` frame, leaving every other frame byte-identical
+    """
+    if setup_model_rewriter is None:
+        return text_data
+    try:
+        message: Final = json.loads(text_data)
+    except json.JSONDecodeError:
+        return text_data
+    if not isinstance(message, dict):
+        return text_data
+    setup: Final = message.get("setup")
+    if not isinstance(setup, dict):
+        return text_data
+    setup_model: Final = setup.get("model")
+    if not isinstance(setup_model, str):
+        return text_data
+    rewritten_model: Final = setup_model_rewriter(setup_model)
+    if rewritten_model == setup_model:
+        return text_data
+    return json.dumps({**message, "setup": {**setup, "model": rewritten_model}})  # mutable-ok: one-shot json payload
+
+
+def _truncated_close_reason(reason: str) -> str:
+    """
+    Fit a close reason inside the byte budget a WebSocket close frame allows, without splitting a character
+    """
+    encoded: Final = reason.encode("utf-8")
+    if len(encoded) <= WEBSOCKET_CLOSE_REASON_MAX_BYTES:
+        return reason
+    return encoded[:WEBSOCKET_CLOSE_REASON_MAX_BYTES].decode("utf-8", errors="ignore")
+
+
+def _upstream_close_to_relay(task_results: Iterable[object]) -> Close | None:
+    """
+    The upstream close worth telling the client about: anything other than a plain, reasonless normal close
+    """
+    upstream_close: Final = next((result for result in task_results if isinstance(result, Close)), None)
+    if upstream_close is None:
+        return None
+    if upstream_close.code == 1000 and upstream_close.reason == "":
+        return None
+    return upstream_close
+
+
 async def websocket_passthrough_request(
     websocket: WebSocket,
     target: str,
@@ -1899,6 +1949,7 @@ async def websocket_passthrough_request(
     endpoint: str | None = None,
     cost_per_request: float | None = None,
     accept_websocket: bool = True,
+    setup_model_rewriter: Callable[[str], str] | None = None,
 ):
     """
     WebSocket passthrough request handler.
@@ -1911,6 +1962,7 @@ async def websocket_passthrough_request(
         forward_headers: Whether to forward incoming headers
         endpoint: The endpoint path (for logging purposes)
         cost_per_request: Optional field - cost per request to the target endpoint
+        setup_model_rewriter: Optional rewrite of the setup frame's model before it reaches the upstream
     """
     from litellm.litellm_core_utils.litellm_logging import Logging
     from litellm.proxy.proxy_server import proxy_logging_obj
@@ -2100,7 +2152,7 @@ async def websocket_passthrough_request(
                                     )
                                     # Not a JSON message or doesn't contain setup data
 
-                            await upstream_ws.send(text_data)
+                            await upstream_ws.send(_rewrite_vertex_live_setup_model(text_data, setup_model_rewriter))
                         elif bytes_data is not None:
                             await upstream_ws.send(bytes_data)
                 except asyncio.CancelledError:
@@ -2111,8 +2163,8 @@ async def websocket_passthrough_request(
                     )
                     await upstream_ws.close()
 
-            async def forward_upstream_to_client() -> None:
-                """Forward messages from upstream to client WebSocket"""
+            async def forward_upstream_to_client() -> Close | None:
+                """Forward messages from upstream to client WebSocket, returning the upstream's close frame"""
                 try:
                     # Wait for the first response from upstream
                     raw_response = await upstream_ws.recv(decode=False)
@@ -2177,6 +2229,7 @@ async def websocket_passthrough_request(
 
                 except (ConnectionClosedOK, ConnectionClosedError) as e:
                     verbose_proxy_logger.debug("Upstream WebSocket connection closed: %s", e)
+                    return e.rcvd
                 except asyncio.CancelledError:
                     verbose_proxy_logger.debug("asyncio.CancelledError in forward_upstream_to_client")
                     raise
@@ -2208,6 +2261,13 @@ async def websocket_passthrough_request(
                 exception = task.exception()
                 if exception is not None:
                     raise exception
+
+            upstream_close: Final = _upstream_close_to_relay(task.result() for task in done)
+            if upstream_close is not None and websocket.application_state != WebSocketState.DISCONNECTED:
+                await websocket.close(
+                    code=upstream_close.code,
+                    reason=_truncated_close_reason(upstream_close.reason),
+                )
 
             end_time: Final = datetime.now()
 
@@ -2325,7 +2385,10 @@ async def websocket_passthrough_request(
         if websocket.client_state != WebSocketState.DISCONNECTED:
             await websocket.close(code=1011, reason="WebSocket passthrough error")
     finally:
-        if websocket.client_state != WebSocketState.DISCONNECTED:
+        if (
+            websocket.client_state != WebSocketState.DISCONNECTED
+            and websocket.application_state != WebSocketState.DISCONNECTED
+        ):
             await websocket.close()
 
 

--- a/litellm/proxy/pass_through_endpoints/passthrough_endpoint_router.py
+++ b/litellm/proxy/pass_through_endpoints/passthrough_endpoint_router.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Final
 
@@ -25,6 +26,15 @@ def _get_proxy_llm_router() -> "Router | None":
 def _get_str_value(values: dict[str, object] | None, key: str) -> str | None:
     value: Final = values.get(key) if values is not None else None
     return value if isinstance(value, str) else None
+
+
+def _credential_identity(credentials: VERTEX_CREDENTIALS_TYPES | None) -> str | None:
+    """
+    A hashable stand-in for a credential, so two deployments can be compared for holding the same one
+    """
+    if isinstance(credentials, dict):
+        return json.dumps(credentials, sort_keys=True)
+    return credentials
 
 
 class PassthroughEndpointRouter:
@@ -127,8 +137,8 @@ class PassthroughEndpointRouter:
         ``deployment_key_to_vertex_credentials`` is only reachable when the caller names a project and location,
         which WebSocket clients never do, so DB-stored deployments need this lookup to be usable at all.
 
-        With no model to go on, only deployments that agree on a project and location answer: guessing between
-        two Vertex projects would mint a token for one and later send the other one's model name
+        With no model to go on, only deployments that agree on a project, a location, and a credential answer:
+        guessing between two Vertex projects would mint a token for one and later send the other one's model name
         """
         llm_router: Final = self.llm_router_getter()
         if llm_router is None:
@@ -149,7 +159,12 @@ class PassthroughEndpointRouter:
         if matched is not None:
             return matched
         targets: Final = frozenset(
-            (credentials.vertex_project, credentials.vertex_location) for _, credentials in resolved
+            (
+                credentials.vertex_project,
+                credentials.vertex_location,
+                _credential_identity(credentials.vertex_credentials),
+            )
+            for _, credentials in resolved
         )
         if len(targets) != 1:
             return None
@@ -172,9 +187,12 @@ class PassthroughEndpointRouter:
         vertex_location: Final = _get_str_value(credential_values, "vertex_location") or litellm_params.get(
             "vertex_location"
         )
-        vertex_credentials: Final = _get_str_value(credential_values, "vertex_credentials") or litellm_params.get(
-            "vertex_credentials"
+        stored_credentials: Final = (
+            credential_values.get("vertex_credentials") if credential_values is not None else None
         )
+        vertex_credentials: Final = (
+            stored_credentials if isinstance(stored_credentials, (str, dict)) else None
+        ) or litellm_params.get("vertex_credentials")
         if vertex_project is None or vertex_location is None:
             return None
         return VertexPassThroughCredentials(

--- a/litellm/proxy/pass_through_endpoints/passthrough_endpoint_router.py
+++ b/litellm/proxy/pass_through_endpoints/passthrough_endpoint_router.py
@@ -10,7 +10,7 @@ from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.vertex_ai import VERTEX_CREDENTIALS_TYPES
 from litellm.types.passthrough_endpoints.vertex_ai import VertexPassThroughCredentials
-from litellm.types.router import LiteLLMParamsTypedDict
+from litellm.types.router import DeploymentTypedDict, LiteLLMParamsTypedDict
 
 if TYPE_CHECKING:
     from litellm.router import Router
@@ -119,6 +119,69 @@ class PassthroughEndpointRouter:
         except litellm.exceptions.BadRequestError:
             return None
         return provider
+
+    def get_vertex_credentials_from_router_deployments(self, model: str | None) -> VertexPassThroughCredentials | None:
+        """
+        Resolve vertex pass-through credentials from the live router deployments flagged ``use_in_pass_through``.
+
+        ``deployment_key_to_vertex_credentials`` is only reachable when the caller names a project and location,
+        which WebSocket clients never do, so DB-stored deployments need this lookup to be usable at all.
+        """
+        llm_router: Final = self.llm_router_getter()
+        if llm_router is None:
+            return None
+        resolved: Final = tuple(
+            (deployment, credentials)
+            for deployment in (llm_router.get_model_list() or ())
+            if (credentials := self._resolve_vertex_deployment_credentials(deployment["litellm_params"])) is not None
+        )
+        if len(resolved) == 0:
+            return None
+        return next(
+            (
+                credentials
+                for deployment, credentials in resolved
+                if model is not None and self._deployment_matches_model(deployment, model)
+            ),
+            resolved[0][1],
+        )
+
+    def _resolve_vertex_deployment_credentials(
+        self, litellm_params: LiteLLMParamsTypedDict
+    ) -> VertexPassThroughCredentials | None:
+        if litellm_params.get("use_in_pass_through") is not True:
+            return None
+        if self._get_deployment_provider(litellm_params) != "vertex_ai":
+            return None
+        credential_name: Final = litellm_params.get("litellm_credential_name")
+        credential_values: Final = (
+            CredentialAccessor.get_credential_values(credential_name) if credential_name is not None else None
+        )
+        vertex_project: Final = _get_str_value(credential_values, "vertex_project") or litellm_params.get(
+            "vertex_project"
+        )
+        vertex_location: Final = _get_str_value(credential_values, "vertex_location") or litellm_params.get(
+            "vertex_location"
+        )
+        vertex_credentials: Final = _get_str_value(credential_values, "vertex_credentials") or litellm_params.get(
+            "vertex_credentials"
+        )
+        if vertex_project is None or vertex_location is None:
+            return None
+        return VertexPassThroughCredentials(
+            vertex_project=vertex_project,
+            vertex_location=vertex_location,
+            vertex_credentials=vertex_credentials,
+        )
+
+    @staticmethod
+    def _deployment_matches_model(deployment: DeploymentTypedDict, model: str) -> bool:
+        upstream_model: Final = deployment["litellm_params"].get("model")
+        return model in (
+            deployment.get("model_name"),
+            upstream_model,
+            upstream_model.split("/", 1)[-1] if upstream_model is not None else None,
+        )
 
     def _get_vertex_env_vars(self) -> VertexPassThroughCredentials:
         """

--- a/litellm/proxy/pass_through_endpoints/passthrough_endpoint_router.py
+++ b/litellm/proxy/pass_through_endpoints/passthrough_endpoint_router.py
@@ -126,6 +126,9 @@ class PassthroughEndpointRouter:
 
         ``deployment_key_to_vertex_credentials`` is only reachable when the caller names a project and location,
         which WebSocket clients never do, so DB-stored deployments need this lookup to be usable at all.
+
+        With no model to go on, only deployments that agree on a project and location answer: guessing between
+        two Vertex projects would mint a token for one and later send the other one's model name
         """
         llm_router: Final = self.llm_router_getter()
         if llm_router is None:
@@ -135,16 +138,22 @@ class PassthroughEndpointRouter:
             for deployment in (llm_router.get_model_list() or ())
             if (credentials := self._resolve_vertex_deployment_credentials(deployment["litellm_params"])) is not None
         )
-        if len(resolved) == 0:
-            return None
-        return next(
+        matched: Final = next(
             (
                 credentials
                 for deployment, credentials in resolved
                 if model is not None and self._deployment_matches_model(deployment, model)
             ),
-            resolved[0][1],
+            None,
         )
+        if matched is not None:
+            return matched
+        targets: Final = frozenset(
+            (credentials.vertex_project, credentials.vertex_location) for _, credentials in resolved
+        )
+        if len(targets) != 1:
+            return None
+        return resolved[0][1]
 
     def _resolve_vertex_deployment_credentials(
         self, litellm_params: LiteLLMParamsTypedDict

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3889,6 +3889,9 @@ class TestComprehendMedicalProxyRoute:
         assert exc_info.value.status_code == 400
 
 
+LIVE_RESOURCE_PATH = "projects/proj-db/locations/global/publishers/google/models/gemini-live-2.5-flash"
+
+
 class TestVertexAILiveWebsocketPassthrough:
     def _websocket(self):
         from starlette.websockets import WebSocketState
@@ -3958,6 +3961,110 @@ class TestVertexAILiveWebsocketPassthrough:
             "projects/proj-db/locations/global/publishers/google/models/gemini-live-2.5-flash"
         )
         websocket.close.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "setup_model, expected",
+        [
+            ("gemini-live-2.5-flash", LIVE_RESOURCE_PATH),
+            ("models/gemini-live-2.5-flash", LIVE_RESOURCE_PATH),
+            ("vertex_ai/gemini-live-2.5-flash", LIVE_RESOURCE_PATH),
+            ("gemini-live", LIVE_RESOURCE_PATH),
+            ("models/gemini-live", LIVE_RESOURCE_PATH),
+            (
+                "publishers/meta/models/llama-3.3-70b-instruct-maas",
+                "projects/proj-db/locations/global/publishers/meta/models/llama-3.3-70b-instruct-maas",
+            ),
+            (
+                "projects/other/locations/us-central1/publishers/google/models/gemini-2.0-flash",
+                "projects/other/locations/us-central1/publishers/google/models/gemini-2.0-flash",
+            ),
+        ],
+    )
+    def test_setup_model_rewriter_normalises_the_forms_clients_send(self, setup_model, expected):
+        from litellm.proxy.pass_through_endpoints import (
+            llm_passthrough_endpoints as passthrough_module,
+        )
+
+        llm_router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "gemini-live",
+                    "litellm_params": {
+                        "model": "vertex_ai/gemini-live-2.5-flash",
+                        "use_in_pass_through": True,
+                        "vertex_project": "proj-db",
+                        "vertex_location": "global",
+                    },
+                }
+            ]
+        )
+
+        rewriter = passthrough_module._build_vertex_live_setup_model_rewriter(
+            vertex_project="proj-db",
+            vertex_location="global",
+            llm_router=llm_router,
+        )
+
+        assert rewriter is not None
+        assert rewriter(setup_model) == expected
+
+    @pytest.mark.asyncio
+    async def test_default_vertex_config_outranks_db_deployment(self, monkeypatch):
+        from litellm.proxy.pass_through_endpoints import (
+            llm_passthrough_endpoints as passthrough_module,
+        )
+        from litellm.types.passthrough_endpoints.vertex_ai import (
+            VertexPassThroughCredentials,
+        )
+
+        llm_router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "gemini-live",
+                    "litellm_params": {
+                        "model": "vertex_ai/gemini-live-2.5-flash",
+                        "use_in_pass_through": True,
+                        "vertex_project": "proj-db",
+                        "vertex_location": "global",
+                        "vertex_credentials": '{"type": "db_account"}',
+                    },
+                }
+            ]
+        )
+        monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", llm_router)
+        monkeypatch.setattr(
+            passthrough_module.passthrough_endpoint_router,
+            "default_vertex_config",
+            VertexPassThroughCredentials(
+                vertex_project="proj-env",
+                vertex_location="global",
+                vertex_credentials='{"type": "env_account"}',
+            ),
+        )
+        self._clear_vertex_env(monkeypatch)
+        websocket = self._websocket()
+        ensure_token = AsyncMock(return_value=("token-abc", "proj-env"))
+        ws_passthrough = AsyncMock()
+
+        with (
+            patch.object(passthrough_module.vertex_llm_base, "_ensure_access_token_async", ensure_token),
+            patch.object(passthrough_module, "websocket_passthrough_request", ws_passthrough),
+        ):
+            await passthrough_module.vertex_ai_live_websocket_passthrough(
+                websocket=websocket,
+                model="gemini-live",
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+        ensure_token.assert_awaited_once_with(
+            credentials='{"type": "env_account"}',
+            project_id="proj-env",
+            custom_llm_provider="vertex_ai_beta",
+        )
+        rewriter = ws_passthrough.await_args.kwargs["setup_model_rewriter"]
+        assert rewriter("gemini-live") == (
+            "projects/proj-env/locations/global/publishers/google/models/gemini-live-2.5-flash"
+        )
 
     @pytest.mark.asyncio
     async def test_credential_failure_close_names_configuration_options(self, monkeypatch):

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3887,3 +3887,104 @@ class TestComprehendMedicalProxyRoute:
                 user_api_key_dict=Mock(),
             )
         assert exc_info.value.status_code == 400
+
+
+class TestVertexAILiveWebsocketPassthrough:
+    def _websocket(self):
+        from starlette.websockets import WebSocketState
+
+        websocket = MagicMock()
+        websocket.accept = AsyncMock()
+        websocket.close = AsyncMock()
+        websocket.headers = {}
+        websocket.client_state = WebSocketState.CONNECTED
+        return websocket
+
+    def _clear_vertex_env(self, monkeypatch):
+        monkeypatch.delenv("DEFAULT_VERTEXAI_PROJECT", raising=False)
+        monkeypatch.delenv("DEFAULT_VERTEXAI_LOCATION", raising=False)
+        monkeypatch.delenv("DEFAULT_GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+    @pytest.mark.asyncio
+    async def test_uses_db_deployment_credentials_without_query_params(self, monkeypatch):
+        from litellm.proxy.pass_through_endpoints import (
+            llm_passthrough_endpoints as passthrough_module,
+        )
+
+        llm_router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "gemini-live",
+                    "litellm_params": {
+                        "model": "vertex_ai/gemini-live-2.5-flash",
+                        "use_in_pass_through": True,
+                        "vertex_project": "proj-db",
+                        "vertex_location": "global",
+                        "vertex_credentials": '{"type": "service_account"}',
+                    },
+                }
+            ]
+        )
+        monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", llm_router)
+        monkeypatch.setattr(
+            passthrough_module.passthrough_endpoint_router, "default_vertex_config", None
+        )
+        self._clear_vertex_env(monkeypatch)
+        websocket = self._websocket()
+        ensure_token = AsyncMock(return_value=("token-abc", "proj-db"))
+        ws_passthrough = AsyncMock()
+
+        with (
+            patch.object(passthrough_module.vertex_llm_base, "_ensure_access_token_async", ensure_token),
+            patch.object(passthrough_module, "websocket_passthrough_request", ws_passthrough),
+        ):
+            await passthrough_module.vertex_ai_live_websocket_passthrough(
+                websocket=websocket,
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+        ensure_token.assert_awaited_once_with(
+            credentials='{"type": "service_account"}',
+            project_id="proj-db",
+            custom_llm_provider="vertex_ai_beta",
+        )
+        passthrough_kwargs = ws_passthrough.await_args.kwargs
+        assert passthrough_kwargs["target"] == (
+            "wss://aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent"
+        )
+        assert passthrough_kwargs["custom_headers"]["Authorization"] == "Bearer token-abc"
+        rewriter = passthrough_kwargs["setup_model_rewriter"]
+        assert rewriter("gemini-live") == (
+            "projects/proj-db/locations/global/publishers/google/models/gemini-live-2.5-flash"
+        )
+        websocket.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_credential_failure_close_names_configuration_options(self, monkeypatch):
+        from litellm.proxy.pass_through_endpoints import (
+            llm_passthrough_endpoints as passthrough_module,
+        )
+
+        monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", None)
+        monkeypatch.setattr(
+            passthrough_module.passthrough_endpoint_router, "default_vertex_config", None
+        )
+        self._clear_vertex_env(monkeypatch)
+        websocket = self._websocket()
+        ensure_token = AsyncMock(side_effect=Exception("Unable to find your credentials"))
+
+        with (
+            patch.object(passthrough_module.vertex_llm_base, "_ensure_access_token_async", ensure_token),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging,
+        ):
+            mock_proxy_logging.post_call_failure_hook = AsyncMock()
+            await passthrough_module.vertex_ai_live_websocket_passthrough(
+                websocket=websocket,
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+        close_kwargs = websocket.close.await_args.kwargs
+        assert close_kwargs["code"] == 1011
+        assert "use_in_pass_through" in close_kwargs["reason"]
+        assert "default_vertex_config" in close_kwargs["reason"]
+        assert len(close_kwargs["reason"].encode("utf-8")) <= 123

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -5243,6 +5243,38 @@ async def test_websocket_passthrough_leaves_full_resource_setup_model_untouched(
     )
 
 
+@pytest.mark.asyncio
+async def test_websocket_passthrough_does_not_close_twice_when_success_logging_fails():
+    from websockets.exceptions import ConnectionClosedError
+    from websockets.frames import Close
+
+    upstream_reason = "Publisher Model `projects/p/locations/global/publishers/google/models/nope` was not found"
+    upstream_ws = ClosingUpstreamWebSocket(
+        ConnectionClosedError(rcvd=Close(1008, upstream_reason), sent=Close(1008, ""), rcvd_then_sent=True)
+    )
+    websocket = _client_websocket(_pending_receive)
+
+    with (
+        _patched_websocket_passthrough_environment(upstream_ws),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints."
+            "GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue",
+            side_effect=RuntimeError("logging worker down"),
+        ),
+    ):
+        await websocket_passthrough_request(
+            websocket=websocket,
+            target="wss://aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent",
+            custom_headers={"Authorization": "Bearer token"},
+            user_api_key_dict=UserAPIKeyAuth(),
+            forward_headers=False,
+            endpoint="/vertex_ai/live",
+            accept_websocket=False,
+        )
+
+    websocket.close.assert_awaited_once_with(code=1008, reason=upstream_reason)
+
+
 def _passthrough_kwargs_for_reservation(
     user_api_key_dict: UserAPIKeyAuth, parsed_body: Optional[dict] = None
 ) -> dict:

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -4994,6 +4994,212 @@ async def test_websocket_passthrough_forwards_non_ascii_first_frame():
     assert all(call.kwargs.get("code") != 1011 for call in websocket.close.await_args_list)
 
 
+class ClosingUpstreamWebSocket:
+    def __init__(self, close_exc: Exception):
+        self._close_exc = close_exc
+        self.close = AsyncMock()
+        self.send = AsyncMock()
+
+    async def recv(self, decode: bool = True):
+        raise self._close_exc
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class RecordingUpstreamWebSocket:
+    def __init__(self):
+        self.close = AsyncMock()
+        self.send = AsyncMock()
+
+    async def recv(self, decode: bool = True):
+        await asyncio.Event().wait()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+def _client_websocket(receive):
+    from starlette.websockets import WebSocketState
+
+    websocket = MagicMock()
+    websocket.accept = AsyncMock()
+    websocket.send_text = AsyncMock()
+    websocket.send_bytes = AsyncMock()
+    websocket.receive = receive
+    websocket.headers = {}
+    websocket.client_state = WebSocketState.CONNECTED
+    websocket.application_state = WebSocketState.CONNECTED
+
+    def _mark_closed(*args, **kwargs):
+        websocket.application_state = WebSocketState.DISCONNECTED
+
+    websocket.close = AsyncMock(side_effect=_mark_closed)
+    return websocket
+
+
+@contextmanager
+def _patched_websocket_passthrough_environment(upstream_ws):
+    with (
+        patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging,
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.connect",
+            return_value=FakeUpstreamConnect(upstream_ws),
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.GLOBAL_LOGGING_WORKER"
+        ) as mock_worker,
+    ):
+        mock_proxy_logging.pre_call_hook = AsyncMock(return_value={})
+        mock_proxy_logging.post_call_success_hook = AsyncMock()
+        mock_proxy_logging.post_call_failure_hook = AsyncMock()
+        mock_worker.ensure_initialized_and_enqueue = MagicMock(
+            side_effect=lambda async_coroutine: async_coroutine.close()
+        )
+        yield
+
+
+async def _pending_receive():
+    await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_websocket_passthrough_relays_upstream_policy_close_to_client():
+    from websockets.exceptions import ConnectionClosedError
+    from websockets.frames import Close
+
+    upstream_reason = "Publisher Model `projects/p/locations/global/publishers/google/models/nope` was not found"
+    upstream_ws = ClosingUpstreamWebSocket(
+        ConnectionClosedError(
+            rcvd=Close(1008, upstream_reason),
+            sent=Close(1008, ""),
+            rcvd_then_sent=True,
+        )
+    )
+    websocket = _client_websocket(_pending_receive)
+
+    with _patched_websocket_passthrough_environment(upstream_ws):
+        await websocket_passthrough_request(
+            websocket=websocket,
+            target="wss://aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent",
+            custom_headers={"Authorization": "Bearer token"},
+            user_api_key_dict=UserAPIKeyAuth(),
+            forward_headers=False,
+            endpoint="/vertex_ai/live",
+            accept_websocket=False,
+        )
+
+    websocket.close.assert_awaited_once_with(code=1008, reason=upstream_reason)
+
+
+@pytest.mark.asyncio
+async def test_websocket_passthrough_keeps_normal_upstream_close_normal():
+    from websockets.exceptions import ConnectionClosedOK
+    from websockets.frames import Close
+
+    upstream_ws = ClosingUpstreamWebSocket(
+        ConnectionClosedOK(rcvd=Close(1000, ""), sent=Close(1000, ""), rcvd_then_sent=True)
+    )
+    websocket = _client_websocket(_pending_receive)
+
+    with _patched_websocket_passthrough_environment(upstream_ws):
+        await websocket_passthrough_request(
+            websocket=websocket,
+            target="wss://aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent",
+            custom_headers={"Authorization": "Bearer token"},
+            user_api_key_dict=UserAPIKeyAuth(),
+            forward_headers=False,
+            endpoint="/vertex_ai/live",
+            accept_websocket=False,
+        )
+
+    websocket.close.assert_awaited_once_with()
+
+
+async def _run_setup_rewrite_passthrough(setup_model: str, llm_router) -> str:
+    from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+        _build_vertex_live_setup_model_rewriter,
+    )
+
+    upstream_ws = RecordingUpstreamWebSocket()
+    setup_frame = json.dumps({"setup": {"model": setup_model, "generationConfig": {"responseModalities": ["TEXT"]}}})
+    websocket = _client_websocket(
+        AsyncMock(
+            side_effect=[
+                {"type": "websocket.receive", "text": setup_frame},
+                {"type": "websocket.disconnect"},
+            ]
+        )
+    )
+
+    with _patched_websocket_passthrough_environment(upstream_ws):
+        await websocket_passthrough_request(
+            websocket=websocket,
+            target="wss://aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent",
+            custom_headers={"Authorization": "Bearer token"},
+            user_api_key_dict=UserAPIKeyAuth(),
+            forward_headers=False,
+            endpoint="/vertex_ai/live",
+            accept_websocket=False,
+            setup_model_rewriter=_build_vertex_live_setup_model_rewriter(
+                vertex_project="proj-db",
+                vertex_location="global",
+                llm_router=llm_router,
+            ),
+        )
+
+    upstream_ws.send.assert_awaited_once()
+    return upstream_ws.send.await_args.args[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "setup_model",
+    ["gemini-live-2.5-flash", "publishers/google/models/gemini-live-2.5-flash"],
+)
+async def test_websocket_passthrough_rewrites_setup_model_to_full_resource(setup_model):
+    sent_frame = await _run_setup_rewrite_passthrough(setup_model, llm_router=None)
+
+    sent_setup = json.loads(sent_frame)["setup"]
+    assert sent_setup["model"] == "projects/proj-db/locations/global/publishers/google/models/gemini-live-2.5-flash"
+    assert sent_setup["generationConfig"] == {"responseModalities": ["TEXT"]}
+
+
+@pytest.mark.asyncio
+async def test_websocket_passthrough_rewrites_gateway_alias_setup_model():
+    llm_router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gemini-live",
+                "litellm_params": {"model": "vertex_ai/gemini-live-2.5-flash"},
+            }
+        ]
+    )
+
+    sent_frame = await _run_setup_rewrite_passthrough("gemini-live", llm_router=llm_router)
+
+    sent_setup = json.loads(sent_frame)["setup"]
+    assert sent_setup["model"] == "projects/proj-db/locations/global/publishers/google/models/gemini-live-2.5-flash"
+
+
+@pytest.mark.asyncio
+async def test_websocket_passthrough_leaves_full_resource_setup_model_untouched():
+    full_resource = "projects/other/locations/us-central1/publishers/google/models/gemini-2.0-flash-live-preview-04-09"
+
+    sent_frame = await _run_setup_rewrite_passthrough(full_resource, llm_router=None)
+
+    assert json.loads(sent_frame)["setup"]["model"] == full_resource
+    assert sent_frame == json.dumps(
+        {"setup": {"model": full_resource, "generationConfig": {"responseModalities": ["TEXT"]}}}
+    )
+
+
 def _passthrough_kwargs_for_reservation(
     user_api_key_dict: UserAPIKeyAuth, parsed_body: Optional[dict] = None
 ) -> dict:

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -5189,6 +5189,49 @@ async def test_websocket_passthrough_rewrites_gateway_alias_setup_model():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("rcvd_close", [None, "abnormal", "no_status"])
+async def test_websocket_passthrough_does_not_relay_unsendable_upstream_close(rcvd_close):
+    from websockets.exceptions import ConnectionClosedError
+    from websockets.frames import Close
+
+    rcvd = {
+        None: None,
+        "abnormal": Close(1006, "connection died"),
+        "no_status": Close(1005, ""),
+    }[rcvd_close]
+    upstream_ws = ClosingUpstreamWebSocket(
+        ConnectionClosedError(rcvd=rcvd, sent=None, rcvd_then_sent=None)
+    )
+    websocket = _client_websocket(_pending_receive)
+
+    with _patched_websocket_passthrough_environment(upstream_ws):
+        await websocket_passthrough_request(
+            websocket=websocket,
+            target="wss://aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent",
+            custom_headers={"Authorization": "Bearer token"},
+            user_api_key_dict=UserAPIKeyAuth(),
+            forward_headers=False,
+            endpoint="/vertex_ai/live",
+            accept_websocket=False,
+        )
+
+    websocket.close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_websocket_passthrough_rewrites_alias_of_unrecognised_upstream_model():
+    llm_router = MagicMock()
+    llm_router.get_model_list.return_value = [
+        {"model_name": "gemini-live", "litellm_params": {"model": "self-hosted-live-endpoint"}}
+    ]
+
+    sent_frame = await _run_setup_rewrite_passthrough("gemini-live", llm_router=llm_router)
+
+    sent_setup = json.loads(sent_frame)["setup"]
+    assert sent_setup["model"] == "projects/proj-db/locations/global/publishers/google/models/self-hosted-live-endpoint"
+
+
+@pytest.mark.asyncio
 async def test_websocket_passthrough_leaves_full_resource_setup_model_untouched():
     full_resource = "projects/other/locations/us-central1/publishers/google/models/gemini-2.0-flash-live-preview-04-09"
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_endpoint_router.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_endpoint_router.py
@@ -293,6 +293,59 @@ def test_vertex_without_hint_falls_back_when_deployments_share_a_target():
     assert resolved is not None and resolved.vertex_project == "proj-one"
 
 
+def test_vertex_without_hint_refuses_to_guess_between_service_accounts():
+    llm_router = litellm.Router(
+        model_list=[
+            _vertex_deployment(
+                "gemini-flash",
+                "vertex_ai/gemini-2.5-flash",
+                vertex_project="proj-one",
+                vertex_location="global",
+                vertex_credentials='{"client_email": "flash@proj-one.iam"}',
+            ),
+            _vertex_deployment(
+                "gemini-live",
+                "vertex_ai/gemini-live-2.5-flash",
+                vertex_project="proj-one",
+                vertex_location="global",
+                vertex_credentials='{"client_email": "live@proj-one.iam"}',
+            ),
+        ]
+    )
+    passthrough_router = _passthrough_router(llm_router)
+
+    assert passthrough_router.get_vertex_credentials_from_router_deployments(model=None) is None
+
+
+def test_vertex_named_credential_keeps_dict_service_account():
+    service_account = {"type": "service_account", "client_email": "live@proj-db.iam"}
+    CredentialAccessor.upsert_credentials(
+        [
+            _vertex_credential(
+                "cred_gcp_dict",
+                {
+                    "vertex_project": "proj-db",
+                    "vertex_location": "global",
+                    "vertex_credentials": service_account,
+                },
+            )
+        ]
+    )
+    llm_router = litellm.Router(
+        model_list=[
+            _vertex_deployment(
+                "gemini-live", "vertex_ai/gemini-live-2.5-flash", litellm_credential_name="cred_gcp_dict"
+            )
+        ]
+    )
+    passthrough_router = _passthrough_router(llm_router)
+
+    resolved = passthrough_router.get_vertex_credentials_from_router_deployments(model=None)
+
+    assert resolved is not None
+    assert resolved.vertex_credentials == service_account
+
+
 def test_no_flagged_vertex_deployment_returns_none():
     llm_router = litellm.Router(
         model_list=[

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_endpoint_router.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_endpoint_router.py
@@ -172,3 +172,144 @@ def test_returns_none_when_no_router_and_no_env():
     passthrough_router = _passthrough_router(None)
 
     assert passthrough_router.get_credentials(custom_llm_provider="openai", region_name=None) is None
+
+
+def _vertex_credential(name: str, values: dict) -> CredentialItem:
+    return CredentialItem(credential_name=name, credential_values=values, credential_info={})
+
+
+def _vertex_deployment(model_name: str, model: str, **litellm_params) -> dict:
+    return {
+        "model_name": model_name,
+        "litellm_params": {"model": model, "use_in_pass_through": True, **litellm_params},
+    }
+
+
+def test_vertex_deployment_resolves_via_named_credential():
+    CredentialAccessor.upsert_credentials(
+        [
+            _vertex_credential(
+                "cred_gcp",
+                {
+                    "vertex_project": "proj-db",
+                    "vertex_location": "global",
+                    "vertex_credentials": '{"type": "service_account"}',
+                },
+            )
+        ]
+    )
+    llm_router = litellm.Router(
+        model_list=[
+            _vertex_deployment(
+                "gemini-live", "vertex_ai/gemini-live-2.5-flash", litellm_credential_name="cred_gcp"
+            )
+        ]
+    )
+    passthrough_router = _passthrough_router(llm_router)
+
+    resolved = passthrough_router.get_vertex_credentials_from_router_deployments(model=None)
+
+    assert resolved is not None
+    assert resolved.vertex_project == "proj-db"
+    assert resolved.vertex_location == "global"
+    assert resolved.vertex_credentials == '{"type": "service_account"}'
+
+
+def test_vertex_deployment_resolves_from_inline_litellm_params():
+    llm_router = litellm.Router(
+        model_list=[
+            _vertex_deployment(
+                "gemini-live",
+                "vertex_ai/gemini-live-2.5-flash",
+                vertex_project="proj-inline",
+                vertex_location="us-east4",
+                vertex_credentials='{"type": "service_account", "project_id": "proj-inline"}',
+            )
+        ]
+    )
+    passthrough_router = _passthrough_router(llm_router)
+
+    resolved = passthrough_router.get_vertex_credentials_from_router_deployments(model=None)
+
+    assert resolved is not None
+    assert resolved.vertex_project == "proj-inline"
+    assert resolved.vertex_location == "us-east4"
+    assert resolved.vertex_credentials == '{"type": "service_account", "project_id": "proj-inline"}'
+
+
+def _two_vertex_deployments_router() -> litellm.Router:
+    return litellm.Router(
+        model_list=[
+            _vertex_deployment(
+                "gemini-flash",
+                "vertex_ai/gemini-2.5-flash",
+                vertex_project="proj-first",
+                vertex_location="us-central1",
+            ),
+            _vertex_deployment(
+                "gemini-live",
+                "vertex_ai/gemini-live-2.5-flash",
+                vertex_project="proj-live",
+                vertex_location="global",
+            ),
+        ]
+    )
+
+
+def test_vertex_model_hint_prefers_matching_deployment():
+    passthrough_router = _passthrough_router(_two_vertex_deployments_router())
+
+    by_alias = passthrough_router.get_vertex_credentials_from_router_deployments(model="gemini-live")
+    by_upstream_id = passthrough_router.get_vertex_credentials_from_router_deployments(
+        model="gemini-live-2.5-flash"
+    )
+
+    assert by_alias is not None and by_alias.vertex_project == "proj-live"
+    assert by_upstream_id is not None and by_upstream_id.vertex_project == "proj-live"
+
+
+def test_vertex_unmatched_hint_falls_back_to_first_flagged_deployment():
+    passthrough_router = _passthrough_router(_two_vertex_deployments_router())
+
+    unmatched = passthrough_router.get_vertex_credentials_from_router_deployments(model="unknown-model")
+    no_hint = passthrough_router.get_vertex_credentials_from_router_deployments(model=None)
+
+    assert unmatched is not None and unmatched.vertex_project == "proj-first"
+    assert no_hint is not None and no_hint.vertex_project == "proj-first"
+
+
+def test_no_flagged_vertex_deployment_returns_none():
+    llm_router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gemini-live",
+                "litellm_params": {
+                    "model": "vertex_ai/gemini-live-2.5-flash",
+                    "vertex_project": "proj-unflagged",
+                    "vertex_location": "global",
+                },
+            },
+            _flagged_deployment("openai/gpt-4o", api_key="sk-flagged"),
+        ]
+    )
+    passthrough_router = _passthrough_router(llm_router)
+
+    assert passthrough_router.get_vertex_credentials_from_router_deployments(model=None) is None
+    assert _passthrough_router(None).get_vertex_credentials_from_router_deployments(model=None) is None
+
+
+def test_vertex_deployment_with_deleted_credential_is_skipped(monkeypatch):
+    CredentialAccessor.upsert_credentials(
+        [_vertex_credential("cred_gone", {"vertex_project": "proj-db", "vertex_location": "global"})]
+    )
+    llm_router = litellm.Router(
+        model_list=[
+            _vertex_deployment(
+                "gemini-live", "vertex_ai/gemini-live-2.5-flash", litellm_credential_name="cred_gone"
+            )
+        ]
+    )
+    passthrough_router = _passthrough_router(llm_router)
+    monkeypatch.setattr(litellm, "credential_list", [])
+
+    assert passthrough_router.get_vertex_credentials_from_router_deployments(model=None) is None

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_endpoint_router.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_endpoint_router.py
@@ -268,14 +268,29 @@ def test_vertex_model_hint_prefers_matching_deployment():
     assert by_upstream_id is not None and by_upstream_id.vertex_project == "proj-live"
 
 
-def test_vertex_unmatched_hint_falls_back_to_first_flagged_deployment():
+def test_vertex_without_usable_hint_refuses_to_guess_between_projects():
     passthrough_router = _passthrough_router(_two_vertex_deployments_router())
 
-    unmatched = passthrough_router.get_vertex_credentials_from_router_deployments(model="unknown-model")
-    no_hint = passthrough_router.get_vertex_credentials_from_router_deployments(model=None)
+    assert passthrough_router.get_vertex_credentials_from_router_deployments(model="unknown-model") is None
+    assert passthrough_router.get_vertex_credentials_from_router_deployments(model=None) is None
 
-    assert unmatched is not None and unmatched.vertex_project == "proj-first"
-    assert no_hint is not None and no_hint.vertex_project == "proj-first"
+
+def test_vertex_without_hint_falls_back_when_deployments_share_a_target():
+    llm_router = litellm.Router(
+        model_list=[
+            _vertex_deployment(
+                "gemini-flash", "vertex_ai/gemini-2.5-flash", vertex_project="proj-one", vertex_location="global"
+            ),
+            _vertex_deployment(
+                "gemini-live", "vertex_ai/gemini-live-2.5-flash", vertex_project="proj-one", vertex_location="global"
+            ),
+        ]
+    )
+    passthrough_router = _passthrough_router(llm_router)
+
+    resolved = passthrough_router.get_vertex_credentials_from_router_deployments(model=None)
+
+    assert resolved is not None and resolved.vertex_project == "proj-one"
 
 
 def test_no_flagged_vertex_deployment_returns_none():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Live passthrough ignores Vertex credentials stored in the DB
- Sessions die with no close code or reason
- Google's own rejection reaches the client as a clean 1000
- Bare model ids and gateway aliases are rejected by Vertex

How it solves it:

- Resolve credentials from pass-through-enabled router deployments
- Close 1011 naming both ways to configure credentials
- Relay the upstream close code and reason through
- Rewrite the setup frame's model to Vertex's resource path

## User Flow

Before: a developer whose Live app connects through the gateway is dropped the moment the session starts, with nothing saying why

1. The proxy admin saves the Vertex service-account credential with POST https://litellm-domain/credentials, sending `vertex_project`, `vertex_location` and the key JSON, and gets `{"success":true}` back
2. The admin registers the Live model with POST https://litellm-domain/model/new, sending `litellm_credential_name` and `use_in_pass_through: true`, and gets 200 with the new model id
3. The developer checks GET https://litellm-domain/v1/models, sees the model listed, and takes it as ready to use
4. The developer's app opens a WebSocket to wss://litellm-domain/vertex_ai/live with its virtual key in the Authorization header, and the handshake returns 101
5. The app sends its first `setup` frame naming the model
6. Seconds later the socket closes with no session ever started: 1011 "Vertex AI authentication failed" where the gateway host carries no Google credentials of its own, or a bare 1000 with an empty reason where it does, which reads exactly like a normal end of session
7. The developer tries a model Vertex will not serve and gets that same empty 1000, so nothing separates a bad model from broken credentials from a finished session
8. The one thing that yields a working session is appending `?vertex_project=` and `?vertex_location=` to the URL, which the Live SDK never sends

After: the same app gets a real Live session on the credential the admin already saved, and anything Vertex turns down comes back in Google's own words

1. The proxy admin saves the Vertex service-account credential with POST https://litellm-domain/credentials, sending `vertex_project`, `vertex_location` and the key JSON, and gets `{"success":true}` back
2. The admin registers the Live model with POST https://litellm-domain/model/new, sending `litellm_credential_name` and `use_in_pass_through: true`, and gets 200 with the new model id
3. The developer checks GET https://litellm-domain/v1/models, sees the model listed, and takes it as ready to use
4. The developer's app opens a WebSocket to wss://litellm-domain/vertex_ai/live with its virtual key in the Authorization header, and the handshake returns 101
5. The app sends its first `setup` frame naming the model
6. The gateway answers `setupComplete` with a session id, and the app's first turn comes back as model text followed by `turnComplete` carrying real token counts
7. The developer tries a model Vertex will not serve and the socket closes 1008 in Google's own words, "Publisher model `projects/.../not-a-real-model` was not found or ", so the mistake is obvious
8. Naming the model as a bare id, as the gateway's own model name, or as the full `projects/.../publishers/google/models/...` path all work the same, with no query parameters on the URL

## Relevant issues

## Linear ticket

Resolves LIT-5868

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, run once for both legs. `$PROJECT` stands in for a real GCP project id and `sa.json` for its service-account key

1. Write the config the customer runs, which stores everything in the DB and sets no `default_vertex_config`:

```
cat > config_a.yaml <<'YAML'
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  store_model_in_db: true
litellm_settings:
  set_verbose: true
YAML
```

2. Boot the proxy on a free port, with no `GOOGLE_APPLICATION_CREDENTIALS`, `VERTEXAI_*` or `DEFAULT_VERTEXAI_*` anywhere in its environment:

```
export PORT=38211 LITELLM_MASTER_KEY=sk-1234 PROJECT=<gcp project id>
export DATABASE_URL=postgresql://<user>@127.0.0.1:5432/litellm_lit5868 STORE_MODEL_IN_DB=True
python litellm/proxy/proxy_cli.py --config config_a.yaml --port $PORT --detailed_debug --use_v2_migration_resolver
```

3. Store the Vertex credential, register the Live model against it for pass-through, and mint a virtual key:

```
curl -s -X POST http://127.0.0.1:$PORT/credentials -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d "{\"credential_name\":\"GCP global\",\"credential_info\":{},\"credential_values\":{\"vertex_project\":\"$PROJECT\",\"vertex_location\":\"global\",\"vertex_credentials\":$(jq -Rs . < sa.json)}}"
{"success":true}

curl -s -X POST http://127.0.0.1:$PORT/model/new -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"model_name":"gemini-live","litellm_params":{"model":"vertex_ai/gemini-live-2.5-flash","litellm_credential_name":"GCP global","use_in_pass_through":true}}'

export KEY=$(curl -s -X POST http://127.0.0.1:$PORT/key/generate -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d '{}' | jq -r .key)

curl -s http://127.0.0.1:$PORT/v1/models -H "Authorization: Bearer $KEY"
{"data":[{"id":"gemini-live","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}
```

4. The real client is the Google Live SDK, which the customer's agent framework drives. Pointing its `base_url` at the gateway with no project or location puts it in the API-gateway mode it documents in `live.py`: it takes the URL verbatim, sends the model name exactly as the caller typed it, and authenticates with the custom header. It only speaks `wss://`, so a self-signed TLS terminator sits in front of the local proxy and the client trusts that certificate:

```
openssl req -x509 -newkey rsa:2048 -keyout tls_key.pem -out tls_cert.pem -days 2 -nodes \
  -subj "/CN=127.0.0.1" -addext "subjectAltName=IP:127.0.0.1"
python tls_front.py 38212 $PORT   # TLS on 38212, plain TCP to the proxy

cat > adk_live_probe.py <<'PY'
import asyncio
import os
import ssl
import sys

import websockets.exceptions
from google import genai
from google.genai import types

PORT = os.environ["PORT"]
KEY = os.environ["KEY"]
MODEL = sys.argv[1] if len(sys.argv) > 1 else "gemini-live-2.5-flash"


async def main() -> None:
    client = genai.Client(
        vertexai=True,
        http_options=types.HttpOptions(
            base_url=f"wss://127.0.0.1:{PORT}/vertex_ai/live",
            headers={"Authorization": f"Bearer {KEY}"},
            async_client_args={"ssl": ssl.create_default_context(cafile=os.environ["CAFILE"])},
        ),
    )
    api = client._api_client
    print(f"CLIENT vertexai=True project={api.project} location={api.location} url={api.custom_base_url}")
    print(f"CLIENT model argument {MODEL!r}")
    config = types.LiveConnectConfig(response_modalities=["TEXT"])
    try:
        async with client.aio.live.connect(model=MODEL, config=config) as session:
            print("SESSION OPEN (setupComplete received)")
            await session.send_client_content(
                turns=types.Content(role="user", parts=[types.Part(text="Say hello in one word")]),
                turn_complete=True,
            )
            print("SENT clientContent")
            async for message in session.receive():
                sc = message.server_content
                if sc is not None and sc.model_turn is not None:
                    text = "".join(p.text or "" for p in (sc.model_turn.parts or []))
                    if text:
                        print(f"RECV model text {text!r}")
                if message.usage_metadata is not None:
                    print(f"RECV usage tokens={message.usage_metadata.total_token_count}")
                if sc is not None and sc.turn_complete:
                    print("RECV turnComplete")
                    return
    except websockets.exceptions.ConnectionClosed as exc:
        rcvd = exc.rcvd
        code = rcvd.code if rcvd else None
        reason = repr(rcvd.reason) if rcvd else None
        print(f"CLOSED code={code} reason={reason}")
    except Exception as exc:
        print(f"ERROR {type(exc).__name__}: {exc}")


asyncio.run(main())
PY
```

5. The SDK only ever sends one shape of model name, so a second probe drives the raw socket to cover the other shapes a client can send. It opens the socket, sends one `setup` frame with the model given on the command line, then one turn, and prints every frame or the close it gets back:

```
cat > live_probe.py <<'PY'
import asyncio
import json
import os
import sys

import websockets

URL = f"ws://127.0.0.1:{os.environ['PORT']}/vertex_ai/live"


async def main() -> None:
    setup = json.loads(sys.argv[1])
    async with websockets.connect(URL, additional_headers={"Authorization": f"Bearer {os.environ['KEY']}"}) as ws:
        print("UPGRADE OK (101)")
        await ws.send(json.dumps({"setup": setup}))
        print(f"SENT {json.dumps({'setup': setup})}")
        while True:
            try:
                frame = json.loads(await asyncio.wait_for(ws.recv(), timeout=20))
            except websockets.exceptions.ConnectionClosed as e:
                print(f"CLOSED code={e.rcvd.code} reason={e.rcvd.reason!r}")
                return
            except asyncio.TimeoutError:
                print("TIMEOUT waiting for a frame")
                return
            if "setupComplete" in frame:
                print(f"RECV {json.dumps(frame)}")
                await ws.send(json.dumps({"clientContent": {"turns": [{"role": "user", "parts": [{"text": "Say hello in one word"}]}], "turnComplete": True}}))
                print("SENT clientContent")
                continue
            server_content = frame.get("serverContent", {})
            text = "".join(p.get("text", "") for p in server_content.get("modelTurn", {}).get("parts", []))
            if text:
                print(f"RECV model text {text!r}")
            if server_content.get("turnComplete"):
                print(f"RECV turnComplete, usage {json.dumps(frame.get('usageMetadata', {}))}")
                return


asyncio.run(main())
PY
```

The last case needs credential resolution to succeed so the failure comes from Vertex rather than the gateway, so it runs against a second config that adds the documented `default_vertex_config`:

```
cat > config_b.yaml <<'YAML'
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  store_model_in_db: true
litellm_settings:
  set_verbose: true
default_vertex_config:
  vertex_project: "<gcp project id>"
  vertex_location: "global"
  vertex_credentials: "sa.json"
YAML
```

### Before (5290150a05)

#### Google Live SDK, the client the customer runs

1. `PORT=38212 CAFILE=tls_cert.pem python adk_live_probe.py gemini-live-2.5-flash`
2. The SDK reaches the gateway and the session is killed before it ever starts:

```
CLIENT vertexai=True project=None location=None url=wss://127.0.0.1:38212/vertex_ai/live
CLIENT model argument 'gemini-live-2.5-flash'
ERROR APIError: 1011 None. Vertex AI authentication failed
```

3. `grep -c "GCP global" proxy.log` prints `0`: the stored credential is never consulted

#### Bare Vertex model id

1. `python live_probe.py '{"model":"gemini-live-2.5-flash","generationConfig":{"responseModalities":["TEXT"]}}'`
2. The upgrade succeeds and the session then dies with nothing from Vertex:

```
UPGRADE OK (101)
SENT {"setup": {"model": "gemini-live-2.5-flash", "generationConfig": {"responseModalities": ["TEXT"]}}}
CLOSED code=1011 reason='Vertex AI authentication failed'
```

#### Gateway model name

1. `python live_probe.py '{"model":"gemini-live","generationConfig":{"responseModalities":["TEXT"]}}'`
2. Same close:

```
UPGRADE OK (101)
SENT {"setup": {"model": "gemini-live", "generationConfig": {"responseModalities": ["TEXT"]}}}
CLOSED code=1011 reason='Vertex AI authentication failed'
```

#### Full Vertex resource path

1. `python live_probe.py "{\"model\":\"projects/$PROJECT/locations/global/publishers/google/models/gemini-live-2.5-flash\",\"generationConfig\":{\"responseModalities\":[\"TEXT\"]}}"`
2. Same close, so no way of naming the model helps:

```
UPGRADE OK (101)
SENT {"setup": {"model": "projects/$PROJECT/locations/global/publishers/google/models/gemini-live-2.5-flash", "generationConfig": {"responseModalities": ["TEXT"]}}}
CLOSED code=1011 reason='Vertex AI authentication failed'
```

#### Model Vertex does not serve

1. Restart the proxy on `config_b.yaml`, so credentials resolve and the rejection comes from Google
2. `python live_probe.py "{\"model\":\"projects/$PROJECT/locations/global/publishers/google/models/not-a-real-model\",\"generationConfig\":{\"responseModalities\":[\"TEXT\"]}}"`
3. Google's 1008 and its message are dropped and the client is told the session simply ended:

```
UPGRADE OK (101)
SENT {"setup": {"model": "projects/$PROJECT/locations/global/publishers/google/models/not-a-real-model", "generationConfig": {"responseModalities": ["TEXT"]}}}
CLOSED code=1000 reason=''
```

### After (4f04e59ca0)

#### Google Live SDK, the client the customer runs

1. `PORT=38212 CAFILE=tls_cert.pem python adk_live_probe.py gemini-live-2.5-flash`
2. The SDK gets a real Live session on the credential the admin saved, and a full turn comes back:

```
CLIENT vertexai=True project=None location=None url=wss://127.0.0.1:38212/vertex_ai/live
CLIENT model argument 'gemini-live-2.5-flash'
SESSION OPEN (setupComplete received)
SENT clientContent
RECV model text 'Hello'
RECV usage tokens=6
RECV turnComplete
```

3. `PORT=38212 CAFILE=tls_cert.pem python adk_live_probe.py gemini-live` does the same on the gateway's own model name:

```
CLIENT vertexai=True project=None location=None url=wss://127.0.0.1:38212/vertex_ai/live
CLIENT model argument 'gemini-live'
SESSION OPEN (setupComplete received)
SENT clientContent
RECV model text 'Hello'
RECV usage tokens=6
RECV turnComplete
```

#### Bare Vertex model id

1. `python live_probe.py '{"model":"gemini-live-2.5-flash","generationConfig":{"responseModalities":["TEXT"]}}'`
2. The session runs on the stored credential and completes a real turn:

```
UPGRADE OK (101)
SENT {"setup": {"model": "gemini-live-2.5-flash", "generationConfig": {"responseModalities": ["TEXT"]}}}
RECV {"setupComplete": {"sessionId": "9bb0932e-5bb5-4236-bd0b-6f8533f672d2"}}
SENT clientContent
RECV model text 'Hello'
RECV turnComplete, usage {"promptTokenCount": 5, "candidatesTokenCount": 1, "totalTokenCount": 6, "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 5}], "candidatesTokensDetails": [{"modality": "TEXT", "tokenCount": 1}]}
```

#### Gateway model name

1. `python live_probe.py '{"model":"gemini-live","generationConfig":{"responseModalities":["TEXT"]}}'`
2. The gateway's own model name resolves to the deployment behind it and the turn completes:

```
UPGRADE OK (101)
SENT {"setup": {"model": "gemini-live", "generationConfig": {"responseModalities": ["TEXT"]}}}
RECV {"setupComplete": {"sessionId": "4b229967-601f-4435-9160-a702dcdc0c71"}}
SENT clientContent
RECV model text 'Hello'
RECV turnComplete, usage {"promptTokenCount": 5, "candidatesTokenCount": 1, "totalTokenCount": 6, "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 5}], "candidatesTokensDetails": [{"modality": "TEXT", "tokenCount": 1}]}
```

#### Full Vertex resource path

1. `python live_probe.py "{\"model\":\"projects/$PROJECT/locations/global/publishers/google/models/gemini-live-2.5-flash\",\"generationConfig\":{\"responseModalities\":[\"TEXT\"]}}"`
2. A client that already sends the full path is passed through untouched:

```
UPGRADE OK (101)
SENT {"setup": {"model": "projects/$PROJECT/locations/global/publishers/google/models/gemini-live-2.5-flash", "generationConfig": {"responseModalities": ["TEXT"]}}}
RECV {"setupComplete": {"sessionId": "54969701-94e1-46aa-a3a9-1d9f8a245ce0"}}
SENT clientContent
RECV model text 'Hello'
RECV turnComplete, usage {"promptTokenCount": 5, "candidatesTokenCount": 1, "totalTokenCount": 6, "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 5}], "candidatesTokensDetails": [{"modality": "TEXT", "tokenCount": 1}]}
```

#### Model Vertex does not serve

1. Restart the proxy on `config_b.yaml`, so credentials resolve and the rejection comes from Google
2. `python live_probe.py "{\"model\":\"projects/$PROJECT/locations/global/publishers/google/models/not-a-real-model\",\"generationConfig\":{\"responseModalities\":[\"TEXT\"]}}"`
3. Google's own close code and message reach the client, cut only by the 123-byte limit the WebSocket close frame imposes, exactly as a direct connection to Vertex reports it:

```
UPGRADE OK (101)
SENT {"setup": {"model": "projects/$PROJECT/locations/global/publishers/google/models/not-a-real-model", "generationConfig": {"responseModalities": ["TEXT"]}}}
CLOSED code=1008 reason='Publisher model `projects/$PROJECT/locations/global/publishers/google/models/not-a-real-model` was not found or '
```

## Type

🐛 Bug Fix

## Caveats (if any)

- `default_vertex_config` and the `DEFAULT_VERTEXAI_*` env vars still outrank the DB entries, so a global default keeps winning where one is set
- Needs `?model=`, `default_vertex_config`, or one project, location, and credential across the pass-through deployments, since it will not guess between them
- Close reasons are cut to the 123-byte WebSocket limit
- The close relay is shared, so the OpenAI WebSocket passthrough surfaces upstream close codes too, matching a direct connection

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 4f04e59ca0 passes /live-pr-risk
