### PR TITLE
test(ci): reject coverage-allowlist entries that no longer match a file

### DIFF
--- a/.github/scripts/assert_ci_coverage.py
+++ b/.github/scripts/assert_ci_coverage.py
@@ -368,6 +368,25 @@ def _uncovered_dockerfiles(allowlist: Allowlist, tokens: frozenset[str]) -> tupl
     )
 
 
+def _stale_allowlist_paths(
+    allowlist: Allowlist,
+    *,
+    test_files: tuple[str, ...],
+    dockerfiles: tuple[str, ...],
+) -> tuple[Finding, ...]:
+    sections: Final[tuple[tuple[str, tuple[AllowEntry, ...], tuple[str, ...]], ...]] = (
+        ("test_paths", allowlist.test_paths, test_files),
+        ("dockerfiles", allowlist.dockerfiles, dockerfiles),
+    )
+    return tuple(
+        Finding(subject=path, detail=f"listed under '{section}' but matches no file the census looks at")
+        for section, entries, candidates in sections
+        for entry in entries
+        for path in entry.paths
+        if not any(_token_covers(path, candidate) for candidate in candidates)
+    )
+
+
 def _parse_entry(item: object, section: str) -> AllowEntry:
     if not isinstance(item, dict):
         raise SystemExit(f"{ALLOWLIST_FILE.name}: '{section}' entries must be mappings")
@@ -465,7 +484,14 @@ def main() -> int:
 
     test_findings = _uncovered_tests(allowlist, _invoked_test_tokens(scalars))
     dockerfile_findings = _uncovered_dockerfiles(allowlist, _built_dockerfile_tokens(scalars))
+    stale_findings = _stale_allowlist_paths(allowlist, test_files=_test_files(), dockerfiles=_dockerfiles())
 
+    if stale_findings:
+        _report(
+            "allowlist entries that exempt nothing",
+            stale_findings,
+            "Delete each from .github/ci-coverage-allowlist.yml; the file it named is gone or was renamed.",
+        )
     if test_findings:
         _report(
             "test files that no CI job invokes",
@@ -478,7 +504,7 @@ def main() -> int:
             dockerfile_findings,
             "Build each in a workflow, or list it in .github/ci-coverage-allowlist.yml with a reason.",
         )
