### PR TITLE
fix(proxy): only gate premium metadata fields when a key update changes them

### DIFF
--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -1,4 +1,5 @@
 import math
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Final, Optional, Union
 
 from fastapi import HTTPException, status
@@ -410,6 +411,7 @@ def _set_object_metadata_field(
     ],
     field_name: str,
     value: Any,
+    existing_metadata: Mapping[str, object] | None = None,
 ) -> None:
     """
     Helper function to set metadata fields that require premium user checks
@@ -418,8 +420,12 @@ def _set_object_metadata_field(
         object_data: The team/key/organization/project data object to modify
         field_name: Name of the metadata field to set
         value: Value to set for the field
+        existing_metadata: Stored metadata on update flows. When the submitted value
+            already matches what is stored, the premium check is skipped so that
+            re-submitting an unchanged field is not treated as enabling the feature.
     """
-    if field_name in LiteLLM_ManagementEndpoint_MetadataFields_Premium and value:
+    is_new_value: Final = existing_metadata is None or existing_metadata.get(field_name) != value
+    if field_name in LiteLLM_ManagementEndpoint_MetadataFields_Premium and value and is_new_value:
         _premium_user_check(field_name)
 
     object_data.metadata = object_data.metadata or {}

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2022,7 +2022,7 @@ def prepare_metadata_fields(data: BaseModel, non_default_values: dict, existing_
             if k in LiteLLM_ManagementEndpoint_MetadataFields_Premium:
                 from litellm.proxy.utils import _premium_user_check
 
-                if v:
+                if v and v != existing_metadata.get(k):
                     _premium_user_check(k)
                 casted_metadata[k] = v
 
@@ -2061,6 +2061,7 @@ async def prepare_key_update_data(
                 object_data=data,
                 field_name=field,
                 value=getattr(data, field),
+                existing_metadata=existing_key_row.metadata,
             )
     for k, v in data_json.items():
         if k in LiteLLM_ManagementEndpoint_MetadataFields or k in LiteLLM_ManagementEndpoint_MetadataFields_Premium:

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -2075,6 +2075,76 @@ async def test_prepare_key_update_data_disable_global_guardrails_true_premium_pe
 
 
 @pytest.mark.asyncio
+async def test_prepare_key_update_data_unchanged_premium_field_no_premium(monkeypatch):
+    """
+    Regression #15230: the UI echoes a key's stored premium fields back on every save,
+    so editing an unrelated field on a key that already carries tags or guardrails must
+    not 403 a non-premium user, and the stored values must survive the update.
+    """
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", False)
+    existing_key = LiteLLM_VerificationToken(
+        token="hashed",
+        metadata={"tags": ["prod"], "guardrails": ["pii-guard"]},
+    )
+    data = UpdateKeyRequest(
+        key="sk-1",
+        max_budget=10.0,
+        tags=["prod"],
+        guardrails=["pii-guard"],
+    )
+
+    result = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert result["metadata"]["tags"] == ["prod"]
+    assert result["metadata"]["guardrails"] == ["pii-guard"]
+    assert result["max_budget"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_prepare_key_update_data_changed_premium_field_requires_premium(monkeypatch):
+    """Control: changing a stored premium value without a license still 403s."""
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", False)
+    existing_key = LiteLLM_VerificationToken(token="hashed", metadata={"tags": ["prod"]})
+    data = UpdateKeyRequest(key="sk-1", tags=["prod", "eu"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_prepare_key_update_data_new_premium_field_requires_premium(monkeypatch):
+    """Control: setting a premium field a key does not have yet still 403s."""
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", False)
+    existing_key = LiteLLM_VerificationToken(token="hashed", metadata={})
+    data = UpdateKeyRequest(key="sk-1", tags=["prod"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_prepare_key_update_data_unchanged_premium_field_keeps_later_metadata(monkeypatch):
+    """
+    Regression #15230: prepare_metadata_fields swallows the premium HTTPException, so the
+    gate firing on an unchanged field aborted the loop and silently dropped every metadata
+    field ordered after it. Editing enforced_params on a key that already carries tags must
+    persist enforced_params.
+    """
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", False)
+    existing_key = LiteLLM_VerificationToken(token="hashed", metadata={"tags": ["prod"]})
+    data = UpdateKeyRequest(key="sk-1", tags=["prod"], enforced_params=["user"])
+
+    result = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert result["metadata"]["enforced_params"] == ["user"]
+    assert result["metadata"]["tags"] == ["prod"]
+
+
+@pytest.mark.asyncio
 async def test_validate_team_id_used_in_service_account_request_requires_team_id():
     """
     Test that validate_team_id_used_in_service_account_request raises HTTPException


### PR DESCRIPTION
## TLDR

Problem this solves:

- Keys carrying tags or guardrails cannot be edited without a license
- The enterprise gate fires on a field being present, not changed
- The raised 403 is swallowed, silently dropping later metadata fields

How it solves it:

- Both key update gates compare the submitted value against the stored one
- Re-submitting an unchanged premium field is now a no-op
- Creation paths are untouched and still gate on presence

## User Flow

Before: an operator on a free install cannot edit any virtual key that already carries tags or guardrails, because saving the form sends those fields back untouched

1. They POST http://localhost:4000/key/generate with `{"key_alias":"team-a","metadata":{"tags":["prod"]}}` and the key is created
2. They GET http://localhost:4000/key/info?key=sk-... and see `metadata` holding `{"tags": ["prod"]}`
3. They open http://localhost:4000/ui/?page=api-keys, click the key, change only its max budget and save
4. The save sends the stored `tags` back unchanged along with the new budget
5. The response is 403 saying the feature is only available for LiteLLM Enterprise users, naming `tags`
6. The budget change is lost. The only workarounds are deleting and recreating the key, or stripping the premium field over the API first

After: the same edit succeeds, and turning a premium feature on still requires a license

1. They POST the same /key/generate request and the key is created
2. They GET the same /key/info and see `metadata` holding `{"tags": ["prod"]}`
3. They open the same page, change only its max budget and save
4. The save sends the stored `tags` back unchanged along with the new budget
5. The response is 200, the new budget is on the key, and `tags` is still `["prod"]`
6. Changing `tags` to a different value, or adding it to a key that never had it, still returns the same 403

## Relevant issues

Fixes #15230

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup, identical on both sides. A proxy on a free install, no `LITELLM_LICENSE` in the environment, backed by Postgres:

```
DATABASE_URL="postgresql://postgres:litellm@localhost:5433/litellm" \
LITELLM_MASTER_KEY="sk-1234" \
litellm --config config.yaml --port 4010
```

### Before (6fcdea03b0)

1. Create a key that already carries a premium metadata field

```
curl -s -X POST http://localhost:4010/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"key_alias":"pr-proof-before","metadata":{"tags":["prod"]}}'
```

2. Confirm it is stored

```
curl -s -X GET "http://localhost:4010/key/info?key=$KEY" -H "Authorization: Bearer sk-1234"

stored metadata = {"tags": ["prod"]}
```

3. Edit one unrelated field, echoing tags back exactly as the Admin UI does

```
curl -s -w "HTTP %{http_code}\n" -X POST http://localhost:4010/key/update \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"key\":\"$KEY\",\"max_budget\":10,\"tags\":[\"prod\"]}"

HTTP 403
{"error":{"message":"{'error': 'This feature is only available for LiteLLM Enterprise users: tags. ...'}","type":"auth_error","code":"403"}}
```

### After (5c44a65960)

1. Create a key that already carries a premium metadata field

```
curl -s -X POST http://localhost:4010/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"key_alias":"pr-proof-after","metadata":{"tags":["prod"]}}'
```

2. Confirm it is stored

```
curl -s -X GET "http://localhost:4010/key/info?key=$KEY" -H "Authorization: Bearer sk-1234"

stored metadata = {"tags": ["prod"]}
```

3. The same edit as the Before run

```
curl -s -w "HTTP %{http_code}\n" -X POST http://localhost:4010/key/update \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"key\":\"$KEY\",\"max_budget\":10,\"tags\":[\"prod\"]}"

HTTP 200
max_budget = 10.0 | metadata = {"tags": ["prod"]}
```

4. Control, changing the premium value is still refused

```
curl -s -w "HTTP %{http_code}\n" -X POST http://localhost:4010/key/update \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"key\":\"$KEY\",\"tags\":[\"prod\",\"eu\"]}"

HTTP 403
{"error":{"message":"{'error': 'This feature is only available for LiteLLM Enterprise users: tags. ...'}"}}
```

5. Control, setting a premium field on a key that never had it is still refused

```
curl -s -w "HTTP %{http_code}\n" -X POST http://localhost:4010/key/update \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"key\":\"$KEY2\",\"tags\":[\"prod\"]}"

HTTP 403
{"error":{"message":"{'error': 'This feature is only available for LiteLLM Enterprise users: tags. ...'}"}}
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Removing a premium field stays ungated, matching the existing falsy check
- #30285 fixed the falsy half of this; this covers unchanged truthy values
