### PR TITLE
feat(newrelic): per-team New Relic trace routing via team callbacks

### DIFF
--- a/litellm/integrations/callback_configs.json
+++ b/litellm/integrations/callback_configs.json
@@ -294,12 +294,18 @@
     "id": "newrelic",
     "displayName": "New Relic",
     "logo": "newrelic.png",
-    "supports_key_team_logging": false,
+    "supports_key_team_logging": true,
     "dynamic_params": {
-      "NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED": {
+      "newrelic_api_key": {
+        "type": "password",
+        "ui_name": "New Relic Ingest License Key",
+        "description": "Per-team ingest (license) key. Team traces export to this key's New Relic account over OTLP.",
+        "required": false
+      },
+      "newrelic_region": {
         "type": "text",
-        "ui_name": "Record AI Content (default: true)",
-        "description": "Whether to record AI message content. Set to false to disable.",
+        "ui_name": "New Relic Region (us or eu)",
+        "description": "Data center region for this team's account. Defaults to us.",
         "required": false
       }
     },

--- a/litellm/integrations/otel/emitter.py
+++ b/litellm/integrations/otel/emitter.py
@@ -156,6 +156,12 @@ class SpanEmitter:
             links=list(links) if links else None,
         )
 
+    def mark_emitted(self, dedup_key: str | None, role: SpanRole) -> None:
+        """Register a span emitted outside :meth:`emit` (the boundary-opened
+        LLM-call span closed via :meth:`finish_span`) so a later :meth:`emit`
+        for the same ``(dedup_key, role)`` deduplicates against it."""
+        self._seen(dedup_key, role)
+
     def _seen(self, dedup_key: str | None, role: SpanRole) -> bool:
         """Return True once a ``(dedup_key, role)`` pair has been emitted.
 

--- a/litellm/integrations/otel/logger.py
+++ b/litellm/integrations/otel/logger.py
@@ -484,10 +484,15 @@ class OpenTelemetryV2(CustomLogger):
         # ``pop`` is the dedup: this method runs from both the success and failure
         # paths, and whichever fires first removes the carrier and closes the span.
         carrier: Final = self._open_llm_calls.pop(call_id, None) if call_id else None
-        if carrier is None:
+        # A missing carrier does not always mean nothing happened: a team/key-scoped
+        # logger is a success/failure callback only, so ``pre_call`` never reaches it
+        # and no carrier exists. The payload plus the request-level provider-handoff
+        # stamp (``upstream_started``) is the affirmative signal of a real call; a
+        # gate rejection carries ``is_no_upstream_call`` and gets no span.
+        if carrier is None and (call.is_no_upstream_call or not call.upstream_started or call.payload is None):
             return None
         try:
-            return self._finish_carrier(carrier, call, end_time)
+            return self._finish_carrier(carrier, call, start_time, end_time)
         finally:
             # After the span has ended, so a release-triggered provider shutdown
             # force-flushes it out rather than racing its enqueue.
@@ -512,15 +517,20 @@ class OpenTelemetryV2(CustomLogger):
 
     def _finish_carrier(
         self,
-        carrier: _LLMCallSpan,
+        carrier: "_LLMCallSpan | None",
         call: LLMCallEvent,
+        start_time: datetime | float | None,
         end_time: datetime | float | None,
     ) -> Span | None:
         payload: Final = call.payload
+        call_id: Final = call.call_id
         if payload is None:
-            if carrier.span is not None:
+            if carrier is not None and carrier.span is not None:
                 # Opened at the boundary but the payload never materialized — end
-                # it (named provisionally) so it isn't leaked as an open span.
+                # it (named provisionally) so it isn't leaked as an open span, and
+                # register the dedup marker so a later payload-carrying close for
+                # the same call id cannot re-emit through the deferred branch.
+                self._emitter.mark_emitted(call_id, SpanRole.LLM_CALL)
                 carrier.span.end(end_time=to_ns(end_time))
             return None
         data: Final = LLMCallSpanData.from_standard_logging_payload(
@@ -529,10 +539,13 @@ class OpenTelemetryV2(CustomLogger):
             time_to_first_chunk_seconds=call.time_to_first_chunk_seconds,
         )
         end_time_ns: Final = to_ns(end_time)
-        if carrier.span is not None:
+        if carrier is not None and carrier.span is not None:
             # Born at the boundary: stamp attributes from the typed payload, set
             # status, and end it. Its parent (the server span) was captured at
-            # creation from real ambient context.
+            # creation from real ambient context. Register the dedup marker so a
+            # second close for the same call id (success then failure on one
+            # logging object) cannot re-emit through the deferred branch.
+            self._emitter.mark_emitted(call_id, SpanRole.LLM_CALL)
             self._emitter.finish_span(SpanRole.LLM_CALL, carrier.span, data, end_time_ns=end_time_ns)
             return carrier.span
         # Deferred: ``pre_call`` saw no recordable parent, so create the span now.
@@ -549,7 +562,7 @@ class OpenTelemetryV2(CustomLogger):
                 SpanRole.LLM_CALL,
                 data,
                 parent_context=(set_span_in_context(INVALID_SPAN, parent_ctx) if route.detached else parent_ctx),
-                start_time_ns=carrier.start_time_ns,
+                start_time_ns=(carrier.start_time_ns if carrier is not None else to_ns(start_time)),
                 end_time_ns=end_time_ns,
                 tracer=route.tracer,
                 links=_request_trace_links(parent_ctx) if route.detached else None,

--- a/litellm/integrations/otel/logger.py
+++ b/litellm/integrations/otel/logger.py
@@ -502,8 +502,11 @@ class OpenTelemetryV2(CustomLogger):
         """Remember an in-flight LLM call, evicting the oldest if over budget.
 
         A call that opens but never closes (a stream that only fires stream
-        events) would linger otherwise; the evicted span is simply dropped
-        (never exported).
+        events) would linger otherwise. Eviction only drops the boundary carrier,
+        not the call: if that call later closes as a real completed call, it still
+        emits through the deferred branch in ``_close_llm_call`` (the same path a
+        team/key-scoped logger uses, since it never opens a carrier), deduplicated
+        by call id. Only a call that is evicted and never closes goes unexported.
         """
         self._open_llm_calls[call_id] = carrier
         if len(self._open_llm_calls) > _OPEN_CALLS_MAX:

--- a/litellm/integrations/otel/model/config.py
+++ b/litellm/integrations/otel/model/config.py
@@ -39,6 +39,7 @@ class ExporterOwner(str, Enum):
     WEAVE_OTEL = "weave_otel"
     LEVO = "levo"
     AGENTOPS = "agentops"
+    NEWRELIC = "newrelic"
 
 
 class _OTelV2Flag(BaseSettings):
@@ -95,6 +96,15 @@ class ExporterSpec(BaseModel):
         description=(
             "Force SimpleSpanProcessor regardless of exporter kind. Default: "
             "auto (Simple for console/in_memory, Batch otherwise)."
+        ),
+    )
+    requires_headers: bool = Field(
+        default=False,
+        description=(
+            "Skip this exporter when no headers are resolved. For destinations "
+            "that reject unauthenticated exports (e.g. New Relic), a spec kept "
+            "only as the per-request credential-stamping target would otherwise "
+            "export keyless traffic and produce a 4xx for every span batch."
         ),
     )
 

--- a/litellm/integrations/otel/model/metadata.py
+++ b/litellm/integrations/otel/model/metadata.py
@@ -203,6 +203,11 @@ class LLMCallEvent:
     # True for synthetic proxy-gate logs (auth / rate-limit rejections): they fire
     # the ``pre_call`` hook but never made an upstream call, so they get no span.
     is_no_upstream_call: bool
+    # True once the request handed off to a provider (``pre_call`` stamped
+    # ``api_call_start_time``). The affirmative signal that an LLM call was
+    # actually attempted — router pre-call rejections, SDK failures before the
+    # provider handoff, and standalone guardrail runs all lack it.
+    upstream_started: bool
     # A best-effort ``"{operation} {model}"`` name known at ``pre_call`` time. The
     # span is renamed from the typed payload at close (``finish_span``); this only
     # needs to be reasonable for a span that never gets closed (a leak).
@@ -221,6 +226,7 @@ class LLMCallEvent:
             dynamic_params=kwargs.get("standard_callback_dynamic_params"),
             auth_metadata=auth_metadata(payload, kwargs),
             is_no_upstream_call=bool(kwargs.get(LITELLM_LOGGING_NO_UPSTREAM_LLM_CALL)),
+            upstream_started=kwargs.get("api_call_start_time") is not None,
             provisional_span_name=f"{operation.value} {model}".strip(),
             time_to_first_chunk_seconds=time_to_first_chunk_seconds(kwargs),
         )

--- a/litellm/integrations/otel/plumbing/providers.py
+++ b/litellm/integrations/otel/plumbing/providers.py
@@ -436,6 +436,8 @@ def build_tracer_provider(
     # ``config._normalize`` guarantees at least one spec (it folds the top-level
     # ``exporter``/``endpoint``/``headers`` fields in when ``exporters`` is empty).
     for spec in config.exporters:
+        if spec.requires_headers and not spec.headers:
+            continue
         exp = _exporter_from_spec(spec)
         provider.add_span_processor(
             _processor_for(

--- a/litellm/integrations/otel/plumbing/routing.py
+++ b/litellm/integrations/otel/plumbing/routing.py
@@ -28,6 +28,7 @@ from litellm.integrations.otel.plumbing.providers import (
     get_tracer,
 )
 from litellm.integrations.otel.presets import (
+    dynamic_otlp_endpoint,
     dynamic_otlp_headers,
     project_routing_headers,
 )
@@ -129,7 +130,9 @@ class TenantTracerCache:
         # thread-pool workers concurrently with the event loop, so cache
         # updates, span counts, and retirement must be atomic.
         self._lock: Final = threading.Lock()
-        self._providers: OrderedDict[tuple[_HeaderItems, _HeaderItems], TracerProvider] = OrderedDict()
+        self._providers: OrderedDict[tuple[_HeaderItems, _HeaderItems, str | None], TracerProvider] = (
+            OrderedDict()  # mutable-ok: bounded LRU; eviction needs in-place ordered mutation
+        )
         self._open_span_counts: dict[TracerProvider, int] = {}  # mutable-ok: live refcount state
         # Oldest-first so an overflow of draining providers sheds the stalest.
         self._retired: OrderedDict[TracerProvider, None] = OrderedDict()  # mutable-ok: draining evicted providers
@@ -182,12 +185,16 @@ class TenantTracerCache:
         project_headers: Final = self._project_headers(auth_metadata)
         if not credential_headers and not project_headers:
             return TenantRoute(tracer=default, detached=False)
+        # A fixed per-integration region endpoint (New Relic us/eu), never a
+        # caller-supplied host; ``None`` keeps the preset's own endpoint.
+        endpoint: Final = dynamic_otlp_endpoint(self._callback_name, dynamic_params)
         cache_key: Final = (
             tuple(sorted(credential_headers.items())),
             tuple(sorted(project_headers.items())),
+            endpoint,
         )
         with self._lock:
-            provider: Final = self._cached_provider_locked(cache_key, credential_headers, project_headers)
+            provider: Final = self._cached_provider_locked(cache_key, credential_headers, project_headers, endpoint)
             self._open_span_counts[provider] = self._open_span_counts.get(provider, 0) + 1
             evicted: Final = self._evicted_on_overflow_locked()
         if evicted is not None:
@@ -200,15 +207,16 @@ class TenantTracerCache:
 
     def _cached_provider_locked(
         self,
-        cache_key: tuple[_HeaderItems, _HeaderItems],
+        cache_key: tuple[_HeaderItems, _HeaderItems, str | None],
         credential_headers: Mapping[str, str],
         project_headers: Mapping[str, str],
+        endpoint: str | None,
     ) -> TracerProvider:
         cached: Final = self._providers.get(cache_key)
         if cached is not None:
             self._providers.move_to_end(cache_key)
             return cached
-        built: Final = build_tracer_provider(self._routed_config(credential_headers, project_headers))
+        built: Final = build_tracer_provider(self._routed_config(credential_headers, project_headers, endpoint))
         self._providers[cache_key] = built
         return built
 
@@ -257,6 +265,7 @@ class TenantTracerCache:
         self,
         credential_headers: Mapping[str, str],
         project_headers: Mapping[str, str],
+        endpoint: str | None = None,
     ) -> OpenTelemetryV2Config:
         """Clone the config, rewriting headers on the callback's own exporter.
 
