### PR TITLE
fix(vertex_ai): stop dropping conversation history on agent engine

### DIFF
--- a/litellm/llms/vertex_ai/agent_engine/transformation.py
+++ b/litellm/llms/vertex_ai/agent_engine/transformation.py
@@ -10,6 +10,7 @@ API Reference:
 """
 
 import json
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Final, Optional, Union, cast
 
 import httpx
@@ -174,6 +175,13 @@ class VertexAgentEngineConfig(BaseConfig, VertexBase):
         """Get session ID if provided."""
         return optional_params.get("session_id")
 
+    def _build_prompt(self, messages: Sequence[AllMessageValues], session_id: str | None) -> str:
+        """A session holds the history server side; without one it has nowhere to live but the prompt."""
+        if session_id or len(messages) == 1:
+            return convert_content_list_to_str(messages[-1])
+
+        return "\n\n".join(f"{message.get('role')}: {convert_content_list_to_str(message)}" for message in messages)
+
     def transform_request(
         self,
         model: str,
@@ -195,12 +203,9 @@ class VertexAgentEngineConfig(BaseConfig, VertexBase):
             }
         }
         """
-        # Use the last message content as the prompt
-        prompt: Final = convert_content_list_to_str(messages[-1])
-
-        # Get user_id and session_id
         user_id: Final = self._get_user_id(optional_params)
         session_id: Final = self._get_session_id(optional_params)
