### PR TITLE
fix(mcp): pass user auth into prompt and resource clients

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3943,6 +3943,7 @@ class MCPServerManager:
         extra_headers: dict[str, str] | None = None,
         add_prefix: bool = True,
         raw_headers: dict[str, str] | None = None,
+        user_api_key_auth: UserAPIKeyAuth | None = None,
     ) -> list[Prompt]:
         """
         Helper method to get prompts from a single MCP server with prefixed names.
@@ -3975,6 +3976,7 @@ class MCPServerManager:
                 extra_headers=extra_headers,
                 stdio_env=stdio_env,
                 subject_token=subject_token,
+                user_api_key_auth=user_api_key_auth,
             )
 
             prompts: Final = await client.list_prompts()
@@ -3994,6 +3996,7 @@ class MCPServerManager:
         extra_headers: dict[str, str] | None = None,
         add_prefix: bool = True,
         raw_headers: dict[str, str] | None = None,
+        user_api_key_auth: UserAPIKeyAuth | None = None,
     ) -> list[Resource]:
         """Fetch available resources from a single MCP server."""
 
@@ -4017,6 +4020,7 @@ class MCPServerManager:
                 extra_headers=extra_headers,
                 stdio_env=stdio_env,
                 subject_token=subject_token,
+                user_api_key_auth=user_api_key_auth,
             )
 
             resources: Final = await client.list_resources()
@@ -4036,6 +4040,7 @@ class MCPServerManager:
         extra_headers: dict[str, str] | None = None,
         add_prefix: bool = True,
         raw_headers: dict[str, str] | None = None,
+        user_api_key_auth: UserAPIKeyAuth | None = None,
     ) -> list[ResourceTemplate]:
         """Fetch available resource templates from a single MCP server."""
 
@@ -4059,6 +4064,7 @@ class MCPServerManager:
                 extra_headers=extra_headers,
                 stdio_env=stdio_env,
                 subject_token=subject_token,
+                user_api_key_auth=user_api_key_auth,
             )
 
             resource_templates: Final = await client.list_resource_templates()
@@ -4080,6 +4086,7 @@ class MCPServerManager:
         mcp_auth_header: str | dict[str, str] | None = None,
         extra_headers: dict[str, str] | None = None,
         raw_headers: dict[str, str] | None = None,
+        user_api_key_auth: UserAPIKeyAuth | None = None,
     ) -> ReadResourceResult:
         """Read resource contents from a specific MCP server."""
 
@@ -4100,6 +4107,7 @@ class MCPServerManager:
             extra_headers=extra_headers,
             stdio_env=stdio_env,
             subject_token=subject_token,
+            user_api_key_auth=user_api_key_auth,
         )
 
         return await client.read_resource(url)
@@ -4112,6 +4120,7 @@ class MCPServerManager:
         mcp_auth_header: str | dict[str, str] | None = None,
         extra_headers: dict[str, str] | None = None,
         raw_headers: dict[str, str] | None = None,
+        user_api_key_auth: UserAPIKeyAuth | None = None,
     ) -> GetPromptResult:
         """Fetch a specific prompt definition from a single MCP server."""
 
@@ -4132,6 +4141,7 @@ class MCPServerManager:
             extra_headers=extra_headers,
             stdio_env=stdio_env,
             subject_token=subject_token,
+            user_api_key_auth=user_api_key_auth,
         )
 
         get_prompt_request_params: Final = GetPromptRequestParams(

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2181,6 +2181,7 @@ if MCP_AVAILABLE:
                     extra_headers=extra_headers,
                     add_prefix=True,  # Always add server prefix
                     raw_headers=raw_headers,
+                    user_api_key_auth=user_api_key_auth,
                 )
 
                 all_prompts.extend(prompts)
@@ -2234,6 +2235,7 @@ if MCP_AVAILABLE:
                     extra_headers=extra_headers,
                     add_prefix=True,  # Always add server prefix
                     raw_headers=raw_headers,
+                    user_api_key_auth=user_api_key_auth,
                 )
                 all_resources.extend(resources)
 
@@ -2285,6 +2287,7 @@ if MCP_AVAILABLE:
                     extra_headers=extra_headers,
                     add_prefix=True,  # Always add server prefix
                     raw_headers=raw_headers,
+                    user_api_key_auth=user_api_key_auth,
                 )
                 all_resource_templates.extend(resource_templates)
                 verbose_logger.debug(
@@ -3204,6 +3207,7 @@ if MCP_AVAILABLE:
             mcp_auth_header=server_auth_header,
             extra_headers=extra_headers,
             raw_headers=raw_headers,
+            user_api_key_auth=user_api_key_auth,
         )
 
     async def mcp_read_resource(
@@ -3253,6 +3257,7 @@ if MCP_AVAILABLE:
             mcp_auth_header=server_auth_header,
             extra_headers=extra_headers,
             raw_headers=raw_headers,
+            user_api_key_auth=user_api_key_auth,
         )
 
     def _get_standard_logging_mcp_tool_call(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -918,6 +918,7 @@ async def test_mcp_get_prompt_success():
         mcp_auth_header={"Authorization": "token"},
         extra_headers={"X-Test": "1"},
         raw_headers=None,
+        user_api_key_auth=user_api_key_auth,
     )
     assert result is prompt_result
 
@@ -979,8 +980,58 @@ async def test_mcp_read_resource_success():
         mcp_auth_header={"Authorization": "token"},
         extra_headers={"X-Test": "1"},
         raw_headers=None,
+        user_api_key_auth=user_api_key_auth,
     )
     assert result is read_result
+
+
+@pytest.mark.asyncio
+async def test_prompt_and_resource_manager_paths_pass_user_api_key_auth():
+    """Regression for GitHub #37497: prompt/resource clients get the same auth context as tools."""
+    try:
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    from pydantic import AnyUrl
+
+    manager = MCPServerManager()
+    server = MCPServer(
+        server_id="protected-mcp",
+        name="protected-mcp",
+        server_name="protected-mcp",
+        url="https://mcp.example.com/mcp",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        oauth2_flow="authorization_code",
+    )
+    sentinel = UserAPIKeyAuth(api_key="sk-test", user_id="user-1")
+
+    mock_client = MagicMock()
+    mock_client.list_prompts = AsyncMock(return_value=[])
+    mock_client.list_resources = AsyncMock(return_value=[])
+    mock_client.list_resource_templates = AsyncMock(return_value=[])
+    mock_client.get_prompt = AsyncMock(return_value=MagicMock())
+    mock_client.read_resource = AsyncMock(return_value=MagicMock())
+
+    with patch.object(
+        manager, "_create_mcp_client", new=AsyncMock(return_value=mock_client)
+    ) as create_mock:
+        await manager.get_prompts_from_server(server=server, user_api_key_auth=sentinel)
+        await manager.get_resources_from_server(server=server, user_api_key_auth=sentinel)
+        await manager.get_resource_templates_from_server(server=server, user_api_key_auth=sentinel)
+        await manager.get_prompt_from_server(server=server, prompt_name="hello", user_api_key_auth=sentinel)
+        await manager.read_resource_from_server(
+            server=server,
+            url=AnyUrl("https://example.com/r"),
+            user_api_key_auth=sentinel,
+        )
+
+    assert create_mock.await_count == 5
+    for call in create_mock.await_args_list:
+        assert call.kwargs["user_api_key_auth"] is sentinel
 
 
 def test_normalize_resource_contents_passes_metadata():


