### PR TITLE
fix(deepseek): aggregate missing reasoning warnings

### DIFF
--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -72,6 +72,15 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
              (LiteLLM stores provider-specific response fields there).
           2. Otherwise inject a single space — the minimum value the API accepts.
         """
+        missing_reasoning_content: Final = any(
+            msg.get("role") == "assistant"
+            and not msg.get("reasoning_content")
+            and not (
+                isinstance(provider_fields := msg.get("provider_specific_fields"), dict)
+                and provider_fields.get("reasoning_content")
+            )
+            for msg in messages
+        )
         result: Final[list[AllMessageValues]] = []
         for msg in messages:
             if msg.get("role") == "assistant" and not msg.get("reasoning_content"):
@@ -84,20 +93,21 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
                     cleaned.pop("reasoning_content", None)
                     patched["provider_specific_fields"] = cleaned
                 else:
-                    litellm.verbose_logger.warning(
-                        "DeepSeek thinking mode: assistant message is missing "
-                        "`reasoning_content` and none was saved in "
-                        "`provider_specific_fields`. A single-space placeholder "
-                        "is being injected to satisfy API validation, but the "
-                        "model will receive a blank reasoning chain for this turn, "
-                        "which may silently degrade multi-turn response quality. "
-                        "Preserve `reasoning_content` from the original assistant "
-                        "response when building multi-turn conversation history."
-                    )
                     patched["reasoning_content"] = " "
                 result.append(cast(AllMessageValues, patched))
             else:
                 result.append(msg)
+        if missing_reasoning_content:
+            litellm.verbose_logger.warning(
+                "DeepSeek thinking mode: assistant message is missing "
+                "`reasoning_content` and none was saved in "
+                "`provider_specific_fields`. A single-space placeholder "
+                "is being injected to satisfy API validation, but the "
+                "model will receive a blank reasoning chain for this turn, "
+                "which may silently degrade multi-turn response quality. "
+                "Preserve `reasoning_content` from the original assistant "
+                "response when building multi-turn conversation history."
+            )
         return result
 
     @overload

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -1,3 +1,6 @@
+from copy import deepcopy
+from unittest.mock import patch
+
 from litellm.llms.deepseek.chat.transformation import DeepSeekChatConfig
 
 
@@ -103,32 +106,42 @@ async def test_async_transform_request_strips_unsupported_tools_from_body():
     assert body["tools"][0]["function"]["name"] == "shell"
 
 
-def test_fill_reasoning_content_warns_once_per_request_and_preserves_history(caplog):
+def test_fill_reasoning_content_warns_once_per_request_and_preserves_history():
     messages = [
         {"role": "user", "content": "Use both tools."},
-        {"role": "assistant", "content": None, "tool_calls": [{"id": "first"}], "reasoning_content": ""},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "first"}],
+            "reasoning_content": "",
+        },
         {"role": "tool", "tool_call_id": "first", "content": "first result"},
-        {"role": "assistant", "content": None, "tool_calls": [{"id": "second"}], "reasoning_content": ""},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "second"}],
+            "reasoning_content": "",
+        },
         {"role": "tool", "tool_call_id": "second", "content": "second result"},
         {"role": "user", "content": "Continue."},
     ]
+    original_messages = deepcopy(messages)
+    config = DeepSeekChatConfig()
 
-    with caplog.at_level("WARNING"):
-        first_result = DeepSeekChatConfig()._fill_reasoning_content(messages)
-        second_result = DeepSeekChatConfig()._fill_reasoning_content(messages)
+    warning_path = "litellm.llms.deepseek.chat.transformation.litellm.verbose_logger.warning"
+    with patch(warning_path) as warning:
+        first_result = config._fill_reasoning_content(messages)
+        warning.assert_called_once()
 
-    warnings = [
-        record
-        for record in caplog.records
-        if "DeepSeek thinking mode: assistant message is missing `reasoning_content`" in record.message
-    ]
-    assert len(warnings) == 2
-    assert first_result[1]["reasoning_content"] == " "
-    assert first_result[3]["reasoning_content"] == " "
-    assert second_result[1]["reasoning_content"] == " "
-    assert second_result[3]["reasoning_content"] == " "
-    assert messages[1]["reasoning_content"] == ""
-    assert messages[3]["reasoning_content"] == ""
+    with patch(warning_path) as warning:
+        second_result = config._fill_reasoning_content(messages)
+        warning.assert_called_once()
+
+    assert [first_result[index]["reasoning_content"] for index in (1, 3)] == [" ", " "]
+    assert [second_result[index]["reasoning_content"] for index in (1, 3)] == [" ", " "]
+    assert first_result[0] is messages[0]
+    assert second_result[4] is messages[4]
+    assert messages == original_messages
 
 
 def test_thinking_mode_active_bool_thinking_returns_false_without_crashing():

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -106,7 +106,7 @@ async def test_async_transform_request_strips_unsupported_tools_from_body():
     assert body["tools"][0]["function"]["name"] == "shell"
 
 
-def test_fill_reasoning_content_warns_once_per_request_and_preserves_history():
+def test_transform_request_warns_once_per_replayed_history_and_preserves_history():
     messages = [
         {"role": "user", "content": "Use both tools."},
         {
@@ -130,17 +130,20 @@ def test_fill_reasoning_content_warns_once_per_request_and_preserves_history():
 
     warning_path = "litellm.llms.deepseek.chat.transformation.litellm.verbose_logger.warning"
     with patch(warning_path) as warning:
-        first_result = config._fill_reasoning_content(messages)
-        warning.assert_called_once()
+        results = [
+            config.transform_request(
+                model="deepseek-reasoner",
+                messages=messages,
+                optional_params={"thinking": {"type": "enabled"}},
+                litellm_params={},
+                headers={},
+            )
+            for _ in range(2)
+        ]
 
-    with patch(warning_path) as warning:
-        second_result = config._fill_reasoning_content(messages)
-        warning.assert_called_once()
-
-    assert [first_result[index]["reasoning_content"] for index in (1, 3)] == [" ", " "]
-    assert [second_result[index]["reasoning_content"] for index in (1, 3)] == [" ", " "]
-    assert first_result[0] is messages[0]
-    assert second_result[4] is messages[4]
+    assert warning.call_count == 2
+    for result in results:
+        assert [result["messages"][index]["reasoning_content"] for index in (1, 3)] == [" ", " "]
     assert messages == original_messages
 
 

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -103,6 +103,34 @@ async def test_async_transform_request_strips_unsupported_tools_from_body():
     assert body["tools"][0]["function"]["name"] == "shell"
 
 
+def test_fill_reasoning_content_warns_once_per_request_and_preserves_history(caplog):
+    messages = [
+        {"role": "user", "content": "Use both tools."},
+        {"role": "assistant", "content": None, "tool_calls": [{"id": "first"}], "reasoning_content": ""},
+        {"role": "tool", "tool_call_id": "first", "content": "first result"},
+        {"role": "assistant", "content": None, "tool_calls": [{"id": "second"}], "reasoning_content": ""},
+        {"role": "tool", "tool_call_id": "second", "content": "second result"},
+        {"role": "user", "content": "Continue."},
+    ]
+
+    with caplog.at_level("WARNING"):
+        first_result = DeepSeekChatConfig()._fill_reasoning_content(messages)
+        second_result = DeepSeekChatConfig()._fill_reasoning_content(messages)
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "DeepSeek thinking mode: assistant message is missing `reasoning_content`" in record.message
+    ]
+    assert len(warnings) == 2
+    assert first_result[1]["reasoning_content"] == " "
+    assert first_result[3]["reasoning_content"] == " "
+    assert second_result[1]["reasoning_content"] == " "
+    assert second_result[3]["reasoning_content"] == " "
+    assert messages[1]["reasoning_content"] == ""
+    assert messages[3]["reasoning_content"] == ""
+
+
 def test_thinking_mode_active_bool_thinking_returns_false_without_crashing():
     config = DeepSeekChatConfig()
     assert config._thinking_mode_active(model="deepseek-reasoner", optional_params={"thinking": True}) is False


### PR DESCRIPTION
## TLDR

Problem this solves:

- Replay histories repeat the same DeepSeek warning per assistant turn

How it solves it:

- Emits one request-level warning while retaining placeholder injection

## User Flow

Before: a developer replays a tool conversation with missing reasoning data and their application log is flooded with repeated warnings

1. They send a DeepSeek thinking-mode chat completion through LiteLLM with two historical assistant tool turns missing `reasoning_content`
2. The request continues, but the application log contains the same warning once for each affected assistant turn

After: the same history remains compatible with DeepSeek and produces one actionable warning

1. They send the same DeepSeek thinking-mode chat completion through LiteLLM
2. The request retains the single-space compatibility placeholders and the application log contains one warning for the request

## Relevant issues

Fixes #37629

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live provider proof is not included because this environment has no configured DeepSeek credential. The PR remains a draft pending that proof and CI

### Before (fad8116cdc4cd268c02bfa39a4e8dd17dc10f4da)

1. Not run against DeepSeek because no credential is configured

### After (d06deb060cd5e7da350cb5024026dad3a401dc7b)

1. Not run against DeepSeek because no credential is configured

## Type

🐛 Bug Fix

## Caveats (if any)

- Draft pending live provider proof and CI

### Final Attestation

- [x] The tests check the warning count, placeholder injection, and caller history immutability