### PR TITLE
fix(ui): make dark-mode form controls visible

### DIFF
--- a/ui/litellm-dashboard/src/app/globals.css
+++ b/ui/litellm-dashboard/src/app/globals.css
@@ -134,7 +134,7 @@
   --warning: oklch(0.828 0.189 84.429);
   --info: oklch(0.707 0.165 254.624);
   --border: oklch(0.309 0 0);
-  --input: oklch(0.309 0 0);
+  --input: oklch(0.56 0 0);
   --ring: oklch(0.569 0 0);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -228,6 +228,13 @@
     padding: 0;
     font: inherit;
     letter-spacing: inherit;
+  }
+
+  /* Same plugin's white fill, on the hand-rolled controls outside components/ui that the audit
+     above did not cover. Tracks --background so light mode keeps the white it already painted.
+     Delete along with the plugin. */
+  :is(input, textarea, select):not([type="checkbox"]):not([type="radio"]) {
+    background-color: var(--color-background);
   }
 
   button:not(:disabled),

--- a/ui/litellm-dashboard/src/app/globals.css
+++ b/ui/litellm-dashboard/src/app/globals.css
@@ -233,7 +233,7 @@
   /* Same plugin's white fill, on the hand-rolled controls outside components/ui that the audit
      above did not cover. Tracks --background so light mode keeps the white it already painted.
      Delete along with the plugin. */
-  :is(input, textarea, select):not([type="checkbox"]):not([type="radio"]) {
+  :is(input, textarea, select):not([type="checkbox"], [type="radio"], [data-slot="combobox-chip-input"]) {
     background-color: var(--color-background);
   }
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Form controls in dark mode have no visible outline
- Inside dialogs the outline is 6 steps out of 255
- Hand-rolled inputs render white on the dark page
- Typed text in those inputs sits at 1.11:1

How it solves it:

- Split `--input` off `--border` and raise it in `.dark`
- Neutralize the plugin white fill on bare controls
- Both scoped so light mode is byte-identical

## User Flow

Before: an admin creating a guardrail in dark mode cannot tell where the form fields are

1. They set the dashboard to dark and open http://localhost:4000/ui/?page=guardrails
2. They click "Add New Guardrail", then "Add Provider Guardrail"
3. The dialog shows labels and placeholder text floating on a flat surface, with no field outlines
4. They click roughly where they think "Guardrail Name" is and hope focus landed in the box
5. On http://localhost:4000/ui/?page=model-hub-table the "Friendly name" box is instead a white rectangle, and text they type into it is near-white on white, so they cannot read what they typed

After: every field is outlined, and typed text is readable

1. They set the dashboard to dark and open http://localhost:4000/ui/?page=guardrails
2. They click "Add New Guardrail", then "Add Provider Guardrail"
3. Each field in the dialog now has a visible outline, so the click target is obvious
4. On http://localhost:4000/ui/?page=model-hub-table the "Friendly name" box matches the page instead of glowing white, and text typed into it is legible
5. In light mode every one of these screens looks exactly as it did before

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup, once: run the proxy on :4000 and the dashboard dev server, then use the dashboard's own dark toggle

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

```bash
cd ui/litellm-dashboard && npm run dev
```

### Before (ffab5a39d0)

#### Guardrail dialog, dark

1. Open http://localhost:3000/guardrails and switch the dashboard to dark
2. Click "Add New Guardrail", then "Add Provider Guardrail"
3. Screenshot the dialog: the six fields have no discernible outline

#### AI Hub controls, dark

1. Open http://localhost:3000/model-hub-table in dark
2. Screenshot the "Add New Link" row: "Friendly name" and the URL box are white rectangles
3. Type into "Friendly name" and screenshot: the text is not readable

#### Same screens, light

1. Switch to light and screenshot both pages for the comparison below

### After (b46a3aed7a)

#### Guardrail dialog, dark

1. Same steps
2. Every field now carries a visible outline
3. Click the "Guardrail Provider" multi-select and screenshot it: the chip editor stays transparent against the control, with no solid rectangle inside it

#### AI Hub controls, dark

1. Same steps
2. The boxes now match the page surface, and typed text is legible

#### Same screens, light

1. Same steps; the screenshots should be indistinguishable from Before

## Type

🐛 Bug Fix

## Caveats (if any)

- No tests: rendered contrast is not assertable in jsdom
- `--border` deliberately unchanged; it draws separators, not controls
- Controls using `border-border` keep a weaker outline
- Native select popup lists still render light; `color-scheme` deferred

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

