### PR TITLE
fix(chatgpt): forward prompt cache key

### DIFF
--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -100,6 +100,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             "tools",
             "tool_choice",
             "reasoning",
+            "prompt_cache_key",
             "previous_response_id",
             "truncation",
         }

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -101,6 +101,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             "tool_choice",
             "reasoning",
             "prompt_cache_key",
+            "context_management",
             "previous_response_id",
             "truncation",
         }

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -101,7 +101,6 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             "tool_choice",
             "reasoning",
             "prompt_cache_key",
-            "context_management",
             "previous_response_id",
             "truncation",
         }

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -121,14 +121,12 @@ class TestChatGPTResponsesAPITransformation:
                 "user": "user_123",
                 "temperature": 0.2,
                 "top_p": 0.9,
-                "context_management": [
-                    {"type": "compaction", "compact_threshold": 200000}
-                ],
                 "metadata": {"foo": "bar"},
                 "max_output_tokens": 123,
                 "stream_options": {"include_usage": True},
                 # supported and should be preserved
                 "prompt_cache_key": "session_123",
+                "context_management": [{"type": "compaction", "compact_threshold": 200000}],
                 "truncation": "auto",
                 "previous_response_id": "resp_123",
                 "reasoning": {"effort": "medium"},
@@ -142,12 +140,14 @@ class TestChatGPTResponsesAPITransformation:
         assert "user" not in request
         assert "temperature" not in request
         assert "top_p" not in request
-        assert "context_management" not in request
         assert "metadata" not in request
         assert "max_output_tokens" not in request
         assert "stream_options" not in request
 
         assert request["prompt_cache_key"] == "session_123"
+        assert request["context_management"] == [
+            {"type": "compaction", "compact_threshold": 200000}
+        ]
         assert request["truncation"] == "auto"
         assert request["previous_response_id"] == "resp_123"
         assert request["reasoning"] == {"effort": "medium"}

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -128,6 +128,7 @@ class TestChatGPTResponsesAPITransformation:
                 "max_output_tokens": 123,
                 "stream_options": {"include_usage": True},
                 # supported and should be preserved
+                "prompt_cache_key": "session_123",
                 "truncation": "auto",
                 "previous_response_id": "resp_123",
                 "reasoning": {"effort": "medium"},
@@ -146,6 +147,7 @@ class TestChatGPTResponsesAPITransformation:
         assert "max_output_tokens" not in request
         assert "stream_options" not in request
 
+        assert request["prompt_cache_key"] == "session_123"
         assert request["truncation"] == "auto"
         assert request["previous_response_id"] == "resp_123"
         assert request["reasoning"] == {"effort": "medium"}

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -121,12 +121,14 @@ class TestChatGPTResponsesAPITransformation:
                 "user": "user_123",
                 "temperature": 0.2,
                 "top_p": 0.9,
+                "context_management": [
+                    {"type": "compaction", "compact_threshold": 200000}
+                ],
                 "metadata": {"foo": "bar"},
                 "max_output_tokens": 123,
                 "stream_options": {"include_usage": True},
                 # supported and should be preserved
                 "prompt_cache_key": "session_123",
-                "context_management": [{"type": "compaction", "compact_threshold": 200000}],
                 "truncation": "auto",
                 "previous_response_id": "resp_123",
                 "reasoning": {"effort": "medium"},
@@ -140,14 +142,12 @@ class TestChatGPTResponsesAPITransformation:
         assert "user" not in request
         assert "temperature" not in request
         assert "top_p" not in request
+        assert "context_management" not in request
         assert "metadata" not in request
         assert "max_output_tokens" not in request
         assert "stream_options" not in request
 
         assert request["prompt_cache_key"] == "session_123"
-        assert request["context_management"] == [
-            {"type": "compaction", "compact_threshold": 200000}
-        ]
         assert request["truncation"] == "auto"
         assert request["previous_response_id"] == "resp_123"
         assert request["reasoning"] == {"effort": "medium"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- ChatGPT Responses requests silently drop `prompt_cache_key`
- Session-scoped prompt caching cannot reach ChatGPT Codex

How it solves it:

- Forward `prompt_cache_key` through the ChatGPT provider allowlist
- Retain filtering of unsupported `context_management`

## User Flow

Before: a developer sends a ChatGPT Responses request with a cache key, but the backend never receives it

1. They send POST `https://litellm-domain/v1/responses` with model `chatgpt/gpt-5.6-sol` and `"prompt_cache_key": "session_123"`
2. LiteLLM forwards a ChatGPT Codex request without `prompt_cache_key`
3. The request cannot use the caller's intended prompt-cache scope

After: the same request forwards the caller's cache key

1. They send the same POST `https://litellm-domain/v1/responses` with `"prompt_cache_key": "session_123"`
2. LiteLLM forwards the ChatGPT Codex request with `prompt_cache_key` unchanged
3. The backend receives the caller's intended prompt-cache scope

## Relevant issues

- Related to #21193 and #21209
- Restores the field previously included by unmerged #24983
- Complements #35720 and #37623
- Does not forward `context_management`; live subscription proof was unavailable

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

### Before (6d47468daeac7ce630c7185f5fed59d02578562e)

1. Run `uv run pytest tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py::TestChatGPTResponsesAPITransformation::test_chatgpt_drops_unsupported_responses_params -q -o 'addopts='` after asserting `prompt_cache_key` is preserved.
2. Result: 2 failures, both `KeyError: 'prompt_cache_key'`.

### After (025438cffdabf00c67eb2f5b8d94bda3629ca378)

1. Run `uv run pytest tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py -q -o 'addopts='`.
2. Result: 19 passed, 1 existing dependency warning.
3. Run `uv run pytest tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py -q -o 'addopts='`.
4. Result: 63 passed, 2 existing warnings.

## Type

🐛 Bug Fix

## Caveats (if any)

- GPT-5.6 Sol/Luna/Terra context-management probes received identical 401 responses
- The stored ChatGPT subscription tokens were expired and refresh was unauthorized
- Keep `context_management` filtered pending authenticated backend acceptance proof
- Codex's documented `/responses/compact` path remains the likely compaction integration

### Final Attestation

- [x] The test covers allowlist preservation while retaining existing unsupported-field filtering