@@ -272,7 +281,8 @@ class TenantTracerCache:
         ``Authorization``), which must survive routing to a project.
         """
         exporters: Final = [
-            self._routed_exporter(spec, credential_headers, project_headers) for spec in self._config.exporters
+            self._routed_exporter(spec, credential_headers, project_headers, endpoint)
+            for spec in self._config.exporters
         ]
         return self._config.model_copy(update={"exporters": exporters})
 
@@ -281,6 +291,7 @@ class TenantTracerCache:
         spec: ExporterSpec,
         credential_headers: Mapping[str, str],
         project_headers: Mapping[str, str],
+        endpoint: str | None = None,
     ) -> ExporterSpec:
         kind: Final = spec.kind.lower()
         if spec.owner != self._callback_name or kind in _NON_OTLP_KINDS:
@@ -291,4 +302,10 @@ class TenantTracerCache:
             if project_headers and kind not in _GRPC_KINDS
             else base
         )
-        return spec if routed == spec.headers else spec.model_copy(update={"headers": routed})
+        update: Final = {  # mutable-ok: model_copy(update=...) requires a plain dict
+            field: value
+            for field, value in (("headers", routed), ("endpoint", endpoint))
+            if (field == "headers" and routed != spec.headers)
+            or (field == "endpoint" and endpoint is not None and endpoint != spec.endpoint)
+        }
+        return spec if not update else spec.model_copy(update=update)

--- a/litellm/integrations/otel/presets/__init__.py
+++ b/litellm/integrations/otel/presets/__init__.py
@@ -21,6 +21,11 @@ from litellm.integrations.otel.presets.langfuse import (
 )
 from litellm.integrations.otel.presets.langtrace import langtrace_preset
 from litellm.integrations.otel.presets.levo import levo_preset
+from litellm.integrations.otel.presets.newrelic import (
+    newrelic_dynamic_endpoint,
+    newrelic_dynamic_headers,
+    newrelic_preset,
+)
 from litellm.integrations.otel.presets.phoenix import (
     phoenix_preset,
     phoenix_project_headers,
@@ -30,25 +35,45 @@ from litellm.types.utils import StandardCallbackDynamicParams
 
 #: Callback name → preset. The ``Preset`` annotation makes mypy verify every
 #: registered value matches the preset interface.
-PRESET_BY_CALLBACK: Final[dict[str, Preset]] = {
-    "agentops": agentops_preset,
-    "arize": arize_preset,
-    "arize_phoenix": phoenix_preset,
-    "langfuse_otel": langfuse_preset,
-    "langtrace": langtrace_preset,
-    "levo": levo_preset,
-    "weave_otel": weave_preset,
-}
+PRESET_BY_CALLBACK: Final[Mapping[str, Preset]] = MappingProxyType(
+    {
+        "agentops": agentops_preset,
+        "arize": arize_preset,
+        "arize_phoenix": phoenix_preset,
+        "langfuse_otel": langfuse_preset,
+        "langtrace": langtrace_preset,
+        "levo": levo_preset,
+        "newrelic": newrelic_preset,
+        "weave_otel": weave_preset,
+    }
+)
 
 #: Callback name → per-request OTLP header builder (team/key multi-tenant
 #: routing). Only integrations that support dynamic credentials appear here —
 #: Arize-Phoenix/Langtrace/Levo/AgentOps don't, so they use the logger's
 #: default tracer.
-DYNAMIC_HEADERS_BY_CALLBACK: Final[dict[str, Callable[[StandardCallbackDynamicParams], dict[str, str]]]] = {
-    "arize": arize_dynamic_headers,
-    "langfuse_otel": langfuse_dynamic_headers,
-    "weave_otel": weave_dynamic_headers,
-}
+DYNAMIC_HEADERS_BY_CALLBACK: Final[Mapping[str, Callable[[StandardCallbackDynamicParams], dict[str, str]]]] = (
+    MappingProxyType(
+        {
+            "arize": arize_dynamic_headers,
+            "langfuse_otel": langfuse_dynamic_headers,
+            "newrelic": newrelic_dynamic_headers,
+            "weave_otel": weave_dynamic_headers,
+        }
+    )
+)
+
+#: Callback name → per-request OTLP endpoint resolver. Only integrations whose
+#: destination host varies per tenant (from a fixed region table, never a
+#: caller-supplied URL) appear here; for everyone else the preset's endpoint is
+#: authoritative.
+DYNAMIC_ENDPOINT_BY_CALLBACK: Final[Mapping[str, Callable[[StandardCallbackDynamicParams], str | None]]] = (
+    MappingProxyType(
+        {
+            "newrelic": newrelic_dynamic_endpoint,
+        }
+    )
+)
 
 
 #: Callback name → per-request *routing* header builder, sourced from the key/team
@@ -98,17 +123,34 @@ def project_routing_headers(
     return builder(auth_metadata)
 
 
+def dynamic_otlp_endpoint(
+    callback_name: str | None,
+    dynamic_params: StandardCallbackDynamicParams | None,
+) -> str | None:
+    """Per-request OTLP endpoint for ``callback_name``, or ``None`` if N/A.
+
+    ``None`` means "keep the preset's own endpoint".
+    """
+    resolver: Final = DYNAMIC_ENDPOINT_BY_CALLBACK.get(callback_name or "")
+    if resolver is None or not dynamic_params:
+        return None
+    return resolver(dynamic_params)
+
+
 __all__ = [
+    "DYNAMIC_ENDPOINT_BY_CALLBACK",
     "DYNAMIC_HEADERS_BY_CALLBACK",
     "PRESET_BY_CALLBACK",
     "PROJECT_HEADERS_BY_CALLBACK",
     "Preset",
     "agentops_preset",
     "arize_preset",
+    "dynamic_otlp_endpoint",
     "dynamic_otlp_headers",
     "langfuse_preset",
     "langtrace_preset",
     "levo_preset",
+    "newrelic_preset",
     "phoenix_preset",
     "project_routing_headers",
     "weave_preset",

--- a/litellm/integrations/otel/presets/newrelic.py
+++ b/litellm/integrations/otel/presets/newrelic.py
@@ -1,0 +1,104 @@
+"""New Relic preset — OTLP/HTTP exporter to New Relic + GenAI vocabulary."""
+
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Final
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from litellm._logging import verbose_logger
+from litellm.integrations.otel.model.config import (
+    ExporterOwner,
+    ExporterSpec,
+    OpenTelemetryV2Config,
+)
+from litellm.integrations.otel.presets.utils import ensure_mappers
+from litellm.types.utils import StandardCallbackDynamicParams
+
+#: Region -> OTLP base endpoint. A fixed table by design: team config picks a
+#: region enum rather than a free-form endpoint, so callback vars can never
+#: redirect telemetry to an arbitrary host.
+NEWRELIC_OTLP_ENDPOINT_BY_REGION: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "us": "https://otlp.nr-data.net",
+        "eu": "https://otlp.eu01.nr-data.net",
+    }
+)
+
+_DEFAULT_REGION: Final = "us"
+
+
+class _NewRelicSettings(BaseSettings):
+    model_config = SettingsConfigDict(case_sensitive=False, extra="ignore")
+
+    # The same env vars the agent-based integration documents; the key is the
+    # operator-level fallback for traffic without team credentials, the region
+    # picks that fallback's data center, and the record-content flag keeps its
+    # documented meaning when the OTel path replaces the agent.
+    license_key: str | None = Field(default=None, validation_alias="NEW_RELIC_LICENSE_KEY")
+    region: str | None = Field(default=None, validation_alias="NEW_RELIC_REGION")
+    record_content: bool | None = Field(default=None, validation_alias="NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED")
+
+
+def newrelic_preset(
+    *,
+    config_overrides: OpenTelemetryV2Config | None = None,
+) -> OpenTelemetryV2Config:
+    settings: Final = _NewRelicSettings()
+    base: Final = config_overrides or OpenTelemetryV2Config()
+    endpoint: Final = NEWRELIC_OTLP_ENDPOINT_BY_REGION.get(
+        (settings.region or _DEFAULT_REGION).lower(), NEWRELIC_OTLP_ENDPOINT_BY_REGION[_DEFAULT_REGION]
+    )
+    return base.model_copy(
+        update={
+            "exporters": [
+                *base.exporters,
+                ExporterSpec(
+                    kind="otlp_http",
+                    endpoint=endpoint,
+                    headers=(f"api-key={settings.license_key}" if settings.license_key else None),
+                    owner=ExporterOwner.NEWRELIC,
+                    requires_headers=True,
+                ),
+            ],
+            # New Relic ingests the OTLP GenAI semantic conventions natively.
+            "mapper_names": ensure_mappers(base.mapper_names, "genai"),
+            **(
+                {"capture_message_content": ("span_only" if settings.record_content else "no_content")}
+                if settings.record_content is not None
+                else {}
+            ),
+        }
+    )
+
+
+def newrelic_dynamic_headers(params: StandardCallbackDynamicParams) -> dict[str, str]:
+    """Per-request New Relic OTLP headers from team/key dynamic params."""
+    api_key: Final = params.get("newrelic_api_key")
+    return {header: value for header, value in (("api-key", api_key),) if value}
+
+
+def newrelic_dynamic_endpoint(params: StandardCallbackDynamicParams) -> str:
+    """Per-request OTLP endpoint for the team's ``newrelic_region``.
+
+    Always the team's own region endpoint, defaulting to US when the team left
+    the region unset. It never falls through to the preset's endpoint, which
+    follows the operator's ``NEW_RELIC_REGION`` env; a team that saved only its
+    ingest key must not inherit the operator's region and have its US-account
+    spans rejected by an EU-configured default (or vice versa). An unknown
+    region likewise resolves to the documented US default rather than a guess.
+    """
+    region: Final = params.get("newrelic_region")
+    default_endpoint: Final = NEWRELIC_OTLP_ENDPOINT_BY_REGION[_DEFAULT_REGION]
+    if not region:
+        return default_endpoint
+    endpoint: Final = NEWRELIC_OTLP_ENDPOINT_BY_REGION.get(region.lower())
+    if endpoint is None:
+        verbose_logger.warning(
+            "New Relic: unknown newrelic_region %r; supported regions: %s. Using the default (US) endpoint.",
+            region,
+            ", ".join(sorted(NEWRELIC_OTLP_ENDPOINT_BY_REGION)),
+        )
+        return default_endpoint
+    return endpoint

--- a/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
+++ b/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
@@ -46,7 +46,7 @@ def validate_no_callback_env_reference(param: str, value: object, *, source: str
 
 
 # Hardcoded list of supported callback params to avoid runtime inspection issues with TypedDict
-_supported_callback_params: Final = [
+_supported_callback_params: Final[tuple[str, ...]] = (
     "langfuse_public_key",
     "langfuse_secret",
     "langfuse_secret_key",
@@ -72,8 +72,10 @@ _supported_callback_params: Final = [
     "dd_site",
     "dd_agent_host",
     "dd_agent_port",
+    "newrelic_api_key",
+    "newrelic_region",
     "turn_off_message_logging",
-]
+)
 
 _request_blocked_callback_params: Final = frozenset(
     {
@@ -83,6 +85,20 @@ _request_blocked_callback_params: Final = frozenset(
         "dd_site",
         "dd_agent_host",
         "dd_agent_port",
+        "newrelic_api_key",
+        "newrelic_region",
+    }
+)
+
+# Request-blocked params that must still reach ``standard_callback_dynamic_params``
+# when the proxy itself stamped them from admin-configured team/key callback
+# settings (the trusted-vars channel). The OTel per-tenant tracer routing reads
+# ``standard_callback_dynamic_params``, so without this overlay a blocked param
+# could never drive routing at all.
+_trusted_overlay_callback_params: Final = frozenset(
+    {
+        "newrelic_api_key",
+        "newrelic_region",
     }
 )
 
@@ -121,7 +137,9 @@ def initialize_standard_callback_dynamic_params(
             if param in kwargs:
                 _param_value = kwargs.get(param)
                 validate_no_callback_env_reference(param, _param_value, source="request body")
-                standard_callback_dynamic_params[param] = _param_value
+                standard_callback_dynamic_params[param] = (  # pyright: ignore[reportGeneralTypeIssues]  # several supported params predate their StandardCallbackDynamicParams fields
+                    _param_value
+                )
 
         for slot_label, metadata in iter_client_callback_metadata_dicts(kwargs):
             for param in _supported_callback_params:
@@ -130,6 +148,12 @@ def initialize_standard_callback_dynamic_params(
                 if param not in standard_callback_dynamic_params and param in metadata:
                     _param_value = metadata.get(param)
                     validate_no_callback_env_reference(param, _param_value, source=slot_label)
-                    standard_callback_dynamic_params[param] = _param_value
+                    standard_callback_dynamic_params[param] = (  # pyright: ignore[reportGeneralTypeIssues]  # several supported params predate their StandardCallbackDynamicParams fields
+                        _param_value
+                    )
+
+        for param, trusted_value in get_trusted_callback_params(kwargs):
+            if param in _trusted_overlay_callback_params:
+                standard_callback_dynamic_params[param] = trusted_value
 
     return standard_callback_dynamic_params

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4503,6 +4503,9 @@ def _init_custom_logger_compatible_class(
             _in_memory_loggers.append(gitlab_logger)
             return gitlab_logger
         elif logging_integration == "newrelic":
+            _v2 = _maybe_construct_otel_v2("newrelic", _in_memory_loggers)
+            if _v2 is not None:
+                return _v2
             for callback in _in_memory_loggers:
                 if isinstance(callback, NewRelicLogger):
                     return callback
@@ -4789,7 +4792,11 @@ def get_custom_logger_compatible_class(
                 if isinstance(callback, SMTPEmailLogger):
                     return callback
         elif logging_integration == "newrelic":
+            from litellm.integrations.otel.logger import OpenTelemetryV2
+
             for callback in _in_memory_loggers:
+                if isinstance(callback, OpenTelemetryV2) and callback.callback_name == "newrelic":
+                    return callback
                 if isinstance(callback, NewRelicLogger):
                     return callback
         return None

--- a/litellm/proxy/common_utils/callback_config_validation.py
+++ b/litellm/proxy/common_utils/callback_config_validation.py
@@ -1,0 +1,77 @@
+"""Save-time validation of team/key logging configs the runtime cannot honor.
+
+Team callbacks arrive as a single ``AddTeamCallback``, key callbacks arrive as a
+``logging`` list inside the key metadata, so both shapes funnel into the same
+per-integration checks here.
+"""
+
+from collections.abc import Mapping, Sequence
+from types import MappingProxyType
+from typing import Final
+
+_NEWRELIC_CALLBACK: Final = "newrelic"
+_NEWRELIC_VAR_PREFIX: Final = "newrelic_"
+
+
+def callback_config_error(callback_name: str | None, callback_vars: Mapping[str, str] | None) -> str | None:
+    if callback_name != _NEWRELIC_CALLBACK or not callback_vars:
+        return None
+    return _newrelic_config_error(callback_vars)
+
+
+def logging_metadata_config_error(metadata: Mapping[str, object] | None) -> str | None:
+    """Validate every ``logging`` entry of a team/key metadata payload."""
+    if not metadata:
+        return None
+    entries: Final = metadata.get("logging")
+    if not isinstance(entries, Sequence) or isinstance(entries, (str, bytes)):
+        return None
+    return next(
+        (error for error in (_logging_entry_error(entry) for entry in entries) if error is not None),
+        None,
+    )
+
+
+def _logging_entry_error(entry: object) -> str | None:
+    if not isinstance(entry, Mapping):
+        return None
+    callback_name: Final = entry.get("callback_name")
+    callback_vars: Final = entry.get("callback_vars")
+    if not isinstance(callback_name, str) or not isinstance(callback_vars, Mapping):
+        return None
+    return callback_config_error(
+        callback_name,
+        MappingProxyType({str(key): str(value) for key, value in callback_vars.items()}),
+    )
+
+
+def _newrelic_config_error(callback_vars: Mapping[str, str]) -> str | None:
+    """Per-team New Relic routing runs on the OTel v2 path only.
+
+    Accepting the config with the flag off would silently ship the team's traffic
+    through the operator's env-configured agent instead of the team's account. A
+    region outside the fixed table, or a region without a key, would likewise be
+    accepted and then silently ignored or misrouted at request time.
+    """
+    if not any(key.startswith(_NEWRELIC_VAR_PREFIX) for key in callback_vars):
+        return None
+
+    from litellm.integrations.otel.model.config import is_otel_v2_enabled
+    from litellm.integrations.otel.presets.newrelic import NEWRELIC_OTLP_ENDPOINT_BY_REGION
+
+    if not is_otel_v2_enabled():
+        return "Per-team New Relic routing requires the proxy to run with LITELLM_OTEL_V2=true."
+
+    region: Final = callback_vars.get("newrelic_region")
+    if region is not None and region.lower() not in NEWRELIC_OTLP_ENDPOINT_BY_REGION:
+        return (
+            f"Unknown newrelic_region {region!r}. "
+            f"Supported regions: {', '.join(sorted(NEWRELIC_OTLP_ENDPOINT_BY_REGION))}."
+        )
+
+    # ``callback_vars`` values are str()-coerced upstream, so a JSON ``null`` key
+    # arrives as the literal ``"None"``; treat that and the empty string as absent.
+    api_key: Final = callback_vars.get("newrelic_api_key")
+    if region is not None and (not api_key or api_key == "None"):
+        return "newrelic_region requires newrelic_api_key; the region rides the team's own key."
+    return None

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -754,6 +754,12 @@ def convert_key_logging_metadata_to_callback(
             team_callback_settings_obj.callbacks.append(data.callback_name)
 
     for var, value in data.callback_vars.items():
+        # New Relic routing reads these from the trusted-vars overlay with no
+        # callback-name check, so scope them to the newrelic entry: a team that
+        # put newrelic_* under a different callback never asked for New Relic and
+        # must not export to it.
+        if var.startswith("newrelic_") and data.callback_name != "newrelic":
+            continue
         if team_callback_settings_obj.callback_vars is None:
             team_callback_settings_obj.callback_vars = {}
         team_callback_settings_obj.callback_vars[var] = str(value)

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -62,6 +62,7 @@ from litellm.proxy.auth.auth_utils import (
     enforce_output_token_estimates_are_admin_only,
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.callback_config_validation import logging_metadata_config_error
 from litellm.proxy.common_utils.callback_utils import (
     decrypt_callback_vars,
     encrypt_callback_vars,
@@ -553,6 +554,17 @@ def key_generation_check(
         return _personal_key_generation_check(user_api_key_dict=user_api_key_dict, data=data)
 
 
+def raise_on_invalid_key_logging_config(metadata: Mapping[str, object] | None) -> None:
+    """Key-level logging writes go through key metadata, not /team/callback.
+
+    Without this the same New Relic config the team endpoint rejects would be
+    accepted here and then silently ignored or misrouted at request time.
+    """
+    error: Final = logging_metadata_config_error(metadata)
+    if error is not None:
+        raise HTTPException(status_code=400, detail={"error": error})  # mutable-ok: FastAPI detail contract
+
+
 def common_key_access_checks(
     user_api_key_dict: UserAPIKeyAuth,
     data: GenerateKeyRequest | UpdateKeyRequest,
@@ -891,6 +903,7 @@ async def _common_key_generation_helper(
     )
 
     validate_budget_duration(data.budget_duration)
+    raise_on_invalid_key_logging_config(data.metadata)
 
     if data.throttle_on_budget_exceeded is True and user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value:
         raise HTTPException(
@@ -1992,6 +2005,8 @@ def prepare_metadata_fields(data: BaseModel, non_default_values: dict, existing_
     """
     Check LiteLLM_ManagementEndpoint_MetadataFields (proxy/_types.py) for fields that are allowed to be updated
     """
+    raise_on_invalid_key_logging_config(non_default_values.get("metadata"))
+
     if "metadata" not in non_default_values:  # allow user to set metadata to none
         non_default_values["metadata"] = existing_metadata.copy()
 

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -51,6 +51,42 @@ router: Final = APIRouter()
 _CALLBACK_VARS_REDACTED: Final = "***REDACTED***"
 
 
+def _callback_config_error(message: str) -> HTTPException:
+    return HTTPException(status_code=400, detail={"error": message})  # mutable-ok: FastAPI detail contract
+
+
+def _validate_newrelic_callback(data: "AddTeamCallback") -> None:
+    """Reject New Relic team-callback configs the runtime cannot honor.
+
+    Per-team New Relic routing runs on the OTel v2 path only; accepting the
+    config with the flag off would silently ship the team's traffic through the
+    operator's env-configured agent instead of the team's account. A region
+    outside the fixed table, or a region without a key, would likewise be
+    accepted and then silently ignored or misrouted at request time.
+    """
+    if data.callback_name != "newrelic" or not data.callback_vars:
+        return
+    callback_vars: Final = data.callback_vars
+    if not any(key.startswith("newrelic_") for key in callback_vars):
+        return
+    from litellm.integrations.otel.model.config import is_otel_v2_enabled
+    from litellm.integrations.otel.presets.newrelic import NEWRELIC_OTLP_ENDPOINT_BY_REGION
+
+    if not is_otel_v2_enabled():
+        raise _callback_config_error("Per-team New Relic routing requires the proxy to run with LITELLM_OTEL_V2=true.")
+    region: Final = callback_vars.get("newrelic_region")
+    if region is not None and region.lower() not in NEWRELIC_OTLP_ENDPOINT_BY_REGION:
+        raise _callback_config_error(
+            f"Unknown newrelic_region {region!r}. "
+            f"Supported regions: {', '.join(sorted(NEWRELIC_OTLP_ENDPOINT_BY_REGION))}."
+        )
+    # ``callback_vars`` values are str()-coerced upstream, so a JSON ``null`` key
+    # arrives as the literal ``"None"``; treat that and the empty string as absent.
+    api_key: Final = callback_vars.get("newrelic_api_key")
+    if region is not None and (not api_key or api_key == "None"):
+        raise _callback_config_error("newrelic_region requires newrelic_api_key; the region rides the team's own key.")
+
+
 def _redact_callback_secrets(metadata: Any) -> Any:
     """Strip secret values out of a team-metadata snapshot before audit logging.
 
