### PR TITLE
fix(anthropic): map metadata.user_id to prompt_cache_key on the /v1/messages bridge

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -484,10 +484,14 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         if "output_config" in extra_kwargs:
             request_data["output_config"] = extra_kwargs["output_config"]
 
+        custom_llm_provider: Final = extra_kwargs.get("custom_llm_provider")
         (
             openai_request,
             tool_name_mapping,
-        ) = ANTHROPIC_ADAPTER.translate_completion_input_params_with_tool_mapping(request_data)
+        ) = ANTHROPIC_ADAPTER.translate_completion_input_params_with_tool_mapping(
+            request_data,
+            custom_llm_provider=custom_llm_provider if isinstance(custom_llm_provider, str) else None,
+        )
 
         if openai_request is None:
             raise ValueError("Failed to translate request to OpenAI format")
@@ -525,6 +529,10 @@ class LiteLLMMessagesToCompletionTransformationHandler:
                 setattr(value, "stream_options", completion_kwargs.get("stream_options"))
             if key not in excluded_keys and key not in completion_kwargs and value is not None:
                 completion_kwargs[key] = value
+
+        explicit_prompt_cache_key: Final = extra_kwargs.get("prompt_cache_key")
+        if explicit_prompt_cache_key is not None:
+            completion_kwargs["prompt_cache_key"] = explicit_prompt_cache_key
 
         # Normalize reasoning_effort based on model capabilities
         # (e.g. "max" → "xhigh"/"high", "minimal" → "low" if unsupported)

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -15,6 +15,7 @@ from litellm.llms.anthropic.experimental_pass_through.utils import (
 OPENAI_MAX_TOOL_NAME_LENGTH: Final = 64
 TOOL_NAME_HASH_LENGTH: Final = 8
 TOOL_NAME_PREFIX_LENGTH: Final = OPENAI_MAX_TOOL_NAME_LENGTH - TOOL_NAME_HASH_LENGTH - 1  # 55
+PROVIDERS_PROXYING_AN_UNKNOWN_BACKEND: Final = frozenset({"litellm_proxy"})
 
 
 def truncate_tool_name(name: str) -> str:
@@ -915,6 +916,8 @@ class LiteLLMAnthropicMessagesAdapter:
     @staticmethod
     def _supports_prompt_cache_key(model: str | None, custom_llm_provider: str | None) -> bool:
         if not model or not custom_llm_provider:
+            return False
+        if custom_llm_provider in PROVIDERS_PROXYING_AN_UNKNOWN_BACKEND:
             return False
         supported_params: Final = litellm.get_supported_openai_params(
             model=model, custom_llm_provider=custom_llm_provider

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -4,8 +4,10 @@ import json
 from collections.abc import AsyncIterator, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
+import litellm
 from litellm.llms.anthropic.experimental_pass_through.utils import (
     is_reasoning_auto_summary_enabled,
+    prompt_cache_key_from_user_id,
 )
 
 # OpenAI has a 64-character limit for function/tool names
@@ -148,7 +150,7 @@ class AnthropicAdapter:
         return result
 
     def translate_completion_input_params_with_tool_mapping(
-        self, kwargs
+        self, kwargs, *, custom_llm_provider: str | None = None
     ) -> tuple[ChatCompletionRequest | None, dict[str, str]]:
         """
         Translate Anthropic request params to OpenAI format, returning tool name mapping.
@@ -179,7 +181,10 @@ class AnthropicAdapter:
         (
             translated_body,
             tool_name_mapping,
-        ) = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(anthropic_message_request=request_body)
+        ) = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
+            anthropic_message_request=request_body,
+            custom_llm_provider=custom_llm_provider,
+        )
 
         return translated_body, tool_name_mapping
 
@@ -907,16 +912,32 @@ class LiteLLMAnthropicMessagesAdapter:
                     ChatCompletionSystemMessage(role="system", content=openai_system_content),
                 )
 
+    @staticmethod
+    def _supports_prompt_cache_key(model: str | None, custom_llm_provider: str | None) -> bool:
+        if not model or not custom_llm_provider:
+            return False
+        supported_params: Final = litellm.get_supported_openai_params(
+            model=model, custom_llm_provider=custom_llm_provider
+        )
+        return "prompt_cache_key" in (supported_params or ())
+
     def _translate_metadata_to_openai(
         self,
         anthropic_message_request: AnthropicMessagesRequest,
         new_kwargs: ChatCompletionRequest,
+        *,
+        custom_llm_provider: str | None = None,
     ) -> None:
         """Translate metadata fields from Anthropic request to OpenAI request."""
         if "metadata" in anthropic_message_request:
             metadata: Final = anthropic_message_request["metadata"]
             if metadata and "user_id" in metadata:
                 new_kwargs["user"] = metadata["user_id"]
+                prompt_cache_key: Final = prompt_cache_key_from_user_id(metadata["user_id"])
+                if prompt_cache_key is not None and self._supports_prompt_cache_key(
+                    anthropic_message_request.get("model"), custom_llm_provider
+                ):
+                    new_kwargs["prompt_cache_key"] = prompt_cache_key
 
         if "litellm_metadata" in anthropic_message_request:
             # metadata will be passed to litellm.acompletion(), it's a litellm_param
@@ -1069,7 +1090,10 @@ class LiteLLMAnthropicMessagesAdapter:
                 new_kwargs[k] = v
 
     def translate_anthropic_to_openai(
-        self, anthropic_message_request: AnthropicMessagesRequest
+        self,
+        anthropic_message_request: AnthropicMessagesRequest,
+        *,
+        custom_llm_provider: str | None = None,
     ) -> tuple[ChatCompletionRequest, dict[str, str]]:
         """
         This is used by the beta Anthropic Adapter, for translating anthropic `/v1/messages` requests to the openai format.
@@ -1103,6 +1127,7 @@ class LiteLLMAnthropicMessagesAdapter:
         self._translate_metadata_to_openai(
             anthropic_message_request=anthropic_message_request,
             new_kwargs=new_kwargs,
+            custom_llm_provider=custom_llm_provider,
         )
         ## CONVERT TOOL CHOICE
         self._translate_tool_choice_to_openai(

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
@@ -105,7 +105,8 @@ def _build_responses_kwargs(
 
     # Forward litellm-specific kwargs (api_key, api_base, logging obj, etc.)
     excluded: Final = {"anthropic_messages"}
-    for key, value in _forwarded_kwargs(extra_kwargs).items():
+    forwarded_kwargs: Final = _forwarded_kwargs(extra_kwargs)
+    for key, value in forwarded_kwargs.items():
         if key == "litellm_logging_obj" and value is not None:
             from litellm.litellm_core_utils.litellm_logging import (
                 Logging as LiteLLMLoggingObject,
@@ -120,6 +121,10 @@ def _build_responses_kwargs(
             responses_kwargs[key] = value
         elif key not in excluded and key not in responses_kwargs and value is not None:
             responses_kwargs[key] = value
+
+    explicit_prompt_cache_key: Final = forwarded_kwargs.get("prompt_cache_key")
+    if explicit_prompt_cache_key is not None:
+        responses_kwargs["prompt_cache_key"] = explicit_prompt_cache_key
 
     return responses_kwargs
 

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -18,6 +18,7 @@ from litellm.litellm_core_utils.reasoning_effort_utils import (
 )
 from litellm.llms.anthropic.experimental_pass_through.utils import (
     is_reasoning_auto_summary_enabled,
+    prompt_cache_key_from_user_id,
 )
 from litellm.types.llms.anthropic import (
     AllAnthropicPassThroughMessageValues,
@@ -452,10 +453,13 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             if openai_cm is not None:
                 responses_kwargs["context_management"] = openai_cm
 
-        # metadata user_id -> user
+        # metadata user_id -> user and prompt_cache_key
         metadata: Final = anthropic_request.get("metadata")
         if isinstance(metadata, dict) and "user_id" in metadata:
             responses_kwargs["user"] = str(metadata["user_id"])[:64]
+            prompt_cache_key: Final = prompt_cache_key_from_user_id(metadata["user_id"])
+            if prompt_cache_key is not None:
+                responses_kwargs["prompt_cache_key"] = prompt_cache_key
 
         return responses_kwargs
 

--- a/litellm/llms/anthropic/experimental_pass_through/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/utils.py
@@ -1,7 +1,16 @@
 import os
+from typing import Final
 
 import litellm
 from litellm.types.utils import ModelInfo
+
+OPENAI_MAX_PROMPT_CACHE_KEY_LENGTH: Final = 64
+
+
+def prompt_cache_key_from_user_id(user_id: object) -> str | None:
+    if user_id is None:
+        return None
+    return str(user_id)[:OPENAI_MAX_PROMPT_CACHE_KEY_LENGTH] or None
 
 
 def is_reasoning_auto_summary_enabled() -> bool:

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -917,6 +917,7 @@ class ChatCompletionRequest(TypedDict, total=False):
     seed: int
     service_tier: str
     safety_identifier: str
+    prompt_cache_key: str  # writable-ok: the /v1/messages adapter assigns it after construction
     stop: str | list[str]
     stream_options: dict
     temperature: float

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -4,6 +4,8 @@ from typing import Any, cast
 
 import pytest
 
+import litellm
+
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
 
@@ -684,6 +686,15 @@ def test_translate_anthropic_to_openai_skips_prompt_cache_key_when_provider_lack
     model: str, custom_llm_provider: str
 ):
     openai_request = _translate_with_metadata(model, {"user_id": "session-abc"}, custom_llm_provider)
+    assert openai_request["user"] == "session-abc"
+    assert "prompt_cache_key" not in openai_request
+
+
+def test_translate_anthropic_to_openai_skips_prompt_cache_key_for_chained_litellm_proxy():
+    assert "prompt_cache_key" in litellm.get_supported_openai_params(
+        model="xai", custom_llm_provider="litellm_proxy"
+    )
+    openai_request = _translate_with_metadata("litellm_proxy/xai", {"user_id": "session-abc"}, "litellm_proxy")
     assert openai_request["user"] == "session-abc"
     assert "prompt_cache_key" not in openai_request
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -635,6 +635,85 @@ def test_translate_anthropic_to_openai_orders_top_level_and_midturn_system():
     ]
 
 
+def _translate_with_metadata(
+    model: str, metadata: dict[str, Any], custom_llm_provider: str | None
+) -> dict[str, Any]:
+    openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
+        anthropic_message_request={
+            "model": model,
+            "max_tokens": 100,
+            "metadata": metadata,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+        custom_llm_provider=custom_llm_provider,
+    )
+    return cast(dict[str, Any], openai_request)
+
+
+def test_translate_anthropic_to_openai_maps_user_id_to_prompt_cache_key_for_openai():
+    openai_request = _translate_with_metadata("openai/gpt-5.6-luna", {"user_id": "session-abc"}, "openai")
+    assert openai_request["user"] == "session-abc"
+    assert openai_request["prompt_cache_key"] == "session-abc"
+
+
+def test_translate_anthropic_to_openai_truncates_prompt_cache_key_but_keeps_full_user():
+    long_id = "".join(str(i % 10) for i in range(100))
+    openai_request = _translate_with_metadata("openai/gpt-5.6-luna", {"user_id": long_id}, "openai")
+    assert openai_request["user"] == long_id
+    assert openai_request["prompt_cache_key"] == long_id[:64]
+    assert len(openai_request["prompt_cache_key"]) == 64
+
+
+@pytest.mark.parametrize("model", ["azure/my-gpt-5-deployment", "my-gpt-5-deployment"])
+def test_translate_anthropic_to_openai_sets_prompt_cache_key_for_azure(model: str):
+    openai_request = _translate_with_metadata(model, {"user_id": "session-abc"}, "azure")
+    assert openai_request["prompt_cache_key"] == "session-abc"
+
+
+@pytest.mark.parametrize(
+    "model, custom_llm_provider",
+    [
+        ("gemini/gemini-2.5-pro", "gemini"),
+        ("vertex_ai/gemini-2.5-pro", "vertex_ai"),
+        ("anthropic/claude-sonnet-4-5", "anthropic"),
+        ("bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0", "bedrock"),
+        ("no-such-model-lit5875", "no-such-provider-lit5875"),
+    ],
+)
+def test_translate_anthropic_to_openai_skips_prompt_cache_key_when_provider_lacks_it(
+    model: str, custom_llm_provider: str
+):
+    openai_request = _translate_with_metadata(model, {"user_id": "session-abc"}, custom_llm_provider)
+    assert openai_request["user"] == "session-abc"
+    assert "prompt_cache_key" not in openai_request
+
+
+def test_translate_anthropic_to_openai_skips_prompt_cache_key_without_provider():
+    openai_request = _translate_with_metadata("openai/gpt-5.6-luna", {"user_id": "session-abc"}, None)
+    assert openai_request["user"] == "session-abc"
+    assert "prompt_cache_key" not in openai_request
+
+
+@pytest.mark.parametrize("user_id", ["", None])
+def test_translate_anthropic_to_openai_skips_prompt_cache_key_for_empty_or_null_user_id(user_id: str | None):
+    openai_request = _translate_with_metadata("openai/gpt-5.6-luna", {"user_id": user_id}, "openai")
+    assert openai_request["user"] == user_id
+    assert "prompt_cache_key" not in openai_request
+
+
+def test_translate_anthropic_to_openai_without_metadata_sets_neither_user_nor_prompt_cache_key():
+    openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
+        anthropic_message_request={
+            "model": "openai/gpt-5.6-luna",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+        custom_llm_provider="openai",
+    )
+    assert "user" not in openai_request
+    assert "prompt_cache_key" not in openai_request
+
+
 def test_translate_openai_content_to_anthropic_empty_function_arguments():
     """Test that empty function arguments are handled safely and don't cause JSON parsing errors."""
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_prompt_cache_key.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_prompt_cache_key.py
@@ -1,0 +1,64 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../..")))
+
+from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+    LiteLLMMessagesToCompletionTransformationHandler,
+)
+
+MESSAGES = [{"role": "user", "content": "hello"}]
+
+
+def _prepare(model: str, extra_kwargs: dict[str, object], thinking: dict[str, object] | None = None):
+    completion_kwargs, _ = LiteLLMMessagesToCompletionTransformationHandler._prepare_completion_kwargs(
+        max_tokens=1024,
+        messages=MESSAGES,
+        model=model,
+        metadata={"user_id": "session-abc"},
+        thinking=thinking,
+        extra_kwargs=extra_kwargs,
+    )
+    return completion_kwargs
+
+
+def test_prepare_completion_kwargs_derives_prompt_cache_key_for_openai_provider():
+    completion_kwargs = _prepare("openai/gpt-5.6-luna", {"custom_llm_provider": "openai"})
+    assert completion_kwargs["user"] == "session-abc"
+    assert completion_kwargs["prompt_cache_key"] == "session-abc"
+
+
+def test_prepare_completion_kwargs_prefers_explicit_prompt_cache_key_over_derived():
+    completion_kwargs = _prepare(
+        "openai/gpt-5.6-luna",
+        {"custom_llm_provider": "openai", "prompt_cache_key": "explicit-key"},
+    )
+    assert completion_kwargs["user"] == "session-abc"
+    assert completion_kwargs["prompt_cache_key"] == "explicit-key"
+
+
+@pytest.mark.parametrize(
+    "model, extra_kwargs",
+    [
+        ("gemini/gemini-2.5-pro", {"custom_llm_provider": "gemini"}),
+        ("openai/gpt-5.6-luna", {}),
+    ],
+)
+def test_prepare_completion_kwargs_skips_prompt_cache_key_without_provider_support(
+    model: str, extra_kwargs: dict[str, object]
+):
+    completion_kwargs = _prepare(model, extra_kwargs)
+    assert completion_kwargs["user"] == "session-abc"
+    assert "prompt_cache_key" not in completion_kwargs
+
+
+def test_prepare_completion_kwargs_keeps_prompt_cache_key_through_responses_reroute():
+    completion_kwargs = _prepare(
+        "openai/gpt-5.6-luna",
+        {"custom_llm_provider": "openai"},
+        thinking={"type": "enabled", "budget_tokens": 1024},
+    )
+    assert completion_kwargs["model"] == "responses/openai/gpt-5.6-luna"
+    assert completion_kwargs["prompt_cache_key"] == "session-abc"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_prompt_cache_key.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_prompt_cache_key.py
@@ -54,6 +54,12 @@ def test_prepare_completion_kwargs_skips_prompt_cache_key_without_provider_suppo
     assert "prompt_cache_key" not in completion_kwargs
 
 
+def test_prepare_completion_kwargs_skips_prompt_cache_key_for_chained_litellm_proxy():
+    completion_kwargs = _prepare("litellm_proxy/xai", {"custom_llm_provider": "litellm_proxy"})
+    assert completion_kwargs["user"] == "session-abc"
+    assert "prompt_cache_key" not in completion_kwargs
+
+
 def test_prepare_completion_kwargs_keeps_prompt_cache_key_through_responses_reroute():
     completion_kwargs = _prepare(
         "openai/gpt-5.6-luna",

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../..")))
+
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters.handler import (
+    _build_responses_kwargs,
+)
+
+MESSAGES = [{"role": "user", "content": "hello"}]
+
+
+def test_build_responses_kwargs_derives_prompt_cache_key_from_user_id():
+    responses_kwargs = _build_responses_kwargs(
+        max_tokens=1024,
+        messages=MESSAGES,
+        model="openai/gpt-5.6-luna",
+        metadata={"user_id": "session-abc"},
+        extra_kwargs={"custom_llm_provider": "openai"},
+    )
+    assert responses_kwargs["user"] == "session-abc"
+    assert responses_kwargs["prompt_cache_key"] == "session-abc"
+
+
+def test_build_responses_kwargs_prefers_explicit_prompt_cache_key_over_derived():
+    responses_kwargs = _build_responses_kwargs(
+        max_tokens=1024,
+        messages=MESSAGES,
+        model="openai/gpt-5.6-luna",
+        metadata={"user_id": "session-abc"},
+        extra_kwargs={"custom_llm_provider": "openai", "prompt_cache_key": "explicit-key"},
+    )
+    assert responses_kwargs["user"] == "session-abc"
+    assert responses_kwargs["prompt_cache_key"] == "explicit-key"
+
+
+def test_build_responses_kwargs_without_metadata_sets_no_prompt_cache_key():
+    responses_kwargs = _build_responses_kwargs(
+        max_tokens=1024,
+        messages=MESSAGES,
+        model="openai/gpt-5.6-luna",
+        extra_kwargs={"custom_llm_provider": "openai"},
+    )
+    assert "user" not in responses_kwargs
+    assert "prompt_cache_key" not in responses_kwargs

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -992,6 +992,29 @@ class TestTranslateRequestBroaderCoverage:
         kwargs = _ADAPTER.translate_request(req)
         assert len(kwargs["user"]) == 64
 
+    def test_metadata_user_id_mapped_to_prompt_cache_key(self):
+        req = _make_request(metadata={"user_id": "user-42"})
+        kwargs = _ADAPTER.translate_request(req)
+        assert kwargs["prompt_cache_key"] == "user-42"
+
+    def test_metadata_user_id_prompt_cache_key_truncated_to_first_64_chars(self):
+        long_id = "".join(str(i % 10) for i in range(100))
+        req = _make_request(metadata={"user_id": long_id})
+        kwargs = _ADAPTER.translate_request(req)
+        assert kwargs["prompt_cache_key"] == long_id[:64]
+        assert len(kwargs["prompt_cache_key"]) == 64
+
+    def test_metadata_empty_user_id_sets_no_prompt_cache_key(self):
+        req = _make_request(metadata={"user_id": ""})
+        kwargs = _ADAPTER.translate_request(req)
+        assert kwargs["user"] == ""
+        assert "prompt_cache_key" not in kwargs
+
+    def test_metadata_null_user_id_sets_no_prompt_cache_key(self):
+        req = _make_request(metadata={"user_id": None})
+        kwargs = _ADAPTER.translate_request(req)
+        assert "prompt_cache_key" not in kwargs
+
     def test_no_optional_fields_does_not_add_spurious_keys(self):
         req = _make_request()
         kwargs = _ADAPTER.translate_request(req)
@@ -1005,6 +1028,7 @@ class TestTranslateRequestBroaderCoverage:
             "text",
             "context_management",
             "user",
+            "prompt_cache_key",
         ):
             assert key not in kwargs, f"unexpected key: {key}"
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/messages` maps `metadata.user_id` to OpenAI's `user` but never to `prompt_cache_key`
- OpenAI gets no cache-routing hint from Anthropic-SDK and Claude Code traffic
- Claude Code's 150-char `user_id` is longer than OpenAI's 64-char key limit anyway

How it solves it:

- Both bridges set `prompt_cache_key` to the first 64 chars of `user_id`
- The chat-completions bridge only sets it when the target provider accepts the param
- A `prompt_cache_key` the client sends itself still wins over the derived one
- `litellm_proxy/` deployments are skipped: the downstream proxy's real provider is unknown and rejects the key unless it runs with `drop_params`

## User Flow

Before: the request reaches OpenAI with `user` filled in but no `prompt_cache_key`, so GPT-5.6's cache routing never gets the per-session key the client is already sending

1. The gateway admin adds `openai/gpt-5.6-luna` to the proxy config under `model_name: gpt-5.6-luna` and starts the proxy
2. A developer points Claude Code at the gateway (`ANTHROPIC_BASE_URL=https://litellm-domain`, `ANTHROPIC_AUTH_TOKEN=<virtual key>`, `ANTHROPIC_MODEL=gpt-5.6-luna`) and types a prompt
3. Claude Code sends `POST https://litellm-domain/v1/messages` with `model: gpt-5.6-luna`, its system prompt, the message, and `metadata.user_id` set to its 150-character session identity (`{"device_id":"8c33...","account_uuid":"...","session_id":"..."}`), byte-identical on every turn of the session
4. A `200` comes back in Anthropic shape: `id` starts with `resp_`, the answer text, and `usage.cache_creation_input_tokens` on the first turn
5. The developer opens that call in OpenAI's request log (`https://platform.openai.com/logs`): the request carries `user` set to the first 64 characters of the `user_id` and no `prompt_cache_key` at all; the response object echoes `"prompt_cache_key": null`
6. The admin sees the same thing in the proxy's own `--detailed_debug` output: the `POST Request Sent from LiteLLM` body going to `https://api.openai.com/v1/responses` has `user` and no `prompt_cache_key`
7. With `litellm_settings.use_chat_completions_url_for_anthropic_messages: true`, the same `POST https://litellm-domain/v1/messages` goes out as `POST https://api.openai.com/v1/chat/completions` with `user` set and, again, no `prompt_cache_key`

After: the same request leaves the gateway with `prompt_cache_key` set to the first 64 characters of `metadata.user_id`, and OpenAI echoes it back

1. The gateway admin adds `openai/gpt-5.6-luna` to the proxy config under `model_name: gpt-5.6-luna` and starts the proxy
2. A developer points Claude Code at the gateway (`ANTHROPIC_BASE_URL=https://litellm-domain`, `ANTHROPIC_AUTH_TOKEN=<virtual key>`, `ANTHROPIC_MODEL=gpt-5.6-luna`) and types a prompt
3. Claude Code sends `POST https://litellm-domain/v1/messages` with `model: gpt-5.6-luna`, its system prompt, the message, and `metadata.user_id` set to its 150-character session identity (`{"device_id":"8c33...","account_uuid":"...","session_id":"..."}`), byte-identical on every turn of the session
4. A `200` comes back in Anthropic shape: `id` starts with `resp_`, the answer text, and `usage.cache_creation_input_tokens` on the first turn
5. The developer opens that call in OpenAI's request log (`https://platform.openai.com/logs`): the request carries `user` and `prompt_cache_key`, both set to the same first 64 characters of the `user_id` (`{"device_id":"8c33...`); the response object echoes `"prompt_cache_key": "{\"device_id\":\"8c33..."`
6. The admin sees the same thing in the proxy's own `--detailed_debug` output: the `POST Request Sent from LiteLLM` body going to `https://api.openai.com/v1/responses` has both `user` and `prompt_cache_key`
7. With `litellm_settings.use_chat_completions_url_for_anthropic_messages: true`, the same `POST https://litellm-domain/v1/messages` goes out as `POST https://api.openai.com/v1/chat/completions` with both `user` and `prompt_cache_key` set
8. A client that already sends its own `prompt_cache_key` in the `POST https://litellm-domain/v1/messages` body sees that exact value in the upstream request, not the derived one

## Relevant issues

Fixes #37508

## Linear ticket

Resolves LIT-5875

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live before/after QA, no mocks, real calls to `openai/gpt-5.6-luna`. Before is a proxy booted from the merge base `6fcdea03b0`, After a proxy booted from this PR's tip `8e1c8c1c62`. Each side ran two proxies from its commit on random free ports with `--detailed_debug`: proxy A with the default Responses-API bridge (`config_responses.yaml`), proxy C with the chat-completions bridge (`config_chat.yaml`)

`config_responses.yaml`:

```yaml
model_list:
  - model_name: gpt-5.6-luna
    litellm_params:
      model: openai/gpt-5.6-luna
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

`config_chat.yaml` is the same file plus:

```yaml
litellm_settings:
  use_chat_completions_url_for_anthropic_messages: true
```

Clients: Anthropic Python SDK 0.125.0 pointed at the proxy, OpenAI Python SDK 3.3.1 to retrieve the stored upstream objects the way a developer checks what OpenAI received, Claude Code v2.1.237 driven in tmux. Every case sends a ~2860-token system prompt with a fresh nonce so OpenAI starts cold, then the same `metadata.user_id` on both calls of a pair, 3 s apart. The SDK pair used by cases 1, 2, 4 and 5 (case 2 adds `extra_body={"store": True}` so the completions can be retrieved, case 4 adds `extra_body={"prompt_cache_key": ...}`, case 5 adds `thinking={"type": "enabled", "budget_tokens": 1024}`):

```python
client = anthropic.Anthropic(base_url=f"http://127.0.0.1:{port}", api_key=os.environ["LITELLM_MASTER_KEY"])
for _ in range(2):
    client.messages.create(
        model="gpt-5.6-luna", max_tokens=32, system=SYSTEM_PROMPT,
        messages=[{"role": "user", "content": "Reply with the single word ok."}],
        metadata={"user_id": user_id},
    )
    time.sleep(3)
openai.OpenAI().responses.retrieve(upstream_id)
```

The `id` the Responses bridge returns is a 241-char wrapper around the upstream `resp_` id, which OpenAI's retrieve endpoint rejects (`string_above_max_length`), so the retrievals below use the upstream id decoded out of it. OpenAI's stored chat object (`chat.completions.retrieve`) exposes `input_user` and no `prompt_cache_key` field on either side, so case 2 shows the request body the gateway sent upstream as read from the admin's `--detailed_debug` log (`POST Request Sent from LiteLLM`) plus the raw usage OpenAI returned. Read the cache numbers honestly: `cached_tokens` rose on the second call on both sides because OpenAI also caches by prefix on a quiet account, so what this PR changes is the routing key OpenAI stores with the request, which is what keeps one user's hits together under load

Surprises seen during QA, none of them a failure:

- Bridged Responses `id` is a 241-char wrapper, OpenAI retrieve rejects it. PR leaves it alone
- Gateway `GET /v1/responses/<id>` returns a differently encoded id. PR leaves it alone
- Retrieved objects report `cache_write_tokens` 0, live responses showed thousands. PR leaves it alone
- Chat retrieve exposes `input_user`, no `prompt_cache_key`, null `prompt_tokens_details`. PR leaves it alone
- Case 2 second completion 404s on immediate retrieve, found on retry. PR leaves it alone
- Thinking reroute returns `chatcmpl-<uuid>`, hides upstream `resp_` id. PR leaves it alone
- Thinking reroute logs "Error decoding response_id ... Incorrect padding". PR leaves it alone
- `budget_tokens: 1024` becomes `reasoning.effort: low` upstream. PR leaves it alone
- Claude Code `user` and key cut mid-JSON at 64 chars. PR causes the key half, by design (OpenAI limit)
- Claude Code title side request also carries the key. PR causes it
- Client `store: true` in `extra_body` is forwarded upstream. PR leaves it alone
- OpenAI cached the second call even without a key. PR leaves it alone
- Chat-path debug curl block prints only `https://api.openai.com/v1/`. PR leaves it alone
- One-model config, yet `/v1/models` lists 35 (DB-stored models). PR leaves it alone
- Proxy re-reads the worktree `.env`, `DATABASE_URL` survives `env -u`. PR leaves it alone

### Before (6fcdea03b0)

#### Case 1: Anthropic SDK, Responses-API bridge (proxy A)

1. Run the SDK pair against proxy A (port 32698) with `user_id = lit5875-qa-before-2a635bbf-e707-4a3f-8d39-56e5641ee726`, then retrieve both upstream ids with the OpenAI SDK and the second bridged id through the gateway itself
2. Observed:

```
### openai.responses.retrieve('resp_00afb75bc2b408db006a86e8245d2887d0a0e0b69fcfdf1a88')
"user": "lit5875-qa-before-2a635bbf-e707-4a3f-8d39-56e5641ee726"
"prompt_cache_key": null
"usage.input_tokens": 2864
"usage.input_tokens_details.cached_tokens": 0
### openai.responses.retrieve('resp_0692d2d40fe1c329006a86e828618c819b9614357123fab4e2')
"user": "lit5875-qa-before-2a635bbf-e707-4a3f-8d39-56e5641ee726"
"prompt_cache_key": null
"usage.input_tokens": 2864
"usage.input_tokens_details.cached_tokens": 2861
### GET http://127.0.0.1:32698/v1/responses/<bridged id>  (Authorization: Bearer <master key>)
HTTP 200
"user": "lit5875-qa-before-2a635bbf-e707-4a3f-8d39-56e5641ee726"
"prompt_cache_key": null
"usage.input_tokens_details.cached_tokens": 2861
```

3. The bridged Anthropic responses report `usage.cache_creation_input_tokens: 2861` on call 1 and `usage.cache_read_input_tokens: 2861` on call 2 (OpenAI caches by prefix even without a key)

#### Case 2: Anthropic SDK, chat-completions bridge (proxy C)

1. Run the SDK pair against proxy C (port 52572) with `user_id = lit5875-qa-before-7b40ece8-d047-40f8-9ea2-3868fa0837b2` and `extra_body={"store": True}`, then read the two `POST Request Sent from LiteLLM` bodies and the raw usage from the proxy's `--detailed_debug` log
2. Observed:

```
[outbound 1] keys=['max_completion_tokens', 'messages', 'model', 'store', 'user']
             user='lit5875-qa-before-7b40ece8-d047-40f8-9ea2-3868fa0837b2' prompt_cache_key=<absent>
[outbound 2] keys=['max_completion_tokens', 'messages', 'model', 'store', 'user']
             user='lit5875-qa-before-7b40ece8-d047-40f8-9ea2-3868fa0837b2' prompt_cache_key=<absent>
chatcmpl-EEvSEhQFCjWH4THQelIEI47KC5F5y  prompt_tokens 2864  prompt_tokens_details {"cached_tokens": 0, "cache_write_tokens": 2861}
chatcmpl-EEvSIkhqqE92PUqhvU2aziV9FsIXc  prompt_tokens 2864  prompt_tokens_details {"cached_tokens": 2861, "cache_write_tokens": 0}
```

#### Case 3: Claude Code against proxy A

1. Launch Claude Code in tmux with a fresh config dir and cwd, `ANTHROPIC_BASE_URL=http://127.0.0.1:32698`, `ANTHROPIC_AUTH_TOKEN=<master key>`, `ANTHROPIC_MODEL=gpt-5.6-luna`, send `Reply with the single word ok.` then `Now reply with the word again.`, then retrieve the two prompt requests' upstream ids (the title side request is omitted)
2. Observed in the pane:

```
❯ Reply with the single word ok.
⏺ ok
❯ Now reply with the word again.
⏺ again
```

3. Observed on retrieve (`user` is the first 64 chars of the 150-char `user_id`, no key):

```
resp_06ba3dc35262ae3d006a86e8e3661c87d0b1e1e0fe6a137516  user: {"device_id":"14ff65a7dbdf2c27d8cbe71d1202b24bc0263838ea205ee6d1  prompt_cache_key: null  input_tokens 21027  cached_tokens 0
resp_0fba1f46c67c5fa9006a86e8f8f16487d09aee22bb320063ab  user: {"device_id":"14ff65a7dbdf2c27d8cbe71d1202b24bc0263838ea205ee6d1  prompt_cache_key: null  input_tokens 21062  cached_tokens 19376
```

#### Case 4: explicit key wins (proxy A)

1. Run one SDK call against proxy A with `metadata={"user_id": user_id}` and `extra_body={"prompt_cache_key": "explicit-lit5875-qa2-before"}`, then retrieve the upstream id
2. Observed (unchanged by this PR, the explicit key already passed through):

```
resp_062b189ab3605d50006a86e9231b00819891f18277fbabc54c  user: lit5875-qa-before-2c89a0e2-c655-4cc0-bbbf-a56b4a9fce3e  prompt_cache_key: "explicit-lit5875-qa2-before"
```

#### Case 5: chat bridge with thinking enabled (proxy C)

1. Run one SDK call against proxy C with `metadata={"user_id": user_id}` and `thinking={"type": "enabled", "budget_tokens": 1024}` (the chat bridge reroutes this to `/v1/responses`), then retrieve the upstream id
2. Observed:

```
resp_01ba7eed2c31a209006a86e8c78dac87d0ab9fcf5151f0f877  user: lit5875-qa-before-9ed3962b-9bdc-4d9c-9573-34694c1c56f6  prompt_cache_key: null  reasoning: present
```

### After (8e1c8c1c62b965e14a06492c34ec44f2f062e382)

#### Case 1: Anthropic SDK, Responses-API bridge (proxy A)

1. Run the SDK pair against proxy A (port 35912) with `user_id = lit5875-qa-after-90a0a703-2528-46f9-ab3e-811ba4c5fd9c`, then retrieve both upstream ids with the OpenAI SDK and the second bridged id through the gateway itself
2. Observed:

```
### openai.responses.retrieve('resp_0c833379cda56c2d006a86e810ff58819b9bb041cc86da9657')
"user": "lit5875-qa-after-90a0a703-2528-46f9-ab3e-811ba4c5fd9c"
"prompt_cache_key": "lit5875-qa-after-90a0a703-2528-46f9-ab3e-811ba4c5fd9c"
"usage.input_tokens": 2866
"usage.input_tokens_details.cached_tokens": 0
### openai.responses.retrieve('resp_02beb47bc7e2158a006a86e814f0a481989e67f832b37c5d19')
"user": "lit5875-qa-after-90a0a703-2528-46f9-ab3e-811ba4c5fd9c"
"prompt_cache_key": "lit5875-qa-after-90a0a703-2528-46f9-ab3e-811ba4c5fd9c"
"usage.input_tokens": 2866
"usage.input_tokens_details.cached_tokens": 2863
### GET http://127.0.0.1:35912/v1/responses/<bridged id>  (Authorization: Bearer <master key>)
HTTP 200
"user": "lit5875-qa-after-90a0a703-2528-46f9-ab3e-811ba4c5fd9c"
"prompt_cache_key": "lit5875-qa-after-90a0a703-2528-46f9-ab3e-811ba4c5fd9c"
"usage.input_tokens_details.cached_tokens": 2863
```

3. The bridged Anthropic responses report `usage.cache_creation_input_tokens: 2863` on call 1 and `usage.cache_read_input_tokens: 2863` on call 2

#### Case 2: Anthropic SDK, chat-completions bridge (proxy C)

1. Run the SDK pair against proxy C (port 25467) with `user_id = lit5875-qa-after-a95c5d9f-b481-410f-8a7b-ff7a571f533c` and `extra_body={"store": True}`, then read the two `POST Request Sent from LiteLLM` bodies and the raw usage from the proxy's `--detailed_debug` log
2. Observed:

```
[outbound 1] keys=['max_completion_tokens', 'messages', 'model', 'prompt_cache_key', 'store', 'user']
             user='lit5875-qa-after-a95c5d9f-b481-410f-8a7b-ff7a571f533c' prompt_cache_key='lit5875-qa-after-a95c5d9f-b481-410f-8a7b-ff7a571f533c'
[outbound 2] keys=['max_completion_tokens', 'messages', 'model', 'prompt_cache_key', 'store', 'user']
             user='lit5875-qa-after-a95c5d9f-b481-410f-8a7b-ff7a571f533c' prompt_cache_key='lit5875-qa-after-a95c5d9f-b481-410f-8a7b-ff7a571f533c'
chatcmpl-EEvRwUA5kYw3g5i9XeoAFkyzrcC5O  prompt_tokens 2862  prompt_tokens_details {"cached_tokens": 0, "cache_write_tokens": 2859}
chatcmpl-EEvS06rNPrAhuOhb8LkPX1EnW6k6y  prompt_tokens 2862  prompt_tokens_details {"cached_tokens": 2859, "cache_write_tokens": 0}
```

#### Case 3: Claude Code against proxy A

1. Launch Claude Code in tmux with a fresh config dir and cwd, `ANTHROPIC_BASE_URL=http://127.0.0.1:35912`, `ANTHROPIC_AUTH_TOKEN=<master key>`, `ANTHROPIC_MODEL=gpt-5.6-luna`, send `Reply with the single word ok.` then `Now reply with the word again.`, then retrieve the two prompt requests' upstream ids (the title side request is omitted)
2. Observed in the pane:

```
❯ Reply with the single word ok.
⏺ ok
❯ Now reply with the word again.
⏺ again
```

3. Observed on retrieve (`user` and `prompt_cache_key` are both the first 64 chars of the 150-char `user_id`):

```
resp_05dc7e3993afed48006a86e86043f48199b8244f201a934b00  user: {"device_id":"c146cfa1f87b4ec714fcce3646878f7c2d01c6b7a64ed00d21  prompt_cache_key: {"device_id":"c146cfa1f87b4ec714fcce3646878f7c2d01c6b7a64ed00d21  input_tokens 21027  cached_tokens 0
resp_093be5234b7b1521006a86e86e3cf0819aa270530c458286a2  user: {"device_id":"c146cfa1f87b4ec714fcce3646878f7c2d01c6b7a64ed00d21  prompt_cache_key: {"device_id":"c146cfa1f87b4ec714fcce3646878f7c2d01c6b7a64ed00d21  input_tokens 21062  cached_tokens 19376
```

#### Case 4: explicit key wins (proxy A)

1. Run one SDK call against proxy A with `metadata={"user_id": user_id}` and `extra_body={"prompt_cache_key": "explicit-lit5875-after"}`, then retrieve the upstream id
2. Observed:

```
resp_00e9ad99e39fcee6006a86e88ed0a887d08e50abf850ba1e41  user: lit5875-qa-after-13ef6437-cb4d-49f1-b01a-57d52a4fe8ac  prompt_cache_key: "explicit-lit5875-after"
```

#### Case 5: chat bridge with thinking enabled (proxy C)

1. Run one SDK call against proxy C with `metadata={"user_id": user_id}` and `thinking={"type": "enabled", "budget_tokens": 1024}` (the chat bridge reroutes this to `/v1/responses`), then retrieve the upstream id
2. Observed:

```
resp_04785407f76d7fb2006a86e83e38608198a1fe654829824360  user: lit5875-qa-after-ca6b3fe5-0db9-401f-ba0e-9acfc1cb8c19  prompt_cache_key: lit5875-qa-after-ca6b3fe5-0db9-401f-ba0e-9acfc1cb8c19  reasoning: present
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Every provider advertising `prompt_cache_key` (azure, groq, deepseek, openrouter, vllm, ...) now gets it implicitly on `/v1/messages`, and there is no config switch to turn the derivation off
- A LiteLLM proxy chained in front of OpenAI through `litellm_proxy/` gets no derived key
- Claude Code's key ends up per device: its `session_id` falls past the 64-char cut
- Guardrail and shadow-eval translations never derive the key, since they run without a provider

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cc2013e9660ab722fab9f8097497a121336a034f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] 8e1c8c1c62b965e14a06492c34ec44f2f062e382 passes /live-pr-risk
