### PR TITLE
fix(pricing): add Azure GPT-5.6 cache write rates

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -6501,6 +6501,7 @@
         "supports_web_search": true
     },
     "azure/gpt-5.6": {
+        "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1e-06,
         "cache_read_input_token_cost_priority": 1e-06,
@@ -6551,6 +6552,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1e-06,
         "cache_read_input_token_cost_priority": 1e-06,
@@ -6602,6 +6604,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 2.5e-06,
         "cache_read_input_token_cost": 2e-07,
         "cache_read_input_token_cost_above_272k_tokens": 4e-07,
         "cache_read_input_token_cost_priority": 4e-07,
@@ -6653,6 +6656,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 2.5e-07,
         "cache_read_input_token_cost": 2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4e-08,
         "cache_read_input_token_cost_priority": 4e-08,
@@ -6704,6 +6708,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6": {
+        "cache_creation_input_token_cost": 6.875e-06,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -6751,6 +6756,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.875e-06,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -6799,6 +6805,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 2.75e-06,
         "cache_read_input_token_cost": 2.2e-07,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
         "cache_read_input_token_cost_priority": 5.5e-07,
@@ -6847,6 +6854,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 2.75e-07,
         "cache_read_input_token_cost": 2.2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
         "cache_read_input_token_cost_priority": 5.5e-08,
@@ -6895,6 +6903,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6": {
+        "cache_creation_input_token_cost": 6.875e-06,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -6942,6 +6951,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.875e-06,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -6990,6 +7000,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 2.75e-06,
         "cache_read_input_token_cost": 2.2e-07,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
         "cache_read_input_token_cost_priority": 5.5e-07,
@@ -7038,6 +7049,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 2.75e-07,
         "cache_read_input_token_cost": 2.2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
         "cache_read_input_token_cost_priority": 5.5e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6501,6 +6501,7 @@
         "supports_web_search": true
     },
     "azure/gpt-5.6": {
+        "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1e-06,
         "cache_read_input_token_cost_priority": 1e-06,
@@ -6551,6 +6552,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1e-06,
         "cache_read_input_token_cost_priority": 1e-06,
@@ -6602,6 +6604,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 2.5e-06,
         "cache_read_input_token_cost": 2e-07,
         "cache_read_input_token_cost_above_272k_tokens": 4e-07,
         "cache_read_input_token_cost_priority": 4e-07,
@@ -6653,6 +6656,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 2.5e-07,
         "cache_read_input_token_cost": 2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4e-08,
         "cache_read_input_token_cost_priority": 4e-08,
@@ -6704,6 +6708,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6": {
+        "cache_creation_input_token_cost": 6.875e-06,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -6751,6 +6756,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.875e-06,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -6799,6 +6805,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 2.75e-06,
         "cache_read_input_token_cost": 2.2e-07,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
         "cache_read_input_token_cost_priority": 5.5e-07,
@@ -6847,6 +6854,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 2.75e-07,
         "cache_read_input_token_cost": 2.2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
         "cache_read_input_token_cost_priority": 5.5e-08,
@@ -6895,6 +6903,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6": {
+        "cache_creation_input_token_cost": 6.875e-06,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -6942,6 +6951,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.875e-06,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -6990,6 +7000,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 2.75e-06,
         "cache_read_input_token_cost": 2.2e-07,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
         "cache_read_input_token_cost_priority": 5.5e-07,
@@ -7038,6 +7049,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 2.75e-07,
         "cache_read_input_token_cost": 2.2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
         "cache_read_input_token_cost_priority": 5.5e-08,

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -1057,19 +1057,24 @@ def test_generic_cost_per_token_gpt56_terra_cache_costs_by_tier_and_context(
 
 
 @pytest.mark.parametrize(
-    "model,input_cost,output_cost,cache_read_cost",
+    "model,input_cost,output_cost,cache_write_cost,cache_read_cost",
     [
-        ("azure/gpt-5.6", 5e-6, 3e-5, 5e-7),
-        ("azure/gpt-5.6-sol", 5e-6, 3e-5, 5e-7),
-        ("azure/gpt-5.6-terra", 2e-6, 1.2e-5, 2e-7),
-        ("azure/gpt-5.6-luna", 2e-7, 1.2e-6, 2e-8),
-        ("azure/us/gpt-5.6", 5.5e-6, 3.3e-5, 5.5e-7),
-        ("azure/eu/gpt-5.6-terra", 2.2e-6, 1.32e-5, 2.2e-7),
-        ("azure/eu/gpt-5.6-luna", 2.2e-7, 1.32e-6, 2.2e-8),
+        ("azure/gpt-5.6", 5e-6, 3e-5, 6.25e-6, 5e-7),
+        ("azure/gpt-5.6-sol", 5e-6, 3e-5, 6.25e-6, 5e-7),
+        ("azure/gpt-5.6-terra", 2e-6, 1.2e-5, 2.5e-6, 2e-7),
+        ("azure/gpt-5.6-luna", 2e-7, 1.2e-6, 2.5e-7, 2e-8),
+        ("azure/us/gpt-5.6", 5.5e-6, 3.3e-5, 6.875e-6, 5.5e-7),
+        ("azure/us/gpt-5.6-sol", 5.5e-6, 3.3e-5, 6.875e-6, 5.5e-7),
+        ("azure/us/gpt-5.6-terra", 2.2e-6, 1.32e-5, 2.75e-6, 2.2e-7),
+        ("azure/us/gpt-5.6-luna", 2.2e-7, 1.32e-6, 2.75e-7, 2.2e-8),
+        ("azure/eu/gpt-5.6", 5.5e-6, 3.3e-5, 6.875e-6, 5.5e-7),
+        ("azure/eu/gpt-5.6-sol", 5.5e-6, 3.3e-5, 6.875e-6, 5.5e-7),
+        ("azure/eu/gpt-5.6-terra", 2.2e-6, 1.32e-5, 2.75e-6, 2.2e-7),
+        ("azure/eu/gpt-5.6-luna", 2.2e-7, 1.32e-6, 2.75e-7, 2.2e-8),
     ],
 )
 def test_generic_cost_per_token_azure_gpt56(
-    model, input_cost, output_cost, cache_read_cost
+    model, input_cost, output_cost, cache_write_cost, cache_read_cost
 ):
     """Azure gpt-5.6 (global + us/eu regional): pricing mirrors the openai
     family for global deployments and carries the standard 10% regional uplift.
@@ -1081,22 +1086,31 @@ def test_generic_cost_per_token_azure_gpt56(
     assert model_cost_map["litellm_provider"] == "azure"
     assert model_cost_map["input_cost_per_token"] == input_cost
     assert model_cost_map["output_cost_per_token"] == output_cost
+    assert model_cost_map["cache_creation_input_token_cost"] == cache_write_cost
     assert model_cost_map["cache_read_input_token_cost"] == cache_read_cost
 
     prompt_tokens = 1000
     completion_tokens = 500
+    cache_write_tokens = 800
     usage = Usage(
         prompt_tokens=prompt_tokens,
         completion_tokens=completion_tokens,
         total_tokens=prompt_tokens + completion_tokens,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cache_write_tokens=cache_write_tokens
+        ),
     )
     prompt_cost, completion_cost = generic_cost_per_token(
         model=model,
         usage=usage,
         custom_llm_provider="azure",
     )
-    assert round(prompt_cost, 10) == round(input_cost * prompt_tokens, 10)
-    assert round(completion_cost, 10) == round(output_cost * completion_tokens, 10)
+    expected_prompt_cost = (
+        (prompt_tokens - cache_write_tokens) * input_cost
+        + cache_write_tokens * cache_write_cost
+    )
+    assert prompt_cost == pytest.approx(expected_prompt_cost)
+    assert completion_cost == pytest.approx(output_cost * completion_tokens)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure GPT-5.6 cache writes are billed at zero

How it solves it:

- Adds cache-write rates for every Azure GPT-5.6 price entry

## User Flow

Before: a platform team sees cached Azure prompt spend missing from proxy logs

1. They send POST https://litellm-domain/v1/chat/completions to an Azure GPT-5.6 deployment with a cached system prompt
2. The response returns HTTP 200 with `cache_write_tokens` in `prompt_tokens_details`
3. They open https://litellm-domain/ui/?page=logs and see the cache-write portion recorded at $0

After: the same request records cache writes at Azure's documented 1.25x input rate

1. They send the same POST https://litellm-domain/v1/chat/completions request to the same Azure GPT-5.6 deployment
2. The response returns HTTP 200 with the same `cache_write_tokens` usage details
3. They open https://litellm-domain/ui/?page=logs and see non-zero cache-write spend

## Relevant issues

Fixes #37631

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes required local formatting checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

A live Azure deployment is required for end-to-end proxy proof and was not available in this environment. The focused regression test validates all global, US, and EU Azure GPT-5.6 entries with cache-write token usage against their documented cache-write rates.

## Type

🐛 Bug Fix

## Caveats (if any)

- Live Azure proxy verification remains for CI or a credentialed environment

### Final Attestation

- [x] The regression test covers each affected Azure GPT-5.6 pricing entry