@@ -303,6 +339,8 @@ async def add_team_callbacks(
             team_obj=LiteLLM_TeamTable(**_existing_team.model_dump()),
             user_api_key_dict=user_api_key_dict,
         )
+
+        _validate_newrelic_callback(data)
 
         # store team callback settings in metadata
         team_metadata = _existing_team.metadata

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -28,6 +28,7 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.callback_config_validation import callback_config_error
 from litellm.proxy.common_utils.callback_utils import (
     _CALLBACK_VAR_ENCRYPTED_PREFIX,
     decrypt_callback_vars,
@@ -55,36 +56,10 @@ def _callback_config_error(message: str) -> HTTPException:
     return HTTPException(status_code=400, detail={"error": message})  # mutable-ok: FastAPI detail contract
 
 
-def _validate_newrelic_callback(data: "AddTeamCallback") -> None:
-    """Reject New Relic team-callback configs the runtime cannot honor.
-
-    Per-team New Relic routing runs on the OTel v2 path only; accepting the
-    config with the flag off would silently ship the team's traffic through the
-    operator's env-configured agent instead of the team's account. A region
-    outside the fixed table, or a region without a key, would likewise be
-    accepted and then silently ignored or misrouted at request time.
-    """
-    if data.callback_name != "newrelic" or not data.callback_vars:
-        return
-    callback_vars: Final = data.callback_vars
-    if not any(key.startswith("newrelic_") for key in callback_vars):
-        return
-    from litellm.integrations.otel.model.config import is_otel_v2_enabled
-    from litellm.integrations.otel.presets.newrelic import NEWRELIC_OTLP_ENDPOINT_BY_REGION
-
-    if not is_otel_v2_enabled():
-        raise _callback_config_error("Per-team New Relic routing requires the proxy to run with LITELLM_OTEL_V2=true.")
-    region: Final = callback_vars.get("newrelic_region")
-    if region is not None and region.lower() not in NEWRELIC_OTLP_ENDPOINT_BY_REGION:
-        raise _callback_config_error(
-            f"Unknown newrelic_region {region!r}. "
-            f"Supported regions: {', '.join(sorted(NEWRELIC_OTLP_ENDPOINT_BY_REGION))}."
-        )
-    # ``callback_vars`` values are str()-coerced upstream, so a JSON ``null`` key
-    # arrives as the literal ``"None"``; treat that and the empty string as absent.
-    api_key: Final = callback_vars.get("newrelic_api_key")
-    if region is not None and (not api_key or api_key == "None"):
-        raise _callback_config_error("newrelic_region requires newrelic_api_key; the region rides the team's own key.")
+def _validate_team_callback(data: "AddTeamCallback") -> None:
+    error: Final = callback_config_error(data.callback_name, data.callback_vars)
+    if error is not None:
+        raise _callback_config_error(error)
 
 
 def _redact_callback_secrets(metadata: Any) -> Any:
@@ -340,7 +315,7 @@ async def add_team_callbacks(
             user_api_key_dict=user_api_key_dict,
         )
 
-        _validate_newrelic_callback(data)
+        _validate_team_callback(data)
 
         # store team callback settings in metadata
         team_metadata = _existing_team.metadata

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3300,6 +3300,11 @@ class StandardCallbackDynamicParams(TypedDict, total=False):
     dd_agent_host: str | None
     dd_agent_port: str | None
 
+    # New Relic dynamic params (proxy-stamped team/key callback vars only;
+    # request-supplied values are blocked)
+    newrelic_api_key: str | None  # writable-ok: initialize_standard_callback_dynamic_params assigns into the dict
+    newrelic_region: str | None  # writable-ok: initialize_standard_callback_dynamic_params assigns into the dict
+
     # Logging settings
     turn_off_message_logging: bool | None  # when true will not log messages
     litellm_disabled_callbacks: list[str] | None

--- a/tests/test_litellm/integrations/otel/test_otel_v2_dynamic.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_dynamic.py
@@ -7,6 +7,7 @@ from opentelemetry.trace import NoOpTracer
 
 from litellm.integrations.otel.model.config import ExporterSpec, OpenTelemetryV2Config
 from litellm.integrations.otel.presets import (
+    dynamic_otlp_endpoint,
     dynamic_otlp_headers,
     project_routing_headers,
 )
@@ -23,31 +24,23 @@ def _cache(callback_name, exporters=None):
 
 
 def test_arize_dynamic_headers():
-    headers = dynamic_otlp_headers(
-        "arize", {"arize_space_id": "S", "arize_api_key": "K"}
-    )
+    headers = dynamic_otlp_headers("arize", {"arize_space_id": "S", "arize_api_key": "K"})
     assert headers == {"arize-space-id": "S", "api_key": "K"}
 
 
 def test_arize_space_key_overrides_space_id():
-    headers = dynamic_otlp_headers(
-        "arize", {"arize_space_id": "S", "arize_space_key": "SK"}
-    )
+    headers = dynamic_otlp_headers("arize", {"arize_space_id": "S", "arize_space_key": "SK"})
     assert headers == {"arize-space-id": "SK"}
 
 
 def test_langfuse_dynamic_headers_need_both_keys():
     assert dynamic_otlp_headers("langfuse_otel", {"langfuse_public_key": "pk"}) is None
-    headers = dynamic_otlp_headers(
-        "langfuse_otel", {"langfuse_public_key": "pk", "langfuse_secret_key": "sk"}
-    )
+    headers = dynamic_otlp_headers("langfuse_otel", {"langfuse_public_key": "pk", "langfuse_secret_key": "sk"})
     assert headers is not None and "Authorization" in headers
 
 
 def test_langfuse_dynamic_headers_carry_v4_ingestion_version():
-    headers = dynamic_otlp_headers(
-        "langfuse_otel", {"langfuse_public_key": "pk", "langfuse_secret_key": "sk"}
-    )
+    headers = dynamic_otlp_headers("langfuse_otel", {"langfuse_public_key": "pk", "langfuse_secret_key": "sk"})
     expected_auth = "Basic " + base64.b64encode(b"pk:sk").decode()
     assert headers == {
         "Authorization": expected_auth,
@@ -56,9 +49,7 @@ def test_langfuse_dynamic_headers_carry_v4_ingestion_version():
 
 
 def test_weave_dynamic_headers():
-    headers = dynamic_otlp_headers(
-        "weave_otel", {"wandb_api_key": "w", "weave_project_id": "p"}
-    )
+    headers = dynamic_otlp_headers("weave_otel", {"wandb_api_key": "w", "weave_project_id": "p"})
     assert headers is not None
     assert "Authorization" in headers and headers["project_id"] == "p"
 
@@ -100,9 +91,7 @@ def test_provider_cache_is_bounded_and_evicts_lru(monkeypatch):
 
     monkeypatch.setattr(routing_mod, "_MAX_CACHED_PROVIDERS", 2)
     shut_down = []
-    monkeypatch.setattr(
-        routing_mod, "_shutdown_provider", lambda p: shut_down.append(p)
-    )
+    monkeypatch.setattr(routing_mod, "_shutdown_provider", lambda p: shut_down.append(p))
 
     cache = _cache("arize")
     default = NoOpTracer()
@@ -179,9 +168,7 @@ def test_dynamic_headers_do_not_leak_to_other_owners_exporter():
             ),
         ],
     )