### PR DESCRIPTION
## TLDR

Problem this solves:

- after OAuth authorization code, `tools/list` and `tools/call` succeed
- `prompts/list` and `resources/list` hit the upstream with no per-user credential and return 401
- `prompts/get`, `resources/read`, and `resources/templates/list` share that same client-construction path

How it solves it:

- prompt and resource manager methods take the same `user_api_key_auth` that tools already pass
- that identity is forwarded into `_create_mcp_client` on every prompt/resource call
- auth stays an explicit argument, not a hidden global lookup

## User Flow

Before: a user who finished MCP OAuth can list tools but cannot list prompts or resources on the same server

1. They complete OAuth authorization code for a protected MCP server
2. They call `tools/list` and `tools/call` and both succeed
3. They call `prompts/list` and the upstream returns 401
4. They call `resources/list` and the upstream returns 401

After: the same OAuth session works for tools, prompts, and resources

1. They complete the same OAuth authorization code
2. `tools/list` and `tools/call` still succeed
3. `prompts/list` and `prompts/get` succeed with the same per-user credential
4. `resources/list`, `resources/read`, and `resources/templates/list` succeed as well

Another user still cannot use this user's stored OAuth token, because the credential is resolved from the request's auth context rather than a process-wide default

## Relevant issues

Fixes #37497

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is auth-context propagation. A live OAuth server is not required to show the missing argument; the manager now always passes the same sentinel into `_create_mcp_client`

### Before (6d47468)

1. Call `prompts/list` / `resources/list` after a successful `tools/list` on an OAuth MCP server
2. Observed: tools return 200, prompts and resources return upstream 401 because the client was built without the per-user credential

### After (e0473fa)

1. Mock `_create_mcp_client` and call `get_prompts_from_server`, `get_resources_from_server`, `get_resource_templates_from_server`, `get_prompt_from_server`, and `read_resource_from_server` with the same `UserAPIKeyAuth` sentinel
2. Observed: all 5 calls pass `user_api_key_auth is sentinel`

Local tests: `uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py::test_prompt_and_resource_manager_paths_pass_user_api_key_auth tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py::test_mcp_get_prompt_success tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py::test_mcp_read_resource_success -v` → 3 passed

## Type

🐛 Bug Fix

## Caveats (if any)

- Auth context is passed explicitly on each call on purpose, so it stays auditable
- I will sign the CLA if the bot asks

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Made with [Cursor](https://cursor.com)