-    if test_findings or dockerfile_findings:
+    if stale_findings or test_findings or dockerfile_findings:
         return 1
 
     _write(

--- a/.github/scripts/assert_ci_coverage.py
+++ b/.github/scripts/assert_ci_coverage.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import ast
+import operator
 import pathlib
 import re
 import sys
 import warnings
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Final
 
@@ -54,6 +55,14 @@ class Allowlist:
 
     def covers_dockerfile(self, relative_path: str) -> bool:
         return any(relative_path == path for entry in self.dockerfiles for path in entry.paths)
+
+
+@dataclass(frozen=True, slots=True)
+class Section:
+    name: str
+    entries: tuple[AllowEntry, ...]
+    candidates: tuple[str, ...]
+    matches: Callable[[str, str], bool]
 
 
 @dataclass(frozen=True, slots=True)
@@ -374,16 +383,16 @@ def _stale_allowlist_paths(
     test_files: tuple[str, ...],
     dockerfiles: tuple[str, ...],
 ) -> tuple[Finding, ...]:
-    sections: Final[tuple[tuple[str, tuple[AllowEntry, ...], tuple[str, ...]], ...]] = (
-        ("test_paths", allowlist.test_paths, test_files),
-        ("dockerfiles", allowlist.dockerfiles, dockerfiles),
+    sections: Final[tuple[Section, ...]] = (
+        Section("test_paths", allowlist.test_paths, test_files, _token_covers),
+        Section("dockerfiles", allowlist.dockerfiles, dockerfiles, operator.eq),
     )
     return tuple(
-        Finding(subject=path, detail=f"listed under '{section}' but matches no file the census looks at")
-        for section, entries, candidates in sections
-        for entry in entries
+        Finding(subject=path, detail=f"listed under '{section.name}' but matches no file the census looks at")
+        for section in sections
+        for entry in section.entries
         for path in entry.paths
-        if not any(_token_covers(path, candidate) for candidate in candidates)
+        if not any(section.matches(path, candidate) for candidate in section.candidates)
     )
 
 

--- a/tests/test_litellm/test_assert_ci_coverage.py
+++ b/tests/test_litellm/test_assert_ci_coverage.py
@@ -219,8 +219,6 @@ def _allowlist(*, tests: tuple[str, ...] = (), dockerfiles: tuple[str, ...] = ()
 
 
 def test_an_allowlist_path_whose_file_is_gone_is_reported():
-    # Deleting a suite without deleting its entry leaves a permanent exemption for a
-    # path nothing can ever match, which reads as coverage the repo does not have.
     findings = coverage._stale_allowlist_paths(
         _allowlist(tests=("tests/gone/test_a.py",)),
         test_files=("tests/live/test_b.py",),
@@ -273,3 +271,12 @@ def test_the_repo_as_it_stands_has_no_stale_allowlist_entry():
         dockerfiles=coverage._dockerfiles(),
     )
     assert [f.subject for f in findings] == []
+
+
+def test_a_dockerfile_directory_entry_is_stale_because_only_an_exact_path_exempts_one():
+    findings = coverage._stale_allowlist_paths(
+        _allowlist(dockerfiles=("docker",)),
+        test_files=(),
+        dockerfiles=("docker/Dockerfile.database",),
+    )
+    assert [f.subject for f in findings] == ["docker"]

--- a/tests/test_litellm/test_assert_ci_coverage.py
+++ b/tests/test_litellm/test_assert_ci_coverage.py
@@ -209,3 +209,67 @@ def test_character_class_globs_match_the_letter_shards_circleci_uses():
 def test_the_repo_as_it_stands_has_no_unrecorded_slice_gap():
     findings = coverage._deselected_everywhere(coverage._load_allowlist())
     assert [f.subject for f in findings] == []
+
+
+def _allowlist(*, tests: tuple[str, ...] = (), dockerfiles: tuple[str, ...] = ()):
+    return coverage.Allowlist(
+        test_paths=(coverage.AllowEntry(paths=tests, reason="r"),) if tests else (),
+        dockerfiles=(coverage.AllowEntry(paths=dockerfiles, reason="r"),) if dockerfiles else (),
+    )
+
+
+def test_an_allowlist_path_whose_file_is_gone_is_reported():
+    # Deleting a suite without deleting its entry leaves a permanent exemption for a
+    # path nothing can ever match, which reads as coverage the repo does not have.
+    findings = coverage._stale_allowlist_paths(
+        _allowlist(tests=("tests/gone/test_a.py",)),
+        test_files=("tests/live/test_b.py",),
+        dockerfiles=(),
+    )
+    assert [f.subject for f in findings] == ["tests/gone/test_a.py"]
+    assert "test_paths" in findings[0].detail
+
+
+def test_an_allowlist_path_that_still_matches_a_file_is_left_alone():
+    findings = coverage._stale_allowlist_paths(
+        _allowlist(tests=("tests/live/test_b.py",)),
+        test_files=("tests/live/test_b.py",),
+        dockerfiles=(),
+    )
+    assert findings == ()
+
+
+def test_a_directory_entry_survives_while_any_file_below_it_remains():
+    findings = coverage._stale_allowlist_paths(
+        _allowlist(tests=("tests/live",)),
+        test_files=("tests/live/nested/test_b.py",),
+        dockerfiles=(),
+    )
+    assert findings == ()
+
+
+def test_a_glob_entry_matching_nothing_is_reported_like_any_other():
+    findings = coverage._stale_allowlist_paths(
+        _allowlist(tests=("tests/live/test_z*.py",)),
+        test_files=("tests/live/test_b.py",),
+        dockerfiles=(),
+    )
+    assert [f.subject for f in findings] == ["tests/live/test_z*.py"]
+
+
+def test_a_stale_dockerfile_entry_is_named_under_its_own_section():
+    findings = coverage._stale_allowlist_paths(
+        _allowlist(dockerfiles=("docker/Dockerfile.gone",)),
+        test_files=(),
+        dockerfiles=("docker/Dockerfile.database",),
+    )
+    assert [(f.subject, "dockerfiles" in f.detail) for f in findings] == [("docker/Dockerfile.gone", True)]
+
+
+def test_the_repo_as_it_stands_has_no_stale_allowlist_entry():
+    findings = coverage._stale_allowlist_paths(
+        coverage._load_allowlist(),
+        test_files=coverage._test_files(),
+        dockerfiles=coverage._dockerfiles(),
+    )
+    assert [f.subject for f in findings] == []


### PR DESCRIPTION
> #37593 and #37601 have both merged, so this now stands alone against staging.

## TLDR

Problem this solves:

- The allowlist exempts a test file from the census by path
- Nothing checks that the path still names a file
- A deleted or renamed suite leaves an exemption behind forever
- #37605 shipped exactly that mistake, and CI stayed green

How it solves it:

- Every allowlist path must match at least one file the census looks at
- A path that matches nothing fails the check by name
- Applies to `test_paths` and `dockerfiles` alike

## User Flow

Before: a suite is deleted and its exemption quietly outlives it

1. Someone deletes a test directory that carried an allowlist entry, and leaves the entry in place
2. `assert-ci-coverage` passes, because the entry only ever needs to match; nothing needs it to match something real
3. The allowlist keeps 20 paths that cannot exist, and reads to the next person as coverage the repo does not have
4. Later a new file lands at one of those paths and inherits an exemption written for something else

After: the same deletion fails until the entry goes with it

1. The deletion lands in a PR without the allowlist edit
2. `assert-ci-coverage` fails and names each path that no longer matches a file
3. The author deletes the entry too, and the allowlist shrinks with the code
4. A later file at that path starts out uncovered, and has to be argued for on its own terms

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup, deleting a file that the allowlist exempts, which is the exact shape of the mistake in #37605:

```
git rm tests/local_testing/test_prompt_caching.py
```

### Before (77a38d5bf8)

1. Command:

```
python3 .github/scripts/assert_ci_coverage.py; echo "exit=$?"
```

2. Output, green with a dead exemption on the books:

```
OK: 2422 test files and 10 Dockerfiles are each invoked by at least one job or carry an explicit allowlist entry.
exit=0
```

### After (31232dcab8)

#### The same deletion now fails

1. Command:

```
python3 .github/scripts/assert_ci_coverage.py; echo "exit=$?"
```

2. Output:

```
ERROR: allowlist entries that exempt nothing
  - tests/local_testing/test_prompt_caching.py: listed under 'test_paths' but matches no file the census looks at

Delete each from .github/ci-coverage-allowlist.yml; the file it named is gone or was renamed.
exit=1
```

#### The repo as it stands is clean, and the other two modes did not move

1. Command, with the file restored:

```
python3 .github/scripts/assert_ci_coverage.py
python3 .github/scripts/assert_ci_coverage.py --shards
python3 .github/scripts/assert_ci_coverage.py --slices
```

2. Output:

```
OK: 2423 test files and 10 Dockerfiles are each invoked by at least one job or carry an explicit allowlist entry.
OK: all 327 test children across 3 sharded trees are assigned to a shard.
OK: no test file is globbed by a job and then deselected by every -k across 36 slices.
```

#### Unit tests

1. Command:

```
uv run pytest tests/test_litellm/test_assert_ci_coverage.py -q
```

2. Output:

```
30 passed, 1 warning in 8.70s
```

3. Command, the new ones against the script without this change, to show they fail first:

```
git checkout 77a38d5bf8 -- .github/scripts/assert_ci_coverage.py
uv run pytest tests/test_litellm/test_assert_ci_coverage.py -q -k "stale or gone or glob_entry or directory_entry"
```

4. Output:

```
6 failed, 24 deselected, 1 warning in 0.23s
```

## Type

🆕 New Feature
✅ Test

## Caveats

- A directory entry stays valid while any file below it survives
- A glob entry matching nothing is reported like any other dead path
- A dockerfile entry must match exactly, since that is how those exempt
- No allowlist entry in the repo today is stale, so this starts green

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