-    new_cfg = cache._routed_config(
-        {"arize-space-id": "TEAMX", "api_key": "TEAMX_KEY"}, {}
-    )
+    new_cfg = cache._routed_config({"arize-space-id": "TEAMX", "api_key": "TEAMX_KEY"}, {})
     by_owner = {e.owner: e.headers for e in new_cfg.exporters}
     assert by_owner["arize"] == "arize-space-id=TEAMX,api_key=TEAMX_KEY"
     assert by_owner[None] == "x=base-collector"
@@ -206,16 +193,14 @@ def _phoenix_cache(kind="otlp_http"):
 
 
 def test_phoenix_project_headers_precedence_and_blanks():
-    assert project_routing_headers(
-        "arize_phoenix", {"phoenix_project_name": "team-proj"}
-    ) == {"x-project-name": "team-proj"}
+    assert project_routing_headers("arize_phoenix", {"phoenix_project_name": "team-proj"}) == {
+        "x-project-name": "team-proj"
+    }
     assert project_routing_headers(
         "arize_phoenix",
         {"phoenix_project_name_override": "override", "phoenix_project_name": "base"},
     ) == {"x-project-name": "override"}
-    assert (
-        project_routing_headers("arize_phoenix", {"phoenix_project_name": "   "}) == {}
-    )
+    assert project_routing_headers("arize_phoenix", {"phoenix_project_name": "   "}) == {}
     assert project_routing_headers("arize_phoenix", None) == {}
     # Only Phoenix participates in project routing.
     assert project_routing_headers("arize", {"phoenix_project_name": "p"}) == {}
@@ -286,10 +271,7 @@ def test_client_dynamic_params_cannot_choose_phoenix_project():
     cache = _phoenix_cache()
     default = NoOpTracer()
     assert cache.route_for(default, {"phoenix_project_name": "attacker"}).tracer is default
-    assert (
-        cache.route_for(default, {"phoenix_project_name_override": "attacker"}).tracer
-        is default
-    )
+    assert cache.route_for(default, {"phoenix_project_name_override": "attacker"}).tracer is default
     assert cache._providers == {}
 
 
@@ -321,9 +303,7 @@ def test_eviction_defers_shutdown_while_a_span_is_open(monkeypatch):
 
     monkeypatch.setattr(routing_mod, "_MAX_CACHED_PROVIDERS", 1)
     shut_down = []
-    monkeypatch.setattr(
-        routing_mod, "_shutdown_provider", lambda p: shut_down.append(p)
-    )
+    monkeypatch.setattr(routing_mod, "_shutdown_provider", lambda p: shut_down.append(p))
     cache = _cache("arize")
     default = NoOpTracer()
 
@@ -347,18 +327,13 @@ def test_retired_providers_are_capped(monkeypatch):
     monkeypatch.setattr(routing_mod, "_MAX_CACHED_PROVIDERS", 1)
     monkeypatch.setattr(routing_mod, "_MAX_RETIRED_PROVIDERS", 2)
     shut_down = []
-    monkeypatch.setattr(
-        routing_mod, "_shutdown_provider", lambda p: shut_down.append(p)
-    )
+    monkeypatch.setattr(routing_mod, "_shutdown_provider", lambda p: shut_down.append(p))
     cache = _cache("arize")
     default = NoOpTracer()
 
     # Every route stays held (no release), so each one evicts and retires its
     # predecessor instead of shutting it down.
-    routes = [
-        cache.route_for(default, {"arize_space_id": str(i), "arize_api_key": "K"})
-        for i in range(5)
-    ]
+    routes = [cache.route_for(default, {"arize_space_id": str(i), "arize_api_key": "K"}) for i in range(5)]
 
     assert len(cache._providers) == 1
     assert len(cache._retired) == 2  # capped, not one retiree per open call
@@ -374,11 +349,112 @@ def test_release_without_eviction_keeps_provider_alive(monkeypatch):
     from litellm.integrations.otel.plumbing import routing as routing_mod
 
     shut_down = []
-    monkeypatch.setattr(
-        routing_mod, "_shutdown_provider", lambda p: shut_down.append(p)
-    )
+    monkeypatch.setattr(routing_mod, "_shutdown_provider", lambda p: shut_down.append(p))
     cache = _cache("arize")
     route = cache.route_for(NoOpTracer(), {"arize_space_id": "A", "arize_api_key": "K"})
     cache.release(route.provider)
     assert shut_down == []  # still cached, never retired
     cache.release(None)  # default-route release is a no-op