+        prompt: Final = self._build_prompt(messages, session_id)
 
         # Build the input
         input_data: Final[dict[str, Any]] = {

--- a/tests/test_litellm/llms/vertex_ai/agent_engine/test_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/agent_engine/test_transformation.py
@@ -1,19 +1,27 @@
-from litellm.llms.vertex_ai.agent_engine.transformation import VertexAgentEngineConfig
+from collections.abc import Mapping, Sequence
+from typing import Any
 
-MULTI_TURN = [
+from litellm.llms.vertex_ai.agent_engine.transformation import VertexAgentEngineConfig
+from litellm.types.llms.openai import AllMessageValues
+
+MULTI_TURN: Sequence[AllMessageValues] = [
     {"role": "user", "content": "Remember the number 42"},
     {"role": "assistant", "content": "Noted."},
     {"role": "user", "content": "Which number?"},
 ]
 
 
-def _transform(messages, optional_params=None, litellm_params=None) -> dict:
+def _transform(
+    messages: Sequence[AllMessageValues],
+    optional_params: Mapping[str, Any] | None = None,
+    litellm_params: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     config = VertexAgentEngineConfig()
     return config.transform_request(
         model="agent_engine/123456789",
-        messages=messages,
-        optional_params=optional_params if optional_params is not None else {"user_id": "u1"},
-        litellm_params=litellm_params if litellm_params is not None else {},
+        messages=list(messages),
+        optional_params=dict(optional_params) if optional_params is not None else {"user_id": "u1"},
+        litellm_params=dict(litellm_params) if litellm_params is not None else {},
         headers={},
     )
 
@@ -38,7 +46,7 @@ class TestPromptWithoutSession:
         assert message == "Hello"
 
     def test_list_content_is_flattened(self):
-        messages = [
+        messages: Sequence[AllMessageValues] = [
             {"role": "user", "content": [{"type": "text", "text": "first"}]},
             {"role": "user", "content": [{"type": "text", "text": "second"}]},
         ]

--- a/tests/test_litellm/llms/vertex_ai/agent_engine/test_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/agent_engine/test_transformation.py
@@ -1,0 +1,70 @@
+from litellm.llms.vertex_ai.agent_engine.transformation import VertexAgentEngineConfig
+
+MULTI_TURN = [
+    {"role": "user", "content": "Remember the number 42"},
+    {"role": "assistant", "content": "Noted."},
+    {"role": "user", "content": "Which number?"},
+]
+
+
+def _transform(messages, optional_params=None, litellm_params=None) -> dict:
+    config = VertexAgentEngineConfig()
+    return config.transform_request(
+        model="agent_engine/123456789",
+        messages=messages,
+        optional_params=optional_params if optional_params is not None else {"user_id": "u1"},
+        litellm_params=litellm_params if litellm_params is not None else {},
+        headers={},
+    )
+
+
+class TestPromptWithoutSession:
+    def test_history_travels_in_the_prompt(self):
+        message = _transform(MULTI_TURN)["input"]["message"]
+
+        assert "Remember the number 42" in message
+        assert "Noted." in message
+        assert "Which number?" in message
+
+    def test_roles_are_labelled_so_turns_stay_distinguishable(self):
+        message = _transform(MULTI_TURN)["input"]["message"]
+
+        assert message.startswith("user: Remember the number 42")
+        assert "assistant: Noted." in message
+
+    def test_a_single_message_is_sent_verbatim(self):
+        message = _transform([{"role": "user", "content": "Hello"}])["input"]["message"]
+
+        assert message == "Hello"
+
+    def test_list_content_is_flattened(self):
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "first"}]},
+            {"role": "user", "content": [{"type": "text", "text": "second"}]},
+        ]
+
+        message = _transform(messages)["input"]["message"]
+
+        assert message == "user: first\n\nuser: second"
+
+
+class TestPromptWithSession:
+    def test_only_the_new_message_is_sent(self):
+        result = _transform(MULTI_TURN, optional_params={"user_id": "u1", "session_id": "s-1"})
+
+        assert result["input"]["message"] == "Which number?"
+        assert result["input"]["session_id"] == "s-1"
+
+
+class TestSessionResolution:
+    def test_no_session_key_is_sent_when_none_is_given(self):
+        assert "session_id" not in _transform(MULTI_TURN)["input"]
+
+    def test_the_proxy_session_does_not_become_an_agent_session(self):
+        """An Agent Engine session is keyed by user too, and `_get_user_id` invents a new
+        one per request, so adopting the proxy's session would send only the newest message
+        to a session that can never be found again."""
+        result = _transform(MULTI_TURN, litellm_params={"litellm_session_id": "s-proxy"})
+
+        assert "session_id" not in result["input"]
+        assert "Remember the number 42" in result["input"]["message"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Only the last message ever reaches the agent
- Every turn starts with no conversation context

How it solves it:

- Flatten the whole message list when there is no session
- Send only the new message when the caller supplies one

## User Flow

Before: a developer chatting with a Vertex AI Agent Engine deployment finds the agent remembers nothing they said

1. They send POST https://litellm-domain/v1/chat/completions with `model: vertex_ai/agent_engine/<id>` and one user message naming their internal project, and get an acknowledgement back
2. They send the same POST again with all three messages, the two above plus "What is my internal project called?"
3. The reply does not name the project, because the two earlier messages were dropped and only the last question was forwarded

After: the same conversation carries its own context

1. They send the same first POST and get the same acknowledgement
2. They send the same three-message POST
3. The reply names the project, because the earlier turns now travel with the request

## Relevant issues

None open for this specific behaviour. Related report against the same provider: #19121

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5**

## Screenshots / Proof of Fix

A note on the setup, so it is not overstated. The provider needs a real reasoning engine on Vertex AI, which I have access to, and a proxy instance a reviewer could reach, which I do not. So each commit builds the request body it would send, and both bodies then go to a deployed Agent Engine agent in `europe-west1` as real unmocked calls. What differs between the two runs is only the body the provider produced.

Shared setup, the same three-message conversation on both sides:

```python
messages = [
    {"role": "user", "content": "My internal project is called QUARTZ-BADGER-7731."},
    {"role": "assistant", "content": "Understood."},
    {"role": "user", "content": "What is my internal project called?"},
]
```

The token is deliberately one the model cannot produce on its own, so an answer naming it can only have come from the conversation

### Before (5290150a05)

1. The merge base builds this body:

```json
{"class_method": "stream_query",
 "input": {"message": "What is my internal project called?",
           "user_id": "pf-user"}}
```

2. Send it to the deployment:

```
$ curl -sN -X POST -H "Authorization: Bearer $(gcloud auth print-access-token)" \
    -H "Content-Type: application/json" \
    ".../reasoningEngines/<id>:streamQuery?alt=sse" -d @before.json
HTTP 200

Here is a proposed research plan to identify your internal project name:
* [RESEARCH] Investigate contextual workspace metadata, configuration files,
  and repository manifests to detect explicit internal project identifiers
  or codenames.
* [RESEARCH] Analyze version control history, branch names, and commit
  messages for references to project aliases or development tags.
  ...
```

3. The agent cannot name the project. The first two messages never left the gateway

### After (4b8c94a0eb)

1. The PR tip builds this body:

```json
{"class_method": "stream_query",
 "input": {"message": "user: My internal project is called QUARTZ-BADGER-7731.\n\nassistant: Understood.\n\nuser: What is my internal project called?",
           "user_id": "pf-user"}}
```

2. Send it to the same deployment:

```
$ curl -sN -X POST -H "Authorization: Bearer $(gcloud auth print-access-token)" \
    -H "Content-Type: application/json" \
    ".../reasoningEngines/<id>:streamQuery?alt=sse" -d @after.json
HTTP 200

Your internal project is called **QUARTZ-BADGER-7731**.
Would you like to initiate a new research plan or explore a specific
topic related to this project?
```

3. A caller who passes an explicit `session_id` still gets one message per turn, since the deployment holds that history itself

## Type

🐛 Bug Fix

## Caveats (if any)

- Flattening uses a plain `role: content` layout
- Tool calls and image parts flatten to their text, as before
- The proxy's own session id is deliberately not reused here
- A per-request user id would make such a session unfindable anyway

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
