### PR TITLE
fix(realtime): bound Vertex credential resolution and make realtime failures loud

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -243,6 +243,9 @@ AIOHTTP_NEEDS_CLEANUP_CLOSED: Final = (3, 13, 0) <= sys.version_info < (
 # https://github.com/openai/openai-agents-python/blob/cf1b933660e44fd37b4350c41febab8221801409/src/agents/realtime/openai_realtime.py#L235
 _max_size_env: Final = os.getenv("REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES")
 REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES: Final = int(_max_size_env) if _max_size_env is not None else None
+REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS: Final = float(
+    os.getenv("REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS", "20.0")
+)
 
 # SSL/TLS cipher configuration for faster handshakes
 # Strategy: Strongly prefer fast modern ciphers, but allow fallback to commonly supported ones

--- a/litellm/litellm_core_utils/realtime_errors.py
+++ b/litellm/litellm_core_utils/realtime_errors.py
@@ -1,0 +1,31 @@
+"""Loud-failure helpers for the realtime WebSocket paths.
+
+A realtime caller that only gets a bare close frame has nothing to act on, so
+every failure surfaces as an OpenAI-style ``error`` event plus a close frame
+whose reason names the failure. Close reasons are capped at
+``WEBSOCKET_CLOSE_REASON_MAX_BYTES``: RFC 6455 control frames carry at most 125
+bytes, two of which hold the status code, and a longer reason makes the close
+frame itself fail, which is how a loud failure turns back into a silent one.
+"""
+
+import json
+from typing import Final
+
+from litellm.types.realtime import RealtimeErrorDetail, RealtimeErrorEvent
+
+WEBSOCKET_CLOSE_REASON_MAX_BYTES: Final = 123
+
+
+def realtime_error_event(message: str, error_type: str) -> str:
+    detail: Final[RealtimeErrorDetail] = {"type": error_type, "message": message}
+    event: Final[RealtimeErrorEvent] = {"type": "error", "error": detail}
+    return json.dumps(event)
+
+
+def websocket_close_reason(message: str, fallback: str) -> str:
+    encoded: Final = message.encode("utf-8")
+    if not encoded:
+        return fallback
+    if len(encoded) <= WEBSOCKET_CLOSE_REASON_MAX_BYTES:
+        return message
+    return encoded[:WEBSOCKET_CLOSE_REASON_MAX_BYTES].decode("utf-8", errors="ignore")

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -20,6 +20,7 @@ from litellm._logging import _redact_string, verbose_logger
 from litellm.anthropic_beta_headers_manager import update_headers_with_filtered_beta
 from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
 from litellm.litellm_core_utils.asyncify import run_async_function
+from litellm.litellm_core_utils.realtime_errors import realtime_error_event, websocket_close_reason
 from litellm.litellm_core_utils.realtime_streaming import RealTimeStreaming
 from litellm.litellm_core_utils.url_utils import encode_url_path_segment
 from litellm.llms.base_llm.anthropic_messages.transformation import (
@@ -5976,8 +5977,19 @@ class BaseLLMHTTPHandler:
             await websocket.close(code=e.status_code, reason=_redact_string(str(e)))
         except Exception as e:
             verbose_logger.exception("Error connecting to backend: %s", e)
+            redacted_error: Final = _redact_string(str(e))
             try:
-                await websocket.close(code=1011, reason=_redact_string(f"Internal server error: {e}"))
+                await websocket.send_text(realtime_error_event(redacted_error, error_type="server_error"))
+            except Exception:  # noqa: BLE001  # best-effort notice: a dead client socket must not skip the close below
+                verbose_logger.debug("Could not send realtime error event to client; closing anyway")
+            try:
+                await websocket.close(
+                    code=1011,
+                    reason=websocket_close_reason(
+                        _redact_string(f"Internal server error: {e}"),
+                        fallback="Internal server error",
+                    ),
+                )
             except RuntimeError as close_error:
                 if "already completed" in str(close_error) or "websocket.close" in str(close_error):
                     # The WebSocket is already closed or the response is completed, so we can ignore this error

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -222,7 +222,7 @@ from functools import lru_cache
 import litellm
 import litellm._redis
 from litellm import Router
-from litellm._logging import verbose_proxy_logger, verbose_router_logger
+from litellm._logging import _redact_string, verbose_proxy_logger, verbose_router_logger
 from litellm.caching.caching import DualCache, RedisCache
 from litellm.caching.redis_cluster_cache import RedisClusterCache
 from litellm.constants import (
@@ -259,6 +259,10 @@ from litellm.litellm_core_utils.core_helpers import (
 )
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.litellm_core_utils.realtime_errors import (
+    realtime_error_event,
+    websocket_close_reason,
+)
 from litellm.litellm_core_utils.sensitive_data_masker import (
     SensitiveDataMasker,
     mask_sensitive_keys,
@@ -10993,9 +10997,20 @@ async def realtime_websocket_endpoint(
     except websockets.exceptions.InvalidStatusCode as e:
         verbose_proxy_logger.exception("Invalid status code")
         await websocket.close(code=e.status_code, reason="Invalid status code")
-    except Exception:
+    except Exception as e:
         verbose_proxy_logger.exception("Internal server error")
-        await websocket.close(code=1011, reason="Internal server error")
+        redacted_error: Final = _redact_string(str(e))
+        try:
+            await websocket.send_text(realtime_error_event(redacted_error, error_type="server_error"))
+        except Exception:  # noqa: BLE001  # best-effort notice: a dead client socket must not skip the close below
+            verbose_proxy_logger.debug("Could not send realtime error event to client; closing anyway")
+        try:
+            await websocket.close(
+                code=1011,
+                reason=websocket_close_reason(redacted_error, fallback="Internal server error"),
+            )
+        except Exception:  # noqa: BLE001  # the lower layer may have closed the socket already; closing twice is not an error
+            verbose_proxy_logger.debug("Could not close realtime client websocket; it is already gone")
 
 
 ######################################################################

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import os
-from typing import Any, Final, cast
+from typing import Any, Final, Literal, cast
 
 import litellm
 from litellm.constants import (
@@ -43,7 +43,6 @@ openai_realtime: Final = OpenAIRealtime()
 bedrock_realtime: Final = BedrockRealtime()
 xai_realtime: Final = XAIRealtime()
 vertex_llm_base: Final = VertexBase()
-vertex_access_token_resolver: Final[VertexAccessTokenResolver] = vertex_llm_base._ensure_access_token_async
 base_llm_http_handler = BaseLLMHTTPHandler()
 
 
@@ -285,6 +284,18 @@ async def arealtime_calls(
         extra_headers=kwargs.get("extra_headers"),
         client=kwargs.get("client"),
         api_version=litellm_params.api_version,
+    )
+
+
+async def vertex_access_token_resolver(
+    credentials: VERTEX_CREDENTIALS_TYPES | None,
+    project_id: str | None,
+    custom_llm_provider: Literal["vertex_ai", "vertex_ai_beta", "gemini"],
+) -> tuple[str, str]:
+    return await vertex_llm_base._ensure_access_token_async(
+        credentials=credentials,
+        project_id=project_id,
+        custom_llm_provider=custom_llm_provider,
     )
 
 

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -15,7 +15,7 @@ from litellm.llms.base_llm.realtime.transformation import BaseRealtimeConfig
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.llms.xai.common_utils import XAIModelInfo
 from litellm.secret_managers.main import get_secret_str
-from litellm.types.llms.vertex_ai import VERTEX_CREDENTIALS_TYPES
+from litellm.types.llms.vertex_ai import VERTEX_CREDENTIALS_TYPES, VertexAccessTokenResolver
 from litellm.types.realtime import (
     RealtimeClientSecretRequest,
     RealtimeExpiresAfter,
@@ -43,6 +43,7 @@ openai_realtime: Final = OpenAIRealtime()
 bedrock_realtime: Final = BedrockRealtime()
 xai_realtime: Final = XAIRealtime()
 vertex_llm_base: Final = VertexBase()
+vertex_access_token_resolver: Final[VertexAccessTokenResolver] = vertex_llm_base._ensure_access_token_async
 base_llm_http_handler = BaseLLMHTTPHandler()
 
 
@@ -290,20 +291,22 @@ async def arealtime_calls(
 async def _resolve_vertex_access_token_bounded(
     credentials: VERTEX_CREDENTIALS_TYPES | None,
     project_id: str | None,
+    resolver: VertexAccessTokenResolver,
+    timeout_seconds: float,
 ) -> tuple[str, str]:
     try:
         return await asyncio.wait_for(
-            vertex_llm_base._ensure_access_token_async(
+            resolver(
                 credentials=credentials,
                 project_id=project_id,
                 custom_llm_provider="vertex_ai",
             ),
-            timeout=REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except asyncio.TimeoutError as e:
         raise ValueError(
             "Vertex AI realtime: timed out fetching Google OAuth access token after "
-            f"{REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS}s; check network egress from the proxy "
+            f"{timeout_seconds}s; check network egress from the proxy "
             "to the OAuth token endpoint (oauth2.googleapis.com)"
         ) from e
 
@@ -508,6 +511,8 @@ async def _arealtime(
         ) = await _resolve_vertex_access_token_bounded(
             credentials=vertex_credentials,
             project_id=vertex_project,
+            resolver=vertex_access_token_resolver,
+            timeout_seconds=REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS,
         )
 
         vertex_realtime_config: Final = VertexAIRealtimeConfig(
@@ -588,6 +593,8 @@ async def _realtime_health_check(
         ) = await _resolve_vertex_access_token_bounded(
             credentials=VertexBase.safe_get_vertex_ai_credentials(vertex_model_params),
             project_id=VertexBase.safe_get_vertex_ai_project(vertex_model_params),
+            resolver=vertex_access_token_resolver,
+            timeout_seconds=REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS,
         )
         vertex_realtime_config: Final = VertexAIRealtimeConfig(
             access_token=access_token,

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -1,15 +1,21 @@
 """Abstraction function for OpenAI's realtime API"""
 
+import asyncio
 import os
 from typing import Any, Final, cast
 
 import litellm
-from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES, request_timeout
+from litellm.constants import (
+    REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS,
+    REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
+    request_timeout,
+)
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 from litellm.llms.base_llm.realtime.transformation import BaseRealtimeConfig
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.llms.xai.common_utils import XAIModelInfo
 from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.vertex_ai import VERTEX_CREDENTIALS_TYPES
 from litellm.types.realtime import (
     RealtimeClientSecretRequest,
     RealtimeExpiresAfter,
@@ -281,6 +287,27 @@ async def arealtime_calls(
     )
 
 
+async def _resolve_vertex_access_token_bounded(
+    credentials: VERTEX_CREDENTIALS_TYPES | None,
+    project_id: str | None,
+) -> tuple[str, str]:
+    try:
+        return await asyncio.wait_for(
+            vertex_llm_base._ensure_access_token_async(
+                credentials=credentials,
+                project_id=project_id,
+                custom_llm_provider="vertex_ai",
+            ),
+            timeout=REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError as e:
+        raise ValueError(
+            "Vertex AI realtime: timed out fetching Google OAuth access token after "
+            f"{REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS}s; check network egress from the proxy "
+            "to the OAuth token endpoint (oauth2.googleapis.com)"
+        ) from e
+
+
 @wrapper_client
 async def _arealtime(
     model: str,
@@ -478,10 +505,9 @@ async def _arealtime(
         (
             access_token,
             resolved_project,
-        ) = await vertex_llm_base._ensure_access_token_async(
+        ) = await _resolve_vertex_access_token_bounded(
             credentials=vertex_credentials,
             project_id=vertex_project,
-            custom_llm_provider="vertex_ai",
         )
 
         vertex_realtime_config: Final = VertexAIRealtimeConfig(
@@ -559,10 +585,9 @@ async def _realtime_health_check(
         (
             access_token,
             resolved_project,
-        ) = await vertex_llm_base._ensure_access_token_async(
+        ) = await _resolve_vertex_access_token_bounded(
             credentials=VertexBase.safe_get_vertex_ai_credentials(vertex_model_params),
             project_id=VertexBase.safe_get_vertex_ai_project(vertex_model_params),
-            custom_llm_provider="vertex_ai",
         )
         vertex_realtime_config: Final = VertexAIRealtimeConfig(
             access_token=access_token,

--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Final, Literal
+from typing import Any, Final, Literal, Protocol
 
 from typing_extensions import (
     Required,
@@ -745,6 +745,17 @@ class VertexVideoGenerationResponse(TypedDict, total=False):
 
 
 VERTEX_CREDENTIALS_TYPES = str | dict[str, str]
+
+
+class VertexAccessTokenResolver(Protocol):
+    """Resolves a Google OAuth access token and the project id it belongs to."""
+
+    async def __call__(
+        self,
+        credentials: VERTEX_CREDENTIALS_TYPES | None,
+        project_id: str | None,
+        custom_llm_provider: Literal["vertex_ai", "vertex_ai_beta", "gemini"],
+    ) -> tuple[str, str]: ...
 
 
 class VertexPartnerProvider(str, Enum):

--- a/litellm/types/realtime.py
+++ b/litellm/types/realtime.py
@@ -1,7 +1,7 @@
 from typing import Any, Literal
 
 from pydantic import BaseModel
-from typing_extensions import TypedDict
+from typing_extensions import ReadOnly, TypedDict
 
 from .llms.openai import (
     OpenAIRealtimeEvents,
@@ -152,3 +152,13 @@ class RealtimeTranscriptionSessionResponse(BaseModel):
     model_config = {"extra": "allow"}
 
     client_secret: dict[str, Any] | None = None
+
+
+class RealtimeErrorDetail(TypedDict):
+    type: ReadOnly[str]
+    message: ReadOnly[str]
+
+
+class RealtimeErrorEvent(TypedDict):
+    type: ReadOnly[Literal["error"]]
+    error: ReadOnly[RealtimeErrorDetail]

--- a/tests/test_litellm/litellm_core_utils/test_realtime_errors.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_errors.py
@@ -1,0 +1,47 @@
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.litellm_core_utils.realtime_errors import (
+    WEBSOCKET_CLOSE_REASON_MAX_BYTES,
+    realtime_error_event,
+    websocket_close_reason,
+)
+
+
+def test_realtime_error_event_shape():
+    event = json.loads(realtime_error_event("token refresh failed", error_type="server_error"))
+
+    assert event == {
+        "type": "error",
+        "error": {"type": "server_error", "message": "token refresh failed"},
+    }
+
+
+def test_websocket_close_reason_keeps_short_messages_intact():
+    assert websocket_close_reason("boom", fallback="Internal server error") == "boom"
+
+
+def test_websocket_close_reason_falls_back_on_empty_message():
+    assert websocket_close_reason("", fallback="Internal server error") == "Internal server error"
+
+
+def test_websocket_close_reason_truncates_long_ascii_message():
+    reason = websocket_close_reason("x" * 500, fallback="Internal server error")
+
+    assert len(reason.encode("utf-8")) <= WEBSOCKET_CLOSE_REASON_MAX_BYTES
+    assert reason == "x" * WEBSOCKET_CLOSE_REASON_MAX_BYTES
+
+
+def test_websocket_close_reason_truncates_multibyte_message_by_bytes():
+    """A close frame carries at most 123 bytes of reason, not 123 characters:
+    truncating by characters lets a multibyte message overflow the control
+    frame, which makes the close itself fail and leaves the caller with a bare
+    abnormal closure and no reason at all."""
+    reason = websocket_close_reason("あ" * 200, fallback="Internal server error")
+
+    assert len(reason.encode("utf-8")) <= WEBSOCKET_CLOSE_REASON_MAX_BYTES
+    assert reason == "あ" * (WEBSOCKET_CLOSE_REASON_MAX_BYTES // 3)
+    assert "�" not in reason

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1738,6 +1738,74 @@ async def test_realtime_backend_open_does_not_retry_auth_failure(rejection):
     assert fake.attempts == 1
 
 
+class _FakeClientWebSocket:
+    def __init__(self, send_error=None):
+        self.events = []
+        self._send_error = send_error
+
+    async def send_text(self, payload):
+        if self._send_error is not None:
+            raise self._send_error
+        self.events.append(("send_text", payload))
+
+    async def close(self, code=None, reason=None):
+        self.events.append(("close", (code, reason)))
+
+
+async def _run_async_realtime_with_backend_failure(client_ws):
+    import websockets.exceptions  # noqa: F401  # binds the submodule so async_realtime's except clause resolves, as in the proxy process
+
+    handler = BaseLLMHTTPHandler()
+    provider_config = Mock()
+    provider_config.get_complete_url.return_value = "wss://backend.example/live"
+    provider_config.validate_environment.return_value = {}
+
+    with patch.object(
+        handler,
+        "_open_realtime_backend_ws",
+        AsyncMock(side_effect=Exception("vertex token refresh exploded")),
+    ):
+        await handler.async_realtime(
+            model="gemini-live-2.5-flash",
+            websocket=client_ws,
+            logging_obj=Mock(),
+            provider_config=provider_config,
+            headers={},
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_realtime_generic_failure_sends_error_event_then_reasoned_close():
+    """Regression for the realtime accept-then-silence hang: a generic backend
+    failure used to close the client socket without any error event, so callers
+    only saw a bare 1011. The client must receive an OpenAI-style error event
+    before the reasoned close."""
+    client_ws = _FakeClientWebSocket()
+
+    await _run_async_realtime_with_backend_failure(client_ws)
+
+    assert [name for name, _ in client_ws.events] == ["send_text", "close"]
+
+    error_event = json.loads(client_ws.events[0][1])
+    assert error_event["type"] == "error"
+    assert error_event["error"]["type"] == "server_error"
+    assert "vertex token refresh exploded" in error_event["error"]["message"]
+
+    assert client_ws.events[1][1] == (1011, "Internal server error: vertex token refresh exploded")
+
+
+@pytest.mark.asyncio
+async def test_async_realtime_error_event_send_failure_still_closes():
+    """A client socket that already dropped must not turn the loud-failure path
+    into a new exception: the error-event send may fail, but the reasoned close
+    must still be attempted."""
+    client_ws = _FakeClientWebSocket(send_error=RuntimeError("client already disconnected"))
+
+    await _run_async_realtime_with_backend_failure(client_ws)
+
+    assert client_ws.events == [("close", (1011, "Internal server error: vertex token refresh exploded"))]
+
+
 class _JSONBodyAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
     def get_supported_openai_params(self, model):
         return []

--- a/tests/test_litellm/proxy/realtime_endpoints/test_realtime_webrtc_endpoints.py
+++ b/tests/test_litellm/proxy/realtime_endpoints/test_realtime_webrtc_endpoints.py
@@ -819,6 +819,114 @@ async def test_realtime_transcription_websocket_default_model_checks_team_scope(
 
 
 @pytest.mark.asyncio
+async def test_realtime_websocket_phase2_failure_sends_error_event_and_reasoned_close():
+    """Regression for the realtime accept-then-silence hang: a phase-2 failure
+    (routing / upstream credential resolution) used to close 1011 with the bare
+    reason "Internal server error" and no error event, leaving the client with
+    no clue what happened. The client must get an OpenAI-style error event and
+    a close reason naming the failure."""
+    from litellm.proxy import proxy_server
+
+    events = []
+
+    websocket = MagicMock()
+    websocket.headers = {}
+    websocket.scope = {"headers": []}
+    websocket.accept = AsyncMock()
+    websocket.send_text = AsyncMock(side_effect=lambda payload: events.append(("send_text", payload)))
+    websocket.close = AsyncMock(side_effect=lambda **kwargs: events.append(("close", kwargs)))
+
+    mock_processor = MagicMock()
+    mock_processor.common_processing_pre_call_logic = AsyncMock(
+        return_value=({"model": "gpt-4o-realtime-preview"}, MagicMock())
+    )
+
+    with (
+        patch(
+            "litellm.proxy.proxy_server.can_key_call_resolved_model",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.ProxyBaseLLMRequestProcessing",
+            return_value=mock_processor,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.route_request",
+            new=AsyncMock(side_effect=RuntimeError("vertex token refresh exploded")),
+        ),
+    ):
+        await proxy_server.realtime_websocket_endpoint(
+            websocket=websocket,
+            model="gpt-4o-realtime-preview",
+            intent=None,
+            guardrails=None,
+            user_api_key_dict=UserAPIKeyAuth(models=["*"]),
+        )
+
+    websocket.accept.assert_awaited_once()
+    assert [name for name, _ in events] == ["send_text", "close"]
+
+    error_event = json.loads(events[0][1])
+    assert error_event["type"] == "error"
+    assert error_event["error"]["type"] == "server_error"
+    assert "vertex token refresh exploded" in error_event["error"]["message"]
+
+    close_kwargs = events[1][1]
+    assert close_kwargs["code"] == 1011
+    assert "vertex token refresh exploded" in close_kwargs["reason"]
+    assert len(close_kwargs["reason"].encode("utf-8")) <= 123
+
+
+@pytest.mark.asyncio
+async def test_realtime_websocket_phase2_failure_on_closed_socket_does_not_escape():
+    """The lower handler layer may have already closed the client socket before
+    the phase-2 handler runs (it closes on backend failures itself, then can
+    re-raise). Send and close must each be guarded: the close is still
+    attempted after a failed send, and neither failure escapes to the ASGI
+    layer."""
+    from litellm.proxy import proxy_server
+
+    websocket = MagicMock()
+    websocket.headers = {}
+    websocket.scope = {"headers": []}
+    websocket.accept = AsyncMock()
+    websocket.send_text = AsyncMock(side_effect=RuntimeError('Cannot call "send" once a close message has been sent.'))
+    websocket.close = AsyncMock(side_effect=RuntimeError('Cannot call "send" once a close message has been sent.'))
+
+    mock_processor = MagicMock()
+    mock_processor.common_processing_pre_call_logic = AsyncMock(
+        return_value=({"model": "gpt-4o-realtime-preview"}, MagicMock())
+    )
+
+    with (
+        patch(
+            "litellm.proxy.proxy_server.can_key_call_resolved_model",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.ProxyBaseLLMRequestProcessing",
+            return_value=mock_processor,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.route_request",
+            new=AsyncMock(side_effect=RuntimeError("vertex token refresh exploded")),
+        ),
+    ):
+        await proxy_server.realtime_websocket_endpoint(
+            websocket=websocket,
+            model="gpt-4o-realtime-preview",
+            intent=None,
+            guardrails=None,
+            user_api_key_dict=UserAPIKeyAuth(models=["*"]),
+        )
+
+    websocket.close.assert_awaited_once()
+    _, close_kwargs = websocket.close.call_args
+    assert close_kwargs["code"] == 1011
+    assert "vertex token refresh exploded" in close_kwargs["reason"]
+
+
+@pytest.mark.asyncio
 async def test_transcription_sessions_encrypts_client_secret(
     proxy_app,
     mock_route_request_transcription_sessions,

--- a/tests/test_litellm/realtime_api/test_main.py
+++ b/tests/test_litellm/realtime_api/test_main.py
@@ -1,6 +1,8 @@
 import asyncio
 import os
 import sys
+import time
+from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath("../../.."))
 
@@ -89,6 +91,67 @@ def test_client_secret_session_model_takes_priority_over_top_level(monkeypatch):
     )
     assert captured["model"] == "gpt-realtime-session"
     assert captured["request_data"]["session"]["model"] == "gpt-realtime-session"
+
+
+@pytest.mark.asyncio
+async def test_arealtime_vertex_hung_credential_resolution_raises_promptly(monkeypatch):
+    """Regression for the realtime accept-then-silence hang: a stalled Google
+    OAuth token refresh used to block _arealtime's vertex branch unbounded
+    (minutes of zero frames for the client). It must instead raise a clear,
+    prompt error naming the credential-resolution timeout."""
+
+    async def hanging_token_refresh(**kwargs):
+        await asyncio.sleep(30)
+
+    def mock_get_llm_provider(model, api_base, api_key):
+        return model, "vertex_ai", None, api_base
+
+    monkeypatch.setattr(realtime_main, "get_llm_provider", mock_get_llm_provider)
+    monkeypatch.setattr(realtime_main.vertex_llm_base, "_ensure_access_token_async", hanging_token_refresh)
+    monkeypatch.setattr(realtime_main, "REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS", 0.05)
+
+    start = time.monotonic()
+    with pytest.raises(ValueError, match="timed out fetching Google OAuth access token"):
+        await realtime_main._arealtime.__wrapped__(
+            model="gemini-live-2.5-flash",
+            websocket=MagicMock(),
+            litellm_logging_obj=FakeLogging(),
+            vertex_credentials="fake-credentials",
+            vertex_project="fake-project",
+            vertex_location="us-central1",
+        )
+    assert time.monotonic() - start < 5
+
+
+@pytest.mark.asyncio
+async def test_arealtime_vertex_credential_timeout_survives_thread_offloaded_refresh(monkeypatch):
+    """The real stall is a blocking google-auth refresh that runs in a worker
+    thread via asyncify, not a plain awaitable sleep. A timeout that only bounds
+    cancellable awaits would leave that shape hanging, so bound the shape the
+    proxy actually runs."""
+    from litellm.litellm_core_utils.asyncify import asyncify
+
+    async def thread_offloaded_hanging_refresh(**kwargs):
+        return await asyncify(time.sleep)(30)
+
+    def mock_get_llm_provider(model, api_base, api_key):
+        return model, "vertex_ai", None, api_base
+
+    monkeypatch.setattr(realtime_main, "get_llm_provider", mock_get_llm_provider)
+    monkeypatch.setattr(realtime_main.vertex_llm_base, "_ensure_access_token_async", thread_offloaded_hanging_refresh)
+    monkeypatch.setattr(realtime_main, "REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS", 0.05)
+
+    start = time.monotonic()
+    with pytest.raises(ValueError, match="timed out fetching Google OAuth access token"):
+        await realtime_main._arealtime.__wrapped__(
+            model="gemini-live-2.5-flash",
+            websocket=MagicMock(),
+            litellm_logging_obj=FakeLogging(),
+            vertex_credentials="fake-credentials",
+            vertex_project="fake-project",
+            vertex_location="us-central1",
+        )
+    assert time.monotonic() - start < 5
 
 
 def test_client_secret_forwards_nested_transcription_model_untouched(monkeypatch):

--- a/tests/test_litellm/realtime_api/test_main.py
+++ b/tests/test_litellm/realtime_api/test_main.py
@@ -93,12 +93,70 @@ def test_client_secret_session_model_takes_priority_over_top_level(monkeypatch):
     assert captured["request_data"]["session"]["model"] == "gpt-realtime-session"
 
 
+async def _hanging_resolver(credentials, project_id, custom_llm_provider) -> tuple[str, str]:
+    await asyncio.sleep(30)
+    return "", ""
+
+
+async def _thread_offloaded_hanging_resolver(credentials, project_id, custom_llm_provider) -> tuple[str, str]:
+    from litellm.litellm_core_utils.asyncify import asyncify
+
+    await asyncify(time.sleep)(30)
+    return "", ""
+
+
+async def _instant_resolver(credentials, project_id, custom_llm_provider) -> tuple[str, str]:
+    return "token-abc", "resolved-project"
+
+
 @pytest.mark.asyncio
-async def test_arealtime_vertex_hung_credential_resolution_raises_promptly(monkeypatch):
+async def test_vertex_credential_resolution_returns_the_resolved_token_and_project():
+    assert await realtime_main._resolve_vertex_access_token_bounded(
+        credentials="fake-credentials",
+        project_id="fake-project",
+        resolver=_instant_resolver,
+        timeout_seconds=5,
+    ) == ("token-abc", "resolved-project")
+
+
+@pytest.mark.asyncio
+async def test_vertex_credential_resolution_times_out_instead_of_hanging():
     """Regression for the realtime accept-then-silence hang: a stalled Google
-    OAuth token refresh used to block _arealtime's vertex branch unbounded
-    (minutes of zero frames for the client). It must instead raise a clear,
-    prompt error naming the credential-resolution timeout."""
+    OAuth token refresh used to block the vertex branch unbounded (minutes of
+    zero frames for the client). It must raise promptly and name the timeout."""
+    start = time.monotonic()
+    with pytest.raises(ValueError, match="timed out fetching Google OAuth access token"):
+        await realtime_main._resolve_vertex_access_token_bounded(
+            credentials="fake-credentials",
+            project_id="fake-project",
+            resolver=_hanging_resolver,
+            timeout_seconds=0.05,
+        )
+    assert time.monotonic() - start < 5
+
+
+@pytest.mark.asyncio
+async def test_vertex_credential_resolution_bounds_a_thread_offloaded_refresh():
+    """The real stall is a blocking google-auth refresh that runs in a worker
+    thread via asyncify, not a plain awaitable sleep. A timeout that only bounds
+    cancellable awaits would leave that shape hanging, so bound the shape the
+    proxy actually runs."""
+    start = time.monotonic()
+    with pytest.raises(ValueError, match="timed out fetching Google OAuth access token"):
+        await realtime_main._resolve_vertex_access_token_bounded(
+            credentials="fake-credentials",
+            project_id="fake-project",
+            resolver=_thread_offloaded_hanging_resolver,
+            timeout_seconds=0.05,
+        )
+    assert time.monotonic() - start < 5
+
+
+@pytest.mark.asyncio
+async def test_arealtime_vertex_branch_resolves_credentials_under_a_bound(monkeypatch):
+    """The wiring half of the regression: the vertex branch of _arealtime must
+    go through the bounded resolver, so a hung token refresh surfaces as a
+    prompt error there rather than as an accepted-then-silent websocket."""
 
     async def hanging_token_refresh(**kwargs):
         await asyncio.sleep(30)
@@ -107,38 +165,7 @@ async def test_arealtime_vertex_hung_credential_resolution_raises_promptly(monke
         return model, "vertex_ai", None, api_base
 
     monkeypatch.setattr(realtime_main, "get_llm_provider", mock_get_llm_provider)
-    monkeypatch.setattr(realtime_main.vertex_llm_base, "_ensure_access_token_async", hanging_token_refresh)
-    monkeypatch.setattr(realtime_main, "REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS", 0.05)
-
-    start = time.monotonic()
-    with pytest.raises(ValueError, match="timed out fetching Google OAuth access token"):
-        await realtime_main._arealtime.__wrapped__(
-            model="gemini-live-2.5-flash",
-            websocket=MagicMock(),
-            litellm_logging_obj=FakeLogging(),
-            vertex_credentials="fake-credentials",
-            vertex_project="fake-project",
-            vertex_location="us-central1",
-        )
-    assert time.monotonic() - start < 5
-
-
-@pytest.mark.asyncio
-async def test_arealtime_vertex_credential_timeout_survives_thread_offloaded_refresh(monkeypatch):
-    """The real stall is a blocking google-auth refresh that runs in a worker
-    thread via asyncify, not a plain awaitable sleep. A timeout that only bounds
-    cancellable awaits would leave that shape hanging, so bound the shape the
-    proxy actually runs."""
-    from litellm.litellm_core_utils.asyncify import asyncify
-
-    async def thread_offloaded_hanging_refresh(**kwargs):
-        return await asyncify(time.sleep)(30)
-
-    def mock_get_llm_provider(model, api_base, api_key):
-        return model, "vertex_ai", None, api_base
-
-    monkeypatch.setattr(realtime_main, "get_llm_provider", mock_get_llm_provider)
-    monkeypatch.setattr(realtime_main.vertex_llm_base, "_ensure_access_token_async", thread_offloaded_hanging_refresh)
+    monkeypatch.setattr(realtime_main, "vertex_access_token_resolver", hanging_token_refresh)
     monkeypatch.setattr(realtime_main, "REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS", 0.05)
 
     start = time.monotonic()


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/realtime` accepts the upgrade, then goes silent for minutes
- A stalled Google OAuth token fetch blocks before any session event
- Failures close with a bare 1011 and no error event
- Callers see an open socket, no frames, and no reason

How it solves it:

- Bound the pre-session Vertex token fetch at 20s, env-tunable
- Send an OpenAI-style `error` event before closing the socket
- Put the real failure text in the close reason
- Truncate close reasons by bytes so the close frame itself survives

## User Flow

Before: a developer pointing a voice app at a Vertex AI Live model gets a socket that connects and then never says anything

1. They open a WebSocket to `wss://litellm-domain/v1/realtime?model=gemini-live-2.5-flash-native-audio` with their virtual key
2. The upgrade is accepted in under a second, so the client reports itself connected
3. No `session.created` arrives, no `error` event arrives, and the socket sits open with zero frames on it
4. Nearly four minutes later the socket closes with code 1011 and the reason `Internal server error`, having delivered nothing
5. The same app pointed at `gpt-realtime-2025-08-28` on the same gateway connects and streams normally, so nothing on the client side looks broken

After: the same connection fails within about a minute and says exactly what went wrong

1. They open a WebSocket to `wss://litellm-domain/v1/realtime?model=gemini-live-2.5-flash-native-audio` with their virtual key
2. The upgrade is accepted in under a second, so the client reports itself connected
3. The socket delivers an `error` event of type `server_error` whose message says the Google OAuth token fetch timed out after 20s and names egress to `oauth2.googleapis.com` as the thing to check
4. The socket then closes with code 1011 carrying that same message as the close reason, so a client that only logs close frames still learns the cause
5. A Vertex AI Live model with reachable credentials still returns `session.created` in under a second, and `gpt-realtime-2025-08-28` is unchanged

## Relevant issues

## Linear ticket

Resolves LIT-5867

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, identical on both sides. One proxy against real Vertex AI and real OpenAI, on a random high port, with three Vertex AI Live deployments registered through `/model/new`: one shaped the way a customer's config is (`tags: []`, `guardrails: []`, `vector_store_ids: []`), one clean, and one whose service-account JSON has its `token_uri` pointed at an unroutable address so the OAuth token fetch hangs the way blocked egress does in the customer's cluster.

```bash
# proxy, same command for both sides, only the checked-out commit differs
DATABASE_URL=postgresql://.../litellm_lit5867 \
GOOGLE_APPLICATION_CREDENTIALS=/path/to/vertex-sa.json \
VERTEXAI_PROJECT=vertex-check-481318 VERTEXAI_LOCATION=us-central1 \
  .venv/bin/python litellm/proxy/proxy_cli.py --config lit5867_config.yaml --detailed_debug --port <port>

# a realtime client cannot be driven with curl, so this is the whole probe
cat > ws_probe.py <<'PY'
import asyncio, sys, time
import websockets

PORT, MODEL = sys.argv[1], sys.argv[2]
LISTEN_S = float(sys.argv[3])

async def main():
    url = f"ws://127.0.0.1:{PORT}/v1/realtime?model={MODEL}"
    print(f"$ probe {url}")
    t0 = time.monotonic()
    ws = await websockets.connect(url, additional_headers={"Authorization": "Bearer sk-1234"}, open_timeout=15)
    print(f"  +{time.monotonic()-t0:.1f}s upgrade ACCEPTED")
    n, deadline = 0, time.monotonic() + LISTEN_S
    while time.monotonic() < deadline:
        try:
            raw = await asyncio.wait_for(ws.recv(), timeout=deadline - time.monotonic())
        except asyncio.TimeoutError:
            break
        except websockets.ConnectionClosed as e:
            print(f"  +{time.monotonic()-t0:.1f}s CLOSED code={e.rcvd.code} reason={e.rcvd.reason!r}")
            print(f"  RESULT: frames_before_close={n}")
            return
        n += 1
        print(f"  +{time.monotonic()-t0:.1f}s frame {n}: {raw[:300]}")
        if n >= 3:
            break
    print(f"  RESULT: {n} frame(s), socket still open after {LISTEN_S:.0f}s, state={ws.state.name}")
    await ws.close()

asyncio.run(main())
PY
```

### Before (5290150a05)

#### Vertex AI Live, OAuth token endpoint unreachable

1. `python ws_probe.py 41207 gemini-live-badtoken 300`
2. Output, the reported symptom: the upgrade is accepted, then 230 seconds pass with nothing on the socket, and the close carries no usable reason

```
$ probe ws://127.0.0.1:41207/v1/realtime?model=gemini-live-badtoken
  +0.1s upgrade ACCEPTED
  +229.9s CLOSED code=1011 reason='Internal server error'
  RESULT: frames_before_close=0
```

#### Vertex AI Live, working credentials

1. `python ws_probe.py 41207 gemini-live-2.5-flash-native-audio 20` and `python ws_probe.py 41207 gemini-live-clean 20`
2. Output, both shapes healthy:

```
$ probe ws://127.0.0.1:41207/v1/realtime?model=gemini-live-2.5-flash-native-audio
  +0.2s upgrade ACCEPTED
  +0.9s frame 1: {"type": "session.created", "session": {"id": "8e7a0431-a2b4-46f1-9f3f-1d2f06c31e6e", "modalities": ["audio"], "model": "gemini-live-2.5-flash-native-audio"}, "event_id": "8566f590-35e7-4f2c-a547-6870ddd0354a"}
  RESULT: 1 frame(s), socket still open after 20s, state=OPEN

$ probe ws://127.0.0.1:41207/v1/realtime?model=gemini-live-clean
  +0.1s upgrade ACCEPTED
  +0.5s frame 1: {"type": "session.created", "session": {"id": "e3b37e4b-e3ef-4750-90a8-2b83a2e3dda7", "modalities": ["audio"], "model": "gemini-live-2.5-flash-native-audio"}, "event_id": "22fd105a-ec38-4fc9-a9e4-147350848092"}
  RESULT: 1 frame(s), socket still open after 20s, state=OPEN
```

#### OpenAI realtime control

1. `python ws_probe.py 41207 gpt-realtime-2025-08-28 20`
2. Output, full duplex on the same gateway:

```
$ probe ws://127.0.0.1:41207/v1/realtime?model=gpt-realtime-2025-08-28
  +0.0s upgrade ACCEPTED
  +0.3s frame 1: {"type": "session.created", "event_id": "event_EEt1C4H04kvAwV0ugO3Fe", "session": {"type": "realtime", "object": "realtime.session", "id": "sess_EEt1CgHd6MEibZlpzVBzX", "model": "gpt-realtime-2025-08-28", "output_modalities": ["audio"], "instructions": "Your knowledge cutoff is 2023-10. You are a he
  RESULT: 1 frame(s), socket still open after 20s, state=OPEN
```

### After (d643136895)

#### Vertex AI Live, OAuth token endpoint unreachable

1. `python ws_probe.py 39177 gemini-live-badtoken 300`
2. Output, the fix: an error event naming the timeout arrives at 65s instead of 230s of silence, and the close reason carries the same text

```
$ probe ws://127.0.0.1:39177/v1/realtime?model=gemini-live-badtoken
  +0.0s upgrade ACCEPTED
  +64.8s frame 1: {"type": "error", "error": {"type": "server_error", "message": "Vertex AI realtime: timed out fetching Google OAuth access token after 20.0s; check network egress from the proxy to the OAuth token endpoint (oauth2.googleapis.com)"}}
  +64.8s CLOSED code=1011 reason='Vertex AI realtime: timed out fetching Google OAuth access token after 20.0s; check network egress from the proxy to the OA'
  RESULT: frames_before_close=1
```

#### Vertex AI Live, working credentials

1. `python ws_probe.py 39177 gemini-live-2.5-flash-native-audio 20` and `python ws_probe.py 39177 gemini-live-clean 20`
2. Output, unchanged from Before:

```
$ probe ws://127.0.0.1:39177/v1/realtime?model=gemini-live-2.5-flash-native-audio
  +0.0s upgrade ACCEPTED
  +0.7s frame 1: {"type": "session.created", "session": {"id": "949d9210-0e03-424a-aa8b-9f2d633b2fb8", "modalities": ["audio"], "model": "gemini-live-2.5-flash-native-audio"}, "event_id": "e7e041fd-0ae9-4bae-bf49-a62624a52673"}
  RESULT: 1 frame(s), socket still open after 20s, state=OPEN

$ probe ws://127.0.0.1:39177/v1/realtime?model=gemini-live-clean
  +0.0s upgrade ACCEPTED
  +0.3s frame 1: {"type": "session.created", "session": {"id": "d87e7c58-e17e-45e5-8454-9a6db888d251", "modalities": ["audio"], "model": "gemini-live-2.5-flash-native-audio"}, "event_id": "4cea47bb-c9d7-4e8c-a025-a35783fe7dc8"}
  RESULT: 1 frame(s), socket still open after 20s, state=OPEN
```

#### OpenAI realtime control

1. `python ws_probe.py 39177 gpt-realtime-2025-08-28 20`
2. Output, unchanged from Before:

```
$ probe ws://127.0.0.1:39177/v1/realtime?model=gpt-realtime-2025-08-28
  +0.0s upgrade ACCEPTED
  +0.3s frame 1: {"type": "session.created", "event_id": "event_EEthHFekSZ6CrQBMpX3MI", "session": {"type": "realtime", "object": "realtime.session", "id": "sess_EEthHYZiDHH30LQB0hjin", "model": "gpt-realtime-2025-08-28", "output_modalities": ["audio"], "instructions": "Your knowledge cutoff is 2023-10. You are a he
  RESULT: 1 frame(s), socket still open after 20s, state=OPEN
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Router retries multiply the bound: 3 attempts, so ~65s worst case
- 20s default stays conservative to avoid timing out healthy deployments
- `REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS` tunes it per deployment
- Backend connect was already bounded; the token fetch was the gap
- Failure text reaches the caller, matching what the HTTP routes already return; Veria flagged that as a disclosure risk
- A timed-out refresh leaves its worker thread running until Google's own timeout; sequential retries stack up to three, while concurrent callers share one through the per-credential lock

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d643136895d6d3c00f2339b75e63162098bc0802. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