+
+
+# --- New Relic: per-team api-key header + fixed-table region endpoint --- #
+
+
+def test_newrelic_dynamic_headers():
+    assert dynamic_otlp_headers("newrelic", {"newrelic_api_key": "NRAL-KEY"}) == {"api-key": "NRAL-KEY"}
+    assert dynamic_otlp_headers("newrelic", {"newrelic_region": "eu"}) is None
+
+
+def test_newrelic_dynamic_endpoint_resolves_from_fixed_table():
+    from litellm.integrations.otel.presets import dynamic_otlp_endpoint
+
+    assert dynamic_otlp_endpoint("newrelic", {"newrelic_region": "eu"}) == "https://otlp.eu01.nr-data.net"
+    assert dynamic_otlp_endpoint("newrelic", {"newrelic_region": "US"}) == "https://otlp.nr-data.net"
+    # A key-only team (no region) resolves to the fixed US default deterministically,
+    # never the operator's NEW_RELIC_REGION-configured preset endpoint.
+    assert dynamic_otlp_endpoint("newrelic", {"newrelic_api_key": "k"}) == "https://otlp.nr-data.net"
+    # An unknown region also resolves to the documented US default, not a guess.
+    assert dynamic_otlp_endpoint("newrelic", {"newrelic_region": "mars"}) == "https://otlp.nr-data.net"
+    # Callbacks without an endpoint resolver keep their preset endpoint.
+    assert dynamic_otlp_endpoint("arize", {"newrelic_region": "eu"}) is None
+
+
+def test_newrelic_endpoint_stamped_onto_owned_exporter_only():
+    cache = _cache(
+        "newrelic",
+        exporters=[
+            ExporterSpec(
+                kind="otlp_http",
+                endpoint="http://self-hosted-collector:4318",
+                headers="x=base-collector",
+                owner=None,
+            ),
+            ExporterSpec(
+                kind="otlp_http",
+                endpoint="https://otlp.nr-data.net",
+                owner="newrelic",
+                requires_headers=True,
+            ),
+        ],
+    )
+    new_cfg = cache._routed_config({"api-key": "TEAM-EU-KEY"}, {}, "https://otlp.eu01.nr-data.net")
+    by_owner = {e.owner: e for e in new_cfg.exporters}
+    assert by_owner["newrelic"].endpoint == "https://otlp.eu01.nr-data.net"
+    assert by_owner["newrelic"].headers == "api-key=TEAM-EU-KEY"
+    assert by_owner[None].endpoint == "http://self-hosted-collector:4318"
+    assert by_owner[None].headers == "x=base-collector"
+
+
+def test_newrelic_provider_cached_per_key_and_region():
+    cache = _cache(
+        "newrelic",
+        exporters=[ExporterSpec(kind="in_memory"), ExporterSpec(kind="otlp_http", owner="newrelic")],
+    )
+    default = NoOpTracer()
+    cache.route_for(default, {"newrelic_api_key": "K1", "newrelic_region": "us"})
+    cache.route_for(default, {"newrelic_api_key": "K1", "newrelic_region": "us"})
+    assert len(cache._providers) == 1
+    # Same key, different region → distinct provider (distinct endpoint).
+    cache.route_for(default, {"newrelic_api_key": "K1", "newrelic_region": "eu"})
+    assert len(cache._providers) == 2
+    cache.route_for(default, {"newrelic_api_key": "K2", "newrelic_region": "eu"})
+    assert len(cache._providers) == 3
+
+
+def test_requires_headers_spec_skipped_without_headers():
+    from litellm.integrations.otel.plumbing.providers import build_tracer_provider
+
+    cfg = OpenTelemetryV2Config(
+        exporters=[ExporterSpec(kind="otlp_http", endpoint="https://otlp.nr-data.net", requires_headers=True)]
+    )
+    provider = build_tracer_provider(cfg)
+    processors = provider._active_span_processor._span_processors
+    # Only the baggage processor: the keyless spec must not export (New Relic
+    # rejects unauthenticated posts with a 4xx per span batch).
+    assert [type(p).__name__ for p in processors] == ["LiteLLMBaggageSpanProcessor"]
+
+    keyed = OpenTelemetryV2Config(
+        exporters=[
+            ExporterSpec(
+                kind="otlp_http", endpoint="https://otlp.nr-data.net", headers="api-key=k", requires_headers=True
+            )
+        ]
+    )
+    keyed_provider = build_tracer_provider(keyed)
+    assert len(keyed_provider._active_span_processor._span_processors) == 2
+
+
+def test_newrelic_key_only_team_routes_to_us_not_operator_region(monkeypatch):
+    """A team that saves a key but no region must export to the fixed US default,
+    independent of the operator's NEW_RELIC_REGION, so its spans are never
+    silently dropped by an operator-configured region its key does not match."""
+    monkeypatch.setenv("NEW_RELIC_REGION", "eu")
+    cache = _cache(
+        "newrelic",
+        exporters=[ExporterSpec(kind="otlp_http", endpoint="https://otlp.eu01.nr-data.net", owner="newrelic")],
+    )
+    new_cfg = cache._routed_config(
+        {"api-key": "US-KEY"}, {}, dynamic_otlp_endpoint("newrelic", {"newrelic_api_key": "US-KEY"})
+    )
+    owned = next(e for e in new_cfg.exporters if e.owner == "newrelic")
+    assert owned.endpoint == "https://otlp.nr-data.net"

--- a/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
@@ -2522,3 +2522,149 @@ def test_deferred_pre_call_does_not_churn_tenant_cache(monkeypatch):
     server.end()
     headers_b = next(h for h in captured if "proj-b" in h)
     assert [s.name for s in captured[headers_b].get_finished_spans()] == ["chat gpt-4o"]
+
+
+# --- New Relic team-scoped deferred emit + dedup (no pre_call carrier) --- #
+
+
+def test_no_span_when_request_never_reached_upstream():
+    """A request rejected before the upstream call — at the auth/budget gate, or
+    blocked by a pre-call guardrail — carries the ``no upstream call`` marker
+    (stamped in ``proxy/utils.py`` before its handlers fire), so the failure log
+    produces no phantom CLIENT span even though a payload exists."""
+    from litellm.constants import LITELLM_LOGGING_NO_UPSTREAM_LLM_CALL
+
+    logger, exporter = _logger()
+    payload = _payload(
+        status="failure",
+        error_information={"error_class": "ProxyException", "error_code": "401"},
+    )
+    kwargs = _kwargs(payload=payload)
+    kwargs[LITELLM_LOGGING_NO_UPSTREAM_LLM_CALL] = True
+    # No log_pre_api_call: the call never started.
+    asyncio.run(logger.async_log_failure_event(kwargs, None, None, None))
+    assert exporter.get_finished_spans() == ()  # no phantom LLM span
+
+
+def test_success_without_pre_call_emits_deferred_span():
+    """A team/key-scoped logger is registered as a success callback only, so
+    ``pre_call`` never reaches it and no carrier exists. A completed call (it has
+    its payload, no ``no upstream call`` marker) must still get its span — the
+    deferred branch — or team-scoped destinations receive nothing at all."""
+    logger, exporter = _logger()
+    # No log_pre_api_call: this logger never receives the input hook. The
+    # request-level provider-handoff stamp is present (pre_call ran globally).
+    asyncio.run(
+        logger.async_log_success_event({**_kwargs(), "api_call_start_time": 100.0}, None, 100.0, 101.5)
+    )
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes.get("gen_ai.operation.name")
+    # Start time comes from the callback's start_time, not a bogus zero.
+    assert spans[0].start_time == 100_000_000_000
+    assert spans[0].end_time == 101_500_000_000
+
+
+def test_no_carrier_and_no_payload_is_noop():
+    logger, exporter = _logger()
+    asyncio.run(
+        logger.async_log_success_event({"litellm_params": {}}, None, None, None)
+    )
+    assert exporter.get_finished_spans() == ()
+
+
+def test_second_close_for_same_call_does_not_duplicate_span():
+    """Success and failure can both fire on one logging object for the same call
+    id. The first close pops the carrier and finishes the boundary span; the
+    second must dedup against it, not fabricate a duplicate through the
+    deferred branch."""
+    logger, exporter = _logger()
+    kwargs = {**_kwargs(), "api_call_start_time": 100.0}
+    # Boundary open: the span is born at pre_call under a live server span and
+    # closed via finish_span, which never passes through emit()'s dedup.
+    server = logger._emitter.start_span(SpanRole.PROXY_REQUEST, LITELLM_PROXY_REQUEST_SPAN_NAME)
+    _emit_llm(logger, kwargs, ambient=server)
+    server.end()
+    llm_before = [s for s in exporter.get_finished_spans() if s.name.startswith("chat")]
+    assert len(llm_before) == 1
+    # Second close: carrier already popped, payload still present, handoff stamped.
+    asyncio.run(logger.async_log_failure_event(kwargs, None, None, None))
+    llm_after = [s for s in exporter.get_finished_spans() if s.name.startswith("chat")]
+    assert len(llm_after) == 1
+
+
+def test_failure_without_pre_call_emits_deferred_error_span():
+    """A team-scoped logger registered as a failure callback only still gets an
+    ERROR span for a real provider failure (payload present, no marker)."""
+    from opentelemetry.trace import StatusCode
+
+    logger, exporter = _logger()
+    payload = _payload(
+        status="failure",
+        error_information={"error_class": "RateLimitError", "error_code": "429"},
+    )
+    asyncio.run(
+        logger.async_log_failure_event(
+            {**_kwargs(payload=payload), "api_call_start_time": 100.0}, None, None, None
+        )
+    )
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == StatusCode.ERROR
+
+
+def test_boundary_open_with_no_payload_ends_provisional_span():
+    """Opened at pre_call but the payload never materialized: the boundary span
+    is ended provisionally (no payload attributes) rather than leaked open."""
+    logger, exporter = _logger()
+    kwargs = _kwargs()
+    server = logger._emitter.start_span(SpanRole.PROXY_REQUEST, LITELLM_PROXY_REQUEST_SPAN_NAME)
+    with trace.use_span(server, end_on_exit=False):
+        logger.log_pre_api_call(model="gpt-4o", messages=[], kwargs=kwargs)
+    asyncio.run(
+        logger.async_log_success_event(
+            {**kwargs, "standard_logging_object": None, "litellm_call_id": "call_1"}, None, None, None
+        )
+    )
+    server.end()
+    llm_spans = [s for s in exporter.get_finished_spans() if s.name.startswith("chat")]
+    assert len(llm_spans) == 1
+    assert "gen_ai.usage.input_tokens" not in llm_spans[0].attributes
+
+
+def test_failure_before_provider_handoff_emits_nothing():
+    """A failure event whose request never handed off to a provider (router
+    pre-call rejection, SDK error before the call, standalone guardrail run)
+    has a payload but no ``api_call_start_time``; without a carrier it must not
+    fabricate an LLM-call span."""
+    logger, exporter = _logger()
+    payload = _payload(
+        status="failure",
+        error_information={"error_class": "RateLimitError", "error_code": "429"},
+    )
+    asyncio.run(logger.async_log_failure_event(_kwargs(payload=payload), None, None, None))
+    assert exporter.get_finished_spans() == ()
+
+
+def test_provisional_close_then_payload_close_does_not_duplicate():
+    """Streaming shape: the success close arrives with no assembled payload (the
+    boundary span is ended provisionally), then the failure close arrives with a
+    payload for the same call id. Exactly one exported span."""
+    logger, exporter = _logger()
+    kwargs = {**_kwargs(), "api_call_start_time": 100.0}
+    payload = kwargs["standard_logging_object"]
+    server = logger._emitter.start_span(SpanRole.PROXY_REQUEST, LITELLM_PROXY_REQUEST_SPAN_NAME)
+    with trace.use_span(server, end_on_exit=False):
+        logger.log_pre_api_call(model="gpt-4o", messages=[], kwargs=kwargs)
+    asyncio.run(
+        logger.async_log_success_event(
+            {**kwargs, "standard_logging_object": None, "litellm_call_id": payload["litellm_call_id"]},
+            None,
+            None,
+            None,
+        )
+    )
+    asyncio.run(logger.async_log_failure_event(kwargs, None, None, None))
+    server.end()
+    llm_spans = [s for s in exporter.get_finished_spans() if s.name.startswith("chat")]
+    assert len(llm_spans) == 1

--- a/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
@@ -341,6 +341,35 @@ def test_idempotent_on_repeat_callback():
     assert len(exporter.get_finished_spans()) == 1
 
 
