### PR TITLE
fix(cost): stop double-billing the Azure AI Model Router flat fee

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -39,6 +39,7 @@ from litellm.llms.anthropic.cost_calculation import (
 from litellm.llms.azure.cost_calculation import (
     cost_per_token as azure_openai_cost_per_token,
 )
+from litellm.llms.azure_ai.cost_calculator import _is_azure_model_router
 from litellm.llms.azure_ai.cost_calculator import (
     cost_per_token as azure_ai_cost_per_token,
 )
@@ -1592,7 +1593,11 @@ def completion_cost(
                 )
 
                 # Get additional costs from provider (e.g., routing fees, infrastructure costs)
-                if custom_llm_provider == "azure_ai":
+                token_path_billed_router: Final = custom_llm_provider == "azure_ai" and (
+                    _is_azure_model_router(model)
+                    or (request_model_for_cost is not None and _is_azure_model_router(request_model_for_cost))
+                )
+                if custom_llm_provider == "azure_ai" and not token_path_billed_router:
                     model_for_additional_costs = request_model_for_cost
                     if completion_response is not None:
                         hidden_params = getattr(completion_response, "_hidden_params", None) or {}

--- a/tests/test_litellm/llms/azure_ai/test_azure_ai_cost_calculator.py
+++ b/tests/test_litellm/llms/azure_ai/test_azure_ai_cost_calculator.py
@@ -377,25 +377,11 @@ class TestAzureModelRouterCostBreakdown:
             litellm_logging_obj=logging_obj,
         )
 
-        # Check that cost breakdown contains additional_costs
-        assert hasattr(logging_obj, "cost_breakdown")
-        assert logging_obj.cost_breakdown is not None
-        assert "additional_costs" in logging_obj.cost_breakdown
-        assert isinstance(logging_obj.cost_breakdown["additional_costs"], dict)
-
-        # Check that the Azure Model Router flat cost is in additional_costs
-        additional_costs = logging_obj.cost_breakdown["additional_costs"]
-        assert "Azure Model Router Flat Cost" in additional_costs
-
-        # Verify the flat cost value
-        expected_flat_cost = (
-            5000 * AZURE_MODEL_ROUTER_FLAT_COST_PER_M_INPUT_TOKENS / 1_000_000
-        )
-        actual_flat_cost = additional_costs["Azure Model Router Flat Cost"]
-        assert actual_flat_cost == pytest.approx(expected_flat_cost, rel=1e-9)
-
-        print(f"Additional costs in breakdown: {additional_costs}")
-        print(f"Azure Model Router Flat Cost: ${actual_flat_cost:.6f}")
+        # For a pure model-router response (no underlying model pricing) the flat fee is
+        # billed once, through the token-cost path, so the total equals a single flat fee.
+        # It must not also be summed via additional_costs, which would double-bill it.
+        expected_flat_cost = 5000 * AZURE_MODEL_ROUTER_FLAT_COST_PER_M_INPUT_TOKENS / 1_000_000
+        assert cost == pytest.approx(expected_flat_cost, rel=1e-9)
 
     def test_additional_costs_when_response_has_actual_model_via_hidden_params(self):
         """additional_costs populated when response has actual model but request was via model router (hidden_params)."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure AI Foundry Model Router requests are billed the flat routing fee twice
- logged spend for those requests is ~2x the real cost

How it solves it:

- when the token-cost path already folded the flat fee into prompt cost, skip adding it again via additional_costs

## User Flow

Before: a developer routing through Azure AI Foundry Model Router sees double the expected spend

1. They send a completion whose model resolves to the Azure Model Router (e.g. `azure-model-router`)
2. `cost_per_token` folds the flat $0.14 per million input-token fee into prompt cost, and `completion_cost` then adds the same fee again through its additional_costs hook
3. Their logged spend is twice the flat fee

After: the same request is billed the flat fee once

1. They send the same completion
2. The flat fee is billed a single time through the token-cost path
3. Logged spend matches the real charge

## Relevant issues

## Type

🐛 Bug Fix

## Changes

`completion_cost` computes token cost via `azure_ai` `cost_per_token`, which already folds the Model Router flat fee into prompt cost whenever it detects the router from the response `model` or the `request_model` (`is_router_request`). Right after, for `custom_llm_provider == "azure_ai"`, `completion_cost` separately computed the same flat fee through `_get_additional_costs` and summed it into the total, so any request where the token path detected the router was charged the fee twice. This guards the additional_costs branch: when `_is_azure_model_router(model)` or `_is_azure_model_router(request_model_for_cost)` is true, the token path already billed the fee, so additional_costs is left unset. The hidden-params-only path (response carries the underlying model, router known only from `_hidden_params`) is unchanged and still bills the fee once through additional_costs.

## Screenshots / Proof of Fix

For a pure `azure-model-router` response with 5000 prompt tokens, `completion_cost` now returns a single flat fee (5000 * rate / 1e6) instead of twice that. Regression test `tests/test_litellm/llms/azure_ai/test_azure_ai_cost_calculator.py::TestAzureModelRouterCostBreakdown::test_additional_costs_in_cost_breakdown` asserts the single-fee total; it fails on the pre-fix code (double) and passes after. All 32 tests in that file pass.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