+def test_evicted_carrier_completed_call_emits_one_deferred_span():
+    """Eviction over the concurrency budget drops only the boundary carrier, not
+    the call. When an evicted call later closes as a real completed call
+    (``upstream_started``, payload present) it still emits exactly one span
+    through the deferred branch, and a second close for the same id dedups. Only
+    an evicted call that never closes goes unexported."""
+    logger, exporter = _logger()
+    kwargs = {**_kwargs(), "api_call_start_time": datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc)}
+    logger.log_pre_api_call(model="gpt-4o", messages=[], kwargs=kwargs)
+    assert "call_1" in logger._open_llm_calls
+
+    # Evict exactly as ``_store_open_call`` does over budget: drop the oldest
+    # carrier and release its routed provider.
+    _, evicted = logger._open_llm_calls.popitem(last=False)
+    logger._release_carrier(evicted)
+    assert not logger._open_llm_calls
+    assert exporter.get_finished_spans() == ()  # the evicted boundary span is never exported
+
+    asyncio.run(logger.async_log_success_event(kwargs, None, None, None))
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, "the evicted call's real close re-emits one deferred span, not zero"
+    assert spans[0].name == "chat gpt-4o"
+    assert spans[0].attributes[LiteLLM.CALL_ID] == "call_1"
+
+    # Success-then-failure on one logging object: the deferred branch dedups by id.
+    asyncio.run(logger.async_log_failure_event(kwargs, None, None, None))
+    assert len(exporter.get_finished_spans()) == 1, "second close for the same id must not duplicate"
+
+
 # --------------------------------------------------------------------------- #
 #  MCP tool-call spans
 # --------------------------------------------------------------------------- #

--- a/tests/test_litellm/integrations/otel/test_otel_v2_presets.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_presets.py
@@ -160,3 +160,55 @@ def test_agentops_endpoint_points_at_live_host():
     # so a typo or stale domain can never ship again.
     assert _AGENTOPS_ENDPOINT == "https://otlp.agentops.ai/v1/traces"
     assert "agentops.cloud" not in _AGENTOPS_ENDPOINT
+
+
+def test_newrelic_preset_reads_env_license_key(monkeypatch):
+    monkeypatch.setenv("NEW_RELIC_LICENSE_KEY", "env-license-key")
+    from litellm.integrations.otel.model.config import ExporterOwner
+    from litellm.integrations.otel.presets.newrelic import newrelic_preset
+
+    cfg = newrelic_preset()
+    spec = next(e for e in cfg.exporters if e.owner == ExporterOwner.NEWRELIC)
+    assert spec.kind == "otlp_http"
+    assert spec.endpoint == "https://otlp.nr-data.net"
+    assert spec.headers == "api-key=env-license-key"
+    assert spec.requires_headers is True
+    assert "genai" in cfg.mapper_names
+
+
+def test_newrelic_preset_without_key_still_contributes_owned_spec(monkeypatch):
+    # The owned spec is the stamping target for per-team credentials, so it must
+    # exist even with no operator env key; requires_headers keeps the keyless
+    # copy from ever exporting.
+    monkeypatch.delenv("NEW_RELIC_LICENSE_KEY", raising=False)
+    from litellm.integrations.otel.model.config import ExporterOwner
+    from litellm.integrations.otel.presets.newrelic import newrelic_preset
+
+    cfg = newrelic_preset()
+    spec = next(e for e in cfg.exporters if e.owner == ExporterOwner.NEWRELIC)
+    assert spec.headers is None
+    assert spec.requires_headers is True
+
+
+def test_newrelic_preset_operator_region_and_content_knob(monkeypatch):
+    monkeypatch.setenv("NEW_RELIC_LICENSE_KEY", "env-license-key")
+    monkeypatch.setenv("NEW_RELIC_REGION", "EU")
+    monkeypatch.setenv("NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED", "true")
+    from litellm.integrations.otel.model.config import ExporterOwner
+    from litellm.integrations.otel.presets.newrelic import newrelic_preset
+
+    cfg = newrelic_preset()
+    spec = next(e for e in cfg.exporters if e.owner == ExporterOwner.NEWRELIC)
+    assert spec.endpoint == "https://otlp.eu01.nr-data.net"
+    assert cfg.capture_span_content is True
+
+    monkeypatch.setenv("NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED", "false")
+    assert newrelic_preset().capture_span_content is False
+
+
+def test_newrelic_preset_unset_content_knob_keeps_default(monkeypatch):
+    monkeypatch.delenv("NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED", raising=False)
+    monkeypatch.delenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", raising=False)
+    from litellm.integrations.otel.presets.newrelic import newrelic_preset
+
+    assert newrelic_preset().capture_span_content is False

--- a/tests/test_litellm/litellm_core_utils/test_initialize_dynamic_callback_params.py
+++ b/tests/test_litellm/litellm_core_utils/test_initialize_dynamic_callback_params.py
@@ -187,3 +187,49 @@ def test_empty_kwargs_returns_empty_params():
 
     params = initialize_standard_callback_dynamic_params({})
     assert dict(params) == {}
+
+
+def test_newrelic_callback_params_are_not_extracted_from_request_kwargs():
+    kwargs = {
+        "newrelic_api_key": "caller-key",
+        "metadata": {"newrelic_api_key": "caller-key-2", "newrelic_region": "eu"},
+        "litellm_params": {"metadata": {"newrelic_region": "eu"}},
+    }
+
+    params = initialize_standard_callback_dynamic_params(kwargs)
+
+    assert params.get("newrelic_api_key") is None
+    assert params.get("newrelic_region") is None
+
+
+def test_newrelic_trusted_vars_overlay_reaches_standard_params():
+    from litellm.types.utils import TRUSTED_CALLBACK_VARS_FIELD
+
+    kwargs = {
+        # A caller-supplied copy must lose to the proxy-stamped trusted value.
+        "newrelic_api_key": "caller-key",
+        TRUSTED_CALLBACK_VARS_FIELD: {
+            "newrelic_api_key": "team-key",
+            "newrelic_region": "eu",
+            # Non-overlay trusted vars must not be copied by the overlay.
+            "langfuse_public_key": "pk-team",
+        },
+    }
+
+    params = initialize_standard_callback_dynamic_params(kwargs)
+
+    assert params.get("newrelic_api_key") == "team-key"
+    assert params.get("newrelic_region") == "eu"
+    assert params.get("langfuse_public_key") is None
+
+
+def test_trusted_vars_overlay_uses_shared_parser_semantics():
+    # The overlay rides get_trusted_callback_params, the same parser the
+    # datadog handler consumes, so values are str()-coerced identically.
+    from litellm.types.utils import TRUSTED_CALLBACK_VARS_FIELD
+
+    params = initialize_standard_callback_dynamic_params(
+        {TRUSTED_CALLBACK_VARS_FIELD: {"newrelic_api_key": 12345}}
+    )
+
+    assert params.get("newrelic_api_key") == "12345"

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -5200,3 +5200,81 @@ def test_prompt_hooks_skip_prompt_managers_when_no_prompt_id(logging_obj, tmp_pa
             )
         for hook in [cb for cb in litellm.callbacks if isinstance(cb, VectorStorePreCallHook)]:
             litellm.logging_callback_manager.remove_callback_from_list_by_object(litellm.callbacks, hook)
+def test_newrelic_dispatch_prefers_otel_v2_when_flag_on(monkeypatch):
+    """With LITELLM_OTEL_V2 on, the "newrelic" callback builds the OTel v2
+    logger (per-team credential routing); with the flag off (default) it keeps
+    the legacy agent-based logger, so existing deployments are untouched."""
+    from litellm.integrations.otel.logger import OpenTelemetryV2
+    from litellm.integrations.otel.model.config import is_otel_v2_enabled
+    from litellm.litellm_core_utils import litellm_logging as logging_module
+
+    logging_module._in_memory_loggers.clear()
+    monkeypatch.setenv("LITELLM_OTEL_V2", "true")
+    is_otel_v2_enabled.cache_clear()
+    try:
+        v2_logger = logging_module._init_custom_logger_compatible_class(
+            logging_integration="newrelic",
+            internal_usage_cache=None,
+            llm_router=None,
+            custom_logger_init_args={},
+        )
+        assert isinstance(v2_logger, OpenTelemetryV2)
+        assert v2_logger.callback_name == "newrelic"
+        # Same name resolves to the same instance, not a second logger.
+        again = logging_module._init_custom_logger_compatible_class(
+            logging_integration="newrelic",
+            internal_usage_cache=None,
+            llm_router=None,
+            custom_logger_init_args={},
+        )
+        assert again is v2_logger
+    finally:
+        logging_module._in_memory_loggers.clear()
+        monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
+        is_otel_v2_enabled.cache_clear()
+
+
+def test_newrelic_dispatch_keeps_legacy_agent_when_flag_off(monkeypatch):
+    from litellm.integrations.newrelic import NewRelicLogger
+    from litellm.integrations.otel.model.config import is_otel_v2_enabled
+    from litellm.litellm_core_utils import litellm_logging as logging_module
+
+    logging_module._in_memory_loggers.clear()
+    monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
+    is_otel_v2_enabled.cache_clear()
+    try:
+        legacy = logging_module._init_custom_logger_compatible_class(
+            logging_integration="newrelic",
+            internal_usage_cache=None,
+            llm_router=None,
+            custom_logger_init_args={},
+        )
+        assert isinstance(legacy, NewRelicLogger)
+    finally:
+        logging_module._in_memory_loggers.clear()
+        is_otel_v2_enabled.cache_clear()
+
+
+def test_get_custom_logger_compatible_class_finds_v2_newrelic(monkeypatch):
+    """Under LITELLM_OTEL_V2 the "newrelic" instance is an OpenTelemetryV2; the
+    cached-lookup must find it or hook resolution (post-call failure/success
+    hooks) silently skips the callback."""
+    from litellm.integrations.otel.model.config import is_otel_v2_enabled
+    from litellm.litellm_core_utils import litellm_logging as logging_module
+
+    logging_module._in_memory_loggers.clear()
+    monkeypatch.setenv("LITELLM_OTEL_V2", "true")
+    is_otel_v2_enabled.cache_clear()
+    try:
+        created = logging_module._init_custom_logger_compatible_class(
+            logging_integration="newrelic",
+            internal_usage_cache=None,
+            llm_router=None,
+            custom_logger_init_args={},
+        )
+        found = logging_module.get_custom_logger_compatible_class("newrelic")
+        assert found is created
+    finally:
+        logging_module._in_memory_loggers.clear()
+        monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
+        is_otel_v2_enabled.cache_clear()

--- a/tests/test_litellm/proxy/management_endpoints/test_callback_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_callback_management_endpoints.py
@@ -295,13 +295,13 @@ class TestNewRelicTeamCallbackValidation:
         from fastapi import HTTPException
 
         from litellm.integrations.otel.model.config import is_otel_v2_enabled
-        from litellm.proxy.management_endpoints.team_callback_endpoints import _validate_newrelic_callback
+        from litellm.proxy.management_endpoints.team_callback_endpoints import _validate_team_callback
 
         monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
         is_otel_v2_enabled.cache_clear()
         try:
             with pytest.raises(HTTPException) as exc:
-                _validate_newrelic_callback(self._data({"newrelic_api_key": "k"}))
+                _validate_team_callback(self._data({"newrelic_api_key": "k"}))
             assert "LITELLM_OTEL_V2" in str(exc.value.detail)
         finally:
             is_otel_v2_enabled.cache_clear()
@@ -310,22 +310,22 @@ class TestNewRelicTeamCallbackValidation:
         from fastapi import HTTPException
 
         from litellm.integrations.otel.model.config import is_otel_v2_enabled
-        from litellm.proxy.management_endpoints.team_callback_endpoints import _validate_newrelic_callback
+        from litellm.proxy.management_endpoints.team_callback_endpoints import _validate_team_callback
 
         monkeypatch.setenv("LITELLM_OTEL_V2", "true")
         is_otel_v2_enabled.cache_clear()
         try:
             with pytest.raises(HTTPException) as exc:
-                _validate_newrelic_callback(self._data({"newrelic_api_key": "k", "newrelic_region": "mars"}))
+                _validate_team_callback(self._data({"newrelic_api_key": "k", "newrelic_region": "mars"}))
             assert "Unknown newrelic_region" in str(exc.value.detail)
             with pytest.raises(HTTPException) as exc:
-                _validate_newrelic_callback(self._data({"newrelic_region": "eu"}))
+                _validate_team_callback(self._data({"newrelic_region": "eu"}))
             assert "requires newrelic_api_key" in str(exc.value.detail)
-            _validate_newrelic_callback(self._data({"newrelic_api_key": "k", "newrelic_region": "EU"}))
+            _validate_team_callback(self._data({"newrelic_api_key": "k", "newrelic_region": "EU"}))
             # A JSON-null key is str()-coerced to "None" upstream; it must not
             # slip past the region-requires-key guard.
             with pytest.raises(HTTPException) as exc:
-                _validate_newrelic_callback(self._data({"newrelic_api_key": None, "newrelic_region": "eu"}))
+                _validate_team_callback(self._data({"newrelic_api_key": None, "newrelic_region": "eu"}))
             assert "requires newrelic_api_key" in str(exc.value.detail)
         finally:
             is_otel_v2_enabled.cache_clear()
@@ -333,18 +333,73 @@ class TestNewRelicTeamCallbackValidation:
     def test_ignores_other_callbacks_and_bare_newrelic(self, monkeypatch):
         from litellm.integrations.otel.model.config import is_otel_v2_enabled
         from litellm.proxy._types import AddTeamCallback
-        from litellm.proxy.management_endpoints.team_callback_endpoints import _validate_newrelic_callback
+        from litellm.proxy.management_endpoints.team_callback_endpoints import _validate_team_callback
 
         monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
         is_otel_v2_enabled.cache_clear()
         try:
-            _validate_newrelic_callback(self._data({}))
-            _validate_newrelic_callback(
+            _validate_team_callback(self._data({}))
+            _validate_team_callback(
                 AddTeamCallback(
                     callback_name="langfuse",
                     callback_type="success",
                     callback_vars={"langfuse_public_key": "pk", "langfuse_secret_key": "sk"},
                 )
+            )
+        finally:
+            is_otel_v2_enabled.cache_clear()
+
+
+class TestNewRelicKeyLoggingValidation:
+    """Key-level logging is written through key metadata, not /team/callback."""
+
+    def _metadata(self, callback_vars):
+        return {"logging": [{"callback_name": "newrelic", "callback_type": "success", "callback_vars": callback_vars}]}
+
+    def test_rejects_same_configs_as_team_endpoint(self, monkeypatch):
+        from fastapi import HTTPException
+
+        from litellm.integrations.otel.model.config import is_otel_v2_enabled
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            raise_on_invalid_key_logging_config,
+        )
+
+        monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
+        is_otel_v2_enabled.cache_clear()
+        try:
+            with pytest.raises(HTTPException) as exc:
+                raise_on_invalid_key_logging_config(self._metadata({"newrelic_api_key": "k"}))
+            assert "LITELLM_OTEL_V2" in str(exc.value.detail)
+
+            monkeypatch.setenv("LITELLM_OTEL_V2", "true")
+            is_otel_v2_enabled.cache_clear()
+            with pytest.raises(HTTPException) as exc:
+                raise_on_invalid_key_logging_config(
+                    self._metadata({"newrelic_api_key": "k", "newrelic_region": "mars"})
+                )
+            assert "Unknown newrelic_region" in str(exc.value.detail)
+            with pytest.raises(HTTPException) as exc:
+                raise_on_invalid_key_logging_config(self._metadata({"newrelic_region": "eu"}))
+            assert "requires newrelic_api_key" in str(exc.value.detail)
+            raise_on_invalid_key_logging_config(self._metadata({"newrelic_api_key": "k", "newrelic_region": "EU"}))
+        finally:
+            is_otel_v2_enabled.cache_clear()
+
+    def test_ignores_metadata_without_newrelic_logging(self, monkeypatch):
+        from litellm.integrations.otel.model.config import is_otel_v2_enabled
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            raise_on_invalid_key_logging_config,
+        )
+
+        monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
+        is_otel_v2_enabled.cache_clear()
+        try:
+            raise_on_invalid_key_logging_config(None)
+            raise_on_invalid_key_logging_config({"logging": "not-a-list"})
+            raise_on_invalid_key_logging_config({"tags": ["a"]})
+            raise_on_invalid_key_logging_config(self._metadata({}))
+            raise_on_invalid_key_logging_config(
+                {"logging": [{"callback_name": "langfuse", "callback_vars": {"langfuse_public_key": "pk"}}]}
             )
         finally:
             is_otel_v2_enabled.cache_clear()

--- a/tests/test_litellm/proxy/management_endpoints/test_callback_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_callback_management_endpoints.py
@@ -338,13 +338,16 @@ class TestNewRelicTeamCallbackValidation:
         monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
         is_otel_v2_enabled.cache_clear()
         try:
-            _validate_team_callback(self._data({}))
-            _validate_team_callback(
-                AddTeamCallback(
-                    callback_name="langfuse",
-                    callback_type="success",
-                    callback_vars={"langfuse_public_key": "pk", "langfuse_secret_key": "sk"},
+            assert _validate_team_callback(self._data({})) is None
+            assert (
+                _validate_team_callback(
+                    AddTeamCallback(
+                        callback_name="langfuse",
+                        callback_type="success",
+                        callback_vars={"langfuse_public_key": "pk", "langfuse_secret_key": "sk"},
+                    )
                 )
+                is None
             )
         finally:
             is_otel_v2_enabled.cache_clear()
@@ -394,12 +397,15 @@ class TestNewRelicKeyLoggingValidation:
         monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
         is_otel_v2_enabled.cache_clear()
         try:
-            raise_on_invalid_key_logging_config(None)
-            raise_on_invalid_key_logging_config({"logging": "not-a-list"})
-            raise_on_invalid_key_logging_config({"tags": ["a"]})
-            raise_on_invalid_key_logging_config(self._metadata({}))
-            raise_on_invalid_key_logging_config(
-                {"logging": [{"callback_name": "langfuse", "callback_vars": {"langfuse_public_key": "pk"}}]}
+            assert raise_on_invalid_key_logging_config(None) is None
+            assert raise_on_invalid_key_logging_config({"logging": "not-a-list"}) is None
+            assert raise_on_invalid_key_logging_config({"tags": ["a"]}) is None
+            assert raise_on_invalid_key_logging_config(self._metadata({})) is None
+            assert (
+                raise_on_invalid_key_logging_config(
+                    {"logging": [{"callback_name": "langfuse", "callback_vars": {"langfuse_public_key": "pk"}}]}
+                )
+                is None
             )
         finally:
             is_otel_v2_enabled.cache_clear()

--- a/tests/test_litellm/proxy/management_endpoints/test_callback_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_callback_management_endpoints.py
@@ -264,3 +264,87 @@ class TestCallbackManagementEndpoints:
         assert galileo_config["displayName"] == "Galileo"
         assert "GALILEO_API_KEY" in galileo_config["dynamic_params"]
         assert "GALILEO_PROJECT_ID" in galileo_config["dynamic_params"]
+
+
+class TestNewRelicCallbackConfig:
+    def test_newrelic_entry_supports_team_logging_with_dynamic_params(self):
+        client = TestClient(app)
+        response = client.get("/callbacks/configs", headers={"Authorization": "Bearer sk-1234"})
+        assert response.status_code == 200
+        newrelic = next(
+            (config for config in response.json() if config.get("id") == "newrelic"),
+            None,
+        )
+        assert newrelic is not None
+        assert newrelic["supports_key_team_logging"] is True
+        params = newrelic["dynamic_params"]
+        assert params["newrelic_api_key"]["type"] == "password"
+        assert "newrelic_region" in params
+        # The operator-only agent env flag must not appear as a team-configurable
+        # field: it is not a StandardCallbackDynamicParams key and would be rejected.
+        assert "NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED" not in params
+
+
+class TestNewRelicTeamCallbackValidation:
+    def _data(self, callback_vars):
+        from litellm.proxy._types import AddTeamCallback
+
+        return AddTeamCallback(callback_name="newrelic", callback_type="success", callback_vars=callback_vars)
+
+    def test_rejects_when_otel_v2_off(self, monkeypatch):
+        from fastapi import HTTPException
+
+        from litellm.integrations.otel.model.config import is_otel_v2_enabled
+        from litellm.proxy.management_endpoints.team_callback_endpoints import _validate_newrelic_callback
+
+        monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
+        is_otel_v2_enabled.cache_clear()
+        try:
+            with pytest.raises(HTTPException) as exc:
+                _validate_newrelic_callback(self._data({"newrelic_api_key": "k"}))
+            assert "LITELLM_OTEL_V2" in str(exc.value.detail)
+        finally:
+            is_otel_v2_enabled.cache_clear()
+
+    def test_rejects_unknown_region_and_region_without_key(self, monkeypatch):
+        from fastapi import HTTPException
+
+        from litellm.integrations.otel.model.config import is_otel_v2_enabled
+        from litellm.proxy.management_endpoints.team_callback_endpoints import _validate_newrelic_callback
+
+        monkeypatch.setenv("LITELLM_OTEL_V2", "true")
+        is_otel_v2_enabled.cache_clear()
+        try:
+            with pytest.raises(HTTPException) as exc:
+                _validate_newrelic_callback(self._data({"newrelic_api_key": "k", "newrelic_region": "mars"}))
+            assert "Unknown newrelic_region" in str(exc.value.detail)
+            with pytest.raises(HTTPException) as exc:
+                _validate_newrelic_callback(self._data({"newrelic_region": "eu"}))
+            assert "requires newrelic_api_key" in str(exc.value.detail)
+            _validate_newrelic_callback(self._data({"newrelic_api_key": "k", "newrelic_region": "EU"}))
+            # A JSON-null key is str()-coerced to "None" upstream; it must not
+            # slip past the region-requires-key guard.
+            with pytest.raises(HTTPException) as exc:
+                _validate_newrelic_callback(self._data({"newrelic_api_key": None, "newrelic_region": "eu"}))
+            assert "requires newrelic_api_key" in str(exc.value.detail)
+        finally:
+            is_otel_v2_enabled.cache_clear()
+
+    def test_ignores_other_callbacks_and_bare_newrelic(self, monkeypatch):
+        from litellm.integrations.otel.model.config import is_otel_v2_enabled
+        from litellm.proxy._types import AddTeamCallback
+        from litellm.proxy.management_endpoints.team_callback_endpoints import _validate_newrelic_callback
+
+        monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
+        is_otel_v2_enabled.cache_clear()
+        try:
+            _validate_newrelic_callback(self._data({}))
+            _validate_newrelic_callback(
+                AddTeamCallback(
+                    callback_name="langfuse",
+                    callback_type="success",
+                    callback_vars={"langfuse_public_key": "pk", "langfuse_secret_key": "sk"},
+                )
+            )
+        finally:
+            is_otel_v2_enabled.cache_clear()

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -7380,6 +7380,12 @@ async def test_newrelic_team_callback_vars_reach_trusted_field():
     assert dynamic_otlp_headers("newrelic", params) == {"api-key": "team-nr-key"}
     assert dynamic_otlp_endpoint("newrelic", params) == "https://otlp.eu01.nr-data.net"
 
+    from litellm.utils import get_non_default_completion_params
+
+    forwarded = get_non_default_completion_params(updated)
+    assert not any(param.startswith("newrelic_") for param in forwarded)
+    assert TRUSTED_CALLBACK_VARS_FIELD not in forwarded
+
 
 def test_newrelic_vars_scoped_to_newrelic_callback_entry():
     """New Relic routing reads these vars from the trusted overlay with no

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -7329,3 +7329,86 @@ def test_vertex_sends_exactly_one_authorization_header():
     vertex_request_headers.update(forwarded)
 
     assert _authorization_values(vertex_request_headers) == [GOOGLE_ACCESS_TOKEN]
+@pytest.mark.asyncio
+async def test_newrelic_team_callback_vars_reach_trusted_field():
+    """A key with a newrelic team callback stamps its vars into the proxy-owned
+    trusted field, and a caller-supplied newrelic_api_key in the body is
+    stripped rather than merged."""
+    key_with_newrelic_callback = UserAPIKeyAuth(
+        api_key="hashed-key",
+        metadata={
+            "logging": [
+                {
+                    "callback_name": "newrelic",
+                    "callback_type": "success",
+                    "callback_vars": {"newrelic_api_key": "team-nr-key", "newrelic_region": "eu"},
+                }
+            ]
+        },
+    )
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "hello"}],
+        "newrelic_api_key": "attacker-key",
+    }
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=_callback_credential_request_mock(),
+        user_api_key_dict=key_with_newrelic_callback,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated[TRUSTED_CALLBACK_VARS_FIELD] == {
+        "newrelic_api_key": "team-nr-key",
+        "newrelic_region": "eu",
+    }
+    assert updated["success_callback"] == ["newrelic"]
+
+    from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
+        initialize_standard_callback_dynamic_params,
+    )
+
+    params = initialize_standard_callback_dynamic_params(updated)
+    assert params.get("newrelic_api_key") == "team-nr-key"
+    assert params.get("newrelic_region") == "eu"
+
+    from litellm.integrations.otel.presets import dynamic_otlp_endpoint, dynamic_otlp_headers
+
+    assert dynamic_otlp_headers("newrelic", params) == {"api-key": "team-nr-key"}
+    assert dynamic_otlp_endpoint("newrelic", params) == "https://otlp.eu01.nr-data.net"
+
+
+def test_newrelic_vars_scoped_to_newrelic_callback_entry():
+    """New Relic routing reads these vars from the trusted overlay with no
+    callback-name check, so a team that puts newrelic_* under a different
+    callback's vars must not have them enter the shared bag (and so never
+    exports to New Relic). Vars under a real newrelic entry are kept."""
+    from litellm.proxy._types import AddTeamCallback
+    from litellm.proxy.litellm_pre_call_utils import convert_key_logging_metadata_to_callback
+
+    smuggled = convert_key_logging_metadata_to_callback(
+        AddTeamCallback(
+            callback_name="langfuse",
+            callback_type="success",
+            callback_vars={
+                "langfuse_public_key": "pk",
+                "newrelic_api_key": "SMUGGLED",
+                "newrelic_region": "eu",
+            },
+        ),
+        None,
+    )
+    assert smuggled.callback_vars == {"langfuse_public_key": "pk"}
+
+    legit = convert_key_logging_metadata_to_callback(
+        AddTeamCallback(
+            callback_name="newrelic",
+            callback_type="success",
+            callback_vars={"newrelic_api_key": "REAL", "newrelic_region": "us"},
+        ),
+        None,
+    )
+    assert legit.callback_vars == {"newrelic_api_key": "REAL", "newrelic_region": "us"}

--- a/ui/litellm-dashboard/src/components/callback_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/callback_info_helpers.tsx
@@ -6,6 +6,7 @@ import galileoLogo from "../../public/assets/logos/galileo.ico";
 import lagoLogo from "../../public/assets/logos/lago.svg";
 import langfuseLogo from "../../public/assets/logos/langfuse.png";
 import langsmithLogo from "../../public/assets/logos/langsmith.png";
+import newrelicLogo from "../../public/assets/logos/newrelic.png";
 import openmeterLogo from "../../public/assets/logos/openmeter.png";
 import otelLogo from "../../public/assets/logos/otel.png";
 
@@ -76,6 +77,17 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
       dd_site: "text",
     },
     description: "Datadog Logging Integration",
+  },
+  {
+    id: "newrelic",
+    displayName: "New Relic",
+    logo: newrelicLogo.src,
+    supports_key_team_logging: true,
+    dynamic_params: {
+      newrelic_api_key: "password",
+      newrelic_region: "text",
+    },
+    description: "New Relic Logging Integration",
   },
   {
     id: "lago",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Each team needs its LLM call traces in its own New Relic account
- The existing New Relic integration is one global agent, no per-team routing
- Team callback config rejected New Relic credentials outright

How it solves it:

- Team callback `newrelic` now carries `newrelic_api_key` and `newrelic_region`
- Traces export over OTLP to that team's account and region
- Requests without team credentials export nowhere, no cross-tenant leakage

## User Flow

Before: a platform admin cannot route a team's traces to that team's New Relic account

1. Admin sends POST https://litellm-domain/team/{team_id}/callback with `{"callback_name": "newrelic", "callback_vars": {"newrelic_api_key": "...", "newrelic_region": "us"}}`
2. The proxy replies 422 `Invalid callback variable: newrelic_api_key`
3. Configuring `newrelic` with no vars returns 200 but sends the team nothing; the team's New Relic account stays empty

After: the same call configures per-team routing, and traces land in the team's own account

1. Admin sends the same POST https://litellm-domain/team/{team_id}/callback body
2. The proxy replies 200; a GET of the same route shows `newrelic_api_key` as `***REDACTED***`
3. A developer on that team sends POST https://litellm-domain/v1/chat/completions with the team's key
4. Within about a minute the span appears in that team's New Relic account: `FROM Span SELECT name, litellm.team.alias, litellm.cost.total` shows the call with its team alias, model, tokens, and cost
5. A request from any other team leaves nothing in that account, and a caller who puts `newrelic_api_key` in a request body gets a 401 naming the rejected field

## Relevant issues

## Linear ticket

Resolves LIT-5094

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: proxy with one Gemini model, `LITELLM_OTEL_V2=true`, fresh Postgres, two teams (tenant-a with a real New Relic ingest key for account 8412808 via the team callback, tenant-b with no New Relic callback). All completions hit the real Gemini API.

### Before (5290150a05)

#### Per-team New Relic callback is rejected

1. `curl -X POST http://127.0.0.1:14195/team/$TEAM/callback -H "Authorization: Bearer $MASTER" -d '{"callback_name": "newrelic", "callback_type": "success", "callback_vars": {"newrelic_api_key": "NRAL-x", "newrelic_region": "us"}}'`
2. `422` with `Invalid callback variable: newrelic_api_key. Must be one of {...}`

#### Bare newrelic callback silently binds nothing

1. Same POST with `"callback_vars": {}`
2. `200`, but requests export nothing to any New Relic account (the global agent path needs env keys)

### After (1ae5b27b82)

#### Team A's real trace lands in its own account

1. `curl -X POST http://127.0.0.1:14194/team/$TEAM_A/callback ... '{"callback_name": "newrelic", "callback_type": "success", "callback_vars": {"newrelic_api_key": "<team A ingest key>", "newrelic_region": "us"}}'` -> `200`
2. `curl http://127.0.0.1:14194/team/$TEAM_A/callback ...` -> `"newrelic_api_key": "***REDACTED***"`, `"newrelic_region": "us"`
3. `curl http://127.0.0.1:14194/v1/chat/completions -H "Authorization: Bearer $KEY_A" -d '{"model": "gemini-flash", "messages": [{"role": "user", "content": "Reply with exactly: lit5094-final-1787211946"}]}'` -> `200`, content `lit5094-final-1787211946`
4. NRQL against account 8412808 about a minute later: `FROM Span SELECT name, litellm.team.id, litellm.team.alias, gen_ai.usage.output_tokens, litellm.cost.total SINCE 6 minutes ago` returns exactly one row: `chat gemini-flash`, `litellm.team.alias: tenant-a`, `litellm.cost.total: 0.00045225`

#### Team B's request leaves nothing in team A's account

1. `curl http://127.0.0.1:14194/v1/chat/completions -H "Authorization: Bearer $KEY_B" -d '{"model": "gemini-flash", ...}'` -> `200` in the same window
2. The NRQL above still returns only the tenant-a row

#### Caller-supplied credentials are rejected

1. `curl http://127.0.0.1:14194/v1/chat/completions -H "Authorization: Bearer $KEY_B" -d '{"model": "gemini-flash", "messages": [...], "newrelic_api_key": "NRAL-attacker"}'`
2. `401` `Rejected Request: newrelic_api_key is not allowed in request body`

#### Provider failures reach the team as ERROR spans, gate rejections do not

1. `curl ... -d '{"model": "gemini-flash", "messages": [...], "temperature": 99}'` -> `400` from Gemini
2. NRQL shows the span with `otel.status_code: ERROR` and the provider's message
3. `curl ... -d '{"model": "gemini/does-not-exist", ...}'` -> `400`, and no span appears (the call never reached a provider)

#### Misconfiguration is rejected at save time

1. `curl -X POST .../team/$TEAM_B/callback ... '{"callback_vars": {"newrelic_api_key": "k", "newrelic_region": "mars"}}'` -> `400` `Unknown newrelic_region 'mars'. Supported regions: eu, us.`
2. `curl -X POST .../team/$TEAM_B/callback ... '{"callback_vars": {"newrelic_region": "eu"}}'` -> `400` `newrelic_region requires newrelic_api_key`

#### Admin UI (screenshots to be added after merge-base run)

1. Open http://localhost:4000/ui/?page=teams with `LITELLM_OTEL_V2=true`, pick a team, Settings, Add Integration under Logging Integrations
2. Integration Type lists New Relic; the New Relic Api Key field carries the Sensitive badge, New Relic Region takes us or eu
3. Save Changes, reopen: the key reads back masked

## Type

🆕 New Feature

## Caveats (if any)

- Requires `LITELLM_OTEL_V2=true`; flag off keeps the legacy agent path untouched
- With the flag on, `newrelic` upgrades from the agent to OTLP export (same shape as `langfuse_otel`)
- Region is a fixed `us`/`eu` table, never a caller-supplied URL
- `newrelic_api_key`/`newrelic_region` are now rejected in request bodies (matches `dd_*`)
- Global exporters still receive team spans (LIT-4764, pre-existing, unchanged here)
- Masked `***REDACTED***` write-back on team callbacks is pre-existing family behavior
- Disable-by-header/team for v2 logger instances misses the registry (pre-existing, same as arize)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/37603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tenant telemetry routing, ingest-key handling, and OTel span emission/dedup. Misrouting could leak traces across New Relic accounts, but request-body credentials are blocked and regions are a fixed table.
> 
> **Overview**
> Enables **per-team/key New Relic** logging: callback vars `newrelic_api_key` and `newrelic_region` (`us`/`eu`) export traces over OTLP to that tenant’s account. Requires `LITELLM_OTEL_V2=true`; otherwise the legacy agent path is unchanged.
> 
> Routing uses a New Relic OTel preset plus dynamic headers/endpoint. Tenant tracers now cache by credential **and** region. Specs with `requires_headers` skip keyless export. Request-supplied New Relic params are blocked; only proxy-stamped trusted team/key vars drive routing. Save-time validation on team callbacks and key metadata rejects unknown regions, region-without-key, and per-team config when v2 is off.
> 
> OTel close path now emits **deferred LLM spans** for success/failure-only team loggers (no `pre_call` carrier), using `upstream_started` so gate/guardrail rejections stay span-free. Dedup via `mark_emitted` prevents duplicate spans after eviction or success-then-failure. Dashboard lists New Relic as a team logging integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18625795ebd3aef5f67f11beb5bc3c7962802bc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->